### PR TITLE
ParameterAcceptor.

### DIFF
--- a/doc/news/changes/major/20170920LucaHeltai
+++ b/doc/news/changes/major/20170920LucaHeltai
@@ -1,0 +1,12 @@
+New: A new ParameterAcceptor class has been added to the library.
+The class is intended to be used as a base class for any class
+that wants to handle parameters using the ParameterHandler class.
+
+If you derive all your classes from ParameterAcceptor, and declare 
+your parameters either with parse/declare_parameters methods or
+via the ParameterAcceptor::add_parameter() method, then the declaring
+and parsing of your parameter files will be automatically managed 
+by the ParameterAcceptor::initialize() function.
+<br>
+(Luca Heltai, 2017/09/20)
+

--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -500,10 +500,10 @@ protected:
 
 // Inline and template functions
 template<class ParameterType>
-void ParameterAcceptor::add_parameter(const std::string& entry,
-                                      ParameterType& parameter,
-                                      const std::string& documentation,
-                                      const Patterns::PatternBase& pattern)
+void ParameterAcceptor::add_parameter(const std::string &entry,
+                                      ParameterType &parameter,
+                                      const std::string &documentation,
+                                      const Patterns::PatternBase &pattern)
 {
   enter_my_subsection(prm);
   prm.add_parameter(entry, parameter, documentation, pattern);

--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -1,0 +1,517 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2014 - 2016 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+#ifndef dealii_base_parameter_acceptor_h
+#define dealii_base_parameter_acceptor_h
+
+#include <deal.II/base/config.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/exceptions.h>
+#include <boost/signals2/signal.hpp>
+#include <typeinfo>
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * A parameter acceptor base class. This class is used to define a public
+ * interface for classes wich want to use a single global ParameterHandler to
+ * handle parameters. This class declares one static ParameterHandler, and two
+ * static functions (declare_all_parameters() and parse_all_parameters()) that
+ * manage all of the derived classes.
+ *
+ * The basic interface provides two subscription mechanisms: a **global
+ * subscription mechanism** and a **local subscription mechanism**.
+ *
+ * The global subscription mechanism is such that whenever a class that was
+ * derived by ParameterAcceptor is constructed, a static registry
+ * (ParameterAcceptor::class_list) in the base class is updated with a pointer
+ * to the derived class, and a path in the parameter file. Such registry is
+ * traversed upon invocation of the single function
+ * ParameterAcceptor::initialize(file.prm) which in turn calls the method
+ * ParameterAcceptor::declare_parameters() for each of the registered classes,
+ * reads the file `file.prm` and subsequently calls the method
+ * ParameterAcceptor::parse_parameters(), again for each of the registered
+ * classes. The method log_info() can be used to extract informations about the
+ * classes that have been derived from ParameterAcceptor, and that will be
+ * parsed when calling ParameterAcceptor::initialize().
+ *
+ * ParameterAcceptor can be used in two different ways: by overloading the
+ * ParameterAcceptor::declare_parameters() and
+ * ParameterAcceptor::parse_parameters() methods, or by calling its
+ * ParameterAcceptor::add_parameter() method for each parameter we want to
+ * have. This in turns makes sure that the given parameter is registered in the
+ * global parameter handler (by calling ParameterHandler::add_parameter()), at
+ * the correct path. If you define all your parameters using the
+ * ParameterAcceptor::add_parameter() method, then you don't need to overload
+ * any of the virtual methods of this class.
+ *
+ * If some post processing is required on the parsed values, the user can
+ * attach a signal to ParameterAcceptor::parse_parameters_call_back can be
+ * overridden, which is called just after the parse_parameters() function of
+ * each class.
+ *
+ * A typical usage of this class is the following:
+ *
+ * @code
+ * // This is your own class, derived from ParameterAcceptor
+ * class MyClass : public ParameterAcceptor {
+ *
+ * // The constructor of ParameterAcceptor requires a std::string,
+ * // which defines the section name where the parameters of MyClass
+ * // will be stored.
+ *
+ * MyClass(std::string name) :
+ *   ParameterAcceptor(name)
+ * {
+ *    add_parameter("A param", member_var);
+ * }
+ *
+ * private:
+ *   std::vector<unsigned int> member_var;
+ * ...
+ * };
+ *
+ * int main() {
+ *  // Make sure you build your class BEFORE calling
+ *  // ParameterAcceptor::initialize()
+ *  MyClass class;
+ *
+ *  // With this call, all derived classes will have their
+ *  // parameters initialized
+ *  ParameterAcceptor::initialize("file.prm");
+ * }
+ * @endcode
+ *
+ * An implementation that uses user defined declare and parse functions is given
+ * by the following example:
+ *
+ * @code
+ * // Again your own class, derived from ParameterAcceptor
+ * class MyClass : public ParameterAcceptor {
+ *
+ * MyClass(std::string name) :
+ *   ParameterAcceptor(name)
+ *   {}
+ *
+ *   virtual void declare_parameters(ParameterHandler &prm) {
+ *    ...
+ *   }
+ *
+ *   virtual void parse_parameters(ParameterHandler &prm) {
+ *     ...
+ *   }
+ * };
+ *
+ * int main() {
+ *  // Make sure you build your class BEFORE calling
+ *  // ParameterAcceptor::initialize()
+ *  MyClass class;
+ *  ParameterAcceptor::initialize("file.prm");
+ *  class.run();
+ * }
+ * @endcode
+ *
+ *
+ * Parameter files can be organised into section/subsection/subsubsection.
+ * To do so, the std::string passed to ParameterAcceptor within the
+ * constructor of the derived class needs to contain the separator "/".
+ * In fact, "first/second/third/My Class" will organize the parameters
+ * as follows
+ *
+ * @code
+ * subsection first
+ *   subsection second
+ *     subsection third
+ *       subsection My Class
+ *        ... # all the parameters
+ *       end
+ *     end
+ *   end
+ * end
+ * @endcode
+ *
+ * In the following examles, we propose some use cases with increasing
+ * complexities.
+ *
+ * MyClass is derived from ParameterAcceptor and has a
+ * member object that is derived itself from ParameterAcceptor.
+ * @code
+ * class MyClass : public ParameterAcceptor
+ * {
+ *   MyClass (std::string name);
+ *   virtual void declare_parameters(ParameterHandler &prm);
+ * private:
+ *   SomeParsedClass<dim> my_subclass;
+ *  ...
+ * };
+ *
+ * MyClass::MyClass(std::string name)
+ *  :
+ * ParameterAcceptor(name),
+ * my_subclass("Forcing term")
+ * {}
+ *
+ * void MyClass::declare_parmeters(ParameterHandler &prm)
+ * {
+ *  // many add_parameter(...);
+ * }
+ *
+ * ...
+ *
+ * int main()
+ * {
+ * MyClass mc("My Class");
+ *
+ * ParameterAcceptor::initialize("file.prm");
+ * }
+ * @endcode
+ *
+ * In this case, the structure of the parameters will be
+ * @code
+ * subsection Forcing term
+ * ... #parameters of SomeParsedClass
+ * end
+ * subsection My class
+ * ... #all the parameters of MyClass defined in declare_parameters
+ * end
+ * @endcode
+ * Note that the sections are alphabetically sorted.
+ *
+ * Now suppose that in the main file we need two or more objects of MyClass
+ * @code
+ * int main()
+ * {
+ *  MyClass ca("Class A");
+ *  MyClass cb("Class B");
+ *  ParameterAcceptor::initialize("file.prm");
+ * }
+ * @endcode
+ *
+ * What we will read in the parameter file looks like
+ * @code
+ * subsection Class A
+ * ...
+ * end
+ * subsection Class B
+ * ...
+ * end
+ * subsection Forcing term
+ * ...
+ * end
+ * @endcode
+ * Note that there is only one section "Forcing term", this is because
+ * both objects have defined the same name for the section of their
+ * SomeParsedClass. There are two strategies to manage this issue. The
+ * first one (not recommended) would be to change the name of the section
+ * of SomeParsedClass such that it contains also the string passed to
+ * the constructor of MyClass:
+ * @code
+ * MyClass::MyClass(std::string name)
+ *  :
+ * ParameterAcceptor(name),
+ * my_subclass(name+" --- forcing term")
+ * {}
+ * @endcode
+ *
+ * The other way to proceed (recommended) is to use exploit the /section/subsection
+ * approach **in the main class**.
+ * @code
+ * int main()
+ * {
+ *  MyClass ca("/Class A/Class");
+ *  MyClass cb("/Class B/Class");
+ *  ParameterAcceptor::initialize("file.prm");
+ * }
+ * @endcode
+ * Now, in the parameter file we can find
+ * @code
+ * subsection Class A
+ *   subsection Class
+ *   ...
+ *   end
+ *   subsection Forcing term
+ *   ...
+ *   end
+ * end
+ * subsection Class B
+ *   subsection Class
+ *   ...
+ *   end
+ *   subsection Forcing term
+ *   ...
+ *   end
+ * end
+ * @endcode
+ * Note the "/" at the begin of the string name. This is interpreted by
+ * ParameterAcceptor like the root folder in Unix systems. This means
+ * that the sections "Class A" and "Class B" will not be nested under any
+ * section. On the other hand, if the string does not begin with a "/"
+ * as in the previous cases (and for the ParsedFunction also in this last
+ * example) the section will be created **under the current path**, which
+ * depends on the previously defined sections/subsections/subsubsections.
+ * Indeed, the section "Forcing term" is nested under "Class A" or "Class B".
+ * To make things more clear. let's consider the following two examples
+ * @code
+ * int main()
+ * {
+ *  MyClass ca("/Class A/Class");
+ *  MyClass cb("Class B/Class");
+ *  ParameterAcceptor::initialize("file.prm");
+ * }
+ * @endcode
+ * The parameter file will have the following structure
+ * @code
+ * subsection Class A
+ *   subsection Class
+ *   ...
+ *   end
+ *   subsection Forcing term
+ *   ...
+ *   end
+ *   subsection Class B
+ *     subsection Class
+ *     ...
+ *     end
+ *     subsection Forcing term
+ *     ...
+ *     end
+ *   end
+ * end
+ * @endcode
+ *
+ * If instead one of the paths ends with "/" instead of just
+ * a name of the class, subsequent classes will be declared
+ * under the full path, as if the class name should be interpreted
+ * as a directory:
+ * @code
+ * int main()
+ * {
+ *  MyClass ca("/Class A/Class/");
+ *  MyClass cb("Class B/Class");
+ *  ParameterAcceptor::initialize("file.prm");
+ * }
+ * @endcode
+ * The parameter file will have the following structure
+ * @code
+ * subsection Class A
+ *   subsection Class
+ *      ...
+ *      subsection Forcing term
+ *      ...
+ *      end
+ *      subsection Class B
+ *          subsection Class
+ *          ...
+ *          end
+ *          subsection Forcing term
+ *          ...
+ *          end
+ *      end
+ *   end
+ * end
+ * @endcode
+ *
+ * As a final remark, in order to allow a proper management of all the
+ * sections/subsections, the instantiation of objects and the call to
+ * ParameterAcceptor::initialize() **cannot be done in multithread**.
+ *
+ * If you pass an empty name, the boost::core::demangle() function is used to
+ * fill the section name with a human readable version of the class name
+ * itself.
+ *
+ * @author Luca Heltai, 2017.
+ */
+class ParameterAcceptor : public Subscriptor
+{
+public:
+  /**
+   * The constructor adds derived classes to the list of acceptors. If
+   * a section name is specified, then this is used to scope the
+   * parameters in the given section, otherwise a pretty printed
+   * version of the derived class is used.
+   */
+  ParameterAcceptor(const std::string section_name="");
+
+  /**
+   * The destructor sets to zero the pointer relative to this index,
+   * so that it is safe to destroy the mother class.
+   */
+  virtual ~ParameterAcceptor();
+
+  /**
+   * Call declare_all_parameters(), read filename (if it is present as input
+   * parameter) and parse_all_parameters() on the static member prm. If
+   * outfilename is not the emtpy string, then write the content that was read
+   * in to the outfilename. The format of both input and output files are
+   * selected using the extensions of the files themselves. This can be either
+   * `prm` or `xml`. If the output format is `prm`, then the
+   * `output_style_for_prm_format` is used to decide wether we write the full
+   * documentation as well, or only the parameters.
+   *
+   * If the input file does not exist, a default one with the same name is created
+   * for you, and an exception is thrown.
+   *
+   * @param filename Input file name
+   * @param output_filename Output file name
+   * @param output_style_for_prm_format How to write the output file if format is `prm`
+   */
+  static void initialize(const std::string filename,
+                         const std::string output_filename="",
+                         const ParameterHandler::OutputStyle output_style_for_prm_format=ParameterHandler::ShortText);
+
+  /**
+   * Clear class list and global parameter file.
+   */
+  static void clear();
+
+  /**
+   * Declare parameter entries of the derived class.
+   */
+  virtual void declare_parameters(ParameterHandler &prm);
+
+  /**
+   * Declare parameter call back. This function is called at the end of
+   * declare_all_parameters, to allow users to process their parameters right
+   * after they have been parsed. The default implementation is empty.
+   *
+   * You can use this function, for example, to create a quadrature
+   * rule after you have read how many quadrature points you wanted
+   * to use from the parameter file.
+   */
+  boost::signals2::signal<void()> declare_parameters_call_back;
+
+  /**
+   * Parse the (derived class) parameters.
+   */
+  virtual void parse_parameters(ParameterHandler &prm);
+
+  /**
+   * Parse parameter call back. This function is called at the end of
+   * parse_all_parameters, to allow users to process their parameters right
+   * after they have been parsed. The default implementation is empty.
+   *
+   * You can use this function, for example, to create a quadrature
+   * rule after you have read how many quadrature points you wanted
+   * to use from the parameter file.
+   */
+  boost::signals2::signal<void()> parse_parameters_call_back;
+
+  /**
+   * Parse the given ParameterHandler. This function enters the
+   * subsection returned by get_section_name() for each derived class,
+   * and parses all parameters that were added using add_parameter().
+   */
+  static void parse_all_parameters(ParameterHandler &prm=ParameterAcceptor::prm);
+
+
+  /**
+   * Print information to deallog about all stored classes.
+   */
+  static void log_info();
+
+
+  /**
+   * Initialize the global ParameterHandler with all derived classes
+   * parameters.This function enters the subsection returned by
+   * get_section_name() for each derived class, and declares all parameters
+   * that were added using add_parameter().
+   */
+  static void declare_all_parameters(ParameterHandler &prm=ParameterAcceptor::prm);
+
+
+  /**
+   * Return the section name of this class. If a name was provided
+   * at construction time, then that name is returned, otherwise it
+   * returns the name of this class, pretty printed.
+   */
+  std::string get_section_name() const;
+
+  /**
+   * Travers all registered classes, and figure out what
+   * subsections we need to enter.
+   */
+  std::vector<std::string> get_section_path() const;
+
+  /**
+   * Add a parameter in the correct path. This method forwards all arguments to
+   * the ParameterHandler::add_parameter() method, after entering the correct
+   * section path.
+   *
+   * See the documentation of ParameterHandler::add_parameter() for more
+   * information.
+   */
+  template <class ParameterType>
+  void add_parameter(const std::string &entry,
+                     ParameterType &parameter,
+                     const std::string &documentation = std::string(),
+                     const Patterns::PatternBase &pattern =
+                       *Patterns::Tools::Convert<ParameterType>::to_pattern());
+
+  /**
+   * The global parameter handler.
+   */
+  static ParameterHandler prm;
+
+private:
+  /**
+   * Make sure we enter the right subsection of the global parameter file.
+   */
+  void enter_my_subsection(ParameterHandler &prm);
+
+  /**
+   * This function undoes what the enter_my_subsection() function did. It only
+   * makes sense if enter_my_subsection() is called before this one.
+   */
+  void leave_my_subsection(ParameterHandler &prm);
+
+  /**
+   * A list containing all constructed classes of type
+   * ParameterAcceptor.
+   */
+  static std::vector<SmartPointer<ParameterAcceptor> > class_list;
+
+  /** The index of this specific class within the class list. */
+  const unsigned int acceptor_id;
+
+  /**
+   * Separator between section and subsection.
+   */
+  static const char sep = '/';
+
+protected:
+  /** The subsection name for this class. */
+  const std::string section_name;
+};
+
+
+// Inline and template functions
+template<class ParameterType>
+void ParameterAcceptor::add_parameter(const std::string& entry,
+                                      ParameterType& parameter,
+                                      const std::string& documentation,
+                                      const Patterns::PatternBase& pattern)
+{
+  enter_my_subsection(prm);
+  prm.add_parameter(entry, parameter, documentation, pattern);
+  leave_my_subsection(prm);
+}
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif
+

--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -379,7 +379,21 @@ public:
    */
   static void initialize(const std::string &filename="",
                          const std::string &output_filename="",
-                         const ParameterHandler::OutputStyle output_style_for_prm_format=ParameterHandler::ShortText);
+                         const ParameterHandler::OutputStyle output_style_for_prm_format=ParameterHandler::ShortText,
+                         ParameterHandler &prm = ParameterAcceptor::prm);
+
+  /**
+   * Call declare_all_parameters(), read the parameters from the `input_stream`
+   * in `prm` format, and then call parse_all_parameters().
+   *
+   * An exception is thrown if the `input_stream` is invalid.
+   *
+   * @param input_stream Input stream
+   * @param prm The ParameterHandler to use
+   */
+  static void initialize(std::istream &input_stream,
+                         ParameterHandler &prm = ParameterAcceptor::prm);
+
 
   /**
    * Clear class list and global parameter file.

--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -47,6 +47,7 @@ SET(_unity_include_src
   named_selection.cc
   parallel.cc
   parameter_handler.cc
+  parameter_acceptor.cc
   parsed_function.cc
   partitioner.cc
   patterns.cc

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -1,0 +1,237 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 - 2016 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+#include <deal.II/base/parameter_acceptor.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/revision.h>
+#include <deal.II/base/path_search.h>
+#include <boost/core/demangle.hpp>
+#include <fstream>
+
+DEAL_II_NAMESPACE_OPEN
+
+
+// Static empty class list
+std::vector<SmartPointer<ParameterAcceptor> > ParameterAcceptor::class_list;
+// Static parameter handler
+ParameterHandler ParameterAcceptor::prm;
+
+ParameterAcceptor::ParameterAcceptor(const std::string name) :
+  acceptor_id(class_list.size()),
+  section_name(name)
+{
+  SmartPointer<ParameterAcceptor> pt(this, boost::core::demangle(typeid(*this).name()).c_str());
+  class_list.push_back(pt);
+}
+
+
+ParameterAcceptor::~ParameterAcceptor()
+{
+  class_list[acceptor_id] = 0;
+}
+
+std::string ParameterAcceptor::get_section_name() const
+{
+  return (section_name != "" ? section_name : boost::core::demangle(typeid(*this).name()));
+}
+
+
+void
+ParameterAcceptor::initialize(const std::string filename,
+                              const std::string output_filename,
+                              const ParameterHandler::OutputStyle output_style_for_prm_format)
+{
+  declare_all_parameters();
+  // check the extension of input file
+  if (filename.substr(filename.find_last_of(".") + 1) == "prm")
+    {
+      try
+        {
+          prm.parse_input(filename);
+        }
+      catch (dealii::PathSearch::ExcFileNotFound)
+        {
+          std::ofstream out(filename);
+          Assert(out, ExcIO());
+          prm.print_parameters(out, ParameterHandler::Text);
+          out.close();
+          AssertThrow(false, ExcMessage("You specified "+filename+" as input "+
+                                        "parameter file, but it does not exist. " +
+                                        "We created one for you."));
+        }
+    }
+  else if (filename.substr(filename.find_last_of(".") + 1) == "xml")
+    {
+      std::ifstream is(filename);
+      if (!is)
+        {
+          std::ofstream out(filename);
+          Assert(out, ExcIO());
+          prm.print_parameters(out, ParameterHandler::XML);
+          out.close();
+          is.clear();
+          AssertThrow(false, ExcMessage("You specified "+filename+" as input "+
+                                        "parameter file, but it does not exist. " +
+                                        "We created one for you."));
+        }
+      prm.parse_input_from_xml(is);
+    }
+  else
+    AssertThrow(false, ExcMessage("Invalid extension of parameter file. Please use .prm or .xml"));
+
+  parse_all_parameters();
+  if (output_filename != "")
+    {
+      std::ofstream outfile(output_filename.c_str());
+      Assert(outfile, ExcIO());
+      std::string extension = output_filename.substr(output_filename.find_last_of(".") + 1);
+
+      if ( extension == "prm")
+        {
+          outfile << "# Parameter file generated with " << std::endl
+                  << "# DEAL_II_GIT_BRANCH=   " << DEAL_II_GIT_BRANCH  << std::endl
+                  << "# DEAL_II_GIT_SHORTREV= " << DEAL_II_GIT_SHORTREV << std::endl;
+          Assert(output_style_for_prm_format == ParameterHandler::Text ||
+                 output_style_for_prm_format == ParameterHandler::ShortText,
+                 ExcMessage("Only Text or ShortText can be specified in output_style_for_prm_format."))
+          prm.print_parameters(outfile, output_style_for_prm_format);
+        }
+      else if (extension == "xml")
+        prm.print_parameters(outfile, ParameterHandler::XML);
+      else if (extension == "latex" || extension == "tex")
+        prm.print_parameters(outfile, ParameterHandler::LaTeX);
+      else
+        AssertThrow(false,ExcNotImplemented());
+    }
+}
+
+void
+ParameterAcceptor::clear()
+{
+  class_list.clear();
+  prm.clear();
+}
+
+
+
+void ParameterAcceptor::declare_parameters(ParameterHandler &prm)
+{}
+
+
+
+void ParameterAcceptor::parse_parameters(ParameterHandler &prm)
+{}
+
+
+
+void
+ParameterAcceptor::log_info()
+{
+  deallog.push("ParameterAcceptor");
+  for (unsigned int i=0; i<class_list.size(); ++i)
+    {
+      deallog << "Class " << i << ":";
+      if (class_list[i])
+        deallog << class_list[i]->get_section_name() << std::endl;
+      else
+        deallog << " NULL" << std::endl;
+    }
+  deallog.pop();
+}
+
+void ParameterAcceptor::parse_all_parameters(ParameterHandler &prm)
+{
+  for (unsigned int i=0; i< class_list.size(); ++i)
+    if (class_list[i] != NULL)
+      {
+        class_list[i]->enter_my_subsection(prm);
+        class_list[i]->parse_parameters(prm);
+        class_list[i]->parse_parameters_call_back();
+        class_list[i]->leave_my_subsection(prm);
+      }
+}
+
+void ParameterAcceptor::declare_all_parameters(ParameterHandler &prm)
+{
+  for (unsigned int i=0; i< class_list.size(); ++i)
+    if (class_list[i] != NULL)
+      {
+        class_list[i]->enter_my_subsection(prm);
+        class_list[i]->declare_parameters(prm);
+        class_list[i]->declare_parameters_call_back();
+        class_list[i]->leave_my_subsection(prm);
+      }
+}
+
+
+std::vector<std::string>
+ParameterAcceptor::get_section_path() const
+{
+  Assert(acceptor_id < class_list.size(), ExcInternalError());
+  std::vector<std::string> sections =
+    Utilities::split_string_list(class_list[acceptor_id]->get_section_name(), sep);
+  bool is_absolute = false;
+  if (sections.size() > 1)
+    {
+      // Handle the cases of a leading "/"
+      if (sections[0] == "")
+        {
+          is_absolute = true;
+          sections.erase(sections.begin());
+        }
+    }
+  if (is_absolute == false)
+    {
+      // In all other cases, we scan for earlier classes, and prepend the
+      // first absolute path (in reverse order) we find to ours
+      for (int i=acceptor_id-1; i>=0; --i)
+        if (class_list[i] != NULL)
+          if (class_list[i]->get_section_name().front() == sep)
+            {
+              bool has_trailing = class_list[i]->get_section_name().back() == sep;
+              // Absolute path found
+              auto secs = Utilities::split_string_list(class_list[i]->get_section_name(), sep);
+              Assert(secs[0] == "", ExcInternalError());
+              // Insert all sections except first and last
+              sections.insert(sections.begin(), secs.begin()+1, secs.end()-(has_trailing ? 0 : 1));
+              // exit from for cycle
+              break;
+            }
+    }
+  return sections;
+}
+
+void ParameterAcceptor::enter_my_subsection(ParameterHandler &prm=ParameterAcceptor::prm)
+{
+  std::vector<std::string> sections = get_section_path();
+  for (auto sec : sections)
+    {
+      prm.enter_subsection(sec);
+    }
+}
+
+void ParameterAcceptor::leave_my_subsection(ParameterHandler &prm=ParameterAcceptor::prm)
+{
+  std::vector<std::string> sections = get_section_path();
+  for (auto sec : sections)
+    {
+      prm.leave_subsection();
+    }
+}
+
+
+
+DEAL_II_NAMESPACE_CLOSE
+

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -51,9 +51,10 @@ std::string ParameterAcceptor::get_section_name() const
 void
 ParameterAcceptor::initialize(const std::string &filename,
                               const std::string &output_filename,
-                              const ParameterHandler::OutputStyle output_style_for_prm_format)
+                              const ParameterHandler::OutputStyle output_style_for_prm_format,
+                              ParameterHandler &prm)
 {
-  declare_all_parameters();
+  declare_all_parameters(prm);
   if (filename != "")
     {
       // check the extension of input file
@@ -118,7 +119,19 @@ ParameterAcceptor::initialize(const std::string &filename,
     }
 
   // Finally do the parsing.
-  parse_all_parameters();
+  parse_all_parameters(prm);
+}
+
+
+
+void ParameterAcceptor::initialize(std::istream &input_stream,
+                                   ParameterHandler &prm)
+
+{
+  AssertThrow(input_stream, ExcIO());
+  declare_all_parameters(prm);
+  prm.parse_input(input_stream);
+  parse_all_parameters(prm);
 }
 
 void

--- a/tests/parameter_handler/parameter_acceptor_01.cc
+++ b/tests/parameter_handler/parameter_acceptor_01.cc
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------
 //
-//    Copyright (C) 2015 by the deal.II authors
+//    Copyright (C) 2017 by the deal.II authors
 //
 //    This file is part of the deal.II library.
 //

--- a/tests/parameter_handler/parameter_acceptor_01.cc
+++ b/tests/parameter_handler/parameter_acceptor_01.cc
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+// Classical way of working with parameters.
+
+#include "../tests.h"
+#include <deal.II/base/parameter_acceptor.h>
+
+template<int dim>
+class Test : public ParameterAcceptor
+{
+public:
+  virtual void declare_parameters(ParameterHandler &prm)
+  {
+    prm.declare_entry("A double", "0.0", Patterns::Double(),
+                      "Documentation");
+  };
+
+  virtual void parse_parameters(ParameterHandler &prm)
+  {
+    deallog << "Double: "
+            << prm.get_double("A double") << std::endl;
+  };
+};
+
+
+int main ()
+{
+  initlog();
+  Test<2> a;
+  Test<1> b;
+
+  ParameterHandler prm;
+  a.declare_all_parameters(prm);
+  prm.log_parameters(deallog);
+}

--- a/tests/parameter_handler/parameter_acceptor_01.output
+++ b/tests/parameter_handler/parameter_acceptor_01.output
@@ -1,0 +1,3 @@
+
+DEAL:parameters:Test<1>::A double: 0.0
+DEAL:parameters:Test<2>::A double: 0.0

--- a/tests/parameter_handler/parameter_acceptor_02.cc
+++ b/tests/parameter_handler/parameter_acceptor_02.cc
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------
 //
-//    Copyright (C) 2015 by the deal.II authors
+//    Copyright (C) 2017 by the deal.II authors
 //
 //    This file is part of the deal.II library.
 //

--- a/tests/parameter_handler/parameter_acceptor_02.cc
+++ b/tests/parameter_handler/parameter_acceptor_02.cc
@@ -1,0 +1,80 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/parameter_acceptor.h>
+#include <boost/core/demangle.hpp>
+
+template<int dim>
+class Test : public ParameterAcceptor
+{
+public:
+  Test()
+  {
+    add_parameter("A double", a);
+    add_parameter("An int"  , b);
+    add_parameter("A string", c);
+    add_parameter("A bool"  , d);
+  };
+
+  void log_info()
+  {
+    deallog << "My type: " << boost::core::demangle(typeid(*this).name()) << std::endl
+            << "a: " << a << std::endl
+            << "b: " << b << std::endl
+            << "c: " << c << std::endl
+            << "d: " << (d ? "true" : "false") << std::endl;
+  }
+
+private:
+  double a = 1.0;
+  int b = 2;
+  std::string c = "Ciao";
+  bool d = true;
+
+};
+
+
+int main ()
+{
+  initlog();
+  Test<1> a;
+  Test<2> b;
+
+  auto &prm = ParameterAcceptor::prm;
+
+  ParameterAcceptor::declare_all_parameters();
+  ParameterAcceptor::parse_all_parameters();
+  prm.log_parameters(deallog);
+
+  a.log_info();
+  b.log_info();
+
+  prm.parse_input_from_string(""
+                              "subsection Test<1>\n"
+                              "  set A double = 3.0\n"
+                              "end\n"
+                              "subsection Test<2>\n"
+                              "  set A double = 5.0\n"
+                              "end\n");
+
+  prm.log_parameters(deallog);
+  ParameterAcceptor::parse_all_parameters(prm);
+
+  a.log_info();
+  b.log_info();
+
+}

--- a/tests/parameter_handler/parameter_acceptor_02.output
+++ b/tests/parameter_handler/parameter_acceptor_02.output
@@ -1,0 +1,37 @@
+
+DEAL:parameters:Test<1>::A bool: true
+DEAL:parameters:Test<1>::A double: 1.0
+DEAL:parameters:Test<1>::A string: Ciao
+DEAL:parameters:Test<1>::An int: 2
+DEAL:parameters:Test<2>::A bool: true
+DEAL:parameters:Test<2>::A double: 1.0
+DEAL:parameters:Test<2>::A string: Ciao
+DEAL:parameters:Test<2>::An int: 2
+DEAL::My type: Test<1>
+DEAL::a: 1.00000
+DEAL::b: 2
+DEAL::c: Ciao
+DEAL::d: true
+DEAL::My type: Test<2>
+DEAL::a: 1.00000
+DEAL::b: 2
+DEAL::c: Ciao
+DEAL::d: true
+DEAL:parameters:Test<1>::A bool: true
+DEAL:parameters:Test<1>::A double: 3.0
+DEAL:parameters:Test<1>::A string: Ciao
+DEAL:parameters:Test<1>::An int: 2
+DEAL:parameters:Test<2>::A bool: true
+DEAL:parameters:Test<2>::A double: 5.0
+DEAL:parameters:Test<2>::A string: Ciao
+DEAL:parameters:Test<2>::An int: 2
+DEAL::My type: Test<1>
+DEAL::a: 3.00000
+DEAL::b: 2
+DEAL::c: Ciao
+DEAL::d: true
+DEAL::My type: Test<2>
+DEAL::a: 5.00000
+DEAL::b: 2
+DEAL::c: Ciao
+DEAL::d: true

--- a/tests/parameter_handler/parameter_acceptor_03.cc
+++ b/tests/parameter_handler/parameter_acceptor_03.cc
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------
 //
-//    Copyright (C) 2015 by the deal.II authors
+//    Copyright (C) 2017 by the deal.II authors
 //
 //    This file is part of the deal.II library.
 //

--- a/tests/parameter_handler/parameter_acceptor_03.cc
+++ b/tests/parameter_handler/parameter_acceptor_03.cc
@@ -1,0 +1,72 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/parameter_acceptor.h>
+
+#include <deal.II/base/point.h>
+
+template<int dim>
+class Test : public ParameterAcceptor
+{
+public:
+  Test()
+  {
+    std::string def = "0.";
+    for (int i=1; i<dim; ++i)
+      def += ",0.";
+    add_parameter("A point", p);
+  };
+
+  void log_info()
+  {
+    deallog << "My type: " << boost::core::demangle(typeid(*this).name()) << std::endl
+            << "p: " << p << std::endl;
+  }
+
+private:
+  Point<dim> p;
+};
+
+
+int main ()
+{
+  initlog();
+  Test<1> a;
+  Test<2> b;
+  Test<3> c;
+
+  auto &prm = ParameterAcceptor::prm;
+  ParameterAcceptor::declare_all_parameters();
+  prm.parse_input_from_string(""
+                              "subsection Test<1>\n"
+                              "  set A point = 1.0\n"
+                              "end\n"
+                              "subsection Test<2>\n"
+                              "  set A point = 1.0, 2.0\n"
+                              "end\n"
+                              "subsection Test<3>\n"
+                              "  set A point = 1.0, 2.0, 3.0\n"
+                              "end\n");
+
+  prm.log_parameters(deallog);
+  ParameterAcceptor::parse_all_parameters(prm);
+
+  a.log_info();
+  b.log_info();
+  c.log_info();
+}

--- a/tests/parameter_handler/parameter_acceptor_03.output
+++ b/tests/parameter_handler/parameter_acceptor_03.output
@@ -1,0 +1,10 @@
+
+DEAL:parameters:Test<1>::A point: 1.0
+DEAL:parameters:Test<2>::A point: 1.0, 2.0
+DEAL:parameters:Test<3>::A point: 1.0, 2.0, 3.0
+DEAL::My type: Test<1>
+DEAL::p: 1.00000
+DEAL::My type: Test<2>
+DEAL::p: 1.00000 2.00000
+DEAL::My type: Test<3>
+DEAL::p: 1.00000 2.00000 3.00000

--- a/tests/parameter_handler/parameter_acceptor_04.cc
+++ b/tests/parameter_handler/parameter_acceptor_04.cc
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------
 //
-//    Copyright (C) 2015 by the deal.II authors
+//    Copyright (C) 2017 by the deal.II authors
 //
 //    This file is part of the deal.II library.
 //

--- a/tests/parameter_handler/parameter_acceptor_04.cc
+++ b/tests/parameter_handler/parameter_acceptor_04.cc
@@ -1,0 +1,71 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+
+
+#include "../tests.h"
+#include <deal.II/base/path_search.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/parameter_acceptor.h>
+
+class FirstClass : public ParameterAcceptor
+{
+public:
+  FirstClass(const std::string &name = "First Class"):
+    ParameterAcceptor(name)
+  {
+    add_parameter("First int",   f_i);
+    add_parameter("First double",f_d);
+    add_parameter("First bool",  f_b);
+    add_parameter("First string",f_s);
+  };
+
+private:
+  int         f_i = 3;
+  double      f_d = 7.7;
+  bool        f_b = true;
+  std::string f_s = "hello";
+};
+
+class SecondClass : public ParameterAcceptor
+{
+public:
+  SecondClass(const std::string &name = "Second Class"):
+    ParameterAcceptor(name)
+  {
+    add_parameter("Second int",   s_i);
+    add_parameter("Second double",s_d);
+    add_parameter("Second bool",  s_b);
+    add_parameter("Second string",s_s);
+  };
+
+private:
+  int         s_i = 5;
+  double      s_d = 9.9;
+  bool        s_b = false;
+  std::string s_s = "bye bye";
+};
+
+int main ()
+{
+  initlog();
+
+  FirstClass  f;
+  SecondClass s;
+  std::string output_name = "used_parameter_acceptor_04.prm";
+  ParameterAcceptor::initialize(SOURCE_DIR "/parameter_acceptor_parameters/parameter_acceptor_04.prm", output_name);
+  ParameterAcceptor::prm.log_parameters(deallog);
+
+}

--- a/tests/parameter_handler/parameter_acceptor_04.output
+++ b/tests/parameter_handler/parameter_acceptor_04.output
@@ -1,0 +1,9 @@
+
+DEAL:parameters:First Class::First bool: true
+DEAL:parameters:First Class::First double: 7.7
+DEAL:parameters:First Class::First int: 3
+DEAL:parameters:First Class::First string: hello
+DEAL:parameters:Second Class::Second bool: false
+DEAL:parameters:Second Class::Second double: 9.9
+DEAL:parameters:Second Class::Second int: 5
+DEAL:parameters:Second Class::Second string: bye bye

--- a/tests/parameter_handler/parameter_acceptor_05.cc
+++ b/tests/parameter_handler/parameter_acceptor_05.cc
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------
 //
-//    Copyright (C) 2015 by the deal.II authors
+//    Copyright (C) 2017 by the deal.II authors
 //
 //    This file is part of the deal.II library.
 //

--- a/tests/parameter_handler/parameter_acceptor_05.cc
+++ b/tests/parameter_handler/parameter_acceptor_05.cc
@@ -1,0 +1,78 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+
+
+#include "../tests.h"
+#include <deal.II/base/path_search.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/parameter_acceptor.h>
+
+class FirstClass : public ParameterAcceptor
+{
+public:
+  FirstClass(const std::string &name = "First Class"):
+    ParameterAcceptor(name)
+  {
+    add_parameter("First int",   f_i);
+    add_parameter("First double",f_d);
+    add_parameter("First bool",  f_b);
+    add_parameter("First string",f_s);
+  };
+
+private:
+  int         f_i = 3;
+  double      f_d = 7.7;
+  bool        f_b = true;
+  std::string f_s = "hello";
+};
+
+class SecondClass : public ParameterAcceptor
+{
+public:
+  SecondClass(const std::string &name = "Second Class"):
+    ParameterAcceptor(name)
+  {
+    add_parameter("Second int",   s_i);
+    add_parameter("Second double",s_d);
+    add_parameter("Second bool",  s_b);
+    add_parameter("Second string",s_s);
+  };
+
+private:
+  int         s_i = 5;
+  double      s_d = 9.9;
+  bool        s_b = false;
+  std::string s_s = "bye bye";
+};
+
+int main ()
+{
+  initlog();
+
+  FirstClass  f;
+  SecondClass s;
+  std::string output_name = "used_parameter_acceptor_05.xml";
+  ParameterAcceptor::initialize(SOURCE_DIR "/parameter_acceptor_parameters/parameter_acceptor_05.prm", output_name);
+  ParameterAcceptor::prm.log_parameters(deallog);
+  std::ifstream file (output_name.c_str());
+
+  std::string str;
+  deallog << "reading " << output_name << std::endl;
+  while (std::getline(file, str))
+    deallog << str << std::endl;
+
+
+}

--- a/tests/parameter_handler/parameter_acceptor_05.output
+++ b/tests/parameter_handler/parameter_acceptor_05.output
@@ -1,0 +1,12 @@
+
+DEAL:parameters:First Class::First bool: true
+DEAL:parameters:First Class::First double: 7.7
+DEAL:parameters:First Class::First int: 3
+DEAL:parameters:First Class::First string: hello
+DEAL:parameters:Second Class::Second bool: false
+DEAL:parameters:Second Class::Second double: 9.9
+DEAL:parameters:Second Class::Second int: 5
+DEAL:parameters:Second Class::Second string: bye bye
+DEAL::reading used_parameter_acceptor_05.xml
+DEAL::<?xml version="1.0" encoding="utf-8"?>
+DEAL::<ParameterHandler><First_20Class><First_20int><value>3</value><default_value>3</default_value><documentation/><pattern>0</pattern><pattern_description>[Integer range -2147483648...2147483647 (inclusive)]</pattern_description><actions>0</actions></First_20int><First_20double><value>7.7</value><default_value>7.700000</default_value><documentation/><pattern>1</pattern><pattern_description>[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]</pattern_description><actions>1</actions></First_20double><First_20bool><value>true</value><default_value>true</default_value><documentation/><pattern>2</pattern><pattern_description>[Bool]</pattern_description><actions>2</actions></First_20bool><First_20string><value>hello</value><default_value>hello</default_value><documentation/><pattern>3</pattern><pattern_description>[Anything]</pattern_description><actions>3</actions></First_20string></First_20Class><Second_20Class><Second_20int><value>5</value><default_value>5</default_value><documentation/><pattern>4</pattern><pattern_description>[Integer range -2147483648...2147483647 (inclusive)]</pattern_description><actions>4</actions></Second_20int><Second_20double><value>9.9</value><default_value>9.900000</default_value><documentation/><pattern>5</pattern><pattern_description>[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]</pattern_description><actions>5</actions></Second_20double><Second_20bool><value>false</value><default_value>false</default_value><documentation/><pattern>6</pattern><pattern_description>[Bool]</pattern_description><actions>6</actions></Second_20bool><Second_20string><value>bye bye</value><default_value>bye bye</default_value><documentation/><pattern>7</pattern><pattern_description>[Anything]</pattern_description><actions>7</actions></Second_20string></Second_20Class></ParameterHandler>

--- a/tests/parameter_handler/parameter_acceptor_06.cc
+++ b/tests/parameter_handler/parameter_acceptor_06.cc
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------
 //
-//    Copyright (C) 2015 by the deal.II authors
+//    Copyright (C) 2017 by the deal.II authors
 //
 //    This file is part of the deal.II library.
 //

--- a/tests/parameter_handler/parameter_acceptor_06.cc
+++ b/tests/parameter_handler/parameter_acceptor_06.cc
@@ -1,0 +1,78 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+
+
+#include "../tests.h"
+#include <deal.II/base/path_search.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/parameter_acceptor.h>
+
+class FirstClass : public ParameterAcceptor
+{
+public:
+  FirstClass(const std::string &name = "First Class"):
+    ParameterAcceptor(name)
+  {
+    add_parameter("First int",   f_i);
+    add_parameter("First double",f_d);
+    add_parameter("First bool",  f_b);
+    add_parameter("First string",f_s);
+  };
+
+private:
+  int         f_i = 3;
+  double      f_d = 7.7;
+  bool        f_b = true;
+  std::string f_s = "hello";
+};
+
+class SecondClass : public ParameterAcceptor
+{
+public:
+  SecondClass(const std::string &name = "Second Class"):
+    ParameterAcceptor(name)
+  {
+    add_parameter("Second int",   s_i);
+    add_parameter("Second double",s_d);
+    add_parameter("Second bool",  s_b);
+    add_parameter("Second string",s_s);
+  };
+
+private:
+  int         s_i = 5;
+  double      s_d = 9.9;
+  bool        s_b = false;
+  std::string s_s = "bye bye";
+};
+
+int main ()
+{
+  initlog();
+
+  FirstClass  f;
+  SecondClass s;
+  std::string output_name = "used_parameter_acceptor_06.tex";
+  ParameterAcceptor::initialize(SOURCE_DIR "/parameter_acceptor_parameters/parameter_acceptor_05.prm", output_name);
+  ParameterAcceptor::prm.log_parameters(deallog);
+  std::ifstream file (output_name.c_str());
+
+  std::string str;
+  deallog << "reading " << output_name << std::endl;
+  while (std::getline(file, str))
+    deallog << str << std::endl;
+
+
+}

--- a/tests/parameter_handler/parameter_acceptor_06.output
+++ b/tests/parameter_handler/parameter_acceptor_06.output
@@ -1,0 +1,130 @@
+
+DEAL:parameters:First Class::First bool: true
+DEAL:parameters:First Class::First double: 7.7
+DEAL:parameters:First Class::First int: 3
+DEAL:parameters:First Class::First string: hello
+DEAL:parameters:Second Class::Second bool: false
+DEAL:parameters:Second Class::Second double: 9.9
+DEAL:parameters:Second Class::Second int: 5
+DEAL:parameters:Second Class::Second string: bye bye
+DEAL::reading used_parameter_acceptor_06.tex
+DEAL::\subsection{Global parameters}
+DEAL::\label{parameters:global}
+DEAL::
+DEAL::
+DEAL::
+DEAL::\subsection{Parameters in section \tt First Class}
+DEAL::\label{parameters:First_20Class}
+DEAL::
+DEAL::\begin{itemize}
+DEAL::\item {\it Parameter name:} {\tt First bool}
+DEAL::\phantomsection\label{parameters:First Class/First bool}
+DEAL::
+DEAL::
+DEAL::\index[prmindex]{First bool}
+DEAL::\index[prmindexfull]{First Class!First bool}
+DEAL::{\it Value:} true
+DEAL::
+DEAL::
+DEAL::{\it Default:} true
+DEAL::
+DEAL::
+DEAL::{\it Possible values:} A boolean value (true or false)
+DEAL::\item {\it Parameter name:} {\tt First double}
+DEAL::\phantomsection\label{parameters:First Class/First double}
+DEAL::
+DEAL::
+DEAL::\index[prmindex]{First double}
+DEAL::\index[prmindexfull]{First Class!First double}
+DEAL::{\it Value:} 7.7
+DEAL::
+DEAL::
+DEAL::{\it Default:} 7.700000
+DEAL::
+DEAL::
+DEAL::{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
+DEAL::\item {\it Parameter name:} {\tt First int}
+DEAL::\phantomsection\label{parameters:First Class/First int}
+DEAL::
+DEAL::
+DEAL::\index[prmindex]{First int}
+DEAL::\index[prmindexfull]{First Class!First int}
+DEAL::{\it Value:} 3
+DEAL::
+DEAL::
+DEAL::{\it Default:} 3
+DEAL::
+DEAL::
+DEAL::{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
+DEAL::\item {\it Parameter name:} {\tt First string}
+DEAL::\phantomsection\label{parameters:First Class/First string}
+DEAL::
+DEAL::
+DEAL::\index[prmindex]{First string}
+DEAL::\index[prmindexfull]{First Class!First string}
+DEAL::{\it Value:} hello
+DEAL::
+DEAL::
+DEAL::{\it Default:} hello
+DEAL::
+DEAL::
+DEAL::{\it Possible values:} Any string
+DEAL::\end{itemize}
+DEAL::
+DEAL::\subsection{Parameters in section \tt Second Class}
+DEAL::\label{parameters:Second_20Class}
+DEAL::
+DEAL::\begin{itemize}
+DEAL::\item {\it Parameter name:} {\tt Second bool}
+DEAL::\phantomsection\label{parameters:Second Class/Second bool}
+DEAL::
+DEAL::
+DEAL::\index[prmindex]{Second bool}
+DEAL::\index[prmindexfull]{Second Class!Second bool}
+DEAL::{\it Value:} false
+DEAL::
+DEAL::
+DEAL::{\it Default:} false
+DEAL::
+DEAL::
+DEAL::{\it Possible values:} A boolean value (true or false)
+DEAL::\item {\it Parameter name:} {\tt Second double}
+DEAL::\phantomsection\label{parameters:Second Class/Second double}
+DEAL::
+DEAL::
+DEAL::\index[prmindex]{Second double}
+DEAL::\index[prmindexfull]{Second Class!Second double}
+DEAL::{\it Value:} 9.9
+DEAL::
+DEAL::
+DEAL::{\it Default:} 9.900000
+DEAL::
+DEAL::
+DEAL::{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
+DEAL::\item {\it Parameter name:} {\tt Second int}
+DEAL::\phantomsection\label{parameters:Second Class/Second int}
+DEAL::
+DEAL::
+DEAL::\index[prmindex]{Second int}
+DEAL::\index[prmindexfull]{Second Class!Second int}
+DEAL::{\it Value:} 5
+DEAL::
+DEAL::
+DEAL::{\it Default:} 5
+DEAL::
+DEAL::
+DEAL::{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
+DEAL::\item {\it Parameter name:} {\tt Second string}
+DEAL::\phantomsection\label{parameters:Second Class/Second string}
+DEAL::
+DEAL::
+DEAL::\index[prmindex]{Second string}
+DEAL::\index[prmindexfull]{Second Class!Second string}
+DEAL::{\it Value:} bye bye
+DEAL::
+DEAL::
+DEAL::{\it Default:} bye bye
+DEAL::
+DEAL::
+DEAL::{\it Possible values:} Any string
+DEAL::\end{itemize}

--- a/tests/parameter_handler/parameter_acceptor_07.cc
+++ b/tests/parameter_handler/parameter_acceptor_07.cc
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------
 //
-//    Copyright (C) 2015 by the deal.II authors
+//    Copyright (C) 2017 by the deal.II authors
 //
 //    This file is part of the deal.II library.
 //

--- a/tests/parameter_handler/parameter_acceptor_07.cc
+++ b/tests/parameter_handler/parameter_acceptor_07.cc
@@ -1,0 +1,69 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+
+
+#include "../tests.h"
+#include <deal.II/base/path_search.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/parameter_acceptor.h>
+
+class FirstClass : public ParameterAcceptor
+{
+public:
+  FirstClass(const std::string &name = "First Class"):
+    ParameterAcceptor(name)
+  {
+    add_parameter("First int",   f_i);
+    add_parameter("First double",f_d);
+    add_parameter("First bool",  f_b);
+    add_parameter("First string",f_s);
+  };
+
+private:
+  int         f_i = 3;
+  double      f_d = 7.7;
+  bool        f_b = true;
+  std::string f_s = "hello";
+};
+
+class SecondClass : public ParameterAcceptor
+{
+public:
+  SecondClass(const std::string &name = "Second Class"):
+    ParameterAcceptor(name)
+  {
+    add_parameter("Second int",   s_i);
+    add_parameter("Second double",s_d);
+    add_parameter("Second bool",  s_b);
+    add_parameter("Second string",s_s);
+  };
+
+private:
+  int         s_i = 5;
+  double      s_d = 9.9;
+  bool        s_b = false;
+  std::string s_s = "bye bye";
+};
+
+int main ()
+{
+  initlog();
+
+  FirstClass  f;
+  SecondClass s;
+  std::string output_name = "used_parameter_acceptor_07.custom";
+  ParameterAcceptor::initialize(SOURCE_DIR "/parameter_acceptor_parameters/parameter_acceptor_05.prm", output_name);
+}

--- a/tests/parameter_handler/parameter_acceptor_08.cc
+++ b/tests/parameter_handler/parameter_acceptor_08.cc
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------
 //
-//    Copyright (C) 2015 by the deal.II authors
+//    Copyright (C) 2017 by the deal.II authors
 //
 //    This file is part of the deal.II library.
 //

--- a/tests/parameter_handler/parameter_acceptor_08.cc
+++ b/tests/parameter_handler/parameter_acceptor_08.cc
@@ -1,0 +1,90 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+
+
+#include "../tests.h"
+#include <deal.II/base/path_search.h>
+#include <deal.II/base/parameter_acceptor.h>
+
+// Test subsectioning
+
+class Test : public ParameterAcceptor
+{
+public:
+  Test(const std::string &sec_name  = "First Class",
+       const std::string &par_name  = "Parameter name",
+       const std::string &par_value = "Parameter value"):
+    ParameterAcceptor(sec_name),
+    par_name(par_name),
+    par_value(par_value)
+  {
+    add_parameter(par_name, this->par_value);
+
+    deallog << "Section Name    : " << sec_name << std::endl;
+    deallog << "N sections      : " << get_section_path().size() << std::endl;
+    deallog << "Sections        : ";
+    for (auto s : get_section_path())
+      deallog << "\"" << s << "\"    ";
+    deallog << std::endl << std::endl;
+  };
+
+private:
+  std::string par_name;
+  std::string par_value;
+};
+
+int main ()
+{
+  initlog();
+  auto &prm = ParameterAcceptor::prm;
+
+  // Relative
+  Test a("Class A", "Parameter A", "a");
+
+  // Absolute (== relative if no other path is added)
+  Test c("/Class B", "Parameter C", "c");
+
+
+  // Absolute (== relative if no other path is added)
+  Test c2("/Class C/", "Parameter C", "c");
+
+  // Absolute and no name
+  Test a0("/", "Absolute parameter", "a");
+
+  // Relative to absolute = absolute
+  Test d("Class C", "Parameter C", "d");
+
+  // Explicit, with absolute path
+  Test d1("/Class D/Class D1", "Parameter D1", "d");
+
+  // Relative to previous, with trailing
+  Test d2("Class D2/", "Parameter D2", "d");
+
+  // Relative to previous
+  Test d3("Class D2D3", "Parameter D2D3", "e");
+
+  // Another relative to reset
+  Test d4("/Class E", "Parameter E", "e");
+
+  // Same level of E1
+  Test d5("Class E2/", "Parameter E", "e");
+
+  // One level below E2
+  Test d6("Class E2E3", "Parameter E", "e");
+
+  ParameterAcceptor::declare_all_parameters();
+  prm.log_parameters(deallog);
+}

--- a/tests/parameter_handler/parameter_acceptor_08.output
+++ b/tests/parameter_handler/parameter_acceptor_08.output
@@ -1,0 +1,55 @@
+
+DEAL::Section Name    : Class A
+DEAL::N sections      : 1
+DEAL::Sections        : "Class A"    
+DEAL::
+DEAL::Section Name    : /Class B
+DEAL::N sections      : 1
+DEAL::Sections        : "Class B"    
+DEAL::
+DEAL::Section Name    : /Class C/
+DEAL::N sections      : 1
+DEAL::Sections        : "Class C"    
+DEAL::
+DEAL::Section Name    : /
+DEAL::N sections      : 0
+DEAL::Sections        : 
+DEAL::
+DEAL::Section Name    : Class C
+DEAL::N sections      : 1
+DEAL::Sections        : "Class C"    
+DEAL::
+DEAL::Section Name    : /Class D/Class D1
+DEAL::N sections      : 2
+DEAL::Sections        : "Class D"    "Class D1"    
+DEAL::
+DEAL::Section Name    : Class D2/
+DEAL::N sections      : 2
+DEAL::Sections        : "Class D"    "Class D2"    
+DEAL::
+DEAL::Section Name    : Class D2D3
+DEAL::N sections      : 3
+DEAL::Sections        : "Class D"    "Class D2"    "Class D2D3"    
+DEAL::
+DEAL::Section Name    : /Class E
+DEAL::N sections      : 1
+DEAL::Sections        : "Class E"    
+DEAL::
+DEAL::Section Name    : Class E2/
+DEAL::N sections      : 1
+DEAL::Sections        : "Class E2"    
+DEAL::
+DEAL::Section Name    : Class E2E3
+DEAL::N sections      : 2
+DEAL::Sections        : "Class E2"    "Class E2E3"    
+DEAL::
+DEAL:parameters::Absolute parameter: a
+DEAL:parameters:Class A::Parameter A: a
+DEAL:parameters:Class B::Parameter C: c
+DEAL:parameters:Class C::Parameter C: d
+DEAL:parameters:Class D:Class D1::Parameter D1: d
+DEAL:parameters:Class D:Class D2::Parameter D2: d
+DEAL:parameters:Class D:Class D2:Class D2D3::Parameter D2D3: e
+DEAL:parameters:Class E::Parameter E: e
+DEAL:parameters:Class E2::Parameter E: e
+DEAL:parameters:Class E2:Class E2E3::Parameter E: e

--- a/tests/parameter_handler/parameter_acceptor_parameters/parameter_acceptor_04.prm
+++ b/tests/parameter_handler/parameter_acceptor_parameters/parameter_acceptor_04.prm
@@ -1,0 +1,18 @@
+# Listing of Parameters
+# ---------------------
+subsection First Class
+  set First bool   = true
+  set First double = 7.7
+  set First int    = 3
+  set First string = hello
+end
+
+
+subsection Second Class
+  set Second bool   = false
+  set Second double = 9.9
+  set Second int    = 5
+  set Second string = bye bye
+end
+
+

--- a/tests/parameter_handler/parameter_acceptor_parameters/parameter_acceptor_05.prm
+++ b/tests/parameter_handler/parameter_acceptor_parameters/parameter_acceptor_05.prm
@@ -1,0 +1,18 @@
+# Listing of Parameters
+# ---------------------
+subsection First Class
+  set First bool   = true
+  set First double = 7.7
+  set First int    = 3
+  set First string = hello
+end
+
+
+subsection Second Class
+  set Second bool   = false
+  set Second double = 9.9
+  set Second int    = 5
+  set Second string = bye bye
+end
+
+


### PR DESCRIPTION
This is another one of those classes that have been sitting in our github.com/mathLab/deal2lkit repository for some time, and that can now be included in the library.

It is fairly well tested, and already used (in a slightly different form) in all our base code.

This class allows you to do:

~~~
class Test : public ParameterAcceptor
{
public:
  Test()
  {
    add_parameter("A double", a);
    add_parameter("An int"  , b);
    add_parameter("A string", c);
    add_parameter("A bool"  , d);
  };

private:
  double a = 1.0;
  int b = 2;
  std::string c = "Ciao";
  bool d = true;
}

int main() {
  Test a;
  ParameterAcceptor::initialize("input_parameters.prm");
}
~~~

For any class that has been derived from `parameter_acceptor`, the parameters are then synchronized with the content of the `input_parameters.prm` file.
