### PR TITLE
fix tests/readwritevector_0x

### DIFF
--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -404,6 +404,11 @@ namespace LinearAlgebra
                                   VectorOperation::values                         operation,
                                   std::shared_ptr<const CommunicationPatternBase> communication_pattern)
   {
+    // While the import does work with Trilinos 12.8.x, it fails with 12.4.x. To be safe,
+    // we disable it here. Note that it would be a useful case, as ReadWriteVector is
+    // supposed to replace ghosted vectors anyways.
+    AssertThrow(!trilinos_vec.has_ghost_elements(),
+                ExcMessage("Import() from TrilinosWrappers::MPI::Vector with ghost entries is not supported!"));
     import(trilinos_vec.trilinos_vector(), trilinos_vec.locally_owned_elements(),
            operation, trilinos_vec.get_mpi_communicator(), communication_pattern);
   }

--- a/tests/trilinos/readwritevector_02.mpirun=2.output
+++ b/tests/trilinos/readwritevector_02.mpirun=2.output
@@ -18,17 +18,17 @@ size:8 local_size:6 :
 DEAL:0::ghosted IS: {[0,5]}
 DEAL:0::tril_vector_ghosted.owned_elements() {[0,3]}
 DEAL:0::import of ghosted vector should fail:
-DEAL:0::ExcMessage("Epetra Import() failed with error code: " + Utilities::to_string(err))
+DEAL:0::ExcMessage("Import() from TrilinosWrappers::MPI::Vector with ghost entries is not supported!")
 DEAL:0::import of distributed vector should work:
 DEAL:0::RWVector contents:
 IndexSet: {[0,5]}
 
-0.000e+00
-1.000e+00
-2.000e+00
-3.000e+00
-4.000e+00
-5.000e+00
+[0]: 0.000e+00
+[1]: 1.000e+00
+[2]: 2.000e+00
+[3]: 3.000e+00
+[4]: 4.000e+00
+[5]: 5.000e+00
 DEAL:0::OK
 
 DEAL:1::IS: {[4,7]}
@@ -50,16 +50,16 @@ size:8 local_size:6 :
 DEAL:1::ghosted IS: {[2,7]}
 DEAL:1::tril_vector_ghosted.owned_elements() {[4,7]}
 DEAL:1::import of ghosted vector should fail:
-DEAL:1::ExcMessage("Epetra Import() failed with error code: " + Utilities::to_string(err))
+DEAL:1::ExcMessage("Import() from TrilinosWrappers::MPI::Vector with ghost entries is not supported!")
 DEAL:1::import of distributed vector should work:
 DEAL:1::RWVector contents:
 IndexSet: {[2,7]}
 
-2.000e+00
-3.000e+00
-4.000e+00
-5.000e+00
-6.000e+00
-7.000e+00
+[2]: 2.000e+00
+[3]: 3.000e+00
+[4]: 4.000e+00
+[5]: 5.000e+00
+[6]: 6.000e+00
+[7]: 7.000e+00
 DEAL:1::OK
 

--- a/tests/trilinos/readwritevector_03.mpirun=2.output
+++ b/tests/trilinos/readwritevector_03.mpirun=2.output
@@ -20,19 +20,19 @@ DEAL:0::tril_vector_ghosted.owned_elements() {[0,3]}
 DEAL:0::RWVector contents from tril_vector:
 IndexSet: {[0,3]}
 
-0.000e+00
-1.000e+00
-2.000e+00
-3.000e+00
+[0]: 0.000e+00
+[1]: 1.000e+00
+[2]: 2.000e+00
+[3]: 3.000e+00
 DEAL:0::RWVector contents from tril_vector_ghosted:
 IndexSet: {[0,5]}
 
-0.000e+00
-1.000e+00
-2.000e+00
-3.000e+00
-4.000e+00
-5.000e+00
+[0]: 0.000e+00
+[1]: 1.000e+00
+[2]: 2.000e+00
+[3]: 3.000e+00
+[4]: 4.000e+00
+[5]: 5.000e+00
 DEAL:0::OK
 
 DEAL:1::is: {[4,7]}
@@ -56,18 +56,18 @@ DEAL:1::tril_vector_ghosted.owned_elements() {[4,7]}
 DEAL:1::RWVector contents from tril_vector:
 IndexSet: {[4,7]}
 
-4.000e+00
-5.000e+00
-6.000e+00
-7.000e+00
+[4]: 4.000e+00
+[5]: 5.000e+00
+[6]: 6.000e+00
+[7]: 7.000e+00
 DEAL:1::RWVector contents from tril_vector_ghosted:
 IndexSet: {[2,7]}
 
-2.000e+00
-3.000e+00
-4.000e+00
-5.000e+00
-6.000e+00
-7.000e+00
+[2]: 2.000e+00
+[3]: 3.000e+00
+[4]: 4.000e+00
+[5]: 5.000e+00
+[6]: 6.000e+00
+[7]: 7.000e+00
 DEAL:1::OK
 


### PR DESCRIPTION
- correct output for vector printing
- throw and catch exception when using a ghosted vector (newer Trilinos versions seems to allow doing this import operation)

fixes #5057 