### PR TITLE
Properly qualify a function name.

### DIFF
--- a/doc/news/changes/minor/20170926EldarKhattatov
+++ b/doc/news/changes/minor/20170926EldarKhattatov
@@ -1,6 +1,6 @@
 Fixed: the hp version of DoFTools::make_flux_sparsity_pattern() with masks for 
 DoF couplings now works with non-primitive FE spaces, similarly to its non-hp version.
-The hp version of project_boundary_values() is modified to work properly with Hdiv
+The hp version of VectorTools::project_boundary_values() is modified to work properly with Hdiv
 conforming finite elements. 
 <br>
 (Eldar Khattatov, 2017/09/26)


### PR DESCRIPTION
Follow-up to #5107.