### PR TITLE
Move default pure virtual destructor of Function

### DIFF
--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -850,6 +850,18 @@ private:
 };
 
 
+#ifndef DOXYGEN
+// icc 2018 complains about an undefined reference
+// if we put this in the templates.h file
+//
+// The destructor is pure virtual so we can't default it
+// in the declaration.
+template <int dim, typename Number>
+inline
+Function<dim, Number>::~Function () = default;
+#endif
+
+
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/base/function.templates.h
+++ b/include/deal.II/base/function.templates.h
@@ -46,13 +46,6 @@ Function<dim, Number>::Function (const unsigned int n_components,
 
 
 
-// The destructor is pure virtual so we can't default it
-// in the declaration.
-template <int dim, typename Number>
-Function<dim, Number>::~Function () = default;
-
-
-
 template <int dim, typename Number>
 Function<dim, Number> &Function<dim, Number>::operator= (const Function &f)
 {


### PR DESCRIPTION
ICC 18.0 complains about `undefined reference`s for `Function`'s default pure virtual destructor
if its definition is only available in `function.templates.h`. Moving it to the header file satisfies the compiler again.