### PR TITLE
Relax polynomial degree in ShapeInfo test

### DIFF
--- a/tests/matrix_free/shape_info.cc
+++ b/tests/matrix_free/shape_info.cc
@@ -89,7 +89,7 @@ int main ()
 
   test(FE_DGQArbitraryNodes<2>(QIterated<1>(QTrapez<1>(), 1)), gauss3);
   test(FE_DGQArbitraryNodes<3>(QIterated<1>(QTrapez<1>(), 6)), gauss3);
-  test(FE_DGQArbitraryNodes<2>(QIterated<1>(QTrapez<1>(), 17)), gauss8);
+  test(FE_DGQArbitraryNodes<2>(QIterated<1>(QTrapez<1>(), 13)), gauss8);
   test(FE_DGQArbitraryNodes<2>(QGauss<1>(8)), gauss8);
   test(FE_DGQArbitraryNodes<2>(QGauss<1>(6)), gauss8);
 

--- a/tests/matrix_free/shape_info.output
+++ b/tests/matrix_free/shape_info.output
@@ -31,7 +31,7 @@ DEAL::Detected shape info type for FE_DGQ<2>(17): 2
 DEAL::Detected shape info type for FE_DGQ<2>(25): 2
 DEAL::Detected shape info type for FE_DGQ<2>(1): 2
 DEAL::Detected shape info type for FE_DGQArbitraryNodes<3>(QIterated(QTrapez(),6)): 2
-DEAL::Detected shape info type for FE_DGQArbitraryNodes<2>(QIterated(QTrapez(),17)): 2
+DEAL::Detected shape info type for FE_DGQArbitraryNodes<2>(QIterated(QTrapez(),13)): 2
 DEAL::Detected shape info type for FE_DGQArbitraryNodes<2>(QGauss(8)): 0
 DEAL::Detected shape info type for FE_DGQArbitraryNodes<2>(QGauss(6)): 2
 DEAL::Detected shape info type for FE_DGP<2>(1): 4


### PR DESCRIPTION
Lagrange polynomials of degree 17 on equidistant points are too bad. It is enough to test degree 13. Should make Intel compiler happy, see #4878.