### PR TITLE
Fix FESystem::convert_generalized_support_point_values_to_dof_values

### DIFF
--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -1345,7 +1345,7 @@
  * code that describes a finite element simply by providing a polynomial
  * space (without having to give it any particular basis -- whatever is convenient
  * is entirely sufficient) and the nodal functionals. This is used, for example
- * in the FiniteElement::convert_generalized_support_point_values_to_nodal_values()
+ * in the FiniteElement::convert_generalized_support_point_values_to_dof_values()
  * function.
  * </dd>
  *

--- a/doc/news/changes/major/20170831MatthiasMaierLucaHeltai
+++ b/doc/news/changes/major/20170831MatthiasMaierLucaHeltai
@@ -1,6 +1,9 @@
 Improved: The support for non-Lagrangian elements with generalized support
-points has been vastly improved: FESystem::get_generalized_support_point()
+points has been vastly improved. FESystem::get_generalized_support_point()
 now returns a list of unique generalized support points for the finite
-element system; TODO
+element system. In order to do interpolation a function
+FiniteElement::convert_generalized_support_points_to_dof_values() can be
+used. This interface is implement for a wide variety of base classes and
+FESystem. TODO
 <br> (Matthias Maier, Luca Heltai, 2017/08/31)
 

--- a/doc/news/changes/minor/20170405Bangerth
+++ b/doc/news/changes/minor/20170405Bangerth
@@ -1,6 +1,6 @@
 New: The classes FE_Q, FE_DGQ, and FE_DGQArbitraryNodes now implement
 the
-FiniteElement::convert_generalized_support_point_values_to_nodal_values()
+FiniteElement::convert_generalized_support_point_values_to_dof_values()
 interface.
 <br>
 (Wolfgang Bangerth, 2017/04/05)

--- a/doc/news/changes/minor/20170405Bangerth-2
+++ b/doc/news/changes/minor/20170405Bangerth-2
@@ -1,6 +1,6 @@
 New: The class FESystem now implements
 the
-FiniteElement::convert_generalized_support_point_values_to_nodal_values()
+FiniteElement::convert_generalized_support_point_values_to_dof_values()
 interface.
 <br>
-(Wolfgang Bangerth, 2017/04/05)
+(Wolfgang Bangerth, Matthias Maier, 2017/08/31)

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -2087,8 +2087,8 @@ public:
    */
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
   //@}
 

--- a/include/deal.II/fe/fe_abf.h
+++ b/include/deal.II/fe/fe_abf.h
@@ -126,8 +126,8 @@ public:
   // documentation inherited from the base class
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
   virtual std::size_t memory_consumption () const;
 

--- a/include/deal.II/fe/fe_bdm.h
+++ b/include/deal.II/fe/fe_bdm.h
@@ -77,8 +77,8 @@ public:
   // documentation inherited from the base class
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
 private:
   /**

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -309,8 +309,8 @@ public:
    */
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -426,8 +426,8 @@ public:
    */
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
   clone() const;

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -258,8 +258,8 @@ public:
   // documentation inherited from the base class
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
   /**
    * Return a list of constant modes of the element.

--- a/include/deal.II/fe/fe_q.h
+++ b/include/deal.II/fe/fe_q.h
@@ -599,8 +599,8 @@ public:
    */
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 };
 
 

--- a/include/deal.II/fe/fe_q_bubbles.h
+++ b/include/deal.II/fe/fe_q_bubbles.h
@@ -107,8 +107,8 @@ public:
   // documentation inherited from the base class
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
   /**
    * Return the matrix interpolating from the given finite element to the

--- a/include/deal.II/fe/fe_q_dg0.h
+++ b/include/deal.II/fe/fe_q_dg0.h
@@ -261,8 +261,8 @@ public:
   // documentation inherited from the base class
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
   /**
    * Return the matrix interpolating from the given finite element to the

--- a/include/deal.II/fe/fe_q_iso_q1.h
+++ b/include/deal.II/fe/fe_q_iso_q1.h
@@ -138,8 +138,8 @@ public:
    */
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
   /**
    * @name Functions to support hp

--- a/include/deal.II/fe/fe_rannacher_turek.h
+++ b/include/deal.II/fe/fe_rannacher_turek.h
@@ -73,8 +73,8 @@ public:
   // documentation inherited from the base class
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
 private:
   /**

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -135,8 +135,8 @@ public:
   // documentation inherited from the base class
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
   /**
    * Return a list of constant modes of the element. This method is currently
@@ -264,8 +264,8 @@ public:
 
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
   virtual void get_face_interpolation_matrix (const FiniteElement<dim> &source,
                                               FullMatrix<double>       &matrix) const;

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -853,15 +853,15 @@ public:
 
   /**
    * Implementation of the
-   * FiniteElement::convert_generalized_support_point_values_to_nodal_values()
+   * FiniteElement::convert_generalized_support_point_values_to_dof_values()
    * function. The current function simply takes the input argument apart,
    * passes the pieces to the base elements, and then re-assembles everything
    * into the output argument.
    */
   virtual
   void
