### PR TITLE
Require boost 1.59

### DIFF
--- a/cmake/configure/configure_boost.cmake
+++ b/cmake/configure/configure_boost.cmake
@@ -79,15 +79,6 @@ MACRO(FEATURE_BOOST_FIND_EXTERNAL var)
 
   IF(BOOST_FOUND)
     SET(${var} TRUE)
-
-    #
-    # Blacklist version 1.58 because we get serialization errors with it. At
-    # least version 1.56 and 1.59 are known to work.
-    #
-    IF("${BOOST_VERSION_MAJOR}" STREQUAL "1" AND "${BOOST_VERSION_MINOR}" STREQUAL "58")
-      MESSAGE(STATUS "Boost version 1.58 is not compatible with deal.II!")
-      SET(${var} FALSE)
-    ENDIF()
   ENDIF()
 ENDMACRO()
 

--- a/cmake/modules/FindBOOST.cmake
+++ b/cmake/modules/FindBOOST.cmake
@@ -26,6 +26,9 @@
 #     BOOST_VERSION_MINOR
 #     BOOST_VERSION_SUBMINOR
 #
+# We require at least boost 1.59 since boost::container::small_vector was
+# introduced in 1.58 and some serialization bugs in 1.58 were not fixed until
+# 1.59.
 
 SET(BOOST_DIR "" CACHE PATH "An optional hint to a BOOST installation")
 SET_IF_EMPTY(BOOST_DIR "$ENV{BOOST_DIR}")
@@ -43,7 +46,7 @@ ENDIF()
 
 # temporarily disable ${CMAKE_SOURCE_DIR}/cmake/modules for module lookup
 LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
