### PR TITLE
Timer multithreaded fixes

### DIFF
--- a/doc/news/changes/minor/20170914DavidWells
+++ b/doc/news/changes/minor/20170914DavidWells
@@ -1,0 +1,7 @@
+Fixed: The destructor of TimerOutput::Scope will now always exit the subsection
+it entered in its constructor, instead of just exiting the last subsection that
+was created in the provided TimerOutput object. This fixes timing output
+measurements for multithreaded applications and cases where subsections are
+nested.
+<br>
+(David Wells, 2017/09/14)

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -586,6 +586,12 @@ public:
      * Reference to the TimerOutput object
      */
     dealii::TimerOutput &timer;
+
+    /**
+     * Name of the section we need to exit
+     */
+    const std::string section_name;
+
     /**
      * Do we still need to exit the section we are in?
      */
@@ -981,9 +987,12 @@ TimerOutput::exit_section (const std::string &section_name)
 }
 
 inline
-TimerOutput::Scope::Scope(dealii::TimerOutput &timer_, const std::string &section_name)
+TimerOutput::Scope::Scope(dealii::TimerOutput &timer_,
+                          const std::string &section_name_)
   :
-  timer(timer_), in(true)
+  timer(timer_),
+  section_name(section_name_),
+  in(true)
 {
   timer.enter_section(section_name);
 }
@@ -1006,7 +1015,7 @@ TimerOutput::Scope::stop()
   if (!in) return;
   in=false;
 
-  timer.exit_section();
+  timer.exit_section(section_name);
 }
 
 

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -431,13 +431,13 @@ TimerOutput::leave_subsection (const std::string &section_name)
 
   sections[actual_section_name].timer.stop();
   sections[actual_section_name].total_wall_time
-  += sections[actual_section_name].timer.wall_time();
+  += sections[actual_section_name].timer.last_wall_time();
 
   // Get cpu time. On MPI systems, if constructed with an mpi_communicator
   // like MPI_COMM_WORLD, then the Timer will sum up the CPU time between
   // processors among the provided mpi_communicator. Therefore, no
   // communication is needed here.
-  const double cpu_time = sections[actual_section_name].timer();
+  const double cpu_time = sections[actual_section_name].timer.last_cpu_time();
   sections[actual_section_name].total_cpu_time += cpu_time;
 
   // in case we have to print out something, do that here...
@@ -448,7 +448,7 @@ TimerOutput::leave_subsection (const std::string &section_name)
       std::ostringstream cpu;
       cpu << cpu_time << "s";
       std::ostringstream wall;
-      wall << sections[actual_section_name].timer.wall_time() << "s";
+      wall << sections[actual_section_name].timer.last_wall_time() << "s";
       if (output_type == cpu_times)
         output_time = ", CPU time: " + cpu.str();
       else if (output_type == wall_times)


### PR DESCRIPTION
The class `TimerOutput::Scope` (prior to this patch) always exits the last subsection that was created. This is not necessarily the correct one to exit. Consider the following sequence of events:

Thread 1: start and create `Scope scope_1(timer_output, "1")`
Thread 2: start and create `Scope scope_2(timer_output, "2")`
Thread 1: call `~scope_1()` and join
Thread 2: call `~scope_2()` and join

The current implementation of `~Scope()` exits the most recent subsection, so when `~scope_1()` is called we leave subsection `"2"` and when `~scope_2()` is called we leave subsection `"1"`. We can get around this by always explicitly exiting the subsection in which we started.

Similar bad things will happen if the scopes are nested.

While I was there I also fixed two Timer calls farther up. We always reset the timers (so the previous calls were correct) but I would prefer to explicitly use the lap times instead of relying on the reset.