### PR TITLE
Fix self-inclusion in distributed/grid_tools.h

### DIFF
--- a/include/deal.II/distributed/grid_tools.h
+++ b/include/deal.II/distributed/grid_tools.h
@@ -20,7 +20,6 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/distributed/tria_base.h>
-#include <deal.II/distributed/grid_tools.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/optional.hpp>


### PR DESCRIPTION
Why would you want to do that? I hope that this is the cause for doxygen not
showing the documentation of this header.