### PR TITLE
Prefer data to address of first

### DIFF
--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -431,7 +431,7 @@ inline
 ArrayView<ElementType>
 make_array_view (std::vector<ElementType> &vector)
 {
-  return ArrayView<ElementType> (&vector[0], vector.size());
+  return ArrayView<ElementType> (vector.data(), vector.size());
 }
 
 
@@ -455,7 +455,7 @@ inline
 ArrayView<const ElementType>
 make_array_view (const std::vector<ElementType> &vector)
 {
-  return ArrayView<const ElementType> (&vector[0], vector.size());
+  return ArrayView<const ElementType> (vector.data(), vector.size());
 }
 
 

--- a/include/deal.II/distributed/grid_tools.h
+++ b/include/deal.II/distributed/grid_tools.h
@@ -243,7 +243,7 @@ namespace parallel
             decompressing_stream.push(boost::iostreams::gzip_decompressor());
             decompressing_stream.push(boost::iostreams::back_inserter(decompressed_buffer));
 
-            decompressing_stream.write (&buffer[0], buffer.size());
+            decompressing_stream.write (buffer.data(), buffer.size());
           }
 
           // then restore the object from the buffer
@@ -372,7 +372,7 @@ namespace parallel
 
           receive.resize(len);
 
-          char *ptr = &receive[0];
+          char *ptr = receive.data();
           ierr = MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
                           tria->get_communicator(), &status);
           AssertThrowMPI(ierr);
@@ -397,7 +397,7 @@ namespace parallel
       // when we leave this function.
       if (requests.size())
         {
-          const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+          const int ierr = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
           AssertThrowMPI(ierr);
         }
 #endif // DEAL_II_WITH_MPI

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -144,7 +144,7 @@ namespace FETools
         {
           buffer.resize(bytes_for_buffer());
 
-          char *ptr = &buffer[0];
+          char *ptr = buffer.data();
 
           unsigned int n_dofs = dof_values.size ();
           std::memcpy(ptr, &n_dofs, sizeof(unsigned int));
@@ -159,13 +159,13 @@ namespace FETools
           std::memcpy(ptr,&quadrant,sizeof(typename dealii::internal::p4est::types<dim>::quadrant));
           ptr += sizeof(typename dealii::internal::p4est::types<dim>::quadrant);
 
-          Assert (ptr == &buffer[0]+buffer.size(),
+          Assert (ptr == buffer.data()+buffer.size(),
                   ExcInternalError());
         }
 
         void unpack_data (const std::vector<char> &buffer)
         {
-          const char *ptr = &buffer[0];
+          const char *ptr = buffer.data();
           unsigned int n_dofs;
           memcpy(&n_dofs, ptr, sizeof(unsigned int));
           ptr += sizeof(unsigned int);
@@ -180,7 +180,7 @@ namespace FETools
           std::memcpy(&quadrant,ptr,sizeof(typename dealii::internal::p4est::types<dim>::quadrant));
           ptr += sizeof(typename dealii::internal::p4est::types<dim>::quadrant);
 
-          Assert (ptr == &buffer[0]+buffer.size(),
+          Assert (ptr == buffer.data()+buffer.size(),
                   ExcInternalError());
         }
       };
@@ -1100,7 +1100,7 @@ namespace FETools
           AssertThrowMPI(ierr);
           receive.resize (len);
 
-          char *buf = &receive[0];
+          char *buf = receive.data();
           ierr = MPI_Recv (buf, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG, communicator, &status);
           AssertThrowMPI(ierr);
 
@@ -1116,7 +1116,7 @@ namespace FETools
 
       if (requests.size () > 0)
         {
-          const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+          const int ierr = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
           AssertThrowMPI(ierr);
         }
 

--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -550,12 +550,12 @@ void ArpackSolver::solve (const MatrixType1                  &/*system_matrix*/,
       // call of ARPACK dsaupd/dnaupd routine
       if (additional_data.symmetric)
         dsaupd_(&ido, bmat, &n, which, &nev, &tol,
-                &resid[0], &ncv, &v[0], &ldv, &iparam[0], &ipntr[0],
-                &workd[0], &workl[0], &lworkl, &info);
+                resid.data(), &ncv, v.data(), &ldv, iparam.data(), ipntr.data(),
+                workd.data(), workl.data(), &lworkl, &info);
       else
         dnaupd_(&ido, bmat, &n, which, &nev, &tol,
-                &resid[0], &ncv, &v[0], &ldv, &iparam[0], &ipntr[0],
-                &workd[0], &workl[0], &lworkl, &info);
+                resid.data(), &ncv, v.data(), &ldv, iparam.data(), ipntr.data(),
+                workd.data(), workl.data(), &lworkl, &info);
 
       if (ido == 99)
         break;
