### PR TITLE
Update to VectorTools::interpolate

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -138,10 +138,10 @@ namespace VectorTools
               auto shifted_view = boost::make_iterator_range(
                                     std::begin(function_values[i]) + offset,
                                     std::begin(function_values[i]) + offset + dim);
-              std::vector<number> old_value;
+              std::vector<number> old_value(dim);
               std::copy(std::begin(shifted_view),
                         std::end(shifted_view),
-                        std::back_inserter(old_value));
+                        std::begin(old_value));
 
               // value[m] <- sum jacobian_transpose[m][n] * old_value[n]:
               TensorAccessors::contract<1, 2, 1, dim>(
@@ -167,10 +167,10 @@ namespace VectorTools
               auto shifted_view = boost::make_iterator_range(
                                     std::begin(function_values[i]) + offset,
                                     std::begin(function_values[i]) + offset + dim);
-              std::vector<number> old_value;
+              std::vector<number> old_value(dim);
               std::copy(std::begin(shifted_view),
                         std::end(shifted_view),
-                        std::back_inserter(old_value));
+                        std::begin(old_value));
 
               // value[m] <- sum inverse_jacobians[m][n] * old_value[n]:
               TensorAccessors::contract<1, 2, 1, dim>(

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -136,7 +136,7 @@ namespace VectorTools
               auto shifted_view = boost::make_iterator_range(
                                     std::begin(function_values[i]) + offset,
                                     std::begin(function_values[i]) + offset + dim);
-              std::vector<number> old_value(dim);
+              std::array<number,dim> old_value;
               std::copy(std::begin(shifted_view),
                         std::end(shifted_view),
                         std::begin(old_value));
@@ -164,7 +164,7 @@ namespace VectorTools
               auto shifted_view = boost::make_iterator_range(
                                     std::begin(function_values[i]) + offset,
                                     std::begin(function_values[i]) + offset + dim);
-              std::vector<number> old_value(dim);
+              std::array<number,dim> old_value;
               std::copy(std::begin(shifted_view),
                         std::end(shifted_view),
                         std::begin(old_value));


### PR DESCRIPTION
Here are a couple of minor updates to #5151 (@tamiko 's patch). The first two are just minor code edits. The third one is explained in more detail in the commit message.

The third commit unconditionally changes the set of things we update in an `FEValues` object when interpolating on a cell. We could probably restrict this to exclude the Jacobians if the element doesn't actually need this. I'm not sure how much that would buy in actual computations, but would be willing to add this if @tamiko wants me to.

Passes the testsuite with no new failures.