### PR TITLE
Formally deprecate the Boundary classes.

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1258,8 +1258,11 @@ public:
   /**
    * Default manifold object. This is used for those objects for which no
    * boundary description has been explicitly set using set_manifold().
+   *
+   * @deprecated This member variable has been deprecated in favor of creating
+   * an independent FlatManifold.
    */
-  static const StraightBoundary<dim,spacedim> straight_boundary;
+  static const StraightBoundary<dim,spacedim> straight_boundary DEAL_II_DEPRECATED;
 
   /**
    * Declare some symbolic names for mesh smoothing algorithms. The meaning of
@@ -1688,11 +1691,14 @@ public:
    *
    * @ingroup boundary
    *
+   * @deprecated This method has been deprecated. Use
+   * Triangulation::set_manifold() instead.
+   *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   void set_boundary (const types::manifold_id   number,
-                     const Boundary<dim,spacedim> &boundary_object);
+                     const Boundary<dim,spacedim> &boundary_object) DEAL_II_DEPRECATED;
 
 
   /**
@@ -1703,10 +1709,13 @@ public:
    *
    * @ingroup boundary
    *
+   * @deprecated This method has been deprecated. Use
+   * Triangulation::set_manifold() instead.
+   *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  void set_boundary (const types::manifold_id number);
+  void set_boundary (const types::manifold_id number) DEAL_II_DEPRECATED;
 
   /**
    * Assign a manifold object to a certain part of the triangulation. If
@@ -1788,10 +1797,13 @@ public:
    *
    * @ingroup boundary
    *
+   * @deprecated This method has been deprecated. Use
+   * Triangulation::get_manifold() instead.
+   *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  const Boundary<dim,spacedim> &get_boundary (const types::manifold_id number) const;
+  const Boundary<dim,spacedim> &get_boundary (const types::manifold_id number) const DEAL_II_DEPRECATED;
 
   /**
    * Return a constant reference to a Manifold object used for this

--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -73,6 +73,9 @@ DEAL_II_NAMESPACE_OPEN
  * right into the middle of the given points, and HyperBallBoundary creating a
  * hyperball with given radius around a given center point.
  *
+ * @deprecated This class has been deprecated in favor of the more general
+ * Manifold class.
+ *
  * @ingroup boundary
  * @author Wolfgang Bangerth, 1999, 2001, 2009, Ralf Hartmann, 2001, 2008,
  * Luca Heltai, 2014
@@ -216,7 +219,7 @@ private:
    * Mutex for protecting the points array.
    */
   mutable Threads::Mutex mutex;
-};
+} DEAL_II_DEPRECATED;
 
 
 
@@ -229,6 +232,9 @@ private:
  * placing new points in the middle of old ones, it rather assumes that the
  * boundary of the domain is given by the polygon/polyhedron defined by the
  * boundary of the initial coarse triangulation.
+ *
+ * @deprecated This class has been deprecated in favor of the more general
+ * FlatManifold class.
  *
  * @ingroup boundary
  *
@@ -361,7 +367,7 @@ public:
   Point<spacedim>
   project_to_surface (const typename Triangulation<dim,spacedim>::hex_iterator &hex,
                       const Point<spacedim> &candidate) const;
-};
+} DEAL_II_DEPRECATED;
 
 
 

--- a/include/deal.II/grid/tria_boundary_lib.h
+++ b/include/deal.II/grid/tria_boundary_lib.h
@@ -41,6 +41,9 @@ DEAL_II_NAMESPACE_OPEN
  * which would seem natural, since this way we can use the
  * StraightBoundary::in_between() function.
  *
+ * @deprecated The boundary classes have been deprecated in favor of the more
+ * general Manifold classes.
+ *
  * @ingroup boundary
  *
  * @author Guido Kanschat, 2001, Wolfgang Bangerth, 2007
@@ -155,7 +158,7 @@ private:
    * Given a number for the axis, return a vector that denotes this direction.
    */
   static Point<spacedim> get_axis_vector (const unsigned int axis);
-};
+} DEAL_II_DEPRECATED;
 
 
 
@@ -188,6 +191,9 @@ private:
  *
  * @image html cone_2d.png
  * @image html cone_3d.png
+ *
+ * @deprecated The boundary classes have been deprecated in favor of the more
+ * general Manifold classes.
  *
  * @author Markus B&uuml;rg, 2009
  */
@@ -307,7 +313,7 @@ private:
   get_intermediate_points_between_points (const Point<dim> &p0,
                                           const Point<dim> &p1,
                                           std::vector<Point<dim> > &points) const;
-};
+} DEAL_II_DEPRECATED;
 
 
 
@@ -325,6 +331,9 @@ private:
  * StraightBoundary::in_between() function.
  *
  * @ingroup boundary
