### PR TITLE
Default constructors and destructors

### DIFF
--- a/include/deal.II/algorithms/operator.h
+++ b/include/deal.II/algorithms/operator.h
@@ -106,7 +106,7 @@ namespace Algorithms
   template <typename VectorType>
   class OutputOperator : public Subscriptor
   {
-    OutputOperator(const OutputOperator<VectorType> &);
+    OutputOperator(const OutputOperator<VectorType> &) = delete;
   public:
     OutputOperator ();
     /**

--- a/include/deal.II/algorithms/operator.h
+++ b/include/deal.II/algorithms/operator.h
@@ -73,7 +73,7 @@ namespace Algorithms
     /**
      * The virtual destructor.
      */
-    ~OperatorBase();
+    virtual ~OperatorBase() = default;
 
     /**
      * The actual operation, which is implemented in a derived class.
@@ -106,13 +106,22 @@ namespace Algorithms
   template <typename VectorType>
   class OutputOperator : public Subscriptor
   {
-    OutputOperator(const OutputOperator<VectorType> &) = delete;
   public:
+    /**
+     * Constructor initializing member variables with invalid data.
+     */
     OutputOperator ();
+
+    /**
+     * The copy constructor is deleted since objects of this class
+     * should not be copied.
+     */
+    OutputOperator(const OutputOperator<VectorType> &) = delete;
+
     /**
      * Empty virtual destructor.
      */
-    virtual ~OutputOperator();
+    virtual ~OutputOperator() = default;
 
     /**
      * Set the stream @p os to which data is written. If no stream is selected

--- a/include/deal.II/algorithms/operator.templates.h
+++ b/include/deal.II/algorithms/operator.templates.h
@@ -26,9 +26,6 @@ DEAL_II_NAMESPACE_OPEN
 namespace Algorithms
 {
   template <typename VectorType>
-  OutputOperator<VectorType>::~OutputOperator() = default;
-
-  template <typename VectorType>
   OutputOperator<VectorType>::OutputOperator()
     :
     step (numbers::invalid_unsigned_int),

--- a/include/deal.II/algorithms/operator.templates.h
+++ b/include/deal.II/algorithms/operator.templates.h
@@ -26,8 +26,7 @@ DEAL_II_NAMESPACE_OPEN
 namespace Algorithms
 {
   template <typename VectorType>
-  OutputOperator<VectorType>::~OutputOperator()
-  {}
+  OutputOperator<VectorType>::~OutputOperator() = default;
 
   template <typename VectorType>
   OutputOperator<VectorType>::OutputOperator()

--- a/include/deal.II/base/auto_derivative_function.h
+++ b/include/deal.II/base/auto_derivative_function.h
@@ -132,7 +132,7 @@ public:
   /**
    * Virtual destructor; absolutely necessary in this case.
    */
-  virtual ~AutoDerivativeFunction ();
+  virtual ~AutoDerivativeFunction () = default;
 
   /**
    * Choose the difference formula. See the enum #DifferenceFormula for

--- a/include/deal.II/base/convergence_table.h
+++ b/include/deal.II/base/convergence_table.h
@@ -65,7 +65,7 @@ public:
   /**
    * Constructor.
    */
-  ConvergenceTable();
+  ConvergenceTable() = default;
 
   /**
    * Rate in relation to the rows.

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2374,7 +2374,7 @@ public:
    * Destructor. Does nothing, but is declared virtual since this class has
    * virtual functions.
    */
-  virtual ~DataOutInterface ();
+  virtual ~DataOutInterface () = default;
 
   /**
    * Obtain data through get_patches() and write it to <tt>out</tt> in OpenDX

--- a/include/deal.II/base/flow_function.h
+++ b/include/deal.II/base/flow_function.h
@@ -56,7 +56,7 @@ namespace Functions
     /**
      * Virtual destructor.
      */
-    virtual ~FlowFunction();
+    virtual ~FlowFunction() = default;
 
     /**
      * Store an adjustment for the pressure function, such that its mean value
@@ -145,7 +145,8 @@ namespace Functions
      */
     PoisseuilleFlow<dim> (const double r,
                           const double Re);
-    virtual ~PoisseuilleFlow();
+
+    virtual ~PoisseuilleFlow() = default;
 
     virtual void vector_values (const std::vector<Point<dim> > &points,
                                 std::vector<std::vector<double> > &values) const;
@@ -187,7 +188,8 @@ namespace Functions
      * Change the viscosity and the reaction parameter.
      */
     void set_parameters (const double viscosity, const double reaction);
-    virtual ~StokesCosine();
+
+    virtual ~StokesCosine() = default;
 
     virtual void vector_values (const std::vector<Point<dim> > &points,
                                 std::vector<std::vector<double> > &values) const;
@@ -276,7 +278,8 @@ namespace Functions
      * Stokes problem.
      */
     Kovasznay (const double Re, bool Stokes = false);
-    virtual ~Kovasznay();
+
+    virtual ~Kovasznay() = default;
 
     virtual void vector_values (const std::vector<Point<2> > &points,
                                 std::vector<std::vector<double> > &values) const;

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -807,7 +807,7 @@ public:
    * This destructor is defined as virtual so as to coincide with all other
    * aspects of class.
    */
-  virtual ~VectorFunctionFromTensorFunction();
+  virtual ~VectorFunctionFromTensorFunction() = default;
 
   /**
    * Return a single component of a vector-valued function at a given point.

--- a/include/deal.II/base/function.templates.h
+++ b/include/deal.II/base/function.templates.h
@@ -45,6 +45,9 @@ Function<dim, Number>::Function (const unsigned int n_components,
 }
 
 
+
+// The destructor is pure virtual so we can't default it
+// in the declaration.
 template <int dim, typename Number>
 Function<dim, Number>::~Function () = default;
 
@@ -678,9 +681,6 @@ VectorFunctionFromTensorFunction<dim, Number>::VectorFunctionFromTensorFunction 
           ExcIndexRange (selected_component, 0, this->n_components));
 }
 
-
-template <int dim, typename Number>
-VectorFunctionFromTensorFunction<dim, Number>::~VectorFunctionFromTensorFunction () = default;
 
 
 template <int dim, typename Number>

--- a/include/deal.II/base/function.templates.h
+++ b/include/deal.II/base/function.templates.h
@@ -46,8 +46,7 @@ Function<dim, Number>::Function (const unsigned int n_components,
 
 
 template <int dim, typename Number>
-Function<dim, Number>::~Function ()
-{}
+Function<dim, Number>::~Function () = default;
 
 
 
@@ -681,8 +680,7 @@ VectorFunctionFromTensorFunction<dim, Number>::VectorFunctionFromTensorFunction 
 
 
 template <int dim, typename Number>
-VectorFunctionFromTensorFunction<dim, Number>::~VectorFunctionFromTensorFunction ()
-{}
+VectorFunctionFromTensorFunction<dim, Number>::~VectorFunctionFromTensorFunction () = default;
 
 
 template <int dim, typename Number>

--- a/include/deal.II/base/function_time.h
+++ b/include/deal.II/base/function_time.h
@@ -81,7 +81,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~FunctionTime();
+  virtual ~FunctionTime() = default;
 
   /**
    * Return the value of the time variable.

--- a/include/deal.II/base/function_time.templates.h
+++ b/include/deal.II/base/function_time.templates.h
@@ -30,11 +30,6 @@ FunctionTime<Number>::FunctionTime(const Number initial_time)
 
 
 template <typename Number>
-FunctionTime<Number>::~FunctionTime() = default;
-
-
-
-template <typename Number>
 void
 FunctionTime<Number>::set_time (const Number new_time)
 {

--- a/include/deal.II/base/function_time.templates.h
+++ b/include/deal.II/base/function_time.templates.h
@@ -30,8 +30,7 @@ FunctionTime<Number>::FunctionTime(const Number initial_time)
 
 
 template <typename Number>
-FunctionTime<Number>::~FunctionTime()
-{}
+FunctionTime<Number>::~FunctionTime() = default;
 
 
 

--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -477,7 +477,7 @@ namespace parallel
      * Destructor. Made virtual to ensure that derived classes also have
      * virtual destructors.
      */
-    virtual ~ParallelForInteger ();
+    virtual ~ParallelForInteger () = default;
 
     /**
      * This function runs the for loop over the given range
@@ -841,11 +841,6 @@ namespace parallel
   }
 
 #endif
-
-
-  inline
-  ParallelForInteger::~ParallelForInteger () = default;
-
 
 
   inline

--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -844,8 +844,8 @@ namespace parallel
 
 
   inline
-  ParallelForInteger::~ParallelForInteger ()
-  {}
+  ParallelForInteger::~ParallelForInteger () = default;
+
 
 
   inline

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -802,12 +802,12 @@ private:
   /**
    * Inhibit automatic CopyConstructor.
    */
-  ParameterHandler (const ParameterHandler &);
+  ParameterHandler (const ParameterHandler &) = delete;
 
   /**
    * Inhibit automatic assignment operator.
    */
-  ParameterHandler &operator= (const ParameterHandler &);
+  ParameterHandler &operator= (const ParameterHandler &) = delete;
 
 public:
   /**

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -863,7 +863,7 @@ public:
    * safer as we have virtual functions.  It actually does nothing
    * spectacular.
    */
-  virtual ~ParameterHandler ();
+  virtual ~ParameterHandler () = default;
 
   /**
    * Parse each line from a stream until the stream returns the <tt>eof</tt>
@@ -1765,7 +1765,7 @@ public:
      * Destructor. It doesn't actually do anything, but is declared to force
      * derived classes to have a virtual destructor.
      */
-    virtual ~UserClass ();
+    virtual ~UserClass () = default;
 
     /**
      * <tt>create_new</tt> must provide a clean object, either by creating a
@@ -1788,7 +1788,7 @@ public:
    * Destructor. Declare this only to have a virtual destructor, which is
    * safer as we have virtual functions. It actually does nothing spectacular.
    */
-  virtual ~MultipleParameterLoop ();
+  virtual ~MultipleParameterLoop () = default;
 
   /**
    * Read input from a stream until the stream returns the <tt>eof</tt>

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -74,7 +74,7 @@ namespace Patterns
     /**
      * Make destructor of this and all derived classes virtual.
      */
-    virtual ~PatternBase ();
+    virtual ~PatternBase () = default;
 
     /**
      * Return <tt>true</tt> if the given string matches the pattern.
@@ -787,7 +787,7 @@ namespace Patterns
      * Constructor. (Allow for at least one non-virtual function in this
      * class, as otherwise sometimes no virtual table is emitted.)
      */
-    Anything ();
+    Anything () = default;
 
     /**
      * Return <tt>true</tt> if the string matches its constraints, i.e.
@@ -919,7 +919,7 @@ namespace Patterns
     /**
      * Constructor.
      */
-    DirectoryName ();
+    DirectoryName () = default;
 
     /**
      * Return <tt>true</tt> if the string matches its constraints, i.e.

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -253,8 +253,7 @@ public:
 // and we can't use 'Point<dim,Number>::Point () = default' here.
 template <int dim, typename Number>
 inline
-Point<dim,Number>::Point ()
-{}
+Point<dim,Number>::Point () = default;
 
 
 

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -253,7 +253,8 @@ public:
 // and we can't use 'Point<dim,Number>::Point () = default' here.
 template <int dim, typename Number>
 inline
-Point<dim,Number>::Point () = default;
+Point<dim,Number>::Point ()
+{}
 
 
 

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -452,7 +452,7 @@ public:
   /**
    * Destructor. Free allocated memory.
    */
-  ~TableBase ();
+  ~TableBase () = default;
 
   /**
    * Assignment operator. Copy all elements of <tt>src</tt> into the matrix.
@@ -1794,12 +1794,6 @@ namespace internal
     }
   }
 }
-
-
-
-template <int N, typename T>
-inline
-TableBase<N,T>::~TableBase () = default;
 
 
 

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -1799,8 +1799,7 @@ namespace internal
 
 template <int N, typename T>
 inline
-TableBase<N,T>::~TableBase ()
-{}
+TableBase<N,T>::~TableBase () = default;
 
 
 

--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -54,7 +54,7 @@ namespace internal
     /**
      * Default constructor.
      */
-    TableEntry ();
+    TableEntry () = default;
 
     /**
      * Constructor. Initialize this table element with the value

--- a/include/deal.II/base/tensor_function.h
+++ b/include/deal.II/base/tensor_function.h
@@ -75,7 +75,7 @@ public:
    * usually not used by their true type, but rather through pointers to this
    * base class.
    */
-  virtual ~TensorFunction ();
+  virtual ~TensorFunction () = default;
 
   /**
    * Return the value of the function at the given point.
@@ -127,7 +127,7 @@ public:
   ConstantTensorFunction (const dealii::Tensor<rank, dim, Number> &value,
                           const Number initial_time = 0.0);
 
-  virtual ~ConstantTensorFunction ();
+  virtual ~ConstantTensorFunction () = default;
 
   virtual typename dealii::TensorFunction<rank, dim, Number>::value_type value (const Point<dim> &p) const;
 

--- a/include/deal.II/base/tensor_function.templates.h
+++ b/include/deal.II/base/tensor_function.templates.h
@@ -34,8 +34,7 @@ TensorFunction<rank, dim, Number>::TensorFunction (const Number initial_time)
 
 
 template <int rank, int dim, typename Number>
-TensorFunction<rank, dim, Number>::~TensorFunction ()
-{}
+TensorFunction<rank, dim, Number>::~TensorFunction () = default;
 
 
 template <int rank, int dim, typename Number>
@@ -96,8 +95,7 @@ ConstantTensorFunction<rank, dim, Number>::ConstantTensorFunction (
 
 
 template <int rank, int dim, typename Number>
-ConstantTensorFunction<rank, dim, Number>::~ConstantTensorFunction ()
-{}
+ConstantTensorFunction<rank, dim, Number>::~ConstantTensorFunction () = default;
 
 
 template <int rank, int dim, typename Number>

--- a/include/deal.II/base/tensor_function.templates.h
+++ b/include/deal.II/base/tensor_function.templates.h
@@ -33,9 +33,6 @@ TensorFunction<rank, dim, Number>::TensorFunction (const Number initial_time)
 {}
 
 
-template <int rank, int dim, typename Number>
-TensorFunction<rank, dim, Number>::~TensorFunction () = default;
-
 
 template <int rank, int dim, typename Number>
 typename TensorFunction<rank, dim, Number>::value_type
@@ -93,9 +90,6 @@ ConstantTensorFunction<rank, dim, Number>::ConstantTensorFunction (
   _value(value)
 {}
 
-
-template <int rank, int dim, typename Number>
-ConstantTensorFunction<rank, dim, Number>::~ConstantTensorFunction () = default;
 
 
 template <int rank, int dim, typename Number>

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -74,7 +74,7 @@ namespace Threads
      * Default constructor. Initialize each thread local object using its
      * default constructor.
      */
-    ThreadLocalStorage ();
+    ThreadLocalStorage () = default;
 
     /**
      * A kind of copy constructor. Initialize each thread local object by
@@ -178,11 +178,6 @@ namespace Threads
   };
 
 // ----------------- inline and template functions ----------------------------
-
-  template <typename T>
-  inline
-  ThreadLocalStorage<T>::ThreadLocalStorage() = default;
-
 
   template <typename T>
   inline

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -181,8 +181,7 @@ namespace Threads
 
   template <typename T>
   inline
-  ThreadLocalStorage<T>::ThreadLocalStorage()
-  {}
+  ThreadLocalStorage<T>::ThreadLocalStorage() = default;
 
 
   template <typename T>

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -104,7 +104,7 @@ namespace Threads
        * Destructor. Unlock the mutex. Since this is a dummy mutex class, this
        * of course does nothing.
        */
-      ~ScopedLock () {}
+      ~ScopedLock () = default;
     };
 
     /**
@@ -719,7 +719,9 @@ namespace Threads
     private:
       RT *value;
     public:
-      inline return_value () : value(nullptr) {}
+      inline return_value ()
+        : value(nullptr)
+      {}
 
       inline RT &get () const
       {

--- a/include/deal.II/base/time_stepping.h
+++ b/include/deal.II/base/time_stepping.h
@@ -83,7 +83,7 @@ namespace TimeStepping
     /**
      * Virtual destructor.
      */
