### PR TITLE
Some minor cleanups of LogStream.

### DIFF
--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -95,8 +95,8 @@ public:
    * <code>continue</code>, <code>break</code>, <code>return</code>,
    * <code>throw</code>, or by simply reaching the closing brace. In all of
    * these cases, it is not necessary to remember to pop the prefix manually
-   * using LogStream::pop. In this, it works just like the better known
-   * Threads::Mutex::ScopedLock class.
+   * using LogStream::pop(). In this, it works just like the better known
+   * std::unique_ptr and Threads::Mutex::ScopedLock classes.
    */
   class Prefix
   {
@@ -120,6 +120,10 @@ public:
     ~Prefix ();
 
   private:
+    /**
+     * A pointer to the LogStream object to which the prefix is
+     * applied.
+     */
     SmartPointer<LogStream,LogStream::Prefix> stream;
   };
 
@@ -367,44 +371,6 @@ LogStream &operator<< (LogStream &log, const T &t)
 }
 
 
-inline
-std::ostringstream &
-LogStream::get_stream()
-{
-  // see if we have already created this stream. if not, do so and
-  // set the default flags (why we set these flags is lost to
-  // history, but this is what we need to keep several hundred tests
-  // from producing different output)
-  //
-  // note that in all of this we need not worry about thread-safety
-  // because we operate on a thread-local object and by definition
-  // there can only be one access at a time
-  if (outstreams.get().get() == nullptr)
-    {
-      outstreams.get().reset (new std::ostringstream);
-      outstreams.get()->setf(std::ios::showpoint | std::ios::left);
-    }
-
-  // then return the stream
-  return *outstreams.get();
-}
-
-
-
-inline
-LogStream::Prefix::Prefix(const std::string &text, LogStream &s)
-  :
-  stream(&s)
-{
-  stream->push(text);
-}
-
-
-inline
-LogStream::Prefix::~Prefix()
-{
-  stream->pop();
-}
 
 
 /**
@@ -414,14 +380,6 @@ LogStream::Prefix::~Prefix()
  */
 extern LogStream deallog;
 
-
-inline
-LogStream::Prefix::Prefix(const std::string &text)
-  :
-  stream(&deallog)
-{
-  stream->push(text);
-}
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -36,6 +36,34 @@ namespace
 LogStream deallog;
 
 
+
+
+LogStream::Prefix::Prefix(const std::string &text)
+  :
+  stream(&deallog)
+{
+  stream->push(text);
+}
+
+
+
+LogStream::Prefix::Prefix(const std::string &text,
+                          LogStream &s)
+  :
+  stream(&s)
+{
+  stream->push(text);
+}
+
+
+
+LogStream::Prefix::~Prefix()
+{
+  stream->pop();
+}
+
+
+
 LogStream::LogStream()
   :
   std_out(&std::cout),
@@ -47,6 +75,7 @@ LogStream::LogStream()
 {
   get_prefixes().push("DEAL:");
 }
+
 
 
 LogStream::~LogStream()
@@ -200,6 +229,30 @@ LogStream::get_console()
 }
 
 
+
+std::ostringstream &
+LogStream::get_stream()
+{
+  // see if we have already created this stream. if not, do so and
+  // set the default flags (why we set these flags is lost to
+  // history, but this is what we need to keep several hundred tests
+  // from producing different output)
+  //
+  // note that in all of this we need not worry about thread-safety
+  // because we operate on a thread-local object and by definition
+  // there can only be one access at a time
+  if (outstreams.get().get() == nullptr)
+    {
+      outstreams.get().reset (new std::ostringstream);
+      outstreams.get()->setf(std::ios::showpoint | std::ios::left);
+    }
+
+  // then return the stream
+  return *outstreams.get();
+}
+
+
+
 std::ostream &
 LogStream::get_file_stream()
 {
@@ -210,11 +263,13 @@ LogStream::get_file_stream()
 }
 
 
+
 bool
 LogStream::has_file() const
 {
   return (file != nullptr);
 }
+
 
 
 const std::string &
@@ -227,6 +282,7 @@ LogStream::get_prefix() const
   else
     return empty_string;
 }
+
 
 
 void
@@ -242,11 +298,13 @@ LogStream::push (const std::string &text)
 }
 
 
+
 void LogStream::pop ()
 {
   if (get_prefixes().size() > 0)
     get_prefixes().pop();
 }
+
 
 
 std::ios::fmtflags
@@ -256,6 +314,7 @@ LogStream::flags(const std::ios::fmtflags f)
 }
 
 
+
 std::streamsize
 LogStream::precision (const std::streamsize prec)
 {
@@ -263,11 +322,13 @@ LogStream::precision (const std::streamsize prec)
 }
 
 
+
 std::streamsize
 LogStream::width (const std::streamsize wide)
 {
   return get_stream().width (wide);
 }
+
 
 
 unsigned int
@@ -280,6 +341,7 @@ LogStream::depth_console (const unsigned int n)
 }
 
 
+
 unsigned int
 LogStream::depth_file (const unsigned int n)
 {
@@ -290,6 +352,7 @@ LogStream::depth_file (const unsigned int n)
 }
 
 
+
 bool
 LogStream::log_thread_id (const bool flag)
 {
@@ -298,6 +361,8 @@ LogStream::log_thread_id (const bool flag)
   print_thread_id = flag;
   return h;
 }
+
+
 
 std::stack<std::string> &
 LogStream::get_prefixes() const
@@ -330,6 +395,7 @@ LogStream::get_prefixes() const
   return prefixes.get();
 #endif
 }
+
 
 
 void


### PR DESCRIPTION
In particular, move some functions into the .cc file -- surely, these
functions do not need to be 'inline' in the header file.