### PR TITLE
Introduce a class that can't be used.

### DIFF
--- a/include/deal.II/dofs/dof_iterator_selector.h
+++ b/include/deal.II/dofs/dof_iterator_selector.h
@@ -21,7 +21,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int, int, int> class InvalidAccessor;
+template <int, int, int> class DoFInvalidAccessor;
 
 template <int structdim, typename DoFHandlerType, bool lda> class DoFAccessor;
 template <typename DoFHandlerType, bool lda> class DoFCellAccessor;
@@ -61,13 +61,13 @@ namespace internal
       typedef TriaIterator      <CellAccessor> line_iterator;
       typedef TriaActiveIterator<CellAccessor> active_line_iterator;
 
-      typedef TriaRawIterator   <InvalidAccessor<2,1,spacedim> > raw_quad_iterator;
-      typedef TriaIterator      <InvalidAccessor<2,1,spacedim> > quad_iterator;
-      typedef TriaActiveIterator<InvalidAccessor<2,1,spacedim> > active_quad_iterator;
+      typedef TriaRawIterator   <DoFInvalidAccessor<2,1,spacedim> > raw_quad_iterator;
+      typedef TriaIterator      <DoFInvalidAccessor<2,1,spacedim> > quad_iterator;
+      typedef TriaActiveIterator<DoFInvalidAccessor<2,1,spacedim> > active_quad_iterator;
 
-      typedef TriaRawIterator   <InvalidAccessor<3,1,spacedim> > raw_hex_iterator;
-      typedef TriaIterator      <InvalidAccessor<3,1,spacedim> > hex_iterator;
-      typedef TriaActiveIterator<InvalidAccessor<3,1,spacedim> > active_hex_iterator;
+      typedef TriaRawIterator   <DoFInvalidAccessor<3,1,spacedim> > raw_hex_iterator;
+      typedef TriaIterator      <DoFInvalidAccessor<3,1,spacedim> > hex_iterator;
+      typedef TriaActiveIterator<DoFInvalidAccessor<3,1,spacedim> > active_hex_iterator;
 
       typedef raw_line_iterator    raw_cell_iterator;
       typedef line_iterator        cell_iterator;
@@ -108,9 +108,9 @@ namespace internal
       typedef TriaIterator      <CellAccessor> quad_iterator;
       typedef TriaActiveIterator<CellAccessor> active_quad_iterator;
 
