### PR TITLE
Enable doxygen for the LAPACKSupport namespace.

### DIFF
--- a/include/deal.II/lac/lapack_support.h
+++ b/include/deal.II/lac/lapack_support.h
@@ -23,6 +23,10 @@
 DEAL_II_NAMESPACE_OPEN
 
 
+/**
+ * A namespace containing constants, exceptions, enumerations, and other
+ * utilities used by the deal.II LAPACK bindings.
+ */
 namespace LAPACKSupport
 {
   /**


### PR DESCRIPTION
Doxygen does not pick up undocumented namespaces; all I had to do to get things working on my machine was add a blurb before the namespace.

Fixes #5184.