### PR TITLE
Corrected error in documentation of point input operator

### DIFF
--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -560,8 +560,7 @@ std::ostream &operator << (std::ostream            &out,
 
 
 /**
- * Output operator for points. Print the elements consecutively, with a space
- * in between.
+ * Input operator for points. Inputs the elements consecutively.
  * @relates Point
  */
 template <int dim, typename Number>


### PR DESCRIPTION
The documentation of output/input operator for points was the same.
When first using deal.II I noticed this and it confused me...think it's time to change it.
"Input operator for points. Inputs the elements consecutively." is ok?