-      typedef TriaRawIterator   <InvalidAccessor<3,2,spacedim> > raw_hex_iterator;
-      typedef TriaIterator      <InvalidAccessor<3,2,spacedim> > hex_iterator;
-      typedef TriaActiveIterator<InvalidAccessor<3,2,spacedim> > active_hex_iterator;
+      typedef TriaRawIterator   <DoFInvalidAccessor<3,2,spacedim> > raw_hex_iterator;
+      typedef TriaIterator      <DoFInvalidAccessor<3,2,spacedim> > hex_iterator;
+      typedef TriaActiveIterator<DoFInvalidAccessor<3,2,spacedim> > active_hex_iterator;
 
       typedef raw_quad_iterator    raw_cell_iterator;
       typedef quad_iterator        cell_iterator;

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -479,12 +479,13 @@ private:
  * create objects (it will in fact throw an exception if this should ever be
  * attempted but it sometimes allows code to be written in a simpler way in a
  * dimension independent way. For example, it allows to write code that works
- * on quad iterators that is dimension independent because quad iterators
- * (with the current class) exist and are syntactically correct. You can not
- * expect, however, to ever generate one of these iterators, meaning you need
- * to expect to wrap the code block in which you use quad iterators into
- * something like <code>if (dim@>1)</code> -- which makes eminent sense
- * anyway.
+ * on quad iterators that is dimension independent -- i.e., also compiles
+ * in 1d -- because quad iterators
+ * (via the current class) exist and are syntactically correct. You can not
+ * expect, however, to ever create an actual object of one of these iterators
+ * in 1d, meaning you need to expect to wrap the code block in which you use
+ * quad iterators into something like <code>if (dim@>1)</code> -- which makes
+ * eminent sense anyway.
  *
  * This class provides the minimal interface necessary for Accessor classes to
  * interact with Iterator classes. However, this is only for syntactic
@@ -503,11 +504,11 @@ public:
   typedef typename TriaAccessorBase<structdim,dim,spacedim>::AccessorData AccessorData;
 
   /**
-   * Constructor.  This class is used for iterators that make sense in a given
-   * dimension, for example quads for 1d meshes. Consequently, while the
-   * creation of such objects is syntactically valid, they make no semantic
-   * sense, and we generate an exception when such an object is actually
-   * generated.
+   * Constructor.  This class is used for iterators that do not make
+   * sense in a given dimension, for example quads for 1d meshes. Consequently,
+   * while the creation of such objects is syntactically valid, they make no
+   * semantic sense, and we generate an exception when such an object is
+   * actually generated.
    */
   InvalidAccessor (const Triangulation<dim,spacedim> *parent     =  0,
                    const int                 level      = -1,
@@ -515,11 +516,11 @@ public:
                    const AccessorData       *local_data =  0);
 
   /**
-   * Copy constructor.  This class is used for iterators that make sense in a
-   * given dimension, for example quads for 1d meshes. Consequently, while the
-   * creation of such objects is syntactically valid, they make no semantic
-   * sense, and we generate an exception when such an object is actually
-   * generated.
+   * Copy constructor.  This class is used for iterators that do not make
+   * sense in a given dimension, for example quads for 1d meshes. Consequently,
+   * while the creation of such objects is syntactically valid, they make no
+   * semantic sense, and we generate an exception when such an object is
+   * actually generated.
    */
   InvalidAccessor (const InvalidAccessor &);
 

--- a/source/dofs/dof_accessor.cc
+++ b/source/dofs/dof_accessor.cc
@@ -36,6 +36,53 @@ const unsigned int DoFAccessor<structdim,DoFHandlerType,level_dof_access>::space
 
 
 
+/*------------------------ Functions: DoFInvalidAccessor ---------------------------*/
+
+template <int structdim, int dim, int spacedim>
+DoFInvalidAccessor<structdim, dim, spacedim>::
+DoFInvalidAccessor (const Triangulation<dim,spacedim> *,
+                    const int,
+                    const int,
+                    const AccessorData *)
+{
+  Assert (false,
+          ExcMessage ("You are attempting an illegal conversion between "
+                      "iterator/accessor types. The constructor you call "
+                      "only exists to make certain template constructs "
+                      "easier to write as dimension independent code but "
+                      "the conversion is not valid in the current context."));
+}
+
+
+
+template <int structdim, int dim, int spacedim>
+DoFInvalidAccessor<structdim, dim, spacedim>::
+DoFInvalidAccessor (const DoFInvalidAccessor &i)
+  :
+  InvalidAccessor<structdim,dim,spacedim> (static_cast<const InvalidAccessor<structdim,dim,spacedim>&>(i))
+{
+  Assert (false,
+          ExcMessage ("You are attempting an illegal conversion between "
+                      "iterator/accessor types. The constructor you call "
+                      "only exists to make certain template constructs "
+                      "easier to write as dimension independent code but "
+                      "the conversion is not valid in the current context."));
+}
+
+
+
+template <int structdim, int dim, int spacedim>
+void
+DoFInvalidAccessor<structdim, dim, spacedim>::
+set_dof_index (const unsigned int,
+               const types::global_dof_index,
+               const unsigned int) const
+{
+  Assert (false, ExcInternalError());
+}
+
+
+
 /*------------------------- Functions: DoFCellAccessor -----------------------*/
 
 

--- a/source/dofs/dof_accessor.inst.in
+++ b/source/dofs/dof_accessor.inst.in
@@ -164,3 +164,7 @@ for (deal_II_dimension : DIMENSIONS; lda : BOOL)
 #endif
 }
 
+for (deal_II_struct_dimension : DIMENSIONS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
+{
+    template class DoFInvalidAccessor<deal_II_struct_dimension,deal_II_dimension,deal_II_space_dimension>;
+}


### PR DESCRIPTION
Specifically, declare DoFInvalidAccessor that is the accessor
for cases where dim>spacedim -- i.e., things that can't logically
happen, but that at times do happen in code like
```
  for (quad=0; quad<GeometryInfo<dim>::quads_per_cell; ++quad)
    cell->quad(quad)->do_something();
```
Here, the code is not executed in 1d, but we want it to be syntactically
correct so that we can compile the function. Having a DoFInvalidAccessor
then serves the same purpose that InvalidAccessor already does for
tria accessor functions: such objects cannot be created but rather
throw an exception, but they provide the correct syntax.