### PR TITLE
Add missing (unused) return value in Convert::to_pattern

### DIFF
--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1162,6 +1162,10 @@ namespace Patterns
         else if (std::is_floating_point<T>::value)
           return std_cxx14::make_unique<Patterns::Double>(
                    -std::numeric_limits<T>::max(), std::numeric_limits<T>::max());
+
+        Assert(false, ExcNotImplemented());
+        //the following line should never be invoked
+        return nullptr;
       }
 
       static std::string to_string(const T &value,


### PR DESCRIPTION
ICC 18.0 complains about a missing return value. Technically, we should not be able to get there as we consider all the possible cases before. On the other hand, it certainly doesn't harm to make sure that this assumption holds indeed.