### PR TITLE
Two small parallel hp fixes

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1842,7 +1842,7 @@ namespace internal
           tasks.join_all ();
 
           // update the cache used for cell dof indices
-          update_all_level_cell_dof_indices_caches(dof_handler);
+          update_all_active_cell_dof_indices_caches (dof_handler);
         }
 
 

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -927,10 +927,16 @@ namespace internal
               };
 
               auto unpack
-                = [] (const typename dealii::hp::DoFHandler<dim,spacedim>::active_cell_iterator &cell,
-                      const unsigned int                                                        &active_fe_index) -> void
+                = [&dof_handler] (const typename dealii::hp::DoFHandler<dim,spacedim>::active_cell_iterator &cell,
+                                  const unsigned int                                                        &active_fe_index) -> void
               {
-                cell->set_active_fe_index(active_fe_index);
+                // we would like to say
+                //   cell->set_active_fe_index(active_fe_index);
+                // but this is not allowed on cells that are not
+                // locally owned, and we are on a ghost cell
+                dof_handler.levels[cell->level()]->
+                set_active_fe_index(cell->index(),
+                active_fe_index);
               };
 
               parallel::GridTools::exchange_cell_data_to_ghosts<unsigned int, dealii::hp::DoFHandler<dim,spacedim>>


### PR DESCRIPTION
Here are two small patches I found while continuing work on #3511. 

The first is a bug that shows up in one of my tests that are currently still failing: we are trying to set an `active_fe_index` on a ghost cell, but this is not allowed. There is an easy way to work around that that we already utilize a few lines above that location for the `parallel::shared` case.

The second is a bug in the sense that we were doing too much work: we were updating DoF index caches on *all* cells, not just active cells, in the function that only deals with the non-MG case. That's not wrong, it's just unnecessary for all non-active cells. However, in the parallel hp case, this requires querying the active fe index on non-active cells, and this operation is not allowed -- so my test fails the first time we encounter a non-active cell.

The PR passes the testsuite.