-    virtual ~TimeStepping() {}
+    virtual ~TimeStepping() = default;
 
     /**
      * Purely virtual function. This function is used to advance from time @p
@@ -128,7 +128,7 @@ namespace TimeStepping
     /**
      * Virtual destructor.
      */
-    virtual ~RungeKutta() {}
+    virtual ~RungeKutta() = default;
 
     /**
      * Purely virtual method used to initialize the Runge-Kutta method.
@@ -210,7 +210,7 @@ namespace TimeStepping
      * you will want to call <code>initialize(runge_kutta_method)</code>
      * before it can be used.
      */
-    ExplicitRungeKutta() {}
+    ExplicitRungeKutta() = default;
 
     /**
      * Constructor. This function calls initialize(runge_kutta_method).
@@ -305,7 +305,7 @@ namespace TimeStepping
      * set_newton_solver_parameters(unsigned int,double) need to be called
      * before the object can be used.
      */
-    ImplicitRungeKutta() {}
+    ImplicitRungeKutta() = default;
 
     /**
      * Constructor. This function calls initialize(runge_kutta_method) and
@@ -439,7 +439,7 @@ namespace TimeStepping
      * set_time_adaptation_parameters(double, double, double, double, double,
      * double) need to be called before the object can be used.
      */
-    EmbeddedExplicitRungeKutta() {}
+    EmbeddedExplicitRungeKutta() = default;
 
     /**
      * Constructor. This function calls initialize(runge_kutta_method) and

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -207,7 +207,7 @@ namespace parallel
       /**
        * Destructor.
        */
-      virtual ~Triangulation ();
+      virtual ~Triangulation () = default;
 
       /**
        * Coarsen and refine the mesh according to refinement and coarsening

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -131,7 +131,7 @@ namespace parallel
       /**
        * Destructor.
        */
-      ~SolutionTransfer();
+      ~SolutionTransfer() = default;
 
       /**
        * Prepares the @p SolutionTransfer for coarsening and refinement. It

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -683,7 +683,7 @@ public:
     /**
      * Destructor. Made virtual to allow polymorphism.
      */
-    virtual ~InternalDataBase ();
+    virtual ~InternalDataBase () = default;
 
     /**
      * A set of update flags specifying the kind of information that an

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -671,7 +671,7 @@ public:
     /**
      * Copy construction is forbidden.
      */
-    InternalDataBase (const InternalDataBase &);
+    InternalDataBase (const InternalDataBase &) = delete;
 
   public:
     /**

--- a/include/deal.II/fe/fe_p1nc.h
+++ b/include/deal.II/fe/fe_p1nc.h
@@ -272,7 +272,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~FE_P1NC ();
+  virtual ~FE_P1NC () = default;
 
 
 

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -96,7 +96,7 @@ namespace FETools
     /**
      * Virtual destructor doing nothing but making the compiler happy.
      */
-    virtual ~FEFactoryBase();
+    virtual ~FEFactoryBase() = default;
   };
 
   /**

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1319,8 +1319,7 @@ namespace
 namespace FETools
 {
   template <int dim, int spacedim>
-  FEFactoryBase<dim,spacedim>::~FEFactoryBase()
-  {}
+  FEFactoryBase<dim,spacedim>::~FEFactoryBase() = default;
 
 
 

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1319,11 +1319,6 @@ namespace
 namespace FETools
 {
   template <int dim, int spacedim>
-  FEFactoryBase<dim,spacedim>::~FEFactoryBase() = default;
-
-
-
-  template <int dim, int spacedim>
   void compute_component_wise(
     const FiniteElement<dim,spacedim> &element,
     std::vector<unsigned int> &renumbering,

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -291,7 +291,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~Mapping ();
+  virtual ~Mapping () = default;
 
   /**
    * Return a pointer to a copy of the present object. The caller of this copy
@@ -525,12 +525,6 @@ public:
    */
   class InternalDataBase
   {
-  private:
-    /**
-     * Copy construction is forbidden.
-     */
-    InternalDataBase (const InternalDataBase &) = delete;
-
   public:
     /**
      * Constructor. Sets update_flags to @p update_default and @p first_cell
@@ -539,9 +533,14 @@ public:
     InternalDataBase ();
 
     /**
+     * Copy construction is forbidden.
+     */
+    InternalDataBase (const InternalDataBase &) = delete;
+
+    /**
      * Virtual destructor for derived classes
      */
-    virtual ~InternalDataBase ();
+    virtual ~InternalDataBase () = default;
 
     /**
      * A set of update flags specifying the kind of information that an

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -529,7 +529,7 @@ public:
     /**
      * Copy construction is forbidden.
      */
-    InternalDataBase (const InternalDataBase &);
+    InternalDataBase (const InternalDataBase &) = delete;
 
   public:
     /**

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -63,7 +63,7 @@ public:
   /**
    * Constructor.
    */
-  MappingManifold ();
+  MappingManifold () = default;
 
   /**
    * Copy constructor.
@@ -174,7 +174,7 @@ public:
     /**
      * Constructor.
      */
-    InternalData();
+    InternalData() = default;
 
     /**
      * Initialize the object's member variables related to cell data based on

--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -691,7 +691,7 @@ private:
      * Mark the destructor virtual to allow destruction through pointers to
      * the base class.
      */
-    virtual ~PredicateBase () {}
+    virtual ~PredicateBase () = default;
 
     /**
      * Abstract function which in derived classes denotes the evaluation of

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -345,7 +345,7 @@ public:
    * Destructor. Does nothing here, but needs to be declared virtual to make
    * class hierarchies derived from this class possible.
    */
-  virtual ~Manifold ();
+  virtual ~Manifold () = default;
 
   /**
    * @name Computing the location of points.
@@ -930,7 +930,7 @@ public:
    * Destructor. Does nothing here, but needs to be declared to make it
    * virtual.
    */
-  virtual ~ChartManifold ();
+  virtual ~ChartManifold () = default;
 
   /**
    * Refer to the general documentation of this class and the documentation of

--- a/include/deal.II/grid/persistent_tria.h
+++ b/include/deal.II/grid/persistent_tria.h
@@ -133,7 +133,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~PersistentTriangulation ();
+  virtual ~PersistentTriangulation () = default;
 
   /**
    * Overloaded version of the same function in the base class which stores

--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -241,7 +241,7 @@ public:
   /**
    * Default constructor. Some compilers require this for some reasons.
    */
-  StraightBoundary () = default;
+  StraightBoundary ();
 
   /**
    * Let the new point be the arithmetic mean of the two vertices of the line.

--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -86,7 +86,7 @@ public:
    * Destructor. Does nothing here, but needs to be declared to make it
    * virtual.
    */
-  virtual ~Boundary ();
+  virtual ~Boundary () = default;
 
 
   /**
@@ -241,7 +241,7 @@ public:
   /**
    * Default constructor. Some compilers require this for some reasons.
    */
-  StraightBoundary ();
+  StraightBoundary () = default;
 
   /**
    * Let the new point be the arithmetic mean of the two vertices of the line.

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -58,7 +58,7 @@ namespace hp
      * Default constructor. Leads to an empty collection that can later be
      * filled using push_back().
      */
-    FECollection ();
+    FECollection () = default;
 
     /**
      * Conversion constructor. This constructor creates a FECollection from a

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -58,7 +58,7 @@ namespace hp
      * Default constructor. Leads to an empty collection that can later be
      * filled using push_back().
      */
-    MappingCollection ();
+    MappingCollection () = default;
 
     /**
      * Conversion constructor. This constructor creates a MappingCollection

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -382,7 +382,7 @@ public:
    * useful if you want such objects as member variables in other classes. You
    * can make the structure usable by calling the reinit() function.
    */
-  BlockSparsityPattern ();
+  BlockSparsityPattern () = default;
 
   /**
    * Initialize the matrix with the given number of block rows and columns.
@@ -488,7 +488,7 @@ public:
    * useful if you want such objects as member variables in other classes. You
    * can make the structure usable by calling the reinit() function.
    */
-  BlockDynamicSparsityPattern ();
+  BlockDynamicSparsityPattern () = default;
 
   /**
    * Initialize the matrix with the given number of block rows and columns.
@@ -604,7 +604,7 @@ namespace TrilinosWrappers
      * useful if you want such objects as member variables in other classes.
      * You can make the structure usable by calling the reinit() function.
      */
-    BlockSparsityPattern ();
+    BlockSparsityPattern () = default;
 
     /**
      * Initialize the matrix with the given number of block rows and columns.

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -167,7 +167,7 @@ public:
   /**
    * Destructor. Clears memory
    */
-  ~BlockVector ();
+  ~BlockVector () = default;
 
   /**
    * Call the compress() function on all the subblocks.

--- a/include/deal.II/lac/block_vector.templates.h
+++ b/include/deal.II/lac/block_vector.templates.h
@@ -140,9 +140,10 @@ void BlockVector<Number>::reinit (const BlockVector<Number2> &v,
 }
 
 
+
 template <typename Number>
-BlockVector<Number>::~BlockVector ()
-{}
+BlockVector<Number>::~BlockVector () = default;
+
 
 
 #ifdef DEAL_II_WITH_TRILINOS

--- a/include/deal.II/lac/block_vector.templates.h
+++ b/include/deal.II/lac/block_vector.templates.h
@@ -141,11 +141,6 @@ void BlockVector<Number>::reinit (const BlockVector<Number2> &v,
 
 
 
-template <typename Number>
-BlockVector<Number>::~BlockVector () = default;
-
-
-
 #ifdef DEAL_II_WITH_TRILINOS
 template <typename Number>
 inline

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -334,7 +334,7 @@ public:
   /**
    * Destructor.
    */
-  ~ChunkSparsityPattern ();
+  ~ChunkSparsityPattern () = default;
 
   /**
    * Copy operator. For this the same holds as for the copy constructor: it is

--- a/include/deal.II/lac/communication_pattern_base.h
+++ b/include/deal.II/lac/communication_pattern_base.h
@@ -41,7 +41,7 @@ namespace LinearAlgebra
     /**
      * Destructor.
      */
-    virtual ~CommunicationPatternBase() {};
+    virtual ~CommunicationPatternBase() = default;
 
     /**
      * Reinitialize the communication pattern. The first argument @p

--- a/include/deal.II/lac/householder.h
+++ b/include/deal.II/lac/householder.h
@@ -126,8 +126,7 @@ private:
 // QR-transformation cf. Stoer 1 4.8.2 (p. 191)
 
 template <typename number>
-Householder<number>::Householder()
-{}
+Householder<number>::Householder() = default;
 
 
 

--- a/include/deal.II/lac/householder.h
+++ b/include/deal.II/lac/householder.h
@@ -64,7 +64,7 @@ public:
   /**
    * Create an empty object.
    */
-  Householder ();
+  Householder () = default;
 
   /**
    * Create an object holding the QR-decomposition of a matrix.
@@ -124,11 +124,6 @@ private:
 /*-------------------------Inline functions -------------------------------*/
 
 // QR-transformation cf. Stoer 1 4.8.2 (p. 191)
-
-template <typename number>
-Householder<number>::Householder() = default;
-
-
 
 template <typename number>
 template <typename number2>

--- a/include/deal.II/lac/matrix_out.h
+++ b/include/deal.II/lac/matrix_out.h
@@ -114,7 +114,7 @@ public:
   /**
    * Destructor. Declared in order to make it virtual.
    */
-  virtual ~MatrixOut ();
+  virtual ~MatrixOut () = default;
 
   /**
    * Generate a list of patches from the given matrix and use the given string

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -941,11 +941,11 @@ namespace PETScWrappers
     /**
      * purposefully not implemented
      */
-    MatrixBase(const MatrixBase &);
+    MatrixBase(const MatrixBase &) = delete;
     /**
      * purposefully not implemented
      */
-    MatrixBase &operator=(const MatrixBase &);
+    MatrixBase &operator=(const MatrixBase &) = delete;
 
     /**
      * An internal array of integer values that is used to store the column

--- a/include/deal.II/lac/petsc_parallel_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_parallel_block_sparse_matrix.h
@@ -101,12 +101,12 @@ namespace PETScWrappers
        * reinit(BlockSparsityPattern). The number of blocks per row and column
        * are then determined by that function.
        */
-      BlockSparseMatrix ();
+      BlockSparseMatrix () = default;
 
       /**
        * Destructor.
        */
-      ~BlockSparseMatrix ();
+      ~BlockSparseMatrix () = default;
 
       /**
        * Pseudo copy operator only copying empty objects. The sizes of the

--- a/include/deal.II/lac/petsc_parallel_block_vector.h
+++ b/include/deal.II/lac/petsc_parallel_block_vector.h
@@ -136,7 +136,7 @@ namespace PETScWrappers
       /**
        * Destructor. Clears memory
        */
-      ~BlockVector ();
+      ~BlockVector () = default;
 
       /**
        * Copy operator: fill all components of the vector that are locally
@@ -356,8 +356,6 @@ namespace PETScWrappers
       return *this;
     }
 
-    inline
-    BlockVector::~BlockVector () = default;
 
 
     inline

--- a/include/deal.II/lac/petsc_parallel_block_vector.h
+++ b/include/deal.II/lac/petsc_parallel_block_vector.h
@@ -357,8 +357,7 @@ namespace PETScWrappers
     }
 
     inline
-    BlockVector::~BlockVector ()
-    {}
+    BlockVector::~BlockVector () = default;
 
 
     inline

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -141,7 +141,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionJacobi ();
+    PreconditionJacobi () = default;
 
 
     /**
@@ -215,7 +215,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionBlockJacobi ();
+    PreconditionBlockJacobi () = default;
 
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,
@@ -291,7 +291,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionSOR ();
+    PreconditionSOR () = default;
 
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,
@@ -351,7 +351,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionSSOR ();
+    PreconditionSSOR () = default;
 
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,
@@ -414,7 +414,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionEisenstat ();
+    PreconditionEisenstat () = default;
 
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,
@@ -474,7 +474,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionICC ();
+    PreconditionICC () = default;
 
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,
@@ -534,7 +534,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionILU ();
+    PreconditionILU () = default;
 
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,
@@ -612,7 +612,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionLU ();
+    PreconditionLU () = default;
 
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,
@@ -718,7 +718,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionBoomerAMG ();
+    PreconditionBoomerAMG () = default;
 
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,
@@ -859,7 +859,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionParaSails ();
+    PreconditionParaSails () = default;
 
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,
@@ -906,7 +906,7 @@ namespace PETScWrappers
      * Empty Constructor. You need to call initialize() before using this
      * object.
      */
-    PreconditionNone ();
+    PreconditionNone () = default;
 
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -122,7 +122,7 @@ namespace PETScWrappers
     /**
      * Destructor.
      */
-    virtual ~SolverBase ();
+    virtual ~SolverBase () = default;
 
     /**
      * Solve the linear system <tt>Ax=b</tt>. Depending on the information

--- a/include/deal.II/lac/petsc_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_sparse_matrix.h
@@ -214,11 +214,11 @@ namespace PETScWrappers
     /**
      * Purposefully not implemented
      */
-    SparseMatrix(const SparseMatrix &);
+    SparseMatrix(const SparseMatrix &) = delete;
     /**
      * Purposefully not implemented
      */
-    SparseMatrix &operator= (const SparseMatrix &);
+    SparseMatrix &operator= (const SparseMatrix &) = delete;
 
     /**
      * Do the actual work for the respective reinit() function and the

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -761,7 +761,7 @@ namespace PETScWrappers
      * deliberately left as private (and undefined) to prevent accidental
      * usage.
      */
-    VectorBase &operator=(const VectorBase &);
+    VectorBase &operator=(const VectorBase &) = delete;
   };
 
 

