### PR TITLE
Relax lac/gmres_reorthogonalize_01

### DIFF
--- a/tests/lac/gmres_reorthogonalize_01.cc
+++ b/tests/lac/gmres_reorthogonalize_01.cc
@@ -26,7 +26,7 @@
 
 
 template <typename number>
-void test (unsigned int variant)
+void test (unsigned int variant, unsigned int min_convergence_steps)
 {
   const unsigned int n = 64;
   Vector<number> rhs(n), sol(n);
@@ -70,30 +70,31 @@ void test (unsigned int variant)
   data.max_n_tmp_vectors = 80;
 
   SolverGMRES<Vector<number> > solver(control, data);
-  solver.solve(matrix, sol, rhs, PreconditionIdentity());
+
+  check_solver_within_range
+  (solver.solve(matrix, sol, rhs, PreconditionIdentity()),
+   control.last_step(), min_convergence_steps, min_convergence_steps+2);
 
   deallog.pop();
 }
 
 int main()
 {
-  std::ofstream logfile("output");
-  deallog << std::setprecision(3);
-  deallog.attach(logfile);
+  initlog();
 
   deallog.push("double");
-  test<double>(0);
-  test<double>(1);
-  test<double>(2);
-  test<double>(3);
-  test<double>(4);
-  test<double>(5);
+  test<double>(0, 56);
+  test<double>(1, 64);
+  test<double>(2, 56);
+  test<double>(3, 64);
+  test<double>(4, 56);
+  test<double>(5, 64);
   deallog.pop();
   deallog.push("float");
-  test<float>(0);
-  test<float>(1);
-  test<float>(2);
-  test<float>(3);
+  test<float>(0, 36);
+  test<float>(1, 64);
+  test<float>(2, 36);
+  test<float>(3, 64);
   deallog.pop();
 }
 

--- a/tests/lac/gmres_reorthogonalize_01.debug.output
+++ b/tests/lac/gmres_reorthogonalize_01.debug.output
@@ -1,26 +1,11 @@
 
-DEAL:double:0:GMRES::Starting value 8.00
-DEAL:double:0:GMRES::Convergence step 57 value 1.62e-14
-DEAL:double:1:GMRES::Starting value 8.00
-DEAL:double:1:GMRES::Re-orthogonalization enabled at step 65
-DEAL:double:1:GMRES::Convergence step 65 value 1.04e-23
-DEAL:double:2:GMRES::Starting value 8.00
-DEAL:double:2:GMRES::Convergence step 57 value 1.72e-14
-DEAL:double:3:GMRES::Starting value 8.00
-DEAL:double:3:GMRES::Re-orthogonalization enabled at step 65
-DEAL:double:3:GMRES::Convergence step 65 value 2.56e-24
-DEAL:double:4:GMRES::Starting value 8.00
-DEAL:double:4:GMRES::Convergence step 57 value 1.59e-14
-DEAL:double:5:GMRES::Starting value 8.00
-DEAL:double:5:GMRES::Re-orthogonalization enabled at step 65
-DEAL:double:5:GMRES::Convergence step 65 value 1.96e-24
-DEAL:float:0:GMRES::Starting value 8.00
-DEAL:float:0:GMRES::Convergence step 37 value 7.73e-06
-DEAL:float:1:GMRES::Starting value 8.00
-DEAL:float:1:GMRES::Re-orthogonalization enabled at step 65
-DEAL:float:1:GMRES::Convergence step 65 value 1.11e-05
-DEAL:float:2:GMRES::Starting value 8.00
-DEAL:float:2:GMRES::Convergence step 37 value 6.87e-06
-DEAL:float:3:GMRES::Starting value 8.00
-DEAL:float:3:GMRES::Re-orthogonalization enabled at step 65
-DEAL:float:3:GMRES::Convergence step 66 value 3.27e-10
+DEAL:double:0::Solver stopped within 56 - 58 iterations
+DEAL:double:1::Solver stopped within 64 - 66 iterations
+DEAL:double:2::Solver stopped within 56 - 58 iterations
+DEAL:double:3::Solver stopped within 64 - 66 iterations
+DEAL:double:4::Solver stopped within 56 - 58 iterations
+DEAL:double:5::Solver stopped within 64 - 66 iterations
+DEAL:float:0::Solver stopped within 36 - 38 iterations
+DEAL:float:1::Solver stopped within 64 - 66 iterations
+DEAL:float:2::Solver stopped within 36 - 38 iterations
+DEAL:float:3::Solver stopped within 64 - 66 iterations


### PR DESCRIPTION
This failed when running with `DEAL_II_WITH_THREADS=OFF` with one iteration off.