### PR TITLE
Added: bounding box is neigbhour and updated locally owned bbox

### DIFF
--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -77,6 +77,24 @@ public:
   const std::pair<Point<spacedim,Number>,Point<spacedim,Number>> &get_boundary_points () const;
 
   /**
+   * Check if the current object and @p other_bbox are neighbours i.e. if the boxes
+   * have dimension spacedim, check if their insersection is non empty and has at least dimension
+   * spacedim-2 (i.e. a point in dimension 2, an edge in dimension 3)
+   *
+   * Return values:
+   * - 0 : not neighbours
+   * Values which are non zero are used for neighbours, in particular:
+   * - 1 : neighbours
+   * - 2 : neighbours which can be expressed with a single Bounding Box, e.g.
+   *  @code
+   *  .--V--W    .-----V
+   *  |  |  | =  |     |
+   *  V--W--.    V-----.
+   *  @endcode
+   */
+  unsigned int is_neighbour(const BoundingBox<spacedim,Number> &other_bbox, const double &err=1e-12) const;
+
+  /**
    * Enlarge the current object so that it contains @p other_bbox .
    * If the current object already contains @p other_bbox then it is not changed
    * by this function.
@@ -84,9 +102,10 @@ public:
   void merge_with(const BoundingBox<spacedim,Number> &other_bbox);
 
   /**
-   * Return true if the point is inside the Bounding Box, false otherwise
+   * Return true if the point is inside the Bounding Box within the numerical error
+   * @p err, false otherwise.
    */
