### PR TITLE
Clean up some variable names in the Timer class.

### DIFF
--- a/tests/base/timer_05.cc
+++ b/tests/base/timer_05.cc
@@ -72,14 +72,14 @@ test_timer(Timer &t)
   AssertThrow(old_cpu_time > 0., ExcInternalError());
   assert_min_max_avg_invalid(t.get_data());
   assert_min_max_avg_invalid(t.get_total_data());
-  assert_min_max_avg_invalid(t.get_last_lap_data());
+  assert_min_max_avg_invalid(t.get_last_lap_wall_time_data());
   assert_min_max_avg_invalid(t.get_accumulated_wall_time_data());
 
   burn(50);
   AssertThrow(t.stop() > 0., ExcInternalError());
   assert_min_max_avg_valid(t.get_data());
   assert_min_max_avg_valid(t.get_total_data());
-  assert_min_max_avg_valid(t.get_last_lap_data());
+  assert_min_max_avg_valid(t.get_last_lap_wall_time_data());
   assert_min_max_avg_valid(t.get_accumulated_wall_time_data());
 
   AssertThrow(t.wall_time() > old_wall_time, ExcInternalError());
@@ -92,7 +92,7 @@ test_timer(Timer &t)
   AssertThrow(t.cpu_time()== 0., ExcInternalError());
   assert_min_max_avg_invalid(t.get_data());
   assert_min_max_avg_invalid(t.get_total_data());
-  assert_min_max_avg_invalid(t.get_last_lap_data());
+  assert_min_max_avg_invalid(t.get_last_lap_wall_time_data());
   assert_min_max_avg_invalid(t.get_accumulated_wall_time_data());
 
   deallog << "OK" << std::endl;


### PR DESCRIPTION
This is compatible with 8.5 but not with some previous patches to this class made since then. Since I am just renaming names that were added in the last three weeks I think that it is okay to break a little bit here to further improve consistency.

Part of #4867.