### PR TITLE
Removing an unused variable in mesh_loop.h

### DIFF
--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -236,8 +236,6 @@ namespace MeshWorker
                       = periodic_neighbor?
                         cell->periodic_neighbor_of_coarser_periodic_neighbor(face_no):
                         cell->neighbor_of_coarser_neighbor(face_no);
-                    const typename CellIteratorType::AccessorType::Container::face_iterator nface
-                      = neighbor->face(neighbor_face_no.first);
 
                     face_worker(cell, face_no, numbers::invalid_unsigned_int,
                                 neighbor, neighbor_face_no.first, neighbor_face_no.second,


### PR DESCRIPTION
When running a computation using `mesh_loop` I was getting a warning of an unused variable of `nface` when I would compile. The `face_worker()` function takes in information needed to create this `face_iterator`, but it is the job of the user to actually create it if needed. The variable `nface` appears to have been accidentally left in the code (@tjhei  agrees) and so I removed it.