### PR TITLE
Fix two tests failing for clang

### DIFF
--- a/tests/fe/fe_system_generalized_support_points.cc
+++ b/tests/fe/fe_system_generalized_support_points.cc
@@ -44,15 +44,15 @@ void test()
   print(FE_Q<dim>(1));
   print(FE_RaviartThomas<dim>(0));
   print(FE_Nedelec<dim>(0));
-  print(FESystem(FE_RaviartThomas<dim>(0), 3, FE_Nedelec<dim>(0), 3));
-  print(FESystem(FESystem(FE_RaviartThomas<dim>(0), 3, FE_Nedelec<dim>(0), 3), 2, FE_Q<dim>(1), 3, FE_Q<dim>(1), 3));
+  print(FESystem<dim>(FE_RaviartThomas<dim>(0), 3, FE_Nedelec<dim>(0), 3));
+  print(FESystem<dim>(FESystem<dim>(FE_RaviartThomas<dim>(0), 3, FE_Nedelec<dim>(0), 3), 2, FE_Q<dim>(1), 3, FE_Q<dim>(1), 3));
 
   deallog << "dim " << dim << " higher order" << std::endl;
   print(FE_Q<dim>(2));
   print(FE_RaviartThomas<dim>(1));
   print(FE_Nedelec<dim>(1));
-  print(FESystem(FE_RaviartThomas<dim>(1), 3, FE_Nedelec<dim>(1), 3));
-  print(FESystem(FESystem(FE_RaviartThomas<dim>(1), 3, FE_Nedelec<dim>(1), 3), 2, FE_Q<dim>(2), 3, FE_Q<dim>(1), 3));
+  print(FESystem<dim>(FE_RaviartThomas<dim>(1), 3, FE_Nedelec<dim>(1), 3));
+  print(FESystem<dim>(FESystem<dim>(FE_RaviartThomas<dim>(1), 3, FE_Nedelec<dim>(1), 3), 2, FE_Q<dim>(2), 3, FE_Q<dim>(1), 3));
 }
 
 int main ()

--- a/tests/lac/vector_memory.debug.output.clang
+++ b/tests/lac/vector_memory.debug.output.clang
@@ -1,0 +1,25 @@
+
+DEAL::GrowingVectorMemory:Overall allocated vectors: 10
+DEAL::GrowingVectorMemory:Maximum allocated vectors: 6
+DEAL::Exception: StandardExceptions::ExcMemoryLeak(current_alloc)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <vector_memory.templates.h> in function
+    virtual dealii::GrowingVectorMemory<dealii::Vector<double> >::~GrowingVectorMemory() [VectorType = dealii::Vector<double>]
+The violated condition was: 
+    current_alloc == 0
+Additional information: 
+    (none)
+--------------------------------------------------------
+
+DEAL::Exception: StandardExceptions::ExcMemoryLeak(current_alloc)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <vector_memory.templates.h> in function
+    virtual dealii::GrowingVectorMemory<dealii::Vector<float> >::~GrowingVectorMemory() [VectorType = dealii::Vector<float>]
+The violated condition was: 
+    current_alloc == 0
+Additional information: 
+    (none)
+--------------------------------------------------------
+


### PR DESCRIPTION
- At least `clang` can't deduce the appropriate template arguments for `FESystem` in `fe/fe_system_generalized_support_points`.  According to [CDash](https://cdash.kyomu.43-1.org/testSummary.php?project=1&name=fe%2Ffe_system_generalized_support_points.debug&date=2017-09-01) this also holds for many more compilers.
- The error message in `vector_memory.debug.output.clang` is slightly different for `clang` (see [CDash](https://cdash.kyomu.43-1.org/testSummary.php?project=1&name=lac%2Fvector_memory.debug&date=2017-09-01).
```
$ diff vector_memory.debug.output*
8c8
<     dealii::GrowingVectorMemory<VectorType>::~GrowingVectorMemory() [with VectorType = dealii::Vector<double>]
---
>     virtual dealii::GrowingVectorMemory<dealii::Vector<double> >::~GrowingVectorMemory() [VectorType = dealii::Vector<double>]
19c19
<     dealii::GrowingVectorMemory<VectorType>::~GrowingVectorMemory() [with VectorType = dealii::Vector<float>]
---
>     virtual dealii::GrowingVectorMemory<dealii::Vector<float> >::~GrowingVectorMemory() [VectorType = dealii::Vector<float>]
```