### PR TITLE
Replace single character strings

### DIFF
--- a/source/base/job_identifier.cc
+++ b/source/base/job_identifier.cc
@@ -54,9 +54,9 @@ std::string
 JobIdentifier::base_name(const char *filename)
 {
   std::string name(filename);
-  std::string::size_type pos = name.find(".");
+  std::string::size_type pos = name.find('.');
   name.erase(pos, name.size());
-  pos = name.rfind("/");
+  pos = name.rfind('/');
   if (pos < name.size())
     name.erase(0,pos);
   return name;

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1901,7 +1901,7 @@ ParameterHandler::scan_line (std::string         line,
 
   // if there is a comment, delete it
   if (line.find('#') != std::string::npos)
-    line.erase (line.find("#"), std::string::npos);
+    line.erase (line.find('#'), std::string::npos);
 
   // replace \t by space:
   while (line.find('\t') != std::string::npos)
@@ -1958,7 +1958,7 @@ ParameterHandler::scan_line (std::string         line,
       // erase "set" statement
       line.erase (0, 4);
 
-      std::string::size_type pos = line.find("=");
+      std::string::size_type pos = line.find('=');
       AssertThrow (pos != std::string::npos,
                    ExcCannotParseLine (current_line_n,
                                        input_filename,

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -955,7 +955,7 @@ namespace Patterns
 
   MultipleSelection::MultipleSelection (const std::string &seq)
   {
-    Assert (seq.find (",") == std::string::npos, ExcCommasNotAllowed(seq.find(",")));
+    Assert (seq.find (',') == std::string::npos, ExcCommasNotAllowed(seq.find(',')));
 
     sequence = seq;
     while (sequence.find(" |") != std::string::npos)
@@ -977,10 +977,10 @@ namespace Patterns
         std::string name;
         name = tmp;
 
-        if (name.find(",") != std::string::npos)
+        if (name.find(',') != std::string::npos)
           {
-            name.erase (name.find(","), std::string::npos);
-            tmp.erase (0, tmp.find(",")+1);
+            name.erase (name.find(','), std::string::npos);
+            tmp.erase (0, tmp.find(',')+1);
           }
         else
           tmp = "";

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -546,7 +546,7 @@ TimerOutput::print_summary () const
 
           // resize the array so that it is always
           // of the same size
-          unsigned int pos_non_space = name_out.find_first_not_of (" ");
+          unsigned int pos_non_space = name_out.find_first_not_of (' ');
           name_out.erase(0, pos_non_space);
           name_out.resize (32, ' ');
           out_stream << std::endl;
@@ -617,7 +617,7 @@ TimerOutput::print_summary () const
 
           // resize the array so that it is always
           // of the same size
-          unsigned int pos_non_space = name_out.find_first_not_of (" ");
+          unsigned int pos_non_space = name_out.find_first_not_of (' ');
           name_out.erase(0, pos_non_space);
           name_out.resize (32, ' ');
           out_stream << std::endl;

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -348,7 +348,7 @@ namespace Utilities
         while ((text.length() != 0) && (text[0] == delimiter))
           text.erase(0, 1);
 
-        std::size_t pos_newline = text.find_first_of("\n", 0);
+        std::size_t pos_newline = text.find_first_of('\n', 0);
         if (pos_newline != std::string::npos && pos_newline <= width)
           {
             std::string line (text, 0, pos_newline);

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -2142,7 +2142,7 @@ void GridIn<dim, spacedim>::parse_tecplot_header(std::string &header,
 
   // now remove whitespace in front of and
   // after '='
-  std::string::size_type pos=header.find("=");
+  std::string::size_type pos=header.find('=');
 
   while (pos!=static_cast<std::string::size_type>(std::string::npos))
     if (header[pos+1]==' ')
@@ -2153,7 +2153,7 @@ void GridIn<dim, spacedim>::parse_tecplot_header(std::string &header,
         --pos;
       }
     else
-      pos=header.find("=",++pos);
+      pos=header.find('=',++pos);
 
   // split the string into individual entries
   std::vector<std::string> entries=Utilities::break_text_into_lines(header,1,' ');


### PR DESCRIPTION
This results from a recent `clang-tidy` run. It is more efficient to use characters instead of single character strings.