### PR TITLE
Use std::unique_ptr instead of std::shared_ptr.

### DIFF
--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -41,6 +41,7 @@
 #include <array>
 #include <numeric>
 #include <memory>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -309,11 +310,11 @@ namespace DoFTools
       ensure_existence_of_master_dof_mask (const FiniteElement<dim,spacedim> &fe1,
                                            const FiniteElement<dim,spacedim> &fe2,
                                            const FullMatrix<double> &face_interpolation_matrix,
-                                           std::shared_ptr<std::vector<bool> > &master_dof_mask)
+                                           std::unique_ptr<std::vector<bool> > &master_dof_mask)
       {
         if (master_dof_mask == nullptr)
           {
-            master_dof_mask = std::make_shared<std::vector<bool> > (fe1.dofs_per_face);
+            master_dof_mask = std_cxx14::make_unique<std::vector<bool> > (fe1.dofs_per_face);
             select_master_dofs_for_face_restriction (fe1,
                                                      fe2,
                                                      face_interpolation_matrix,
@@ -333,12 +334,12 @@ namespace DoFTools
       void
       ensure_existence_of_face_matrix (const FiniteElement<dim,spacedim> &fe1,
                                        const FiniteElement<dim,spacedim> &fe2,
-                                       std::shared_ptr<FullMatrix<double> > &matrix)
+                                       std::unique_ptr<FullMatrix<double> > &matrix)
       {
         if (matrix == nullptr)
           {
-            matrix = std::make_shared<FullMatrix<double> > (fe2.dofs_per_face,
-                                                            fe1.dofs_per_face);
+            matrix = std_cxx14::make_unique<FullMatrix<double> > (fe2.dofs_per_face,
+                                                                  fe1.dofs_per_face);
             fe1.get_face_interpolation_matrix (fe2,
                                                *matrix);
           }
@@ -354,12 +355,12 @@ namespace DoFTools
       ensure_existence_of_subface_matrix (const FiniteElement<dim,spacedim> &fe1,
                                           const FiniteElement<dim,spacedim> &fe2,
                                           const unsigned int        subface,
-                                          std::shared_ptr<FullMatrix<double> > &matrix)
+                                          std::unique_ptr<FullMatrix<double> > &matrix)
       {
         if (matrix == nullptr)
           {
-            matrix = std::make_shared<FullMatrix<double> > (fe2.dofs_per_face,
-                                                            fe1.dofs_per_face);
+            matrix = std_cxx14::make_unique<FullMatrix<double> > (fe2.dofs_per_face,
+                                                                  fe1.dofs_per_face);
             fe1.get_subface_interpolation_matrix (fe2,
                                                   subface,
                                                   *matrix);
@@ -376,7 +377,7 @@ namespace DoFTools
       void
       ensure_existence_of_split_face_matrix (const FullMatrix<double> &face_interpolation_matrix,
                                              const std::vector<bool> &master_dof_mask,
-                                             std::shared_ptr<std::pair<FullMatrix<double>,FullMatrix<double> > > &split_matrix)
+                                             std::unique_ptr<std::pair<FullMatrix<double>,FullMatrix<double> > > &split_matrix)
       {
         AssertDimension (master_dof_mask.size(), face_interpolation_matrix.m());
         Assert (std::count (master_dof_mask.begin(), master_dof_mask.end(), true) ==
@@ -385,7 +386,7 @@ namespace DoFTools
 
         if (split_matrix == nullptr)
           {
-            split_matrix = std::make_shared<std::pair<FullMatrix<double>,FullMatrix<double> > >();
+            split_matrix = std_cxx14::make_unique<std::pair<FullMatrix<double>,FullMatrix<double> > >();
 
             const unsigned int n_master_dofs = face_interpolation_matrix.n();
             const unsigned int n_dofs        = face_interpolation_matrix.m();
@@ -1050,10 +1051,10 @@ namespace DoFTools
       // different (or the same) finite elements. we compute them only
       // once, namely the first time they are needed, and then just reuse
       // them
-      Table<2,std::shared_ptr<FullMatrix<double> > >
+      Table<2,std::unique_ptr<FullMatrix<double> > >
       face_interpolation_matrices (n_finite_elements (dof_handler),
                                    n_finite_elements (dof_handler));
-      Table<3,std::shared_ptr<FullMatrix<double> > >
+      Table<3,std::unique_ptr<FullMatrix<double> > >
       subface_interpolation_matrices (n_finite_elements (dof_handler),
                                       n_finite_elements (dof_handler),
                                       GeometryInfo<dim>::max_children_per_face);
@@ -1062,14 +1063,14 @@ namespace DoFTools
       // master and slave parts, and for which the master part is inverted.
       // these two matrices are derived from the face interpolation matrix
       // as described in the @ref hp_paper "hp paper"
-      Table<2,std::shared_ptr<std::pair<FullMatrix<double>,FullMatrix<double> > > >
+      Table<2,std::unique_ptr<std::pair<FullMatrix<double>,FullMatrix<double> > > >
       split_face_interpolation_matrices (n_finite_elements (dof_handler),
                                          n_finite_elements (dof_handler));
 
       // finally, for each pair of finite elements, have a mask that states
       // which of the degrees of freedom on the coarse side of a refined
       // face will act as master dofs.
-      Table<2,std::shared_ptr<std::vector<bool> > >
+      Table<2,std::unique_ptr<std::vector<bool> > >
       master_dof_masks (n_finite_elements (dof_handler),
                         n_finite_elements (dof_handler));
 


### PR DESCRIPTION
With #5188 resolved by #5189, I can now use `std::unique_ptr` in `Table` objects. Do so! :-)