### PR TITLE
Improve documentation for MultigridTransfer::copy_to_mg

### DIFF
--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -154,7 +154,9 @@ public:
 
   /**
    * Transfer from a vector on the global grid to vectors defined on each of
-   * the levels separately, i.a. an @p MGVector.
+   * the levels separately for the active degrees of freedom. In particular,
+   * for a globally refined mesh only the finest level in @p dst is filled as a
+   * plain copy of @p src. All the other level objects are left untouched.
    */
   template <int dim, class InVector, int spacedim>
   void
@@ -302,7 +304,9 @@ public:
 
   /**
    * Transfer from a vector on the global grid to vectors defined on each of
-   * the levels separately, i.a. an @p MGVector.
+   * the levels separately for the active degrees of freedom. In particular, for
+   * a globally refined mesh only the finest level in @p dst is filled as a
+   * plain copy of @p src. All the other level objects are left untouched.
    */
   template <int dim, typename Number2, int spacedim>
   void

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -228,7 +228,10 @@ public:
                                  const BlockVector<number> &src) const;
 
   /**
-   * Transfer from a vector on the global grid to a multilevel vector.
+   * Transfer from a vector on the global grid to a multilevel vector for the
+   * active degrees of freedom. In particular, for a globally refined mesh only
+   * the finest level in @p dst is filled  as a plain copy of @p src. All the
+   * other level objects are left untouched.
    *
    * The action for discontinuous elements is as follows: on an active mesh
    * cell, the global vector entries are simply copied to the corresponding
@@ -356,7 +359,9 @@ public:
 
   /**
    * Transfer a single block from a vector on the global grid to a multilevel
-   * vector.
+   * vector for the active degrees of freedom. In particular, for a globally
+   * refined mesh only the finest level in @p dst is filled as a plain copy of
+   * @p src. All the other level objects are left untouched.
    */
   template <int dim, typename number2, int spacedim>
   void
@@ -389,7 +394,10 @@ public:
 
   /**
    * Transfer a block from a vector on the global grid to multilevel vectors.
-   * Only the block selected is transfered.
+   * Only the values for the active degrees of freedom of the block selected are
+   * transfered. In particular, for a globally refined mesh only the finest
+   * level in @p dst is filled as a plain copy of @p src. All the other level
+   * objects are left untouched.
    */
   template <int dim, typename number2, int spacedim>
   void

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -242,7 +242,10 @@ public:
                                  const Vector<number> &src) const;
 
   /**
-   * Transfer from a vector on the global grid to a multilevel vector.
+   * Transfer from a vector on the global grid to a multilevel vector for the
+   * active degrees of freedom. In particular, for a globally refined mesh only
+   * the finest level in @p dst is filled as a plain copy of @p src. All the
+   * other level objects are left untouched.
    */
   template <int dim, typename number2, int spacedim>
   void
@@ -274,7 +277,10 @@ public:
                     const MGLevelObject<Vector<number> > &src) const;
 
   /**
-   * Transfer from a vector on the global grid to multilevel vectors.
+   * Transfer from a vector on the global grid to a multilevel vector for the
+   * active degrees of freedom. In particular, for a globally refined mesh only
+   * the finest level in @p dst is filled as a plain copy of @p src. All the
+   * other level objects are left untouched.
    */
   template <int dim, typename number2, int spacedim>
   void

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -329,7 +329,10 @@ public:
 
   /**
    * Transfer from a block-vector on the global grid to block-vectors defined
-   * on each of the levels separately.
+   * on each of the levels separately for active degrees of freedom.
+   * In particular, for a globally refined mesh only the finest level in @p dst
+   * is filled as a plain copy of @p src. All the other level objects are left
+   * untouched.
    *
    * This function will initialize @p dst accordingly if needed as required by
    * the Multigrid class.


### PR DESCRIPTION
Clarify that `copy_to_mg` only acts on active degrees of freedoms. The current documentation led to the assumption that this function would do similar things as `restrict_add` for the `MultigridTransfer` classes.