-  bool point_inside (const Point<spacedim, Number> &p) const;
+  bool point_inside (const Point<spacedim, Number> &p, const double &err=1e-12) const;
 
   /**
    * Compute the volume (i.e. the dim-dimensional measure) of the BoundingBox.

--- a/source/base/bounding_box.cc
+++ b/source/base/bounding_box.cc
@@ -18,14 +18,14 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int spacedim, typename Number>
-bool BoundingBox<spacedim,Number>::point_inside (const Point<spacedim, Number> &p) const
+bool BoundingBox<spacedim,Number>::point_inside (const Point<spacedim, Number> &p, const double &err) const
 {
   for (unsigned int i=0; i < spacedim; ++i)
     {
       //Bottom left-top right convention: the point is outside if it's smaller than the
       //first or bigger than the second boundary point
       //The bounding box is defined as a closed set
-      if ( p[i] < this->boundary_points.first[i] || this->boundary_points.second[i] < p[i])
+      if ( p[i] + err < this->boundary_points.first[i] || this->boundary_points.second[i] + err < p[i])
         return false;
     }
   return true;
@@ -39,6 +39,86 @@ void BoundingBox<spacedim,Number>::merge_with(const BoundingBox<spacedim,Number>
       this->boundary_points.first[i] = std::min( this->boundary_points.first[i], other_bbox.boundary_points.first[i] );
       this->boundary_points.second[i] = std::max( this->boundary_points.second[i], other_bbox.boundary_points.second[i] );
     }
+}
+
+template <int spacedim, typename Number>
+unsigned int BoundingBox < spacedim,Number >::is_neighbour(const BoundingBox<spacedim,Number> &other_bbox, const double &err) const
+{
+  if (spacedim == 1)
+    {
+      // In dimension 1 if the two bounding box are neighbours
+      // we can merge them
+      if ( this->point_inside(other_bbox.boundary_points.first,err)
+           || this->point_inside(other_bbox.boundary_points.second,err) )
+        return 2;
+      return 0;
+    }
+  else
+    {
+      std::vector<bool > boundary_relations;
+
+      // Check if the boundary points of one bounding box are owned by another
+      boundary_relations.push_back(other_bbox.point_inside(this->boundary_points.first,err));
+      boundary_relations.push_back(other_bbox.point_inside(this->boundary_points.second,err));
+
+      boundary_relations.push_back(this->point_inside(other_bbox.boundary_points.first,err));
+      boundary_relations.push_back(this->point_inside(other_bbox.boundary_points.second,err));
+
+      std::vector<bool> all_false(4,false);
+
+      if ( (boundary_relations[0] && boundary_relations[1]) || (boundary_relations[2] && boundary_relations[3]))
+        // This happens if a bounding box is inside the other
+        return 2;
+      else if ( boundary_relations == all_false)
+        return 0;
+
+      //Translating the first point in 0
+      Tensor< 1 ,spacedim , Number > boundary1 = this->boundary_points.second - this->boundary_points.first;
+      std::vector< Tensor< 1 ,spacedim , Number > > boundary2 = {other_bbox.boundary_points.first-this->boundary_points.first,
+                                                                 other_bbox.boundary_points.second-this->boundary_points.first
+                                                                };
+
+      // These variables keep how many of the projection of the various axis
+      // have the following properties:
+      // on_vertex_1 = combination of the vertices of bounding box1
+      // inside_1 = inside point 1
+      // this is done for the two boundary points boundary2[0,1]
+      unsigned int on_vertex_1 = 0;
+      unsigned int inside_1 = 0;
+      for (unsigned int d=0; d<spacedim; ++d)
+        {
+          if ( std::abs( boundary2[0][d] ) < err ||
+               std::abs( boundary2[0][d] - boundary1[d]) < err )
+            ++on_vertex_1;
+          else if ( -err < boundary2[0][d] && boundary2[0][d] < boundary1[d] + err )
+            ++inside_1;
+        }
+
+      unsigned int on_vertex_2 = 0;
+      unsigned int inside_2 = 0;
+      for (unsigned int d=0; d<spacedim; ++d)
+        {
+          if ( std::abs( boundary2[1][d] ) < err || std::abs(boundary2[1][d] - boundary1[d] ) < err )
+            ++on_vertex_2;
+          else if ( -err < boundary2[1][d] && boundary2[1][d] < boundary1[d] + err )
+            ++inside_2;
+        }
+
+      if ( (on_vertex_1 == spacedim && on_vertex_2 == spacedim -1 )
+           || (on_vertex_2 == spacedim && on_vertex_1 == spacedim -1 ) )
+        return 2;
+      else if ( (on_vertex_1 == spacedim && (on_vertex_2 + inside_2 == 0))
+                || (on_vertex_2 == spacedim && (on_vertex_1 + inside_1 == 0)) )
+        //This happens if the two boxes share only a vertex
+        return 0;
+      else if ( spacedim == 3 )
+        if ( (on_vertex_1 == spacedim - 1 && inside_1 == 1 && (on_vertex_2 + inside_2 == 0) )
+             || (on_vertex_2 == spacedim - 1 && inside_2 == 1 && (on_vertex_1 + inside_1 == 0) ) )
+          // This happens, in dimension 3, if the two boxes share only an edge
+          return 0;
+      return 1;
+    }
+
 }
 
 template <int spacedim, typename Number>

--- a/source/distributed/CMakeLists.txt
+++ b/source/distributed/CMakeLists.txt
@@ -17,6 +17,7 @@ INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
 SET(_unity_include_src
   grid_refinement.cc
+  grid_tools.cc
   solution_transfer.cc
   tria.cc
   tria_base.cc
@@ -38,6 +39,7 @@ SETUP_SOURCE_LIST("${_unity_include_src}"
 
 SET(_inst
   grid_refinement.inst.in
+  grid_tools.inst.in
   solution_transfer.inst.in
   tria.inst.in
   shared_tria.inst.in

--- a/source/distributed/grid_tools.cc
+++ b/source/distributed/grid_tools.cc
@@ -1,0 +1,197 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/point.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/grid_tools.h>
+
+#ifdef DEAL_II_WITH_P4EST
+
+#include <vector>
+#include <cmath>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace parallel
+{
+  namespace GridTools
+  {
+    template < int dim, int spacedim >
+    BoundingBox < spacedim >
+    compute_cell_locally_owned_bounding_box
+    (const typename parallel::distributed::Triangulation< dim, spacedim >::cell_iterator &parent_cell,
+     bool &has_locally_owned)
+    {
+      //Finding all active cells descendants of the current one (or the current one if it is active)
+      std::vector< typename parallel::distributed::Triangulation< dim, spacedim >::active_cell_iterator >
+      local_cells = dealii::GridTools::get_active_child_cells < parallel::distributed::Triangulation< dim, spacedim > >
+                    (parent_cell);
+
+      //If the current cell is active but not locally owned
+      //or none of its children is active:
+      if (local_cells.size()==0)
+        {
+          has_locally_owned = false;
+          BoundingBox < spacedim > bbox;
+          return bbox;
+        }
+
+      Point<spacedim> minp;
+      Point<spacedim> maxp;
+
+      bool flag_first = true;
+      for (unsigned int i=0; i<local_cells.size(); ++i)
+        if ( local_cells[i]->is_locally_owned())
+          {
+            if (flag_first)
+              {
+                minp = local_cells[i]->vertex(0);
+                maxp = local_cells[i]->vertex(0);
+                flag_first = false;
+              }
+
+            for (unsigned int v=0; v<GeometryInfo<spacedim>::vertices_per_cell; ++v)
+              for ( unsigned int d=0; d<spacedim; ++d)
+                {
+                  minp[d] = std::min( minp[d], local_cells[i]->vertex(v)[d]);
+                  maxp[d] = std::max( maxp[d], local_cells[i]->vertex(v)[d]);
+                }
+          }
+
+      if (minp != maxp )
+        {
+          has_locally_owned = true;
+          BoundingBox < spacedim > bbox(std::make_pair(minp,maxp));
+          return bbox;
+        }
+      else
+        {
+          has_locally_owned = false;
+          //If none of the local cells is locally owned then
+          //minp and maxp are never updated:
+          BoundingBox < spacedim > bbox;
+          return bbox;
+        }
+    }
+
+
+    template < int dim, int spacedim>
+    std::vector< BoundingBox<spacedim> >
+    compute_locally_owned_bounding_box
+    (const parallel::distributed::Triangulation< dim, spacedim > &distributed_tria,
+     const unsigned int &refinement_level, const unsigned int &max_boxes, const double &err)
+    {
+      // Algorithm brief description: we begin by using refinement_lefel (and coarser levels)
+      // to create Bounding Boxes of locally owned cells. Then these cells are merged.
+
+      Assert( refinement_level < distributed_tria.n_levels(),
+              ExcMessage ( "Error: refinement level is higher then total levels in the triangulation!") );
+
+      std::vector< BoundingBox < spacedim > > bounding_boxes;
+
+      // Creating a bounding box for all active cell on coarser level: the refinement_level should be
+      // low enough to avoid the creation  of Bounding Boxes here
+      for (unsigned int i=0; i < refinement_level; ++i)
+        for (typename Triangulation< dim, spacedim >::cell_iterator
+             cell: distributed_tria.active_cell_iterators_on_level(i))
+          {
+            bool has_locally_owned = false;
+            BoundingBox < spacedim > bbox = compute_cell_locally_owned_bounding_box <dim,spacedim> (cell,has_locally_owned);
+            if (has_locally_owned)
+              bounding_boxes.push_back(bbox);
+          }
+
+      // Creating a Bounding Box for all cells on the chosen refinement_level
+      for (typename Triangulation< dim, spacedim >::cell_iterator
+           cell: distributed_tria.cell_iterators_on_level(refinement_level))
+        {
+          bool has_locally_owned = false;
+          BoundingBox < spacedim > bbox = compute_cell_locally_owned_bounding_box <dim,spacedim> (cell,has_locally_owned);
+          if (has_locally_owned)
+            bounding_boxes.push_back(bbox);
+        }
+
+
+      // Part 1: merging neighbours
+      bool found_neighbours = true;
+      // This array stores the indices of arrays we have already merged
+      std::vector<unsigned int> merged_boxes;
+
+      while (found_neighbours)
+        {
+          found_neighbours = false;
+          for (unsigned int i=0; i<bounding_boxes.size()-1; ++i)
+            {
+              if ( std::find(merged_boxes.begin(),merged_boxes.end(),i) == merged_boxes.end())
+                for (unsigned int j=i+1; j<bounding_boxes.size(); ++j)
+                  if ( std::find(merged_boxes.begin(),merged_boxes.end(),j) == merged_boxes.end()
+                       && bounding_boxes[i].is_neighbour(bounding_boxes[j], err) == 2  )
+                    {
+                      bounding_boxes[i].merge_with(bounding_boxes[j]);
+                      merged_boxes.push_back(j);
+                      found_neighbours = true;
+                    }
+            }
+        }
+
+      // Part 2: if there are too many bounding boxes, merging smaller boxes
+      std::vector< BoundingBox < spacedim > > merged_b_boxes;
+      for (unsigned int i=0; i<bounding_boxes.size(); ++i)
+        if (std::find(merged_boxes.begin(),merged_boxes.end(),i) == merged_boxes.end())
+          merged_b_boxes.push_back(bounding_boxes[i]);
+
+
+
+      if (merged_b_boxes.size() > max_boxes)
+        {
+          std::vector<double> volumes;
+          for ( BoundingBox<spacedim> box: merged_b_boxes)
+            volumes.push_back(box.volume());
+
+          while ( merged_b_boxes.size() > max_boxes)
+            {
+              unsigned int min_idx = std::min_element(volumes.begin(),volumes.end()) -
+                                     volumes.begin();
+              volumes.erase(volumes.begin() + min_idx);
+              //Finding a neighbour
+              bool not_removed = true;
+              for (unsigned int i=0; i<merged_b_boxes.size() && not_removed; ++i)
+                if ( i != min_idx && merged_b_boxes[i].is_neighbour(merged_b_boxes[min_idx]) > 0 )
+                  {
+                    merged_b_boxes[i].merge_with(merged_b_boxes[min_idx]);
+                    merged_b_boxes.erase(merged_b_boxes.begin() + min_idx);
+                    not_removed = false;
+                  }
+              Assert( !not_removed,
+                      ExcMessage ( "Error: couldn't reach target number of bounding boxes!") );
+            }
+        }
+
+      return merged_b_boxes;
+    }
+  }
+}
+
+#include "grid_tools.inst"
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/source/distributed/grid_tools.inst.in
+++ b/source/distributed/grid_tools.inst.in
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
+{
+#if deal_II_dimension <= deal_II_space_dimension
+    namespace parallel
+    \{
+    namespace GridTools
+    \{
+    template
+    BoundingBox <deal_II_space_dimension>
+    compute_cell_locally_owned_bounding_box<deal_II_dimension,deal_II_space_dimension>
+    (const typename parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>::cell_iterator &,
+     bool &);
+
+    template
+    std::vector < BoundingBox<deal_II_space_dimension > >
+    compute_locally_owned_bounding_box<deal_II_dimension,deal_II_space_dimension>
+    (const parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+     const unsigned int &, const unsigned int &, const double &);
+
+    \}
+    \}
+#endif
+}
+
+

--- a/tests/base/bounding_box_3.cc
+++ b/tests/base/bounding_box_3.cc
@@ -1,0 +1,125 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test for BoundingBox<unsigned int spacedim> which tests the function
+// is_neighbour
+
+#include "../tests.h"
+
+#include <deal.II/base/point.h>
+#include <deal.II/base/bounding_box.h>
+
+template <int spacedim>
+void test_bounding_box()
+{
+
+  std::pair<Point<spacedim>,Point<spacedim>> unit;
+  for (int i=0; i<spacedim; i++)
+    {
+      unit.first[i] = 0.0;
+      unit.second[i] = 1.0;
+    }
+
+  BoundingBox<spacedim> a(unit);
+
+  deallog << "Bounding box boundaries A: " << std::endl;
+  deallog << a.get_boundary_points().first << std::endl;
+  deallog << a.get_boundary_points().second << std::endl;
+  deallog << "Is neighbour of itself: " << a.is_neighbour(a) << std::endl;
+
+  std::pair<Point<spacedim>,Point<spacedim>> second;
+  for (int i=0; i<spacedim; i++)
+    {
+      second.first[i] = 1.0;
+      second.second[i] = 2.0;
+    }
+
+  BoundingBox<spacedim> b(second);
+
+  deallog << "Bounding box boundaries B: " << std::endl;
+  deallog << b.get_boundary_points().first << std::endl;
+  deallog << b.get_boundary_points().second << std::endl;
+
+  deallog << "Is neighbour A with B: " << a.is_neighbour(b) << std::endl;
+  deallog << "Is neighbour B with A: " << b.is_neighbour(a) << std::endl;
+  deallog << "Is neighbour B with B: " << b.is_neighbour(b) << std::endl;
+
+  BoundingBox<spacedim> c(std::make_pair(unit.first,second.second));
+  deallog << "Bounding box boundaries C: " << std::endl;
+  deallog << c.get_boundary_points().first << std::endl;
+  deallog << c.get_boundary_points().second << std::endl;
+
+  deallog << "Is neighbour C with B: " << c.is_neighbour(b) << std::endl;
+  deallog << "Is neighbour B with C: " << b.is_neighbour(c) << std::endl;
+  deallog << "Is neighbour A with C: " << a.is_neighbour(c) << std::endl;
+  deallog << "Is neighbour C with A: " << c.is_neighbour(a) << std::endl;
+  deallog << "Is neighbour C with C: " << c.is_neighbour(c) << std::endl;
+
+
+  unit.second *= 1.4;
+  BoundingBox<spacedim> d(unit);
+
+  deallog << "Bounding box boundaries D: " << std::endl;
+  deallog << d.get_boundary_points().first << std::endl;
+  deallog << d.get_boundary_points().second << std::endl;
+
+  deallog << "Is neighbour D with A: " << d.is_neighbour(a) << std::endl;
+  deallog << "Vice-versa: " << a.is_neighbour(d) << std::endl;
+  deallog << "Is neighbour D with B: " << d.is_neighbour(b) << std::endl;
+  deallog << "Vice-versa: " << b.is_neighbour(d) << std::endl;
+  deallog << "Is neighbour D with C: " << d.is_neighbour(c) << std::endl;
+  deallog << "Vice-versa: " << c.is_neighbour(d) << std::endl;
+  deallog << "Is neighbour D with D: " << d.is_neighbour(d) << std::endl;
+
+  for (int i=0; i<spacedim; i++)
+    {
+      second.first[i] = -10.0;
+      second.second[i] = -8.0;
+    }
+
+  BoundingBox<spacedim> e(second);
+
+  deallog << "Bounding box boundaries E: " << std::endl;
+  deallog << e.get_boundary_points().first << std::endl;
+  deallog << e.get_boundary_points().second << std::endl;
+
+  deallog << "Is neighbour E with A: " << e.is_neighbour(a) << std::endl;
+  deallog << "Vice-versa: " << a.is_neighbour(e) << std::endl;
+  deallog << "Is neighbour E with B: " << e.is_neighbour(b) << std::endl;
+  deallog << "Vice-versa: " << b.is_neighbour(e) << std::endl;
+  deallog << "Is neighbour E with C: " << e.is_neighbour(c) << std::endl;
+  deallog << "Vice-versa: " << c.is_neighbour(e) << std::endl;
+  deallog << "Is neighbour E with D: " << e.is_neighbour(d) << std::endl;
+  deallog << "Vice-versa: " << d.is_neighbour(e) << std::endl;
+  deallog << "Is neighbour E with E: " << e.is_neighbour(e) << std::endl;
+
+  deallog << "End test for dimension " << spacedim << std::endl;
+}
+
+int main()
+{
+  initlog();
+
+  deallog << "Test: Bounding Box class Is neighbour and volume functions" << std::endl;
+  deallog << std::endl << "Test for dimension 1" << std::endl;
+  test_bounding_box<1>();
+
+  deallog << std::endl << "Test for dimension 2" << std::endl;
+  test_bounding_box<2>();
+
+  deallog << std::endl << "Test for dimension 3" << std::endl;
+  test_bounding_box<3>();
+}

--- a/tests/base/bounding_box_3.output
+++ b/tests/base/bounding_box_3.output
@@ -1,0 +1,131 @@
+
+DEAL::Test: Bounding Box class Is neighbour and volume functions
+DEAL::
+DEAL::Test for dimension 1
+DEAL::Bounding box boundaries A: 
+DEAL::0.00000
+DEAL::1.00000
+DEAL::Is neighbour of itself: 2
+DEAL::Bounding box boundaries B: 
+DEAL::1.00000
+DEAL::2.00000
+DEAL::Is neighbour A with B: 2
+DEAL::Is neighbour B with A: 2
+DEAL::Is neighbour B with B: 2
+DEAL::Bounding box boundaries C: 
+DEAL::0.00000
+DEAL::2.00000
+DEAL::Is neighbour C with B: 2
+DEAL::Is neighbour B with C: 2
+DEAL::Is neighbour A with C: 2
+DEAL::Is neighbour C with A: 2
+DEAL::Is neighbour C with C: 2
+DEAL::Bounding box boundaries D: 
+DEAL::0.00000
+DEAL::1.40000
+DEAL::Is neighbour D with A: 2
+DEAL::Vice-versa: 2
+DEAL::Is neighbour D with B: 2
+DEAL::Vice-versa: 2
+DEAL::Is neighbour D with C: 2
+DEAL::Vice-versa: 2
+DEAL::Is neighbour D with D: 2
+DEAL::Bounding box boundaries E: 
+DEAL::-10.0000
+DEAL::-8.00000
+DEAL::Is neighbour E with A: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with B: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with C: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with D: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with E: 2
+DEAL::End test for dimension 1
+DEAL::
+DEAL::Test for dimension 2
+DEAL::Bounding box boundaries A: 
+DEAL::0.00000 0.00000
+DEAL::1.00000 1.00000
+DEAL::Is neighbour of itself: 2
+DEAL::Bounding box boundaries B: 
+DEAL::1.00000 1.00000
+DEAL::2.00000 2.00000
+DEAL::Is neighbour A with B: 0
+DEAL::Is neighbour B with A: 0
+DEAL::Is neighbour B with B: 2
+DEAL::Bounding box boundaries C: 
+DEAL::0.00000 0.00000
+DEAL::2.00000 2.00000
+DEAL::Is neighbour C with B: 2
+DEAL::Is neighbour B with C: 2
+DEAL::Is neighbour A with C: 2
+DEAL::Is neighbour C with A: 2
+DEAL::Is neighbour C with C: 2
+DEAL::Bounding box boundaries D: 
+DEAL::0.00000 0.00000
+DEAL::1.40000 1.40000
+DEAL::Is neighbour D with A: 2
+DEAL::Vice-versa: 2
+DEAL::Is neighbour D with B: 1
+DEAL::Vice-versa: 1
+DEAL::Is neighbour D with C: 2
+DEAL::Vice-versa: 2
+DEAL::Is neighbour D with D: 2
+DEAL::Bounding box boundaries E: 
+DEAL::-10.0000 -10.0000
+DEAL::-8.00000 -8.00000
+DEAL::Is neighbour E with A: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with B: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with C: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with D: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with E: 2
+DEAL::End test for dimension 2
+DEAL::
+DEAL::Test for dimension 3
+DEAL::Bounding box boundaries A: 
+DEAL::0.00000 0.00000 0.00000
+DEAL::1.00000 1.00000 1.00000
+DEAL::Is neighbour of itself: 2
+DEAL::Bounding box boundaries B: 
+DEAL::1.00000 1.00000 1.00000
+DEAL::2.00000 2.00000 2.00000
+DEAL::Is neighbour A with B: 0
+DEAL::Is neighbour B with A: 0
+DEAL::Is neighbour B with B: 2
+DEAL::Bounding box boundaries C: 
+DEAL::0.00000 0.00000 0.00000
+DEAL::2.00000 2.00000 2.00000
+DEAL::Is neighbour C with B: 2
+DEAL::Is neighbour B with C: 2
+DEAL::Is neighbour A with C: 2
+DEAL::Is neighbour C with A: 2
+DEAL::Is neighbour C with C: 2
+DEAL::Bounding box boundaries D: 
+DEAL::0.00000 0.00000 0.00000
+DEAL::1.40000 1.40000 1.40000
+DEAL::Is neighbour D with A: 2
+DEAL::Vice-versa: 2
+DEAL::Is neighbour D with B: 1
+DEAL::Vice-versa: 1
+DEAL::Is neighbour D with C: 2
+DEAL::Vice-versa: 2
+DEAL::Is neighbour D with D: 2
+DEAL::Bounding box boundaries E: 
+DEAL::-10.0000 -10.0000 -10.0000
+DEAL::-8.00000 -8.00000 -8.00000
+DEAL::Is neighbour E with A: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with B: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with C: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with D: 0
+DEAL::Vice-versa: 0
+DEAL::Is neighbour E with E: 2
+DEAL::End test for dimension 3

--- a/tests/distributed_grids/grid_tools_compute_cell_local_bounding_box_1.cc
+++ b/tests/distributed_grids/grid_tools_compute_cell_local_bounding_box_1.cc
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test for the function compute_locally_owned_bounding_box : on various domains and
+// mpi configurations to vary the shape of the various domains
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/distributed/grid_tools.h>
+#include <deal.II/distributed/grid_refinement.h>
+
+template <int dim, int spacedim=dim >
+void test_hypercube(unsigned int ref)
+{
+  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  deallog << "Testing hypercube for spacedim = " << spacedim << " ref " << ref << std::endl;
+
+  parallel::distributed::Triangulation<spacedim> tria(mpi_communicator);
+  GridGenerator::hyper_cube (tria);
+  tria.refine_global(4);
+
+  for (typename dealii::parallel::Triangulation<dim, spacedim>::cell_iterator cell: tria.cell_iterators_on_level(ref))
+    {
+      bool has_locally_owned = true;
+      BoundingBox<spacedim> local_bbox = parallel::GridTools::compute_cell_locally_owned_bounding_box<dim, spacedim>(cell,has_locally_owned);
+
+      if (has_locally_owned)
+        {
+          deallog << "Computed Bounding Box:" << std::endl;
+          deallog << local_bbox.get_boundary_points().first << std::endl;
+          deallog << local_bbox.get_boundary_points().second << std::endl;
+        }
+      else
+        deallog << "Has no locally owned children cells" << std::endl;
+    }
+
+  deallog << "END test hypercube for spacedim = " << spacedim << " ref " << ref << std::endl;
+}
+
+int main (int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+  MPILogInitAll log;
+
+  test_hypercube<2> (0);
+  test_hypercube<2> (1);
+  test_hypercube<2> (2);
+  test_hypercube<3> (0);
+  test_hypercube<3> (1);
+  test_hypercube<3> (2);
+
+  return 0;
+}

--- a/tests/distributed_grids/grid_tools_compute_cell_local_bounding_box_1.with_p4est=true.mpirun=2.output
+++ b/tests/distributed_grids/grid_tools_compute_cell_local_bounding_box_1.with_p4est=true.mpirun=2.output
@@ -1,0 +1,329 @@
+
+DEAL:0::Testing hypercube for spacedim = 2 ref 0
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.00000
+DEAL:0::1.00000 0.500000
+DEAL:0::END test hypercube for spacedim = 2 ref 0
+DEAL:0::Testing hypercube for spacedim = 2 ref 1
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.00000
+DEAL:0::0.500000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.00000
+DEAL:0::1.00000 0.500000
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::END test hypercube for spacedim = 2 ref 1
+DEAL:0::Testing hypercube for spacedim = 3 ref 1
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::0.500000 0.500000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.00000 0.00000
+DEAL:0::1.00000 0.500000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.500000 0.00000
+DEAL:0::0.500000 1.00000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.500000 0.00000
+DEAL:0::1.00000 1.00000 0.500000
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::END test hypercube for spacedim = 3 ref 1
+DEAL:0::Testing hypercube for spacedim = 3 ref 2
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::0.250000 0.250000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.250000 0.00000 0.00000
+DEAL:0::0.500000 0.250000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.250000 0.00000
+DEAL:0::0.250000 0.500000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.250000 0.250000 0.00000
+DEAL:0::0.500000 0.500000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.00000 0.250000
+DEAL:0::0.250000 0.250000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.250000 0.00000 0.250000
+DEAL:0::0.500000 0.250000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.250000 0.250000
+DEAL:0::0.250000 0.500000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.250000 0.250000 0.250000
+DEAL:0::0.500000 0.500000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.00000 0.00000
+DEAL:0::0.750000 0.250000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.750000 0.00000 0.00000
+DEAL:0::1.00000 0.250000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.250000 0.00000
+DEAL:0::0.750000 0.500000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.750000 0.250000 0.00000
+DEAL:0::1.00000 0.500000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.00000 0.250000
+DEAL:0::0.750000 0.250000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.750000 0.00000 0.250000
+DEAL:0::1.00000 0.250000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.250000 0.250000
+DEAL:0::0.750000 0.500000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.750000 0.250000 0.250000
+DEAL:0::1.00000 0.500000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.500000 0.00000
+DEAL:0::0.250000 0.750000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.250000 0.500000 0.00000
+DEAL:0::0.500000 0.750000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.750000 0.00000
+DEAL:0::0.250000 1.00000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.250000 0.750000 0.00000
+DEAL:0::0.500000 1.00000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.500000 0.250000
+DEAL:0::0.250000 0.750000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.250000 0.500000 0.250000
+DEAL:0::0.500000 0.750000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.00000 0.750000 0.250000
+DEAL:0::0.250000 1.00000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.250000 0.750000 0.250000
+DEAL:0::0.500000 1.00000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.500000 0.00000
+DEAL:0::0.750000 0.750000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.750000 0.500000 0.00000
+DEAL:0::1.00000 0.750000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.750000 0.00000
+DEAL:0::0.750000 1.00000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.750000 0.750000 0.00000
+DEAL:0::1.00000 1.00000 0.250000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.500000 0.250000
+DEAL:0::0.750000 0.750000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.750000 0.500000 0.250000
+DEAL:0::1.00000 0.750000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.500000 0.750000 0.250000
+DEAL:0::0.750000 1.00000 0.500000
+DEAL:0::Computed Bounding Box:
+DEAL:0::0.750000 0.750000 0.250000
+DEAL:0::1.00000 1.00000 0.500000
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::Has no locally owned children cells
+DEAL:0::END test hypercube for spacedim = 3 ref 2
+
+DEAL:1::Testing hypercube for spacedim = 2 ref 0
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.500000
+DEAL:1::1.00000 1.00000
+DEAL:1::END test hypercube for spacedim = 2 ref 0
+DEAL:1::Testing hypercube for spacedim = 2 ref 1
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.500000
+DEAL:1::0.500000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.500000
+DEAL:1::1.00000 1.00000
+DEAL:1::END test hypercube for spacedim = 2 ref 1
+DEAL:1::Testing hypercube for spacedim = 3 ref 1
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.00000 0.500000
+DEAL:1::0.500000 0.500000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.00000 0.500000
+DEAL:1::1.00000 0.500000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.500000 0.500000
+DEAL:1::0.500000 1.00000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.500000 0.500000
+DEAL:1::1.00000 1.00000 1.00000
+DEAL:1::END test hypercube for spacedim = 3 ref 1
+DEAL:1::Testing hypercube for spacedim = 3 ref 2
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Has no locally owned children cells
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.00000 0.500000
+DEAL:1::0.250000 0.250000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.250000 0.00000 0.500000
+DEAL:1::0.500000 0.250000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.250000 0.500000
+DEAL:1::0.250000 0.500000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.250000 0.250000 0.500000
+DEAL:1::0.500000 0.500000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.00000 0.750000
+DEAL:1::0.250000 0.250000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.250000 0.00000 0.750000
+DEAL:1::0.500000 0.250000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.250000 0.750000
+DEAL:1::0.250000 0.500000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.250000 0.250000 0.750000
+DEAL:1::0.500000 0.500000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.00000 0.500000
+DEAL:1::0.750000 0.250000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.750000 0.00000 0.500000
+DEAL:1::1.00000 0.250000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.250000 0.500000
+DEAL:1::0.750000 0.500000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.750000 0.250000 0.500000
+DEAL:1::1.00000 0.500000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.00000 0.750000
+DEAL:1::0.750000 0.250000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.750000 0.00000 0.750000
+DEAL:1::1.00000 0.250000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.250000 0.750000
+DEAL:1::0.750000 0.500000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.750000 0.250000 0.750000
+DEAL:1::1.00000 0.500000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.500000 0.500000
+DEAL:1::0.250000 0.750000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.250000 0.500000 0.500000
+DEAL:1::0.500000 0.750000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.750000 0.500000
+DEAL:1::0.250000 1.00000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.250000 0.750000 0.500000
+DEAL:1::0.500000 1.00000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.500000 0.750000
+DEAL:1::0.250000 0.750000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.250000 0.500000 0.750000
+DEAL:1::0.500000 0.750000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.00000 0.750000 0.750000
+DEAL:1::0.250000 1.00000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.250000 0.750000 0.750000
+DEAL:1::0.500000 1.00000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.500000 0.500000
+DEAL:1::0.750000 0.750000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.750000 0.500000 0.500000
+DEAL:1::1.00000 0.750000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.750000 0.500000
+DEAL:1::0.750000 1.00000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.750000 0.750000 0.500000
+DEAL:1::1.00000 1.00000 0.750000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.500000 0.750000
+DEAL:1::0.750000 0.750000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.750000 0.500000 0.750000
+DEAL:1::1.00000 0.750000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.500000 0.750000 0.750000
+DEAL:1::0.750000 1.00000 1.00000
+DEAL:1::Computed Bounding Box:
+DEAL:1::0.750000 0.750000 0.750000
+DEAL:1::1.00000 1.00000 1.00000
+DEAL:1::END test hypercube for spacedim = 3 ref 2
+

--- a/tests/distributed_grids/grid_tools_compute_local_bounding_box_1.cc
+++ b/tests/distributed_grids/grid_tools_compute_local_bounding_box_1.cc
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test for the function compute_locally_owned_bounding_box : on various domains and
+// mpi configurations to vary the shape of the various domains
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/distributed/grid_tools.h>
+#include <deal.II/distributed/grid_refinement.h>
+
+template <int dim, int spacedim=dim >
+void test_hypercube(unsigned int ref, unsigned int max_boxes)
+{
+  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  deallog << "Testing hypercube for spacedim = " << spacedim << " ref " << ref << std::endl;
+
+  parallel::distributed::Triangulation<spacedim> tria(mpi_communicator);
+  GridGenerator::hyper_cube (tria);
+  tria.refine_global(4);
+
+  std::vector< BoundingBox<spacedim> > local_bbox = parallel::GridTools::compute_locally_owned_bounding_box<dim, spacedim>
+                                                    ( tria, ref, max_boxes);
+  if ( local_bbox.size() > 0)
+    {
+      deallog << "Computed Bounding Boxes:" << std::endl;
+      for (BoundingBox<spacedim> b_box: local_bbox)
+        {
+          deallog << b_box.get_boundary_points().first << std::endl;
+          deallog << b_box.get_boundary_points().second << std::endl;
+          deallog << std::endl;
+        }
+    }
+  else
+    deallog << "Has no locally owned children cells" << std::endl;
+
+  //Checking if all the points are inside the bounding boxes
+  bool check = true;
+
+  typename parallel::distributed::Triangulation< dim, spacedim >::active_cell_iterator
+  cell = tria.begin_active();
+  typename parallel::distributed::Triangulation< dim, spacedim >::active_cell_iterator
+  endc = tria.last_active();
+
+  //Looking if every point is at least inside a bounding box
+  for (; cell<endc; ++cell)
+    if (cell->is_locally_owned())
+      for (unsigned int v=0; v<GeometryInfo<spacedim>::vertices_per_cell; ++v)
+        {
+          bool inside_a_box = false;
+          for (unsigned int i=0; i< local_bbox.size(); ++i)
+            {
+              if (local_bbox[i].point_inside(cell->vertex(v)))
+                inside_a_box = true;
+            }
+          if (! inside_a_box)
+            {
+              check = false;
+              deallog << "Point outside " << cell->vertex(v) << std::endl;
+              break;
+            }
+        }
+
+  deallog << "Bounding Boxes surround locally_owned cells: " << check << std::endl;
+
+  deallog << "Current test END"  << std::endl;
+}
+
+int main (int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+  MPILogInitAll log;
+
+  unsigned int max_boxes = 4;
+
+  test_hypercube<2> (0,max_boxes);
+  test_hypercube<2> (1,max_boxes);
+  test_hypercube<2> (2,max_boxes);
+  test_hypercube<2> (3,max_boxes);
+  test_hypercube<3> (1,max_boxes);
+  test_hypercube<3> (2,max_boxes);
+  test_hypercube<3> (3,max_boxes);
+
+
+  return 0;
+}

--- a/tests/distributed_grids/grid_tools_compute_local_bounding_box_1.with_p4est=true.mpirun=2.output
+++ b/tests/distributed_grids/grid_tools_compute_local_bounding_box_1.with_p4est=true.mpirun=2.output
@@ -1,0 +1,101 @@
+
+DEAL:0::Testing hypercube for spacedim = 2 ref 0
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::1.00000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 2 ref 1
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::1.00000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 2 ref 2
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::1.00000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 2 ref 3
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::1.00000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 3 ref 1
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::1.00000 1.00000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 3 ref 2
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::1.00000 1.00000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 3 ref 3
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::1.00000 1.00000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+
+DEAL:1::Testing hypercube for spacedim = 2 ref 0
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.500000
+DEAL:1::1.00000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 2 ref 1
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.500000
+DEAL:1::1.00000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 2 ref 2
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.500000
+DEAL:1::1.00000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 2 ref 3
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.500000
+DEAL:1::1.00000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 3 ref 1
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.00000 0.500000
+DEAL:1::1.00000 1.00000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 3 ref 2
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.00000 0.500000
+DEAL:1::1.00000 1.00000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 3 ref 3
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.00000 0.500000
+DEAL:1::1.00000 1.00000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+

--- a/tests/distributed_grids/grid_tools_compute_local_bounding_box_1.with_p4est=true.mpirun=3.output
+++ b/tests/distributed_grids/grid_tools_compute_local_bounding_box_1.with_p4est=true.mpirun=3.output
@@ -1,0 +1,272 @@
+
+DEAL:0::Testing hypercube for spacedim = 2 ref 0
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::0.875000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 2 ref 1
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::0.500000 0.500000
+DEAL:0::
+DEAL:0::0.500000 0.00000
+DEAL:0::0.875000 0.250000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 2 ref 2
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::0.750000 0.250000
+DEAL:0::
+DEAL:0::0.00000 0.250000
+DEAL:0::0.500000 0.500000
+DEAL:0::
+DEAL:0::0.750000 0.00000
+DEAL:0::0.875000 0.125000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 2 ref 3
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::0.875000 0.125000
+DEAL:0::
+DEAL:0::0.00000 0.125000
+DEAL:0::0.750000 0.250000
+DEAL:0::
+DEAL:0::0.00000 0.250000
+DEAL:0::0.500000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 3 ref 1
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::1.00000 0.500000 0.500000
+DEAL:0::
+DEAL:0::0.00000 0.500000 0.00000
+DEAL:0::0.500000 1.00000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 3 ref 2
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::1.00000 0.500000 0.500000
+DEAL:0::
+DEAL:0::0.00000 0.500000 0.00000
+DEAL:0::0.500000 1.00000 0.250000
+DEAL:0::
+DEAL:0::0.00000 0.500000 0.250000
+DEAL:0::0.250000 0.750000 0.500000
+DEAL:0::
+DEAL:0::0.250000 0.500000 0.250000
+DEAL:0::0.500000 0.750000 0.375000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 3 ref 3
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::1.00000 0.500000 0.500000
+DEAL:0::
+DEAL:0::0.00000 0.500000 0.00000
+DEAL:0::0.500000 1.00000 0.375000
+DEAL:0::
+DEAL:0::0.00000 0.500000 0.250000
+DEAL:0::0.500000 0.625000 0.375000
+DEAL:0::
+DEAL:0::0.00000 0.500000 0.375000
+DEAL:0::0.250000 0.750000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+
+DEAL:1::Testing hypercube for spacedim = 2 ref 0
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.00000
+DEAL:1::1.00000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 2 ref 1
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.500000 0.00000
+DEAL:1::1.00000 0.500000
+DEAL:1::
+DEAL:1::0.00000 0.500000
+DEAL:1::0.500000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 2 ref 2
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.750000 0.00000
+DEAL:1::1.00000 0.500000
+DEAL:1::
+DEAL:1::0.500000 0.250000
+DEAL:1::0.750000 0.500000
+DEAL:1::
+DEAL:1::0.00000 0.500000
+DEAL:1::0.500000 0.750000
+DEAL:1::
+DEAL:1::0.00000 0.750000
+DEAL:1::0.250000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 2 ref 3
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.875000 0.00000
+DEAL:1::1.00000 0.500000
+DEAL:1::
+DEAL:1::0.750000 0.125000
+DEAL:1::0.875000 0.500000
+DEAL:1::
+DEAL:1::0.500000 0.250000
+DEAL:1::0.750000 0.500000
+DEAL:1::
+DEAL:1::0.00000 0.500000
+DEAL:1::0.500000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 3 ref 1
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.500000 0.250000
+DEAL:1::0.500000 1.00000 0.500000
+DEAL:1::
+DEAL:1::0.500000 0.500000 0.00000
+DEAL:1::1.00000 1.00000 0.500000
+DEAL:1::
+DEAL:1::0.00000 0.00000 0.500000
+DEAL:1::0.500000 0.500000 1.00000
+DEAL:1::
+DEAL:1::0.500000 0.00000 0.500000
+DEAL:1::1.00000 0.500000 0.750000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 3 ref 2
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.500000 0.250000
+DEAL:1::1.00000 1.00000 0.500000
+DEAL:1::
+DEAL:1::0.500000 0.500000 0.00000
+DEAL:1::1.00000 1.00000 0.250000
+DEAL:1::
+DEAL:1::0.00000 0.00000 0.500000
+DEAL:1::1.00000 0.500000 0.750000
+DEAL:1::
+DEAL:1::0.00000 0.00000 0.750000
+DEAL:1::0.500000 0.500000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 3 ref 3
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.500000 0.250000
+DEAL:1::1.00000 1.00000 0.500000
+DEAL:1::
+DEAL:1::0.500000 0.500000 0.00000
+DEAL:1::1.00000 1.00000 0.250000
+DEAL:1::
+DEAL:1::0.00000 0.00000 0.500000
+DEAL:1::1.00000 0.500000 1.00000
+DEAL:1::
+DEAL:1::0.00000 0.00000 0.750000
+DEAL:1::0.500000 0.375000 1.00000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+
+
+DEAL:2::Testing hypercube for spacedim = 2 ref 0
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.125000 0.500000
+DEAL:2::1.00000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 2 ref 1
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.125000 0.750000
+DEAL:2::0.500000 1.00000
+DEAL:2::
+DEAL:2::0.500000 0.500000
+DEAL:2::1.00000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 2 ref 2
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.125000 0.875000
+DEAL:2::0.250000 1.00000
+DEAL:2::
+DEAL:2::0.250000 0.750000
+DEAL:2::1.00000 1.00000
+DEAL:2::
+DEAL:2::0.500000 0.500000
+DEAL:2::1.00000 0.750000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 2 ref 3
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.125000 0.875000
+DEAL:2::1.00000 1.00000
+DEAL:2::
+DEAL:2::0.250000 0.750000
+DEAL:2::1.00000 0.875000
+DEAL:2::
+DEAL:2::0.500000 0.500000
+DEAL:2::1.00000 0.750000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 3 ref 1
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.500000 0.00000 0.500000
+DEAL:2::1.00000 1.00000 1.00000
+DEAL:2::
+DEAL:2::0.00000 0.500000 0.500000
+DEAL:2::0.500000 1.00000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 3 ref 2
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.500000 0.250000 0.625000
+DEAL:2::0.750000 0.500000 1.00000
+DEAL:2::
+DEAL:2::0.750000 0.250000 0.500000
+DEAL:2::1.00000 0.500000 1.00000
+DEAL:2::
+DEAL:2::0.500000 0.00000 0.750000
+DEAL:2::1.00000 0.250000 1.00000
+DEAL:2::
+DEAL:2::0.00000 0.500000 0.500000
+DEAL:2::1.00000 1.00000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 3 ref 3
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.500000 0.00000 0.625000
+DEAL:2::1.00000 0.500000 1.00000
+DEAL:2::
+DEAL:2::0.00000 0.250000 0.500000
+DEAL:2::1.00000 1.00000 0.750000
+DEAL:2::
+DEAL:2::0.00000 0.500000 0.625000
+DEAL:2::0.625000 1.00000 0.750000
+DEAL:2::
+DEAL:2::0.00000 0.500000 0.750000
+DEAL:2::1.00000 1.00000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+

--- a/tests/distributed_grids/grid_tools_compute_local_bounding_box_1.with_p4est=true.mpirun=4.output
+++ b/tests/distributed_grids/grid_tools_compute_local_bounding_box_1.with_p4est=true.mpirun=4.output
@@ -1,0 +1,203 @@
+
+DEAL:0::Testing hypercube for spacedim = 2 ref 0
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::0.500000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 2 ref 1
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::0.500000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 2 ref 2
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::0.500000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 2 ref 3
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000
+DEAL:0::0.500000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 3 ref 1
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::1.00000 0.500000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 3 ref 2
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::1.00000 0.500000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+DEAL:0::Testing hypercube for spacedim = 3 ref 3
+DEAL:0::Computed Bounding Boxes:
+DEAL:0::0.00000 0.00000 0.00000
+DEAL:0::1.00000 0.500000 0.500000
+DEAL:0::
+DEAL:0::Bounding Boxes surround locally_owned cells: 1
+DEAL:0::Current test END
+
+DEAL:1::Testing hypercube for spacedim = 2 ref 0
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.500000 0.00000
+DEAL:1::1.00000 0.500000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 2 ref 1
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.500000 0.00000
+DEAL:1::1.00000 0.500000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 2 ref 2
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.500000 0.00000
+DEAL:1::1.00000 0.500000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 2 ref 3
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.500000 0.00000
+DEAL:1::1.00000 0.500000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 3 ref 1
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.500000 0.00000
+DEAL:1::1.00000 1.00000 0.500000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 3 ref 2
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.500000 0.00000
+DEAL:1::1.00000 1.00000 0.500000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+DEAL:1::Testing hypercube for spacedim = 3 ref 3
+DEAL:1::Computed Bounding Boxes:
+DEAL:1::0.00000 0.500000 0.00000
+DEAL:1::1.00000 1.00000 0.500000
+DEAL:1::
+DEAL:1::Bounding Boxes surround locally_owned cells: 1
+DEAL:1::Current test END
+
+
+DEAL:2::Testing hypercube for spacedim = 2 ref 0
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.00000 0.500000
+DEAL:2::0.500000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 2 ref 1
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.00000 0.500000
+DEAL:2::0.500000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 2 ref 2
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.00000 0.500000
+DEAL:2::0.500000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 2 ref 3
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.00000 0.500000
+DEAL:2::0.500000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 3 ref 1
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.00000 0.00000 0.500000
+DEAL:2::1.00000 0.500000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 3 ref 2
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.00000 0.00000 0.500000
+DEAL:2::1.00000 0.500000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+DEAL:2::Testing hypercube for spacedim = 3 ref 3
+DEAL:2::Computed Bounding Boxes:
+DEAL:2::0.00000 0.00000 0.500000
+DEAL:2::1.00000 0.500000 1.00000
+DEAL:2::
+DEAL:2::Bounding Boxes surround locally_owned cells: 1
+DEAL:2::Current test END
+
+
+DEAL:3::Testing hypercube for spacedim = 2 ref 0
+DEAL:3::Computed Bounding Boxes:
+DEAL:3::0.500000 0.500000
+DEAL:3::1.00000 1.00000
+DEAL:3::
+DEAL:3::Bounding Boxes surround locally_owned cells: 1
+DEAL:3::Current test END
+DEAL:3::Testing hypercube for spacedim = 2 ref 1
+DEAL:3::Computed Bounding Boxes:
+DEAL:3::0.500000 0.500000
+DEAL:3::1.00000 1.00000
+DEAL:3::
+DEAL:3::Bounding Boxes surround locally_owned cells: 1
+DEAL:3::Current test END
+DEAL:3::Testing hypercube for spacedim = 2 ref 2
+DEAL:3::Computed Bounding Boxes:
+DEAL:3::0.500000 0.500000
+DEAL:3::1.00000 1.00000
+DEAL:3::
+DEAL:3::Bounding Boxes surround locally_owned cells: 1
+DEAL:3::Current test END
+DEAL:3::Testing hypercube for spacedim = 2 ref 3
+DEAL:3::Computed Bounding Boxes:
+DEAL:3::0.500000 0.500000
+DEAL:3::1.00000 1.00000
+DEAL:3::
+DEAL:3::Bounding Boxes surround locally_owned cells: 1
+DEAL:3::Current test END
+DEAL:3::Testing hypercube for spacedim = 3 ref 1
+DEAL:3::Computed Bounding Boxes:
+DEAL:3::0.00000 0.500000 0.500000
+DEAL:3::1.00000 1.00000 1.00000
+DEAL:3::
+DEAL:3::Bounding Boxes surround locally_owned cells: 1
+DEAL:3::Current test END
+DEAL:3::Testing hypercube for spacedim = 3 ref 2
+DEAL:3::Computed Bounding Boxes:
+DEAL:3::0.00000 0.500000 0.500000
+DEAL:3::1.00000 1.00000 1.00000
+DEAL:3::
+DEAL:3::Bounding Boxes surround locally_owned cells: 1
+DEAL:3::Current test END
+DEAL:3::Testing hypercube for spacedim = 3 ref 3
+DEAL:3::Computed Bounding Boxes:
+DEAL:3::0.00000 0.500000 0.500000
+DEAL:3::1.00000 1.00000 1.00000
+DEAL:3::
+DEAL:3::Bounding Boxes surround locally_owned cells: 1
+DEAL:3::Current test END
+


### PR DESCRIPTION
This is the continuation of https://github.com/dealii/dealii/pull/5117 : I'm opening a new pull request since I'm doing things differently.
I've added a function for bounding boxes which returns 0 if they're not neighbours, 1 or 2 otherwise (to help with the following merging idea).

I added two function to distributed triangulation
- one which, given a cell, creates the bounding box of the locally owned cells inside it (this is done in the dumbest way possible)
- another which, given a refinement level and a target number of boxes, uses the previous function on cells of the given refinement level (or less, if they're active) and then merges the results: first by merging cells which can be expressed with a single bounding box, then by merging looking for the smallest one to a neighbour (not the brightest idea, I know...)

I want to thank you for all the comments in the other thread. This is still a work in progress but it is clear I need to update more often here for comments (and checking if other people are working on bounding boxes).

If there are suggestions on how the functions should be organized I'd be very happy to help: I put the two bounding box creating functions under parallel::distributed because they really make no sense elsewhere...

#5117 