--- a/include/deal.II/lac/pointer_matrix.h
+++ b/include/deal.II/lac/pointer_matrix.h
@@ -583,8 +583,7 @@ new_pointer_matrix_base(const TridiagonalMatrix<numberm> &matrix, const Vector<n
 
 template <typename VectorType>
 inline
-PointerMatrixBase<VectorType>::~PointerMatrixBase ()
-{}
+PointerMatrixBase<VectorType>::~PointerMatrixBase () = default;
 
 
 

--- a/include/deal.II/lac/pointer_matrix.h
+++ b/include/deal.II/lac/pointer_matrix.h
@@ -68,7 +68,7 @@ public:
    * of any derived class is called whenever a pointer-to-base-class object is
    * destroyed.
    */
-  virtual ~PointerMatrixBase ();
+  virtual ~PointerMatrixBase () = default;
 
   /**
    * Reset the object to its original state.
@@ -580,14 +580,6 @@ new_pointer_matrix_base(const TridiagonalMatrix<numberm> &matrix, const Vector<n
 
 /*@}*/
 //---------------------------------------------------------------------------
-
-template <typename VectorType>
-inline
-PointerMatrixBase<VectorType>::~PointerMatrixBase () = default;
-
-
-
-//----------------------------------------------------------------------//
 
 
 template <typename MatrixType, typename VectorType>

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -87,7 +87,7 @@ public:
     /**
      * Constructor.
      */
-    AdditionalData () {}
+    AdditionalData () = default;
   };
 
   /**
@@ -1805,7 +1805,7 @@ namespace internal
                           internal::Vector::minimum_parallel_grain_size);
       }
 
-      ~VectorUpdatesRange() {}
+      ~VectorUpdatesRange() = default;
 
       virtual void
       apply_to_subrange (const std::size_t begin,

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -155,7 +155,7 @@ public:
   /**
    * Destructor.
    */
-  ~PreconditionBlock();
+  ~PreconditionBlock() = default;
 
   /**
    * Initialize matrix and block size.  We store the matrix and the block size

--- a/include/deal.II/lac/precondition_block.templates.h
+++ b/include/deal.II/lac/precondition_block.templates.h
@@ -55,9 +55,6 @@ PreconditionBlock<MatrixType,inverse_type>::PreconditionBlock (bool store)
 {}
 
 
-template <typename MatrixType, typename inverse_type>
-PreconditionBlock<MatrixType,inverse_type>::~PreconditionBlock () = default;
-
 
 template <typename MatrixType, typename inverse_type>
 void PreconditionBlock<MatrixType,inverse_type>::clear ()

--- a/include/deal.II/lac/precondition_block.templates.h
+++ b/include/deal.II/lac/precondition_block.templates.h
@@ -46,8 +46,7 @@ AdditionalData (const size_type block_size,
 
 
 template <typename number>
-PreconditionBlockBase<number>::~PreconditionBlockBase ()
-{}
+PreconditionBlockBase<number>::~PreconditionBlockBase () = default;
 
 
 template <typename MatrixType, typename inverse_type>
@@ -60,8 +59,7 @@ PreconditionBlock<MatrixType,inverse_type>::PreconditionBlock (bool store)
 
 
 template <typename MatrixType, typename inverse_type>
-PreconditionBlock<MatrixType,inverse_type>::~PreconditionBlock ()
-{}
+PreconditionBlock<MatrixType,inverse_type>::~PreconditionBlock () = default;
 
 
 template <typename MatrixType, typename inverse_type>

--- a/include/deal.II/lac/precondition_block.templates.h
+++ b/include/deal.II/lac/precondition_block.templates.h
@@ -45,9 +45,6 @@ AdditionalData (const size_type block_size,
 {}
 
 
-template <typename number>
-PreconditionBlockBase<number>::~PreconditionBlockBase () = default;
-
 
 template <typename MatrixType, typename inverse_type>
 PreconditionBlock<MatrixType,inverse_type>::PreconditionBlock (bool store)

--- a/include/deal.II/lac/precondition_block_base.h
+++ b/include/deal.II/lac/precondition_block_base.h
@@ -89,7 +89,7 @@ public:
   /**
    * The virtual destructor
    */
-  ~PreconditionBlockBase();
+  ~PreconditionBlockBase() = default;
 
   /**
    * Deletes the inverse diagonal block matrices if existent hence leaves the

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -249,8 +249,7 @@ SolverCG<VectorType>::SolverCG (SolverControl        &cn,
 
 
 template <typename VectorType>
-SolverCG<VectorType>::~SolverCG ()
-{}
+SolverCG<VectorType>::~SolverCG () = default;
 
 
 

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -120,7 +120,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~SolverCG ();
+  virtual ~SolverCG () = default;
 
   /**
    * Solve the linear system $Ax=b$ for x.
@@ -245,11 +245,6 @@ SolverCG<VectorType>::SolverCG (SolverControl        &cn,
   Solver<VectorType>(cn),
   additional_data(data)
 {}
-
-
-
-template <typename VectorType>
-SolverCG<VectorType>::~SolverCG () = default;
 
 
 

--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -99,7 +99,7 @@ public:
       : last_step (last_step), last_residual(last_residual)
     {}
 
-    virtual ~NoConvergence () noexcept {}
+    virtual ~NoConvergence () noexcept = default;
 
     virtual void print_info (std::ostream &out) const
     {

--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -155,7 +155,7 @@ public:
    * Virtual destructor is needed as there are virtual functions in this
    * class.
    */
-  virtual ~SolverControl();
+  virtual ~SolverControl() = default;
 
   /**
    * Interface to parameter file.
@@ -429,7 +429,7 @@ public:
    * Virtual destructor is needed as there are virtual functions in this
    * class.
    */
-  virtual ~ReductionControl();
+  virtual ~ReductionControl() = default;
 
   /**
    * Interface to parameter file.
@@ -513,7 +513,7 @@ public:
    * Virtual destructor is needed as there are virtual functions in this
    * class.
    */
-  virtual ~IterationNumberControl();
+  virtual ~IterationNumberControl() = default;
 
   /**
    * Decide about success or failure of an iteration. This function bases
@@ -569,7 +569,7 @@ public:
    * Virtual destructor is needed as there are virtual functions in this
    * class.
    */
-  virtual ~ConsecutiveControl();
+  virtual ~ConsecutiveControl() = default;
 
   /**
    * Decide about success or failure of an iteration, see the class description

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -102,7 +102,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~SolverRichardson ();
+  virtual ~SolverRichardson () = default;
 
   /**
    * Solve the linear system $Ax=b$ for x.
@@ -190,10 +190,6 @@ SolverRichardson<VectorType>::SolverRichardson(SolverControl        &cn,
   additional_data(data)
 {}
 
-
-
-template <class VectorType>
-SolverRichardson<VectorType>::~SolverRichardson() = default;
 
 
 template <class VectorType>

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -193,8 +193,7 @@ SolverRichardson<VectorType>::SolverRichardson(SolverControl        &cn,
 
 
 template <class VectorType>
-SolverRichardson<VectorType>::~SolverRichardson()
-{}
+SolverRichardson<VectorType>::~SolverRichardson() = default;
 
 
 template <class VectorType>

--- a/include/deal.II/lac/sparse_ilu.h
+++ b/include/deal.II/lac/sparse_ilu.h
@@ -71,7 +71,7 @@ public:
    * Call the @p initialize function before using this object as
    * preconditioner.
    */
-  SparseILU ();
+  SparseILU () = default;
 
   /**
    * Make SparseLUDecomposition::AdditionalData accessible to this class as

--- a/include/deal.II/lac/sparse_ilu.templates.h
+++ b/include/deal.II/lac/sparse_ilu.templates.h
@@ -28,10 +28,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <typename number>
-SparseILU<number>::SparseILU () = default;
-
-
 
 template <typename number>
 template <typename somenumber>

--- a/include/deal.II/lac/sparse_ilu.templates.h
+++ b/include/deal.II/lac/sparse_ilu.templates.h
@@ -29,8 +29,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <typename number>
-SparseILU<number>::SparseILU ()
-{}
+SparseILU<number>::SparseILU () = default;
 
 
 

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -327,7 +327,7 @@ public:
    * Destructor. Free all memory, but do not release the memory of the
    * sparsity structure.
    */
