### PR TITLE
add LA::d::BlockVector:: multivector_inner_product()

### DIFF
--- a/doc/news/changes/minor/20170930DenisDavydov
+++ b/doc/news/changes/minor/20170930DenisDavydov
@@ -1,0 +1,4 @@
+New: add LinearAlgebra::distributed::BlockVector<Number>::multivector_inner_product()
+to perform inner product between each block of the two block vectors.
+<br>
+(Denis Davydov, 2017/09/30)

--- a/doc/news/changes/minor/20170930DenisDavydov-2
+++ b/doc/news/changes/minor/20170930DenisDavydov-2
@@ -1,0 +1,3 @@
+New: add Utilities::MPI::sum() for LAPACKFullMatrix objects.
+<br>
+(Denis Davydov, 2017/09/04)

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -55,6 +55,8 @@ template <int rank, int dim, typename Number> class SymmetricTensor;
 template <typename Number> class Vector;
 //Forward type declaration to allow MPI sums over FullMatrix<number> type
 template <typename Number> class FullMatrix;
+//Forward type declaration to allow MPI sums over LAPACKFullMatrix<number> type
+template <typename Number> class LAPACKFullMatrix;
 
 
 namespace Utilities
@@ -194,6 +196,14 @@ namespace Utilities
     void sum (const FullMatrix<T> &values,
               const MPI_Comm &mpi_communicator,
               FullMatrix<T> &sums);
+
+    /**
+     * Same as above but for LAPACKFullMatrix.
+     */
+    template <typename T>
+    void sum (const LAPACKFullMatrix<T> &values,
+              const MPI_Comm &mpi_communicator,
+              LAPACKFullMatrix<T> &sums);
 
     /**
      * Perform an MPI sum of the entries of a symmetric tensor.

--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -23,6 +23,7 @@
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/lapack_full_matrix.h>
 
 #include <vector>
 
@@ -227,6 +228,21 @@ namespace Utilities
         all_reduce(mpi_op, &values[0][0], mpi_communicator, &output[0][0], values.m() * values.n());
       }
 
+
+
+      template <typename T>
+      void all_reduce (const MPI_Op    &mpi_op,
+                       const LAPACKFullMatrix<T> &values,
+                       const MPI_Comm  &mpi_communicator,
+                       LAPACKFullMatrix<T>  &output)
+      {
+        Assert(values.m() == output.m(),
+               ExcDimensionMismatch(values.m(), output.m()));
+        Assert(values.n() == output.n(),
+               ExcDimensionMismatch(values.n(), output.n()));
+        all_reduce(mpi_op, &values(0,0), mpi_communicator, &output(0,0), values.m() * values.n());
+      }
+
     }
 
 
@@ -264,6 +280,16 @@ namespace Utilities
     void sum (const FullMatrix<T> &values,
               const MPI_Comm &mpi_communicator,
               FullMatrix<T> &sums)
+    {
+      internal::all_reduce(MPI_SUM, values, mpi_communicator, sums);
+    }
+
+
+
+    template <typename T>
+    void sum (const LAPACKFullMatrix<T> &values,
+              const MPI_Comm &mpi_communicator,
+              LAPACKFullMatrix<T> &sums)
     {
       internal::all_reduce(MPI_SUM, values, mpi_communicator, sums);
     }

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -448,6 +448,24 @@ namespace LinearAlgebra
       virtual Number operator* (const VectorSpaceVector<Number> &V) const override;
 
       /**
+       * Calculate the scalar product between each block of this vector and @p V
+       * and store the result in a full matrix @p matrix. This function
+       * computes the result by forming $A_{ij}=U_i \cdot V_j$ where $U_i$
+       * and $V_i$ indicate the $i$th block (not element!) of $U$ and the
+       * $j$th block of $V$, respectively. If @p symmetric is
+       * <code>true</code>, it is assumed that inner product results in a
+       * square symmetric matrix and almost half of the scalar products can be avoided.
+       *
+       * Obviously, this function can only be used if each block in this
+       * object and @p V are of the same size.
+       *
+       * @note Internally, a single global reduction will be called to
+       * accumulate scalar product between locally owned degrees of freedom.
+       */
+      template <typename FullMatrixType>
+      void multivector_inner_product(FullMatrixType &matrix, const BlockVector<Number> &V, const bool symmetric = false) const;
+
+      /**
        * Add @p a to all components. Note that @p a is a scalar not a vector.
        */
       virtual void add(const Number a) override;

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -451,19 +451,21 @@ namespace LinearAlgebra
        * Calculate the scalar product between each block of this vector and @p V
        * and store the result in a full matrix @p matrix. This function
        * computes the result by forming $A_{ij}=U_i \cdot V_j$ where $U_i$
