### PR TITLE
Remove unused private function DoFHandler::reserve_space

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1049,11 +1049,6 @@ private:
    */
   void clear_mg_space ();
 
-  /**
-   * Allocate space that will be used by distribute_dofs().
-   */
-  void reserve_space ();
-
   template <int structdim>
   types::global_dof_index get_dof_index (const unsigned int obj_level,
                                          const unsigned int obj_index,

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1058,14 +1058,6 @@ void DoFHandler<dim, spacedim>::distribute_mg_dofs ()
 
 
 template <int dim, int spacedim>
-void DoFHandler<dim, spacedim>::reserve_space ()
-{
-  //TODO: move this to distribute_mg_dofs and remove function
-}
-
-
-
-template <int dim, int spacedim>
 void DoFHandler<dim, spacedim>::clear_mg_space ()
 {
   mg_levels.clear ();


### PR DESCRIPTION
It seems this was forgotten when moving the implementation to `distribute_mg_dof`.
Passes a local test suite run.