+ *
+ * @deprecated The boundary classes have been deprecated in favor of the more
+ * general Manifold classes.
  *
  * @author Wolfgang Bangerth, 1998, Ralf Hartmann, 2001
  */
@@ -450,7 +459,7 @@ private:
    */
   void get_intermediate_points_between_points (const Point<spacedim> &p0, const Point<spacedim> &p1,
                                                std::vector<Point<spacedim> > &points) const;
-};
+} DEAL_II_DEPRECATED;
 
 
 
@@ -463,6 +472,9 @@ private:
  * of rotation.
  *
  * @ingroup boundary
+ *
+ * @deprecated The boundary classes have been deprecated in favor of the more
+ * general Manifold classes.
  *
  * @author Wolfgang Bangerth, 1999, 2001
  */
@@ -517,7 +529,7 @@ public:
   virtual void
   get_normals_at_vertices (const typename Triangulation<dim>::face_iterator &face,
                            typename Boundary<dim>::FaceVertexNormals &face_vertex_normals) const;
-};
+} DEAL_II_DEPRECATED;
 
 
 
@@ -527,6 +539,9 @@ public:
  * computed automatically upon calling one of the virtual functions.
  *
  * @ingroup boundary
+ *
+ * @deprecated The boundary classes have been deprecated in favor of the more
+ * general Manifold classes.
  *
  * @author Wolfgang Bangerth, 1999
  */
@@ -541,7 +556,7 @@ public:
    * radius as argument. This radius will be ignored
    */
   HyperShellBoundary (const Point<dim> &center = Point<dim>());
-};
+} DEAL_II_DEPRECATED;
 
 
 
@@ -554,6 +569,9 @@ public:
  * rotation.
  *
  * @ingroup boundary
+ *
+ * @deprecated The boundary classes have been deprecated in favor of the more
+ * general Manifold classes.
  *
  * @author Wolfgang Bangerth, 2000, 2009
  */
@@ -620,7 +638,7 @@ private:
    */
   const double inner_radius;
   const double outer_radius;
-};
+} DEAL_II_DEPRECATED;
 
 
 /**
@@ -630,6 +648,9 @@ private:
  *
  * This class is only implemented for <tt>dim=2</tt>,<tt>spacedim=3</tt>, that
  * is, just the surface.
+ *
+ * @deprecated This class has been deprecated in favor of the more general
+ * Manifold class.
  */
 template <int dim, int spacedim>
 class TorusBoundary : public Boundary<dim,spacedim>
@@ -714,7 +735,7 @@ private:
    */
   const double R;
   const double r;
-};
+} DEAL_II_DEPRECATED;
 
 
 

--- a/include/deal.II/opencascade/boundary_lib.h
+++ b/include/deal.II/opencascade/boundary_lib.h
@@ -60,6 +60,9 @@ namespace OpenCASCADE
    * face would be collapsed to the edge, and your surrounding points would
    * not be lying on the given shape, raising an exception.
    *
+   * @deprecated This class has been deprecated in favor of the equivalent
+   * Manifold class.
+   *
    * @author Luca Heltai, Andrea Mola, 2011--2014.
    */
   template <int dim, int spacedim>
@@ -104,7 +107,7 @@ namespace OpenCASCADE
      * Relative tolerance used by this class to compute distances.
      */
     const double tolerance;
-  };
+  } DEAL_II_DEPRECATED;
 
   /**
    * A Boundary object based on OpenCASCADE TopoDS_Shape where new points are
@@ -124,6 +127,9 @@ namespace OpenCASCADE
    * the triangulation to be refined is close to the boundary of the given
    * TopoDS_Shape, or when the direction you use at construction time does not
    * intersect the shape. An exception is thrown when this happens.
+   *
+   * @deprecated This class has been deprecated in favor of the equivalent
+   * Manifold class.
    *
    * @author Luca Heltai, Andrea Mola, 2011--2014.
    */
@@ -170,7 +176,7 @@ namespace OpenCASCADE
      * Relative tolerance used by this class to compute distances.
      */
     const double tolerance;
-  };
+  } DEAL_II_DEPRECATED;
 
 
   /**
@@ -215,6 +221,9 @@ namespace OpenCASCADE
    * points does not intersect the shape.  An exception is thrown when this
    * happens.
    *
+   * @deprecated This class has been deprecated in favor of the equivalent
+   * Manifold class.
+   *
    * @author Luca Heltai, Andrea Mola, 2011--2014.
    */
   template <int dim, int spacedim>
@@ -252,7 +261,7 @@ namespace OpenCASCADE
      * Relative tolerance used by this class to compute distances.
      */
     const double tolerance;
-  };
+  } DEAL_II_DEPRECATED;
 
   /**
    * A Boundary object based on OpenCASCADE TopoDS_Shape objects which have


### PR DESCRIPTION
This was much easier than #4798.

Closes #4799. Part of #4921.