@@ -671,19 +671,19 @@ void ArpackSolver::solve (const MatrixType1                  &/*system_matrix*/,
       if (additional_data.symmetric)
         {
           std::vector<double> z (ldz*nev, 0.);
-          dseupd_(&rvec, &howmany, &select[0], &eigenvalues_real[0],
-                  &z[0], &ldz, &sigmar, bmat, &n, which, &nev, &tol,
-                  &resid[0], &ncv, &v[0], &ldv,
-                  &iparam[0], &ipntr[0], &workd[0], &workl[0], &lworkl, &info);
+          dseupd_(&rvec, &howmany, select.data(), eigenvalues_real.data(),
+                  z.data(), &ldz, &sigmar, bmat, &n, which, &nev, &tol,
+                  resid.data(), &ncv, v.data(), &ldv,
+                  iparam.data(), ipntr.data(), workd.data(), workl.data(), &lworkl, &info);
         }
       else
         {
           std::vector<double> workev (3*ncv, 0.);
-          dneupd_(&rvec, &howmany, &select[0], &eigenvalues_real[0],
-                  &eigenvalues_im[0], &v[0], &ldz, &sigmar, &sigmai,
-                  &workev[0], bmat, &n, which, &nev, &tol,
-                  &resid[0], &ncv, &v[0], &ldv,
-                  &iparam[0], &ipntr[0], &workd[0], &workl[0], &lworkl, &info);
+          dneupd_(&rvec, &howmany, select.data(), eigenvalues_real.data(),
+                  eigenvalues_im.data(), v.data(), &ldz, &sigmar, &sigmai,
+                  workev.data(), bmat, &n, which, &nev, &tol,
+                  resid.data(), &ncv, v.data(), &ldv,
+                  iparam.data(), ipntr.data(), workd.data(), workl.data(), &lworkl, &info);
         }
 
       if (info == 1)

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -1659,8 +1659,8 @@ inline
 void
 BlockMatrixBase<MatrixType>::set (const std::vector<size_type> &row_indices,
                                   const std::vector<size_type> &col_indices,
-                                  const FullMatrix<number>        &values,
-                                  const bool                       elide_zero_values)
+                                  const FullMatrix<number>     &values,
+                                  const bool                    elide_zero_values)
 {
   Assert (row_indices.size() == values.m(),
           ExcDimensionMismatch(row_indices.size(), values.m()));
@@ -1679,8 +1679,8 @@ template <typename number>
 inline
 void
 BlockMatrixBase<MatrixType>::set (const std::vector<size_type> &indices,
-                                  const FullMatrix<number>        &values,
-                                  const bool                       elide_zero_values)
+                                  const FullMatrix<number>     &values,
+                                  const bool                    elide_zero_values)
 {
   Assert (indices.size() == values.m(),
           ExcDimensionMismatch(indices.size(), values.m()));

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -1668,7 +1668,7 @@ BlockMatrixBase<MatrixType>::set (const std::vector<size_type> &row_indices,
           ExcDimensionMismatch(col_indices.size(), values.n()));
 
   for (size_type i=0; i<row_indices.size(); ++i)
-    set (row_indices[i], col_indices.size(), &col_indices[0], &values(i,0),
+    set (row_indices[i], col_indices.size(), col_indices.data(), &values(i,0),
          elide_zero_values);
 }
 
@@ -1687,7 +1687,7 @@ BlockMatrixBase<MatrixType>::set (const std::vector<size_type> &indices,
   Assert (values.n() == values.m(), ExcNotQuadratic());
 
   for (size_type i=0; i<indices.size(); ++i)
-    set (indices[i], indices.size(), &indices[0], &values(i,0),
+    set (indices[i], indices.size(), indices.data(), &values(i,0),
          elide_zero_values);
 }
 
@@ -1705,7 +1705,7 @@ BlockMatrixBase<MatrixType>::set (const size_type               row,
   Assert (col_indices.size() == values.size(),
           ExcDimensionMismatch(col_indices.size(), values.size()));
 
-  set (row, col_indices.size(), &col_indices[0], &values[0],
+  set (row, col_indices.size(), col_indices.data(), values.data(),
        elide_zero_values);
 }
 
@@ -1865,7 +1865,7 @@ BlockMatrixBase<MatrixType>::add (const std::vector<size_type> &row_indices,
           ExcDimensionMismatch(col_indices.size(), values.n()));
 
   for (size_type i=0; i<row_indices.size(); ++i)
-    add (row_indices[i], col_indices.size(), &col_indices[0], &values(i,0),
+    add (row_indices[i], col_indices.size(), col_indices.data(), &values(i,0),
          elide_zero_values);
 }
 
@@ -1884,7 +1884,7 @@ BlockMatrixBase<MatrixType>::add (const std::vector<size_type> &indices,
   Assert (values.n() == values.m(), ExcNotQuadratic());
 
   for (size_type i=0; i<indices.size(); ++i)
-    add (indices[i], indices.size(), &indices[0], &values(i,0),
+    add (indices[i], indices.size(), indices.data(), &values(i,0),
          elide_zero_values);
 }
 
@@ -1902,7 +1902,7 @@ BlockMatrixBase<MatrixType>::add (const size_type               row,
   Assert (col_indices.size() == values.size(),
           ExcDimensionMismatch(col_indices.size(), values.size()));
 
-  add (row, col_indices.size(), &col_indices[0], &values[0],
+  add (row, col_indices.size(), col_indices.data(), values.data(),
        elide_zero_values);
 }
 

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -1797,7 +1797,7 @@ BlockVectorBase<VectorType>::add (const std::vector<size_type> &indices,
 {
   Assert (indices.size() == values.size(),
           ExcDimensionMismatch(indices.size(), values.size()));
-  add (indices.size(), &indices[0], &values[0]);
+  add (indices.size(), indices.data(), values.data());
 }
 
 

--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -1580,9 +1580,9 @@ ChunkSparseMatrix<number>::block_write (std::ostream &out) const
   // first the simple objects, bracketed in [...]
   out << '[' << max_len << "][";
   // then write out real data
-  out.write (reinterpret_cast<const char *>(&val[0]),
-             reinterpret_cast<const char *>(&val[max_len])
-             - reinterpret_cast<const char *>(&val[0]));
+  out.write (reinterpret_cast<const char *>(val.get()),
+             reinterpret_cast<const char *>(val.get() + max_len)
+             - reinterpret_cast<const char *>(val.get()));
   out << ']';
 
   AssertThrow (out, ExcIO());
@@ -1612,9 +1612,9 @@ ChunkSparseMatrix<number>::block_read (std::istream &in)
   val.reset (new number[max_len]);
 
   // then read data
-  in.read (reinterpret_cast<char *>(&val[0]),
-           reinterpret_cast<char *>(&val[max_len])
-           - reinterpret_cast<char *>(&val[0]));
+  in.read (reinterpret_cast<char *>(val.get()),
+           reinterpret_cast<char *>(val.get() + max_len)
+           - reinterpret_cast<char *>(val.get()));
   in >> c;
   AssertThrow (c == ']', ExcIO());
 }

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -1794,7 +1794,7 @@ FullMatrix<number>::gauss_jordan ()
 
         // Use the LAPACK function getrf for
         // calculating the LU factorization.
-        getrf(&nn, &nn, &this->values[0], &nn, &ipiv[0], &info);
+        getrf(&nn, &nn, &this->values[0], &nn, ipiv.data(), &info);
 
         Assert(info >= 0, ExcInternalError());
         Assert(info == 0, LACExceptions::ExcSingular());
@@ -1805,7 +1805,7 @@ FullMatrix<number>::gauss_jordan ()
         // Use the LAPACK function getri for
         // calculating the actual inverse using
         // the LU factorization.
-        getri(&nn, &this->values[0], &nn, &ipiv[0], &inv_work[0], &nn, &info);
+        getri(&nn, &this->values[0], &nn, ipiv.data(), inv_work.data(), &nn, &info);
 
         Assert(info >= 0, ExcInternalError());
         Assert(info == 0, LACExceptions::ExcSingular());

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -656,7 +656,7 @@ namespace LinearAlgebra
       // first wait for the receive to complete
       if (compress_requests.size() > 0 && n_import_targets > 0)
         {
-          const int ierr = MPI_Waitall (n_import_targets, &compress_requests[0],
+          const int ierr = MPI_Waitall (n_import_targets, compress_requests.data(),
                                         MPI_STATUSES_IGNORE);
           AssertThrowMPI(ierr);
 
@@ -814,7 +814,7 @@ namespace LinearAlgebra
           Threads::Mutex::ScopedLock lock (mutex);
 
           const int ierr = MPI_Waitall (update_ghost_values_requests.size(),
-                                        &update_ghost_values_requests[0],
+                                        update_ghost_values_requests.data(),
                                         MPI_STATUSES_IGNORE);
           AssertThrowMPI (ierr);
         }
@@ -893,7 +893,7 @@ namespace LinearAlgebra
           if (update_ghost_values_requests.size()>0)
             {
               const int ierr = MPI_Testall (update_ghost_values_requests.size(),
-                                            &update_ghost_values_requests[0],
+                                            update_ghost_values_requests.data(),
                                             &flag, MPI_STATUSES_IGNORE);
               AssertThrowMPI (ierr);
               Assert (flag == 1,
@@ -902,7 +902,7 @@ namespace LinearAlgebra
             }
           if (compress_requests.size()>0)
             {
-              const int ierr = MPI_Testall (compress_requests.size(), &compress_requests[0],
+              const int ierr = MPI_Testall (compress_requests.size(), compress_requests.data(),
                                             &flag, MPI_STATUSES_IGNORE);
               AssertThrowMPI (ierr);
               Assert (flag == 1,

--- a/include/deal.II/lac/matrix_block.h
+++ b/include/deal.II/lac/matrix_block.h
@@ -682,7 +682,7 @@ MatrixBlock<MatrixType>::add (const std::vector<size_type> &r_indices,
   AssertDimension (c_indices.size(), values.n());
 
   for (size_type i=0; i<row_indices.size(); ++i)
-    add (r_indices[i], c_indices.size(), &c_indices[0], &values(i,0),
+    add (r_indices[i], c_indices.size(), c_indices.data(), &values(i,0),
          elide_zero_values);
 }
 
@@ -742,7 +742,7 @@ MatrixBlock<MatrixType>::add (const std::vector<size_type> &indices,
   Assert (values.n() == values.m(), ExcNotQuadratic());
 
   for (size_type i=0; i<indices.size(); ++i)
-    add (indices[i], indices.size(), &indices[0], &values(i,0),
+    add (indices[i], indices.size(), indices.data(), &values(i,0),
          elide_zero_values);
 }
 
@@ -761,7 +761,7 @@ MatrixBlock<MatrixType>::add (const size_type               row,
   Assert(column_indices.size() != 0, ExcNotInitialized());
 
   AssertDimension (col_indices.size(), values.size());
-  add (row, col_indices.size(), &col_indices[0], &values[0],
+  add (row, col_indices.size(), col_indices.data(), values.data(),
        elide_zero_values);
 }
 

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -1156,7 +1156,7 @@ namespace PETScWrappers
     Assert (values.m() == values.n(), ExcNotQuadratic());
 
     for (size_type i=0; i<indices.size(); ++i)
-      set (indices[i], indices.size(), &indices[0], &values(i,0),
+      set (indices[i], indices.size(), indices.data(), &values(i,0),
            elide_zero_values);
   }
 
@@ -1175,7 +1175,7 @@ namespace PETScWrappers
             ExcDimensionMismatch(col_indices.size(), values.n()));
 
     for (size_type i=0; i<row_indices.size(); ++i)
-      set (row_indices[i], col_indices.size(), &col_indices[0], &values(i,0),
+      set (row_indices[i], col_indices.size(), col_indices.data(), &values(i,0),
            elide_zero_values);
   }
 
@@ -1191,7 +1191,7 @@ namespace PETScWrappers
     Assert (col_indices.size() == values.size(),
             ExcDimensionMismatch(col_indices.size(), values.size()));
 
-    set (row, col_indices.size(), &col_indices[0], &values[0],
+    set (row, col_indices.size(), col_indices.data(), values.data(),
          elide_zero_values);
   }
 
@@ -1244,8 +1244,8 @@ namespace PETScWrappers
           }
         Assert(n_columns <= (int)n_cols, ExcInternalError());
 
-        col_index_ptr = &column_indices[0];
-        col_value_ptr = &column_values[0];
+        col_index_ptr = column_indices.data();
+        col_value_ptr = column_values.data();
       }
 
     const PetscErrorCode ierr = MatSetValues (matrix, 1, &petsc_i, n_columns,
@@ -1292,7 +1292,7 @@ namespace PETScWrappers
     Assert (values.m() == values.n(), ExcNotQuadratic());
 
     for (size_type i=0; i<indices.size(); ++i)
-      add (indices[i], indices.size(), &indices[0], &values(i,0),
+      add (indices[i], indices.size(), indices.data(), &values(i,0),
            elide_zero_values);
   }
 
@@ -1311,7 +1311,7 @@ namespace PETScWrappers
             ExcDimensionMismatch(col_indices.size(), values.n()));
 
     for (size_type i=0; i<row_indices.size(); ++i)
-      add (row_indices[i], col_indices.size(), &col_indices[0], &values(i,0),
+      add (row_indices[i], col_indices.size(), col_indices.data(), &values(i,0),
            elide_zero_values);
   }
 
@@ -1327,7 +1327,7 @@ namespace PETScWrappers
     Assert (col_indices.size() == values.size(),
             ExcDimensionMismatch(col_indices.size(), values.size()));
 
-    add (row, col_indices.size(), &col_indices[0], &values[0],
+    add (row, col_indices.size(), col_indices.data(), values.data(),
          elide_zero_values);
   }
 
@@ -1383,8 +1383,8 @@ namespace PETScWrappers
           }
         Assert(n_columns <= (int)n_cols, ExcInternalError());
 
-        col_index_ptr = &column_indices[0];
-        col_value_ptr = &column_values[0];
+        col_index_ptr = column_indices.data();
+        col_value_ptr = column_values.data();
       }
 
     const PetscErrorCode ierr = MatSetValues (matrix, 1, &petsc_i, n_columns,

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -892,7 +892,7 @@ namespace LinearAlgebra
                                 const std::vector<Number2>   &values)
   {
     AssertDimension (indices.size(), values.size());
-    add (indices.size(), &indices[0], &values[0]);
+    add (indices.size(), indices.data(), values.data());
   }
 
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -756,7 +756,7 @@ namespace LinearAlgebra
   typename ReadWriteVector<Number>::iterator
   ReadWriteVector<Number>::begin ()
   {
-    return &val[0];
+    return val;
   }
 
 
@@ -766,7 +766,7 @@ namespace LinearAlgebra
   typename ReadWriteVector<Number>::const_iterator
   ReadWriteVector<Number>::begin () const
   {
-    return &val[0];
+    return val;
   }
 
 
@@ -776,7 +776,7 @@ namespace LinearAlgebra
   typename ReadWriteVector<Number>::iterator
   ReadWriteVector<Number>::end ()
   {
-    return &val[this->n_elements()];
+    return val + this->n_elements();
   }
 
 
@@ -786,7 +786,7 @@ namespace LinearAlgebra
   typename ReadWriteVector<Number>::const_iterator
   ReadWriteVector<Number>::end () const
   {
-    return &val[this->n_elements()];
+    return val + this->n_elements();
   }
 
 

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -438,7 +438,7 @@ namespace LinearAlgebra
     const unsigned int n_elements = stored_elements.n_elements();
     if (operation == VectorOperation::insert)
       {
-        cudaError_t error_code = cudaMemcpy(&val[0], cuda_vec.get_values(),
+        cudaError_t error_code = cudaMemcpy(val, cuda_vec.get_values(),
                                             n_elements*sizeof(Number),
                                             cudaMemcpyDeviceToHost);
         AssertCuda(error_code);

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -447,7 +447,7 @@ namespace LinearAlgebra
       {
         // Copy the vector from the device to a temporary vector on the host
         std::vector<Number> tmp(n_elements);
-        cudaError_t error_code = cudaMemcpy(&tmp[0], cuda_vec.get_values(),
+        cudaError_t error_code = cudaMemcpy(tmp.data(), cuda_vec.get_values(),
                                             n_elements*sizeof(Number),
                                             cudaMemcpyDeviceToHost);
         AssertCuda(error_code);

--- a/include/deal.II/lac/slepc_solver.h
+++ b/include/deal.II/lac/slepc_solver.h
@@ -803,7 +803,7 @@ namespace SLEPcWrappers
     // One could still build a vector that is rich in the directions of all guesses,
     // by taking a linear combination of them. (TODO: make function virtual?)
 
-    const PetscErrorCode ierr = EPSSetInitialSpace (eps, vecs.size(), &vecs[0]);
+    const PetscErrorCode ierr = EPSSetInitialSpace (eps, vecs.size(), vecs.data());
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1692,7 +1692,7 @@ SparseMatrix<number>::set (const std::vector<size_type> &indices,
   Assert (values.m() == values.n(), ExcNotQuadratic());
 
   for (size_type i=0; i<indices.size(); ++i)
-    set (indices[i], indices.size(), &indices[0], &values(i,0),
+    set (indices[i], indices.size(), indices.data(), &values(i,0),
          elide_zero_values);
 }
 
@@ -1713,7 +1713,7 @@ SparseMatrix<number>::set (const std::vector<size_type> &row_indices,
           ExcDimensionMismatch(col_indices.size(), values.n()));
 
   for (size_type i=0; i<row_indices.size(); ++i)
-    set (row_indices[i], col_indices.size(), &col_indices[0], &values(i,0),
+    set (row_indices[i], col_indices.size(), col_indices.data(), &values(i,0),
          elide_zero_values);
 }
 
@@ -1731,7 +1731,7 @@ SparseMatrix<number>::set (const size_type               row,
   Assert (col_indices.size() == values.size(),
           ExcDimensionMismatch(col_indices.size(), values.size()));
 
-  set (row, col_indices.size(), &col_indices[0], &values[0],
+  set (row, col_indices.size(), col_indices.data(), values.data(),
        elide_zero_values);
 }
 
@@ -1779,7 +1779,7 @@ SparseMatrix<number>::add (const std::vector<size_type> &indices,
   Assert (values.m() == values.n(), ExcNotQuadratic());
 
   for (size_type i=0; i<indices.size(); ++i)
-    add (indices[i], indices.size(), &indices[0], &values(i,0),
+    add (indices[i], indices.size(), indices.data(), &values(i,0),
          elide_zero_values);
 }
 
@@ -1800,7 +1800,7 @@ SparseMatrix<number>::add (const std::vector<size_type> &row_indices,
           ExcDimensionMismatch(col_indices.size(), values.n()));
 
   for (size_type i=0; i<row_indices.size(); ++i)
-    add (row_indices[i], col_indices.size(), &col_indices[0], &values(i,0),
+    add (row_indices[i], col_indices.size(), col_indices.data(), &values(i,0),
          elide_zero_values);
 }
 
@@ -1818,7 +1818,7 @@ SparseMatrix<number>::add (const size_type               row,
   Assert (col_indices.size() == values.size(),
           ExcDimensionMismatch(col_indices.size(), values.size()));
 
-  add (row, col_indices.size(), &col_indices[0], &values[0],
+  add (row, col_indices.size(), col_indices.data(), values.data(),
        elide_zero_values);
 }
 
@@ -1832,8 +1832,8 @@ SparseMatrix<number>::operator *= (const number factor)
   Assert (cols != nullptr, ExcNotInitialized());
   Assert (val != nullptr, ExcNotInitialized());
 
-  number             *val_ptr    = &val[0];
-  const number *const end_ptr    = &val[cols->n_nonzero_elements()];
+  number             *val_ptr    = val.get();
+  const number *const end_ptr    = val.get() + cols->n_nonzero_elements();
 
   while (val_ptr != end_ptr)
     *val_ptr++ *= factor;
@@ -1854,8 +1854,8 @@ SparseMatrix<number>::operator /= (const number factor)
 
   const number factor_inv = number(1.) / factor;
 
-  number             *val_ptr    = &val[0];
-  const number *const end_ptr    = &val[cols->n_nonzero_elements()];
+  number             *val_ptr    = val.get();
+  const number *const end_ptr    = val.get() + cols->n_nonzero_elements();
 
   while (val_ptr != end_ptr)
     *val_ptr++ *= factor_inv;

--- a/include/deal.II/lac/sparse_matrix_ez.templates.h
+++ b/include/deal.II/lac/sparse_matrix_ez.templates.h
@@ -599,13 +599,13 @@ SparseMatrixEZ<number>::block_read (std::istream &in)
   DEAL_II_CHECK_INPUT(in,'[',c);
 
   // then read data
-  in.read(reinterpret_cast<char *>(&row_info[0]),
+  in.read(reinterpret_cast<char *>(row_info.data()),
           sizeof(RowInfo) * row_info.size());
 
   DEAL_II_CHECK_INPUT(in,']',c);
   DEAL_II_CHECK_INPUT(in,'[',c);
 
-  in.read(reinterpret_cast<char *>(&data[0]),
+  in.read(reinterpret_cast<char *>(data.data()),
           sizeof(Entry) * data.size());
 
   DEAL_II_CHECK_INPUT(in,']',c);

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2962,7 +2962,7 @@ namespace TrilinosWrappers
     Assert (values.m() == values.n(), ExcNotQuadratic());
 
     for (size_type i=0; i<indices.size(); ++i)
-      set (indices[i], indices.size(), &indices[0], &values(i,0),
+      set (indices[i], indices.size(), indices.data(), &values(i,0),
            elide_zero_values);
   }
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -1519,7 +1519,7 @@ namespace TrilinosWrappers
       Assert (indices.size() == values.size(),
               ExcDimensionMismatch(indices.size(),values.size()));
 
-      set (indices.size(), &indices[0], &values[0]);
+      set (indices.size(), indices.data(), values.data());
     }
 
 
@@ -1536,7 +1536,7 @@ namespace TrilinosWrappers
       Assert (indices.size() == values.size(),
               ExcDimensionMismatch(indices.size(),values.size()));
 
-      set (indices.size(), &indices[0], values.begin());
+      set (indices.size(), indices.data(), values.begin());
     }
 
 
@@ -1595,7 +1595,7 @@ namespace TrilinosWrappers
       Assert (indices.size() == values.size(),
               ExcDimensionMismatch(indices.size(),values.size()));
 
-      add (indices.size(), &indices[0], &values[0]);
+      add (indices.size(), indices.data(), values.data());
     }
 
 
@@ -1611,7 +1611,7 @@ namespace TrilinosWrappers
       Assert (indices.size() == values.size(),
               ExcDimensionMismatch(indices.size(),values.size()));
 
-      add (indices.size(), &indices[0], values.begin());
+      add (indices.size(), indices.data(), values.begin());
     }
 
 

--- a/include/deal.II/lac/utilities.h
+++ b/include/deal.II/lac/utilities.h
@@ -216,8 +216,8 @@ namespace Utilities
       int info;
       // call lapack_templates.h wrapper:
       stev ("N", &n,
-            &diagonal[0], &subdiagonal[0],
-            &Z[0], &ldz, &work[0],
+            diagonal.data(), subdiagonal.data(),
+            Z.data(), &ldz, work.data(),
             &info);
 
       Assert (info == 0,

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1052,7 +1052,7 @@ inline
 typename Vector<Number>::iterator
 Vector<Number>::begin ()
 {
-  return &val[0];
+  return val;
 }
 
 
@@ -1062,7 +1062,7 @@ inline
 typename Vector<Number>::const_iterator
 Vector<Number>::begin () const
 {
-  return &val[0];
+  return val;
 }
 
 
@@ -1072,7 +1072,7 @@ inline
 typename Vector<Number>::iterator
 Vector<Number>::end ()
 {
-  return &val[vec_size];
+  return val + vec_size;
 }
 
 
@@ -1082,7 +1082,7 @@ inline
 typename Vector<Number>::const_iterator
 Vector<Number>::end () const
 {
-  return &val[vec_size];
+  return val + vec_size;
 }
 
 

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -1200,7 +1200,7 @@ namespace internal
             // make sure we allocate an even number of elements,
             // access to the new last element is needed in do_sum()
             large_array.resize(2*((n_chunks+1)/2));
-            array_ptr = &large_array[0];
+            array_ptr = large_array.data();
           }
         else
           array_ptr = &small_array[0];

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.cuh
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.cuh
@@ -73,7 +73,7 @@ namespace CUDAWrappers
       std::vector<Number> old(array_host.size());
       old.swap(array_host);
 
-      transpose(n, m, &old[0], &array_host[0]);
+      transpose(n, m, old.data(), array_host.data());
     }
 
 
@@ -88,7 +88,7 @@ namespace CUDAWrappers
       cudaError_t error_code = cudaMalloc(array_device, n*sizeof(Number1));
       AssertCuda(error_code);
 
-      error_code = cudaMemcpy(*array_device, &array_host[0], n*sizeof(Number1),
+      error_code = cudaMemcpy(*array_device, array_host.data(), n*sizeof(Number1),
                               cudaMemcpyHostToDevice);
       AssertCuda(error_code);
     }
@@ -246,7 +246,7 @@ namespace CUDAWrappers
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         lexicographic_dof_indices[i] = local_dof_indices[lexicographic_inv[i]];
 
-      memcpy(&local_to_global_host[cell_id*padding_length], &lexicographic_dof_indices[0],
+      memcpy(&local_to_global_host[cell_id*padding_length], lexicographic_dof_indices.data(),
              dofs_per_cell*sizeof(unsigned int));
 
       fe_values.reinit(cell);
@@ -255,7 +255,7 @@ namespace CUDAWrappers
       if (update_flags & update_quadrature_points)
         {
           const std::vector<Point<dim>> &q_points = fe_values.get_quadrature_points();
-          memcpy(&q_points_host[cell_id*padding_length], &q_points[0],
+          memcpy(&q_points_host[cell_id*padding_length], q_points.data(),
                  q_points_per_cell*sizeof(Point<dim>));
         }
 
@@ -271,7 +271,7 @@ namespace CUDAWrappers
         {
           const std::vector<DerivativeForm<1,dim,dim>> &inv_jacobians =
                                                       fe_values.get_inverse_jacobians();
-          memcpy(&inv_jacobian_host[cell_id*padding_length*dim*dim], &inv_jacobians[0],
+          memcpy(&inv_jacobian_host[cell_id*padding_length*dim*dim], inv_jacobians.data(),
                  q_points_per_cell*sizeof(DerivativeForm<1,dim,dim>));
         }
     }
@@ -548,7 +548,7 @@ namespace CUDAWrappers
                                 sizeof(dealii::types::global_dof_index));
         AssertCuda(cuda_error);
 
-        cuda_error = cudaMemcpy(constrained_dofs, &constrained_dofs_host[0],
+        cuda_error = cudaMemcpy(constrained_dofs, constrained_dofs_host.data(),
                                 n_constrained_dofs * sizeof(dealii::types::global_dof_index),
                                 cudaMemcpyHostToDevice);
         AssertCuda(cuda_error);

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -432,7 +432,7 @@ namespace internal
       AssertIndexRange (row, row_starts.size()-1);
       const unsigned int index = row_starts[row][0];
       AssertIndexRange(index, dof_indices.size()+1);
-      return dof_indices.empty() ? nullptr : &dof_indices[0] + index;
+      return dof_indices.empty() ? nullptr : &dof_indices[index];
     }
 
 
@@ -444,7 +444,7 @@ namespace internal
       AssertIndexRange (row, row_starts.size()-1);
       const unsigned int index = row_starts[row+1][0];
       AssertIndexRange(index, dof_indices.size()+1);
-      return dof_indices.empty() ? nullptr : &dof_indices[0] + index;
+      return dof_indices.empty() ? nullptr : &dof_indices[index];
     }
 
 
@@ -466,7 +466,7 @@ namespace internal
       AssertIndexRange (row, row_starts.size()-1);
       const unsigned int index = row_starts[row][1];
       AssertIndexRange (index, constraint_indicator.size()+1);
-      return constraint_indicator.empty() ? nullptr : &constraint_indicator[0] + index;
+      return constraint_indicator.empty() ? nullptr : &constraint_indicator[index];
     }
 
 
@@ -478,7 +478,7 @@ namespace internal
       AssertIndexRange (row, row_starts.size()-1);
       const unsigned int index = row_starts[row+1][1];
       AssertIndexRange (index, constraint_indicator.size()+1);
-      return constraint_indicator.empty() ? nullptr : &constraint_indicator[0] + index;
+      return constraint_indicator.empty() ? nullptr : &constraint_indicator[index];
     }
 
 
@@ -509,7 +509,7 @@ namespace internal
           AssertDimension (row_starts.size(), row_starts_plain_indices.size());
           const unsigned int index = row_starts_plain_indices[row];
           AssertIndexRange(index, plain_dof_indices.size()+1);
-          return plain_dof_indices.empty() ? nullptr : &plain_dof_indices[0] + index;
+          return plain_dof_indices.empty() ? nullptr : &plain_dof_indices[index];
         }
     }
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1164,7 +1164,7 @@ MatrixFree<dim,Number>::constraint_pool_begin (const unsigned int row) const
 {
   AssertIndexRange (row, constraint_pool_row_index.size()-1);
   return constraint_pool_data.empty() ? nullptr :
-         &constraint_pool_data[0] + constraint_pool_row_index[row];
+         constraint_pool_data.data() + constraint_pool_row_index[row];
 }
 
 
@@ -1176,7 +1176,7 @@ MatrixFree<dim,Number>::constraint_pool_end (const unsigned int row) const
 {
   AssertIndexRange (row, constraint_pool_row_index.size()-1);
   return constraint_pool_data.empty() ? nullptr :
-         &constraint_pool_data[0] + constraint_pool_row_index[row+1];
+         constraint_pool_data.data() + constraint_pool_row_index[row+1];
 }
 
 
@@ -1235,13 +1235,13 @@ MatrixFree<dim,Number>::create_cell_subrange_hp_by_index
 #endif
       std::pair<unsigned int,unsigned int> return_range;
       return_range.first =
-        std::lower_bound(&fe_indices[0] + range.first,
-                         &fe_indices[0] + range.second, fe_index)
-        -&fe_indices[0] ;
+        std::lower_bound(fe_indices.data() + range.first,
+                         fe_indices.data() + range.second, fe_index)
+        -fe_indices.data() ;
       return_range.second =
-        std::lower_bound(&fe_indices[0] + return_range.first,
-                         &fe_indices[0] + range.second,
-                         fe_index + 1)-&fe_indices[0];
+        std::lower_bound(fe_indices.data() + return_range.first,
+                         fe_indices.data() + range.second,
+                         fe_index + 1)-fe_indices.data();
       Assert(return_range.first >= range.first &&
              return_range.second <= range.second, ExcInternalError());
       return return_range;

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -271,7 +271,7 @@ namespace
         char *compressed_data = new char[compressed_data_length];
         int err = compress2 ((Bytef *) compressed_data,
                              &compressed_data_length,
-                             (const Bytef *) &data[0],
+                             (const Bytef *) data.data(),
                              data.size() * sizeof(T),
                              get_zlib_compression_level(flags.compression_level));
         (void)err;
@@ -1154,7 +1154,7 @@ namespace
   {
     if (flags.data_binary)
       {
-        stream.write(reinterpret_cast<const char *>(&values[0]),
+        stream.write(reinterpret_cast<const char *>(values.data()),
                      values.size()*sizeof(data));
       }
     else
@@ -7010,13 +7010,13 @@ void DataOutBase::write_hdf5_parallel (const std::vector<Patch<dim,spacedim> > &
 
       // And finally, write the node data
       data_filter.fill_node_data(node_data_vec);
-      status = H5Dwrite(node_dataset, H5T_NATIVE_DOUBLE, node_memory_dataspace, node_file_dataspace, plist_id, &node_data_vec[0]);
+      status = H5Dwrite(node_dataset, H5T_NATIVE_DOUBLE, node_memory_dataspace, node_file_dataspace, plist_id, node_data_vec.data());
       AssertThrow(status >= 0, ExcIO());
       node_data_vec.clear();
 
       // And the cell data
       data_filter.fill_cell_data(global_node_cell_offsets[0], cell_data_vec);
-      status = H5Dwrite(cell_dataset, H5T_NATIVE_UINT, cell_memory_dataspace, cell_file_dataspace, plist_id, &cell_data_vec[0]);
+      status = H5Dwrite(cell_dataset, H5T_NATIVE_UINT, cell_memory_dataspace, cell_file_dataspace, plist_id, cell_data_vec.data());
       AssertThrow(status >= 0, ExcIO());
       cell_data_vec.clear();
 

--- a/source/base/function_cspline.cc
+++ b/source/base/function_cspline.cc
@@ -46,7 +46,7 @@ namespace Functions
     const unsigned int n = interpolation_points.size();
     cspline = gsl_spline_alloc (gsl_interp_cspline, n);
     // gsl_spline_init returns something but it seems nobody knows what
-    gsl_spline_init (cspline, &interpolation_points[0], &interpolation_values[0], n);
+    gsl_spline_init (cspline, interpolation_points.data(), interpolation_values.data(), n);
   }
 
 

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -598,7 +598,7 @@ IndexSet::make_trilinos_map (const MPI_Comm &communicator,
                          TrilinosWrappers::types::int_type(n_elements()),
                          (n_elements() > 0
                           ?
-                          reinterpret_cast<TrilinosWrappers::types::int_type *>(&indices[0])
+                          reinterpret_cast<TrilinosWrappers::types::int_type *>(indices.data())
                           :
                           nullptr),
                          0,

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -125,8 +125,8 @@ namespace Utilities
       // processors in this case, which is more expensive than the reduction
       // operation above in MPI_Allreduce)
       std::vector<unsigned int> all_destinations (max_n_destinations * n_procs);
-      const int ierr = MPI_Allgather (&my_destinations[0], max_n_destinations, MPI_UNSIGNED,
-                                      &all_destinations[0], max_n_destinations, MPI_UNSIGNED,
+      const int ierr = MPI_Allgather (my_destinations.data(), max_n_destinations, MPI_UNSIGNED,
+                                      all_destinations.data(), max_n_destinations, MPI_UNSIGNED,
                                       mpi_comm);
       AssertThrowMPI(ierr);
 
@@ -388,8 +388,8 @@ namespace Utilities
 
           std::vector<char> all_hostnames(max_hostname_size *
                                           MPI::n_mpi_processes(MPI_COMM_WORLD));
-          const int ierr = MPI_Allgather (&hostname_array[0], max_hostname_size, MPI_CHAR,
-                                          &all_hostnames[0], max_hostname_size, MPI_CHAR,
+          const int ierr = MPI_Allgather (hostname_array.data(), max_hostname_size, MPI_CHAR,
+                                          all_hostnames.data(), max_hostname_size, MPI_CHAR,
                                           MPI_COMM_WORLD);
           AssertThrowMPI(ierr);
 
@@ -398,7 +398,7 @@ namespace Utilities
           unsigned int n_local_processes=0;
           unsigned int nth_process_on_host = 0;
           for (unsigned int i=0; i<MPI::n_mpi_processes(MPI_COMM_WORLD); ++i)
-            if (std::string (&all_hostnames[0] + i*max_hostname_size) == hostname)
+            if (std::string (all_hostnames.data() + i*max_hostname_size) == hostname)
               {
                 ++n_local_processes;
                 if (i <= MPI::this_mpi_process (MPI_COMM_WORLD))

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -183,7 +183,7 @@ namespace Utilities
       // Allow non-zero start index for the vector. send this data to all
       // processors
       first_index[0] = local_range_data.first;
-      int ierr = MPI_Bcast(&first_index[0], 1, DEAL_II_DOF_INDEX_MPI_TYPE,
+      int ierr = MPI_Bcast(first_index.data(), 1, DEAL_II_DOF_INDEX_MPI_TYPE,
                            0, communicator);
       AssertThrowMPI(ierr);
 
@@ -262,7 +262,7 @@ namespace Utilities
         for (unsigned int i=0; i<n_ghost_targets; i++)
           send_buffer[ghost_targets_data[i].first] = ghost_targets_data[i].second;
 
-        const int ierr = MPI_Alltoall (&send_buffer[0], 1, MPI_INT, &receive_buffer[0], 1,
+        const int ierr = MPI_Alltoall (send_buffer.data(), 1, MPI_INT, receive_buffer.data(), 1,
                                        MPI_INT, communicator);
         AssertThrowMPI(ierr);
 
@@ -314,7 +314,7 @@ namespace Utilities
         if (import_requests.size()>0)
           {
             const int ierr = MPI_Waitall (import_requests.size(),
-                                          &import_requests[0],
+                                          import_requests.data(),
                                           MPI_STATUSES_IGNORE);
             AssertThrowMPI(ierr);
           }

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -104,7 +104,7 @@ namespace Polynomials
   {
     Assert (values.size() > 0, ExcZero());
 
-    value(x,values.size()-1,&values[0]);
+    value(x,values.size()-1,values.data());
   }
 
 

--- a/source/base/polynomials_piecewise.cc
+++ b/source/base/polynomials_piecewise.cc
@@ -47,7 +47,7 @@ namespace Polynomials
   {
     Assert (values.size() > 0, ExcZero());
 
-    value(x,values.size()-1,&values[0]);
+    value(x,values.size()-1,values.data());
   }
 
 

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -274,7 +274,7 @@ namespace
 
       do
         {
-          int ierr = MPI_Bcast (&interesting_range[0], 2, MPI_DOUBLE,
+          int ierr = MPI_Bcast (interesting_range, 2, MPI_DOUBLE,
                                 master_mpi_rank, mpi_communicator);
           AssertThrowMPI(ierr);
 
@@ -371,7 +371,7 @@ namespace
 
       do
         {
-          int ierr = MPI_Bcast (&interesting_range[0], 2, MPI_DOUBLE,
+          int ierr = MPI_Bcast (interesting_range, 2, MPI_DOUBLE,
                                 master_mpi_rank, mpi_communicator);
           AssertThrowMPI(ierr);
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1403,52 +1403,52 @@ namespace parallel
           {
             buffer.resize(bytes_for_buffer());
 
-            char *ptr = &buffer[0];
+            char *ptr = buffer.data();
 
             const unsigned int num_cells = tree_index.size();
             std::memcpy(ptr, &num_cells, sizeof(unsigned int));
             ptr += sizeof(unsigned int);
 
             std::memcpy(ptr,
-                        &tree_index[0],
+                        tree_index.data(),
                         num_cells*sizeof(unsigned int));
             ptr += num_cells*sizeof(unsigned int);
 
             std::memcpy(ptr,
-                        &quadrants[0],
+                        quadrants.data(),
                         num_cells * sizeof(typename dealii::internal::p4est::
                                            types<dim>::quadrant));
             ptr += num_cells*sizeof(typename dealii::internal::p4est::types<dim>::
                                     quadrant);
 
             std::memcpy(ptr,
-                        &vertex_indices[0],
+                        vertex_indices.data(),
                         vertex_indices.size() * sizeof(unsigned int));
             ptr += vertex_indices.size() * sizeof(unsigned int);
 
             std::memcpy(ptr,
-                        &vertices[0],
+                        vertices.data(),
                         vertices.size() * sizeof(dealii::Point<spacedim>));
             ptr += vertices.size() * sizeof(dealii::Point<spacedim>);
 
-            Assert (ptr == &buffer[0]+buffer.size(),
+            Assert (ptr == buffer.data()+buffer.size(),
                     ExcInternalError());
 
           }
 
           void unpack_data (const std::vector<char> &buffer)
           {
-            const char *ptr = &buffer[0];
+            const char *ptr = buffer.data();
             unsigned int cells;
             memcpy(&cells, ptr, sizeof(unsigned int));
             ptr += sizeof(unsigned int);
 
             tree_index.resize(cells);
-            memcpy(&tree_index[0],ptr,sizeof(unsigned int)*cells);
+            memcpy(tree_index.data(),ptr,sizeof(unsigned int)*cells);
             ptr += sizeof(unsigned int)*cells;
 
             quadrants.resize(cells);
-            memcpy(&quadrants[0],ptr,
+            memcpy(quadrants.data(),ptr,
                    sizeof(typename dealii::internal::p4est::types<dim>::quadrant)*cells);
             ptr += sizeof(typename dealii::internal::p4est::types<dim>::quadrant)*cells;
 
@@ -1494,7 +1494,7 @@ namespace parallel
             for (unsigned int c=0; c<cells; ++c)
               first_vertices[c] = &vertices[first_indices[c]];
 
-            Assert (ptr == &buffer[0]+buffer.size(),
+            Assert (ptr == buffer.data() + buffer.size(),
                     ExcInternalError());
           }
         };
@@ -3143,7 +3143,7 @@ namespace parallel
           AssertThrowMPI(ierr);
           receive.resize(len);
 
-          char *ptr = &receive[0];
+          char *ptr = receive.data();
           ierr = MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
                           this->get_communicator(), &status);
           AssertThrowMPI(ierr);
@@ -3173,7 +3173,7 @@ namespace parallel
       // safely destroy the buffers.
       if (requests.size() > 0)
         {
-          const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+          const int ierr = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
           AssertThrowMPI(ierr);
         }
 

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -202,7 +202,7 @@ namespace parallel
     const int ierr = MPI_Allgather (&send_value,
                                     1,
                                     MPI_UNSIGNED,
-                                    &number_cache.n_locally_owned_active_cells[0],
+                                    number_cache.n_locally_owned_active_cells.data(),
                                     1,
                                     MPI_UNSIGNED,
                                     this->mpi_communicator);
@@ -276,7 +276,7 @@ namespace parallel
 
           if (requests.size() > 0)
             {
-              ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+              ierr = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
               AssertThrowMPI(ierr);
             }
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -2872,7 +2872,7 @@ namespace internal
               // set rcounts based on new_numbers:
               int cur_count = new_numbers_copy.size ();
               int ierr = MPI_Allgather (&cur_count,  1, MPI_INT,
-                                        &rcounts[0], 1, MPI_INT,
+                                        rcounts.data(), 1, MPI_INT,
                                         tr->get_communicator ());
               AssertThrowMPI(ierr);
 
@@ -2887,10 +2887,10 @@ namespace internal
               Assert(((int)new_numbers_copy.size()) ==
                      rcounts[Utilities::MPI::this_mpi_process (tr->get_communicator ())],
                      ExcInternalError());
-              ierr = MPI_Allgatherv (&new_numbers_copy[0],     new_numbers_copy.size (),
+              ierr = MPI_Allgatherv (new_numbers_copy.data(),     new_numbers_copy.size (),
                                      DEAL_II_DOF_INDEX_MPI_TYPE,
-                                     &gathered_new_numbers[0], &rcounts[0],
-                                     &displacements[0],
+                                     gathered_new_numbers.data(), rcounts.data(),
+                                     displacements.data(),
                                      DEAL_II_DOF_INDEX_MPI_TYPE,
                                      tr->get_communicator ());
               AssertThrowMPI(ierr);
@@ -3008,8 +3008,8 @@ namespace internal
             // know how to serialize itself. consequently, first copy it over
             // to an array of bytes, and then serialize that
             std::vector<char> quadrants_as_chars (sizeof(quadrants[0]) * quadrants.size());
-            std::memcpy(&quadrants_as_chars[0],
-                        &quadrants[0],
+            std::memcpy(quadrants_as_chars.data(),
+                        quadrants.data(),
                         quadrants_as_chars.size());
 
             // now serialize everything
@@ -3033,8 +3033,8 @@ namespace internal
             &dof_numbers_and_indices;
 
             quadrants.resize (quadrants_as_chars.size() / sizeof(quadrants[0]));
-            std::memcpy(&quadrants[0],
-                        &quadrants_as_chars[0],
+            std::memcpy(quadrants.data(),
+                        quadrants_as_chars.data(),
                         quadrants_as_chars.size());
           }
 
@@ -3083,7 +3083,7 @@ namespace internal
               decompressing_stream.push(boost::iostreams::gzip_decompressor());
               decompressing_stream.push(boost::iostreams::back_inserter(decompressed_buffer));
 
-              decompressing_stream.write (&buffer[0], buffer.size());
+              decompressing_stream.write (buffer.data(), buffer.size());
             }
 
             // then restore the object from the buffer
@@ -3307,7 +3307,7 @@ namespace internal
               AssertThrowMPI(ierr);
               receive.resize(len);
 
-              char *ptr = &receive[0];
+              char *ptr = receive.data();
               ierr = MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
                               tria.get_communicator(), &status);
               AssertThrowMPI(ierr);
@@ -3355,7 +3355,7 @@ namespace internal
               AssertThrowMPI(ierr);
               receive.resize(len);
 
-              char *ptr = &receive[0];
+              char *ptr = receive.data();
               ierr = MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
                               tria.get_communicator(), &status);
               AssertThrowMPI(ierr);
@@ -3391,12 +3391,12 @@ namespace internal
           // buffers.
           if (requests.size() > 0)
             {
-              const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+              const int ierr = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
               AssertThrowMPI(ierr);
             }
           if (reply_requests.size() > 0)
             {
-              const int ierr = MPI_Waitall(reply_requests.size(), &reply_requests[0], MPI_STATUSES_IGNORE);
+              const int ierr = MPI_Waitall(reply_requests.size(), reply_requests.data(), MPI_STATUSES_IGNORE);
               AssertThrowMPI(ierr);
             }
         }
@@ -3739,7 +3739,7 @@ namespace internal
 
         const int ierr = MPI_Allgather ( &n_locally_owned_dofs,
                                          1, DEAL_II_DOF_INDEX_MPI_TYPE,
-                                         &n_locally_owned_dofs_per_processor[0],
+                                         n_locally_owned_dofs_per_processor.data(),
                                          1, DEAL_II_DOF_INDEX_MPI_TYPE,
                                          triangulation->get_communicator());
         AssertThrowMPI(ierr);
@@ -4318,8 +4318,8 @@ namespace internal
           my_data.resize(max_size);
 
           std::vector<char> buffer(max_size*n_cpus);
-          const int ierr = MPI_Allgather(&my_data[0], max_size, MPI_BYTE,
-                                         &buffer[0], max_size, MPI_BYTE,
+          const int ierr = MPI_Allgather(my_data.data(), max_size, MPI_BYTE,
+                                         buffer.data(), max_size, MPI_BYTE,
                                          triangulation->get_communicator());
           AssertThrowMPI(ierr);
 

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -315,10 +315,10 @@ namespace DoFRenumbering
 
       minimum_degree_ordering
       (G,
-       make_iterator_property_map(&degree[0], id, degree[0]),
-       &inverse_perm[0],
-       &perm[0],
-       make_iterator_property_map(&supernode_sizes[0], id, supernode_sizes[0]),
+       make_iterator_property_map(degree.begin(), id, degree[0]),
+       inverse_perm.data(),
+       perm.data(),
+       make_iterator_property_map(supernode_sizes.begin(), id, supernode_sizes[0]),
        delta, id);
 
 
@@ -733,9 +733,9 @@ namespace DoFRenumbering
         all_dof_counts(fe_collection.n_components() *
                        Utilities::MPI::n_mpi_processes (tria->get_communicator()));
 
-        const int ierr = MPI_Allgather ( &local_dof_count[0],
+        const int ierr = MPI_Allgather ( local_dof_count.data(),
                                          n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
-                                         &all_dof_counts[0],
+                                         all_dof_counts.data(),
                                          n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
                                          tria->get_communicator());
         AssertThrowMPI(ierr);
@@ -1021,9 +1021,9 @@ namespace DoFRenumbering
         all_dof_counts(fe_collection.n_components() *
                        Utilities::MPI::n_mpi_processes (tria->get_communicator()));
 
-        const int ierr = MPI_Allgather ( &local_dof_count[0],
+        const int ierr = MPI_Allgather ( local_dof_count.data(),
                                          n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
-                                         &all_dof_counts[0],
+                                         all_dof_counts.data(),
                                          n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
                                          tria->get_communicator());
         AssertThrowMPI(ierr);

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1806,7 +1806,7 @@ namespace DoFTools
       {
         std::vector<types::global_dof_index> local_dof_count = dofs_per_component;
 
-        const int ierr = MPI_Allreduce (&local_dof_count[0], &dofs_per_component[0], n_target_components,
+        const int ierr = MPI_Allreduce (local_dof_count.data(), dofs_per_component.data(), n_target_components,
                                         DEAL_II_DOF_INDEX_MPI_TYPE,
                                         MPI_SUM, tria->get_communicator());
         AssertThrowMPI (ierr);
@@ -1884,7 +1884,7 @@ namespace DoFTools
                (&dof_handler.get_triangulation())))
           {
             std::vector<types::global_dof_index> local_dof_count = dofs_per_block;
-            const int ierr = MPI_Allreduce (&local_dof_count[0], &dofs_per_block[0],
+            const int ierr = MPI_Allreduce (local_dof_count.data(), dofs_per_block.data(),
                                             n_target_blocks,
                                             DEAL_II_DOF_INDEX_MPI_TYPE,
                                             MPI_SUM, tria->get_communicator());

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -92,7 +92,7 @@ FE_ABF<dim>::FE_ABF (const unsigned int deg)
                                                  this->dofs_per_face));
   // TODO: Something goes wrong there. The error of the least squares fit
   // is to large ...
-  // FETools::compute_face_embedding_matrices(*this, &face_embeddings[0], 0, 0);
+  // FETools::compute_face_embedding_matrices(*this, face_embeddings.data(), 0, 0);
   this->interface_constraints.reinit((1<<(dim-1)) * this->dofs_per_face,
                                      this->dofs_per_face);
   unsigned int target_row=0;

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -2160,7 +2160,7 @@ namespace GridGenerator
         cells[i].material_id = 0;
       };
     tria.create_triangulation (
-      std::vector<Point<2> >(&vertices[0], &vertices[10]),
+      std::vector<Point<2> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());       // no boundary information
 
@@ -2188,7 +2188,7 @@ namespace GridGenerator
     vertices_tmp[2] = Point<2> (-half_length, radius_0);
     vertices_tmp[3] = Point<2> (half_length, radius_1);
 
-    const std::vector<Point<2> > vertices (&vertices_tmp[0], &vertices_tmp[4]);
+    const std::vector<Point<2> > vertices (std::begin(vertices_tmp), std::end(vertices_tmp));
     unsigned int cell_vertices[1][GeometryInfo<2>::vertices_per_cell];
 
     for (unsigned int i = 0; i < GeometryInfo<2>::vertices_per_cell; ++i)
@@ -2245,7 +2245,7 @@ namespace GridGenerator
       };
 
     tria.create_triangulation (
-      std::vector<Point<2> >(&vertices[0], &vertices[8]),
+      std::vector<Point<2> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());
 
@@ -2310,7 +2310,7 @@ namespace GridGenerator
       };
 
     tria.create_triangulation (
-      std::vector<Point<2> >(&vertices[0], &vertices[8]),
+      std::vector<Point<2> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());       // no boundary information
   }
@@ -2466,7 +2466,7 @@ namespace GridGenerator
       };
 
     tria.create_triangulation (
-      std::vector<Point<dim> >(&vertices[0], &vertices[7]),
+      std::vector<Point<dim> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());       // no boundary information
 
@@ -2527,7 +2527,7 @@ namespace GridGenerator
       };
 
     tria.create_triangulation (
-      std::vector<Point<2> >(&vertices[0], &vertices[8]),
+      std::vector<Point<2> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());       // no boundary information
 
@@ -2762,7 +2762,7 @@ namespace GridGenerator
         cells[i].material_id = 0;
       };
     tria.create_triangulation (
-      std::vector<Point<3> >(&vertices[0], &vertices[20]),
+      std::vector<Point<3> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());       // no boundary information
 
@@ -2985,7 +2985,7 @@ namespace GridGenerator
       };
 
     tria.create_triangulation (
-      std::vector<Point<3> >(&vertices[0], &vertices[26]),
+      std::vector<Point<3> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());       // no boundary information
 
@@ -3055,7 +3055,7 @@ namespace GridGenerator
       };
 
     tria.create_triangulation (
-      std::vector<Point<3> >(&vertices[0], &vertices[n_vertices]),
+      std::vector<Point<3> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());       // no boundary information
   }
@@ -3144,7 +3144,7 @@ namespace GridGenerator
       };
 
     tria.create_triangulation (
-      std::vector<Point<3> >(&vertices[0], &vertices[24]),
+      std::vector<Point<3> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());       // no boundary information
 
@@ -3236,7 +3236,7 @@ namespace GridGenerator
       };
 
     tria.create_triangulation (
-      std::vector<Point<dim> >(&vertices[0], &vertices[15]),
+      std::vector<Point<dim> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());       // no boundary information
 
@@ -3337,7 +3337,7 @@ namespace GridGenerator
       };
 
     tria.create_triangulation (
-      std::vector<Point<3> >(&vertices[0], &vertices[16]),
+      std::vector<Point<3> >(std::begin(vertices), std::end(vertices)),
       cells,
       SubCellData());       // no boundary information
 
@@ -3676,7 +3676,7 @@ namespace GridGenerator
           };
 
         tria.create_triangulation (
-          std::vector<Point<3> >(&vertices[0], &vertices[16]),
+          std::vector<Point<3> >(std::begin(vertices), std::end(vertices)),
           cells,
           SubCellData());       // no boundary information
       }

--- a/source/grid/grid_reordering.cc
+++ b/source/grid/grid_reordering.cc
@@ -230,7 +230,7 @@ namespace
      */
     const_iterator begin () const
     {
-      return &adjacent_cells[0];
+      return adjacent_cells;
     }
 
 
@@ -245,11 +245,11 @@ namespace
       // adjacent cells, and use this to point to the element past the
       // last valid one
       if (adjacent_cells[0].cell_index == numbers::invalid_unsigned_int)
-        return &adjacent_cells[0];
+        return adjacent_cells;
       else if (adjacent_cells[1].cell_index == numbers::invalid_unsigned_int)
-        return &adjacent_cells[0]+1;
+        return adjacent_cells + 1;
       else
-        return &adjacent_cells[0]+2;
+        return adjacent_cells + 2;
     }
 
   private:
@@ -464,7 +464,7 @@ namespace
      */
     const_iterator begin () const
     {
-      return &edge_indices[0];
+      return edge_indices;
     }
 
 
@@ -477,11 +477,11 @@ namespace
       // indices, and use this to point to the element past the
       // last valid one
       if (edge_indices[0] == numbers::invalid_unsigned_int)
-        return &edge_indices[0];
+        return edge_indices;
       else if (edge_indices[1] == numbers::invalid_unsigned_int)
-        return &edge_indices[0]+1;
+        return edge_indices + 1;
       else
-        return &edge_indices[0]+2;
+        return edge_indices + 2;
     }
 
   private:
@@ -825,8 +825,8 @@ namespace
         for (origin_vertex_of_cell=0;
              origin_vertex_of_cell<GeometryInfo<dim>::vertices_per_cell;
              ++origin_vertex_of_cell)
-          if (std::count (&starting_vertex_of_edge[0],
-                          &starting_vertex_of_edge[0]+GeometryInfo<dim>::lines_per_cell,
+          if (std::count (starting_vertex_of_edge,
+                          starting_vertex_of_edge + GeometryInfo<dim>::lines_per_cell,
                           cell_list[cell_index].vertex_indices[origin_vertex_of_cell])
               == dim)
             break;

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2332,7 +2332,7 @@ next_cell:
     // processors and shifting the indices accordingly
     const unsigned int n_cpu = Utilities::MPI::n_mpi_processes(triangulation.get_communicator());
     std::vector<types::global_vertex_index> indices(n_cpu);
-    int ierr = MPI_Allgather(&next_index, 1, DEAL_II_DOF_INDEX_MPI_TYPE, &indices[0],
+    int ierr = MPI_Allgather(&next_index, 1, DEAL_II_DOF_INDEX_MPI_TYPE, indices.data(),
                              indices.size(), DEAL_II_DOF_INDEX_MPI_TYPE, triangulation.get_communicator());
     AssertThrowMPI(ierr);
     const types::global_vertex_index shift = std::accumulate(&indices[0],

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2335,8 +2335,8 @@ next_cell:
     int ierr = MPI_Allgather(&next_index, 1, DEAL_II_DOF_INDEX_MPI_TYPE, indices.data(),
                              indices.size(), DEAL_II_DOF_INDEX_MPI_TYPE, triangulation.get_communicator());
     AssertThrowMPI(ierr);
-    const types::global_vertex_index shift = std::accumulate(&indices[0],
-                                                             &indices[0]+triangulation.locally_owned_subdomain(),
+    const types::global_vertex_index shift = std::accumulate(indices.begin(),
+                                                             indices.begin()+triangulation.locally_owned_subdomain(),
                                                              types::global_vertex_index(0));
 
     std::map<unsigned int,types::global_vertex_index>::iterator

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -3112,8 +3112,8 @@ next_cell:
 
         const Tensor<spacedim-structdim,spacedim>
         average_parent_alternating_form
-          = std::accumulate (&parent_alternating_forms[0],
-                             &parent_alternating_forms[GeometryInfo<structdim>::vertices_per_cell],
+          = std::accumulate (parent_alternating_forms,
+                             parent_alternating_forms + GeometryInfo<structdim>::vertices_per_cell,
                              Tensor<spacedim-structdim,spacedim>());
 
         // now do the same

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -612,7 +612,7 @@ get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
           for (unsigned int i=0; i<n_points; ++i)
             if ((surrounding_points[i][d]-minP[d]) > periodicity[d]/2.0)
               modified_points[i][d] -= periodicity[d];
-      surrounding_points_start = &modified_points[0];
+      surrounding_points_start = modified_points.data();
     }
 
   // Now perform the interpolation

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -590,7 +590,7 @@ get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
 
   // check whether periodicity shifts some of the points. Only do this if
   // necessary to avoid memory allocation
-  const Point<spacedim> *surrounding_points_start = &surrounding_points[0];
+  const Point<spacedim> *surrounding_points_start = surrounding_points.begin();
 
   boost::container::small_vector<Point<spacedim>, 200> modified_points;
   bool adjust_periodicity = false;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -6373,7 +6373,7 @@ namespace internal
                         ->line((hex->face(5)->refinement_case() == RefinementCase<2>::cut_x) ? 1 : 3)         //3
                       };
 
-                      lines = &lines_x[0];
+                      lines = lines_x;
 
                       unsigned int line_indices_x[4];
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -6296,12 +6296,6 @@ namespace internal
                     {
                     case RefinementCase<dim>::cut_x:
                     {
-                      const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      *lines = nullptr;
-                      const unsigned int *line_indices     = nullptr;
-                      const bool         *line_orientation = nullptr;
-                      const int          *quad_indices     = nullptr;
-
                       //////////////////////////////
                       //
                       //     RefinementCase<dim>::cut_x
@@ -6360,7 +6354,7 @@ namespace internal
                       // this, construct lists of line_indices and
                       // line orientations later on
                       const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      lines_x[4]
+                      lines[4]
                       =
                       {
                         hex->face(2)->child(0)
@@ -6373,20 +6367,16 @@ namespace internal
                         ->line((hex->face(5)->refinement_case() == RefinementCase<2>::cut_x) ? 1 : 3)         //3
                       };
 
-                      lines = lines_x;
-
-                      unsigned int line_indices_x[4];
-
+                      unsigned int line_indices[4];
                       for (unsigned int i=0; i<4; ++i)
-                        line_indices_x[i] = lines[i]->index();
-                      line_indices = &line_indices_x[0];
+                        line_indices[i] = lines[i]->index();
 
                       // the orientation of lines for the inner quads
                       // is quite tricky. as these lines are newly
                       // created ones and thus have no parents, they
                       // cannot inherit this property. set up an array
                       // and fill it with the respective values
-                      bool line_orientation_x[4];
+                      bool line_orientation[4];
 
                       // the middle vertice marked as m0 above is the
                       // start vertex for lines 0 and 2 in standard
@@ -6400,17 +6390,15 @@ namespace internal
 
                       for (unsigned int i=0; i<4; ++i)
                         if (lines[i]->vertex_index(i%2)==middle_vertices[i%2])
-                          line_orientation_x[i]=true;
+                          line_orientation[i]=true;
                         else
                           {
                             // it must be the other
                             // way round then
                             Assert(lines[i]->vertex_index((i+1)%2)==middle_vertices[i%2],
                                    ExcInternalError());
-                            line_orientation_x[i]=false;
+                            line_orientation[i]=false;
                           }
-
-                      line_orientation=&line_orientation_x[0];
 
                       // set up the new quad, line numbering is as
                       // indicated above
@@ -6456,7 +6444,7 @@ namespace internal
                       //
                       // note that we have to take care of the
                       // orientation of faces.
-                      const int quad_indices_x[11]
+                      const int quad_indices[11]
                       =
                       {
                         new_quads[0]->index(),     //0
@@ -6478,7 +6466,6 @@ namespace internal
                         hex->face(5)->child_index(1-child_at_origin[hex->face(5)->refinement_case()-1][f_fl[5]][f_ro[5]])
 
                       };
-                      quad_indices = &quad_indices_x[0];
 
                       new_hexes[0]->set (internal::Triangulation
                                          ::TriaObject<3>(quad_indices[1],
@@ -6499,12 +6486,6 @@ namespace internal
 
                     case RefinementCase<dim>::cut_y:
                     {
-                      const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      *lines = nullptr;
-                      const unsigned int *line_indices     = nullptr;
-                      const bool         *line_orientation = nullptr;
-                      const int          *quad_indices     = nullptr;
-
                       //////////////////////////////
                       //
                       //     RefinementCase<dim>::cut_y
@@ -6568,7 +6549,7 @@ namespace internal
                       // this, construct lists of line_indices and
                       // line orientations later on
                       const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      lines_y[4]
+                      lines[4]
                       =
                       {
                         hex->face(0)->child(0)
@@ -6581,20 +6562,16 @@ namespace internal
                         ->line((hex->face(5)->refinement_case() == RefinementCase<2>::cut_x) ? 1 : 3)         //3
                       };
 
-                      lines=&lines_y[0];
-
-                      unsigned int line_indices_y[4];
-
+                      unsigned int line_indices[4];
                       for (unsigned int i=0; i<4; ++i)
-                        line_indices_y[i]=lines[i]->index();
-                      line_indices=&line_indices_y[0];
+                        line_indices[i]=lines[i]->index();
 
                       // the orientation of lines for the inner quads
                       // is quite tricky. as these lines are newly
                       // created ones and thus have no parents, they
                       // cannot inherit this property. set up an array
                       // and fill it with the respective values
-                      bool line_orientation_y[4];
+                      bool line_orientation[4];
 
                       // the middle vertice marked as m0 above is the
                       // start vertex for lines 0 and 2 in standard
@@ -6608,16 +6585,14 @@ namespace internal
 
                       for (unsigned int i=0; i<4; ++i)
                         if (lines[i]->vertex_index(i%2)==middle_vertices[i%2])
-                          line_orientation_y[i]=true;
+                          line_orientation[i]=true;
                         else
                           {
                             // it must be the other way round then
                             Assert(lines[i]->vertex_index((i+1)%2)==middle_vertices[i%2],
                                    ExcInternalError());
-                            line_orientation_y[i]=false;
+                            line_orientation[i]=false;
                           }
-
-                      line_orientation=&line_orientation_y[0];
 
                       // set up the new quad, line numbering is as
                       // indicated above
@@ -6663,7 +6638,7 @@ namespace internal
                       //
                       // note that we have to take care of the
                       // orientation of faces.
-                      const int quad_indices_y[11]
+                      const int quad_indices[11]
                       =
                       {
                         new_quads[0]->index(),     //0
@@ -6685,7 +6660,6 @@ namespace internal
                         hex->face(5)->child_index(1-child_at_origin[hex->face(5)->refinement_case()-1][f_fl[5]][f_ro[5]])
 
                       };
-                      quad_indices=&quad_indices_y[0];
 
                       new_hexes[0]->set (internal::Triangulation
                                          ::TriaObject<3>(quad_indices[1],
@@ -6706,12 +6680,6 @@ namespace internal
 
                     case RefinementCase<dim>::cut_z:
                     {
-                      const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      *lines = nullptr;
-                      const unsigned int *line_indices     = nullptr;
-                      const bool         *line_orientation = nullptr;
-                      const int          *quad_indices     = nullptr;
-
                       //////////////////////////////
                       //
                       //     RefinementCase<dim>::cut_z
@@ -6777,7 +6745,7 @@ namespace internal
                       // this, construct lists of line_indices and
                       // line orientations later on
                       const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      lines_z[4]
+                      lines[4]
                       =
                       {
                         hex->face(0)->child(0)
@@ -6790,20 +6758,16 @@ namespace internal
                         ->line((hex->face(3)->refinement_case() == RefinementCase<2>::cut_x) ? 1 : 3)         //3
                       };
 
-                      lines=&lines_z[0];
-
-                      unsigned int line_indices_z[4];
-
+                      unsigned int line_indices[4];
                       for (unsigned int i=0; i<4; ++i)
-                        line_indices_z[i]=lines[i]->index();
-                      line_indices=&line_indices_z[0];
+                        line_indices[i]=lines[i]->index();
 
                       // the orientation of lines for the inner quads
                       // is quite tricky. as these lines are newly
                       // created ones and thus have no parents, they
                       // cannot inherit this property. set up an array
                       // and fill it with the respective values
-                      bool line_orientation_z[4];
+                      bool line_orientation[4];
 
                       // the middle vertex marked as m0 above is the
                       // start vertex for lines 0 and 2 in standard
@@ -6817,16 +6781,14 @@ namespace internal
 
                       for (unsigned int i=0; i<4; ++i)
                         if (lines[i]->vertex_index(i%2)==middle_vertices[i%2])
-                          line_orientation_z[i]=true;
+                          line_orientation[i]=true;
                         else
                           {
                             // it must be the other way round then
                             Assert(lines[i]->vertex_index((i+1)%2)==middle_vertices[i%2],
                                    ExcInternalError());
-                            line_orientation_z[i]=false;
+                            line_orientation[i]=false;
                           }
-
-                      line_orientation=&line_orientation_z[0];
 
                       // set up the new quad, line numbering is as
                       // indicated above
@@ -6873,7 +6835,7 @@ namespace internal
                       //
                       // note that we have to take care of the
                       // orientation of faces.
-                      const int quad_indices_z[11]
+                      const int quad_indices[11]
                       =
                       {
                         new_quads[0]->index(),     //0
@@ -6894,7 +6856,6 @@ namespace internal
 
                         hex->face(5)->index()      //10
                       };
-                      quad_indices=&quad_indices_z[0];
 
                       new_hexes[0]->set (internal::Triangulation
                                          ::TriaObject<3>(quad_indices[1],
@@ -6915,12 +6876,6 @@ namespace internal
 
                     case RefinementCase<dim>::cut_xy:
                     {
-                      const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      *lines = nullptr;
-                      const unsigned int *line_indices     = nullptr;
-                      const bool         *line_orientation = nullptr;
-                      const int          *quad_indices     = nullptr;
-
                       //////////////////////////////
                       //
                       //     RefinementCase<dim>::cut_xy
@@ -7010,7 +6965,7 @@ namespace internal
                       // this, construct lists of line_indices and
                       // line orientations later on
                       const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      lines_xy[13]
+                      lines[13]
                       =
                       {
                         hex->face(0)->child(0)
@@ -7043,20 +6998,16 @@ namespace internal
                         new_lines[0]                        //12
                       };
 
-                      lines=&lines_xy[0];
-
-                      unsigned int line_indices_xy[13];
-
+                      unsigned int line_indices[13];
                       for (unsigned int i=0; i<13; ++i)
-                        line_indices_xy[i]=lines[i]->index();
-                      line_indices=&line_indices_xy[0];
+                        line_indices[i]=lines[i]->index();
 
                       // the orientation of lines for the inner quads
                       // is quite tricky. as these lines are newly
                       // created ones and thus have no parents, they
                       // cannot inherit this property. set up an array
                       // and fill it with the respective values
-                      bool line_orientation_xy[13];
+                      bool line_orientation[13];
 
                       // the middle vertices of the lines of our
                       // bottom face
@@ -7073,13 +7024,13 @@ namespace internal
                       // face
                       for (unsigned int i=0; i<4; ++i)
                         if (lines[i]->vertex_index(0)==middle_vertices[i])
-                          line_orientation_xy[i]=true;
+                          line_orientation[i]=true;
                         else
                           {
                             // it must be the other way round then
                             Assert(lines[i]->vertex_index(1)==middle_vertices[i],
                                    ExcInternalError());
-                            line_orientation_xy[i]=false;
+                            line_orientation[i]=false;
                           }
 
                       // note: for lines 4 to 11 (inner lines of the
@@ -7091,7 +7042,7 @@ namespace internal
                       for (unsigned int i=4; i<12; ++i)
                         if (lines[i]->vertex_index((i+1)%2) ==
                             middle_vertex_index<dim,spacedim>(hex->face(3+i/4)))
-                          line_orientation_xy[i]=true;
+                          line_orientation[i]=true;
                         else
                           {
                             // it must be the other way
@@ -7099,14 +7050,12 @@ namespace internal
                             Assert(lines[i]->vertex_index(i%2) ==
                                    (middle_vertex_index<dim,spacedim>(hex->face(3+i/4))),
                                    ExcInternalError());
-                            line_orientation_xy[i]=false;
+                            line_orientation[i]=false;
                           }
                       // for the last line the line orientation is
                       // always true, since it was just constructed
                       // that way
-
-                      line_orientation_xy[12]=true;
-                      line_orientation=&line_orientation_xy[0];
+                      line_orientation[12]=true;
 
                       // set up the 4 quads, numbered as follows (left
                       // quad numbering, right line numbering
@@ -7199,7 +7148,7 @@ namespace internal
                       //
                       // note that we have to take care of the
                       // orientation of faces.
-                      const int quad_indices_xy[20]
+                      const int quad_indices[20]
                       =
                       {
                         new_quads[0]->index(),     //0
@@ -7229,7 +7178,6 @@ namespace internal
                         hex->face(5)->isotropic_child_index(GeometryInfo<dim>::standard_to_real_face_vertex(2,f_or[5],f_fl[5],f_ro[5])),
                         hex->face(5)->isotropic_child_index(GeometryInfo<dim>::standard_to_real_face_vertex(3,f_or[5],f_fl[5],f_ro[5]))
                       };
-                      quad_indices=&quad_indices_xy[0];
 
                       new_hexes[0]->set (internal::Triangulation
                                          ::TriaObject<3>(quad_indices[4],
@@ -7264,12 +7212,6 @@ namespace internal
 
                     case RefinementCase<dim>::cut_xz:
                     {
-                      const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      *lines = nullptr;
-                      const unsigned int *line_indices     = nullptr;
-                      const bool         *line_orientation = nullptr;
-                      const int          *quad_indices     = nullptr;
-
                       //////////////////////////////
                       //
                       //     RefinementCase<dim>::cut_xz
@@ -7359,7 +7301,7 @@ namespace internal
                       // this, construct lists of line_indices and
                       // line orientations later on
                       const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      lines_xz[13]
+                      lines[13]
                       =
                       {
                         hex->face(0)->child(0)
@@ -7392,20 +7334,16 @@ namespace internal
                         new_lines[0]                        //12
                       };
 
-                      lines=&lines_xz[0];
-
-                      unsigned int line_indices_xz[13];
-
+                      unsigned int line_indices[13];
                       for (unsigned int i=0; i<13; ++i)
-                        line_indices_xz[i]=lines[i]->index();
-                      line_indices=&line_indices_xz[0];
+                        line_indices[i]=lines[i]->index();
 
                       // the orientation of lines for the inner quads
                       // is quite tricky. as these lines are newly
                       // created ones and thus have no parents, they
                       // cannot inherit this property. set up an array
                       // and fill it with the respective values
-                      bool line_orientation_xz[13];
+                      bool line_orientation[13];
 
                       // the middle vertices of the
                       // lines of our front face
@@ -7421,13 +7359,13 @@ namespace internal
                       // line is 'true', if vertex 0 is on the front
                       for (unsigned int i=0; i<4; ++i)
                         if (lines[i]->vertex_index(0)==middle_vertices[i])
-                          line_orientation_xz[i]=true;
+                          line_orientation[i]=true;
                         else
                           {
                             // it must be the other way round then
                             Assert(lines[i]->vertex_index(1)==middle_vertices[i],
                                    ExcInternalError());
-                            line_orientation_xz[i]=false;
+                            line_orientation[i]=false;
                           }
 
                       // note: for lines 4 to 11 (inner lines of the
@@ -7439,7 +7377,7 @@ namespace internal
                       for (unsigned int i=4; i<12; ++i)
                         if (lines[i]->vertex_index((i+1)%2) ==
                             middle_vertex_index<dim,spacedim>(hex->face(1+i/4)))
-                          line_orientation_xz[i]=true;
+                          line_orientation[i]=true;
                         else
                           {
                             // it must be the other way
@@ -7447,14 +7385,12 @@ namespace internal
                             Assert(lines[i]->vertex_index(i%2) ==
                                    (middle_vertex_index<dim,spacedim>(hex->face(1+i/4))),
                                    ExcInternalError());
-                            line_orientation_xz[i]=false;
+                            line_orientation[i]=false;
                           }
                       // for the last line the line orientation is
                       // always true, since it was just constructed
                       // that way
-
-                      line_orientation_xz[12]=true;
-                      line_orientation=&line_orientation_xz[0];
+                      line_orientation[12]=true;
 
                       // set up the 4 quads, numbered as follows (left
                       // quad numbering, right line numbering
@@ -7549,7 +7485,7 @@ namespace internal
                       //
                       // note that we have to take care of the
                       // orientation of faces.
-                      const int quad_indices_xz[20]
+                      const int quad_indices[20]
                       =
                       {
                         new_quads[0]->index(),     //0
@@ -7579,7 +7515,6 @@ namespace internal
                         hex->face(5)->child_index(  child_at_origin[hex->face(5)->refinement_case()-1][f_fl[5]][f_ro[5]]),  //18
                         hex->face(5)->child_index(1-child_at_origin[hex->face(5)->refinement_case()-1][f_fl[5]][f_ro[5]])
                       };
-                      quad_indices=&quad_indices_xz[0];
 
                       // due to the exchange of x and y for the front
                       // and back face, we order the children
@@ -7623,12 +7558,6 @@ namespace internal
 
                     case RefinementCase<dim>::cut_yz:
                     {
-                      const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      *lines = nullptr;
-                      const unsigned int *line_indices     = nullptr;
-                      const bool         *line_orientation = nullptr;
-                      const int          *quad_indices     = nullptr;
-
                       //////////////////////////////
                       //
                       //     RefinementCase<dim>::cut_yz
@@ -7720,7 +7649,7 @@ namespace internal
                       // this, construct lists of line_indices and
                       // line orientations later on
                       const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      lines_yz[13]
+                      lines[13]
                       =
                       {
                         hex->face(2)->child(0)
@@ -7753,20 +7682,17 @@ namespace internal
                         new_lines[0]                        //12
                       };
 
-                      lines=&lines_yz[0];
-
-                      unsigned int line_indices_yz[13];
+                      unsigned int line_indices[13];
 
                       for (unsigned int i=0; i<13; ++i)
-                        line_indices_yz[i]=lines[i]->index();
-                      line_indices=&line_indices_yz[0];
+                        line_indices[i]=lines[i]->index();
 
                       // the orientation of lines for the inner quads
                       // is quite tricky. as these lines are newly
                       // created ones and thus have no parents, they
                       // cannot inherit this property. set up an array
                       // and fill it with the respective values
-                      bool line_orientation_yz[13];
+                      bool line_orientation[13];
 
                       // the middle vertices of the lines of our front
                       // face
@@ -7782,13 +7708,13 @@ namespace internal
                       // line is 'true', if vertex 0 is on the front
                       for (unsigned int i=0; i<4; ++i)
                         if (lines[i]->vertex_index(0)==middle_vertices[i])
-                          line_orientation_yz[i]=true;
+                          line_orientation[i]=true;
                         else
                           {
                             // it must be the other way round then
                             Assert(lines[i]->vertex_index(1)==middle_vertices[i],
                                    ExcInternalError());
-                            line_orientation_yz[i]=false;
+                            line_orientation[i]=false;
                           }
 
                       // note: for lines 4 to 11 (inner lines of the
@@ -7800,7 +7726,7 @@ namespace internal
                       for (unsigned int i=4; i<12; ++i)
                         if (lines[i]->vertex_index((i+1)%2) ==
                             middle_vertex_index<dim,spacedim>(hex->face(i/4-1)))
-                          line_orientation_yz[i]=true;
+                          line_orientation[i]=true;
                         else
                           {
                             // it must be the other way
@@ -7808,14 +7734,12 @@ namespace internal
                             Assert(lines[i]->vertex_index(i%2) ==
                                    (middle_vertex_index<dim,spacedim>(hex->face(i/4-1))),
                                    ExcInternalError());
-                            line_orientation_yz[i]=false;
+                            line_orientation[i]=false;
                           }
                       // for the last line the line orientation is
                       // always true, since it was just constructed
                       // that way
-
-                      line_orientation_yz[12]=true;
-                      line_orientation=&line_orientation_yz[0];
+                      line_orientation[12]=true;
 
                       // set up the 4 quads, numbered as follows (left
                       // quad numbering, right line numbering
@@ -7904,7 +7828,7 @@ namespace internal
                       //
                       // note that we have to take care of the
                       // orientation of faces.
-                      const int quad_indices_yz[20]
+                      const int quad_indices[20]
                       =
                       {
                         new_quads[0]->index(),     //0
@@ -7934,7 +7858,6 @@ namespace internal
                         hex->face(5)->child_index(  child_at_origin[hex->face(5)->refinement_case()-1][f_fl[5]][f_ro[5]]),  //18
                         hex->face(5)->child_index(1-child_at_origin[hex->face(5)->refinement_case()-1][f_fl[5]][f_ro[5]])
                       };
-                      quad_indices=&quad_indices_yz[0];
 
                       new_hexes[0]->set (internal::Triangulation
                                          ::TriaObject<3>(quad_indices[4],
@@ -7969,13 +7892,6 @@ namespace internal
 
                     case RefinementCase<dim>::cut_xyz:
                     {
-                      const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      *lines = nullptr;
-                      const unsigned int *vertex_indices   = nullptr;
-                      const unsigned int *line_indices     = nullptr;
-                      const bool         *line_orientation = nullptr;
-                      const int          *quad_indices     = nullptr;
-
                       //////////////////////////////
                       //
                       //     RefinementCase<dim>::cut_xyz
@@ -8033,7 +7949,7 @@ namespace internal
                       //  /  0  /      |  4  |
                       // *--*--*       *--*--*
                       //
-                      const unsigned int vertex_indices_xyz[7]
+                      const unsigned int vertex_indices[7]
                         = { middle_vertex_index<dim,spacedim>(hex->face(0)),
                             middle_vertex_index<dim,spacedim>(hex->face(1)),
                             middle_vertex_index<dim,spacedim>(hex->face(2)),
@@ -8042,7 +7958,6 @@ namespace internal
                             middle_vertex_index<dim,spacedim>(hex->face(5)),
                             next_unused_vertex
                           };
-                      vertex_indices=&vertex_indices_xyz[0];
 
                       new_lines[0]->set (internal::Triangulation::
                                          TriaObject<1>(vertex_indices[2], vertex_indices[6]));
@@ -8123,7 +8038,7 @@ namespace internal
                       // this, construct lists of line_indices and
                       // line orientations later on
                       const typename Triangulation<dim,spacedim>::raw_line_iterator
-                      lines_xyz[30]
+                      lines[30]
                       =
                       {
                         hex->face(0)->isotropic_child(GeometryInfo<dim>::standard_to_real_face_vertex(0,f_or[0],f_fl[0],f_ro[0]))
@@ -8188,19 +8103,16 @@ namespace internal
                         new_lines[5]                        //29
                       };
 
-                      lines=&lines_xyz[0];
-
-                      unsigned int line_indices_xyz[30];
+                      unsigned int line_indices[30];
                       for (unsigned int i=0; i<30; ++i)
-                        line_indices_xyz[i]=lines[i]->index();
-                      line_indices=&line_indices_xyz[0];
+                        line_indices[i]=lines[i]->index();
 
                       // the orientation of lines for the inner quads
                       // is quite tricky. as these lines are newly
                       // created ones and thus have no parents, they
                       // cannot inherit this property. set up an array
                       // and fill it with the respective values
-                      bool line_orientation_xyz[30];
+                      bool line_orientation[30];
 
                       // note: for the first 24 lines (inner lines of
                       // the outer quads) the following holds: the
@@ -8210,21 +8122,20 @@ namespace internal
                       // vertex is the same middle vertex.
                       for (unsigned int i=0; i<24; ++i)
                         if (lines[i]->vertex_index((i+1)%2)==vertex_indices[i/4])
-                          line_orientation_xyz[i]=true;
+                          line_orientation[i]=true;
                         else
                           {
                             // it must be the other way
                             // round then
                             Assert(lines[i]->vertex_index(i%2)==vertex_indices[i/4],
                                    ExcInternalError());
-                            line_orientation_xyz[i]=false;
+                            line_orientation[i]=false;
                           }
                       // for the last 6 lines the line orientation is
                       // always true, since they were just constructed
                       // that way
                       for (unsigned int i=24; i<30; ++i)
-                        line_orientation_xyz[i]=true;
-                      line_orientation=&line_orientation_xyz[0];
+                        line_orientation[i]=true;
 
                       // set up the 12 quads, numbered as follows
                       // (left quad numbering, right line numbering
@@ -8395,7 +8306,7 @@ namespace internal
                       // take care of the
                       // orientation of
                       // faces.
-                      const int quad_indices_xyz[36]
+                      const int quad_indices[36]
                       =
                       {
                         new_quads[0]->index(),     //0
@@ -8441,7 +8352,6 @@ namespace internal
                         hex->face(5)->isotropic_child_index(GeometryInfo<dim>::standard_to_real_face_vertex(2,f_or[5],f_fl[5],f_ro[5])),
                         hex->face(5)->isotropic_child_index(GeometryInfo<dim>::standard_to_real_face_vertex(3,f_or[5],f_fl[5],f_ro[5]))
                       };
-                      quad_indices=&quad_indices_xyz[0];
 
                       // bottom children
                       new_hexes[0]->set (internal::Triangulation

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -593,7 +593,7 @@ namespace LinearAlgebra
           AssertCuda(error_code);
 
           // Copy the vector from the host to the temporary vector on the device
-          error_code = cudaMemcpy(&tmp[0], V.begin(), n_elements*sizeof(Number),
+          error_code = cudaMemcpy(tmp, V.begin(), n_elements*sizeof(Number),
                                   cudaMemcpyHostToDevice);
           AssertCuda(error_code);
 

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -150,7 +150,7 @@ namespace PETScWrappers
     IS index_set;
 
     ISCreateGeneral (get_mpi_communicator(), rows.size(),
-                     &petsc_rows[0], PETSC_COPY_VALUES, &index_set);
+                     petsc_rows.data(), PETSC_COPY_VALUES, &index_set);
 
     const PetscErrorCode ierr = MatZeroRowsIS(matrix, index_set, new_diag_value,
                                               nullptr, nullptr);

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -298,9 +298,9 @@ namespace PETScWrappers
                                   (communicator,
                                    local_rows, local_columns,
                                    m, n,
-                                   0, &int_row_lengths[0],
+                                   0, int_row_lengths.data(),
                                    0,
-                                   offdiag_row_lengths.size() ? &int_offdiag_row_lengths[0] : nullptr,
+                                   offdiag_row_lengths.size() ? int_offdiag_row_lengths.data() : nullptr,
                                    &matrix);
 
 //TODO: Sometimes the actual number of nonzero entries allocated is greater than the number of nonzero entries, which petsc will complain about unless explicitly disabled with MatSetOption. There is probably a way to prevent a different number nonzero elements being allocated in the first place. (See also previous TODO).
@@ -429,8 +429,8 @@ namespace PETScWrappers
           // that summarily allocates these
           // entries:
           ierr = MatMPIAIJSetPreallocationCSR (matrix,
-                                               &rowstart_in_window[0],
-                                               &colnums_in_window[0],
+                                               rowstart_in_window.data(),
+                                               colnums_in_window.data(),
                                                nullptr);
           AssertThrow (ierr == 0, ExcPETScError(ierr));
         }
@@ -558,8 +558,8 @@ namespace PETScWrappers
           // that summarily allocates these
           // entries:
           ierr = MatMPIAIJSetPreallocationCSR (matrix,
-                                               &rowstart_in_window[0],
-                                               &colnums_in_window[0],
+                                               rowstart_in_window.data(),
+                                               colnums_in_window.data(),
                                                nullptr);
           AssertThrow (ierr == 0, ExcPETScError(ierr));
 

--- a/source/lac/petsc_sparse_matrix.cc
+++ b/source/lac/petsc_sparse_matrix.cc
@@ -180,7 +180,7 @@ namespace PETScWrappers
     int_row_lengths (row_lengths.begin(), row_lengths.end());
 
     const PetscErrorCode ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, 0,
-                                                &int_row_lengths[0], &matrix);
+                                                int_row_lengths.data(), &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set symmetric flag, if so requested
@@ -231,8 +231,8 @@ namespace PETScWrappers
 
             const PetscInt int_row = i;
             const PetscErrorCode ierr = MatSetValues (matrix, 1, &int_row,
-                                                      row_lengths[i], &row_entries[0],
-                                                      &row_values[0], INSERT_VALUES);
+                                                      row_lengths[i], row_entries.data(),
+                                                      row_values.data(), INSERT_VALUES);
             AssertThrow (ierr == 0, ExcPETScError(ierr));
           }
         compress (VectorOperation::insert);

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -289,7 +289,7 @@ namespace PETScWrappers
   {
     Assert (indices.size() == values.size(),
             ExcMessage ("Function called with arguments of different sizes"));
-    do_set_add_operation(indices.size(), &indices[0], &values[0], false);
+    do_set_add_operation(indices.size(), indices.data(), values.data(), false);
   }
 
 
@@ -300,7 +300,7 @@ namespace PETScWrappers
   {
     Assert (indices.size() == values.size(),
             ExcMessage ("Function called with arguments of different sizes"));
-    do_set_add_operation(indices.size(), &indices[0], &values[0], true);
+    do_set_add_operation(indices.size(), indices.data(), values.data(), true);
   }
 
 
@@ -311,7 +311,7 @@ namespace PETScWrappers
   {
     Assert (indices.size() == values.size(),
             ExcMessage ("Function called with arguments of different sizes"));
-    do_set_add_operation(indices.size(), &indices[0], values.begin(), true);
+    do_set_add_operation(indices.size(), indices.data(), values.begin(), true);
   }
 
 

--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -59,7 +59,7 @@ SparseDirectUMFPACK::SparseDirectUMFPACK ()
   numeric_decomposition (nullptr),
   control (UMFPACK_CONTROL)
 {
-  umfpack_dl_defaults (&control[0]);
+  umfpack_dl_defaults (control.data());
 }
 
 
@@ -95,7 +95,7 @@ SparseDirectUMFPACK::clear ()
     tmp.swap (Ax);
   }
 
-  umfpack_dl_defaults (&control[0]);
+  umfpack_dl_defaults (control.data());
 }
 
 
@@ -279,16 +279,16 @@ factorize (const Matrix &matrix)
 
   int status;
   status = umfpack_dl_symbolic (N, N,
-                                &Ap[0], &Ai[0], &Ax[0],
+                                Ap.data(), Ai.data(), Ax.data(),
                                 &symbolic_decomposition,
-                                &control[0], nullptr);
+                                control.data(), nullptr);
   AssertThrow (status == UMFPACK_OK,
                ExcUMFPACKError("umfpack_dl_symbolic", status));
 
-  status = umfpack_dl_numeric (&Ap[0], &Ai[0], &Ax[0],
+  status = umfpack_dl_numeric (Ap.data(), Ai.data(), Ax.data(),
                                symbolic_decomposition,
                                &numeric_decomposition,
-                               &control[0], nullptr);
+                               control.data(), nullptr);
   AssertThrow (status == UMFPACK_OK,
                ExcUMFPACKError("umfpack_dl_numeric", status));
 
@@ -317,10 +317,10 @@ SparseDirectUMFPACK::solve (Vector<double> &rhs_and_solution,
   // instead.
   const int status
     = umfpack_dl_solve (transpose ? UMFPACK_A : UMFPACK_At,
-                        &Ap[0], &Ai[0], &Ax[0],
+                        Ap.data(), Ai.data(), Ax.data(),
                         rhs_and_solution.begin(), rhs.begin(),
                         numeric_decomposition,
-                        &control[0], nullptr);
+                        control.data(), nullptr);
   AssertThrow (status == UMFPACK_OK, ExcUMFPACKError("umfpack_dl_solve", status));
 }
 

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -119,17 +119,17 @@ namespace SparsityTools
 
     // Use recursive if the number of partitions is less than or equal to 8
     if (nparts <= 8)
-      ierr = METIS_PartGraphRecursive(&n, &ncon, &int_rowstart[0], &int_colnums[0],
+      ierr = METIS_PartGraphRecursive(&n, &ncon, int_rowstart.data(), int_colnums.data(),
                                       nullptr, nullptr, nullptr,
-                                      &nparts,nullptr,nullptr,&options[0],
-                                      &dummy,&int_partition_indices[0]);
+                                      &nparts,nullptr,nullptr,options,
+                                      &dummy,int_partition_indices.data());
 
     // Otherwise use kway
     else
-      ierr = METIS_PartGraphKway(&n, &ncon, &int_rowstart[0], &int_colnums[0],
+      ierr = METIS_PartGraphKway(&n, &ncon, int_rowstart.data(), int_colnums.data(),
                                  nullptr, nullptr, nullptr,
-                                 &nparts,nullptr,nullptr,&options[0],
-                                 &dummy,&int_partition_indices[0]);
+                                 &nparts,nullptr,nullptr,options,
+                                 &dummy,int_partition_indices.data());
 
     // If metis returns normally, an error code METIS_OK=1 is returned from
     // the above functions (see metish.h)
@@ -604,7 +604,7 @@ namespace SparsityTools
           ierr = MPI_Get_count(&status, DEAL_II_DOF_INDEX_MPI_TYPE, &len);
           AssertThrowMPI(ierr);
           recv_buf.resize(len);
-          ierr = MPI_Recv(&recv_buf[0], len, DEAL_II_DOF_INDEX_MPI_TYPE, status.MPI_SOURCE,
+          ierr = MPI_Recv(recv_buf.data(), len, DEAL_II_DOF_INDEX_MPI_TYPE, status.MPI_SOURCE,
                           status.MPI_TAG, mpi_comm, &status);
           AssertThrowMPI(ierr);
 
@@ -629,7 +629,7 @@ namespace SparsityTools
     // complete all sends, so that we can safely destroy the buffers.
     if (requests.size())
       {
-        const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+        const int ierr = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
         AssertThrowMPI(ierr);
       }
 
@@ -735,7 +735,7 @@ namespace SparsityTools
           ierr = MPI_Get_count(&status, DEAL_II_DOF_INDEX_MPI_TYPE, &len);
           AssertThrowMPI(ierr);
           recv_buf.resize(len);
-          ierr = MPI_Recv(&recv_buf[0], len, DEAL_II_DOF_INDEX_MPI_TYPE, status.MPI_SOURCE,
+          ierr = MPI_Recv(recv_buf.data(), len, DEAL_II_DOF_INDEX_MPI_TYPE, status.MPI_SOURCE,
                           status.MPI_TAG, mpi_comm, &status);
           AssertThrowMPI(ierr);
 
@@ -760,7 +760,7 @@ namespace SparsityTools
     // complete all sends, so that we can safely destroy the buffers.
     if (requests.size())
       {
-        const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+        const int ierr = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
         AssertThrowMPI(ierr);
       }
   }

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -191,7 +191,7 @@ namespace TrilinosWrappers
         // the current processor. Therefore, pass a dummy in that case
         else
           parameter_list.set("null space: vectors",
-                             &dummy[0]);
+                             dummy.data());
       }
 
     initialize (matrix, parameter_list);

--- a/source/lac/trilinos_precondition_muelu.cc
+++ b/source/lac/trilinos_precondition_muelu.cc
@@ -184,7 +184,7 @@ namespace TrilinosWrappers
         // the current processor. Therefore, pass a dummy in that case
         else
           parameter_list.set("null space: vectors",
-                             &dummy[0]);
+                             dummy.data());
       }
 
     initialize (matrix, parameter_list);

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -321,7 +321,7 @@ namespace TrilinosWrappers
 
       if (row_map.Comm().NumProc() > 1)
         graph.reset(new Epetra_FECrsGraph(Copy, row_map,
-                                          &local_entries_per_row[0],
+                                          local_entries_per_row.data(),
                                           false
                                           // TODO: Check which new Trilinos
                                           // version supports this... Remember
@@ -333,7 +333,7 @@ namespace TrilinosWrappers
                                          ));
       else
         graph.reset(new Epetra_FECrsGraph(Copy, row_map, col_map,
-                                          &local_entries_per_row[0],
+                                          local_entries_per_row.data(),
                                           false));
     }
 
@@ -373,11 +373,11 @@ namespace TrilinosWrappers
 
       if (row_map.Comm().NumProc() > 1)
         graph.reset(new Epetra_FECrsGraph(Copy, row_map,
-                                          &n_entries_per_row[0],
+                                          n_entries_per_row.data(),
                                           false));
       else
         graph.reset (new Epetra_FECrsGraph(Copy, row_map, col_map,
-                                           &n_entries_per_row[0],
+                                           n_entries_per_row.data(),
                                            false));
 
       AssertDimension (sp.n_rows(),
@@ -407,7 +407,7 @@ namespace TrilinosWrappers
                 }
             }
             graph->Epetra_CrsGraph::InsertGlobalIndices (row, row_length,
-                                                         &row_indices[0]);
+                                                         row_indices.data());
           }
       else
         for (size_type row=0; row<sp.n_rows(); ++row)
@@ -430,7 +430,7 @@ namespace TrilinosWrappers
             }
             graph->InsertGlobalIndices (1,
                                         reinterpret_cast<TrilinosWrappers::types::int_type *>(&row),
-                                        row_length, &row_indices[0]);
+                                        row_length, row_indices.data());
           }
 
       int ierr =

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -298,7 +298,7 @@ namespace TrilinosWrappers
         }
 
       Assert (n_elements == added_elements, ExcInternalError());
-      Epetra_Map new_map (v.size(), n_elements, &global_ids[0], 0,
+      Epetra_Map new_map (v.size(), n_elements, global_ids.data(), 0,
                           v.block(0).vector_partitioner().Comm());
 
       std::shared_ptr<Epetra_FEVector> actual_vec;

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -200,7 +200,7 @@ namespace internal
                 // just send an empty message.
                 if (data.size())
                   {
-                    const int ierr = MPI_Isend(&data[0], data.size()*sizeof(data[0]),
+                    const int ierr = MPI_Isend(data.data(), data.size()*sizeof(data[0]),
                                                MPI_BYTE, dest, 71, tria->get_communicator(),
                                                &*requests.rbegin());
                     AssertThrowMPI(ierr);
@@ -239,7 +239,7 @@ namespace internal
                 Assert(static_cast<int>(count * sizeof(DoFPair)) == len, ExcInternalError());
                 receive_buffer.resize(count);
 
-                void *ptr = &receive_buffer[0];
+                void *ptr = receive_buffer.data();
                 ierr = MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
                                 tria->get_communicator(), &status);
                 AssertThrowMPI(ierr);
@@ -256,7 +256,7 @@ namespace internal
           // * wait for all MPI_Isend to complete
           if (requests.size() > 0)
             {
-              const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+              const int ierr = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
               AssertThrowMPI(ierr);
               requests.clear();
             }

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -280,7 +280,7 @@ void MGTransferPrebuilt<VectorType>::build_matrices
                 for (unsigned int i=0; i<dofs_per_cell; ++i)
                   prolongation_matrices[level]->set (dof_indices_child[i],
                                                      dofs_per_cell,
-                                                     &dof_indices_parent[0],
+                                                     dof_indices_parent.data(),
                                                      &prolongation(i,0),
                                                      true);
               }

--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -64,7 +64,7 @@ namespace Particles
           {
             const ArrayView<const double> their_properties = particle.get_properties();
 
-            std::copy(&their_properties[0],&their_properties[0]+their_properties.size(),&my_properties[0]);
+            std::copy(their_properties.begin(), their_properties.end(), my_properties.begin());
           }
       }
   }
@@ -131,7 +131,7 @@ namespace Particles
             if (their_properties.size() != 0)
               {
                 const ArrayView<double> my_properties = property_pool->get_properties(properties);
-                std::copy(&their_properties[0],&their_properties[0]+their_properties.size(),&my_properties[0]);
+                std::copy(their_properties.begin(), their_properties.end(), my_properties.begin());
               }
           }
         else
@@ -284,7 +284,7 @@ namespace Particles
                        + "This is not allowed."));
 
     if (old_properties.size() > 0)
-      std::copy(new_properties.begin(),new_properties.end(),&old_properties[0]);
+      std::copy(new_properties.begin(), new_properties.end(), old_properties.begin());
   }
 
 


### PR DESCRIPTION
I had two long train rides this weekend so I figured that I would give this a shot. Fixes #4920.

These commits get rid of the `&v[0]` idiom in most places (in a few places, particularly the matrix free code, this idiom still makes sense) in favor of either using the raw pointer directly (i.e., `p` is equivalent to `&p[0]` if `p` is a pointer), using `v.data()` for `std::vector`, or using `v.get()` for smart pointers.

In a lot of places we write things like

```cpp
const_iterator end() const
{
    return &val[length];
}
```

which is undefined behavior, so these changes are not just cosmetic.