### PR TITLE
Clear data in ThreadLocalStorage also when not using threads

### DIFF
--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -267,6 +267,8 @@ namespace Threads
   {
 #ifdef DEAL_II_WITH_THREADS
     data.clear ();
+#else
+    data = T {};
 #endif
   }
 }   // end of implementation of namespace Threads


### PR DESCRIPTION
This caused `base/function_parser_03.debug` to fail when compiling with `DEAL_II_WITH_THREADS=OFF`.