### PR TITLE
Implement move constructors for FiniteElement and FESystem

### DIFF
--- a/doc/news/changes/minor/20170911DanielArndt
+++ b/doc/news/changes/minor/20170911DanielArndt
@@ -1,0 +1,3 @@
+New: FiniteElement and FESystem have move constructors.
+<br>
+(Daniel Arndt, 2017/09/11)

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -755,6 +755,16 @@ public:
                  const std::vector<ComponentMask> &nonzero_components);
 
   /**
+   * Move constructor.
+   */
+  FiniteElement (FiniteElement<dim, spacedim> &&) = default;
+
+  /**
+   * Copy constructor.
+   */
+  FiniteElement (const FiniteElement<dim, spacedim> &) = default;
+
+  /**
    * Virtual destructor. Makes sure that pointers to this class are deleted
    * properly.
    */

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -428,6 +428,11 @@ public:
   FESystem (const FESystem<dim,spacedim> &) = delete;
 
   /**
+   * Move constructor.
+   */
+  FESystem (FESystem<dim,spacedim> &&) = default;
+
+  /**
    * Destructor.
    */
   virtual ~FESystem ();

--- a/tests/fe/fe_move_01.cc
+++ b/tests/fe/fe_move_01.cc
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check that we can move a FE_Q<dim> object in a reasonable way.
+
+#include "../tests.h"
+#include <deal.II/fe/fe_q.h>
+
+#include <string>
+
+template <int dim>
+void
+check(const FiniteElement<dim> &fe)
+{
+  deallog << "dim: " << dim << std::endl;
+  deallog << "components: " << fe.n_components() << std::endl;
+  deallog << "blocks: " << fe.n_blocks() << std::endl;
+  deallog << "conforms H1: " << fe.conforms(FiniteElementData<dim>::H1) << std::endl;
+  deallog << "n_base_elements: " << fe.n_base_elements() << std::endl;
+  deallog << "memory consumption: " << fe.memory_consumption() << std::endl;
+  deallog << std::endl;
+}
+
+template <int dim>
+void
+move()
+{
+  FE_Q<dim> fe(1);
+  check(fe);
+  FE_Q<dim> fe2 (std::move(fe));
+  check(fe);
+  check(fe2);
+}
+
+int
+main()
+{
+  initlog();
+
+  move<1>();
+  move<2>();
+  move<3>();
+
+  return 0;
+}

--- a/tests/fe/fe_move_01.output
+++ b/tests/fe/fe_move_01.output
@@ -1,0 +1,64 @@
+
+DEAL::dim: 1
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 1368
+DEAL::
+DEAL::dim: 1
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 736
+DEAL::
+DEAL::dim: 1
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 1368
+DEAL::
+DEAL::dim: 2
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 3260
+DEAL::
+DEAL::dim: 2
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 920
+DEAL::
+DEAL::dim: 2
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 3260
+DEAL::
+DEAL::dim: 3
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 8692
+DEAL::
+DEAL::dim: 3
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 1288
+DEAL::
+DEAL::dim: 3
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 8692
+DEAL::

--- a/tests/fe/fe_move_02.cc
+++ b/tests/fe/fe_move_02.cc
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// check that we can move a FESystem<dim> object in a reasonable way.
+
+#include "../tests.h"
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+
+#include <string>
+
+template <int dim>
+void
+check(const FiniteElement<dim> &fe)
+{
+  deallog << fe.get_name() << std::endl;
+  deallog << "components: " << fe.n_components() << std::endl;
+  deallog << "blocks: " << fe.n_blocks() << std::endl;
+  deallog << "conforms H1: " << fe.conforms(FiniteElementData<dim>::H1) << std::endl;
+  deallog << "n_base_elements: " << fe.n_base_elements() << std::endl;
+  deallog << "memory consumption: " << fe.memory_consumption() << std::endl;
+  deallog << std::endl;
+}
+
+template <int dim>
+void
+move()
+{
+  FESystem<dim> fe (FE_Q<dim>(2), dim, FE_Q<dim>(1), 1);
+  check(fe);
+  FESystem<dim> fe2 (std::move(fe));
+  check(fe);
+  check(fe2);
+}
+
+int
+main()
+{
+  initlog();
+
+  move<1>();
+  move<2>();
+  move<3>();
+
+  return 0;
+}
+
+
+

--- a/tests/fe/fe_move_02.output
+++ b/tests/fe/fe_move_02.output
@@ -1,0 +1,64 @@
+
+DEAL::FESystem<1>[FE_Q<1>(2)-FE_Q<1>(1)]
+DEAL::components: 2
+DEAL::blocks: 2
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 4608
+DEAL::
+DEAL::FESystem<1>[]
+DEAL::components: 2
+DEAL::blocks: 2
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 1036
+DEAL::
+DEAL::FESystem<1>[FE_Q<1>(2)-FE_Q<1>(1)]
+DEAL::components: 2
+DEAL::blocks: 2
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 4608
+DEAL::
+DEAL::FESystem<2>[FE_Q<2>(2)^2-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 3
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 13032
+DEAL::
+DEAL::FESystem<2>[]
+DEAL::components: 3
+DEAL::blocks: 3
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 2600
+DEAL::
+DEAL::FESystem<2>[FE_Q<2>(2)^2-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 3
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 13032
+DEAL::
+DEAL::FESystem<3>[FE_Q<3>(2)^3-FE_Q<3>(1)]
+DEAL::components: 4
+DEAL::blocks: 4
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 56040
+DEAL::
+DEAL::FESystem<3>[]
+DEAL::components: 4
+DEAL::blocks: 4
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 8772
+DEAL::
+DEAL::FESystem<3>[FE_Q<3>(2)^3-FE_Q<3>(1)]
+DEAL::components: 4
+DEAL::blocks: 4
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 56040
+DEAL::


### PR DESCRIPTION
The (implicitly declared) move constructor was deleted because
- `FiniteElement` has a user-declared destructor
- `FESystem` has a user-declared (and deleted) copy constructor