### PR TITLE
Variadic constructor for FESystem

### DIFF
--- a/doc/news/changes/minor/20170905DanielArndt
+++ b/doc/news/changes/minor/20170905DanielArndt
@@ -1,0 +1,12 @@
+New: The newly implemented FiniteElement::operator^ allows in combination
+with the new variadic template constructor or the new std::initializer_list
+constructor for FESystem to construct
+FESystem objects using syntax like
+@code
+  FESystem<dim, spacedim> fe_system1 ({FiniteElementType1^n1, 
+                                       FiniteElementType2^n2});
+  FESystem<dim, spacedim> fe_system2 (FiniteElementType1^n3, 
+                                      FiniteElementType2^n4);
+@endcode
+<br>
+(Daniel Arndt, 2017/09/05)

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -27,7 +27,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace
 {
-  // helper struct for is_base_of_all
+  // helper struct for is_base_of_all and all_same_as
   template <bool... Types> struct BoolStorage;
 }
 
@@ -43,6 +43,21 @@ struct is_base_of_all
   static constexpr bool value =
     std::is_same<BoolStorage<std::is_base_of<Base,Derived>::value..., true>,
     BoolStorage<true, std::is_base_of<Base,Derived>::value...>>::value;
+};
+
+
+
+/**
+ * This struct is a generalization of std::is_same to template
+ * parameter packs and tests if all of the Types... classes are
+ * in Type classes. The result is stored in the member variable value.
+ */
+template <class Type, class... Types>
+struct all_same_as
+{
+  static constexpr bool value =
+    std::is_same<BoolStorage<std::is_same<Type, Types>::value..., true>,
+    BoolStorage<true, std::is_same<Type, Types>::value...>>::value;
 };
 
 

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -758,7 +758,18 @@ public:
    * Virtual destructor. Makes sure that pointers to this class are deleted
    * properly.
    */
-  virtual ~FiniteElement ();
+  virtual ~FiniteElement () = default;
+
+  /**
+   * Creates information for creating a FESystem with this class as
+   * base element and with multiplicity @p multiplicity. In particular,
+   * the return type of this function can be used in the constructor
+   * for a FESystem object.
+   * This function calls clone() and hence creates a copy of the
+   * current object.
+   */
+  std::pair<std::unique_ptr<FiniteElement<dim, spacedim> >, unsigned int>
+  operator^ (unsigned int multiplicity) const;
 
   /**
    * A sort of virtual copy constructor, this function returns a copy of
@@ -772,8 +783,8 @@ public:
    * type. They do so through this function.
    */
   virtual
-  std::unique_ptr<FiniteElement<dim,spacedim>>
-                                            clone() const = 0;
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const = 0;
 
   /**
    * Return a string that uniquely identifies a finite element. The general

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -981,12 +981,10 @@ namespace FETools
      * <code>std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int></code>
      * and <code>do_tensor_product = true</code>.
      */
-    template <int dim, int spacedim, class... FESystems,
-              typename = typename std::enable_if<all_same_as<typename std::decay<FESystems>::type...,
-                                                             std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
-                                                                 unsigned int>>::value>::type>
+    template <int dim, int spacedim>
     FiniteElementData<dim>
-    multiply_dof_numbers (FESystems &&... fe_systems);
+    multiply_dof_numbers
+    (const std::initializer_list<std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int>> &fe_systems);
 
     /**
      * Same as above but for a specific number of sub-elements.
@@ -1025,12 +1023,10 @@ namespace FETools
      * Same as above for an arbitrary number of parameters of type
      * <code>std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int></code>.
      */
-    template <int dim, int spacedim, class... FESystems,
-              typename = typename std::enable_if<all_same_as<typename std::decay<FESystems>::type...,
-                                                             std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
-                                                                 unsigned int>>::value>::type>
+    template <int dim, int spacedim>
     std::vector<bool>
-    compute_restriction_is_additive_flags (FESystems &&... fe_systems);
+    compute_restriction_is_additive_flags
+    (const std::initializer_list<std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int>> &fe_systems);
 
     /**
      * Take a @p FiniteElement object and return a boolean vector
@@ -1087,12 +1083,10 @@ namespace FETools
      * <code>std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int></code>
      * and <code>do_tensor_product = true</code>.
      */
-    template <int dim, int spacedim, class... FESystems,
-              typename = typename std::enable_if<all_same_as<typename std::decay<FESystems>::type...,
-                                                             std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
-                                                                 unsigned int>>::value>::type>
+    template <int dim, int spacedim>
     std::vector<ComponentMask>
