### PR TITLE
Fix test.

### DIFF
--- a/tests/fe/interpolate_system_2.cc
+++ b/tests/fe/interpolate_system_2.cc
@@ -30,10 +30,10 @@
 template <int dim, typename T>
 void check(T function, const unsigned int degree)
 {
-  auto fe = FESystem<dim>(FE_RaviartThomas<dim>(degree),
-                          2,
-                          FESystem<dim>(FE_RaviartThomas<dim>(degree), 2),
-                          1);
+  FESystem<dim> fe (FE_RaviartThomas<dim>(degree),
+                    2,
+                    FESystem<dim>(FE_RaviartThomas<dim>(degree), 2),
+                    1);
   deallog << fe.get_name() << std::endl;
 
   std::vector<double> dofs(fe.dofs_per_cell);


### PR DESCRIPTION
As mentioned in several recent PRs, the fe/interpolate_system_2 test is currently
failing because FESystem does not have a copy constructor. This PR fixes this
by not requiring a copy.