-       * and $V_i$ indicate the $i$th block (not element!) of $U$ and the
+       * and $V_j$ indicate the $i$th block (not element!) of $U$ and the
        * $j$th block of $V$, respectively. If @p symmetric is
        * <code>true</code>, it is assumed that inner product results in a
        * square symmetric matrix and almost half of the scalar products can be avoided.
        *
-       * Obviously, this function can only be used if each block in this
-       * object and @p V are of the same size.
+       * Obviously, this function can only be used if all blocks of both vectors
+       * are of the same size.
        *
        * @note Internally, a single global reduction will be called to
        * accumulate scalar product between locally owned degrees of freedom.
        */
       template <typename FullMatrixType>
-      void multivector_inner_product(FullMatrixType &matrix, const BlockVector<Number> &V, const bool symmetric = false) const;
+      void multivector_inner_product(FullMatrixType &matrix,
+                                     const BlockVector<Number> &V,
+                                     const bool symmetric = false) const;
 
       /**
        * Add @p a to all components. Note that @p a is a scalar not a vector.

--- a/source/base/mpi.inst.in
+++ b/source/base/mpi.inst.in
@@ -13,6 +13,11 @@
 //
 // ---------------------------------------------------------------------
 
+for (S : REAL_SCALARS)
+{
+    template
+    void sum<S> (const LAPACKFullMatrix<S> &, const MPI_Comm &, LAPACKFullMatrix<S> &);
+}
 
 for (S : MPI_SCALARS)
 {

--- a/source/lac/la_parallel_block_vector.cc
+++ b/source/lac/la_parallel_block_vector.cc
@@ -16,6 +16,9 @@
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_block_vector.templates.h>
 
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/lapack_full_matrix.h>
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/source/lac/la_parallel_block_vector.inst.in
+++ b/source/lac/la_parallel_block_vector.inst.in
@@ -22,6 +22,12 @@ for (SCALAR : REAL_SCALARS)
     namespace distributed
     \{
     template class BlockVector<SCALAR>;
+    template
+    void
+    BlockVector<SCALAR>::multivector_inner_product(FullMatrix<SCALAR> &, const BlockVector<SCALAR> &V, const bool) const;
+    template
+    void
+    BlockVector<SCALAR>::multivector_inner_product(LAPACKFullMatrix<SCALAR> &, const BlockVector<SCALAR> &V, const bool) const;
     \}
     \}
 }

--- a/tests/mpi/collective_full_matrix_02.cc
+++ b/tests/mpi/collective_full_matrix_02.cc
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check Utilities::MPI::sum() for LAPACKFullMatrix objects
+
+#include "../tests.h"
+#include <deal.II/lac/lapack_full_matrix.h>
+#include <deal.II/lac/vector.h>
+
+template <typename NumberType>
+void test(const unsigned int m = 13, const unsigned int n = 5)
+{
+  Assert( Utilities::MPI::job_supports_mpi(), ExcInternalError());
+
+  LAPACKFullMatrix<NumberType> full_matrix(m,n);
+  {
+    unsigned int index = 0;
+    for (unsigned int i = 0; i < full_matrix.m(); ++i)
+      for (unsigned int j = 0; j < full_matrix.n(); ++j)
+        full_matrix(i,j) = index++;
+  }
+
+  LAPACKFullMatrix<NumberType> full_matrix_original(m,n);
+  full_matrix_original = full_matrix;
+
+  // inplace
+  Utilities::MPI::sum(full_matrix, MPI_COMM_WORLD, full_matrix);
+
+  const unsigned int numprocs = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
+  for (unsigned int i = 0; i < full_matrix.m(); ++i)
+    for (unsigned int j = 0; j < full_matrix.n(); ++j)
+      Assert (full_matrix(i,j) == full_matrix_original(i,j) * double(numprocs), ExcInternalError());
+
+  if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
+    deallog << "Ok" << std::endl;
+}
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
+    {
+      initlog();
+      deallog.push("float");
+      test<float>();
+      deallog.pop();
+      deallog.push("double");
+      test<double>();
+      deallog.pop();
+    }
+  else
+    {
+      test<float>();
+      test<double>();
+    }
+
+}

--- a/tests/mpi/collective_full_matrix_02.mpirun=1.output
+++ b/tests/mpi/collective_full_matrix_02.mpirun=1.output
@@ -1,0 +1,3 @@
+
+DEAL:float::Ok
+DEAL:double::Ok

--- a/tests/mpi/collective_full_matrix_02.mpirun=3.output
+++ b/tests/mpi/collective_full_matrix_02.mpirun=3.output
@@ -1,0 +1,3 @@
+
+DEAL:float::Ok
+DEAL:double::Ok

--- a/tests/mpi/parallel_block_vector_05.cc
+++ b/tests/mpi/parallel_block_vector_05.cc
@@ -1,0 +1,200 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// this BlockVector<Number>::scalar_product().
+// Triangulation and Mass operator are the same as in matrix_free/mass_operator_01.cc
+
+#include "../tests.h"
+
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/function.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/matrix_free/operators.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/lac/la_parallel_block_vector.h>
+
+#include <iostream>
+
+
+
+
+template <int dim, int fe_degree>
+void test (const unsigned int n_blocks = 5)
+{
+  typedef double number;
+
+  parallel::distributed::Triangulation<dim> tria (MPI_COMM_WORLD);
+  GridGenerator::hyper_cube (tria);
+  tria.refine_global(1);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  cell = tria.begin_active ();
+  for (; cell!=endc; ++cell)
+    if (cell->is_locally_owned())
+      if (cell->center().norm()<0.2)
+        cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  if (dim < 3 && fe_degree < 2)
+    tria.refine_global(2);
+  else
+    tria.refine_global(1);
+  if (tria.begin(tria.n_levels()-1)->is_locally_owned())
+    tria.begin(tria.n_levels()-1)->set_refine_flag();
+  if (tria.last()->is_locally_owned())
+    tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  cell = tria.begin_active ();
+  for (unsigned int i=0; i<10-3*dim; ++i)
+    {
+      cell = tria.begin_active ();
+      unsigned int counter = 0;
+      for (; cell!=endc; ++cell, ++counter)
+        if (cell->is_locally_owned())
+          if (counter % (7-i) == 0)
+            cell->set_refine_flag();
+      tria.execute_coarsening_and_refinement();
+    }
+
+  FE_Q<dim> fe (fe_degree);
+  DoFHandler<dim> dof (tria);
+  dof.distribute_dofs(fe);
+
+  IndexSet owned_set = dof.locally_owned_dofs();
+  IndexSet relevant_set;
+  DoFTools::extract_locally_relevant_dofs (dof, relevant_set);
+
+  ConstraintMatrix constraints (relevant_set);
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  VectorTools::interpolate_boundary_values (dof, 0, Functions::ZeroFunction<dim>(),
+                                            constraints);
+  constraints.close();
+
+  std::shared_ptr<MatrixFree<dim,number> > mf_data(new MatrixFree<dim,number> ());
+  {
+    const QGauss<1> quad (fe_degree+2);
+    typename MatrixFree<dim,number>::AdditionalData data;
+    data.tasks_parallel_scheme =
+      MatrixFree<dim,number>::AdditionalData::none;
+    data.tasks_block_size = 7;
+    mf_data->reinit (dof, constraints, quad, data);
+  }
+
+  MatrixFreeOperators::MassOperator<dim,fe_degree, fe_degree+2, 1, LinearAlgebra::distributed::Vector<number> > mf;
+  mf.initialize(mf_data);
+  mf.compute_diagonal();
+
+  LinearAlgebra::distributed::BlockVector<number> left(n_blocks), right(n_blocks);
+  for (unsigned int b = 0; b < n_blocks; ++b)
+    {
+      mf_data->initialize_dof_vector (left.block(b));
+      mf_data->initialize_dof_vector (right.block(b));
+
+      for (unsigned int i=0; i<right.block(b).local_size(); ++i)
+        {
+          const unsigned int glob_index =
+            owned_set.nth_index_in_set (i);
+          if (constraints.is_constrained(glob_index))
+            continue;
+          right.block(b).local_element(i) = (double)Testing::rand()/RAND_MAX;
+        }
+
+      mf.vmult (left.block(b), right.block(b));
+    }
+
+  {
+    FullMatrix<number> product(n_blocks,n_blocks), reference(n_blocks,n_blocks);
+
+    deallog << "Symmetric:" << std::endl;
+
+    left.multivector_inner_product(product, right, true);
+
+    for (unsigned int i = 0; i < n_blocks; ++i)
+      for (unsigned int j = 0; j < n_blocks; ++j)
+        reference(i,j) = left.block(i) * right.block(j);
+
+    product.add(-1.,reference);
+
+    const double diff_norm = product.frobenius_norm();
+
+    deallog << "Norm of difference: " << diff_norm << std::endl;
+  }
+
+  // Non-symmetric case
+  {
+    const unsigned int n_blocks_2 = n_blocks+3;
+    LinearAlgebra::distributed::BlockVector<number> left2(n_blocks_2);
+    for (unsigned int b = 0; b < left2.n_blocks(); ++b)
+      {
+        mf_data->initialize_dof_vector (left2.block(b));
+        for (unsigned int i=0; i<left2.block(b).local_size(); ++i)
+          {
+            const unsigned int glob_index =
+              owned_set.nth_index_in_set (i);
+            if (constraints.is_constrained(glob_index))
+              continue;
+            left2.block(b).local_element(i) = (double)Testing::rand()/RAND_MAX;
+          }
+      }
+
+    FullMatrix<number> product2(n_blocks_2,n_blocks), reference2(n_blocks_2,n_blocks);
+
+    deallog << "Non-Symmetric:" << std::endl;
+
+    left2.multivector_inner_product(product2, right, false);
+
+    for (unsigned int i = 0; i < n_blocks_2; ++i)
+      for (unsigned int j = 0; j < n_blocks; ++j)
+        reference2(i,j) = left2.block(i) * right.block(j);
+
+    product2.add(-1.,reference2);
+
+    const double diff_norm2 = product2.frobenius_norm();
+
+    deallog << "Norm of difference: " << diff_norm2 << std::endl;
+  }
+
+
+}
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+  deallog.push(Utilities::int_to_string(myid));
+
+  if (myid == 0)
+    {
+      initlog();
+      deallog << std::setprecision(4);
+
+      test<2,1>();
+    }
+  else
+    {
+      test<2,1>();
+    }
+}
+

--- a/tests/mpi/parallel_block_vector_05.with_p4est=true.mpirun=1.output
+++ b/tests/mpi/parallel_block_vector_05.with_p4est=true.mpirun=1.output
@@ -1,0 +1,5 @@
+
+DEAL:0::Symmetric:
+DEAL:0::Norm of difference: 0.000
+DEAL:0::Non-Symmetric:
+DEAL:0::Norm of difference: 0.000

--- a/tests/mpi/parallel_block_vector_05.with_p4est=true.mpirun=4.output
+++ b/tests/mpi/parallel_block_vector_05.with_p4est=true.mpirun=4.output
@@ -1,0 +1,5 @@
+
+DEAL:0::Symmetric:
+DEAL:0::Norm of difference: 0.000
+DEAL:0::Non-Symmetric:
+DEAL:0::Norm of difference: 0.000

--- a/tests/mpi/parallel_block_vector_06.cc
+++ b/tests/mpi/parallel_block_vector_06.cc
@@ -1,0 +1,204 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// this BlockVector<Number>::scalar_product().
+// same as parallel_block_vector_05, but uses LAPACKFUllMatrix and tests
+// that internally we set it to be symmetric and so, for example, one can
+// immediately run Cholesky factorization
+
+#include "../tests.h"
+
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/function.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/matrix_free/operators.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/lapack_full_matrix.h>
+
+#include <iostream>
+
+
+
+
+template <int dim, int fe_degree>
+void test (const unsigned int n_blocks = 5)
+{
+  typedef double number;
+
+  parallel::distributed::Triangulation<dim> tria (MPI_COMM_WORLD);
+  GridGenerator::hyper_cube (tria);
+  tria.refine_global(1);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  cell = tria.begin_active ();
+  for (; cell!=endc; ++cell)
+    if (cell->is_locally_owned())
+      if (cell->center().norm()<0.2)
+        cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  if (dim < 3 && fe_degree < 2)
+    tria.refine_global(2);
+  else
+    tria.refine_global(1);
+  if (tria.begin(tria.n_levels()-1)->is_locally_owned())
+    tria.begin(tria.n_levels()-1)->set_refine_flag();
+  if (tria.last()->is_locally_owned())
+    tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  cell = tria.begin_active ();
+  for (unsigned int i=0; i<10-3*dim; ++i)
+    {
+      cell = tria.begin_active ();
+      unsigned int counter = 0;
+      for (; cell!=endc; ++cell, ++counter)
+        if (cell->is_locally_owned())
+          if (counter % (7-i) == 0)
+            cell->set_refine_flag();
+      tria.execute_coarsening_and_refinement();
+    }
+
+  FE_Q<dim> fe (fe_degree);
+  DoFHandler<dim> dof (tria);
+  dof.distribute_dofs(fe);
+
+  IndexSet owned_set = dof.locally_owned_dofs();
+  IndexSet relevant_set;
+  DoFTools::extract_locally_relevant_dofs (dof, relevant_set);
+
+  ConstraintMatrix constraints (relevant_set);
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  VectorTools::interpolate_boundary_values (dof, 0, Functions::ZeroFunction<dim>(),
+                                            constraints);
+  constraints.close();
+
+  std::shared_ptr<MatrixFree<dim,number> > mf_data(new MatrixFree<dim,number> ());
+  {
+    const QGauss<1> quad (fe_degree+2);
+    typename MatrixFree<dim,number>::AdditionalData data;
+    data.tasks_parallel_scheme =
+      MatrixFree<dim,number>::AdditionalData::none;
+    data.tasks_block_size = 7;
+    mf_data->reinit (dof, constraints, quad, data);
+  }
+
+  MatrixFreeOperators::MassOperator<dim,fe_degree, fe_degree+2, 1, LinearAlgebra::distributed::Vector<number> > mf;
+  mf.initialize(mf_data);
+  mf.compute_diagonal();
+
+  LinearAlgebra::distributed::BlockVector<number> left(n_blocks), right(n_blocks);
+  for (unsigned int b = 0; b < n_blocks; ++b)
+    {
+      mf_data->initialize_dof_vector (left.block(b));
+      mf_data->initialize_dof_vector (right.block(b));
+
+      for (unsigned int i=0; i<right.block(b).local_size(); ++i)
+        {
+          const unsigned int glob_index =
+            owned_set.nth_index_in_set (i);
+          if (constraints.is_constrained(glob_index))
+            continue;
+          right.block(b).local_element(i) = (double)Testing::rand()/RAND_MAX;
+        }
+
+      mf.vmult (left.block(b), right.block(b));
+    }
+
+  {
+    // general lapack matrices:
+    LAPACKFullMatrix<number> product(n_blocks,n_blocks), diff(n_blocks,n_blocks);
+
+    deallog << "Symmetric:" << std::endl;
+
+    // inside LAPACK matrix should have its Property set as symmetric
+    // and so we can call compute_cholesky_factorization() below.
+    left.multivector_inner_product(product, right, true);
+
+    for (unsigned int i = 0; i < n_blocks; ++i)
+      for (unsigned int j = 0; j < n_blocks; ++j)
+        diff(i,j) = left.block(i) * right.block(j) - product(i,j);
+
+    const double diff_norm = diff.frobenius_norm();
+
+    deallog << "Norm of difference: " << diff_norm << std::endl;
+    deallog << "Cholesky: " << std::flush;
+    product.compute_cholesky_factorization();
+    deallog << "Ok" << std::endl;
+  }
+
+  // Non-symmetric case
+  {
+    const unsigned int n_blocks_2 = n_blocks+3;
+    LinearAlgebra::distributed::BlockVector<number> left2(n_blocks_2);
+    for (unsigned int b = 0; b < left2.n_blocks(); ++b)
+      {
+        mf_data->initialize_dof_vector (left2.block(b));
+        for (unsigned int i=0; i<left2.block(b).local_size(); ++i)
+          {
+            const unsigned int glob_index =
+              owned_set.nth_index_in_set (i);
+            if (constraints.is_constrained(glob_index))
+              continue;
+            left2.block(b).local_element(i) = (double)Testing::rand()/RAND_MAX;
+          }
+      }
+
+    LAPACKFullMatrix<number> product2(n_blocks_2,n_blocks), diff2(n_blocks_2,n_blocks);
+
+    deallog << "Non-Symmetric:" << std::endl;
+
+    left2.multivector_inner_product(product2, right, false);
+
+    for (unsigned int i = 0; i < n_blocks_2; ++i)
+      for (unsigned int j = 0; j < n_blocks; ++j)
+        diff2(i,j) = left2.block(i) * right.block(j) - product2(i,j);
+
+    const double diff_norm2 = diff2.frobenius_norm();
+
+    deallog << "Norm of difference: " << diff_norm2 << std::endl;
+  }
+
+
+}
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+  deallog.push(Utilities::int_to_string(myid));
+
+  if (myid == 0)
+    {
+      initlog();
+      deallog << std::setprecision(4);
+
+      test<2,1>();
+    }
+  else
+    {
+      test<2,1>();
+    }
+}

--- a/tests/mpi/parallel_block_vector_06.with_p4est=true.with_lapack=true.mpirun=3.output
+++ b/tests/mpi/parallel_block_vector_06.with_p4est=true.with_lapack=true.mpirun=3.output
@@ -1,0 +1,6 @@
+
+DEAL:0::Symmetric:
+DEAL:0::Norm of difference: 0.000
+DEAL:0::Cholesky: Ok
+DEAL:0::Non-Symmetric:
+DEAL:0::Norm of difference: 0.000


### PR DESCRIPTION
reasons: (i) convenience (ii) a single global reduction as opposed to N*M reductions of each (i,j) products.