### PR TITLE
Replace logstream.push/pop by Logstream::Prefix.

### DIFF
--- a/include/deal.II/algorithms/newton.templates.h
+++ b/include/deal.II/algorithms/newton.templates.h
@@ -100,7 +100,7 @@ namespace Algorithms
                                   const AnyData &in)
   {
     Assert (out.size() == 1, ExcNotImplemented());
-    deallog.push ("Newton");
+    LogStream::Prefix prefix("Newton");
 
     VectorType &u = *out.entry<VectorType *>(0);
 
@@ -197,7 +197,6 @@ namespace Algorithms
             resnorm = res->l2_norm();
           }
       }
-    deallog.pop();
 
     // in case of failure: throw exception
     if (control.last_check() != SolverControl::success)

--- a/include/deal.II/algorithms/theta_timestepping.templates.h
+++ b/include/deal.II/algorithms/theta_timestepping.templates.h
@@ -81,7 +81,7 @@ namespace Algorithms
   {
     Assert(!adaptive, ExcNotImplemented());
 
-    deallog.push ("Theta");
+    LogStream::Prefix prefix("Theta");
 
     VectorType &solution = *out.entry<VectorType *>(0);
     GrowingVectorMemory<VectorType> mem;
@@ -143,7 +143,6 @@ namespace Algorithms
 
         d_explicit.time = control.now();
       }
-    deallog.pop();
   }
 }
 

