### PR TITLE
use range-based for and other C++11 features in tutorials

### DIFF
--- a/examples/step-1/doc/results.dox
+++ b/examples/step-1/doc/results.dox
@@ -35,7 +35,7 @@ places where you can play with it. For example, you could modify the
 criterion by which we decide which cells to refine. An example would
 be to change the condition to this:
 @code
-      for (; cell!=endc; ++cell)
+      for (auto cell: triangulation.active_cell_iterators())
         if (cell->center()[1] > 0)
           cell->set_refine_flag ();
 @endcode

--- a/examples/step-1/step-1.cc
+++ b/examples/step-1/step-1.cc
@@ -143,46 +143,61 @@ void second_grid ()
   // refine the grid in five steps towards the inner circle of the domain:
   for (unsigned int step=0; step<5; ++step)
     {
-      // Next, we need an iterator that points to a cell and which we will
-      // move over all active cells one by one. In a sense, you can think of a
-      // triangulation as a collection of cells. If it was an array, you would
-      // just get a pointer that you move from one array element to the next. In
-      // triangulations, cells aren't stored as an array, so simple pointers
-      // do not work, but one can generalize pointers to iterators (see <a
-      // href="http://en.wikipedia.org/wiki/Iterator#C.2B.2B">this wikipedia
-      // link</a> for more information). We will then get an iterator to the
-      // first cell and iterate over all of the cells until we hit the last
-      // one.
+      // Next, we need to loop over the active cells of the triangulation. You
+      // can think of a triangulation as a collection of cells. If it was an
+      // an array, you would just get a pointer that you increment from one
+      // element to the next using the operator `++`. The cells of a
+      // triangulation aren't stored as a simple array, but the concept of an
+      // <i>iterator</i> generalizes how pointers work to arbitrary collections
+      // of objects (see <a href=
+      // "http://en.wikipedia.org/wiki/Iterator#C.2B.2B">wikipedia</a> for more
+      // information). Typically, any container type in C++ will return an
+      // iterator pointing to the start of the collection with a method called
+      // `begin`, and an iterator point to 1 past the end of the collection with
+      // a method called `end`. We can increment an iterator `it` with the
+      // operator `++it`, dereference it to get the underlying data with `*it`,
+      // and check to see if we're done by comparing `it != collection.end()`.
       //
       // The second important piece is that we only need the active cells.
       // Active cells are those that are not further refined, and the only
-      // ones that can be marked for further refinement, obviously. deal.II
-      // provides iterator categories that allow us to iterate over <i>all</i>
-      // cells (including the parent cells of active ones) or only over the
-      // active cells. Because we want the latter, we need to choose
-      // Triangulation::active_cell_iterator as data type.
+      // ones that can be marked for further refinement. deal.II provides
+      // iterator categories that allow us to iterate over <i>all</i> cells
+      // (including the parent cells of active ones) or only over the active
+      // cells. Because we want the latter, we need to call the method
+      // Triangulation::active_cell_iterators().
       //
-      // Finally, by convention, we almost always use the names
-      // <code>cell</code> and <code>endc</code> for the iterator pointing to
-      // the present cell and to the "one-past-the-end" iterator. This is, in
-      // a sense a misnomer, because the object is not really a "cell": it is
-      // an iterator/pointer to a cell. We should really have started to call
-      // these objects <code>cell_iterator</code> when deal.II started in
-      // 1998, but it is what it is.
+      // Putting all of this together, we can loop over all the active cells of
+      // a triangulation with
+      // @code{.cpp}
+      //     for (auto it = triangulation.active_cell_iterators().begin();
+      //          it != triangulation.active_cell_iterators().end();
+      //          ++it)
+      //       {
+      //         auto cell = *it;
+      //         // Then a miracle occurs...
+      //       }
+      // @endcode
+      // In the initializer of this loop, we've used the `auto` keyword for the
+      // type of the iterator `it`. The `auto` keyword means that the type of
+      // the object being declared will be inferred from the context. This
+      // keyword is useful when the actual type names are long or possibly even
+      // redundant. If you're unsure of what the type is and want to look up
+      // what operations the result supports, you can go to the documentation
+      // for the method Triangulation::active_cell_iterators(). In this case,
+      // the type of `it` is `Triangulation::active_cell_iterator`.
       //
-      // After declaring the iterator variable, the loop over all cells is
-      // then rather trivial, and looks like any loop involving pointers
-      // instead of iterators:
-      Triangulation<2>::active_cell_iterator cell = triangulation.begin_active();
-      Triangulation<2>::active_cell_iterator endc = triangulation.end();
-      for (; cell!=endc; ++cell)
+      // While the `auto` keyword can save us from having to type out long names
+      // of data types, we still have to type a lot of redundant declarations
+      // about the start and end iterator and how to increment it. Instead of
+      // doing that, we'll use
+      // <a href="http://en.cppreference.com/w/cpp/language/range-for">range-
+      // based for loops</a>, which wrap up all of the syntax shown above into a
+      // much shorter form:
+      for (auto cell: triangulation.active_cell_iterators())
         {
-          // @note Writing a loop like this requires a lot of typing, but it
-          // is the only way of doing it in C++98 and C++03. However, if you
-          // have a C++11-compliant compiler, you can also use the C++11
-          // range-based for loop style that requires significantly less
-          // typing. Take a look at @ref CPP11 "the deal.II C++11 page" to see
-          // how this works.
+          // @note See @ref Iterators for more information about the iterator
+          // classes used in deal.II, and @ref CPP11 for more information about
+          // range-based for loops and the `auto` keyword.
           //
           // Next, we want to loop over all vertices of the cells. Since we are
           // in 2d, we know that each cell has exactly four vertices. However,

--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -64,8 +64,8 @@ using namespace dealii;
 // @sect3{Mesh generation}
 
 // This is the function that produced the circular grid in the previous step-1
-// example program with fewer refinements steps. The sole difference is that it returns the grid it
-// produces via its argument.
+// example program with fewer refinements steps. The sole difference is that it
+// returns the grid it produces via its argument.
 //
 // The details of what the function does are explained in step-1. The only
 // thing we would like to comment on is this:
@@ -93,10 +93,7 @@ void make_grid (Triangulation<2> &triangulation)
 
   for (unsigned int step=0; step<3; ++step)
     {
-      Triangulation<2>::active_cell_iterator cell = triangulation.begin_active();
-      Triangulation<2>::active_cell_iterator endc = triangulation.end();
-
-      for (; cell!=endc; ++cell)
+      for (auto cell: triangulation.active_cell_iterators())
         for (unsigned int v=0;
              v < GeometryInfo<2>::vertices_per_cell;
              ++v)

--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -359,7 +359,7 @@ void Step3::assemble_system ()
   //
   // The shortcuts, finally, are only defined to make the following loops a
   // bit more readable. You will see them in many places in larger programs,
-  // and `dofs_per_cell' and `n_q_points' are more or less by convention the
+  // and `dofs_per_cell` and `n_q_points` are more or less by convention the
   // standard names for these purposes:
   const unsigned int   dofs_per_cell = fe.dofs_per_cell;
   const unsigned int   n_q_points    = quadrature_formula.size();
@@ -387,18 +387,19 @@ void Step3::assemble_system ()
   // the type, types::global_dof_index, used here):
   std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
 
-  // Now for the loop over all cells. We have seen before how this works, so
-  // the following code should be familiar including the conventional names
-  // for these variables:
-  DoFHandler<2>::active_cell_iterator cell = dof_handler.begin_active();
-  DoFHandler<2>::active_cell_iterator endc = dof_handler.end();
-  for (; cell!=endc; ++cell)
+  // Now for the loop over all cells. We have seen before how this works for a
+  // triangulation. A DoFHandler has cell iterators that are exactly analogous
+  // to those of a Triangulation, but with extra information about the degrees
+  // of freedom for the finite element you're using. Looping over the active
+  // cells of a degree-of-freedom handler works the same as for a triangulation.
+  //
+  // Note that we declare the type of the cell as `const auto &` instead of
+  // `auto` this time around. In step 1, we were modifying the cells of the
+  // triangulation by flagging them with refinement indicators. Here we're only
+  // examining the cells without modifying them, so it's good practice to
+  // declare `cell` as `const` in order to enforce this invariant.
+  for (const auto &cell: dof_handler.active_cell_iterators())
     {
-      // @note As already mentioned in step-1, there is a more convenient way
-      // of writing such loops if your compiler supports the C++11
-      // standard. See @ref CPP11 "the deal.II C++11 page" to see
-      // how this works.
-      //
       // We are now sitting on one cell, and we would like the values and
       // gradients of the shape functions be computed, as well as the
       // determinants of the Jacobian matrices of the mapping between
@@ -496,8 +497,8 @@ void Step3::assemble_system ()
   // boundary by different numbers and tell the interpolate_boundary_values
   // function to only compute the boundary values on a certain part of the
   // boundary (e.g. the clamped part, or the inflow boundary). By default, all
-  // boundaries have the number `0', and since we have not changed that, this
-  // is still so; therefore, if we give `0' as the desired portion of the
+  // boundaries have the number `0`, and since we have not changed that, this
+  // is still so; therefore, if we give `0` as the desired portion of the
   // boundary, this means we get the whole boundary. If you have boundaries
   // with kinds of boundaries, you have to number them differently. The
   // function call below will then only determine boundary values for parts of

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -344,13 +344,9 @@ void Step4<dim>::assemble_system ()
   // dimensions, but a hexahedron in 3D. In fact, the
   // <code>active_cell_iterator</code> data type is something different,
   // depending on the dimension we are in, but to the outside world they look
-  // alike and you will probably never see a difference although the classes
-  // that this typedef stands for are in fact completely unrelated:
-  typename DoFHandler<dim>::active_cell_iterator
-  cell = dof_handler.begin_active(),
-  endc = dof_handler.end();
-
-  for (; cell!=endc; ++cell)
+  // alike and you will probably never see a difference. In any case, the real
+  // type is hidden by using `auto`:
+  for (const auto &cell: dof_handler.active_cell_iterators())
     {
       fe_values.reinit (cell);
       cell_matrix = 0;

--- a/examples/step-5/step-5.cc
+++ b/examples/step-5/step-5.cc
@@ -190,10 +190,7 @@ void Step5<dim>::assemble_system ()
   // change in this part, compared to step-4, is that we will use the
   // <code>coefficient</code> function defined above to compute the
   // coefficient value at each quadrature point.
-  typename DoFHandler<dim>::active_cell_iterator
-  cell = dof_handler.begin_active(),
-  endc = dof_handler.end();
-  for (; cell!=endc; ++cell)
+  for (const auto &cell: dof_handler.active_cell_iterators())
     {
       cell_matrix = 0;
       cell_rhs = 0;


### PR DESCRIPTION
I was showing the deal.II tutorials to a friend of mine today and he commented on how they still use old-style for loops. This patch changes example 1 to use range-based for loops. I'm happy to update other tutorial programs, but I wanted to make the PR first to see what people think.

I've changed the description of iterators a bit to reflect the move to range-based for loops. Obviously there's more to do than just changing the syntax of a few loops; the tutorials go over some pretty fundamental C++ ideas as well. Since the typical range-based for loop also uses `auto` to declare the loop counter, we might also want to include some discussion of that keyword as well. Alternatively, we can explain `auto` in more detail on the C++11 page of the documentation and simply refer people to that from the tutorial.