### PR TITLE
explicitly oversubscribe with MPI

### DIFF
--- a/cmake/scripts/run_test.sh
+++ b/cmake/scripts/run_test.sh
@@ -34,6 +34,8 @@ shift 2
 export LC_ALL=C
 # Prevent OpenMP from creating additional threads
 export OMP_NUM_THREADS=2
+# Allow oversubscription for MPI (needed for Openmpi@3.0)
+export OMPI_MCA_rmaps_base_oversubscribe=1
 
 case $STAGE in
   run)


### PR DESCRIPTION
fixes https://github.com/dealii/dealii/issues/5123

there should be no harm to set this variable even if it's not used by MPI. @drwells could you please confirm this with your older OpenMPI?