### PR TITLE
Use std::initializer_list instead of variadic constructor in tests

### DIFF
--- a/tests/grid/grid_tools_extract_used_vertices_03.cc
+++ b/tests/grid/grid_tools_extract_used_vertices_03.cc
@@ -38,7 +38,7 @@ void test (const Point<spacedim> &p)
   tria.refine_global(1);
 
   // Vector fe
-  FESystem<dim,spacedim> fe(FE_Q<dim, spacedim>(1)^spacedim);
+  FESystem<dim,spacedim> fe({FE_Q<dim, spacedim>(1)^spacedim});
   DoFHandler<dim,spacedim> dh(tria);
   dh.distribute_dofs(fe);
 

--- a/tests/grid/grid_tools_find_closest_vertex_01.cc
+++ b/tests/grid/grid_tools_find_closest_vertex_01.cc
@@ -38,7 +38,7 @@ void test (const Point<spacedim> &p)
   tria.refine_global(1);
 
   // Vector fe
-  FESystem<dim,spacedim> fe(FE_Q<dim, spacedim>(1)^spacedim);
+  FESystem<dim,spacedim> fe({FE_Q<dim, spacedim>(1)^spacedim});
   DoFHandler<dim,spacedim> dh(tria);
   dh.distribute_dofs(fe);
 


### PR DESCRIPTION
ICC 18 seems to dislike `FESystem`s variadic constructor. Since the purpose of these tests is not to test this constructor, we can simply switch to the one taking a `std::initializer_list` and make the Intel compiler happy.