### PR TITLE
Disable spuriuos intel warning

### DIFF
--- a/cmake/setup_compiler_flags_intel.cmake
+++ b/cmake/setup_compiler_flags_intel.cmake
@@ -56,7 +56,7 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-ansi")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-w2")
 
 #
-# Disable remarks:
+# Disable remarks like "Inlining inhibited by limit max-size"
 #
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-diag-disable=remark")
 

--- a/cmake/setup_compiler_flags_intel.cmake
+++ b/cmake/setup_compiler_flags_intel.cmake
@@ -56,6 +56,11 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-ansi")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-w2")
 
 #
+# Disable remarks:
+#
+ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-diag-disable=remark")
+
+#
 # Disable some warnings that lead to a lot of false positives:
 #
 #   -w21    type qualifiers are meaningless in this declaration
@@ -133,12 +138,16 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd15531")
 #   -w185 dynamic initialization in unreachable code
 #         When initializing a local variable in code
 #         that is executed only for one specific dimension
+#   -w186 pointless comparison of unsigned integer with zero
+#         The condition of for loops often depends on dim
+#         and happens to evaluate to zero sometimes
 #   -w280 selector expression is constant
 #         When writing 'switch(dim)'
 #
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd111")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd128")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd185")
+ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd186")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd280")
 
 


### PR DESCRIPTION
This restricts warnings from ICC18 to a reasonable level. In particular, the only ones left are 
``` 
include/deal.II/lac/la_vector.templates.h(325): warning #15552: loop was not vectorized with "simd"
include/deal.II/lac/vector.templates.h(715): warning #15552: loop was not vectorized with "simd"
include/deal.II/lac/vector.templates.h(755): warning #15552: loop was not vectorized with "simd"
include/deal.II/lac/la_parallel_vector.templates.h(1226): warning #15552: loop was not vectorized with "simd"
include/deal.II/lac/la_parallel_vector.templates.h(1250): warning #15552: loop was not vectorized with "simd"
source/base/mpi.cc(234): warning #1786: function "MPI_Type_struct" (declared at line 1817 of "/mnt/data/darndt/Sources/openmpi-intel-18/include/mpi.h") was declared deprecated ("MPI_Type_struct is superseded by                       MPI_Type_create_struct in MPI-2.0")
```
which seems to be fine.