-  ~SparseMatrixEZ ();
+  ~SparseMatrixEZ () = default;
 
   /**
    * Pseudo operator only copying empty objects.

--- a/include/deal.II/lac/sparse_matrix_ez.templates.h
+++ b/include/deal.II/lac/sparse_matrix_ez.templates.h
@@ -63,9 +63,6 @@ SparseMatrixEZ<number>::SparseMatrixEZ(const size_type    n_rows,
 }
 
 
-template <typename number>
-SparseMatrixEZ<number>::~SparseMatrixEZ() = default;
-
 
 template <typename number>
 SparseMatrixEZ<number> &

--- a/include/deal.II/lac/sparse_matrix_ez.templates.h
+++ b/include/deal.II/lac/sparse_matrix_ez.templates.h
@@ -64,8 +64,7 @@ SparseMatrixEZ<number>::SparseMatrixEZ(const size_type    n_rows,
 
 
 template <typename number>
-SparseMatrixEZ<number>::~SparseMatrixEZ()
-{}
+SparseMatrixEZ<number>::~SparseMatrixEZ() = default;
 
 
 template <typename number>

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -206,8 +206,7 @@ private:
 template <int dim, typename Number, int size>
 inline
 TensorProductMatrixSymmetricSum<dim,Number,size>
-::TensorProductMatrixSymmetricSum()
-{}
+::TensorProductMatrixSymmetricSum() = default;
 
 
 

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -103,7 +103,7 @@ public:
   /**
    * Constructor.
    */
-  TensorProductMatrixSymmetricSum();
+  TensorProductMatrixSymmetricSum() = default;
 
   /**
    * Constructor that is equivalent to the previous constructor and
@@ -201,13 +201,6 @@ private:
 /*----------------------- Inline functions ----------------------------------*/
 
 #ifndef DOXYGEN
-
-
-template <int dim, typename Number, int size>
-inline
-TensorProductMatrixSymmetricSum<dim,Number,size>
-::TensorProductMatrixSymmetricSum() = default;
-
 
 
 template <int dim, typename Number, int size>

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -104,7 +104,7 @@ namespace TrilinosWrappers
      * reinit(BlockSparsityPattern). The number of blocks per row and column
      * are then determined by that function.
      */
-    BlockSparseMatrix ();
+    BlockSparseMatrix () = default;
 
     /**
      * Destructor.
@@ -116,7 +116,7 @@ namespace TrilinosWrappers
      * matrices need to be the same.
      */
     BlockSparseMatrix &
-    operator = (const BlockSparseMatrix &);
+    operator = (const BlockSparseMatrix &) = default;
 
     /**
      * This operator assigns a scalar to a matrix. Since this does usually not

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -138,7 +138,7 @@ namespace TrilinosWrappers
       /**
        * Destructor. Clears memory
        */
-      ~BlockVector ();
+      ~BlockVector () = default;
 
       /**
        * Copy operator: fill all components of the vector that are locally

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -106,7 +106,7 @@ namespace TrilinosWrappers
     /**
      * Destructor.
      */
-    ~PreconditionBase ();
+    ~PreconditionBase () = default;
 
     /**
      * Destroys the preconditioner, leaving an object like just after having

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -146,7 +146,7 @@ namespace TrilinosWrappers
     /**
      * Destructor.
      */
-    virtual ~SolverBase ();
+    virtual ~SolverBase () = default;
 
     /**
      * Solve the linear system <tt>Ax=b</tt>. Depending on the information
@@ -628,7 +628,7 @@ namespace TrilinosWrappers
     /**
      * Destructor.
      */
-    virtual ~SolverDirect ();
+    virtual ~SolverDirect () = default;
 
     /**
      * Initializes the direct solver for the matrix <tt>A</tt> and creates a

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -570,7 +570,7 @@ namespace TrilinosWrappers
     /**
      * Destructor. Made virtual so that one can use pointers to this class.
      */
-    virtual ~SparseMatrix ();
+    virtual ~SparseMatrix () = default;
 
     /**
      * This function initializes the Trilinos matrix with a deal.II sparsity
@@ -2187,7 +2187,7 @@ namespace TrilinosWrappers
         /**
          * Destructor
          */
-        virtual ~TrilinosPayload();
+        virtual ~TrilinosPayload() = default;
 
         /**
          * Returns a payload configured for identity operations

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -1228,10 +1228,7 @@ namespace TrilinosWrappers
 
 
     inline
-    Iterator::Iterator(const Iterator &i)
-      :
-      accessor(i.accessor)
-    {}
+    Iterator::Iterator(const Iterator &i) = default;
 
 
 

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -325,7 +325,7 @@ namespace TrilinosWrappers
     /**
      * Destructor. Made virtual so that one can use pointers to this class.
      */
-    virtual ~SparsityPattern ();
+    virtual ~SparsityPattern () = default;
 
     /**
      * Initialize a sparsity pattern that is completely stored locally, having

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -507,7 +507,7 @@ namespace TrilinosWrappers
       /**
        * Destructor.
        */
-      ~Vector ();
+      ~Vector () = default;
 
       /**
        * Release all memory and return to a state just like after having called

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -230,20 +230,9 @@ namespace LinearAlgebra
      * Destructor. Declared as virtual so that inheriting classes (which may
      * manage their own memory) are destroyed correctly.
      */
-    virtual ~VectorSpaceVector();
+    virtual ~VectorSpaceVector() = default;
   };
   /*@}*/
-
-
-
-#ifndef DOXYGEN
-  // TODO we can get rid of this when we require C++11 by using '=default'
-  // above
-  template <typename Number>
-  inline
-  VectorSpaceVector<Number>::~VectorSpaceVector()
-  {}
-#endif // DOXYGEN
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -66,7 +66,7 @@ namespace internal
       /**
        * Copy constructor.
        */
-      DoFInfo (const DoFInfo &dof_info);
+      DoFInfo (const DoFInfo &dof_info) = default;
 
       /**
        * Clear all data fields in this class.

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -131,10 +131,6 @@ namespace internal
 
 
 
-    DoFInfo::DoFInfo (const DoFInfo &dof_info_in) = default;
-
-
-
     void
     DoFInfo::clear ()
     {

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -130,25 +130,8 @@ namespace internal
     }
 
 
-    DoFInfo::DoFInfo (const DoFInfo &dof_info_in)
-      :
-      row_starts (dof_info_in.row_starts),
-      dof_indices (dof_info_in.dof_indices),
-      constraint_indicator (dof_info_in.constraint_indicator),
-      vector_partitioner (dof_info_in.vector_partitioner),
-      constrained_dofs (dof_info_in.constrained_dofs),
-      row_starts_plain_indices (dof_info_in.row_starts_plain_indices),
-      plain_dof_indices (dof_info_in.plain_dof_indices),
-      dimension (dof_info_in.dimension),
-      n_components (dof_info_in.n_components),
-      dofs_per_cell (dof_info_in.dofs_per_cell),
-      dofs_per_face (dof_info_in.dofs_per_face),
-      store_plain_indices (dof_info_in.store_plain_indices),
-      cell_active_fe_index (dof_info_in.cell_active_fe_index),
-      max_fe_index (dof_info_in.max_fe_index),
-      fe_index_conversion (dof_info_in.fe_index_conversion),
-      ghost_dofs (dof_info_in.ghost_dofs)
-    {}
+
+    DoFInfo::DoFInfo (const DoFInfo &dof_info_in) = default;
 
 
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -295,7 +295,7 @@ public:
   /**
    * Destructor.
    */
-  ~MatrixFree();
+  ~MatrixFree() = default;
 
   /**
    * Extracts the information needed to perform loops over cells. The

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -59,11 +59,6 @@ MatrixFree<dim, Number>::MatrixFree(const MatrixFree<dim,Number> &other)
 
 
 template <int dim, typename Number>
-MatrixFree<dim,Number>::~MatrixFree() = default;
-
-
-
-template <int dim, typename Number>
 void MatrixFree<dim,Number>::
 copy_from (const MatrixFree<dim,Number> &v)
 {

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -59,8 +59,7 @@ MatrixFree<dim, Number>::MatrixFree(const MatrixFree<dim,Number> &other)
 
 
 template <int dim, typename Number>
-MatrixFree<dim,Number>::~MatrixFree()
-{}
+MatrixFree<dim,Number>::~MatrixFree() = default;
 
 
 

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -182,7 +182,7 @@ namespace MatrixFreeOperators
     /**
      * Virtual destructor.
      */
-    virtual ~Base();
+    virtual ~Base() = default;
 
     /**
      * Release all memory and return to a state just like after having called
@@ -882,11 +882,6 @@ namespace MatrixFreeOperators
   }
 
   //----------------- Base operator -----------------------------
-  template <int dim, typename VectorType>
-  Base<dim,VectorType>::~Base () = default;
-
-
-
   template <int dim, typename VectorType>
   Base<dim,VectorType>::Base ()
     :

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -883,9 +883,7 @@ namespace MatrixFreeOperators
 
   //----------------- Base operator -----------------------------
   template <int dim, typename VectorType>
-  Base<dim,VectorType>::~Base ()
-  {
-  }
+  Base<dim,VectorType>::~Base () = default;
 
 
 

--- a/include/deal.II/meshworker/local_integrator.h
+++ b/include/deal.II/meshworker/local_integrator.h
@@ -66,7 +66,7 @@ namespace MeshWorker
     /**
      * The empty virtual destructor.
      */
-    ~LocalIntegrator();
+    virtual ~LocalIntegrator() = default;
 
     /**
      * Virtual function for integrating on cells. Throws exception

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -180,7 +180,7 @@ namespace MeshWorker
     /**
      * Constructor
      */
-    VectorDataBase();
+    VectorDataBase() = default;
 
     /**
      * Constructor from a base class object
@@ -199,7 +199,7 @@ namespace MeshWorker
     /**
      * Virtual, but empty destructor.
      */
-    virtual ~VectorDataBase();
+    virtual ~VectorDataBase() = default;
 
     /**
      * The only function added to VectorSelector is an abstract virtual

--- a/include/deal.II/meshworker/vector_selector.templates.h
+++ b/include/deal.II/meshworker/vector_selector.templates.h
@@ -26,20 +26,10 @@ DEAL_II_NAMESPACE_OPEN
 namespace MeshWorker
 {
   template <int dim, int spacedim, typename Number>
-  VectorDataBase<dim, spacedim, Number>::~VectorDataBase() = default;
-
-
-
-  template <int dim, int spacedim, typename Number>
   VectorDataBase<dim, spacedim, Number>::VectorDataBase(const VectorSelector &v)
     :
     VectorSelector(v)
   {}
-
-
-
-  template <int dim, int spacedim, typename Number>
-  VectorDataBase<dim, spacedim, Number>::VectorDataBase() = default;
 
 
 

--- a/include/deal.II/meshworker/vector_selector.templates.h
+++ b/include/deal.II/meshworker/vector_selector.templates.h
@@ -26,8 +26,8 @@ DEAL_II_NAMESPACE_OPEN
 namespace MeshWorker
 {
   template <int dim, int spacedim, typename Number>
-  VectorDataBase<dim, spacedim, Number>::~VectorDataBase()
-  {}
+  VectorDataBase<dim, spacedim, Number>::~VectorDataBase() = default;
+
 
 
   template <int dim, int spacedim, typename Number>
@@ -37,9 +37,10 @@ namespace MeshWorker
   {}
 
 
+
   template <int dim, int spacedim, typename Number>
-  VectorDataBase<dim, spacedim, Number>::VectorDataBase()
-  {}
+  VectorDataBase<dim, spacedim, Number>::VectorDataBase() = default;
+
 
 
   template <int dim, int spacedim, typename Number>

--- a/include/deal.II/multigrid/mg_base.h
+++ b/include/deal.II/multigrid/mg_base.h
@@ -50,7 +50,7 @@ public:
   /*
    * Virtual destructor.
    */
-  virtual ~MGMatrixBase();
+  virtual ~MGMatrixBase() = default;
 
   /**
    * Matrix-vector-multiplication on a certain level.
@@ -106,7 +106,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~MGCoarseGridBase ();
+  virtual ~MGCoarseGridBase () = default;
 
   /**
    * Solution operator.
@@ -171,7 +171,7 @@ public:
   /**
    * Destructor. Does nothing here, but needs to be declared virtual anyway.
    */
-  virtual ~MGTransferBase();
+  virtual ~MGTransferBase() = default;
 
   /**
    * Prolongate a vector from level <tt>to_level-1</tt> to level
@@ -237,7 +237,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~MGSmootherBase();
+  virtual ~MGSmootherBase() = default;
 
   /**
    * Release matrices.

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -461,7 +461,7 @@ public:
    * Constructor without constraint matrices. Use this constructor only with
    * discontinuous finite elements or with no local refinement.
    */
-  MGTransferPrebuilt ();
+  MGTransferPrebuilt () = default;
 
   /**
    * Constructor with constraints. Equivalent to the default constructor
@@ -481,7 +481,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferPrebuilt ();
+  virtual ~MGTransferPrebuilt () = default;
 
   /**
    * Initialize the constraints to be used in build_matrices().

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -322,7 +322,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferBlockSelect ();
+  virtual ~MGTransferBlockSelect () = default;
 
   /**
    * Actually build the prolongation matrices for grouped blocks.

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -186,7 +186,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferSelect ();
+  virtual ~MGTransferSelect () = default;
 
 //TODO: rewrite docs; make sure defaulted args are actually allowed
   /**

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -68,7 +68,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferMatrixFree ();
+  virtual ~MGTransferMatrixFree () = default;
 
   /**
    * Initialize the constraints to be used in build().
@@ -258,7 +258,7 @@ public:
    * Constructor without constraint matrices. Use this constructor only with
    * discontinuous finite elements or with no local refinement.
    */