-FIND_PACKAGE(Boost 1.56 COMPONENTS
+FIND_PACKAGE(Boost 1.59 COMPONENTS
   iostreams serialization system thread
   )
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
@@ -56,7 +59,7 @@ IF(NOT Boost_FOUND AND Boost_USE_STATIC_LIBS)
 
   # temporarily disable ${CMAKE_SOURCE_DIR}/cmake/modules for module lookup
   LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
-  FIND_PACKAGE(Boost 1.56 COMPONENTS iostreams serialization system thread)
+  FIND_PACKAGE(Boost 1.59 COMPONENTS iostreams serialization system thread)
   LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 ENDIF()
 

--- a/doc/news/changes/incompatibilities/2017090DavidWells
+++ b/doc/news/changes/incompatibilities/2017090DavidWells
@@ -1,0 +1,3 @@
+Changed: deal.II now requires BOOST version 1.59 or newer.
+<br>
+(David Wells, 2017/09/04)

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -470,9 +470,10 @@
       found and <acronym>deal.II</acronym> will be built without support
       for them.
       However, there is one interface that we <i>need</i> to have: <a
-      href="http://www.boost.org/" target="_top">BOOST</a>. If it is not
-      found externally <code>cmake</code> will resort to the bundled boost
-      version that is part of the <acronym>deal.II</acronym> tar file.
+      href="http://www.boost.org/" target="_top">BOOST 1.59</a> or newer.
+      If it is not found externally <code>cmake</code> will resort to the
+      bundled boost version that is part of the <acronym>deal.II</acronym>
+      tar file.
     </p>
 
     <p>

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -42,6 +42,8 @@
 
 #include <deal.II/differentiation/ad/sacado_product_types.h>
 
+#include <boost/container/small_vector.hpp>
+
 DEAL_II_NAMESPACE_OPEN
 
 
@@ -3096,22 +3098,10 @@ void FEValuesBase<dim,spacedim>::get_function_values (
   AssertDimension (fe->n_components(), 1);
   AssertDimension (indices.size(), dofs_per_cell);
 
-  // avoid allocation when the local size is small enough
-  if (dofs_per_cell <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_values(&dof_values[0], this->finite_element_output.shape_values, values);
-    }
-  else
-    {
-      Vector<Number> dof_values(dofs_per_cell);
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_values(dof_values.begin(), this->finite_element_output.shape_values,
-                                   values);
-    }
+  boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
+  for (unsigned int i=0; i<dofs_per_cell; ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_values(dof_values.data(), this->finite_element_output.shape_values, values);
 }
 
 
@@ -3156,24 +3146,12 @@ void FEValuesBase<dim,spacedim>::get_function_values (
           ExcAccessToUninitializedField("update_values"));
 
   VectorSlice<std::vector<Vector<Number> > > val(values);
-  if (indices.size() <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_values(&dof_values[0], this->finite_element_output.shape_values, *fe,
-                                   this->finite_element_output.shape_function_to_row_table, val,
-                                   false, indices.size()/dofs_per_cell);
-    }
-  else
-    {
-      Vector<Number> dof_values(100);
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_values(dof_values.begin(), this->finite_element_output.shape_values, *fe,
-                                   this->finite_element_output.shape_function_to_row_table, val,
-                                   false, indices.size()/dofs_per_cell);
-    }
+  boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
+  for (unsigned int i=0; i<dofs_per_cell; ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_values(dof_values.data(), this->finite_element_output.shape_values, *fe,
+                               this->finite_element_output.shape_function_to_row_table, val,
+                               false, indices.size()/dofs_per_cell);
 }
 
 
@@ -3195,26 +3173,13 @@ void FEValuesBase<dim,spacedim>::get_function_values (
   Assert (indices.size() % dofs_per_cell == 0,
           ExcNotMultiple(indices.size(), dofs_per_cell));
 
-  if (indices.size() <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_values(&dof_values[0], this->finite_element_output.shape_values, *fe,
-                                   this->finite_element_output.shape_function_to_row_table, values,
-                                   quadrature_points_fastest,
-                                   indices.size()/dofs_per_cell);
-    }
-  else
-    {
-      Vector<Number> dof_values(indices.size());
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_values(dof_values.begin(), this->finite_element_output.shape_values, *fe,
-                                   this->finite_element_output.shape_function_to_row_table, values,
-                                   quadrature_points_fastest,
-                                   indices.size()/dofs_per_cell);
-    }
+  boost::container::small_vector<Number, 200> dof_values(indices.size());
+  for (unsigned int i=0; i<indices.size(); ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_values(dof_values.data(), this->finite_element_output.shape_values, *fe,
+                               this->finite_element_output.shape_function_to_row_table, values,
+                               quadrature_points_fastest,
+                               indices.size()/dofs_per_cell);
 }
 
 
@@ -3255,22 +3220,12 @@ void FEValuesBase<dim,spacedim>::get_function_gradients (
           ExcAccessToUninitializedField("update_gradients"));
   AssertDimension (fe->n_components(), 1);
   AssertDimension (indices.size(), dofs_per_cell);
-  if (dofs_per_cell <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(&dof_values[0], this->finite_element_output.shape_gradients,
-                                        gradients);
-    }
-  else
-    {
-      Vector<Number> dof_values(dofs_per_cell);
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(dof_values.begin(), this->finite_element_output.shape_gradients,
-                                        gradients);
-    }
+
+  boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
+  for (unsigned int i=0; i<dofs_per_cell; ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_derivatives(dof_values.data(), this->finite_element_output.shape_gradients,
+                                    gradients);
 }
 
 
@@ -3317,26 +3272,13 @@ void FEValuesBase<dim,spacedim>::get_function_gradients (
   Assert (this->update_flags & update_gradients,
           ExcAccessToUninitializedField("update_gradients"));
 
-  if (indices.size() <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(&dof_values[0], this->finite_element_output.shape_gradients,
-                                        *fe, this->finite_element_output.shape_function_to_row_table,
-                                        gradients, quadrature_points_fastest,
-                                        indices.size()/dofs_per_cell);
-    }
-  else
-    {
-      Vector<Number> dof_values(indices.size());
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(dof_values.begin(),this->finite_element_output.shape_gradients,
-                                        *fe, this->finite_element_output.shape_function_to_row_table,
-                                        gradients, quadrature_points_fastest,
-                                        indices.size()/dofs_per_cell);
-    }
+  boost::container::small_vector<Number, 200> dof_values(indices.size());
+  for (unsigned int i=0; i<indices.size(); ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_derivatives(dof_values.data(), this->finite_element_output.shape_gradients,
+                                    *fe, this->finite_element_output.shape_function_to_row_table,
+                                    gradients, quadrature_points_fastest,
+                                    indices.size()/dofs_per_cell);
 }
 
 
@@ -3377,22 +3319,12 @@ void FEValuesBase<dim,spacedim>::get_function_hessians (
           ExcAccessToUninitializedField("update_hessians"));
   AssertDimension (fe_function.size(), present_cell->n_dofs_for_dof_handler());
   AssertDimension (indices.size(), dofs_per_cell);
-  if (dofs_per_cell <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(&dof_values[0], this->finite_element_output.shape_hessians,
-                                        hessians);
-    }
-  else
-    {
-      Vector<Number> dof_values(dofs_per_cell);
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(dof_values.begin(), this->finite_element_output.shape_hessians,
-                                        hessians);
-    }
+
+  boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
+  for (unsigned int i=0; i<dofs_per_cell; ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_derivatives(dof_values.data(), this->finite_element_output.shape_hessians,
+                                    hessians);
 }
 
 
@@ -3437,26 +3369,14 @@ void FEValuesBase<dim, spacedim>::get_function_hessians (
           ExcAccessToUninitializedField("update_hessians"));
   Assert (indices.size() % dofs_per_cell == 0,
           ExcNotMultiple(indices.size(), dofs_per_cell));
-  if (indices.size() <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(&dof_values[0], this->finite_element_output.shape_hessians,
-                                        *fe, this->finite_element_output.shape_function_to_row_table,
-                                        hessians, quadrature_points_fastest,
-                                        indices.size()/dofs_per_cell);
-    }
-  else
-    {
-      Vector<Number> dof_values(indices.size());
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(dof_values.begin(),this->finite_element_output.shape_hessians,
-                                        *fe, this->finite_element_output.shape_function_to_row_table,
-                                        hessians, quadrature_points_fastest,
-                                        indices.size()/dofs_per_cell);
-    }
+
+  boost::container::small_vector<Number, 200> dof_values(indices.size());
+  for (unsigned int i=0; i<indices.size(); ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_derivatives(dof_values.data(), this->finite_element_output.shape_hessians,
+                                    *fe, this->finite_element_output.shape_function_to_row_table,
+                                    hessians, quadrature_points_fastest,
+                                    indices.size()/dofs_per_cell);
 }
 
 
@@ -3496,22 +3416,12 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
           ExcAccessToUninitializedField("update_hessians"));
   AssertDimension (fe->n_components(), 1);
   AssertDimension (indices.size(), dofs_per_cell);
-  if (dofs_per_cell <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_laplacians(&dof_values[0], this->finite_element_output.shape_hessians,
-                                       laplacians);
-    }
-  else
-    {
-      Vector<Number> dof_values(dofs_per_cell);
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_laplacians(dof_values.begin(), this->finite_element_output.shape_hessians,
-                                       laplacians);
-    }
+
+  boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
+  for (unsigned int i=0; i<dofs_per_cell; ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_laplacians(dof_values.data(), this->finite_element_output.shape_hessians,
+                                   laplacians);
 }
 
 
@@ -3553,26 +3463,14 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
           ExcNotMultiple(indices.size(), dofs_per_cell));
   Assert (this->update_flags & update_hessians,
           ExcAccessToUninitializedField("update_hessians"));
-  if (indices.size() <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_laplacians(&dof_values[0], this->finite_element_output.shape_hessians,
-                                       *fe, this->finite_element_output.shape_function_to_row_table,
-                                       laplacians, false,
-                                       indices.size()/dofs_per_cell);
-    }
-  else
-    {
-      Vector<Number> dof_values(indices.size());
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_laplacians(dof_values.begin(),this->finite_element_output.shape_hessians,
-                                       *fe, this->finite_element_output.shape_function_to_row_table,
-                                       laplacians, false,
-                                       indices.size()/dofs_per_cell);
-    }
+
+  boost::container::small_vector<Number, 200> dof_values(indices.size());
+  for (unsigned int i=0; i<indices.size(); ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_laplacians(dof_values.data(), this->finite_element_output.shape_hessians,
+                                   *fe, this->finite_element_output.shape_function_to_row_table,
+                                   laplacians, false,
+                                   indices.size()/dofs_per_cell);
 }
 
 
@@ -3590,26 +3488,14 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
           ExcNotMultiple(indices.size(), dofs_per_cell));
   Assert (this->update_flags & update_hessians,
           ExcAccessToUninitializedField("update_hessians"));
-  if (indices.size() <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_laplacians(&dof_values[0], this->finite_element_output.shape_hessians,
-                                       *fe, this->finite_element_output.shape_function_to_row_table,
-                                       laplacians, quadrature_points_fastest,
-                                       indices.size()/dofs_per_cell);
-    }
-  else
-    {
-      Vector<Number> dof_values(indices.size());
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_laplacians(dof_values.begin(),this->finite_element_output.shape_hessians,
-                                       *fe, this->finite_element_output.shape_function_to_row_table,
-                                       laplacians, quadrature_points_fastest,
-                                       indices.size()/dofs_per_cell);
-    }
+
+  boost::container::small_vector<Number, 200> dof_values(indices.size());
+  for (unsigned int i=0; i<indices.size(); ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_laplacians(dof_values.data(), this->finite_element_output.shape_hessians,
+                                   *fe, this->finite_element_output.shape_function_to_row_table,
+                                   laplacians, quadrature_points_fastest,
+                                   indices.size()/dofs_per_cell);
 }
 
 
@@ -3650,22 +3536,12 @@ void FEValuesBase<dim,spacedim>::get_function_third_derivatives (
           ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertDimension (fe_function.size(), present_cell->n_dofs_for_dof_handler());
   AssertDimension (indices.size(), dofs_per_cell);
-  if (dofs_per_cell <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(&dof_values[0], this->finite_element_output.shape_3rd_derivatives,
-                                        third_derivatives);
-    }
-  else
-    {
-      Vector<Number> dof_values(dofs_per_cell);
-      for (unsigned int i=0; i<dofs_per_cell; ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(dof_values.begin(), this->finite_element_output.shape_3rd_derivatives,
-                                        third_derivatives);
-    }
+
+  boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
+  for (unsigned int i=0; i<dofs_per_cell; ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_derivatives(dof_values.data(), this->finite_element_output.shape_3rd_derivatives,
+                                    third_derivatives);
 }
 
 
@@ -3710,26 +3586,14 @@ void FEValuesBase<dim, spacedim>::get_function_third_derivatives (
           ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert (indices.size() % dofs_per_cell == 0,
           ExcNotMultiple(indices.size(), dofs_per_cell));
-  if (indices.size() <= 100)
-    {
-      Number dof_values[100];
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(&dof_values[0], this->finite_element_output.shape_3rd_derivatives,
-                                        *fe, this->finite_element_output.shape_function_to_row_table,
-                                        third_derivatives, quadrature_points_fastest,
-                                        indices.size()/dofs_per_cell);
-    }
-  else
-    {
-      Vector<Number> dof_values(indices.size());
-      for (unsigned int i=0; i<indices.size(); ++i)
-        dof_values[i] = get_vector_element (fe_function, indices[i]);
-      internal::do_function_derivatives(dof_values.begin(),this->finite_element_output.shape_3rd_derivatives,
-                                        *fe, this->finite_element_output.shape_function_to_row_table,
-                                        third_derivatives, quadrature_points_fastest,
-                                        indices.size()/dofs_per_cell);
-    }
+
+  boost::container::small_vector<Number, 200> dof_values(indices.size());
+  for (unsigned int i=0; i<indices.size(); ++i)
+    dof_values[i] = get_vector_element (fe_function, indices[i]);
+  internal::do_function_derivatives(dof_values.data(), this->finite_element_output.shape_3rd_derivatives,
+                                    *fe, this->finite_element_output.shape_function_to_row_table,
+                                    third_derivatives, quadrature_points_fastest,
+                                    indices.size()/dofs_per_cell);
 }
 
 

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -20,7 +20,10 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/fe/fe_q.h>
+
 #include <cmath>
+
+#include <boost/container/small_vector.hpp>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -101,23 +104,9 @@ get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
   // First sort points in the order of their weights. This is done to
   // produce unique points even if get_intermediate_points is not
   // associative (as for the SphericalManifold).
-  unsigned int permutation_short[30];
-  std::vector<unsigned int> permutation_long;
-  unsigned int *permutation;
-  if (n_points > 30)
-    {
-      permutation_long.resize(n_points);
-      permutation = &permutation_long[0];
-    }
-  else
-    permutation = &permutation_short[0];
-
-  for (unsigned int i=0; i<n_points; ++i)
-    permutation[i] = i;
-
-  std::sort(permutation,
-            permutation + n_points,
-            CompareWeights(weights));
+  boost::container::small_vector<unsigned int, 100> permutation(n_points);
+  std::iota(permutation.begin(), permutation.end(), 0);
+  std::sort(permutation.begin(), permutation.end(), CompareWeights(weights));
 
   // Now loop over points in the order of their associated weight
   Point<spacedim> p = surrounding_points[permutation[0]];

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -35,6 +35,8 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Teuchos_RCP.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
+#include <boost/container/small_vector.hpp>
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace TrilinosWrappers
@@ -1395,11 +1397,8 @@ namespace TrilinosWrappers
     TrilinosScalar *col_value_ptr;
     TrilinosWrappers::types::int_type n_columns;
 
-    TrilinosScalar short_val_array[100];
-    TrilinosWrappers::types::int_type short_index_array[100];
-    std::vector<TrilinosScalar> long_val_array;
-    std::vector<TrilinosWrappers::types::int_type> long_index_array;
-
+    boost::container::small_vector<TrilinosScalar, 200> local_value_array(n_cols);
+    boost::container::small_vector<TrilinosWrappers::types::int_type, 200> local_index_array(n_cols);
 
     // If we don't elide zeros, the pointers are already available... need to
     // cast to non-const pointers as that is the format taken by Trilinos (but
@@ -1414,18 +1413,8 @@ namespace TrilinosWrappers
       {
         // Otherwise, extract nonzero values in each row and get the
         // respective indices.
-        if (n_cols > 100)
-          {
-            long_val_array.resize(n_cols);
-            long_index_array.resize(n_cols);
-            col_index_ptr = &long_index_array[0];
-            col_value_ptr = &long_val_array[0];
-          }
-        else
-          {
-            col_index_ptr = &short_index_array[0];
-            col_value_ptr = &short_val_array[0];
-          }
+        col_index_ptr = local_index_array.data();
+        col_value_ptr = local_value_array.data();
 
         n_columns = 0;
         for (size_type j=0; j<n_cols; ++j)
@@ -1586,10 +1575,8 @@ namespace TrilinosWrappers
     TrilinosScalar *col_value_ptr;
     TrilinosWrappers::types::int_type n_columns;
 
-    double short_val_array[100];
-    TrilinosWrappers::types::int_type short_index_array[100];
-    std::vector<TrilinosScalar> long_val_array;
-    std::vector<TrilinosWrappers::types::int_type> long_index_array;
+    boost::container::small_vector<TrilinosScalar, 100> local_value_array(n_cols);
+    boost::container::small_vector<TrilinosWrappers::types::int_type, 100> local_index_array(n_cols);
 
     // If we don't elide zeros, the pointers are already available... need to
     // cast to non-const pointers as that is the format taken by Trilinos (but
@@ -1608,18 +1595,8 @@ namespace TrilinosWrappers
       {
         // Otherwise, extract nonzero values in each row and the corresponding
         // index.
-        if (n_cols > 100)
-          {
-            long_val_array.resize(n_cols);
-            long_index_array.resize(n_cols);
-            col_index_ptr = &long_index_array[0];
-            col_value_ptr = &long_val_array[0];
-          }
-        else
-          {
-            col_index_ptr = &short_index_array[0];
-            col_value_ptr = &short_val_array[0];
-          }
+        col_index_ptr = local_index_array.data();
+        col_value_ptr = local_value_array.data();
 
         n_columns = 0;
         for (size_type j=0; j<n_cols; ++j)


### PR DESCRIPTION
This is the first part of #4723: that patch extensively uses `boost::container::small_vector`, which is new in boost 1.58 (which we blacklist). This PR sets 1.59 as the oldest boost version and also converts some of our 'switch between built-in arrays on the stack and `std::vector`' logic to use `small_vector`.

I really like this class and I hope we use it in a lot of other places to keep things on the stack :)