### PR TITLE
minor cleanup of LAPACKSupport

### DIFF
--- a/doc/news/changes/incompatibilities/20170904DenisDavydov
+++ b/doc/news/changes/incompatibilities/20170904DenisDavydov
@@ -1,0 +1,5 @@
+Changed: LAPACKSupport::upper_triangle and LAPACKSupport::lower_triangle are
+renamed to LAPACKSupport::upper_triangular and LAPACKSupport::lower_triangular,
+respectively.
+<br>
+(Denis Davydov, 2017/08/24)

--- a/include/deal.II/lac/lapack_support.h
+++ b/include/deal.II/lac/lapack_support.h
@@ -43,6 +43,8 @@ namespace LAPACKSupport
     inverse_matrix,
     /// Contents is an LU decomposition.
     lu,
+    /// Contents is a Cholesky decomposition.
+    cholesky,
     /// Eigenvalue vector is filled
     eigenvalues,
     /// Matrix contains singular value decomposition,
@@ -90,9 +92,9 @@ namespace LAPACKSupport
     /// Matrix is symmetric
     symmetric = 1,
     /// Matrix is upper triangular
-    upper_triangle = 2,
+    upper_triangular = 2,
     /// Matrix is lower triangular
-    lower_triangle = 4,
+    lower_triangular = 4,
     /// Matrix is diagonal
     diagonal = 6,
     /// Matrix is in upper Hessenberg form
@@ -115,6 +117,10 @@ namespace LAPACKSupport
    * Character constant.
    */
   static const char U = 'U';
+  /**
+   * Character constant.
+   */
+  static const char L = 'L';
   /**
    * Character constant.
    */


### PR DESCRIPTION
those enums are not used at the moment:
```
$ ag "lower_triangle"
include/deal.II/lac/lapack_support.h
95:    lower_triangle = 4,
$ ag "upper_triangle"
include/deal.II/lac/lapack_support.h
93:    upper_triangle = 2,
````

 but I intend to utilzie them in future PRs. 