### PR TITLE
[WIP] Convert FEValuesViews::*::get_function_values_from_...

### DIFF
--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/derivative_form.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/vector_slice.h>
+#include <deal.II/base/array_view.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/table.h>
 #include <deal.II/grid/tria.h>
@@ -351,9 +352,9 @@ namespace FEValuesViews
      * cell->get_dof_values(solution, local_dof_values.begin(), local_dof_values.end());
      * @endcode
      */
-    template <class InputVector>
-    void get_function_values_from_local_dof_values (const InputVector &dof_values,
-                                                    std::vector<typename OutputType<typename InputVector::value_type>::value_type> &values) const;
+    template <typename Number>
+    void get_function_values_from_local_dof_values (const ArrayView<const Number> &dof_values,
+                                                    std::vector<typename OutputType<Number>::value_type> &values) const;
 
     /**
      * Return the gradients of the selected scalar component of the finite

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -1297,11 +1297,11 @@ namespace FEValuesViews
   }
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Scalar<dim,spacedim>::
-  get_function_values_from_local_dof_values (const InputVector &dof_values,
-                                             std::vector<typename OutputType<typename InputVector::value_type>::value_type> &values) const
+  get_function_values_from_local_dof_values (const ArrayView<const Number> &dof_values,
+                                             std::vector<typename OutputType<Number>::value_type> &values) const
   {
     Assert (fe_values->update_flags & update_values,
             (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_values")));

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -139,17 +139,26 @@ for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimensi
 }
 
 
-for (VEC : GENERAL_CONTAINER_TYPES;
-        Number : ALL_SCALAR_TYPES;
+
+for (Number : ALL_SCALAR_TYPES;
         deal_II_dimension : DIMENSIONS;
         deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     template
     void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_values_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::value_type>&) const;
+    ::get_function_values_from_local_dof_values<Number>
+    (const ArrayView<const Number>&, std::vector<typename OutputType<Number>::value_type>&) const;
+#endif
+}
 
+
+for (VEC : GENERAL_CONTAINER_TYPES;
+        Number : ALL_SCALAR_TYPES;
+        deal_II_dimension : DIMENSIONS;
+        deal_II_space_dimension :  SPACE_DIMENSIONS)
+{
+#if deal_II_dimension <= deal_II_space_dimension
     template
     void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
     ::get_function_gradients_from_local_dof_values<VEC<Number>>


### PR DESCRIPTION
This is a try at #4883 where we were talking about converting some of the FEValuesViews::*
member functions to take an ArrayView instead of a std::vector. @drwells -- was this
about what you had in mind?