### PR TITLE
Fix warnings for clang-5.0.0

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -645,7 +645,8 @@ namespace
           case 1:
             Assert (xstep<n_subdivisions+1, ExcIndexRange(xstep,0,n_subdivisions+1));
             point_no+=xstep;
-
+            DEAL_II_FALLTHROUGH;
+          case 0:
             // break here for dim<=3
             break;
 
@@ -657,24 +658,29 @@ namespace
       }
     else
       {
-        // perform a dim-linear interpolation
-        const double stepsize=1./n_subdivisions,
-                     xfrac=xstep*stepsize;
-
-        node = (patch->vertices[1] * xfrac) + (patch->vertices[0] * (1-xfrac));
-        if (dim>1)
+        if (dim==0)
+          node = patch->vertices[0];
+        else
           {
-            const double yfrac=ystep*stepsize;
-            node*= 1-yfrac;
-            node += ((patch->vertices[3] * xfrac) + (patch->vertices[2] * (1-xfrac))) * yfrac;
-            if (dim>2)
+            // perform a dim-linear interpolation
+            const double stepsize=1./n_subdivisions,
+                         xfrac=xstep*stepsize;
+
+            node = (patch->vertices[1] * xfrac) + (patch->vertices[0] * (1-xfrac));
+            if (dim>1)
               {
-                const double zfrac=zstep*stepsize;
-                node *= (1-zfrac);
-                node += (((patch->vertices[5] * xfrac) + (patch->vertices[4] * (1-xfrac)))
-                         * (1-yfrac) +
-                         ((patch->vertices[7] * xfrac) + (patch->vertices[6] * (1-xfrac)))
-                         * yfrac) * zfrac;
+                const double yfrac=ystep*stepsize;
+                node*= 1-yfrac;
+                node += ((patch->vertices[3] * xfrac) + (patch->vertices[2] * (1-xfrac))) * yfrac;
+                if (dim>2)
+                  {
+                    const double zfrac=zstep*stepsize;
+                    node *= (1-zfrac);
+                    node += (((patch->vertices[5] * xfrac) + (patch->vertices[4] * (1-xfrac)))
+                             * (1-yfrac) +
+                             ((patch->vertices[7] * xfrac) + (patch->vertices[6] * (1-xfrac)))
+                             * yfrac) * zfrac;
+                  }
               }
           }
       }

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1040,22 +1040,29 @@ namespace internal
           {
             Threads::TaskGroup<> tasks;
 
-            tasks += Threads::new_task ([&]()
+            unsigned int i=0;
+            tasks += Threads::new_task ([ &,i] ()
             {
-              all_constrained_indices[0] = compute_vertex_dof_identities (dof_handler);
+              all_constrained_indices[i] = compute_vertex_dof_identities (dof_handler);
             });
 
             if (dim > 1)
-              tasks += Threads::new_task ([&]()
               {
-                all_constrained_indices[1] = compute_line_dof_identities (dof_handler);
-              });
+                ++i;
+                tasks += Threads::new_task ([ &,i] ()
+                {
+                  all_constrained_indices[i] = compute_line_dof_identities (dof_handler);
+                });
+              }
 
             if (dim > 2)
-              tasks += Threads::new_task ([&]()
               {
-                all_constrained_indices[2] = compute_quad_dof_identities (dof_handler);
-              });
+                ++i;
+                tasks += Threads::new_task ([ &,i] ()
+                {
+                  all_constrained_indices[i] = compute_quad_dof_identities (dof_handler);
+                });
+              }
 
             tasks.join_all ();
           }


### PR DESCRIPTION
`clang-5.0.0` complains about access to elements which are out of range.
It turns out that the `unify_dof_indices` in `source/dofs/dof_handler_policy.cc` can be simplified
and we implement something sensible for `dim==0` in `compute_node` in `source/base/data_out_base.cc`.