### PR TITLE
Provide DoFAccessor::set_dof_indices() for hp.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2873,87 +2873,14 @@ namespace internal
 
 
       /**
-       * Implement setting dof indices on a cell. Currently not implemented
-       * for hp::DoFHandler objects.
+       * Implement setting dof indices on a cell.
        */
-      template <int spacedim, bool level_dof_access>
+      template <int dim, int spacedim, bool level_dof_access>
       static
       void
-      set_dof_indices (DoFCellAccessor<DoFHandler<1,spacedim>, level_dof_access> &accessor,
-                       const std::vector<types::global_dof_index>          &local_dof_indices)
+      set_dof_indices (DoFCellAccessor<DoFHandler<dim,spacedim>, level_dof_access> &accessor,
+                       const std::vector<types::global_dof_index>                  &local_dof_indices)
       {
-        Assert (accessor.has_children() == false,
-                ExcInternalError());
-
-        const unsigned int dofs_per_vertex = accessor.get_fe().dofs_per_vertex,
-                           dofs_per_line   = accessor.get_fe().dofs_per_line,
-                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
-        (void)dofs_per_cell;
-
-        Assert (local_dof_indices.size() == dofs_per_cell,
-                ExcInternalError());
-
-        unsigned int index = 0;
-
-        for (unsigned int vertex=0; vertex<2; ++vertex)
-          for (unsigned int d=0; d<dofs_per_vertex; ++d, ++index)
-            accessor.set_vertex_dof_index(vertex,d,
-                                          local_dof_indices[index]);
-
-        for (unsigned int d=0; d<dofs_per_line; ++d, ++index)
-          accessor.set_dof_index(d, local_dof_indices[index]);
-
-        Assert (index == dofs_per_cell,
-                ExcInternalError());
-      }
-
-
-
-      template <int spacedim, bool level_dof_access>
-      static
-      void
-      set_dof_indices (DoFCellAccessor<DoFHandler<2,spacedim>, level_dof_access> &accessor,
-                       const std::vector<types::global_dof_index>          &local_dof_indices)
-      {
-        Assert (accessor.has_children() == false,
-                ExcInternalError());
-
-        const unsigned int dofs_per_vertex = accessor.get_fe().dofs_per_vertex,
-                           dofs_per_line   = accessor.get_fe().dofs_per_line,
-                           dofs_per_quad   = accessor.get_fe().dofs_per_quad,
-                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
-        (void)dofs_per_cell;
-
-        Assert (local_dof_indices.size() == dofs_per_cell,
-                ExcInternalError());
-
-        unsigned int index = 0;
-
-        for (unsigned int vertex=0; vertex<4; ++vertex)
-          for (unsigned int d=0; d<dofs_per_vertex; ++d, ++index)
-            accessor.set_vertex_dof_index(vertex,d,
-                                          local_dof_indices[index]);
-        for (unsigned int line=0; line<4; ++line)
-          for (unsigned int d=0; d<dofs_per_line; ++d, ++index)
-            accessor.line(line)->set_dof_index(d, local_dof_indices[index]);
-
-        for (unsigned int d=0; d<dofs_per_quad; ++d, ++index)
-          accessor.set_dof_index(d, local_dof_indices[index]);
-
-        Assert (index == dofs_per_cell,
-                ExcInternalError());
-      }
-
-
-
-      template <int spacedim, bool level_dof_access>
-      static
-      void
-      set_dof_indices (DoFCellAccessor<DoFHandler<3,spacedim>, level_dof_access> &accessor,
-                       const std::vector<types::global_dof_index>          &local_dof_indices)
-      {
-        const unsigned int dim = 3;
-
         Assert (accessor.has_children() == false,
                 ExcInternalError());
 
@@ -2973,20 +2900,26 @@ namespace internal
           for (unsigned int d=0; d<dofs_per_vertex; ++d, ++index)
             accessor.set_vertex_dof_index(vertex,d,
                                           local_dof_indices[index]);
-        // now copy dof numbers into the line. for lines with the
+        // now copy dof numbers into the line. for lines in 3d with the
         // wrong orientation, we have already made sure that we're ok
         // by picking the correct vertices (this happens automatically
         // in the vertex() function). however, if the line is in wrong
         // orientation, we look at it in flipped orientation and we
         // will have to adjust the shape function indices that we see
         // to correspond to the correct (cell-local) ordering.
+        //
+        // of course, if dim<3, then there is nothing to adjust
         for (unsigned int line=0; line<GeometryInfo<dim>::lines_per_cell; ++line)
           for (unsigned int d=0; d<dofs_per_line; ++d, ++index)
-            accessor.line(line)->set_dof_index(accessor.dof_handler->get_fe().
+            accessor.line(line)->set_dof_index(dim < 3
+                                               ?
+                                               d
+                                               :
+                                               accessor.dof_handler->get_fe().
                                                adjust_line_dof_index_for_line_orientation(d,
                                                    accessor.line_orientation(line)),
                                                local_dof_indices[index]);
-        // now copy dof numbers into the face. for faces with the
+        // now copy dof numbers into the face. for faces in 3d with the
         // wrong orientation, we have already made sure that we're ok
         // by picking the correct lines and vertices (this happens
         // automatically in the line() and vertex()
@@ -2995,9 +2928,15 @@ namespace internal
         // adjust the shape function indices that we see to correspond
         // to the correct (cell-local) ordering. The same applies, if
         // the face_rotation or face_orientation is non-standard
+        //
+        // again, if dim<3, then there is nothing to adjust
         for (unsigned int quad=0; quad<GeometryInfo<dim>::quads_per_cell; ++quad)
           for (unsigned int d=0; d<dofs_per_quad; ++d, ++index)
-            accessor.quad(quad)->set_dof_index(accessor.dof_handler->get_fe().
+            accessor.quad(quad)->set_dof_index(dim < 3
+                                               ?
+                                               d
+                                               :
+                                               accessor.dof_handler->get_fe().
                                                adjust_quad_dof_index_for_face_orientation(d,
                                                    accessor.face_orientation(quad),
                                                    accessor.face_flip(quad),

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2875,99 +2875,23 @@ namespace internal
       /**
        * Implement setting dof indices on a cell.
        */
-      template <int dim, int spacedim, bool level_dof_access>
+      template <typename DoFHandlerType, bool level_dof_access>
       static
       void
-      set_dof_indices (DoFCellAccessor<DoFHandler<dim,spacedim>, level_dof_access> &accessor,
-                       const std::vector<types::global_dof_index>                  &local_dof_indices)
-      {
-        Assert (accessor.has_children() == false,
-                ExcInternalError());
-
-        const unsigned int dofs_per_vertex = accessor.get_fe().template n_dofs_per_object<0>(),
-                           dofs_per_line   = accessor.get_fe().template n_dofs_per_object<1>(),
-                           dofs_per_quad   = accessor.get_fe().template n_dofs_per_object<2>(),
-                           dofs_per_hex    = accessor.get_fe().template n_dofs_per_object<3>(),
-                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
-        (void)dofs_per_cell;
-
-        Assert (local_dof_indices.size() == dofs_per_cell,
-                ExcInternalError());
-
-        unsigned int index = 0;
-
-        for (unsigned int vertex=0; vertex<GeometryInfo<dim>::vertices_per_cell; ++vertex)
-          for (unsigned int d=0; d<dofs_per_vertex; ++d, ++index)
-            accessor.set_vertex_dof_index(vertex,d,
-                                          local_dof_indices[index]);
-        // now copy dof numbers into the line. for lines in 3d with the
-        // wrong orientation, we have already made sure that we're ok
-        // by picking the correct vertices (this happens automatically
-        // in the vertex() function). however, if the line is in wrong
-        // orientation, we look at it in flipped orientation and we
-        // will have to adjust the shape function indices that we see
-        // to correspond to the correct (cell-local) ordering.
-        //
-        // of course, if dim<3, then there is nothing to adjust
-        for (unsigned int line=0; line<GeometryInfo<dim>::lines_per_cell; ++line)
-          for (unsigned int d=0; d<dofs_per_line; ++d, ++index)
-            accessor.line(line)->set_dof_index(dim < 3
-                                               ?
-                                               d
-                                               :
-                                               accessor.dof_handler->get_fe().
-                                               adjust_line_dof_index_for_line_orientation(d,
-                                                   accessor.line_orientation(line)),
-                                               local_dof_indices[index]);
-        // now copy dof numbers into the face. for faces in 3d with the
-        // wrong orientation, we have already made sure that we're ok
-        // by picking the correct lines and vertices (this happens
-        // automatically in the line() and vertex()
-        // functions). however, if the face is in wrong orientation,
-        // we look at it in flipped orientation and we will have to
-        // adjust the shape function indices that we see to correspond
-        // to the correct (cell-local) ordering. The same applies, if
-        // the face_rotation or face_orientation is non-standard
-        //
-        // again, if dim<3, then there is nothing to adjust
-        for (unsigned int quad=0; quad<GeometryInfo<dim>::quads_per_cell; ++quad)
-          for (unsigned int d=0; d<dofs_per_quad; ++d, ++index)
-            accessor.quad(quad)->set_dof_index(dim < 3
-                                               ?
-                                               d
-                                               :
-                                               accessor.dof_handler->get_fe().
-                                               adjust_quad_dof_index_for_face_orientation(d,
-                                                   accessor.face_orientation(quad),
-                                                   accessor.face_flip(quad),
-                                                   accessor.face_rotation(quad)),
-                                               local_dof_indices[index]);
-        for (unsigned int d=0; d<dofs_per_hex; ++d, ++index)
-          accessor.set_dof_index(d, local_dof_indices[index]);
-
-        Assert (index == dofs_per_cell,
-                ExcInternalError());
-      }
-
-
-      // implementation for the case of hp::DoFHandler objects
-      template <int dim, int spacedim, bool level_dof_access>
-      static
-      void
-      set_dof_indices (const DoFCellAccessor<dealii::hp::DoFHandler<dim,spacedim>, level_dof_access> &accessor,
+      set_dof_indices (const DoFCellAccessor<DoFHandlerType, level_dof_access> &accessor,
                        const std::vector<types::global_dof_index> &local_dof_indices)
       {
+        const unsigned int dim = DoFHandlerType::dimension;
+
         Assert (accessor.has_children() == false,
                 ExcInternalError());
 
-        const unsigned int dofs_per_vertex = accessor.get_fe().template n_dofs_per_object<0>(),
-                           dofs_per_line   = accessor.get_fe().template n_dofs_per_object<1>(),
-                           dofs_per_quad   = accessor.get_fe().template n_dofs_per_object<2>(),
-                           dofs_per_hex    = accessor.get_fe().template n_dofs_per_object<3>(),
-                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
-        (void)dofs_per_cell;
+        const unsigned int dofs_per_vertex = accessor.get_fe().dofs_per_vertex,
+                           dofs_per_line   = accessor.get_fe().dofs_per_line,
+                           dofs_per_quad   = accessor.get_fe().dofs_per_quad,
+                           dofs_per_hex    = accessor.get_fe().dofs_per_hex;
 
-        Assert (local_dof_indices.size() == dofs_per_cell,
+        Assert (local_dof_indices.size() == accessor.get_fe().dofs_per_cell,
                 ExcInternalError());
 
         unsigned int index = 0;
@@ -3025,7 +2949,7 @@ namespace internal
           accessor.set_dof_index(d, local_dof_indices[index],
                                  accessor.active_fe_index());
 
-        Assert (index == dofs_per_cell,
+        Assert (index == accessor.get_fe().dofs_per_cell,
                 ExcInternalError());
       }
 

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2950,15 +2950,83 @@ namespace internal
       }
 
 
-      // implementation for the case of hp::DoFHandler objects. it's
-      // not implemented there, for no space dimension
+      // implementation for the case of hp::DoFHandler objects
       template <int dim, int spacedim, bool level_dof_access>
       static
       void
-      set_dof_indices (const DoFCellAccessor<dealii::hp::DoFHandler<dim,spacedim>, level_dof_access> &,
-                       const std::vector<types::global_dof_index> &)
+      set_dof_indices (const DoFCellAccessor<dealii::hp::DoFHandler<dim,spacedim>, level_dof_access> &accessor,
+                       const std::vector<types::global_dof_index> &local_dof_indices)
       {
-        Assert (false, ExcNotImplemented());
+        Assert (accessor.has_children() == false,
+                ExcInternalError());
+
+        const unsigned int dofs_per_vertex = accessor.get_fe().template n_dofs_per_object<0>(),
+                           dofs_per_line   = accessor.get_fe().template n_dofs_per_object<1>(),
+                           dofs_per_quad   = accessor.get_fe().template n_dofs_per_object<2>(),
+                           dofs_per_hex    = accessor.get_fe().template n_dofs_per_object<3>(),
+                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
+        (void)dofs_per_cell;
+
+        Assert (local_dof_indices.size() == dofs_per_cell,
+                ExcInternalError());
+
+        unsigned int index = 0;
+
+        for (unsigned int vertex=0; vertex<GeometryInfo<dim>::vertices_per_cell; ++vertex)
+          for (unsigned int d=0; d<dofs_per_vertex; ++d, ++index)
+            accessor.set_vertex_dof_index(vertex,d,
+                                          local_dof_indices[index],
+                                          accessor.active_fe_index());
+        // now copy dof numbers into the line. for lines in 3d with the
+        // wrong orientation, we have already made sure that we're ok
+        // by picking the correct vertices (this happens automatically
+        // in the vertex() function). however, if the line is in wrong
+        // orientation, we look at it in flipped orientation and we
+        // will have to adjust the shape function indices that we see
+        // to correspond to the correct (cell-local) ordering.
+        //
+        // of course, if dim<3, then there is nothing to adjust
+        for (unsigned int line=0; line<GeometryInfo<dim>::lines_per_cell; ++line)
+          for (unsigned int d=0; d<dofs_per_line; ++d, ++index)
+            accessor.line(line)->set_dof_index(dim < 3
+                                               ?
+                                               d
+                                               :
+                                               accessor.get_fe().
+                                               adjust_line_dof_index_for_line_orientation(d,
+                                                   accessor.line_orientation(line)),
+                                               local_dof_indices[index],
+                                               accessor.active_fe_index());
+        // now copy dof numbers into the face. for faces in 3d with the
+        // wrong orientation, we have already made sure that we're ok
+        // by picking the correct lines and vertices (this happens
+        // automatically in the line() and vertex()
+        // functions). however, if the face is in wrong orientation,
+        // we look at it in flipped orientation and we will have to
+        // adjust the shape function indices that we see to correspond
+        // to the correct (cell-local) ordering. The same applies, if
+        // the face_rotation or face_orientation is non-standard
+        //
+        // again, if dim<3, then there is nothing to adjust
+        for (unsigned int quad=0; quad<GeometryInfo<dim>::quads_per_cell; ++quad)
+          for (unsigned int d=0; d<dofs_per_quad; ++d, ++index)
+            accessor.quad(quad)->set_dof_index(dim < 3
+                                               ?
+                                               d
+                                               :
+                                               accessor.get_fe().
+                                               adjust_quad_dof_index_for_face_orientation(d,
+                                                   accessor.face_orientation(quad),
+                                                   accessor.face_flip(quad),
+                                                   accessor.face_rotation(quad)),
+                                               local_dof_indices[index],
+                                               accessor.active_fe_index());
+        for (unsigned int d=0; d<dofs_per_hex; ++d, ++index)
+          accessor.set_dof_index(d, local_dof_indices[index],
+                                 accessor.active_fe_index());
+
+        Assert (index == dofs_per_cell,
+                ExcInternalError());
       }
 
 


### PR DESCRIPTION
I need this for my parallel hp work, but it was not available before. This
patch introduces it in 3 easy steps, though the end result may actually be
easiest to read. It relies on the invalid accessor class of #5075.

Part of #3511.