### PR TITLE
Simplify some function calls now that we have hp::DoFHandler::get_fe(index)

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1166,9 +1166,9 @@ namespace internal
         Assert (dof_handler.finite_elements != nullptr,
                 ExcMessage ("No finite element collection is associated with "
                             "this DoFHandler"));
-        Assert (local_index < (*dof_handler.finite_elements)[fe_index].dofs_per_vertex,
+        Assert (local_index < dof_handler.get_fe(fe_index).dofs_per_vertex,
                 ExcIndexRange(local_index, 0,
-                              (*dof_handler.finite_elements)[fe_index].dofs_per_vertex));
+                              dof_handler.get_fe(fe_index).dofs_per_vertex));
         Assert (fe_index < dof_handler.finite_elements->size(),
                 ExcInternalError());
         Assert (dof_handler.vertex_dof_offsets[vertex_index] !=
@@ -1204,7 +1204,7 @@ namespace internal
               }
             else
               pointer += static_cast<types::global_dof_index>(
-                           (*dof_handler.finite_elements)[this_fe_index].dofs_per_vertex + 1);
+                           dof_handler.get_fe(this_fe_index).dofs_per_vertex + 1);
           }
       }
 
@@ -1251,9 +1251,9 @@ namespace internal
         Assert (dof_handler.finite_elements != nullptr,
                 ExcMessage ("No finite element collection is associated with "
                             "this DoFHandler"));
-        Assert (local_index < (*dof_handler.finite_elements)[fe_index].dofs_per_vertex,
+        Assert (local_index < dof_handler.get_fe(fe_index).dofs_per_vertex,
                 ExcIndexRange(local_index, 0,
-                              (*dof_handler.finite_elements)[fe_index].dofs_per_vertex));
+                              dof_handler.get_fe(fe_index).dofs_per_vertex));
         Assert (vertex_index < dof_handler.vertex_dof_offsets.size(),
                 ExcIndexRange (vertex_index, 0,
                                dof_handler.vertex_dof_offsets.size()));
@@ -1286,7 +1286,7 @@ namespace internal
               return *(pointer + 1 + local_index);
             else
               pointer += static_cast<types::global_dof_index>(
-                           (*dof_handler.finite_elements)[this_fe_index].dofs_per_vertex + 1);
+                           dof_handler.get_fe(this_fe_index).dofs_per_vertex + 1);
           }
       }
 
@@ -1330,7 +1330,7 @@ namespace internal
             else
               {
                 pointer += static_cast<types::global_dof_index>(
-                             (*dof_handler.finite_elements)[this_fe_index].dofs_per_vertex + 1);
+                             dof_handler.get_fe(this_fe_index).dofs_per_vertex + 1);
                 ++counter;
               }
           }
@@ -1388,7 +1388,7 @@ namespace internal
                     ExcInternalError());
 
             pointer += static_cast<types::global_dof_index>(
-                         (*dof_handler.finite_elements)[this_fe_index].dofs_per_vertex + 1);
+                         dof_handler.get_fe(this_fe_index).dofs_per_vertex + 1);
             ++counter;
           }
       }
@@ -1445,7 +1445,7 @@ namespace internal
             else if (this_fe_index == fe_index)
               return true;
             else
-              pointer += (*dof_handler.finite_elements)[this_fe_index].dofs_per_vertex + 1;
+              pointer += dof_handler.get_fe(this_fe_index).dofs_per_vertex + 1;
           }
       }
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -739,37 +739,38 @@ namespace internal
 
                   // do a first loop over all sets of dofs and do identity
                   // uniquification
