### PR TITLE
Simplify logic in p::d::Triangulation.

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -738,24 +738,12 @@ namespace parallel
        * triangulation.
        */
       typename dealii::internal::p4est::types<dim>::forest *parallel_forest;
+
       /**
        * A data structure that holds some information about the ghost cells of
        * the triangulation.
        */
       typename dealii::internal::p4est::types<dim>::ghost  *parallel_ghost;
-
-      /**
-       * A flag that indicates whether refinement of a triangulation is
-       * currently in progress. This flag is used to disambiguate whether a
-       * call to execute_coarsening_and_triangulation came from the outside or
-       * through a recursive call. While the first time we want to take over
-       * work to copy things from a refined p4est, the other times we don't
-       * want to get in the way as these latter calls to
-       * Triangulation::execute_coarsening_and_refinement() are simply there
-       * in order to re-create a triangulation that matches the p4est.
-       */
-      bool refinement_in_progress;
-
 
       /**
        * number of bytes that get attached to the Triangulation through

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1292,7 +1292,6 @@ namespace parallel
       triangulation_has_content (false),
       connectivity (nullptr),
       parallel_forest (nullptr),
-      refinement_in_progress (false),
       attached_data_size(0),
       n_attached_datas(0),
       n_attached_deserialize(0)
@@ -1311,7 +1310,6 @@ namespace parallel
               ExcInternalError());
       Assert (connectivity == nullptr,    ExcInternalError());
       Assert (parallel_forest == nullptr, ExcInternalError());
-      Assert (refinement_in_progress == false, ExcInternalError());
     }
 
 
@@ -2556,9 +2554,6 @@ namespace parallel
               }
 
             this->prepare_coarsening_and_refinement();
-            const bool saved_refinement_in_progress = refinement_in_progress;
-            refinement_in_progress = true;
-
             try
               {
                 dealii::Triangulation<dim,spacedim>::execute_coarsening_and_refinement();
@@ -2569,8 +2564,6 @@ namespace parallel
                 // distorted cells
                 Assert (false, ExcInternalError());
               }
-
-            refinement_in_progress = saved_refinement_in_progress;
           }
 
 
@@ -2675,11 +2668,8 @@ namespace parallel
                 break;
               }
 
-          // actually do the refinement but prevent the refinement hook below
-          // from taking over
-          const bool saved_refinement_in_progress = refinement_in_progress;
-          refinement_in_progress = true;
-
+          // actually do the refinement to change the local mesh by
+          // calling the base class refinement function directly
           try
             {
               dealii::Triangulation<dim,spacedim>::execute_coarsening_and_refinement();
@@ -2690,8 +2680,6 @@ namespace parallel
               // distorted cells
               Assert (false, ExcInternalError());
             }
-
-          refinement_in_progress = saved_refinement_in_progress;
         }
       while (mesh_changed);
 
@@ -2834,9 +2822,6 @@ namespace parallel
     void
     Triangulation<dim, spacedim>::execute_coarsening_and_refinement ()
     {
-      // first make sure that recursive calls are handled correctly
-      Assert (refinement_in_progress == false, ExcInternalError());
-
       // do not allow anisotropic refinement
 #ifdef DEBUG
       for (typename Triangulation<dim,spacedim>::active_cell_iterator
@@ -2862,7 +2847,6 @@ namespace parallel
         }
 
       // now do the work we're supposed to do when we are in charge
-      refinement_in_progress = true;
       this->prepare_coarsening_and_refinement ();
 
       // make sure all flags are cleared on cells we don't own, since nothing
@@ -3032,7 +3016,6 @@ namespace parallel
         }
 #endif
 
-      refinement_in_progress = false;
       this->update_number_cache ();
       this->update_periodic_face_map();
     }
@@ -3051,8 +3034,6 @@ namespace parallel
             !cell->refine_flag_set() && !cell->coarsen_flag_set(),
             ExcMessage ("Error: There shouldn't be any cells flagged for coarsening/refinement when calling repartition()."));
 #endif
-
-      refinement_in_progress = true;
 
       // before repartitioning the mesh let others attach mesh related info
       // (such as SolutionTransfer data) to the p4est
@@ -3099,8 +3080,6 @@ namespace parallel
           // cells
           Assert (false, ExcInternalError());
         }
-
-      refinement_in_progress = false;
 
       // update how many cells, edges, etc, we store locally
       this->update_number_cache ();
@@ -3613,7 +3592,6 @@ namespace parallel
         + MemoryConsumption::memory_consumption(triangulation_has_content)
         + MemoryConsumption::memory_consumption(connectivity)
         + MemoryConsumption::memory_consumption(parallel_forest)
-        + MemoryConsumption::memory_consumption(refinement_in_progress)
         + MemoryConsumption::memory_consumption(attached_data_size)
         + MemoryConsumption::memory_consumption(n_attached_datas)
 //      + MemoryConsumption::memory_consumption(attached_data_pack_callbacks) //TODO[TH]: how?
@@ -3664,10 +3642,6 @@ namespace parallel
       if (const dealii::parallel::distributed::Triangulation<dim,spacedim> *
           other_tria_x = dynamic_cast<const dealii::parallel::distributed::Triangulation<dim,spacedim> *>(&other_tria))
         {
-          Assert (!other_tria_x->refinement_in_progress,
-                  ExcMessage ("Parallel distributed triangulations can only "
-                              "be copied, if no refinement is in progress!"));
-
           coarse_cell_to_p4est_tree_permutation = other_tria_x->coarse_cell_to_p4est_tree_permutation;
           p4est_tree_to_coarse_cell_permutation = other_tria_x->p4est_tree_to_coarse_cell_permutation;
           attached_data_size = other_tria_x->attached_data_size;

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2561,7 +2561,7 @@ namespace parallel
 
             try
               {
-                this->execute_coarsening_and_refinement();
+                dealii::Triangulation<dim,spacedim>::execute_coarsening_and_refinement();
               }
             catch (const typename Triangulation<dim, spacedim>::DistortedCellList &)
               {
@@ -2682,7 +2682,7 @@ namespace parallel
 
           try
             {
-              this->execute_coarsening_and_refinement();
+              dealii::Triangulation<dim,spacedim>::execute_coarsening_and_refinement();
             }
           catch (const typename Triangulation<dim,spacedim>::DistortedCellList &)
             {
@@ -2835,11 +2835,7 @@ namespace parallel
     Triangulation<dim, spacedim>::execute_coarsening_and_refinement ()
     {
       // first make sure that recursive calls are handled correctly
-      if (refinement_in_progress == true)
-        {
-          dealii::Triangulation<dim,spacedim>::execute_coarsening_and_refinement ();
-          return;
-        }
+      Assert (refinement_in_progress == false, ExcInternalError());
 
       // do not allow anisotropic refinement
 #ifdef DEBUG


### PR DESCRIPTION
The logic in p::d::T::execute_coarsening_and_refinement() is overly complicated
because the function calls itself recursively (indirectly, on top of that). But
this is not necessary if the place where that happens just calls the function
in the base class -- which happens to be easy to do by explicitly qualifying
the function call.

Do so.

@tjhei?