### PR TITLE
Add distributed refinement/coarsening/serialization signals

### DIFF
--- a/doc/news/changes/minor/20170925ReneGassmoeller
+++ b/doc/news/changes/minor/20170925ReneGassmoeller
@@ -1,0 +1,9 @@
+New: There are new signals in the Triangulation class
+that signal the beginning and end of a parallel::distributed
+refinement and serialization. This allows to connect functions
+that should be called uniquely once before and after
+refinement and serialization for parallel distributed
+Triangulations (something not possible with the existing
+signals).
+<br>
+(Rene Gassmoeller, 2017/09/25)

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -2197,6 +2197,44 @@ public:
     boost::signals2::signal<unsigned int (const cell_iterator &,
                                           const CellStatus),
                                                 CellWeightSum<unsigned int> > cell_weight;
+
+    /**
+     * This signal is triggered at the beginning of execution of the
+     * parallel::distributed::Triangulation::execute_coarsening_and_refinement()
+     * function (which is
+     * itself called by other functions such as Triangulation::refine_global()
+     * ). At the time this signal is triggered, the triangulation is still
+     * unchanged. This signal
+     * is different from the pre_refinement signal, because in the parallel distributed
+     * case the pre_refinement signal is triggered multiple times without a way to
+     * distinguish the last signal call.
+     */
+    boost::signals2::signal<void ()> pre_distributed_refinement;
+
+    /**
+     * This signal is triggered at the end of execution of the
+     * parallel::distributed::Triangulation::execute_coarsening_and_refinement()
+     * function when the triangulation has reached its final state. This signal
+     * is different from the post_refinement signal, because in the parallel distributed
+     * case the post_refinement signal is triggered multiple times without a way to
+     * distinguish the last signal call.
+     */
+    boost::signals2::signal<void ()> post_distributed_refinement;
+
+    /**
+     * This signal is triggered at the beginning of execution of the
+     * parallel::distributed::Triangulation::save()
+     * function. At the time this signal is triggered, the triangulation
+     * is still unchanged.
+     */
+    boost::signals2::signal<void ()> pre_distributed_save;
+
+    /**
+     * This signal is triggered at the end of execution of the
+     * parallel::distributed::Triangulation::load()
+     * function when the triangulation has reached its final state.
+     */
+    boost::signals2::signal<void ()> post_distributed_load;
   };
 
   /**

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1765,6 +1765,10 @@ namespace parallel
     {
       Assert(n_attached_deserialize==0,
              ExcMessage ("not all SolutionTransfer's got deserialized after the last load()"));
+
+      // signal that serialization is going to happen
+      this->signals.pre_distributed_save();
+
       int real_data_size = 0;
       if (attached_data_size>0)
         real_data_size = attached_data_size+sizeof(CellStatus);
@@ -1887,6 +1891,10 @@ namespace parallel
         }
 
       this->update_number_cache ();
+
+      // signal that de-serialization is finished
+      this->signals.post_distributed_load();
+
       this->update_periodic_face_map();
     }
 
@@ -2865,6 +2873,9 @@ namespace parallel
             }
         }
 
+      // signal that refinement is going to happen
+      this->signals.pre_distributed_refinement();
+
       // now do the work we're supposed to do when we are in charge
       refinement_in_progress = true;
       this->prepare_coarsening_and_refinement ();
@@ -3038,6 +3049,12 @@ namespace parallel
 
       refinement_in_progress = false;
       this->update_number_cache ();
+
+      // signal that refinement is finished,
+      // this is triggered before update_periodic_face_map
+      // to be consistent with the serial triangulation class
+      this->signals.post_distributed_refinement();
+
       this->update_periodic_face_map();
     }
 


### PR DESCRIPTION
See changelog entry for a description of the new signals. 

I need this to allow the `ParticleHandler` class in #5125 to manage the transfer of particles between refinements / serializations without user intervention (like connecting currently private functions in `ParticleHandler` to `p::d::Triangulation::register_data_attach`). But I would assume there are other cases where this could be useful (e.g. the `SolutionTransfer` class?). In ASPECT we currently have signals that are essentially copies of the here introduced signals for exactly that reason (they trigger right before the calls to `execute_coarsening...`,`save`, and `load`).