-  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                            std::vector<double>                &nodal_values) const;
+  convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -291,7 +291,7 @@ namespace FETools
    *   that returns a scalar.
    * - That the finite element has exactly @p dim vector components.
    * - That the function $f_j$ is given by whatever the element implements
-   *   through the FiniteElement::convert_generalized_support_point_values_to_nodal_values()
+   *   through the FiniteElement::convert_generalized_support_point_values_to_dof_values()
    *   function.
    *
    * @param fe The finite element for which the operations above are to be

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -1098,8 +1098,8 @@ FiniteElement<dim,spacedim>::get_constant_modes () const
 template <int dim, int spacedim>
 void
 FiniteElement<dim,spacedim>::
-convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &,
-                                                          std::vector<double> &) const
+convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &,
+                                                        std::vector<double> &) const
 {
   Assert (has_generalized_support_points(),
           ExcMessage ("The element for which you are calling the current "

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -513,8 +513,8 @@ FE_ABF<dim>::has_support_on_face (const unsigned int shape_index,
 template <int dim>
 void
 FE_ABF<dim>::
-convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const
+convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                        std::vector<double>                &nodal_values) const
 {
   Assert (support_point_values.size() == this->generalized_support_points.size(),
           ExcDimensionMismatch(support_point_values.size(), this->generalized_support_points.size()));

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -126,8 +126,8 @@ FE_BDM<dim>::clone() const
 template <int dim>
 void
 FE_BDM<dim>::
-convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double> &nodal_values) const
+convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                        std::vector<double> &nodal_values) const
 {
   Assert (support_point_values.size() == this->generalized_support_points.size(),
           ExcDimensionMismatch(support_point_values.size(), this->generalized_support_points.size()));

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -115,8 +115,8 @@ FE_DGQ<dim, spacedim>::get_name () const
 template <int dim, int spacedim>
 void
 FE_DGQ<dim,spacedim>::
-convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const
+convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                        std::vector<double>                &nodal_values) const
 {
   AssertDimension (support_point_values.size(),
                    this->get_unit_support_points().size());
@@ -795,8 +795,8 @@ FE_DGQArbitraryNodes<dim,spacedim>::get_name () const
 template <int dim, int spacedim>
 void
 FE_DGQArbitraryNodes<dim,spacedim>::
-convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const
+convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                        std::vector<double>                &nodal_values) const
 {
   AssertDimension (support_point_values.size(),
                    this->get_unit_support_points().size());

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -3099,8 +3099,8 @@ FE_Nedelec<dim>
 template <int dim>
 void
 FE_Nedelec<dim>::
-convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double> &nodal_values) const
+convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                        std::vector<double> &nodal_values) const
 {
   const unsigned int deg = this->degree-1;
   Assert (support_point_values.size () == this->generalized_support_points.size (),

--- a/source/fe/fe_q.cc
+++ b/source/fe/fe_q.cc
@@ -143,8 +143,8 @@ FE_Q<dim,spacedim>::get_name () const
 template <int dim, int spacedim>
 void
 FE_Q<dim,spacedim>::
-convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const
+convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                        std::vector<double>                &nodal_values) const
 {
   AssertDimension (support_point_values.size(),
                    this->get_unit_support_points().size());

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -336,8 +336,8 @@ FE_Q_Bubbles<dim,spacedim>::clone() const
 template <int dim, int spacedim>
 void
 FE_Q_Bubbles<dim,spacedim>::
-convert_generalized_support_point_values_to_nodal_values(const std::vector<Vector<double> > &support_point_values,
-                                                         std::vector<double>    &nodal_values) const
+convert_generalized_support_point_values_to_dof_values(const std::vector<Vector<double> > &support_point_values,
+                                                       std::vector<double>    &nodal_values) const
 {
   Assert (support_point_values.size() == this->unit_support_points.size(),
           ExcDimensionMismatch(support_point_values.size(),

--- a/source/fe/fe_q_dg0.cc
+++ b/source/fe/fe_q_dg0.cc
@@ -178,8 +178,8 @@ FE_Q_DG0<dim,spacedim>::clone() const
 template <int dim, int spacedim>
 void
 FE_Q_DG0<dim,spacedim>::
-convert_generalized_support_point_values_to_nodal_values(const std::vector<Vector<double> > &support_point_values,
-                                                         std::vector<double>    &nodal_dofs) const
+convert_generalized_support_point_values_to_dof_values(const std::vector<Vector<double> > &support_point_values,
+                                                       std::vector<double>    &nodal_dofs) const
 {
   Assert (support_point_values.size() == this->unit_support_points.size(),
           ExcDimensionMismatch(support_point_values.size(),

--- a/source/fe/fe_q_iso_q1.cc
+++ b/source/fe/fe_q_iso_q1.cc
@@ -72,8 +72,8 @@ FE_Q_iso_Q1<dim,spacedim>::get_name () const
 template <int dim, int spacedim>
 void
 FE_Q_iso_Q1<dim,spacedim>::
-convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const
+convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                        std::vector<double>                &nodal_values) const
 {
   AssertDimension (support_point_values.size(),
                    this->get_unit_support_points().size());

--- a/source/fe/fe_rannacher_turek.cc
+++ b/source/fe/fe_rannacher_turek.cc
@@ -106,8 +106,8 @@ void FE_RannacherTurek<dim>::initialize_support_points()
 template <int dim>
 void
 FE_RannacherTurek<dim>::
-convert_generalized_support_point_values_to_nodal_values(const std::vector<Vector<double> > &support_point_values,
-                                                         std::vector<double> &nodal_values) const
+convert_generalized_support_point_values_to_dof_values(const std::vector<Vector<double> > &support_point_values,
+                                                       std::vector<double> &nodal_values) const
 {
   AssertDimension(support_point_values.size(), this->generalized_support_points.size());
   AssertDimension(nodal_values.size(), this->dofs_per_cell);

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -465,8 +465,8 @@ FE_RaviartThomas<dim>::has_support_on_face (
 template <int dim>
 void
 FE_RaviartThomas<dim>::
-convert_generalized_support_point_values_to_nodal_values(const std::vector<Vector<double> > &support_point_values,
-                                                         std::vector<double>    &nodal_values) const
+convert_generalized_support_point_values_to_dof_values(const std::vector<Vector<double> > &support_point_values,
+                                                       std::vector<double>    &nodal_values) const
 {
   Assert (support_point_values.size() == this->generalized_support_points.size(),
           ExcDimensionMismatch(support_point_values.size(), this->generalized_support_points.size()));

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -285,8 +285,8 @@ FE_RaviartThomasNodal<dim>::has_support_on_face (
 template <int dim>
 void
 FE_RaviartThomasNodal<dim>::
-convert_generalized_support_point_values_to_nodal_values(const std::vector<Vector<double> > &support_point_values,
-                                                         std::vector<double>    &nodal_values) const
+convert_generalized_support_point_values_to_dof_values(const std::vector<Vector<double> > &support_point_values,
+                                                       std::vector<double>    &nodal_values) const
 {
   Assert (support_point_values.size() == this->generalized_support_points.size(),
           ExcDimensionMismatch(support_point_values.size(), this->generalized_support_points.size()));

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -2251,8 +2251,8 @@ FESystem<dim,spacedim>::get_constant_modes () const
 template <int dim, int spacedim>
 void
 FESystem<dim,spacedim>::
-convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const
+convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
+                                                        std::vector<double>                &nodal_values) const
 {
   // we currently only support the case where each base element has exactly
   // as many generalized support points as there are dofs in that element.
@@ -2301,7 +2301,7 @@ convert_generalized_support_point_values_to_nodal_values (const std::vector<Vect
           // then call the base element to get its version of the
           // nodal values
           base_nodal_values.resize (base_element(base).dofs_per_cell);
-          base_element(base).convert_generalized_support_point_values_to_nodal_values
+          base_element(base).convert_generalized_support_point_values_to_dof_values
           (base_support_point_values, base_nodal_values);
 
           // finally put these nodal values back into global nodal

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -2261,6 +2261,9 @@ convert_generalized_support_point_values_to_dof_values (const std::vector<Vector
                   this->get_generalized_support_points().size());
   AssertDimension(dof_values.size(), this->dofs_per_cell);
 
+  std::vector<double> base_dof_values;
+  std::vector<Vector<double> > base_point_values;
+
   // loop over all base elements (respecting multiplicity) and let them do
   // the work on their share of the input argument
 
@@ -2277,8 +2280,8 @@ convert_generalized_support_point_values_to_dof_values (const std::vector<Vector
         base_element.get_generalized_support_points().size();
       const unsigned int n_base_components = base_element.n_components();
 
-      std::vector<double> base_dof_values(n_base_dofs);
-      std::vector<Vector<double> > base_point_values(n_base_points);
+      base_dof_values.resize(n_base_dofs);
+      base_point_values.resize(n_base_points);
 
       for (unsigned int m = 0; m < multiplicity;
            ++m, current_vector_component += n_base_components)

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1610,10 +1610,10 @@ void FESystem<dim,spacedim>::initialize (const std::vector<const FiniteElement<d
 
     generalized_support_points_index_table.resize(this->n_base_elements());
 
-    for (unsigned int base_el = 0; base_el < this->n_base_elements(); ++base_el)
+    for (unsigned int base = 0; base < this->n_base_elements(); ++base)
       {
         for (const auto &point :
-             base_element(base_el).get_generalized_support_points())
+             base_element(base).get_generalized_support_points())
           {
             // Is point already an element of generalized_support_points?
             const auto p =
@@ -1625,14 +1625,14 @@ void FESystem<dim,spacedim>::initialize (const std::vector<const FiniteElement<d
               {
                 // If no, update the table and add the point to the vector
                 const auto n = this->generalized_support_points.size();
-                generalized_support_points_index_table[base_el].push_back(n);
+                generalized_support_points_index_table[base].push_back(n);
                 this->generalized_support_points.push_back(point);
               }
             else
               {
                 // If yes, just add the correct index to the table.
                 const auto n = p - std::begin(this->generalized_support_points);
-                generalized_support_points_index_table[base_el].push_back(n);
+                generalized_support_points_index_table[base].push_back(n);
               }
           }
       }

--- a/source/fe/fe_tools.cc
+++ b/source/fe/fe_tools.cc
@@ -1649,8 +1649,8 @@ namespace FETools
               Assert (numbers::is_finite(support_point_values[k][d]), ExcInternalError());
             }
 
-        fe.convert_generalized_support_point_values_to_nodal_values(support_point_values,
-                                                                    nodal_values);
+        fe.convert_generalized_support_point_values_to_dof_values(support_point_values,
+                                                                  nodal_values);
 
         // Enter the interpolated dofs into the matrix
         for (unsigned int j=0; j<n_dofs; ++j)

--- a/tests/fe/abf_03.cc
+++ b/tests/fe/abf_03.cc
@@ -15,7 +15,7 @@
 
 
 
-// Check that convert_generalized_support_point_values_to_nodal_values
+// Check that convert_generalized_support_point_values_to_dof_values
 // gives the correct when asking for we the nodal values for a
 // function in the FE_ABF<dim(degree) ansatz space.
 
@@ -43,7 +43,7 @@ void test (const unsigned int degree)
         real_values[i][c] += dof_values[j] * fe.shape_value_component(j, generalized_support_points[i], c);
 
   std::vector<double> compare_values (fe.dofs_per_cell);
-  fe.convert_generalized_support_point_values_to_nodal_values(real_values, compare_values);
+  fe.convert_generalized_support_point_values_to_dof_values(real_values, compare_values);
 
   for (unsigned int i=0; i<dof_values.size(); ++i)
     if (std::abs(dof_values[i]-compare_values[i]) > std::abs(dof_values[i])*1.e-6)

--- a/tests/fe/fe_rannacher_turek_01.cc
+++ b/tests/fe/fe_rannacher_turek_01.cc
@@ -68,7 +68,7 @@ void test_nodal_matrix()
     {
       for (unsigned int k = 0; k < values.size(); ++k)
         values[k][0] = fe.shape_value(i, points[k]);
-      fe.convert_generalized_support_point_values_to_nodal_values(values, local_dofs);
+      fe.convert_generalized_support_point_values_to_dof_values(values, local_dofs);
 
       for (unsigned int j=0; j < n_dofs; ++j)
         N(j,i) = local_dofs[j];
@@ -125,7 +125,7 @@ void test_interpolation()
       fev.get_function_values(input_vector, values);
 
       std::vector<double> interpolated_local_dofs(n_dofs);
-      fe.convert_generalized_support_point_values_to_nodal_values(values, interpolated_local_dofs);
+      fe.convert_generalized_support_point_values_to_dof_values(values, interpolated_local_dofs);
 
       Vector<double> local_dofs(n_dofs);
       cell->get_dof_values(input_vector, local_dofs);

--- a/tests/fe/interpolate_q1.cc
+++ b/tests/fe/interpolate_q1.cc
@@ -36,7 +36,7 @@ void check(const Function<dim> &f,
   std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
                                        Vector<double>(1));
   f.vector_value_list(fe.get_unit_support_points(), values);
-  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << difference(fe,dofs,f) << std::endl;
 }
 
@@ -52,7 +52,7 @@ void check_dg(const Function<dim> &f,
   std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
                                        Vector<double>(1));
   f.vector_value_list(fe.get_unit_support_points(), values);
-  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << difference(fe,dofs,f) << std::endl;
 }
 
@@ -69,7 +69,7 @@ void check_dg_lobatto(const Function<dim> &f,
   std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
                                        Vector<double>(1));
   f.vector_value_list(fe.get_unit_support_points(), values);
-  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << difference(fe,dofs,f) << std::endl;
 }
 

--- a/tests/fe/interpolate_q_bubbles.cc
+++ b/tests/fe/interpolate_q_bubbles.cc
@@ -32,7 +32,7 @@ void check_q_bubbles(const Function<dim> &f,
   std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
                                        Vector<double>(1));
   f.vector_value_list(fe.get_unit_support_points(), values);
-  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " value " << difference(fe,dofs,f) << std::endl;
 }
 

--- a/tests/fe/interpolate_q_dg0.cc
+++ b/tests/fe/interpolate_q_dg0.cc
@@ -32,7 +32,7 @@ void check_q_dg0(const Function<dim> &f,
   std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
                                        Vector<double>(1));
   f.vector_value_list(fe.get_unit_support_points(), values);
-  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << difference(fe,dofs,f) << std::endl;
 }
 

--- a/tests/fe/interpolate_q_iso_q1.cc
+++ b/tests/fe/interpolate_q_iso_q1.cc
@@ -34,7 +34,7 @@ void check(const Function<dim> &f,
   std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
                                        Vector<double>(1));
   f.vector_value_list(fe.get_unit_support_points(), values);
-  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << difference(fe,dofs,f) << std::endl;
 }
 

--- a/tests/fe/interpolate_rt.cc
+++ b/tests/fe/interpolate_rt.cc
@@ -35,7 +35,7 @@ void check1(const Function<dim> &f,
   std::vector<Vector<double> > values (fe.get_generalized_support_points().size(),
                                        Vector<double>(dim));
   f.vector_value_list(fe.get_generalized_support_points(), values);
-  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << vector_difference(fe,dofs,f,0) << std::endl;
 }
 

--- a/tests/fe/interpolate_rtn.cc
+++ b/tests/fe/interpolate_rtn.cc
@@ -35,7 +35,7 @@ void check1(const Function<dim> &f,
   std::vector<Vector<double> > values (fe.get_generalized_support_points().size(),
                                        Vector<double>(dim));
   f.vector_value_list(fe.get_generalized_support_points(), values);
-  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << vector_difference(fe,dofs,f,0) << std::endl;
 }
 

--- a/tests/fe/interpolate_system.cc
+++ b/tests/fe/interpolate_system.cc
@@ -34,9 +34,9 @@ void check1(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
+  std::vector<Vector<double> > values (fe.get_generalized_support_points().size(),
                                        Vector<double>(comp));
-  f.vector_value_list(fe.get_unit_support_points(), values);
+  f.vector_value_list(fe.get_generalized_support_points(), values);
   fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << vector_difference(fe,dofs,f,0) << std::endl;
 }
@@ -56,9 +56,9 @@ void check3(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
+  std::vector<Vector<double> > values (fe.get_generalized_support_points().size(),
                                        Vector<double>(f.n_components));
-  f.vector_value_list(fe.get_unit_support_points(), values);
+  f.vector_value_list(fe.get_generalized_support_points(), values);
   fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << vector_difference(fe,dofs,f,0) << std::endl;
 }

--- a/tests/fe/interpolate_system.cc
+++ b/tests/fe/interpolate_system.cc
@@ -37,7 +37,7 @@ void check1(const Function<dim> &f,
   std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
                                        Vector<double>(comp));
   f.vector_value_list(fe.get_unit_support_points(), values);
-  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << vector_difference(fe,dofs,f,0) << std::endl;
 }
 
@@ -59,7 +59,7 @@ void check3(const Function<dim> &f,
   std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
                                        Vector<double>(f.n_components));
   f.vector_value_list(fe.get_unit_support_points(), values);
-  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
   deallog << " vector " << vector_difference(fe,dofs,f,0) << std::endl;
 }
 

--- a/tests/fe/interpolate_system_2.cc
+++ b/tests/fe/interpolate_system_2.cc
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include "interpolate_common.h"
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/fe/fe_nedelec.h>
+#include <deal.II/fe/fe_raviart_thomas.h>
+#include <deal.II/fe/fe_system.h>
+
+
+//
+// Check convert_generalized_support_opint_values_to_dof_values for systems
+// of non-Lagrangian elements.
+//
+
+template <int dim, typename T>
+void check(T function, const unsigned int degree)
+{
+  auto fe = FESystem<dim>(FE_RaviartThomas<dim>(degree),
+                          2,
+                          FESystem<dim>(FE_RaviartThomas<dim>(degree), 2),
+                          1);
+  deallog << fe.get_name() << std::endl;
+
+  std::vector<double> dofs(fe.dofs_per_cell);
+
+  std::vector<Vector<double>> values(fe.get_generalized_support_points().size(),
+                                     Vector<double>(4 * dim));
+  function.vector_value_list(fe.get_generalized_support_points(), values);
+
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
+  deallog << " vector " << vector_difference(fe, dofs, function, 0) << std::endl;
+}
+
+int main()
+{
+  initlog();
+
+  check<2>(Q1WedgeFunction<2, 1, 4 * 2>(), 1);
+  check<2>(Q1WedgeFunction<2, 2, 4 * 2>(), 2);
+  check<2>(Q1WedgeFunction<2, 3, 4 * 2>(), 3);
+  check<3>(Q1WedgeFunction<3, 1, 4 * 3>(), 1);
+  check<3>(Q1WedgeFunction<3, 2, 4 * 3>(), 2);
+  check<3>(Q1WedgeFunction<3, 3, 4 * 3>(), 3);
+}

--- a/tests/fe/interpolate_system_2.output
+++ b/tests/fe/interpolate_system_2.output
@@ -1,0 +1,13 @@
+
+DEAL::FESystem<2>[FE_RaviartThomas<2>(1)^2-FESystem<2>[FE_RaviartThomas<2>(1)^2]]
+DEAL:: vector 1.66533e-16
+DEAL::FESystem<2>[FE_RaviartThomas<2>(2)^2-FESystem<2>[FE_RaviartThomas<2>(2)^2]]
+DEAL:: vector 2.39392e-16
+DEAL::FESystem<2>[FE_RaviartThomas<2>(3)^2-FESystem<2>[FE_RaviartThomas<2>(3)^2]]
+DEAL:: vector 1.87784e-16
+DEAL::FESystem<3>[FE_RaviartThomas<3>(1)^2-FESystem<3>[FE_RaviartThomas<3>(1)^2]]
+DEAL:: vector 1.59595e-16
+DEAL::FESystem<3>[FE_RaviartThomas<3>(2)^2-FESystem<3>[FE_RaviartThomas<3>(2)^2]]
+DEAL:: vector 5.22585e-16
+DEAL::FESystem<3>[FE_RaviartThomas<3>(3)^2-FESystem<3>[FE_RaviartThomas<3>(3)^2]]
+DEAL:: vector 3.52637e-16


### PR DESCRIPTION
Use generalized_support_points_index_table to correctly convert generalized
support point values to dof values.

In reference to #4992
Closes #4090