--- a/include/deal.II/lac/eigen.h
+++ b/include/deal.II/lac/eigen.h
@@ -237,7 +237,7 @@ EigenPower<VectorType>::solve (double           &value,
 {
   SolverControl::State conv=SolverControl::iterate;
 
-  deallog.push("Power method");
+  LogStream::Prefix prefix("Power method");
 
   typename VectorMemory<VectorType>::Pointer Vy (this->memory);
   VectorType &y = *Vy;
@@ -291,8 +291,6 @@ EigenPower<VectorType>::solve (double           &value,
       conv = this->iteration_status (iter, std::fabs(1./length-1./old_length), x);
     }
 
-  deallog.pop();
-
   // in case of failure: throw exception
   AssertThrow(conv == SolverControl::success, SolverControl::NoConvergence (iter,
               std::fabs(1./length-1./old_length)));
@@ -326,7 +324,7 @@ EigenInverse<VectorType>::solve (double           &value,
                                  const MatrixType &A,
                                  VectorType       &x)
 {
-  deallog.push("Wielandt");
+  LogStream::Prefix prefix("Wielandt");
 
   SolverControl::State conv=SolverControl::iterate;
 
@@ -415,8 +413,6 @@ EigenInverse<VectorType>::solve (double           &value,
         }
       old_value = value;
     }
-
-  deallog.pop();
 
   // in case of failure: throw
   // exception

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -449,7 +449,7 @@ SolverBicgstab<VectorType>::solve(const MatrixType         &A,
                                   const VectorType         &b,
                                   const PreconditionerType &preconditioner)
 {
-  deallog.push("Bicgstab");
+  LogStream::Prefix prefix("Bicgstab");
   Vr    = typename VectorMemory<VectorType>::Pointer(this->memory);
   Vrbar = typename VectorMemory<VectorType>::Pointer(this->memory);
   Vp    = typename VectorMemory<VectorType>::Pointer(this->memory);
@@ -487,8 +487,6 @@ SolverBicgstab<VectorType>::solve(const MatrixType         &A,
       ++step;
     }
   while (state.breakdown == true);
-
-  deallog.pop();
 
   // in case of failure: throw exception
   AssertThrow(state.state == SolverControl::success,

--- a/include/deal.II/lac/solver_fire.h
+++ b/include/deal.II/lac/solver_fire.h
@@ -251,7 +251,7 @@ SolverFIRE<VectorType>::solve
  VectorType                                                    &x,
  const PreconditionerType                                      &inverse_mass_matrix)
 {
-  deallog.push("FIRE");
+  LogStream::Prefix prefix("FIRE");
 
   // FIRE algorithm constants
   const double DELAYSTEP       = 5;
@@ -360,8 +360,6 @@ SolverFIRE<VectorType>::solve
       print_vectors(iter, x, velocities, gradients);
 
     } // While we need to iterate.
-
-  deallog.pop();
 
   // In the case of failure: throw exception.
   if (conv != SolverControl::success)

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -777,7 +777,7 @@ SolverGMRES<VectorType>::solve (const MatrixType         &A,
 //TODO:[?] Check, why there are two different start residuals.
 //TODO:[GK] Make sure the parameter in the constructor means maximum basis size
 
-  deallog.push("GMRES");
+  LogStream::Prefix prefix("GMRES");
   const unsigned int n_tmp_vectors = additional_data.max_n_tmp_vectors;
 
   // Generate an object where basis vectors are stored.
@@ -1046,8 +1046,6 @@ SolverGMRES<VectorType>::solve (const MatrixType         &A,
   if (!krylov_space_signal.empty())
     krylov_space_signal(tmp_vectors);
 
-  deallog.pop();
-
   // in case of failure: throw exception
   AssertThrow(iteration_state == SolverControl::success,
               SolverControl::NoConvergence (accumulated_iterations,
@@ -1172,7 +1170,7 @@ SolverFGMRES<VectorType>::solve (const MatrixType         &A,
                                  const VectorType         &b,
                                  const PreconditionerType &preconditioner)
 {
-  deallog.push("FGMRES");
+  LogStream::Prefix prefix("FGMRES");
 
   SolverControl::State iteration_state = SolverControl::iterate;
 
@@ -1257,7 +1255,6 @@ SolverFGMRES<VectorType>::solve (const MatrixType         &A,
     }
   while (iteration_state == SolverControl::iterate);
 
-  deallog.pop();
   // in case of failure: throw exception
   if (iteration_state != SolverControl::success)
     AssertThrow(false, SolverControl::NoConvergence (accumulated_iterations,

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -193,7 +193,7 @@ SolverMinRes<VectorType>::solve (const MatrixType         &A,
                                  const VectorType         &b,
                                  const PreconditionerType &preconditioner)
 {
-  deallog.push("minres");
+  LogStream::Prefix prefix("minres");
 
   // Memory allocation
   typename VectorMemory<VectorType>::Pointer Vu0 (this->memory);
@@ -349,9 +349,6 @@ SolverMinRes<VectorType>::solve (const MatrixType         &A,
       delta[0] = delta[1];
       delta[1] = delta[2];
     }
-
-  // Output
-  deallog.pop ();
 
   // in case of failure: throw exception
   AssertThrow(conv == SolverControl::success,

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -260,7 +260,7 @@ SolverQMRS<VectorType>::solve (const MatrixType         &A,
                                const VectorType         &b,
                                const PreconditionerType &preconditioner)
 {
-  deallog.push("QMRS");
+  LogStream::Prefix prefix("QMRS");
 
   // temporary vectors, allocated through the @p VectorMemory object at the
   // start of the actual solution process and deallocated at the end.
@@ -290,9 +290,6 @@ SolverQMRS<VectorType>::solve (const MatrixType         &A,
       state = iterate(A, x, b, preconditioner, *Vv, *Vp, *Vq, *Vt, *Vd);
     }
   while (state.state == SolverControl::iterate);
-
-  // Output
-  deallog.pop();
 
   // in case of failure: throw exception
   AssertThrow(state.state == SolverControl::success,

--- a/include/deal.II/lac/solver_relaxation.h
+++ b/include/deal.II/lac/solver_relaxation.h
@@ -122,35 +122,26 @@ SolverRelaxation<VectorType>::solve (const MatrixType     &A,
   VectorType &d  = *Vd;
   d.reinit(x);
 
-  deallog.push("Relaxation");
+  LogStream::Prefix prefix("Relaxation");
 
   int iter=0;
-  try
+  // Main loop
+  for (; conv==SolverControl::iterate; iter++)
     {
-      // Main loop
-      for (; conv==SolverControl::iterate; iter++)
-        {
-          // Compute residual
-          A.vmult(r,x);
-          r.sadd(-1.,1.,b);
+      // Compute residual
+      A.vmult(r,x);
+      r.sadd(-1.,1.,b);
 
-          // The required norm of the
-          // (preconditioned)
-          // residual is computed in
-          // criterion() and stored
-          // in res.
-          conv = this->iteration_status (iter, r.l2_norm(), x);
-          if (conv != SolverControl::iterate)
-            break;
-          R.step(x,b);
-        }
+      // The required norm of the
+      // (preconditioned)
+      // residual is computed in
+      // criterion() and stored
+      // in res.
+      conv = this->iteration_status (iter, r.l2_norm(), x);
+      if (conv != SolverControl::iterate)
+        break;
+      R.step(x,b);
     }
-  catch (...)
-    {
-      deallog.pop();
-      throw;
-    }
-  deallog.pop();
 
   // in case of failure: throw exception
   AssertThrow(conv == SolverControl::success,

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -217,39 +217,29 @@ SolverRichardson<VectorType>::solve (const MatrixType         &A,
   VectorType &d  = *Vd;
   d.reinit(x);
 
-  deallog.push("Richardson");
+  LogStream::Prefix prefix("Richardson");
 
-  try
+  // Main loop
+  while (conv==SolverControl::iterate)
     {
-      // Main loop
-      while (conv==SolverControl::iterate)
-        {
-          // Do not use residual,
-          // but do it in 2 steps
-          A.vmult(r,x);
-          r.sadd(-1.,1.,b);
-          preconditioner.vmult(d,r);
+      // Do not use residual,
+      // but do it in 2 steps
+      A.vmult(r,x);
+      r.sadd(-1.,1.,b);
+      preconditioner.vmult(d,r);
 
-          // get the required norm of the (possibly preconditioned)
-          // residual
-          last_criterion = criterion(r, d);
-          conv = this->iteration_status (iter, last_criterion, x);
-          if (conv != SolverControl::iterate)
-            break;
+      // get the required norm of the (possibly preconditioned)
+      // residual
+      last_criterion = criterion(r, d);
+      conv = this->iteration_status (iter, last_criterion, x);
+      if (conv != SolverControl::iterate)
+        break;
 
-          x.add(additional_data.omega,d);
-          print_vectors(iter,x,r,d);
+      x.add(additional_data.omega,d);
+      print_vectors(iter,x,r,d);
 
-          ++iter;
-        }
+      ++iter;
     }
-  catch (...)
-    {
-      deallog.pop();
-      throw;
-    }
-
-  deallog.pop();
 
   // in case of failure: throw exception
   if (conv != SolverControl::success)
@@ -284,37 +274,28 @@ SolverRichardson<VectorType>::Tsolve (const MatrixType         &A,
   VectorType &d  = *Vd;
   d.reinit(x);
 
-  deallog.push("RichardsonT");
+  LogStream::Prefix prefix("RichardsonT");
 
-  try
+  // Main loop
+  while (conv==SolverControl::iterate)
     {
-      // Main loop
-      while (conv==SolverControl::iterate)
-        {
-          // Do not use Tresidual,
-          // but do it in 2 steps
-          A.Tvmult(r,x);
-          r.sadd(-1.,1.,b);
-          preconditioner.Tvmult(d,r);
+      // Do not use Tresidual,
+      // but do it in 2 steps
+      A.Tvmult(r,x);
+      r.sadd(-1.,1.,b);
+      preconditioner.Tvmult(d,r);
 
-          last_criterion = criterion(r, d);
-          conv = this->iteration_status (iter, last_criterion, x);
-          if (conv != SolverControl::iterate)
-            break;
+      last_criterion = criterion(r, d);
+      conv = this->iteration_status (iter, last_criterion, x);
+      if (conv != SolverControl::iterate)
+        break;
 
-          x.add(additional_data.omega,d);
-          print_vectors(iter,x,r,d);
+      x.add(additional_data.omega,d);
+      print_vectors(iter,x,r,d);
 
-          ++iter;
-        }
-    }
-  catch (...)
-    {
-      deallog.pop();
-      throw;
+      ++iter;
     }
 
-  deallog.pop();
   // in case of failure: throw exception
   if (conv != SolverControl::success)
     AssertThrow(false, SolverControl::NoConvergence (iter, last_criterion));

--- a/include/deal.II/multigrid/mg_block_smoother.h
+++ b/include/deal.II/multigrid/mg_block_smoother.h
@@ -231,7 +231,7 @@ MGSmootherBlock<MatrixType, RelaxationType, number>::smooth(const unsigned int  
                                                             BlockVector<number>       &u,
                                                             const BlockVector<number> &rhs) const
 {
-  deallog.push("Smooth");
+  LogStream::Prefix prefix("Smooth");
 
   unsigned int maxlevel = matrices.max_level();
   unsigned int steps2 = this->steps;
@@ -266,8 +266,6 @@ MGSmootherBlock<MatrixType, RelaxationType, number>::smooth(const unsigned int  
       if (this->symmetric)
         T = !T;
     }
-
-  deallog.pop();
 }
 
 #endif // DOXYGEN


### PR DESCRIPTION
This does the conversion in the linear solvers. It simplifies the logic in a number
of places where we specifically had to have a try-catch block where we pop the
deallog prefix in the catch block but now this can happen automatically via
the destructor of the Prefix class. Consequently, the patch is probably
easiest to read with ?w=1.

In some sense this is a follow-up to #4935 and the patches that resolved
that because they already largely emptied out the catch blocks of the
memory deallocation.