### PR TITLE
Use const& instead of const where applicable

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2988,7 +2988,7 @@ public:
    * cases where <code>solution_filename == mesh_filename</code>, and
    * <code>dim==spacedim</code>.
    */
-  XDMFEntry(const std::string filename,
+  XDMFEntry(const std::string &filename,
             const double time,
             const unsigned int nodes,
             const unsigned int cells,
@@ -2998,8 +2998,8 @@ public:
    * Simplified constructor that calls the complete constructor for
    * cases where <code>dim==spacedim</code>.
    */
-  XDMFEntry(const std::string mesh_filename,
-            const std::string solution_filename,
+  XDMFEntry(const std::string &mesh_filename,
+            const std::string &solution_filename,
             const double time,
             const unsigned int nodes,
             const unsigned int cells,
@@ -3008,8 +3008,8 @@ public:
   /**
    * Constructor that sets all members to provided parameters.
    */
-  XDMFEntry(const std::string mesh_filename,
-            const std::string solution_filename,
+  XDMFEntry(const std::string &mesh_filename,
+            const std::string &solution_filename,
             const double time,
             const unsigned int nodes,
             const unsigned int cells,

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -111,7 +111,7 @@ public:
    */
   MappingFEField (const DoFHandlerType &euler_dof_handler,
                   const VectorType     &euler_vector,
-                  const ComponentMask   mask = ComponentMask());
+                  const ComponentMask   &mask = ComponentMask());
 
   /**
    * Copy constructor.
@@ -253,7 +253,7 @@ public:
      * Constructor.
      */
     InternalData(const FiniteElement<dim,spacedim> &fe,
-                 const ComponentMask mask);
+                 const ComponentMask &mask);
 
     /**
      * Shape function at quadrature point. Shape functions are in tensor

--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -234,7 +234,7 @@ namespace IteratorFilters
      * have to be evaluated to true and state if the iterator must be locally
      * owned.
      */
-    MaterialIdEqualTo (const std::set<types::material_id> material_ids,
+    MaterialIdEqualTo (const std::set<types::material_id> &material_ids,
                        const bool only_locally_owned = false);
 
     /**
@@ -280,7 +280,7 @@ namespace IteratorFilters
      * shall have to be evaluated to true and state if the iterator must be
      * locally owned.
      */
-    ActiveFEIndexEqualTo (const std::set<unsigned int> active_fe_indices,
+    ActiveFEIndexEqualTo (const std::set<unsigned int> &active_fe_indices,
                           const bool only_locally_owned = false);
 
     /**
@@ -1301,7 +1301,7 @@ namespace IteratorFilters
 
 
   inline
-  MaterialIdEqualTo::MaterialIdEqualTo (const std::set<types::material_id> material_ids,
+  MaterialIdEqualTo::MaterialIdEqualTo (const std::set<types::material_id> &material_ids,
                                         const bool only_locally_owned)
     :
     material_ids (material_ids),
@@ -1339,7 +1339,7 @@ namespace IteratorFilters
 
 
   inline
-  ActiveFEIndexEqualTo::ActiveFEIndexEqualTo (const std::set<unsigned int> active_fe_indices,
+  ActiveFEIndexEqualTo::ActiveFEIndexEqualTo (const std::set<unsigned int> &active_fe_indices,
                                               const bool only_locally_owned)
     :
     active_fe_indices (active_fe_indices),

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -283,7 +283,7 @@ namespace LinearAlgebra
      */
     void import(const distributed::Vector<Number> &vec,
                 VectorOperation::values operation,
-                std::shared_ptr<const CommunicationPatternBase> communication_pattern =
+                const std::shared_ptr<const CommunicationPatternBase> &communication_pattern =
                   std::shared_ptr<const CommunicationPatternBase> ());
 
 #ifdef DEAL_II_WITH_PETSC
@@ -297,7 +297,7 @@ namespace LinearAlgebra
      */
     void import(const PETScWrappers::MPI::Vector &petsc_vec,
                 VectorOperation::values operation,
-                std::shared_ptr<const CommunicationPatternBase> communication_pattern =
+                const std::shared_ptr<const CommunicationPatternBase> &communication_pattern =
                   std::shared_ptr<const CommunicationPatternBase> ());
 #endif
 
@@ -564,7 +564,7 @@ namespace LinearAlgebra
                 const IndexSet                                 &locally_owned_elements,
                 VectorOperation::values                         operation,
                 const MPI_Comm                                 &mpi_comm,
-                std::shared_ptr<const CommunicationPatternBase> communication_pattern);
+                const std::shared_ptr<const CommunicationPatternBase> &communication_pattern);
 #endif
 
     /**

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -232,7 +232,7 @@ namespace LinearAlgebra
   void
   ReadWriteVector<Number>::import(const distributed::Vector<Number> &vec,
                                   VectorOperation::values operation,
-                                  std::shared_ptr<const CommunicationPatternBase> communication_pattern)
+                                  const std::shared_ptr<const CommunicationPatternBase> &communication_pattern)
   {
     // If no communication pattern is given, create one. Otherwise, use the
     // given one.
@@ -301,7 +301,7 @@ namespace LinearAlgebra
   void
   ReadWriteVector<Number>::import(const PETScWrappers::MPI::Vector &petsc_vec,
                                   VectorOperation::values /*operation*/,
-                                  std::shared_ptr<const CommunicationPatternBase> /*communication_pattern*/)
+                                  const std::shared_ptr<const CommunicationPatternBase> & /*communication_pattern*/)
   {
     //TODO: this works only if no communication is needed.
     Assert(petsc_vec.locally_owned_elements() == stored_elements,
@@ -330,7 +330,7 @@ namespace LinearAlgebra
                                   const IndexSet                  &source_elements,
                                   VectorOperation::values          operation,
                                   const MPI_Comm                  &mpi_comm,
-                                  std::shared_ptr<const CommunicationPatternBase> communication_pattern)
+                                  const std::shared_ptr<const CommunicationPatternBase> &communication_pattern)
   {
     std::shared_ptr<const EpetraWrappers::CommunicationPattern> epetra_comm_pattern;
 

--- a/include/deal.II/numerics/dof_output_operator.h
+++ b/include/deal.II/numerics/dof_output_operator.h
@@ -47,7 +47,7 @@ namespace Algorithms
      * last step command. Numbers with less digits are filled with
      * zeros from the left.
      */
-    DoFOutputOperator (const std::string filename_base = std::string("output"),
+    DoFOutputOperator (const std::string &filename_base = std::string("output"),
                        const unsigned int digits = 3);
 
     void parse_parameters(ParameterHandler &param);

--- a/include/deal.II/numerics/dof_output_operator.templates.h
+++ b/include/deal.II/numerics/dof_output_operator.templates.h
@@ -25,7 +25,7 @@ namespace Algorithms
 {
   template <typename VectorType, int dim, int spacedim>
   DoFOutputOperator<VectorType, dim, spacedim>::DoFOutputOperator (
-    const std::string filename_base,
+    const std::string &filename_base,
     const unsigned int digits)
     :
     filename_base(filename_base),

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -185,7 +185,7 @@ namespace internal
                     const types::subdomain_id subdomain_id,
                     const types::material_id material_id,
                     const typename FunctionMap<spacedim>::type *neumann_bc,
-                    const ComponentMask                component_mask,
+                    const ComponentMask                &component_mask,
                     const Function<spacedim>                   *coefficients);
 
       /**
@@ -209,7 +209,7 @@ namespace internal
      const types::subdomain_id                           subdomain_id,
      const types::material_id                            material_id,
      const typename FunctionMap<spacedim>::type         *neumann_bc,
-     const ComponentMask                                 component_mask,
+     const ComponentMask                                 &component_mask,
      const Function<spacedim>                           *coefficients)
       :
       finite_element (fe),

--- a/source/base/convergence_table.cc
+++ b/source/base/convergence_table.cc
@@ -105,7 +105,7 @@ void ConvergenceTable::evaluate_convergence_rates(const std::string &data_column
   columns[rate_key].flag = 1;
   set_precision(rate_key, 2);
 
-  std::string superkey = data_column_key;
+  const std::string &superkey = data_column_key;
   if (!supercolumns.count(superkey))
     {
       add_column_to_supercolumn(data_column_key, superkey);
@@ -193,7 +193,7 @@ ConvergenceTable::evaluate_convergence_rates(const std::string &data_column_key,
   set_precision(rate_key, 2);
 
   // set the superkey equal to the key
-  std::string superkey=data_column_key;
+  const std::string &superkey=data_column_key;
   // and set the tex caption of the supercolumn to the tex caption of the
   // data_column.
   if (!supercolumns.count(superkey))

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7652,7 +7652,7 @@ XDMFEntry::XDMFEntry()
 
 
 
-XDMFEntry::XDMFEntry(const std::string filename,
+XDMFEntry::XDMFEntry(const std::string &filename,
                      const double time,
                      const unsigned int nodes,
                      const unsigned int cells,
@@ -7669,8 +7669,8 @@ XDMFEntry::XDMFEntry(const std::string filename,
 
 
 
-XDMFEntry::XDMFEntry(const std::string mesh_filename,
-                     const std::string solution_filename,
+XDMFEntry::XDMFEntry(const std::string &mesh_filename,
+                     const std::string &solution_filename,
                      const double time,
                      const unsigned int nodes,
                      const unsigned int cells,
@@ -7687,8 +7687,8 @@ XDMFEntry::XDMFEntry(const std::string mesh_filename,
 
 
 
-XDMFEntry::XDMFEntry(const std::string mesh_filename,
-                     const std::string solution_filename,
+XDMFEntry::XDMFEntry(const std::string &mesh_filename,
+                     const std::string &solution_filename,
                      const double time,
                      const unsigned int nodes,
                      const unsigned int cells,

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -58,7 +58,7 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::InternalData::InternalData
 (const FiniteElement<dim,spacedim> &fe,
- const ComponentMask                mask)
+ const ComponentMask                &mask)
   :
   n_shape_functions (fe.dofs_per_cell),
   mask (mask),
@@ -204,7 +204,7 @@ template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::MappingFEField
 (const DoFHandlerType            &euler_dof_handler,
  const VectorType    &euler_vector,
- const ComponentMask  mask)
+ const ComponentMask  &mask)
   :
   euler_vector(&euler_vector),
   fe(&euler_dof_handler.get_fe()),

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -328,7 +328,7 @@ namespace OpenCASCADE
                          const double tolerance)
   {
     TopoDS_Edge out_shape;
-    TopoDS_Shape edges = in_shape;
+    const TopoDS_Shape &edges = in_shape;
     std::vector<Handle_Geom_BoundedCurve> intersections;
     TopLoc_Location L;
     Standard_Real First;


### PR DESCRIPTION
This results from a recent `clang-tidy` run. Use `const &` instead of `const` were applicable.