### PR TITLE
Be more generous in what types we allow in the FESystem(...) constructor

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -779,7 +779,7 @@ public:
    * current object.
    */
   std::pair<std::unique_ptr<FiniteElement<dim, spacedim> >, unsigned int>
-  operator^ (unsigned int multiplicity) const;
+  operator^ (const unsigned int multiplicity) const;
 
   /**
    * A sort of virtual copy constructor, this function returns a copy of

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -24,9 +24,11 @@
 #include <deal.II/base/thread_management.h>
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/fe_tools.h>
+
 #include <vector>
 #include <memory>
 #include <utility>
+#include <type_traits>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -449,11 +449,11 @@ public:
    * corresponds to this line, but this does not matter because FESystem
    * creates its own copy of the FE_Q object.
    */
-  template <class... FESystems,
-            typename = typename std::enable_if<all_same_as<typename std::decay<FESystems>::type...,
+  template <class... FEPairs,
+            typename = typename std::enable_if<all_same_as<typename std::decay<FEPairs>::type...,
                                                            std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
                                                                unsigned int>>::value>::type>
-  FESystem (FESystems&& ... fe_systems);
+  FESystem (FEPairs&& ... fe_pairs);
 
   /**
    * Same as above allowing the following syntax:
@@ -1151,14 +1151,19 @@ namespace
   }
 }
 
+
+
 // We are just forwarding/delegating to the constructor taking a std::initializer_list.
 // If we decide to remove the deprecated constructors, we might just use the variadic
 // constructor with a suitable static_assert instead of the std::enable_if.
 template<int dim, int spacedim>
-template <class... FESystems, typename>
-FESystem<dim,spacedim>::FESystem (FESystems &&... fe_systems)
-  : FESystem<dim, spacedim> ({std::forward<FESystems>(fe_systems)...})
+template <class... FEPairs, typename>
+FESystem<dim,spacedim>::FESystem (FEPairs &&... fe_pairs)
+  :
+  FESystem<dim, spacedim> ({std::forward<FEPairs>(fe_pairs)...})
 {}
+
+
 
 template <int dim, int spacedim>
 FESystem<dim,spacedim>::FESystem

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -153,10 +153,9 @@ FiniteElement (const FiniteElementData<dim> &fe_data,
 
 template <int dim, int spacedim>
 std::pair<std::unique_ptr<FiniteElement<dim, spacedim> >, unsigned int>
-FiniteElement<dim, spacedim>::operator^ (unsigned int multiplicity) const
+FiniteElement<dim, spacedim>::operator^ (const unsigned int multiplicity) const
 {
-  return std::make_pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
-         unsigned int> (std::move(this->clone()), std::move(multiplicity));
+  return {this->clone(), multiplicity};
 }
 
 

--- a/tests/fe/system_04.cc
+++ b/tests/fe/system_04.cc
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// like the _03 test, but use the variadic constructor with the
+// promotion rule that converts individual elements into pairs of the
+// element and multiplicity one
+
+#include "../tests.h"
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_dgp.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_tools.h>
+
+#include <string>
+
+template <int dim>
+void
+check(FESystem<dim> &fe)
+{
+  deallog << fe.get_name() << std::endl;
+  deallog << "components: " << fe.n_components() << std::endl;
+  deallog << "blocks: " << fe.n_blocks() << std::endl;
+  deallog << "conforms H1: " << fe.conforms(FiniteElementData<dim>::H1) << std::endl;
+  deallog << "n_base_elements: " << fe.n_base_elements() << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  {
+    FESystem<2> fe (FE_Q<2>(1)^2, FE_Q<2>(1));
+    check<2>(fe);
+  }
+  {
+    FESystem<2> fe (FE_Q<2>(1)^2, FE_DGQ<2>(2)^0, FE_Q<2>(1));
+    check<2>(fe);
+  }
+  {
+    FESystem<2> fe (FESystem<2>(FE_Q<2>(1)^2), FE_Q<2>(1));
+    check<2>(fe);
+  }
+  {
+    FESystem<2> fe (FESystem<2>(FE_Q<2>(1)^2)^1, FE_DGQ<2>(2)^0, FE_Q<2>(1));
+    check<2>(fe);
+  }
+
+  return 0;
+}
+
+
+

--- a/tests/fe/system_04.output
+++ b/tests/fe/system_04.output
@@ -1,0 +1,21 @@
+
+DEAL::FESystem<2>[FE_Q<2>(1)^2-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 3
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::FESystem<2>[FE_Q<2>(1)^2-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 3
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::FESystem<2>[FESystem<2>[FE_Q<2>(1)^2]-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 2
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::FESystem<2>[FESystem<2>[FE_Q<2>(1)^2]-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 2
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2


### PR DESCRIPTION
This is a follow-up to the new variadic constructor of `FESystem` introduced in #5026: We now allow the argument list to be composed of either (i) pairs of a pointer to finite element and multiplicity, or (ii) just finite element. This allows writing things such as
```
  FESystem (FE_Q(2)^dim, FE_Q(1));
```
where the second argument has no multiplicity.

This works by routing each argument to a function `promote_to_pair()` that just forwards the original pair if it really is a pair, or that creates a pair of that element and multiplicity one if it is not a pair.

The last commit extends this a bit by adding another function `promote_to_pair()` that just eats all other possible argument types but has a `static_assert` that explains in detail that you can't do that. For example, if you pass an integer as an argument, you'd get this sort of error message:
```
40: In file included from /home/fac/f/bangerth/p/deal.II/1/dealii/tests/fe/system_04.cc:25:0:
40: /home/fac/f/bangerth/p/deal.II/1/dealii/include/deal.II/fe/fe_system.h: In function ‘std::pair<std::unique_ptr<dealii::FiniteElement<<anonymous>, <anonymous> > >, unsigned int> dealii::{anonymous}::promote_to_fe_pair(const T&)’:
40: /home/fac/f/bangerth/p/deal.II/1/dealii/include/deal.II/fe/fe_system.h:1183:5: error: static assertion failed: The arguments to the FESystem constructor that takes a variable number of arguments all need to either be finite element objects, or pairs of a std::unique pointer to a finite element and an integer multiplicity (i.e., what you get when you write, for example, (FE_Q<dim>(2)^3'). But here, you are calling that constructor with an argument that is neither of these two options.
40:      static_assert (false,
40:      ^
```

There is a new test, `system_04` that is a variation of `system_03` that just omits the `^1` cases. The output is identical to the previous test.