-    compute_nonzero_components (FESystems &&... fe_systems);
+    compute_nonzero_components
+    (const std::initializer_list<std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int>> &fe_systems);
 
     /**
      * Compute the non-zero vector components of a composed finite
@@ -1382,9 +1376,10 @@ namespace FETools
 
   namespace Compositing
   {
-    template <int dim, int spacedim, class... FESystems, typename>
+    template <int dim, int spacedim>
     std::vector<bool>
-    compute_restriction_is_additive_flags (FESystems &&... fe_systems)
+    compute_restriction_is_additive_flags
+    (const std::initializer_list<std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int>> &fe_systems)
     {
       std::vector<const FiniteElement<dim,spacedim>*> fes;
       std::vector<unsigned int> multiplicities;
@@ -1397,18 +1392,18 @@ namespace FETools
         multiplicities.push_back(fe_system.second);
       };
 
-      const auto fe_system_pointers = {&fe_systems...};
-      for (const auto p : fe_system_pointers)
-        extract (*p);
+      for (const auto &p : fe_systems)
+        extract (p);
 
       return compute_restriction_is_additive_flags (fes, multiplicities);
     }
 
 
 
-    template <int dim, int spacedim, class... FESystems, typename>
+    template <int dim, int spacedim>
     FiniteElementData<dim>
-    multiply_dof_numbers (FESystems &&... fe_systems)
+    multiply_dof_numbers
+    (const std::initializer_list<std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int>> &fe_systems)
     {
       std::vector<const FiniteElement<dim,spacedim>*> fes;
       std::vector<unsigned int> multiplicities;
@@ -1421,18 +1416,18 @@ namespace FETools
         multiplicities.push_back(fe_system.second);
       };
 
-      const auto fe_system_pointers = {&fe_systems...};
-      for (const auto p : fe_system_pointers)
-        extract (*p);
+      for (const auto &p : fe_systems)
+        extract (p);
 
       return multiply_dof_numbers (fes, multiplicities, true);
     }
 
 
 
-    template <int dim, int spacedim, class... FESystems, typename>
+    template <int dim, int spacedim>
     std::vector<ComponentMask>
-    compute_nonzero_components (FESystems &&... fe_systems)
+    compute_nonzero_components
+    (const std::initializer_list<std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int>> &fe_systems)
     {
       std::vector<const FiniteElement<dim,spacedim>*> fes;
       std::vector<unsigned int> multiplicities;
@@ -1445,9 +1440,8 @@ namespace FETools
         multiplicities.push_back(fe_system.second);
       };
 
-      const auto fe_system_pointers = {&fe_systems...};
-      for (const auto p : fe_system_pointers)
-        extract (*p);
+      for (const auto &p : fe_systems)
+        extract (p);
 
       return compute_nonzero_components (fes, multiplicities, true);
     }

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -152,9 +152,12 @@ FiniteElement (const FiniteElementData<dim> &fe_data,
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim>::~FiniteElement ()
-{}
-
+std::pair<std::unique_ptr<FiniteElement<dim, spacedim> >, unsigned int>
+FiniteElement<dim, spacedim>::operator^ (unsigned int multiplicity) const
+{
+  return std::make_pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
+         unsigned int> (std::move(this->clone()), std::move(multiplicity));
+}
 
 
 

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -286,12 +286,6 @@ FESystem<dim,spacedim>::FESystem (
 
 
 template <int dim, int spacedim>
-FESystem<dim,spacedim>::~FESystem ()
-{}
-
-
-
-template <int dim, int spacedim>
 std::string
 FESystem<dim,spacedim>::get_name () const
 {

--- a/tests/fe/interpolate_system_3.cc
+++ b/tests/fe/interpolate_system_3.cc
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include "interpolate_common.h"
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/fe/fe_nedelec.h>
+#include <deal.II/fe/fe_raviart_thomas.h>
+#include <deal.II/fe/fe_system.h>
+
+
+// Same as interpolate_system_2.cc but using the new constructor:
+// Check convert_generalized_support_point_values_to_dof_values for systems
+// of non-Lagrangian elements.
+//
+
+template <int dim, typename T>
+void check(T function, const unsigned int degree)
+{
+  FESystem<dim> fe = {FE_RaviartThomas<dim>(degree)^2,
+                      FESystem<dim>(FE_RaviartThomas<dim>(degree), 2)^1
+                     };
+  deallog << fe.get_name() << std::endl;
+
+  std::vector<double> dofs(fe.dofs_per_cell);
+
+  std::vector<Vector<double>> values(fe.get_generalized_support_points().size(),
+                                     Vector<double>(4 * dim));
+  function.vector_value_list(fe.get_generalized_support_points(), values);
+
+  fe.convert_generalized_support_point_values_to_dof_values(values, dofs);
+  deallog << " vector " << vector_difference(fe, dofs, function, 0) << std::endl;
+}
+
+int main()
+{
+  initlog();
+
+  check<2>(Q1WedgeFunction<2, 1, 4 * 2>(), 1);
+  check<2>(Q1WedgeFunction<2, 2, 4 * 2>(), 2);
+  check<2>(Q1WedgeFunction<2, 3, 4 * 2>(), 3);
+  check<3>(Q1WedgeFunction<3, 1, 4 * 3>(), 1);
+  check<3>(Q1WedgeFunction<3, 2, 4 * 3>(), 2);
+  check<3>(Q1WedgeFunction<3, 3, 4 * 3>(), 3);
+}

--- a/tests/fe/interpolate_system_3.output
+++ b/tests/fe/interpolate_system_3.output
@@ -1,0 +1,13 @@
+
+DEAL::FESystem<2>[FE_RaviartThomas<2>(1)^2-FESystem<2>[FE_RaviartThomas<2>(1)^2]]
+DEAL:: vector 1.66533e-16
+DEAL::FESystem<2>[FE_RaviartThomas<2>(2)^2-FESystem<2>[FE_RaviartThomas<2>(2)^2]]
+DEAL:: vector 2.39392e-16
+DEAL::FESystem<2>[FE_RaviartThomas<2>(3)^2-FESystem<2>[FE_RaviartThomas<2>(3)^2]]
+DEAL:: vector 1.87784e-16
+DEAL::FESystem<3>[FE_RaviartThomas<3>(1)^2-FESystem<3>[FE_RaviartThomas<3>(1)^2]]
+DEAL:: vector 1.59595e-16
+DEAL::FESystem<3>[FE_RaviartThomas<3>(2)^2-FESystem<3>[FE_RaviartThomas<3>(2)^2]]
+DEAL:: vector 5.22585e-16
+DEAL::FESystem<3>[FE_RaviartThomas<3>(3)^2-FESystem<3>[FE_RaviartThomas<3>(3)^2]]
+DEAL:: vector 3.52637e-16

--- a/tests/fe/system_03.cc
+++ b/tests/fe/system_03.cc
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// this is the same as system_02 but using the variadic constructor:
+// check what happens with an FE_System if we hand it 0 components
+
+#include "../tests.h"
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_dgp.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_tools.h>
+
+#include <string>
+
+template <int dim>
+void
+check(FESystem<dim> &fe)
+{
+  deallog << fe.get_name() << std::endl;
+  deallog << "components: " << fe.n_components() << std::endl;
+  deallog << "blocks: " << fe.n_blocks() << std::endl;
+  deallog << "conforms H1: " << fe.conforms(FiniteElementData<dim>::H1) << std::endl;
+  deallog << "n_base_elements: " << fe.n_base_elements() << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  {
+    FESystem<2> fe = {FE_Q<2>(1)^2, FE_Q<2>(1)^1};
+    check<2>(fe);
+  }
+  {
+    FESystem<2> fe = {FE_Q<2>(1)^2, FE_DGQ<2>(2)^0, FE_Q<2>(1)^1};
+    check<2>(fe);
+  }
+  {
+    FESystem<2> fe = {FESystem<2>(FE_Q<2>(1)^2)^1, FE_Q<2>(1)^1};
+    check<2>(fe);
+  }
+  {
+    FESystem<2> fe = {FESystem<2>(FE_Q<2>(1)^2)^1, FE_DGQ<2>(2)^0, FE_Q<2>(1)^1};
+    check<2>(fe);
+  }
+
+  return 0;
+}
+
+
+

--- a/tests/fe/system_03.output
+++ b/tests/fe/system_03.output
@@ -1,0 +1,21 @@
+
+DEAL::FESystem<2>[FE_Q<2>(1)^2-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 3
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::FESystem<2>[FE_Q<2>(1)^2-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 3
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::FESystem<2>[FESystem<2>[FE_Q<2>(1)^2]-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 2
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::FESystem<2>[FESystem<2>[FE_Q<2>(1)^2]-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 2
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2


### PR DESCRIPTION
Fixes #4249. Fixes #2299.
This PR allows to initialize `FESystem` objects as suggested in https://github.com/dealii/dealii/issues/2299#issuecomment-197087786, i.e.
```
FESystem<dim> stokes_fe = {FE_Q<dim>(2) ^ dim, FE_Q<dim>(1)^1};
```
At the moment all the calls are just forwarded to the constructor taking a `std::vector< const FiniteElement< dim, spacedim > * >` and a `std::vector< unsigned int >`.
This could probably be written more efficiently rewriting the whole logic but should be fine for now.