### PR TITLE
additional output for fe_move on macOS

### DIFF
--- a/tests/fe/fe_move_01.output.clang9_darwin
+++ b/tests/fe/fe_move_01.output.clang9_darwin
@@ -1,0 +1,64 @@
+
+DEAL::dim: 1
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 1144
+DEAL::
+DEAL::dim: 1
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 608
+DEAL::
+DEAL::dim: 1
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 1144
+DEAL::
+DEAL::dim: 2
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 2684
+DEAL::
+DEAL::dim: 2
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 728
+DEAL::
+DEAL::dim: 2
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 2684
+DEAL::
+DEAL::dim: 3
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 7124
+DEAL::
+DEAL::dim: 3
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 968
+DEAL::
+DEAL::dim: 3
+DEAL::components: 1
+DEAL::blocks: 1
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 1
+DEAL::memory consumption: 7124
+DEAL::

--- a/tests/fe/fe_move_02.output.clang9_darwin
+++ b/tests/fe/fe_move_02.output.clang9_darwin
@@ -1,0 +1,64 @@
+
+DEAL::FESystem<1>[FE_Q<1>(2)-FE_Q<1>(1)]
+DEAL::components: 2
+DEAL::blocks: 2
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 3808
+DEAL::
+DEAL::FESystem<1>[]
+DEAL::components: 2
+DEAL::blocks: 2
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 812
+DEAL::
+DEAL::FESystem<1>[FE_Q<1>(2)-FE_Q<1>(1)]
+DEAL::components: 2
+DEAL::blocks: 2
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 3808
+DEAL::
+DEAL::FESystem<2>[FE_Q<2>(2)^2-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 3
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 10568
+DEAL::
+DEAL::FESystem<2>[]
+DEAL::components: 3
+DEAL::blocks: 3
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 1832
+DEAL::
+DEAL::FESystem<2>[FE_Q<2>(2)^2-FE_Q<2>(1)]
+DEAL::components: 3
+DEAL::blocks: 3
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 10568
+DEAL::
+DEAL::FESystem<3>[FE_Q<3>(2)^3-FE_Q<3>(1)]
+DEAL::components: 4
+DEAL::blocks: 4
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 48136
+DEAL::
+DEAL::FESystem<3>[]
+DEAL::components: 4
+DEAL::blocks: 4
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 0
+DEAL::memory consumption: 5860
+DEAL::
+DEAL::FESystem<3>[FE_Q<3>(2)^3-FE_Q<3>(1)]
+DEAL::components: 4
+DEAL::blocks: 4
+DEAL::conforms H1: 1
+DEAL::n_base_elements: 2
+DEAL::memory consumption: 48136
+DEAL::


### PR DESCRIPTION
differences are in `memory consumption`.