### PR TITLE
add size_type to MGInterfaceOperator

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -483,6 +483,11 @@ namespace MatrixFreeOperators
     typedef typename OperatorType::value_type value_type;
 
     /**
+     * Size type.
+     */
+    typedef typename OperatorType::size_type size_type;
+
+    /**
      * Default constructor.
      */
     MGInterfaceOperator();


### PR DESCRIPTION
This might be needed when one uses a single wrapper class
to define level block operators+interface operators based on non-block versions.