-  MGTransferBlockMatrixFree ();
+  MGTransferBlockMatrixFree () = default;
 
   /**
    * Constructor with constraints. Equivalent to the default constructor
@@ -269,7 +269,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferBlockMatrixFree ();
+  virtual ~MGTransferBlockMatrixFree () = default;
 
   /**
    * Initialize the constraints to be used in build().

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -24,6 +24,7 @@
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 #include <deal.II/base/mg_level_object.h>
 #include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/base/vectorization.h>
 
 #include <deal.II/dofs/dof_handler.h>
 

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -182,7 +182,7 @@ namespace internal
       /**
        * Destructor made virtual.
        */
-      virtual ~DataEntryBase ();
+      virtual ~DataEntryBase () = default;
 
       /**
        * Assuming that the stored vector is a cell vector, extract the given

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -371,8 +371,7 @@ namespace internal
 
 
     template <typename DoFHandlerType>
-    DataEntryBase<DoFHandlerType>::~DataEntryBase ()
-    {}
+    DataEntryBase<DoFHandlerType>::~DataEntryBase () = default;
 
 
 

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -370,11 +370,6 @@ namespace internal
 
 
 
-    template <typename DoFHandlerType>
-    DataEntryBase<DoFHandlerType>::~DataEntryBase () = default;
-
-
-
     /**
      * Class that stores a pointer to a vector of type equal to the template
      * argument, and provides the functions to extract data from it.

--- a/include/deal.II/numerics/data_out_stack.h
+++ b/include/deal.II/numerics/data_out_stack.h
@@ -128,7 +128,7 @@ public:
   /**
    * Destructor. Only declared to make it @p virtual.
    */
-  virtual ~DataOutStack ();
+  virtual ~DataOutStack () = default;
 
   /**
    * Start the next set of data for a specific parameter value. The argument

--- a/include/deal.II/numerics/data_postprocessor.h
+++ b/include/deal.II/numerics/data_postprocessor.h
@@ -430,7 +430,7 @@ public:
    * virtual to ensure that data postprocessors can be destroyed through
    * pointers to the base class.
    */
-  virtual ~DataPostprocessor ();
+  virtual ~DataPostprocessor () = default;
 
   /**
    * This is the main function which actually performs the postprocessing. The

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -622,7 +622,7 @@ namespace MatrixCreator
     {
       struct Scratch
       {
-        Scratch() {}
+        Scratch() = default;
       };
 
       template <typename DoFHandlerType, typename number>

--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -672,7 +672,7 @@ public:
   /**
    * Destructor. At present, this does nothing.
    */
-  virtual ~TimeStepBase ();
+  virtual ~TimeStepBase () = default;
 
   /**
    * Reconstruct all the data that is needed for this time level to work. This

--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -895,7 +895,7 @@ private:
    * private prevents the compiler to provide it's own, incorrect one if
    * anyone chose to copy such an object.
    */
-  TimeStepBase (const TimeStepBase &);
+  TimeStepBase (const TimeStepBase &) = delete;
 
   /**
    * Copy operator. I can see no reason why someone might want to use it, so I
@@ -903,7 +903,7 @@ private:
    * prevents the compiler to provide it's own, incorrect one if anyone chose
    * to copy such an object.
    */
-  TimeStepBase &operator = (const TimeStepBase &);
+  TimeStepBase &operator = (const TimeStepBase &) = delete;
 
   // make the manager object a friend
   friend class TimeDependent;

