### PR TITLE
Use the right types for iota and accumulate.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1546,7 +1546,7 @@ namespace internal
       {
         // initialize original index locations
         std::vector<unsigned int> idx(v_end-v_begin);
-        std::iota(idx.begin(), idx.end(), 0);
+        std::iota(idx.begin(), idx.end(), 0u);
 
         // sort indices based on comparing values in v
         std::sort(idx.begin(), idx.end(),

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -256,7 +256,7 @@ namespace
     const typename internal::p4est::types<dim>::locidx
     num_vtt = std::accumulate (vertex_touch_count.begin(),
                                vertex_touch_count.end(),
-                               0);
+                               0u);
     (void)num_vtt;
     Assert (connectivity->ctt_offset[triangulation.n_vertices()] ==
             num_vtt,
@@ -2019,7 +2019,7 @@ namespace parallel
       const dealii::internal::p4est::types<2>::locidx
       num_vtt = std::accumulate (vertex_touch_count.begin(),
                                  vertex_touch_count.end(),
-                                 0);
+                                 0u);
 
       // now create a connectivity object with the right sizes for all
       // arrays. set vertex information only in debug mode (saves a few bytes
@@ -2090,7 +2090,7 @@ namespace parallel
       const dealii::internal::p4est::types<2>::locidx
       num_vtt = std::accumulate (vertex_touch_count.begin(),
                                  vertex_touch_count.end(),
-                                 0);
+                                 0u);
 
       // now create a connectivity object with the right sizes for all
       // arrays. set vertex information only in debug mode (saves a few bytes
@@ -2159,7 +2159,7 @@ namespace parallel
       const dealii::internal::p4est::types<2>::locidx
       num_vtt = std::accumulate (vertex_touch_count.begin(),
                                  vertex_touch_count.end(),
-                                 0);
+                                 0u);
 
       std::vector<unsigned int> edge_touch_count;
       std::vector<
@@ -2173,7 +2173,7 @@ namespace parallel
       const dealii::internal::p4est::types<2>::locidx
       num_ett = std::accumulate (edge_touch_count.begin(),
                                  edge_touch_count.end(),
-                                 0);
+                                 0u);
 
       // now create a connectivity object with the right sizes for all arrays
       const bool set_vertex_info

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -467,7 +467,7 @@ GridRefinement::refine_and_coarsen_optimize (Triangulation<dim,spacedim> &tria,
 
   // get a decreasing order on the error indicator
   std::vector<unsigned int> cell_indices(criteria.size());
-  std::iota(cell_indices.begin(), cell_indices.end(), 0);
+  std::iota(cell_indices.begin(), cell_indices.end(), 0u);
 
   std::sort(cell_indices.begin(), cell_indices.end(),
             [&criteria](const unsigned int left,

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2258,7 +2258,8 @@ next_cell:
                              indices.size(), DEAL_II_DOF_INDEX_MPI_TYPE, triangulation.get_communicator());
     AssertThrowMPI(ierr);
     const types::global_vertex_index shift = std::accumulate(&indices[0],
-                                                             &indices[0]+triangulation.locally_owned_subdomain(),0);
+                                                             &indices[0]+triangulation.locally_owned_subdomain(),
+                                                             types::global_vertex_index(0));
 
     std::map<unsigned int,types::global_vertex_index>::iterator
     global_index_it = local_to_global_vertex_index.begin(),

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -105,7 +105,7 @@ get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
   // produce unique points even if get_intermediate_points is not
   // associative (as for the SphericalManifold).
   boost::container::small_vector<unsigned int, 100> permutation(n_points);
-  std::iota(permutation.begin(), permutation.end(), 0);
+  std::iota(permutation.begin(), permutation.end(), 0u);
   std::sort(permutation.begin(), permutation.end(), CompareWeights(weights));
 
   // Now loop over points in the order of their associated weight

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -1074,7 +1074,8 @@ namespace MGTools
             Assert (!dof_handler.get_fe().is_primitive()
                     ||
                     std::accumulate (result[l].begin(),
-                                     result[l].end(), 0U)
+                                     result[l].end(),
+                                     types::global_dof_index(0))
                     ==
                     dof_handler.n_dofs(l),
                     ExcInternalError());

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -58,7 +58,7 @@ namespace
     const unsigned int n_selected
       = std::accumulate(selected.begin(),
                         selected.end(),
-                        0U);
+                        0u);
 
     if (ndofs.size() == 0)
       {

--- a/source/multigrid/mg_transfer_component.cc
+++ b/source/multigrid/mg_transfer_component.cc
@@ -120,7 +120,7 @@ namespace
     const unsigned int n_selected
       = std::accumulate(selected.begin(),
                         selected.end(),
-                        0U);
+                        0u);
 
     if (ndofs.size() == 0)
       {


### PR DESCRIPTION
Follow up to a comment in #5024: we should use correct integral types for `std::accumulate` and `std::iota`'s starting values.