### PR TITLE
Avoid raw pointers in favor of VectorMemory::Pointer in SolverRichardson.

### DIFF
--- a/doc/news/changes/incompatibilities/20170912Bangerth
+++ b/doc/news/changes/incompatibilities/20170912Bangerth
@@ -1,0 +1,6 @@
+Changed: The virtual function SolverRichardson::criterion() now
+receives the residual and preconditioned residual vectors as
+arguments, rather than accessing it through the member variables of
+the class. It has also been made @p const.
+<br>
+(Wolfgang Bangerth, 2017/09/12)

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -165,14 +165,6 @@ protected:
    * Control parameters.
    */
   AdditionalData additional_data;
-
-  /**
-   * Within the iteration loop, the norm of the residual is stored in this
-   * variable. The function @p criterion uses this variable to compute the
-   * convergence value, which in this class is the norm of the residual vector
-   * and thus the square root of the @p res2 value.
-   */
-  typename VectorType::value_type res;
 };
 
 /*@}*/
@@ -211,8 +203,7 @@ SolverRichardson<VectorType>::SolverRichardson(SolverControl        &cn,
   Solver<VectorType> (cn),
   Vr(nullptr),
   Vd(nullptr),
-  additional_data(data),
-  res(numbers::signaling_nan<double>())
+  additional_data(data)
 {}
 
 

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -150,18 +150,6 @@ protected:
                                                     const VectorType &d) const;
 
   /**
-   * Residual. Temporary vector allocated through the VectorMemory object at
-   * the start of the actual solution process and deallocated at the end.
-   */
-  VectorType *Vr;
-  /**
-   * Preconditioned residual. Temporary vector allocated through the
-   * VectorMemory object at the start of the actual solution process and
-   * deallocated at the end.
-   */
-  VectorType *Vd;
-
-  /**
    * Control parameters.
    */
   AdditionalData additional_data;
@@ -189,8 +177,6 @@ SolverRichardson<VectorType>::SolverRichardson(SolverControl            &cn,
                                                const AdditionalData     &data)
   :
   Solver<VectorType> (cn,mem),
-  Vr(nullptr),
-  Vd(nullptr),
   additional_data(data)
 {}
 
@@ -201,8 +187,6 @@ SolverRichardson<VectorType>::SolverRichardson(SolverControl        &cn,
                                                const AdditionalData &data)
   :
   Solver<VectorType> (cn),
-  Vr(nullptr),
-  Vd(nullptr),
   additional_data(data)
 {}
 
@@ -227,11 +211,14 @@ SolverRichardson<VectorType>::solve (const MatrixType         &A,
 
   unsigned int iter = 0;
 
-  // Memory allocation
-  Vr  = this->memory.alloc();
+  // Memory allocation.
+  // 'Vr' holds the residual, 'Vd' the preconditioned residual
+  typename VectorMemory<VectorType>::Pointer Vr (this->memory);
+  typename VectorMemory<VectorType>::Pointer Vd (this->memory);
+
   VectorType &r  = *Vr;
   r.reinit(x);
-  Vd  = this->memory.alloc();
+
   VectorType &d  = *Vd;
   d.reinit(x);
 
@@ -263,14 +250,10 @@ SolverRichardson<VectorType>::solve (const MatrixType         &A,
     }
   catch (...)
     {
-      this->memory.free(Vr);
-      this->memory.free(Vd);
       deallog.pop();
       throw;
     }
-  // Deallocate Memory
-  this->memory.free(Vr);
-  this->memory.free(Vd);
+
   deallog.pop();
 
   // in case of failure: throw exception
@@ -279,6 +262,7 @@ SolverRichardson<VectorType>::solve (const MatrixType         &A,
                                                      last_criterion));
   // otherwise exit as normal
 }
+
 
 
 template <class VectorType>
@@ -294,11 +278,14 @@ SolverRichardson<VectorType>::Tsolve (const MatrixType         &A,
 
   unsigned int iter = 0;
 
-  // Memory allocation
-  Vr = this->memory.alloc();
+  // Memory allocation.
+  // 'Vr' holds the residual, 'Vd' the preconditioned residual
+  typename VectorMemory<VectorType>::Pointer Vr (this->memory);
+  typename VectorMemory<VectorType>::Pointer Vd (this->memory);
+
   VectorType &r  = *Vr;
   r.reinit(x);
-  Vd = this-> memory.alloc();
+
   VectorType &d  = *Vd;
   d.reinit(x);
 
@@ -328,15 +315,10 @@ SolverRichardson<VectorType>::Tsolve (const MatrixType         &A,
     }
   catch (...)
     {
-      this->memory.free(Vr);
-      this->memory.free(Vd);
       deallog.pop();
       throw;
     }
 
-  // Deallocate Memory
-  this->memory.free(Vr);
-  this->memory.free(Vd);
   deallog.pop();
   // in case of failure: throw exception
   if (conv != SolverControl::success)

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -21,7 +21,6 @@
 #include <deal.II/base/logstream.h>
 #include <deal.II/lac/solver.h>
 #include <deal.II/lac/solver_control.h>
-#include <deal.II/base/subscriptor.h>
 #include <deal.II/base/signaling_nan.h>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
While there, also clean up a couple of other things.

Passes the testsuite. In reference to #4935.