--- a/source/algorithms/operator.cc
+++ b/source/algorithms/operator.cc
@@ -37,13 +37,16 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace Algorithms
 {
-  OperatorBase::~OperatorBase()
-  {}
+  OperatorBase::~OperatorBase() = default;
+
+
 
   void OperatorBase::notify(const Event &e)
   {
     notifications += e;
   }
+
+
 
   void
   OperatorBase::clear_events ()

--- a/source/algorithms/operator.cc
+++ b/source/algorithms/operator.cc
@@ -37,10 +37,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace Algorithms
 {
-  OperatorBase::~OperatorBase() = default;
-
-
-
   void OperatorBase::notify(const Event &e)
   {
     notifications += e;

--- a/source/base/auto_derivative_function.cc
+++ b/source/base/auto_derivative_function.cc
@@ -37,9 +37,9 @@ AutoDerivativeFunction (const double hh,
 }
 
 
+
 template <int dim>
-AutoDerivativeFunction<dim>::~AutoDerivativeFunction ()
-{}
+AutoDerivativeFunction<dim>::~AutoDerivativeFunction () = default;
 
 
 

--- a/source/base/auto_derivative_function.cc
+++ b/source/base/auto_derivative_function.cc
@@ -39,11 +39,6 @@ AutoDerivativeFunction (const double hh,
 
 
 template <int dim>
-AutoDerivativeFunction<dim>::~AutoDerivativeFunction () = default;
-
-
-
-template <int dim>
 void
 AutoDerivativeFunction<dim>::set_formula (const DifferenceFormula form)
 {

--- a/source/base/convergence_table.cc
+++ b/source/base/convergence_table.cc
@@ -18,10 +18,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-ConvergenceTable::ConvergenceTable() = default;
-
-
-
 void ConvergenceTable::evaluate_convergence_rates(const std::string &data_column_key,
                                                   const std::string &reference_column_key,
                                                   const RateMode     rate_mode,

--- a/source/base/convergence_table.cc
+++ b/source/base/convergence_table.cc
@@ -18,8 +18,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-ConvergenceTable::ConvergenceTable()
-{}
+ConvergenceTable::ConvergenceTable() = default;
+
 
 
 void ConvergenceTable::evaluate_convergence_rates(const std::string &data_column_key,

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -6382,10 +6382,9 @@ DataOutInterface<dim,spacedim>::DataOutInterface ()
 {}
 
 
-template <int dim, int spacedim>
-DataOutInterface<dim,spacedim>::~DataOutInterface ()
-{}
 
+template <int dim, int spacedim>
+DataOutInterface<dim,spacedim>::~DataOutInterface () = default;
 
 
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -6384,11 +6384,6 @@ DataOutInterface<dim,spacedim>::DataOutInterface ()
 
 
 template <int dim, int spacedim>
-DataOutInterface<dim,spacedim>::~DataOutInterface () = default;
-
-
-
-template <int dim, int spacedim>
 void DataOutInterface<dim,spacedim>::write_dx (std::ostream &out) const
 {
   DataOutBase::write_dx (get_patches(), get_dataset_names(),

--- a/source/base/flow_function.cc
+++ b/source/base/flow_function.cc
@@ -38,8 +38,7 @@ namespace Functions
 
 
   template <int dim>
-  FlowFunction<dim>::~FlowFunction()
-  {}
+  FlowFunction<dim>::~FlowFunction() = default;
 
 
   template <int dim>
@@ -192,9 +191,10 @@ namespace Functions
   }
 
 
+
   template <int dim>
-  PoisseuilleFlow<dim>::~PoisseuilleFlow()
-  {}
+  PoisseuilleFlow<dim>::~PoisseuilleFlow() = default;
+
 
 
   template <int dim>
@@ -288,9 +288,10 @@ namespace Functions
   {}
 
 
+
   template <int dim>
-  StokesCosine<dim>::~StokesCosine()
-  {}
+  StokesCosine<dim>::~StokesCosine() = default;
+
 
 
   template <int dim>
@@ -659,8 +660,9 @@ namespace Functions
   }
 
 
-  Kovasznay::~Kovasznay()
-  {}
+
+  Kovasznay::~Kovasznay() = default;
+
 
 
   void Kovasznay::vector_values (

--- a/source/base/flow_function.cc
+++ b/source/base/flow_function.cc
@@ -37,9 +37,6 @@ namespace Functions
   {}
 
 
-  template <int dim>
-  FlowFunction<dim>::~FlowFunction() = default;
-
 
   template <int dim>
   void
@@ -193,11 +190,6 @@ namespace Functions
 
 
   template <int dim>
-  PoisseuilleFlow<dim>::~PoisseuilleFlow() = default;
-
-
-
-  template <int dim>
   void PoisseuilleFlow<dim>::vector_values (
     const std::vector<Point<dim> > &points,
     std::vector<std::vector<double> > &values) const
@@ -286,11 +278,6 @@ namespace Functions
     :
     viscosity(nu), reaction(r)
   {}
-
-
-
-  template <int dim>
-  StokesCosine<dim>::~StokesCosine() = default;
 
 
 
@@ -658,10 +645,6 @@ namespace Functions
     // x-direction
     p_average = 1/(8*l)*(std::exp(3.*l)-std::exp(-l));
   }
-
-
-
-  Kovasznay::~Kovasznay() = default;
 
 
 

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -57,6 +57,9 @@ FunctionParser<dim>::FunctionParser(const unsigned int n_components,
 
 
 
+// We deliberately delay the definition of the default constructor
+// so that we don't need to include the definition of mu::Parser
+// in the header file.
 template <int dim>
 FunctionParser<dim>::~FunctionParser() = default;
 

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -57,7 +57,7 @@ FunctionParser<dim>::FunctionParser(const unsigned int n_components,
 
 
 
-// We deliberately delay the definition of the default constructor
+// We deliberately delay the definition of the default destructor
 // so that we don't need to include the definition of mu::Parser
 // in the header file.
 template <int dim>

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -58,8 +58,8 @@ FunctionParser<dim>::FunctionParser(const unsigned int n_components,
 
 
 template <int dim>
-FunctionParser<dim>::~FunctionParser()
-{}
+FunctionParser<dim>::~FunctionParser() = default;
+
 
 #ifdef DEAL_II_WITH_MUPARSER
 

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -49,8 +49,7 @@ ParameterHandler::ParameterHandler ()
 
 
 
-ParameterHandler::~ParameterHandler ()
-{}
+ParameterHandler::~ParameterHandler () = default;
 
 
 
@@ -2111,9 +2110,7 @@ ParameterHandler::operator == (const ParameterHandler &prm2)  const
 
 
 
-
-MultipleParameterLoop::UserClass::~UserClass ()
-{}
+MultipleParameterLoop::UserClass::~UserClass () = default;
 
 
 
@@ -2124,8 +2121,7 @@ MultipleParameterLoop::MultipleParameterLoop()
 
 
 
-MultipleParameterLoop::~MultipleParameterLoop ()
-{}
+MultipleParameterLoop::~MultipleParameterLoop () = default;
 
 
 

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -49,10 +49,6 @@ ParameterHandler::ParameterHandler ()
 
 
 
-ParameterHandler::~ParameterHandler () = default;
-
-
-
 std::string
 ParameterHandler::mangle (const std::string &s)
 {
@@ -2110,18 +2106,10 @@ ParameterHandler::operator == (const ParameterHandler &prm2)  const
 
 
 
-MultipleParameterLoop::UserClass::~UserClass () = default;
-
-
-
 MultipleParameterLoop::MultipleParameterLoop()
   :
   n_branches(0)
 {}
-
-
-
-MultipleParameterLoop::~MultipleParameterLoop () = default;
 
 
 

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -127,10 +127,6 @@ namespace Patterns
 
 
 
-  PatternBase::~PatternBase () = default;
-
-
-
   std::size_t
   PatternBase::memory_consumption () const
   {
@@ -1156,10 +1152,6 @@ namespace Patterns
 
 
 
-  Anything::Anything () = default;
-
-
-
   bool Anything::match (const std::string &) const
   {
     return true;
@@ -1296,10 +1288,6 @@ namespace Patterns
 
 
   const char *DirectoryName::description_init = "[DirectoryName";
-
-
-
-  DirectoryName::DirectoryName () = default;
 
 
 

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -127,8 +127,8 @@ namespace Patterns
 
 
 
-  PatternBase::~PatternBase ()
-  {}
+  PatternBase::~PatternBase () = default;
+
 
 
   std::size_t
@@ -1155,8 +1155,8 @@ namespace Patterns
   const char *Anything::description_init = "[Anything";
 
 
-  Anything::Anything ()
-  {}
+
+  Anything::Anything () = default;
 
 
 
@@ -1298,8 +1298,8 @@ namespace Patterns
   const char *DirectoryName::description_init = "[DirectoryName";
 
 
-  DirectoryName::DirectoryName ()
-  {}
+
+  DirectoryName::DirectoryName () = default;
 
 
 

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -31,8 +31,7 @@ DEAL_II_NAMESPACE_OPEN
 // inline and template functions
 namespace internal
 {
-  TableEntry::TableEntry ()
-  {}
+  TableEntry::TableEntry () = default;
 
 
   double TableEntry::get_numeric_value () const

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -31,9 +31,6 @@ DEAL_II_NAMESPACE_OPEN
 // inline and template functions
 namespace internal
 {
-  TableEntry::TableEntry () = default;
-
-
   double TableEntry::get_numeric_value () const
   {
     // we don't quite know the data type in 'value', but

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -228,8 +228,7 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    Triangulation<dim,spacedim>::~Triangulation ()
-    {}
+    Triangulation<dim,spacedim>::~Triangulation () = default;
 
 
 

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -228,11 +228,6 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    Triangulation<dim,spacedim>::~Triangulation () = default;
-
-
-
-    template <int dim, int spacedim>
     void
     Triangulation<dim,spacedim>::execute_coarsening_and_refinement ()
     {

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -57,11 +57,6 @@ namespace parallel
 
 
     template <int dim, typename VectorType, typename DoFHandlerType>
-    SolutionTransfer<dim, VectorType, DoFHandlerType>::~SolutionTransfer () = default;
-
-
-
-    template <int dim, typename VectorType, typename DoFHandlerType>
     void
     SolutionTransfer<dim, VectorType, DoFHandlerType>::
     prepare_for_coarsening_and_refinement (const std::vector<const VectorType *> &all_in)

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -57,8 +57,7 @@ namespace parallel
 
 
     template <int dim, typename VectorType, typename DoFHandlerType>
-    SolutionTransfer<dim, VectorType, DoFHandlerType>::~SolutionTransfer ()
-    {}
+    SolutionTransfer<dim, VectorType, DoFHandlerType>::~SolutionTransfer () = default;
 
 
 

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -42,8 +42,7 @@ FiniteElement<dim, spacedim>::InternalDataBase::InternalDataBase ():
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim>::InternalDataBase::~InternalDataBase ()
-{}
+FiniteElement<dim,spacedim>::InternalDataBase::~InternalDataBase () = default;
 
 
 
@@ -158,6 +157,10 @@ FiniteElement<dim, spacedim>::operator^ (unsigned int multiplicity) const
   return std::make_pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
          unsigned int> (std::move(this->clone()), std::move(multiplicity));
 }
+
+
+
+FiniteElement<dim,spacedim>::~FiniteElement () = default;
 
 
 

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -42,11 +42,6 @@ FiniteElement<dim, spacedim>::InternalDataBase::InternalDataBase ():
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim>::InternalDataBase::~InternalDataBase () = default;
-
-
-
-template <int dim, int spacedim>
 std::size_t
 FiniteElement<dim, spacedim>::InternalDataBase::memory_consumption () const
 {
@@ -157,10 +152,6 @@ FiniteElement<dim, spacedim>::operator^ (unsigned int multiplicity) const
   return std::make_pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
          unsigned int> (std::move(this->clone()), std::move(multiplicity));
 }
-
-
-
-FiniteElement<dim,spacedim>::~FiniteElement () = default;
 
 
 

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -73,10 +73,6 @@ std::unique_ptr<FiniteElement<2,2>>
 
 
 
-FE_P1NC::~FE_P1NC () = default;
-
-
-
 std::vector<unsigned int>
 FE_P1NC::get_dpo_vector ()
 {

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -73,7 +73,7 @@ std::unique_ptr<FiniteElement<2,2>>
 
 
 
-FE_P1NC::~FE_P1NC () {}
+FE_P1NC::~FE_P1NC () = default;
 
 
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2173,8 +2173,7 @@ public:
 
 
 template <int dim, int spacedim>
-FEValuesBase<dim,spacedim>::CellIteratorBase::~CellIteratorBase ()
-{}
+FEValuesBase<dim,spacedim>::CellIteratorBase::~CellIteratorBase () = default;
 
 /* ---------------- classes derived from FEValuesBase<dim,spacedim>::CellIteratorBase --------- */
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2130,7 +2130,7 @@ public:
    * pointers to the base
    * class.
    */
-  virtual ~CellIteratorBase ();
+  virtual ~CellIteratorBase () = default;
 
   /**
    * Conversion operator to an
@@ -2170,10 +2170,6 @@ public:
   get_interpolated_dof_values (const IndexSet &in,
                                Vector<IndexSet::value_type> &out) const = 0;
 };
-
-
-template <int dim, int spacedim>
-FEValuesBase<dim,spacedim>::CellIteratorBase::~CellIteratorBase () = default;
 
 /* ---------------- classes derived from FEValuesBase<dim,spacedim>::CellIteratorBase --------- */
 

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -21,8 +21,7 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim, int spacedim>
-Mapping<dim, spacedim>::~Mapping ()
-{}
+Mapping<dim, spacedim>::~Mapping () = default;
 
 
 template <int dim, int spacedim>
@@ -87,8 +86,7 @@ Mapping<dim, spacedim>::InternalDataBase::InternalDataBase ():
 
 
 template <int dim, int spacedim>
-Mapping<dim, spacedim>::InternalDataBase::~InternalDataBase ()
-{}
+Mapping<dim, spacedim>::InternalDataBase::~InternalDataBase () = default;
 
 
 

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -21,10 +21,6 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim, int spacedim>
-Mapping<dim, spacedim>::~Mapping () = default;
-
-
-template <int dim, int spacedim>
 std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell>
 Mapping<dim, spacedim>::get_vertices (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell) const
@@ -82,11 +78,6 @@ template <int dim, int spacedim>
 Mapping<dim, spacedim>::InternalDataBase::InternalDataBase ():
   update_each(update_default)
 {}
-
-
-
-template <int dim, int spacedim>
-Mapping<dim, spacedim>::InternalDataBase::~InternalDataBase () = default;
 
 
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -43,8 +43,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
-MappingManifold<dim,spacedim>::InternalData::InternalData ()
-{}
+MappingManifold<dim,spacedim>::InternalData::InternalData () = default;
 
 
 template <int dim, int spacedim>
@@ -175,8 +174,7 @@ initialize_face (const UpdateFlags      update_flags,
 
 
 template <int dim, int spacedim>
-MappingManifold<dim,spacedim>::MappingManifold ()
-{}
+MappingManifold<dim,spacedim>::MappingManifold () = default;
 
 
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -43,10 +43,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
-MappingManifold<dim,spacedim>::InternalData::InternalData () = default;
-
-
-template <int dim, int spacedim>
 std::size_t
 MappingManifold<dim,spacedim>::InternalData::memory_consumption () const
 {
@@ -170,11 +166,6 @@ initialize_face (const UpdateFlags      update_flags,
         }
     }
 }
-
-
-
-template <int dim, int spacedim>
-MappingManifold<dim,spacedim>::MappingManifold () = default;
 
 
 

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -31,8 +31,7 @@ using namespace Manifolds;
 
 /* -------------------------- Manifold --------------------- */
 template <int dim, int spacedim>
-Manifold<dim, spacedim>::~Manifold ()
-{}
+Manifold<dim, spacedim>::~Manifold () = default;
 
 
 
@@ -693,8 +692,7 @@ FlatManifold<dim, spacedim>::get_tangent_vector (const Point<spacedim> &x1,
 /* -------------------------- ChartManifold --------------------- */
 
 template <int dim, int spacedim, int chartdim>
-ChartManifold<dim,spacedim,chartdim>::~ChartManifold ()
-{}
+ChartManifold<dim,spacedim,chartdim>::~ChartManifold () = default;
 
 
 

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -31,11 +31,6 @@ using namespace Manifolds;
 
 /* -------------------------- Manifold --------------------- */
 template <int dim, int spacedim>
-Manifold<dim, spacedim>::~Manifold () = default;
-
-
-
-template <int dim, int spacedim>
 Point<spacedim>
 Manifold<dim, spacedim>::
 project_to_manifold (const ArrayView<const Point<spacedim>> &,
@@ -690,12 +685,6 @@ FlatManifold<dim, spacedim>::get_tangent_vector (const Point<spacedim> &x1,
 
 
 /* -------------------------- ChartManifold --------------------- */
-
-template <int dim, int spacedim, int chartdim>
-ChartManifold<dim,spacedim,chartdim>::~ChartManifold () = default;
-
-
-
 template <int dim, int spacedim, int chartdim>
 ChartManifold<dim,spacedim,chartdim>::ChartManifold (const Tensor<1,chartdim> &periodicity)
   :

--- a/source/grid/persistent_tria.cc
+++ b/source/grid/persistent_tria.cc
@@ -57,8 +57,7 @@ PersistentTriangulation (const PersistentTriangulation<dim,spacedim> &old_tria)
 
 
 template <int dim, int spacedim>
-PersistentTriangulation<dim,spacedim>::~PersistentTriangulation ()
-{}
+PersistentTriangulation<dim,spacedim>::~PersistentTriangulation () = default;
 
 
 

--- a/source/grid/persistent_tria.cc
+++ b/source/grid/persistent_tria.cc
@@ -57,11 +57,6 @@ PersistentTriangulation (const PersistentTriangulation<dim,spacedim> &old_tria)
 
 
 template <int dim, int spacedim>
-PersistentTriangulation<dim,spacedim>::~PersistentTriangulation () = default;
-
-
-
-template <int dim, int spacedim>
 void
 PersistentTriangulation<dim,spacedim>::execute_coarsening_and_refinement ()
 {

--- a/source/grid/tria_boundary.cc
+++ b/source/grid/tria_boundary.cc
@@ -180,6 +180,12 @@ get_line_support_points (const unsigned int n_intermediate_points) const
 
 /* -------------------------- StraightBoundary --------------------- */
 
+// At least clang < 3.9.0 complains if we move this definition to its
+// declaration when a 'const StraightBoundary' object is built.
+template <int dim, int spacedim>
+StraightBoundary<dim, spacedim>::StraightBoundary () = default;
+
+
 
 template <int dim, int spacedim>
 Point<spacedim>

--- a/source/grid/tria_boundary.cc
+++ b/source/grid/tria_boundary.cc
@@ -29,8 +29,7 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim, int spacedim>
-Boundary<dim, spacedim>::~Boundary ()
-{}
+Boundary<dim, spacedim>::~Boundary () = default;
 
 
 template <int dim, int spacedim>
@@ -187,8 +186,7 @@ get_line_support_points (const unsigned int n_intermediate_points) const
 
 
 template <int dim, int spacedim>
-StraightBoundary<dim, spacedim>::StraightBoundary ()
-{}
+StraightBoundary<dim, spacedim>::StraightBoundary () = default;
 
 
 template <int dim, int spacedim>

--- a/source/grid/tria_boundary.cc
+++ b/source/grid/tria_boundary.cc
@@ -29,10 +29,6 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim, int spacedim>
-Boundary<dim, spacedim>::~Boundary () = default;
-
-
-template <int dim, int spacedim>
 void
 Boundary<dim, spacedim>::
 get_intermediate_points_on_line (const typename Triangulation<dim, spacedim>::line_iterator &,
@@ -183,10 +179,6 @@ get_line_support_points (const unsigned int n_intermediate_points) const
 
 
 /* -------------------------- StraightBoundary --------------------- */
-
-
-template <int dim, int spacedim>
-StraightBoundary<dim, spacedim>::StraightBoundary () = default;
 
 
 template <int dim, int spacedim>

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -87,8 +87,7 @@ namespace hp
   }
 
   template <int dim, int spacedim>
-  FECollection<dim,spacedim>::FECollection ()
-  {}
+  FECollection<dim,spacedim>::FECollection () = default;
 
 
 

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -86,9 +86,6 @@ namespace hp
     return numbers::invalid_unsigned_int;
   }
 
-  template <int dim, int spacedim>
-  FECollection<dim,spacedim>::FECollection () = default;
-
 
 
   template <int dim, int spacedim>

--- a/source/hp/mapping_collection.cc
+++ b/source/hp/mapping_collection.cc
@@ -24,8 +24,7 @@ namespace hp
 {
 
   template <int dim, int spacedim>
-  MappingCollection<dim,spacedim>::MappingCollection ()
-  {}
+  MappingCollection<dim,spacedim>::MappingCollection () = default;
 
 
 

--- a/source/hp/mapping_collection.cc
+++ b/source/hp/mapping_collection.cc
@@ -22,12 +22,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace hp
 {
-
-  template <int dim, int spacedim>
-  MappingCollection<dim,spacedim>::MappingCollection () = default;
-
-
-
   template <int dim, int spacedim>
   MappingCollection<dim,spacedim>::
   MappingCollection (const Mapping<dim,spacedim> &mapping)

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -327,8 +327,7 @@ BlockSparsityPatternBase<SparsityPatternBase>::print_gnuplot(std::ostream &out) 
 
 
 
-BlockSparsityPattern::BlockSparsityPattern ()
-{}
+BlockSparsityPattern::BlockSparsityPattern () = default;
 
 
 
@@ -422,8 +421,7 @@ BlockSparsityPattern::copy_from  (const BlockDynamicSparsityPattern &dsp)
 
 
 
-BlockDynamicSparsityPattern::BlockDynamicSparsityPattern ()
-{}
+BlockDynamicSparsityPattern::BlockDynamicSparsityPattern () = default;
 
 
 
@@ -520,8 +518,7 @@ BlockDynamicSparsityPattern::reinit (
 namespace TrilinosWrappers
 {
 
-  BlockSparsityPattern::BlockSparsityPattern ()
-  {}
+  BlockSparsityPattern::BlockSparsityPattern () = default;
 
 
 

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -327,10 +327,6 @@ BlockSparsityPatternBase<SparsityPatternBase>::print_gnuplot(std::ostream &out) 
 
 
 
-BlockSparsityPattern::BlockSparsityPattern () = default;
-
-
-
 BlockSparsityPattern::BlockSparsityPattern (const size_type n_rows,
                                             const size_type n_columns)
   :
@@ -417,11 +413,6 @@ BlockSparsityPattern::copy_from  (const BlockDynamicSparsityPattern &dsp)
   // sizes
   collect_sizes();
 }
-
-
-
-
-BlockDynamicSparsityPattern::BlockDynamicSparsityPattern () = default;
 
 
 
@@ -517,10 +508,6 @@ BlockDynamicSparsityPattern::reinit (
 #ifdef DEAL_II_WITH_TRILINOS
 namespace TrilinosWrappers
 {
-
-  BlockSparsityPattern::BlockSparsityPattern () = default;
-
-
 
   BlockSparsityPattern::
   BlockSparsityPattern (const size_type n_rows,

--- a/source/lac/chunk_sparsity_pattern.cc
+++ b/source/lac/chunk_sparsity_pattern.cc
@@ -91,8 +91,7 @@ ChunkSparsityPattern::ChunkSparsityPattern (
 
 
 
-ChunkSparsityPattern::~ChunkSparsityPattern ()
-{}
+ChunkSparsityPattern::~ChunkSparsityPattern () = default;
 
 
 

--- a/source/lac/chunk_sparsity_pattern.cc
+++ b/source/lac/chunk_sparsity_pattern.cc
@@ -91,10 +91,6 @@ ChunkSparsityPattern::ChunkSparsityPattern (
 
 
 
-ChunkSparsityPattern::~ChunkSparsityPattern () = default;
-
-
-
 ChunkSparsityPattern &
 ChunkSparsityPattern::operator = (const ChunkSparsityPattern &s)
 {

--- a/source/lac/matrix_out.cc
+++ b/source/lac/matrix_out.cc
@@ -29,10 +29,6 @@ MatrixOut::Options::Options (const bool         show_absolute_values,
 
 
 
-MatrixOut::~MatrixOut () = default;
-
-
-
 const std::vector<MatrixOut::Patch> &
 MatrixOut::get_patches () const
 {

--- a/source/lac/matrix_out.cc
+++ b/source/lac/matrix_out.cc
@@ -29,8 +29,7 @@ MatrixOut::Options::Options (const bool         show_absolute_values,
 
 
 
-MatrixOut::~MatrixOut ()
-{}
+MatrixOut::~MatrixOut () = default;
 
 
 

--- a/source/lac/petsc_parallel_block_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_block_sparse_matrix.cc
@@ -24,12 +24,10 @@ namespace PETScWrappers
   namespace MPI
   {
 
-    BlockSparseMatrix::BlockSparseMatrix ()
-    {}
+    BlockSparseMatrix::BlockSparseMatrix () = default;
 
 
-    BlockSparseMatrix::~BlockSparseMatrix ()
-    {}
+    BlockSparseMatrix::~BlockSparseMatrix () = default;
 
 
     BlockSparseMatrix &

--- a/source/lac/petsc_parallel_block_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_block_sparse_matrix.cc
@@ -24,12 +24,6 @@ namespace PETScWrappers
   namespace MPI
   {
 
-    BlockSparseMatrix::BlockSparseMatrix () = default;
-
-
-    BlockSparseMatrix::~BlockSparseMatrix () = default;
-
-
     BlockSparseMatrix &
     BlockSparseMatrix::operator = (const BlockSparseMatrix &m)
     {

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -123,8 +123,7 @@ namespace PETScWrappers
   }
 
 
-  PreconditionJacobi::PreconditionJacobi ()
-  {}
+  PreconditionJacobi::PreconditionJacobi () = default;
 
 
   PreconditionJacobi::PreconditionJacobi (const MatrixBase     &matrix,
@@ -175,8 +174,7 @@ namespace PETScWrappers
   }
 
 
-  PreconditionBlockJacobi::PreconditionBlockJacobi ()
-  {}
+  PreconditionBlockJacobi::PreconditionBlockJacobi () = default;
 
 
   PreconditionBlockJacobi::
@@ -223,8 +221,7 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionSOR::PreconditionSOR ()
-  {}
+  PreconditionSOR::PreconditionSOR () = default;
 
 
   PreconditionSOR::PreconditionSOR (const MatrixBase     &matrix,
@@ -269,8 +266,7 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionSSOR::PreconditionSSOR ()
-  {}
+  PreconditionSSOR::PreconditionSSOR () = default;
 
 
   PreconditionSSOR::PreconditionSSOR (const MatrixBase     &matrix,
@@ -319,8 +315,7 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionEisenstat::PreconditionEisenstat ()
-  {}
+  PreconditionEisenstat::PreconditionEisenstat () = default;
 
 
   PreconditionEisenstat::PreconditionEisenstat (const MatrixBase     &matrix,
@@ -366,8 +361,7 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionICC::PreconditionICC ()
-  {}
+  PreconditionICC::PreconditionICC () = default;
 
 
   PreconditionICC::PreconditionICC (const MatrixBase     &matrix,
@@ -412,8 +406,7 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionILU::PreconditionILU ()
-  {}
+  PreconditionILU::PreconditionILU () = default;
 
 
   PreconditionILU::PreconditionILU (const MatrixBase     &matrix,
@@ -467,8 +460,7 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionBoomerAMG::PreconditionBoomerAMG ()
-  {}
+  PreconditionBoomerAMG::PreconditionBoomerAMG () = default;
 
   PreconditionBoomerAMG::PreconditionBoomerAMG (const MPI_Comm comm,
                                                 const AdditionalData &additional_data_)
@@ -586,8 +578,7 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionParaSails::PreconditionParaSails ()
-  {}
+  PreconditionParaSails::PreconditionParaSails () = default;
 
 
   PreconditionParaSails::PreconditionParaSails (const MatrixBase     &matrix,
@@ -682,8 +673,7 @@ namespace PETScWrappers
 
   /* ----------------- PreconditionNone ------------------------- */
 
-  PreconditionNone::PreconditionNone ()
-  {}
+  PreconditionNone::PreconditionNone () = default;
 
 
   PreconditionNone::PreconditionNone (const MatrixBase     &matrix,
@@ -728,8 +718,7 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionLU::PreconditionLU ()
-  {}
+  PreconditionLU::PreconditionLU () = default;
 
 
   PreconditionLU::PreconditionLU (const MatrixBase     &matrix,

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -123,8 +123,6 @@ namespace PETScWrappers
   }
 
 
-  PreconditionJacobi::PreconditionJacobi () = default;
-
 
   PreconditionJacobi::PreconditionJacobi (const MatrixBase     &matrix,
                                           const AdditionalData &additional_data)
@@ -174,8 +172,6 @@ namespace PETScWrappers
   }
 
 
-  PreconditionBlockJacobi::PreconditionBlockJacobi () = default;
-
 
   PreconditionBlockJacobi::
   PreconditionBlockJacobi (const MatrixBase     &matrix,
@@ -221,8 +217,6 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionSOR::PreconditionSOR () = default;
-
 
   PreconditionSOR::PreconditionSOR (const MatrixBase     &matrix,
                                     const AdditionalData &additional_data)
@@ -265,8 +259,6 @@ namespace PETScWrappers
     omega (omega)
   {}
 
-
-  PreconditionSSOR::PreconditionSSOR () = default;
 
 
   PreconditionSSOR::PreconditionSSOR (const MatrixBase     &matrix,
@@ -315,8 +307,6 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionEisenstat::PreconditionEisenstat () = default;
-
 
   PreconditionEisenstat::PreconditionEisenstat (const MatrixBase     &matrix,
                                                 const AdditionalData &additional_data)
@@ -361,8 +351,6 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionICC::PreconditionICC () = default;
-
 
   PreconditionICC::PreconditionICC (const MatrixBase     &matrix,
                                     const AdditionalData &additional_data)
@@ -405,8 +393,6 @@ namespace PETScWrappers
     levels (levels)
   {}
 
-
-  PreconditionILU::PreconditionILU () = default;
 
 
   PreconditionILU::PreconditionILU (const MatrixBase     &matrix,
@@ -460,7 +446,6 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionBoomerAMG::PreconditionBoomerAMG () = default;
 
   PreconditionBoomerAMG::PreconditionBoomerAMG (const MPI_Comm comm,
                                                 const AdditionalData &additional_data_)
@@ -578,8 +563,6 @@ namespace PETScWrappers
   {}
 
 
-  PreconditionParaSails::PreconditionParaSails () = default;
-
 
   PreconditionParaSails::PreconditionParaSails (const MatrixBase     &matrix,
                                                 const AdditionalData &additional_data)
@@ -673,9 +656,6 @@ namespace PETScWrappers
 
   /* ----------------- PreconditionNone ------------------------- */
 
-  PreconditionNone::PreconditionNone () = default;
-
-
   PreconditionNone::PreconditionNone (const MatrixBase     &matrix,
                                       const AdditionalData &additional_data)
   {
@@ -717,8 +697,6 @@ namespace PETScWrappers
     damping (damping)
   {}
 
-
-  PreconditionLU::PreconditionLU () = default;
 
 
   PreconditionLU::PreconditionLU (const MatrixBase     &matrix,

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -49,10 +49,6 @@ namespace PETScWrappers
 
 
 
-  SolverBase::~SolverBase () = default;
-
-
-
   void
   SolverBase::solve (const MatrixBase         &A,
                      VectorBase               &x,

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -49,8 +49,7 @@ namespace PETScWrappers
 
 
 
-  SolverBase::~SolverBase ()
-  {}
+  SolverBase::~SolverBase () = default;
 
 
 

--- a/source/lac/solver_control.cc
+++ b/source/lac/solver_control.cc
@@ -48,8 +48,7 @@ SolverControl::SolverControl (const unsigned int maxiter,
 
 
 
-SolverControl::~SolverControl()
-{}
+SolverControl::~SolverControl() = default;
 
 
 
@@ -259,8 +258,7 @@ ReductionControl::operator= (const SolverControl &c)
 }
 
 
-ReductionControl::~ReductionControl()
-{}
+ReductionControl::~ReductionControl() = default;
 
 
 SolverControl::State
@@ -324,8 +322,7 @@ IterationNumberControl::IterationNumberControl(const unsigned int n,
   SolverControl (n, tolerance, m_log_history, m_log_result) {}
 
 
-IterationNumberControl::~IterationNumberControl()
-{}
+IterationNumberControl::~IterationNumberControl() = default;
 
 
 SolverControl::State
@@ -388,8 +385,7 @@ ConsecutiveControl::operator= (const SolverControl &c)
 
 
 
-ConsecutiveControl::~ConsecutiveControl()
-{}
+ConsecutiveControl::~ConsecutiveControl() = default;
 
 
 SolverControl::State

--- a/source/lac/solver_control.cc
+++ b/source/lac/solver_control.cc
@@ -48,10 +48,6 @@ SolverControl::SolverControl (const unsigned int maxiter,
 
 
 
-SolverControl::~SolverControl() = default;
-
-
-
 SolverControl::State
 SolverControl::check (const unsigned int step,
                       const double check_value)
@@ -258,8 +254,6 @@ ReductionControl::operator= (const SolverControl &c)
 }
 
 
-ReductionControl::~ReductionControl() = default;
-
 
 SolverControl::State
 ReductionControl::check (const unsigned int step,
@@ -322,7 +316,6 @@ IterationNumberControl::IterationNumberControl(const unsigned int n,
   SolverControl (n, tolerance, m_log_history, m_log_result) {}
 
 
-IterationNumberControl::~IterationNumberControl() = default;
 
 
 SolverControl::State
@@ -383,9 +376,6 @@ ConsecutiveControl::operator= (const SolverControl &c)
   return *this;
 }
 
-
-
-ConsecutiveControl::~ConsecutiveControl() = default;
 
 
 SolverControl::State

--- a/source/lac/trilinos_block_sparse_matrix.cc
+++ b/source/lac/trilinos_block_sparse_matrix.cc
@@ -24,8 +24,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace TrilinosWrappers
 {
-  BlockSparseMatrix::BlockSparseMatrix ()
-  {}
+  BlockSparseMatrix::BlockSparseMatrix () = default;
 
 
 
@@ -44,12 +43,7 @@ namespace TrilinosWrappers
 
 
   BlockSparseMatrix &
-  BlockSparseMatrix::operator = (const BlockSparseMatrix &m)
-  {
-    BaseClass::operator = (m);
-
-    return *this;
-  }
+  BlockSparseMatrix::operator = (const BlockSparseMatrix &m) = default;
 
 
 

--- a/source/lac/trilinos_block_sparse_matrix.cc
+++ b/source/lac/trilinos_block_sparse_matrix.cc
@@ -24,10 +24,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace TrilinosWrappers
 {
-  BlockSparseMatrix::BlockSparseMatrix () = default;
-
-
-
   BlockSparseMatrix::~BlockSparseMatrix ()
   {
     // delete previous content of
@@ -39,11 +35,6 @@ namespace TrilinosWrappers
     catch (...)
       {}
   }
-
-
-
-  BlockSparseMatrix &
-  BlockSparseMatrix::operator = (const BlockSparseMatrix &m) = default;
 
 
 

--- a/source/lac/trilinos_block_vector.cc
+++ b/source/lac/trilinos_block_vector.cc
@@ -67,11 +67,6 @@ namespace TrilinosWrappers
 
 
 
-
-    BlockVector::~BlockVector () = default;
-
-
-
     void
     BlockVector::reinit (const std::vector<IndexSet> &parallel_partitioning,
                          const MPI_Comm              &communicator,

--- a/source/lac/trilinos_block_vector.cc
+++ b/source/lac/trilinos_block_vector.cc
@@ -68,8 +68,7 @@ namespace TrilinosWrappers
 
 
 
-    BlockVector::~BlockVector ()
-    {}
+    BlockVector::~BlockVector () = default;
 
 
 

--- a/source/lac/trilinos_precondition.cc
+++ b/source/lac/trilinos_precondition.cc
@@ -55,10 +55,6 @@ namespace TrilinosWrappers
 
 
 
-  PreconditionBase::~PreconditionBase() = default;
-
-
-
   void PreconditionBase::clear ()
   {
     preconditioner.reset();

--- a/source/lac/trilinos_precondition.cc
+++ b/source/lac/trilinos_precondition.cc
@@ -55,8 +55,7 @@ namespace TrilinosWrappers
 
 
 
-  PreconditionBase::~PreconditionBase()
-  {}
+  PreconditionBase::~PreconditionBase() = default;
 
 
 

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -68,8 +68,7 @@ namespace TrilinosWrappers
 
 
 
-  SolverBase::~SolverBase ()
-  {}
+  SolverBase::~SolverBase () = default;
 
 
 
@@ -318,7 +317,7 @@ namespace TrilinosWrappers
                                   const double               &reduction,
                                   const Epetra_LinearProblem &linear_problem);
 
-        virtual ~TrilinosReductionControl() {}
+        virtual ~TrilinosReductionControl() = default;
 
         virtual bool
         ResidualVectorRequired () const
@@ -722,8 +721,7 @@ namespace TrilinosWrappers
 
 
 
-  SolverDirect::~SolverDirect ()
-  {}
+  SolverDirect::~SolverDirect () = default;
 
 
 

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -68,10 +68,6 @@ namespace TrilinosWrappers
 
 
 
-  SolverBase::~SolverBase () = default;
-
-
-
   SolverControl &
   SolverBase::control() const
   {
@@ -718,10 +714,6 @@ namespace TrilinosWrappers
     solver_control (cn),
     additional_data (data.output_solver_details,data.solver_type)
   {}
-
-
-
-  SolverDirect::~SolverDirect () = default;
 
 
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -356,8 +356,7 @@ namespace TrilinosWrappers
 
 
 
-  SparseMatrix::~SparseMatrix ()
-  {}
+  SparseMatrix::~SparseMatrix () = default;
 
 
 
@@ -2701,8 +2700,7 @@ namespace TrilinosWrappers
 
 
       // Destructor
-      TrilinosPayload::~TrilinosPayload ()
-      { }
+      TrilinosPayload::~TrilinosPayload () = default;
 
 
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -356,10 +356,6 @@ namespace TrilinosWrappers
 
 
 
-  SparseMatrix::~SparseMatrix () = default;
-
-
-
   void
   SparseMatrix::copy_from (const SparseMatrix &rhs)
   {
@@ -2696,11 +2692,6 @@ namespace TrilinosWrappers
           domain_map (second_op.domain_map),
           range_map (first_op.range_map)
       { }
-
-
-
-      // Destructor
-      TrilinosPayload::~TrilinosPayload () = default;
 
 
 

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -221,8 +221,7 @@ namespace TrilinosWrappers
 
 
 
-  SparsityPattern::~SparsityPattern ()
-  {}
+  SparsityPattern::~SparsityPattern () = default;
 
 
 

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -221,10 +221,6 @@ namespace TrilinosWrappers
 
 
 
-  SparsityPattern::~SparsityPattern () = default;
-
-
-
   void
   SparsityPattern::reinit (const size_type  m,
                            const size_type  n,

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -130,10 +130,6 @@ namespace TrilinosWrappers
 
 
 
-    Vector::~Vector () = default;
-
-
-
     void
     Vector::clear ()
     {

--- a/source/meshworker/mesh_worker.cc
+++ b/source/meshworker/mesh_worker.cc
@@ -71,8 +71,6 @@ namespace MeshWorker
   {}
 
 
-  template <int dim, int spacedim, typename number>
-  LocalIntegrator<dim, spacedim, number>::~LocalIntegrator () = default;
 
   template <int dim, int spacedim, typename number>
   void

--- a/source/meshworker/mesh_worker.cc
+++ b/source/meshworker/mesh_worker.cc
@@ -72,8 +72,7 @@ namespace MeshWorker
 
 
   template <int dim, int spacedim, typename number>
-  LocalIntegrator<dim, spacedim, number>::~LocalIntegrator ()
-  {}
+  LocalIntegrator<dim, spacedim, number>::~LocalIntegrator () = default;
 
   template <int dim, int spacedim, typename number>
   void

--- a/source/multigrid/mg_base.cc
+++ b/source/multigrid/mg_base.cc
@@ -28,18 +28,15 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <typename VectorType>
-MGTransferBase<VectorType>::~MGTransferBase()
-{}
+MGTransferBase<VectorType>::~MGTransferBase() = default;
 
 
 template <typename VectorType>
-MGMatrixBase<VectorType>::~MGMatrixBase()
-{}
+MGMatrixBase<VectorType>::~MGMatrixBase() = default;
 
 
 template <typename VectorType>
-MGSmootherBase<VectorType>::~MGSmootherBase()
-{}
+MGSmootherBase<VectorType>::~MGSmootherBase() = default;
 
 
 template <typename VectorType>
@@ -54,8 +51,7 @@ MGSmootherBase<VectorType>::apply (const unsigned int level,
 
 
 template <typename VectorType>
-MGCoarseGridBase<VectorType>::~MGCoarseGridBase()
-{}
+MGCoarseGridBase<VectorType>::~MGCoarseGridBase() = default;
 
 
 // Explicit instantiations

--- a/source/multigrid/mg_base.cc
+++ b/source/multigrid/mg_base.cc
@@ -28,18 +28,6 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <typename VectorType>
-MGTransferBase<VectorType>::~MGTransferBase() = default;
-
-
-template <typename VectorType>
-MGMatrixBase<VectorType>::~MGMatrixBase() = default;
-
-
-template <typename VectorType>
-MGSmootherBase<VectorType>::~MGSmootherBase() = default;
-
-
-template <typename VectorType>
 void
 MGSmootherBase<VectorType>::apply (const unsigned int level,
                                    VectorType         &u,
@@ -48,10 +36,6 @@ MGSmootherBase<VectorType>::apply (const unsigned int level,
   u = 0;
   smooth(level, u, rhs);
 }
-
-
-template <typename VectorType>
-MGCoarseGridBase<VectorType>::~MGCoarseGridBase() = default;
 
 
 // Explicit instantiations

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -59,11 +59,6 @@ MGTransferMatrixFree<dim,Number>::MGTransferMatrixFree (const MGConstrainedDoFs 
 
 
 template <int dim, typename Number>
-MGTransferMatrixFree<dim,Number>::~MGTransferMatrixFree () = default;
-
-
-
-template <int dim, typename Number>
 void MGTransferMatrixFree<dim,Number>::initialize_constraints
 (const MGConstrainedDoFs &mg_c)
 {
@@ -552,10 +547,6 @@ MGTransferMatrixFree<dim,Number>::memory_consumption() const
 }
 
 
-template <int dim, typename Number>
-MGTransferBlockMatrixFree<dim,Number>::MGTransferBlockMatrixFree () = default;
-
-
 
 template <int dim, typename Number>
 MGTransferBlockMatrixFree<dim,Number>::MGTransferBlockMatrixFree (const MGConstrainedDoFs &mg_c)
@@ -563,11 +554,6 @@ MGTransferBlockMatrixFree<dim,Number>::MGTransferBlockMatrixFree (const MGConstr
   matrix_free_transfer(mg_c)
 {
 }
-
-
-
-template <int dim, typename Number>
-MGTransferBlockMatrixFree<dim,Number>::~MGTransferBlockMatrixFree () = default;
 
 
 

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -59,8 +59,7 @@ MGTransferMatrixFree<dim,Number>::MGTransferMatrixFree (const MGConstrainedDoFs 
 
 
 template <int dim, typename Number>
-MGTransferMatrixFree<dim,Number>::~MGTransferMatrixFree ()
-{}
+MGTransferMatrixFree<dim,Number>::~MGTransferMatrixFree () = default;
 
 
 
@@ -554,8 +553,7 @@ MGTransferMatrixFree<dim,Number>::memory_consumption() const
 
 
 template <int dim, typename Number>
-MGTransferBlockMatrixFree<dim,Number>::MGTransferBlockMatrixFree ()
-{}
+MGTransferBlockMatrixFree<dim,Number>::MGTransferBlockMatrixFree () = default;
 
 
 
@@ -569,8 +567,7 @@ MGTransferBlockMatrixFree<dim,Number>::MGTransferBlockMatrixFree (const MGConstr
 
 
 template <int dim, typename Number>
-MGTransferBlockMatrixFree<dim,Number>::~MGTransferBlockMatrixFree ()
-{}
+MGTransferBlockMatrixFree<dim,Number>::~MGTransferBlockMatrixFree () = default;
 
 
 

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -41,11 +41,6 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <typename VectorType>
-MGTransferPrebuilt<VectorType>::MGTransferPrebuilt () = default;
-
-
-
-template <typename VectorType>
 MGTransferPrebuilt<VectorType>::MGTransferPrebuilt (const MGConstrainedDoFs &mg_c)
 {
   this->mg_constrained_dofs = &mg_c;
@@ -58,11 +53,6 @@ MGTransferPrebuilt<VectorType>::MGTransferPrebuilt (const ConstraintMatrix &/*c*
 {
   this->mg_constrained_dofs = &mg_c;
 }
-
-
-
-template <typename VectorType>
-MGTransferPrebuilt<VectorType>::~MGTransferPrebuilt () = default;
 
 
 

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -41,8 +41,7 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <typename VectorType>
-MGTransferPrebuilt<VectorType>::MGTransferPrebuilt ()
-{}
+MGTransferPrebuilt<VectorType>::MGTransferPrebuilt () = default;
 
 
 
@@ -63,8 +62,7 @@ MGTransferPrebuilt<VectorType>::MGTransferPrebuilt (const ConstraintMatrix &/*c*
 
 
 template <typename VectorType>
-MGTransferPrebuilt<VectorType>::~MGTransferPrebuilt ()
-{}
+MGTransferPrebuilt<VectorType>::~MGTransferPrebuilt () = default;
 
 
 

--- a/source/multigrid/multigrid.cc
+++ b/source/multigrid/multigrid.cc
@@ -215,8 +215,7 @@ MGTransferSelect<number>::MGTransferSelect (const ConstraintMatrix &c)
 {}
 
 template <typename number>
-MGTransferSelect<number>::~MGTransferSelect ()
-{}
+MGTransferSelect<number>::~MGTransferSelect () = default;
 
 
 template <typename number>
@@ -280,8 +279,7 @@ MGTransferBlockSelect<number>::MGTransferBlockSelect (const ConstraintMatrix &/*
 
 
 template <typename number>
-MGTransferBlockSelect<number>::~MGTransferBlockSelect ()
-{}
+MGTransferBlockSelect<number>::~MGTransferBlockSelect () = default;
 
 
 

--- a/source/multigrid/multigrid.cc
+++ b/source/multigrid/multigrid.cc
@@ -214,8 +214,6 @@ MGTransferSelect<number>::MGTransferSelect (const ConstraintMatrix &c)
   constraints(&c)
 {}
 
-template <typename number>
-MGTransferSelect<number>::~MGTransferSelect () = default;
 
 
 template <typename number>
@@ -275,11 +273,6 @@ MGTransferBlockSelect<number>::MGTransferBlockSelect (const ConstraintMatrix &/*
   MGTransferBlockBase(mg_c),
   selected_block (0)
 {}
-
-
-
-template <typename number>
-MGTransferBlockSelect<number>::~MGTransferBlockSelect () = default;
 
 
 

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -42,8 +42,7 @@ DataOutStack<dim,spacedim,DoFHandlerType>::DataVector::memory_consumption () con
 
 
 template <int dim, int spacedim, typename DoFHandlerType>
-DataOutStack<dim,spacedim,DoFHandlerType>::~DataOutStack ()
-{}
+DataOutStack<dim,spacedim,DoFHandlerType>::~DataOutStack () = default;
 
 
 template <int dim, int spacedim, typename DoFHandlerType>

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -42,10 +42,6 @@ DataOutStack<dim,spacedim,DoFHandlerType>::DataVector::memory_consumption () con
 
 
 template <int dim, int spacedim, typename DoFHandlerType>
-DataOutStack<dim,spacedim,DoFHandlerType>::~DataOutStack () = default;
-
-
-template <int dim, int spacedim, typename DoFHandlerType>
 void DataOutStack<dim,spacedim,DoFHandlerType>::new_parameter_value (const double p,
     const double dp)
 {

--- a/source/numerics/data_postprocessor.cc
+++ b/source/numerics/data_postprocessor.cc
@@ -22,8 +22,7 @@ DEAL_II_NAMESPACE_OPEN
 // -------------------------- DataPostprocessor ---------------------------
 
 template <int dim>
-DataPostprocessor<dim>::~DataPostprocessor()
-{}
+DataPostprocessor<dim>::~DataPostprocessor() = default;
 
 
 

--- a/source/numerics/data_postprocessor.cc
+++ b/source/numerics/data_postprocessor.cc
@@ -22,11 +22,6 @@ DEAL_II_NAMESPACE_OPEN
 // -------------------------- DataPostprocessor ---------------------------
 
 template <int dim>
-DataPostprocessor<dim>::~DataPostprocessor() = default;
-
-
-
-template <int dim>
 void
 DataPostprocessor<dim>::
 evaluate_scalar_field (const DataPostprocessorInputs::Scalar<dim> &,

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -735,12 +735,12 @@ namespace DerivativeApproximation
     {
       struct Scratch
       {
-        Scratch() {}
+        Scratch() = default;
       };
 
       struct CopyData
       {
-        CopyData() {}
+        CopyData() = default;
       };
     }
   }

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -264,10 +264,6 @@ TimeStepBase::TimeStepBase (const double time) :
 
 
 
-TimeStepBase::~TimeStepBase () = default;
-
-
-
 void
 TimeStepBase::wake_up (const unsigned int )
 {}

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -264,8 +264,7 @@ TimeStepBase::TimeStepBase (const double time) :
 
 
 
-TimeStepBase::~TimeStepBase ()
-{}
+TimeStepBase::~TimeStepBase () = default;
 
 
 


### PR DESCRIPTION
This results from a recent `clang-tidy` run. Use `=default` and `=delete` where applicable.