### PR TITLE
Remove unused PETSc options

### DIFF
--- a/tests/fe/fe_enriched_step-36.cc
+++ b/tests/fe/fe_enriched_step-36.cc
@@ -647,7 +647,6 @@ int main (int argc,char **argv)
         PETScWrappers::set_option_value("-st_type","sinvert");
         PETScWrappers::set_option_value("-st_ksp_type","cg");
         PETScWrappers::set_option_value("-st_pc_type", "jacobi");
-        PETScWrappers::set_option_value("-st_ksp_tol", "1e-11");
         step36.run();
       }
 

--- a/tests/fe/fe_enriched_step-36b.cc
+++ b/tests/fe/fe_enriched_step-36b.cc
@@ -871,7 +871,6 @@ int main (int argc,char **argv)
         dealii::PETScWrappers::set_option_value("-st_type","sinvert");
         dealii::PETScWrappers::set_option_value("-st_ksp_type","cg");
         dealii::PETScWrappers::set_option_value("-st_pc_type", "jacobi");
-        dealii::PETScWrappers::set_option_value("-st_ksp_tol", "1e-11");
         step36.run();
       }
 


### PR DESCRIPTION
In debug mode, `PETSc` tells me that `st_ksp_tol` is not used in `fe/fe_enriched_step-36b` and `fe/fe_enriched_step-36b`. This causes these tests to fail.