### PR TITLE
Catch exception by reference.

### DIFF
--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -64,7 +64,7 @@ ParameterAcceptor::initialize(const std::string &filename,
             {
               prm.parse_input(filename);
             }
-          catch (dealii::PathSearch::ExcFileNotFound)
+          catch (const dealii::PathSearch::ExcFileNotFound &)
             {
               std::ofstream out(filename);
               Assert(out, ExcIO());


### PR DESCRIPTION
Copying is inefficient and, in this case, clearly unnecessary.

This fixes an issue uncovered by coverity.