### PR TITLE
Fix a bug in the Windows CPU time calculation.

### DIFF
--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -37,8 +37,9 @@ DEAL_II_NAMESPACE_OPEN
 struct CPUClock
 {
   /**
-   * Duration type. Windows measures CPU times in units of 100 nanoseconds
-   * and POSIX uses microseconds, so go with microseconds for uniformity.
+   * Duration type. Windows measures CPU times, by default, in multiples of
+   * 1/64th of a second and and POSIX uses microseconds, so go with
+   * microseconds for uniformity.
    */
   typedef std::chrono::microseconds duration;
 
@@ -111,7 +112,7 @@ struct CPUClock
  * exceed the wall times.
  *
  * @ingroup utilities
- * @author G. Kanschat, W. Bangerth, M. Kronbichler
+ * @author G. Kanschat, W. Bangerth, M. Kronbichler, D. Wells
  */
 class Timer
 {

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -114,7 +114,7 @@ CPUClock::time_point CPUClock::now() noexcept
     {
       system_cpu_duration = (double)
       (((unsigned long long)cpuTime.dwHighDateTime << 32)
-      | cpuTime.dwLowDateTime) / 1e6;
+      | cpuTime.dwLowDateTime) / 1e7;
     }
   // keep the zero value if GetProcessTimes didn't work
 #elif defined(DEAL_II_HAVE_SYS_RESOURCE_H)


### PR DESCRIPTION
The win32 function `GetProcessTImes()` returns a value in units of 100 nanoseconds, so we were previously off by a factor of 10.

Closes #4927.
Closes #4867.

I am very happy with the way the Timer refactoring worked out. This should be the end of the current set of improvements.