### PR TITLE
document parallel::GridTools namespace

### DIFF
--- a/include/deal.II/distributed/grid_tools.h
+++ b/include/deal.II/distributed/grid_tools.h
@@ -39,6 +39,9 @@ DEAL_II_NAMESPACE_OPEN
 namespace parallel
 {
 
+  /**
+   * This namespace defines parallel algorithms that operate on meshes.
+   */
   namespace GridTools
   {
     /**


### PR DESCRIPTION
otherwise the functions won't show up in doxygen