### PR TITLE
Rename loop variable to differ from enclosing one

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -436,9 +436,9 @@ namespace VectorTools
               // that we are allowed to set degrees of freedom if at least
               // one of the components (of the dof) is selected.
               bool selected = false;
-              for (unsigned int i = 0; i < nonzero_components.size(); ++i)
+              for (unsigned int c = 0; c < nonzero_components.size(); ++c)
                 selected =
-                  selected || (nonzero_components[i] && component_mask[i]);
+                  selected || (nonzero_components[c] && component_mask[c]);
 
               if (selected)
                 {


### PR DESCRIPTION
ICC 2018 informs that the outer loop starting in line [425](https://github.com/dealii/dealii/compare/master...masterleinad:intel18_2?expand=1#diff-67a698d893ce19a96cb56c59a93d0a16L425) already uses `i` as loop variable. This might be confusing.