### PR TITLE
Switch order of arguments in constructors for SUNDIALS::*

### DIFF
--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -482,11 +482,11 @@ namespace SUNDIALS
      * passing an AdditionalData() object that sets all of the solver
      * parameters.
      *
-     * @param mpi_comm MPI communicator
      * @param data ARKode configuration data
+     * @param mpi_comm MPI communicator
      */
-    ARKode(const MPI_Comm mpi_comm = MPI_COMM_WORLD,
-           const AdditionalData &data=AdditionalData());
+    ARKode(const AdditionalData &data=AdditionalData(),
+           const MPI_Comm mpi_comm = MPI_COMM_WORLD);
 
     /**
      * Destructor.

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -557,11 +557,11 @@ namespace SUNDIALS
      * consistent. Then you can choose how these are made consistent, using the same three
      * options that you used for the initial conditions in `reset_type`.
      *
-     * @param mpi_comm MPI communicator
      * @param data IDA configuration data
+     * @param mpi_comm MPI communicator
      */
-    IDA(const MPI_Comm mpi_comm = MPI_COMM_WORLD,
-        const AdditionalData &data=AdditionalData());
+    IDA(const AdditionalData &data=AdditionalData(),
+        const MPI_Comm mpi_comm = MPI_COMM_WORLD);
 
     /**
      * Destructor.

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -208,7 +208,7 @@ namespace SUNDIALS
   }
 
   template <typename VectorType>
-  ARKode<VectorType>::ARKode(const MPI_Comm mpi_comm, const AdditionalData &data) :
+  ARKode<VectorType>::ARKode(const AdditionalData &data, const MPI_Comm mpi_comm) :
     data(data),
     arkode_mem(nullptr),
     communicator(Utilities::MPI::duplicate_communicator(mpi_comm))

--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -138,7 +138,7 @@ namespace SUNDIALS
   }
 
   template <typename VectorType>
-  IDA<VectorType>::IDA(const MPI_Comm mpi_comm, const AdditionalData &data) :
+  IDA<VectorType>::IDA(const AdditionalData &data, const MPI_Comm mpi_comm) :
     data(data),
     ida_mem(nullptr),
     communicator(Utilities::MPI::duplicate_communicator(mpi_comm))

--- a/tests/sundials/harmonic_oscillator_01.cc
+++ b/tests/sundials/harmonic_oscillator_01.cc
@@ -56,7 +56,7 @@ class HarmonicOscillator
 
 public:
   HarmonicOscillator(double _kappa, const typename SUNDIALS::IDA<Vector<double>>::AdditionalData &data) :
-    time_stepper(MPI_COMM_WORLD, data),
+    time_stepper(data),
     y(2),
     y_dot(2),
     J(2,2),

--- a/tests/sundials/harmonic_oscillator_02.cc
+++ b/tests/sundials/harmonic_oscillator_02.cc
@@ -70,7 +70,7 @@ int main (int argc, char **argv)
   std::ifstream ifile(SOURCE_DIR "/harmonic_oscillator_02.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(MPI_COMM_WORLD,data);
+  SUNDIALS::ARKode<VectorType> ode(data);
 
   ode.reinit_vector = [&] (VectorType&v)
   {

--- a/tests/sundials/harmonic_oscillator_03.cc
+++ b/tests/sundials/harmonic_oscillator_03.cc
@@ -63,7 +63,7 @@ int main (int argc, char **argv)
   std::ifstream ifile(SOURCE_DIR "/harmonic_oscillator_02.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(MPI_COMM_WORLD,data);
+  SUNDIALS::ARKode<VectorType> ode(data);
 
   ode.reinit_vector = [&] (VectorType&v)
   {

--- a/tests/sundials/harmonic_oscillator_04.cc
+++ b/tests/sundials/harmonic_oscillator_04.cc
@@ -65,7 +65,7 @@ int main (int argc, char **argv)
   std::ifstream ifile(SOURCE_DIR "/harmonic_oscillator_04.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(MPI_COMM_WORLD,data);
+  SUNDIALS::ARKode<VectorType> ode(data);
 
   ode.reinit_vector = [&] (VectorType&v)
   {

--- a/tests/sundials/harmonic_oscillator_05.cc
+++ b/tests/sundials/harmonic_oscillator_05.cc
@@ -65,7 +65,7 @@ int main (int argc, char **argv)
   std::ifstream ifile(SOURCE_DIR "/harmonic_oscillator_05.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(MPI_COMM_WORLD,data);
+  SUNDIALS::ARKode<VectorType> ode(data);
 
   ode.reinit_vector = [&] (VectorType&v)
   {

--- a/tests/sundials/harmonic_oscillator_06.cc
+++ b/tests/sundials/harmonic_oscillator_06.cc
@@ -65,7 +65,7 @@ int main (int argc, char **argv)
   std::ifstream ifile(SOURCE_DIR "/harmonic_oscillator_06.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(MPI_COMM_WORLD,data);
+  SUNDIALS::ARKode<VectorType> ode(data);
 
   ode.reinit_vector = [&] (VectorType&v)
   {


### PR DESCRIPTION
This is an incompatible change, but I doubt it will bother anyone except maybe three people...

:)

Using this order, MPI_Comm is the last argument, and it can safely be omitted in 99% of the cases. 