### PR TITLE
CMake: Avoid -Wunknown-warning-option warnings

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -280,6 +280,8 @@
 _Pragma("GCC diagnostic push")                                   \
 _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")          \
 _Pragma("GCC diagnostic ignored \"-Wpragmas\"")                  \
+_Pragma("GCC diagnostic ignored \"-Wunknown-warning-option\"")   \
+_Pragma("GCC diagnostic ignored \"-Wunknown-warning\"")          \
 _Pragma("GCC diagnostic ignored \"-Wextra\"")                    \
 _Pragma("GCC diagnostic ignored \"-Woverloaded-virtual\"")       \
 _Pragma("GCC diagnostic ignored \"-Wunused-function\"")          \


### PR DESCRIPTION
Clang 5.0.0 complains about unknown warning options in GCC pragma
directives. This causes a lot of spurious warnings whenever the macro

  DEAL_II_DISABLE_EXTRA_DIAGNOSTICS

is encountered. Add a pragma directive to disable warnings about unknown
warnings to silence this.