-                  for (unsigned int f=0; f<line->n_active_fe_indices(); ++f)
-                    for (unsigned int g=f+1; g<line->n_active_fe_indices(); ++g)
+                  const unsigned int n_active_fe_indices = line->n_active_fe_indices();
+                  for (unsigned int f=0; f<n_active_fe_indices; ++f)
+                    for (unsigned int g=f+1; g<n_active_fe_indices; ++g)
                       {
                         const unsigned int fe_index_1 = line->nth_active_fe_index (f),
                                            fe_index_2 = line->nth_active_fe_index (g);
 
-                        if (((*dof_handler.finite_elements)[fe_index_1].dofs_per_line
+                        if ((dof_handler.get_fe(fe_index_1).dofs_per_line
                              ==
-                             (*dof_handler.finite_elements)[fe_index_2].dofs_per_line)
+                             dof_handler.get_fe(fe_index_2).dofs_per_line)
                             &&
-                            ((*dof_handler.finite_elements)[fe_index_1].dofs_per_line > 0))
+                            (dof_handler.get_fe(fe_index_1).dofs_per_line > 0))
                           {
                             ensure_existence_of_dof_identities<1>
-                            ((*dof_handler.finite_elements)[fe_index_1],
-                             (*dof_handler.finite_elements)[fe_index_2],
+                            (dof_handler.get_fe(fe_index_1),
+                             dof_handler.get_fe(fe_index_2),
                              line_dof_identities[fe_index_1][fe_index_2]);
                             // see if these sets of dofs are identical. the first
                             // condition for this is that indeed there are n identities
                             if (line_dof_identities[fe_index_1][fe_index_2]->size()
                                 ==
-                                (*dof_handler.finite_elements)[fe_index_1].dofs_per_line)
+                                dof_handler.get_fe(fe_index_1).dofs_per_line)
                               {
                                 unsigned int i=0;
-                                for (; i<(*dof_handler.finite_elements)[fe_index_1].dofs_per_line; ++i)
+                                for (; i<dof_handler.get_fe(fe_index_1).dofs_per_line; ++i)
                                   if (((*(line_dof_identities[fe_index_1][fe_index_2]))[i].first != i)
                                       &&
                                       ((*(line_dof_identities[fe_index_1][fe_index_2]))[i].second != i))
                                     // not an identity
                                     break;
 
-                                if (i == (*dof_handler.finite_elements)[fe_index_1].dofs_per_line)
+                                if (i == dof_handler.get_fe(fe_index_1).dofs_per_line)
                                   {
                                     // The line dofs (i.e., the ones interior to a line) of these two finite elements are identical.
                                     // Note that there could be situations when one element still dominates another, e.g.:
@@ -778,7 +779,7 @@ namespace internal
 
                                     --unique_sets_of_dofs;
 
-                                    for (unsigned int j=0; j<(*dof_handler.finite_elements)[fe_index_1].dofs_per_line; ++j)
+                                    for (unsigned int j=0; j<dof_handler.get_fe(fe_index_1).dofs_per_line; ++j)
                                       {
                                         const types::global_dof_index master_dof_index
                                           = line->dof_index (j, fe_index_1);
@@ -848,8 +849,8 @@ namespace internal
                                 other_fe_index = line->nth_active_fe_index (f);
 
                                 ensure_existence_of_dof_identities<1>
-                                ((*dof_handler.finite_elements)[most_dominating_fe_index],
-                                 (*dof_handler.finite_elements)[other_fe_index],
+                                (dof_handler.get_fe(most_dominating_fe_index),
+                                 dof_handler.get_fe(other_fe_index),
                                  line_dof_identities[most_dominating_fe_index][other_fe_index]);
 
                                 DoFIdentities &identities
@@ -972,8 +973,8 @@ namespace internal
                             other_fe_index = quad->nth_active_fe_index (f);
 
                             ensure_existence_of_dof_identities<2>
-                            ((*dof_handler.finite_elements)[most_dominating_fe_index],
-                             (*dof_handler.finite_elements)[other_fe_index],
+                            (dof_handler.get_fe(most_dominating_fe_index),
+                             dof_handler.get_fe(other_fe_index),
                              quad_dof_identities[most_dominating_fe_index][other_fe_index]);
 
                             DoFIdentities &identities

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -185,7 +185,7 @@ namespace internal
 
                   for (unsigned int fe=0; fe<dof_handler.finite_elements->size(); ++fe)
                     if (vertex_fe_association[fe][v] == true)
-                      vertex_slots_needed += (*dof_handler.finite_elements)[fe].dofs_per_vertex + 1;
+                      vertex_slots_needed += dof_handler.get_fe(fe).dofs_per_vertex + 1;
 
                   // don't forget the end_marker:
                   ++vertex_slots_needed;
@@ -206,7 +206,7 @@ namespace internal
                         // if this vertex uses this fe, then set the
                         // fe_index and move the pointer ahead
                         dof_handler.vertex_dofs[current_index] = fe;
-                        current_index += (*dof_handler.finite_elements)[fe].dofs_per_vertex + 1;
+                        current_index += dof_handler.get_fe(fe).dofs_per_vertex + 1;
                       }
                   // finally place the end marker
                   dof_handler.vertex_dofs[current_index] = numbers::invalid_dof_index;
@@ -414,7 +414,7 @@ namespace internal
                         // ok, one set of dofs. that makes one active_fe_index, 1
                         // times dofs_per_face dofs, and one stop index
                         n_face_slots
-                        += 1 + (*dof_handler.finite_elements)[cell->active_fe_index()].template n_dofs_per_object<dim-1>() + 1;
+                        += 1 + dof_handler.get_fe(cell->active_fe_index()).template n_dofs_per_object<dim-1>() + 1;
 
                       // otherwise we do indeed need two sets, i.e. two
                       // active_fe_indices, two sets of dofs, and one stop index:
@@ -422,9 +422,9 @@ namespace internal
                         n_face_slots
                         += (2
                             +
-                            (*dof_handler.finite_elements)[cell->active_fe_index()].template n_dofs_per_object<dim-1>()
+                            dof_handler.get_fe(cell->active_fe_index()).template n_dofs_per_object<dim-1>()
                             +
-                            (*dof_handler.finite_elements)[cell->neighbor(face)->active_fe_index()]
+                            dof_handler.get_fe(cell->neighbor(face)->active_fe_index())
                             .template n_dofs_per_object<dim-1>()
                             +
                             1);
@@ -510,7 +510,7 @@ namespace internal
 
                           // finally, mark those slots as used
                           next_free_face_slot
-                          += (*dof_handler.finite_elements)[cell->active_fe_index()].template n_dofs_per_object<dim-1>() + 2;
+                          += dof_handler.get_fe(cell->active_fe_index()).template n_dofs_per_object<dim-1>() + 2;
                         }
                       else
                         {
@@ -529,7 +529,7 @@ namespace internal
                           // cell:
                           face_dof_indices[next_free_face_slot
                                            +
-                                           (*dof_handler.finite_elements)[cell->active_fe_index()].template n_dofs_per_object<dim-1>()
+                                           dof_handler.get_fe(cell->active_fe_index()).template n_dofs_per_object<dim-1>()
                                            +
                                            1]
                             = cell->neighbor(face)->active_fe_index();
@@ -542,9 +542,9 @@ namespace internal
 
                           // finally, mark those slots as used
                           next_free_face_slot
-                          += ((*dof_handler.finite_elements)[cell->active_fe_index()].template n_dofs_per_object<dim-1>()
+                          += (dof_handler.get_fe(cell->active_fe_index()).template n_dofs_per_object<dim-1>()
                               +
-                              (*dof_handler.finite_elements)[cell->neighbor(face)->active_fe_index()]
+                              dof_handler.get_fe(cell->neighbor(face)->active_fe_index())
                               .template n_dofs_per_object<dim-1>()
                               +
                               3);
@@ -730,7 +730,7 @@ namespace internal
 
                     for (unsigned int fe=0; fe<dof_handler.finite_elements->size(); ++fe)
                       if (line_fe_association[fe][line] == true)
-                        line_slots_needed += (*dof_handler.finite_elements)[fe].dofs_per_line + 1;
+                        line_slots_needed += dof_handler.get_fe(fe).dofs_per_line + 1;
                     ++line_slots_needed;
                   }
 
@@ -748,7 +748,7 @@ namespace internal
                           // if this line uses this fe, then set the
                           // fe_index and move the pointer ahead
                           dof_handler.faces->lines.dofs[pointer] = fe;
-                          pointer += (*dof_handler.finite_elements)[fe].dofs_per_line + 1;
+                          pointer += dof_handler.get_fe(fe).dofs_per_line + 1;
                         }
                     // finally place the end marker
                     dof_handler.faces->lines.dofs[pointer] = numbers::invalid_dof_index;


### PR DESCRIPTION
This makes use of the functionality introduced in #4908 and modified in #4959 by @masterleinad .

With the exception of the first hunk in `source/dofs/dof_handler_policy.cc`, the patch is purely mechanical.