### PR TITLE
Sundials fixes

### DIFF
--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -179,6 +179,7 @@ namespace SUNDIALS
     unsigned int step_number = 0;
 
     int status;
+    (void)status;
 
     // The solution is stored in
     // solution. Here we take only a
@@ -306,6 +307,7 @@ namespace SUNDIALS
       }
 
     int status;
+    (void)status;
     system_size = solution.size();
 #ifdef DEAL_II_WITH_MPI
     if (is_serial_vector<VectorType>::value == false)


### PR DESCRIPTION
I got a couple of warnings when using Sundials:
1. The current `FindSUNDIALS.cmake` script does not set all path variables correctly if my installation is in a system directory (i.e., `/usr/include/` and `/usr/lib/`). I fixed the header detection for this case (and preserved the old behavior with an optional hint path).
2. I get a bunch of warnings due to comparisons between unsigned and signed integral types since Sundials uses `long int` by default. I refactored the length checks into an internal function that uses a `static_cast` to avoid the warning.
3. A few variables are not used in release mode so I 'use' them with the old `(void)foo;` trick.