### PR TITLE
Rename the scalar template type of Function and derived classes.

### DIFF
--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -111,24 +111,34 @@ template <int rank, int dim, typename Number> class TensorFunction;
  * convert the former to the latter.
  *
  *
- * <h3>Functions that return different fields</h3>
+ * <h3>Functions that return vectors of other data types</h3>
  *
  * Most of the time, your functions will have the form $f : \Omega \rightarrow
  * {\mathbb R}^{n_\text{components}}$. However, there are occasions where you
  * want the function to return vectors (or scalars) over a different number
  * field, for example functions that return complex numbers or vectors of
  * complex numbers: $f : \Omega \rightarrow {\mathbb
- * C}^{n_\text{components}}$. In such cases, you can use the second template
+ * C}^{n_\text{components}}$. In such cases, you can choose a value different
+ * than the default @p double for the second template
  * argument of this class: it describes the scalar type to be used for each
  * component of your return values. It defaults to @p double, but in the
  * example above, it could be set to <code>std::complex@<double@></code>.
  *
+ * @tparam dim The space dimension of the range space within which the domain
+ *   $\Omega$ of the function lies. Consequently, the function will be
+ *   evaluated at objects of type @p Point<dim>.
+ * @tparam RangeNumberType The scalar type of the vector space that is the range
+ *   (or image) of this function. As discussed above, objects of the current type
+ *   represent functions from ${\mathbb R}^\text{dim}$ to
+ *   $S^{n_\text{components}}$ where $S$ is the underlying scalar type of
+ *   the vector space. The type of $S$ is given by the @p RangeNumberType template
+ *   argument.
  *
  * @ingroup functions
  * @author Wolfgang Bangerth, 1998, 1999, Luca Heltai 2014
  */
-template <int dim, typename Number=double>
-class Function : public FunctionTime<Number>,
+template <int dim, typename RangeNumberType=double>
+class Function : public FunctionTime<RangeNumberType>,
   public Subscriptor
 {
 public:
@@ -149,7 +159,7 @@ public:
    * which defaults to zero.
    */
   Function (const unsigned int n_components = 1,
-            const Number       initial_time = 0.0);
+            const RangeNumberType  initial_time = 0.0);
 
   /**
    * Virtual destructor; absolutely necessary in this case.
@@ -188,8 +198,8 @@ public:
    * component you want to have evaluated; it defaults to zero, i.e. the first
    * component.
    */
-  virtual Number value (const Point<dim>   &p,
-                        const unsigned int  component = 0) const;
+  virtual RangeNumberType value (const Point<dim>   &p,
+                                 const unsigned int  component = 0) const;
 
   /**
    * Return all components of a vector-valued function at a given point.
@@ -199,7 +209,7 @@ public:
    * The default implementation will call value() for each component.
    */
   virtual void vector_value (const Point<dim>   &p,
-                             Vector<Number>     &values) const;
+                             Vector<RangeNumberType>     &values) const;
 
   /**
    * Set <tt>values</tt> to the point values of the specified component of the
@@ -211,7 +221,7 @@ public:
    * separately, to fill the output array.
    */
   virtual void value_list (const std::vector<Point<dim> > &points,
-                           std::vector<Number>            &values,
+                           std::vector<RangeNumberType>            &values,
                            const unsigned int              component = 0) const;
 
   /**
@@ -225,7 +235,7 @@ public:
    * separately, to fill the output array.
    */
   virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                  std::vector<Vector<Number> >   &values) const;
+                                  std::vector<Vector<RangeNumberType> >   &values) const;
 
   /**
    * For each component of the function, fill a vector of values, one for each
@@ -236,20 +246,20 @@ public:
    * can be reimplemented in derived classes to speed up performance.
    */
   virtual void vector_values (const std::vector<Point<dim> > &points,
-                              std::vector<std::vector<Number> > &values) const;
+                              std::vector<std::vector<RangeNumberType> > &values) const;
 
   /**
    * Return the gradient of the specified component of the function at the
    * given point.
    */
-  virtual Tensor<1,dim, Number> gradient (const Point<dim>   &p,
-                                          const unsigned int  component = 0) const;
+  virtual Tensor<1,dim, RangeNumberType> gradient (const Point<dim>   &p,
+                                                   const unsigned int  component = 0) const;
 
   /**
    * Return the gradient of all components of the function at the given point.
    */
   virtual void vector_gradient (const Point<dim>            &p,
-                                std::vector<Tensor<1,dim, Number> > &gradients) const;
+                                std::vector<Tensor<1,dim, RangeNumberType> > &gradients) const;
 
   /**
    * Set <tt>gradients</tt> to the gradients of the specified component of the
@@ -258,7 +268,7 @@ public:
    * array.
    */
   virtual void gradient_list (const std::vector<Point<dim> > &points,
-                              std::vector<Tensor<1,dim, Number> >    &gradients,
+                              std::vector<Tensor<1,dim, RangeNumberType> >    &gradients,
                               const unsigned int              component = 0) const;
 
   /**
@@ -270,7 +280,7 @@ public:
    * can be reimplemented in derived classes to speed up performance.
    */
   virtual void vector_gradients (const std::vector<Point<dim> >            &points,
-                                 std::vector<std::vector<Tensor<1,dim, Number> > > &gradients) const;
+                                 std::vector<std::vector<Tensor<1,dim, RangeNumberType> > > &gradients) const;
 
   /**
    * Set <tt>gradients</tt> to the gradients of the function at the
@@ -282,60 +292,60 @@ public:
    * the inner loop over the different components of the function.
    */
   virtual void vector_gradient_list (const std::vector<Point<dim> >            &points,
-                                     std::vector<std::vector<Tensor<1,dim, Number> > > &gradients) const;
+                                     std::vector<std::vector<Tensor<1,dim, RangeNumberType> > > &gradients) const;
 
   /**
    * Compute the Laplacian of a given component at point <tt>p</tt>.
    */
-  virtual Number laplacian (const Point<dim>   &p,
-                            const unsigned int  component = 0) const;
+  virtual RangeNumberType laplacian (const Point<dim>   &p,
+                                     const unsigned int  component = 0) const;
 
   /**
    * Compute the Laplacian of all components at point <tt>p</tt> and store
    * them in <tt>values</tt>.
    */
   virtual void vector_laplacian (const Point<dim>   &p,
-                                 Vector<Number>     &values) const;
+                                 Vector<RangeNumberType>     &values) const;
 
   /**
    * Compute the Laplacian of one component at a set of points.
    */
   virtual void laplacian_list (const std::vector<Point<dim> > &points,
-                               std::vector<Number>            &values,
+                               std::vector<RangeNumberType>            &values,
                                const unsigned int              component = 0) const;
 
   /**
    * Compute the Laplacians of all components at a set of points.
    */
   virtual void vector_laplacian_list (const std::vector<Point<dim> > &points,
-                                      std::vector<Vector<Number> >   &values) const;
+                                      std::vector<Vector<RangeNumberType> >   &values) const;
 
   /**
    * Compute the Hessian of a given component at point <tt>p</tt>, that is the
    * gradient of the gradient of the function.
    */
-  virtual SymmetricTensor<2,dim,Number> hessian (const Point<dim>   &p,
-                                                 const unsigned int          component = 0) const;
+  virtual SymmetricTensor<2,dim,RangeNumberType> hessian (const Point<dim>   &p,
+                                                          const unsigned int          component = 0) const;
 
   /**
    * Compute the Hessian of all components at point <tt>p</tt> and store them
    * in <tt>values</tt>.
    */
   virtual void vector_hessian (const Point<dim>                           &p,
-                               std::vector<SymmetricTensor<2,dim,Number> > &values) const;
+                               std::vector<SymmetricTensor<2,dim,RangeNumberType> > &values) const;
 
   /**
    * Compute the Hessian of one component at a set of points.
    */
   virtual void hessian_list (const std::vector<Point<dim> >              &points,
-                             std::vector<SymmetricTensor<2,dim,Number> > &values,
+                             std::vector<SymmetricTensor<2,dim,RangeNumberType> > &values,
                              const unsigned int                          component = 0) const;
 
   /**
    * Compute the Hessians of all components at a set of points.
    */
   virtual void vector_hessian_list (const std::vector<Point<dim> >                            &points,
-                                    std::vector<std::vector<SymmetricTensor<2,dim,Number> > > &values) const;
+                                    std::vector<std::vector<SymmetricTensor<2,dim,RangeNumberType> > > &values) const;
 
 
   /**
@@ -357,60 +367,60 @@ namespace Functions
    * @ingroup functions
    * @author Wolfgang Bangerth, 1998, 1999, Lei Qiao, 2015
    */
-  template <int dim, typename Number=double>
-  class ConstantFunction : public Function<dim, Number>
+  template <int dim, typename RangeNumberType=double>
+  class ConstantFunction : public Function<dim, RangeNumberType>
   {
   public:
     /**
      * Constructor; set values of all components to the provided one. The
      * default number of components is one.
      */
-    ConstantFunction (const Number       value,
+    ConstantFunction (const RangeNumberType       value,
                       const unsigned int n_components = 1);
 
     /**
-     * Constructor; takes an <tt>std::vector<Number></tt> object as an argument.
+     * Constructor; takes an <tt>std::vector<RangeNumberType></tt> object as an argument.
      * The number of components is determined by <tt>values.size()</tt>.
      */
-    ConstantFunction (const std::vector<Number> &values);
+    ConstantFunction (const std::vector<RangeNumberType> &values);
 
     /**
-     * Constructor; takes an <tt>Vector<Number></tt> object as an argument. The
+     * Constructor; takes an <tt>Vector<RangeNumberType></tt> object as an argument. The
      * number of components is determined by <tt>values.size()</tt>.
      */
-    ConstantFunction (const Vector<Number> &values);
+    ConstantFunction (const Vector<RangeNumberType> &values);
 
     /**
      * Constructor; uses whatever stores in [begin_ptr, begin_ptr+n_components)
      * to initialize a new object.
      */
-    ConstantFunction (const Number *begin_ptr, const unsigned int n_components);
+    ConstantFunction (const RangeNumberType *begin_ptr, const unsigned int n_components);
 
-    virtual Number value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+    virtual RangeNumberType value (const Point<dim>   &p,
+                                   const unsigned int  component = 0) const;
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<Number>   &return_value) const;
+                               Vector<RangeNumberType>   &return_value) const;
 
     virtual void value_list (const std::vector<Point<dim> > &points,
-                             std::vector<Number>            &return_values,
+                             std::vector<RangeNumberType>            &return_values,
                              const unsigned int              component = 0) const;
 
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<Number> >   &return_values) const;
+                                    std::vector<Vector<RangeNumberType> >   &return_values) const;
 
-    virtual Tensor<1,dim, Number> gradient (const Point<dim> &p,
-                                            const unsigned int component = 0) const;
+    virtual Tensor<1,dim, RangeNumberType> gradient (const Point<dim> &p,
+                                                     const unsigned int component = 0) const;
 
     virtual void vector_gradient (const Point<dim>            &p,
-                                  std::vector<Tensor<1,dim, Number> > &gradients) const;
+                                  std::vector<Tensor<1,dim, RangeNumberType> > &gradients) const;
 
     virtual void gradient_list (const std::vector<Point<dim> > &points,
-                                std::vector<Tensor<1,dim, Number> >    &gradients,
+                                std::vector<Tensor<1,dim, RangeNumberType> >    &gradients,
                                 const unsigned int              component = 0) const;
 
     virtual void vector_gradient_list (const std::vector<Point<dim> >            &points,
-                                       std::vector<std::vector<Tensor<1,dim, Number> > > &gradients) const;
+                                       std::vector<std::vector<Tensor<1,dim, RangeNumberType> > > &gradients) const;
 
     std::size_t memory_consumption () const;
 
@@ -418,7 +428,7 @@ namespace Functions
     /**
      * Store the constant function value vector.
      */
-    std::vector<Number> function_value_vector;
+    std::vector<RangeNumberType> function_value_vector;
   };
 
 
@@ -435,15 +445,14 @@ namespace Functions
    * @ingroup functions
    * @author Wolfgang Bangerth, 1998, 1999
    */
-  template <int dim, typename Number=double>
-  class ZeroFunction : public ConstantFunction<dim, Number>
+  template <int dim, typename RangeNumberType=double>
+  class ZeroFunction : public ConstantFunction<dim, RangeNumberType>
   {
   public:
     /**
      * Constructor. The number of components is preset to one.
      */
     ZeroFunction (const unsigned int n_components = 1);
-
   };
 
 }
@@ -454,16 +463,16 @@ namespace Functions
  *
  * @deprecated use Functions::ConstantFunction instead.
  */
-template <int dim, typename Number=double>
-using ConstantFunction DEAL_II_DEPRECATED = Functions::ConstantFunction<dim,Number>;
+template <int dim, typename RangeNumberType=double>
+using ConstantFunction DEAL_II_DEPRECATED = Functions::ConstantFunction<dim,RangeNumberType>;
 
 /**
  * Provide a function which always returns zero.
  *
  * @deprecated use Functions::ZeroFunction instead.
  */
-template <int dim, typename Number=double>
-using ZeroFunction DEAL_II_DEPRECATED = Functions::ZeroFunction<dim,Number>;
+template <int dim, typename RangeNumberType=double>
+using ZeroFunction DEAL_II_DEPRECATED = Functions::ZeroFunction<dim,RangeNumberType>;
 
 
 
@@ -481,8 +490,8 @@ using ZeroFunction DEAL_II_DEPRECATED = Functions::ZeroFunction<dim,Number>;
  * @ingroup functions
  * @author Guido Kanschat, 2000, Wolfgang Bangerth 2006
  */
-template <int dim, typename Number=double>
-class ComponentSelectFunction : public ConstantFunction<dim, Number>
+template <int dim, typename RangeNumberType=double>
+class ComponentSelectFunction : public ConstantFunction<dim, RangeNumberType>
 {
 public:
   /**
@@ -491,7 +500,7 @@ public:
    * number of vector components.
    */
   ComponentSelectFunction (const unsigned int selected,
-                           const Number       value,
+                           const RangeNumberType       value,
                            const unsigned int n_components);
 
   /**
@@ -514,24 +523,24 @@ public:
 
   /**
    * Substitute function value with value of a <tt>ConstantFunction@<dim,
-   * Number@></tt> object and keep the current selection pattern.
+   * RangeNumberType@></tt> object and keep the current selection pattern.
    *
    * This is useful if you want to have different values in different
    * components since the provided constructors of
-   * <tt>ComponentSelectFunction@<dim, Number@></tt> class can only have same
+   * <tt>ComponentSelectFunction@<dim, RangeNumberType@></tt> class can only have same
    * value for all components.
    *
    * @note: we copy the underlying component value data from @p f from its
    * beginning. So the number of components of @p f cannot be less than the
    * calling object.
    */
-  virtual void substitute_function_value_with (const Functions::ConstantFunction<dim, Number> &f);
+  virtual void substitute_function_value_with (const Functions::ConstantFunction<dim, RangeNumberType> &f);
 
   /**
    * Return the value of the function at the given point for all components.
    */
   virtual void vector_value (const Point<dim> &p,
-                             Vector<Number>   &return_value) const;
+                             Vector<RangeNumberType>   &return_value) const;
 
   /**
    * Set <tt>values</tt> to the point values of the function at the
@@ -540,7 +549,7 @@ public:
    * array.
    */
   virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                  std::vector<Vector<Number> >   &values) const;
+                                  std::vector<Vector<RangeNumberType> >   &values) const;
 
   /**
    * Return an estimate for the memory consumption, in bytes, of this object.
@@ -561,7 +570,7 @@ protected:
 /**
  * This class provides a way to convert a scalar function of the kind
  * @code
- *   Number foo (const Point<dim> &);
+ *   RangeNumberType foo (const Point<dim> &);
  * @endcode
  * into an object of type Function@<dim@>. Since the argument returns a
  * scalar, the result is clearly a Function object for which
@@ -587,11 +596,12 @@ protected:
  * argument. For example, if you need a Function object that returns the norm
  * of a point, you could write it like so:
  * @code
- *   template <int dim, typename Number>
- *   class Norm : public Function<dim, Number> {
+ *   template <int dim, typename RangeNumberType>
+ *   class Norm : public Function<dim, RangeNumberType> {
  *     public:
- *       virtual Number value (const Point<dim> &p,
- *                             const unsigned int component) const {
+ *       virtual RangeNumberType value (const Point<dim> &p,
+ *                                  const unsigned int component) const
+ *       {
  *         Assert (component == 0, ExcMessage ("This object is scalar!"));
  *         return p.norm();
  *       }
@@ -602,18 +612,19 @@ protected:
  * and then pass the <code>my_norm_object</code> around, or you could write it
  * like so:
  * @code
- *   ScalarFunctionFromFunctionObject<dim, Number> my_norm_object (&Point<dim>::norm);
+ *   ScalarFunctionFromFunctionObject<dim, RangeNumberType> my_norm_object (&Point<dim>::norm);
  * @endcode
  *
  * Similarly, to generate an object that computes the distance to a point
  * <code>q</code>, we could do this:
  * @code
- *   template <int dim, typename Number>
- *   class DistanceTo : public Function<dim, Number> {
+ *   template <int dim, typename RangeNumberType>
+ *   class DistanceTo : public Function<dim, RangeNumberType> {
  *     public:
  *       DistanceTo (const Point<dim> &q) : q(q) {}
- *       virtual Number value (const Point<dim> &p,
- *                             const unsigned int component) const {
+ *       virtual RangeNumberType value (const Point<dim> &p,
+ *                                  const unsigned int component) const
+ *       {
  *         Assert (component == 0, ExcMessage ("This object is scalar!"));
  *         return q.distance(p);
  *       }
@@ -626,7 +637,7 @@ protected:
  * @endcode
  * or we could write it like so:
  * @code
- *    ScalarFunctionFromFunctionObject<dim, Number>
+ *    ScalarFunctionFromFunctionObject<dim, RangeNumberType>
  *      my_distance_object (std::bind (&Point<dim>::distance,
  *                                           q,
  *                                           std::placeholders::_1));
@@ -635,30 +646,30 @@ protected:
  *
  * @author Wolfgang Bangerth, 2011
  */
-template <int dim, typename Number=double>
-class ScalarFunctionFromFunctionObject : public Function<dim, Number>
+template <int dim, typename RangeNumberType=double>
+class ScalarFunctionFromFunctionObject : public Function<dim, RangeNumberType>
 {
 public:
   /**
-   * Given a function object that takes a Point and returns a Number value,
-   * convert this into an object that matches the Function<dim, Number>
+   * Given a function object that takes a Point and returns a RangeNumberType value,
+   * convert this into an object that matches the Function<dim, RangeNumberType>
    * interface.
    */
-  ScalarFunctionFromFunctionObject (const std::function<Number (const Point<dim> &)> &function_object);
+  ScalarFunctionFromFunctionObject (const std::function<RangeNumberType (const Point<dim> &)> &function_object);
 
   /**
    * Return the value of the function at the given point. Returns the value
    * the function given to the constructor produces for this point.
    */
-  virtual Number value (const Point<dim>   &p,
-                        const unsigned int  component = 0) const;
+  virtual RangeNumberType value (const Point<dim>   &p,
+                                 const unsigned int  component = 0) const;
 
 private:
   /**
    * The function object which we call when this class's value() or
    * value_list() functions are called.
    */
-  const std::function<Number (const Point<dim> &)> function_object;
+  const std::function<RangeNumberType (const Point<dim> &)> function_object;
 };
 
 
@@ -683,7 +694,7 @@ private:
  *
  * To be more concrete, let us consider the following example:
  * @code
- *   Number one (const Point<2> &p) { return 1; }
+ *   RangeNumberType one (const Point<2> &p) { return 1; }
  *   VectorFunctionFromScalarFunctionObject<2>
  *      component_mask (&one, 1, 3);
  * @endcode
@@ -696,12 +707,12 @@ private:
  *
  * @author Wolfgang Bangerth, 2011
  */
-template <int dim, typename Number=double>
-class VectorFunctionFromScalarFunctionObject : public Function<dim, Number>
+template <int dim, typename RangeNumberType=double>
+class VectorFunctionFromScalarFunctionObject : public Function<dim, RangeNumberType>
 {
 public:
   /**
-   * Given a function object that takes a Point and returns a Number value,
+   * Given a function object that takes a Point and returns a RangeNumberType value,
    * convert this into an object that matches the Function@<dim@> interface.
    *
    * @param function_object The scalar function that will form one component
@@ -711,7 +722,7 @@ public:
    * @param selected_component The single component that should be filled by
    * the first argument.
    */
-  VectorFunctionFromScalarFunctionObject (const std::function<Number (const Point<dim> &)> &function_object,
+  VectorFunctionFromScalarFunctionObject (const std::function<RangeNumberType (const Point<dim> &)> &function_object,
                                           const unsigned int selected_component,
                                           const unsigned int n_components);
 
@@ -719,8 +730,8 @@ public:
    * Return the value of the function at the given point. Returns the value
    * the function given to the constructor produces for this point.
    */
-  virtual Number value (const Point<dim>   &p,
-                        const unsigned int  component = 0) const;
+  virtual RangeNumberType value (const Point<dim>   &p,
+                                 const unsigned int  component = 0) const;
 
   /**
    * Return all components of a vector-valued function at a given point.
@@ -728,14 +739,14 @@ public:
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
    */
   virtual void vector_value (const Point<dim>   &p,
-                             Vector<Number>     &values) const;
+                             Vector<RangeNumberType>     &values) const;
 
 private:
   /**
    * The function object which we call when this class's value() or
    * value_list() functions are called.
    */
-  const std::function<Number (const Point<dim> &)> function_object;
+  const std::function<RangeNumberType (const Point<dim> &)> function_object;
 
   /**
    * The vector component whose value is to be filled by the given scalar
@@ -747,7 +758,7 @@ private:
 
 /**
  * This class is built as a means of translating the <code>Tensor<1,dim,
- * Number> </code> values produced by objects of type TensorFunction and
+ * RangeNumberType> </code> values produced by objects of type TensorFunction and
  * returning them as a multiple component version of the same thing as a
  * Vector for use in, for example, the VectorTools::interpolate or the many
  * other functions taking Function objects. It allows the user to place the
@@ -757,11 +768,11 @@ private:
  *
  * For example: Say you created a class called
  *  @code
- *    class RightHandSide : public TensorFunction<rank,dim, Number>
+ *    class RightHandSide : public TensorFunction<rank,dim, RangeNumberType>
  *  @endcode
  * which extends the TensorFunction class and you have an object
  *  @code
- *    RightHandSide<1,dim, Number> rhs;
+ *    RightHandSide<1,dim, RangeNumberType> rhs;
  *  @endcode
  * of that class which you want to interpolate onto your mesh using the
  * VectorTools::interpolate function, but the finite element you use for the
@@ -771,21 +782,21 @@ private:
  * components. Creating such an object from the existing <code>rhs</code>
  * object is done using this piece of code:
  *  @code
- *      RighHandSide<1,dim, Number> rhs;
- *      VectorFunctionFromTensorFunction<dim, Number> rhs_vector_function (rhs, 0, 3*dim);
+ *      RighHandSide<1,dim, RangeNumberType> rhs;
+ *      VectorFunctionFromTensorFunction<dim, RangeNumberType> rhs_vector_function (rhs, 0, 3*dim);
  *  @endcode
  * where the <code>dim</code> components of the tensor function are placed
  * into the first <code>dim</code> components of the function object.
  *
  * @author Spencer Patty, 2013
  */
-template <int dim, typename Number=double>
-class VectorFunctionFromTensorFunction : public Function<dim, Number>
+template <int dim, typename RangeNumberType=double>
+class VectorFunctionFromTensorFunction : public Function<dim, RangeNumberType>
 {
 public:
   /**
    * Given a TensorFunction object that takes a <tt>Point</tt> and returns a
-   * <tt>Tensor<1,dim, Number></tt> value, convert this into an object that
+   * <tt>Tensor<1,dim, RangeNumberType></tt> value, convert this into an object that
    * matches the Function@<dim@> interface.
    *
    * By default, create a Vector object of the same size as
@@ -799,7 +810,7 @@ public:
    * the first argument.  This should be such that the entire tensor_function
    * fits inside the <tt>n_component</tt> length return vector.
    */
-  VectorFunctionFromTensorFunction (const TensorFunction<1,dim, Number> &tensor_function,
+  VectorFunctionFromTensorFunction (const TensorFunction<1,dim, RangeNumberType> &tensor_function,
                                     const unsigned int selected_component=0,
                                     const unsigned int n_components=dim);
 
@@ -812,8 +823,8 @@ public:
   /**
    * Return a single component of a vector-valued function at a given point.
    */
-  virtual Number value (const Point<dim> &p,
-                        const unsigned int component = 0) const;
+  virtual RangeNumberType value (const Point<dim> &p,
+                                 const unsigned int component = 0) const;
 
   /**
    * Return all components of a vector-valued function at a given point.
@@ -821,7 +832,7 @@ public:
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
    */
   virtual void vector_value (const Point<dim> &p,
-                             Vector<Number>   &values) const;
+                             Vector<RangeNumberType>   &values) const;
 
   /**
    * Return all components of a vector-valued function at a list of points.
@@ -831,20 +842,20 @@ public:
    * function
    */
   virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                  std::vector<Vector<Number> >   &value_list) const;
+                                  std::vector<Vector<RangeNumberType> >   &value_list) const;
 
 private:
   /**
    * The TensorFunction object which we call when this class's vector_value()
    * or vector_value_list() functions are called.
    */
-  const TensorFunction<1,dim,Number> &tensor_function;
+  const TensorFunction<1,dim,RangeNumberType> &tensor_function;
 
   /**
    * The first vector component whose value is to be filled by the given
    * TensorFunction.  The values will be placed in components
    * selected_component to selected_component+dim-1 for a
-   * <tt>TensorFunction<1,dim, Number></tt> object.
+   * <tt>TensorFunction<1,dim, RangeNumberType></tt> object.
    */
   const unsigned int selected_component;
 };
@@ -856,9 +867,9 @@ private:
 //
 // The destructor is pure virtual so we can't default it
 // in the declaration.
-template <int dim, typename Number>
+template <int dim, typename RangeNumberType>
 inline
-Function<dim, Number>::~Function () = default;
+Function<dim, RangeNumberType>::~Function () = default;
 #endif
 
 

--- a/include/deal.II/base/function.templates.h
+++ b/include/deal.II/base/function.templates.h
@@ -27,15 +27,15 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <int dim, typename Number>
-const unsigned int Function<dim, Number>::dimension;
+template <int dim, typename RangeNumberType>
+const unsigned int Function<dim, RangeNumberType>::dimension;
 
 
-template <int dim, typename Number>
-Function<dim, Number>::Function (const unsigned int n_components,
-                                 const Number       initial_time)
+template <int dim, typename RangeNumberType>
+Function<dim, RangeNumberType>::Function (const unsigned int n_components,
+                                          const RangeNumberType       initial_time)
   :
-  FunctionTime<Number>(initial_time),
+  FunctionTime<RangeNumberType>(initial_time),
   n_components(n_components)
 {
   // avoid the construction of function objects that don't return any
@@ -46,8 +46,8 @@ Function<dim, Number>::Function (const unsigned int n_components,
 
 
 
-template <int dim, typename Number>
-Function<dim, Number> &Function<dim, Number>::operator= (const Function &f)
+template <int dim, typename RangeNumberType>
+Function<dim, RangeNumberType> &Function<dim, RangeNumberType>::operator= (const Function &f)
 {
   (void)f;
   AssertDimension (n_components, f.n_components);
@@ -55,18 +55,18 @@ Function<dim, Number> &Function<dim, Number>::operator= (const Function &f)
 }
 
 
-template <int dim, typename Number>
-Number Function<dim, Number>::value (const Point<dim> &,
-                                     const unsigned int) const
+template <int dim, typename RangeNumberType>
+RangeNumberType Function<dim, RangeNumberType>::value (const Point<dim> &,
+                                                       const unsigned int) const
 {
   Assert (false, ExcPureFunctionCalled());
   return 0;
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::vector_value (const Point<dim> &p,
-                                          Vector<Number> &v) const
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::vector_value (const Point<dim> &p,
+                                                   Vector<RangeNumberType> &v) const
 {
   AssertDimension(v.size(), this->n_components);
   for (unsigned int i=0; i<this->n_components; ++i)
@@ -74,10 +74,10 @@ void Function<dim, Number>::vector_value (const Point<dim> &p,
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::value_list (const std::vector<Point<dim> > &points,
-                                        std::vector<Number>            &values,
-                                        const unsigned int              component) const
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::value_list (const std::vector<Point<dim> > &points,
+                                                 std::vector<RangeNumberType>            &values,
+                                                 const unsigned int              component) const
 {
   // check whether component is in the valid range is up to the derived
   // class
@@ -89,9 +89,9 @@ void Function<dim, Number>::value_list (const std::vector<Point<dim> > &points,
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::vector_value_list (const std::vector<Point<dim> > &points,
-                                               std::vector<Vector<Number> >   &values) const
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::vector_value_list (const std::vector<Point<dim> > &points,
+                                                        std::vector<Vector<RangeNumberType> >   &values) const
 {
   // check whether component is in the valid range is up to the derived
   // class
@@ -103,10 +103,10 @@ void Function<dim, Number>::vector_value_list (const std::vector<Point<dim> > &p
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::vector_values (
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::vector_values (
   const std::vector<Point<dim> > &points,
-  std::vector<std::vector<Number> > &values) const
+  std::vector<std::vector<RangeNumberType> > &values) const
 {
   const unsigned int n = this->n_components;
   AssertDimension (values.size(), n);
@@ -115,19 +115,19 @@ void Function<dim, Number>::vector_values (
 }
 
 
-template <int dim, typename Number>
-Tensor<1,dim,Number> Function<dim, Number>::gradient (const Point<dim> &,
-                                                      const unsigned int) const
+template <int dim, typename RangeNumberType>
+Tensor<1,dim,RangeNumberType> Function<dim, RangeNumberType>::gradient (const Point<dim> &,
+    const unsigned int) const
 {
   Assert (false, ExcPureFunctionCalled());
-  return Tensor<1,dim,Number>();
+  return Tensor<1,dim,RangeNumberType>();
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::vector_gradient (
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::vector_gradient (
   const Point<dim> &p,
-  std::vector<Tensor<1,dim,Number> > &v) const
+  std::vector<Tensor<1,dim,RangeNumberType> > &v) const
 {
   AssertDimension(v.size(), this->n_components);
   for (unsigned int i=0; i<this->n_components; ++i)
@@ -135,10 +135,10 @@ void Function<dim, Number>::vector_gradient (
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::gradient_list (
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::gradient_list (
   const std::vector<Point<dim> >     &points,
-  std::vector<Tensor<1,dim,Number> > &gradients,
+  std::vector<Tensor<1,dim,RangeNumberType> > &gradients,
   const unsigned int                  component) const
 {
   Assert (gradients.size() == points.size(),
@@ -149,10 +149,10 @@ void Function<dim, Number>::gradient_list (
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::vector_gradient_list (
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::vector_gradient_list (
   const std::vector<Point<dim> >                   &points,
-  std::vector<std::vector<Tensor<1,dim,Number> > > &gradients) const
+  std::vector<std::vector<Tensor<1,dim,RangeNumberType> > > &gradients) const
 {
   Assert (gradients.size() == points.size(),
           ExcDimensionMismatch(gradients.size(), points.size()));
@@ -166,10 +166,10 @@ void Function<dim, Number>::vector_gradient_list (
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::vector_gradients (
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::vector_gradients (
   const std::vector<Point<dim> > &points,
-  std::vector<std::vector<Tensor<1,dim,Number> > > &values) const
+  std::vector<std::vector<Tensor<1,dim,RangeNumberType> > > &values) const
 {
   const unsigned int n = this->n_components;
   AssertDimension (values.size(), n);
@@ -179,28 +179,28 @@ void Function<dim, Number>::vector_gradients (
 
 
 
-template <int dim, typename Number>
-Number Function<dim, Number>::laplacian (const Point<dim> &,
-                                         const unsigned int) const
+template <int dim, typename RangeNumberType>
+RangeNumberType Function<dim, RangeNumberType>::laplacian (const Point<dim> &,
+                                                           const unsigned int) const
 {
   Assert (false, ExcPureFunctionCalled());
   return 0;
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::vector_laplacian (const Point<dim> &,
-                                              Vector<Number> &) const
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::vector_laplacian (const Point<dim> &,
+                                                       Vector<RangeNumberType> &) const
 {
   Assert (false, ExcPureFunctionCalled());
 }
 
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::laplacian_list (
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::laplacian_list (
   const std::vector<Point<dim> > &points,
-  std::vector<Number>            &laplacians,
+  std::vector<RangeNumberType>            &laplacians,
   const unsigned int              component) const
 {
   // check whether component is in the valid range is up to the derived
@@ -213,10 +213,10 @@ void Function<dim, Number>::laplacian_list (
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::vector_laplacian_list (
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::vector_laplacian_list (
   const std::vector<Point<dim> > &points,
-  std::vector<Vector<Number> >   &laplacians) const
+  std::vector<Vector<RangeNumberType> >   &laplacians) const
 {
   // check whether component is in the valid range is up to the derived
   // class
@@ -228,19 +228,19 @@ void Function<dim, Number>::vector_laplacian_list (
 }
 
 
-template <int dim, typename Number>
-SymmetricTensor<2,dim,Number> Function<dim, Number>::hessian (const Point<dim> &,
+template <int dim, typename RangeNumberType>
+SymmetricTensor<2,dim,RangeNumberType> Function<dim, RangeNumberType>::hessian (const Point<dim> &,
     const unsigned int) const
 {
   Assert (false, ExcPureFunctionCalled());
-  return SymmetricTensor<2,dim,Number>();
+  return SymmetricTensor<2,dim,RangeNumberType>();
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::vector_hessian (
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::vector_hessian (
   const Point<dim> &p,
-  std::vector<SymmetricTensor<2,dim,Number> > &v) const
+  std::vector<SymmetricTensor<2,dim,RangeNumberType> > &v) const
 {
   AssertDimension(v.size(), this->n_components);
   for (unsigned int i=0; i<this->n_components; ++i)
@@ -248,10 +248,10 @@ void Function<dim, Number>::vector_hessian (
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::hessian_list (
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::hessian_list (
   const std::vector<Point<dim> >     &points,
-  std::vector<SymmetricTensor<2,dim,Number> > &hessians,
+  std::vector<SymmetricTensor<2,dim,RangeNumberType> > &hessians,
   const unsigned int                  component) const
 {
   Assert (hessians.size() == points.size(),
@@ -262,10 +262,10 @@ void Function<dim, Number>::hessian_list (
 }
 
 
-template <int dim, typename Number>
-void Function<dim, Number>::vector_hessian_list (
+template <int dim, typename RangeNumberType>
+void Function<dim, RangeNumberType>::vector_hessian_list (
   const std::vector<Point<dim> >                   &points,
-  std::vector<std::vector<SymmetricTensor<2,dim,Number> > > &hessians) const
+  std::vector<std::vector<SymmetricTensor<2,dim,RangeNumberType> > > &hessians) const
 {
   Assert (hessians.size() == points.size(),
           ExcDimensionMismatch(hessians.size(), points.size()));
@@ -280,9 +280,9 @@ void Function<dim, Number>::vector_hessian_list (
 
 
 
-template <int dim, typename Number>
+template <int dim, typename RangeNumberType>
 std::size_t
-Function<dim, Number>::memory_consumption () const
+Function<dim, RangeNumberType>::memory_consumption () const
 {
   // only simple data elements, so use sizeof operator
   return sizeof (*this);
@@ -295,10 +295,10 @@ Function<dim, Number>::memory_consumption () const
 namespace Functions
 {
 
-  template <int dim, typename Number>
-  ZeroFunction<dim, Number>::ZeroFunction (const unsigned int n_components)
+  template <int dim, typename RangeNumberType>
+  ZeroFunction<dim, RangeNumberType>::ZeroFunction (const unsigned int n_components)
     :
-    ConstantFunction<dim, Number> (Number(), n_components)
+    ConstantFunction<dim, RangeNumberType> (RangeNumberType(), n_components)
   {}
 
 }
@@ -308,28 +308,28 @@ namespace Functions
 namespace Functions
 {
 
-  template <int dim, typename Number>
-  ConstantFunction<dim, Number>::ConstantFunction (const Number value,
-                                                   const unsigned int n_components)
+  template <int dim, typename RangeNumberType>
+  ConstantFunction<dim, RangeNumberType>::ConstantFunction (const RangeNumberType value,
+                                                            const unsigned int n_components)
     :
-    Function<dim, Number> (n_components),
+    Function<dim, RangeNumberType> (n_components),
     function_value_vector (n_components, value)
   {}
 
-  template <int dim, typename Number>
-  ConstantFunction<dim, Number>::
-  ConstantFunction (const std::vector<Number> &values)
+  template <int dim, typename RangeNumberType>
+  ConstantFunction<dim, RangeNumberType>::
+  ConstantFunction (const std::vector<RangeNumberType> &values)
     :
-    Function<dim, Number> (values.size()),
+    Function<dim, RangeNumberType> (values.size()),
     function_value_vector (values)
   {}
 
 
-  template <int dim, typename Number>
-  ConstantFunction<dim, Number>::
-  ConstantFunction (const Vector<Number> &values)
+  template <int dim, typename RangeNumberType>
+  ConstantFunction<dim, RangeNumberType>::
+  ConstantFunction (const Vector<RangeNumberType> &values)
     :
-    Function<dim, Number> (values.size()),
+    Function<dim, RangeNumberType> (values.size()),
     function_value_vector (values.size())
   {
     Assert (values.size() == function_value_vector.size(),
@@ -338,11 +338,11 @@ namespace Functions
   }
 
 
-  template <int dim, typename Number>
-  ConstantFunction<dim, Number>::
-  ConstantFunction (const Number *begin_ptr, const unsigned int n_components)
+  template <int dim, typename RangeNumberType>
+  ConstantFunction<dim, RangeNumberType>::
+  ConstantFunction (const RangeNumberType *begin_ptr, const unsigned int n_components)
     :
-    Function<dim, Number> (n_components),
+    Function<dim, RangeNumberType> (n_components),
     function_value_vector (n_components)
   {
     Assert (begin_ptr != nullptr, ExcMessage ("Null pointer encountered!"));
@@ -351,9 +351,9 @@ namespace Functions
 
 
 
-  template <int dim, typename Number>
-  Number ConstantFunction<dim, Number>::value (const Point<dim> &,
-                                               const unsigned int component) const
+  template <int dim, typename RangeNumberType>
+  RangeNumberType ConstantFunction<dim, RangeNumberType>::value (const Point<dim> &,
+      const unsigned int component) const
   {
     Assert (component < this->n_components,
             ExcIndexRange (component, 0, this->n_components));
@@ -362,9 +362,9 @@ namespace Functions
 
 
 
-  template <int dim, typename Number>
-  void ConstantFunction<dim, Number>::vector_value (const Point<dim> &,
-                                                    Vector<Number>   &return_value) const
+  template <int dim, typename RangeNumberType>
+  void ConstantFunction<dim, RangeNumberType>::vector_value (const Point<dim> &,
+                                                             Vector<RangeNumberType>   &return_value) const
   {
     Assert (return_value.size() == this->n_components,
             ExcDimensionMismatch (return_value.size(), this->n_components));
@@ -375,10 +375,10 @@ namespace Functions
 
 
 
-  template <int dim, typename Number>
-  void ConstantFunction<dim, Number>::value_list (
+  template <int dim, typename RangeNumberType>
+  void ConstantFunction<dim, RangeNumberType>::value_list (
     const std::vector<Point<dim> > &points,
-    std::vector<Number>            &return_values,
+    std::vector<RangeNumberType>            &return_values,
     const unsigned int              component) const
   {
     // To avoid warning of unused parameter
@@ -393,10 +393,10 @@ namespace Functions
 
 
 
-  template <int dim, typename Number>
-  void ConstantFunction<dim, Number>::vector_value_list (
+  template <int dim, typename RangeNumberType>
+  void ConstantFunction<dim, RangeNumberType>::vector_value_list (
     const std::vector<Point<dim> > &points,
-    std::vector<Vector<Number> >   &return_values) const
+    std::vector<Vector<RangeNumberType> >   &return_values) const
   {
     Assert (return_values.size() == points.size(),
             ExcDimensionMismatch(return_values.size(), points.size()));
@@ -412,28 +412,28 @@ namespace Functions
 
 
 
-  template <int dim, typename Number>
+  template <int dim, typename RangeNumberType>
   std::size_t
-  ConstantFunction<dim, Number>::memory_consumption () const
+  ConstantFunction<dim, RangeNumberType>::memory_consumption () const
   {
-    // Here we assume Number is a simple type.
-    return (sizeof(*this) + this->n_components*sizeof(Number));
+    // Here we assume RangeNumberType is a simple type.
+    return (sizeof(*this) + this->n_components*sizeof(RangeNumberType));
   }
 
 
 
-  template <int dim, typename Number>
-  Tensor<1,dim,Number> ConstantFunction<dim, Number>::gradient (const Point<dim> &,
+  template <int dim, typename RangeNumberType>
+  Tensor<1,dim,RangeNumberType> ConstantFunction<dim, RangeNumberType>::gradient (const Point<dim> &,
       const unsigned int) const
   {
-    return Tensor<1,dim,Number>();
+    return Tensor<1,dim,RangeNumberType>();
   }
 
 
-  template <int dim, typename Number>
-  void ConstantFunction<dim, Number>::vector_gradient (
+  template <int dim, typename RangeNumberType>
+  void ConstantFunction<dim, RangeNumberType>::vector_gradient (
     const Point<dim> &,
-    std::vector<Tensor<1,dim,Number> > &gradients) const
+    std::vector<Tensor<1,dim,RangeNumberType> > &gradients) const
   {
     Assert (gradients.size() == this->n_components,
             ExcDimensionMismatch(gradients.size(), this->n_components));
@@ -443,10 +443,10 @@ namespace Functions
   }
 
 
-  template <int dim, typename Number>
-  void ConstantFunction<dim, Number>::gradient_list (
+  template <int dim, typename RangeNumberType>
+  void ConstantFunction<dim, RangeNumberType>::gradient_list (
     const std::vector<Point<dim> >     &points,
-    std::vector<Tensor<1,dim,Number> > &gradients,
+    std::vector<Tensor<1,dim,RangeNumberType> > &gradients,
     const unsigned int                  /*component*/) const
   {
     Assert (gradients.size() == points.size(),
@@ -457,10 +457,10 @@ namespace Functions
   }
 
 
-  template <int dim, typename Number>
-  void ConstantFunction<dim, Number>::vector_gradient_list (
+  template <int dim, typename RangeNumberType>
+  void ConstantFunction<dim, RangeNumberType>::vector_gradient_list (
     const std::vector<Point<dim> >                   &points,
-    std::vector<std::vector<Tensor<1,dim,Number> > > &gradients) const
+    std::vector<std::vector<Tensor<1,dim,RangeNumberType> > > &gradients) const
   {
     Assert (gradients.size() == points.size(),
             ExcDimensionMismatch(gradients.size(), points.size()));
@@ -478,24 +478,24 @@ namespace Functions
 
 //---------------------------------------------------------------------------
 
-template <int dim, typename Number>
-ComponentSelectFunction<dim, Number>::
+template <int dim, typename RangeNumberType>
+ComponentSelectFunction<dim, RangeNumberType>::
 ComponentSelectFunction (const unsigned int selected,
-                         const Number value,
+                         const RangeNumberType value,
                          const unsigned int n_components)
   :
-  ConstantFunction<dim, Number> (value, n_components),
+  ConstantFunction<dim, RangeNumberType> (value, n_components),
   selected_components(std::make_pair(selected,selected+1))
 {}
 
 
 
-template <int dim, typename Number>
-ComponentSelectFunction<dim, Number>::
+template <int dim, typename RangeNumberType>
+ComponentSelectFunction<dim, RangeNumberType>::
 ComponentSelectFunction (const unsigned int selected,
                          const unsigned int n_components)
   :
-  ConstantFunction<dim, Number> (1., n_components),
+  ConstantFunction<dim, RangeNumberType> (1., n_components),
   selected_components(std::make_pair(selected,selected+1))
 {
   Assert (selected < n_components,
@@ -504,12 +504,12 @@ ComponentSelectFunction (const unsigned int selected,
 
 
 
-template <int dim, typename Number>
-ComponentSelectFunction<dim, Number>::
+template <int dim, typename RangeNumberType>
+ComponentSelectFunction<dim, RangeNumberType>::
 ComponentSelectFunction (const std::pair<unsigned int,unsigned int> &selected,
                          const unsigned int n_components)
   :
-  ConstantFunction<dim, Number> (1., n_components),
+  ConstantFunction<dim, RangeNumberType> (1., n_components),
   selected_components(selected)
 {
   Assert (selected_components.first < selected_components.second,
@@ -523,10 +523,10 @@ ComponentSelectFunction (const std::pair<unsigned int,unsigned int> &selected,
 
 
 
-template <int dim, typename Number>
+template <int dim, typename RangeNumberType>
 void
-ComponentSelectFunction<dim, Number>::
-substitute_function_value_with (const ConstantFunction<dim, Number> &f)
+ComponentSelectFunction<dim, RangeNumberType>::
+substitute_function_value_with (const ConstantFunction<dim, RangeNumberType> &f)
 {
   Point<dim> p;
   for (unsigned int i=0; i<this->function_value_vector.size(); ++i)
@@ -536,10 +536,10 @@ substitute_function_value_with (const ConstantFunction<dim, Number> &f)
 
 
 
-template <int dim, typename Number>
-void ComponentSelectFunction<dim, Number>::vector_value (
+template <int dim, typename RangeNumberType>
+void ComponentSelectFunction<dim, RangeNumberType>::vector_value (
   const Point<dim> &,
-  Vector<Number>   &return_value) const
+  Vector<RangeNumberType>   &return_value) const
 {
   Assert (return_value.size() == this->n_components,
           ExcDimensionMismatch (return_value.size(), this->n_components));
@@ -552,48 +552,48 @@ void ComponentSelectFunction<dim, Number>::vector_value (
 
 
 
-template <int dim, typename Number>
-void ComponentSelectFunction<dim, Number>::vector_value_list (
+template <int dim, typename RangeNumberType>
+void ComponentSelectFunction<dim, RangeNumberType>::vector_value_list (
   const std::vector<Point<dim> > &points,
-  std::vector<Vector<Number> >   &values) const
+  std::vector<Vector<RangeNumberType> >   &values) const
 {
   Assert (values.size() == points.size(),
           ExcDimensionMismatch(values.size(), points.size()));
 
   for (unsigned int i=0; i<points.size(); ++i)
-    ComponentSelectFunction<dim, Number>::vector_value (points[i],
-                                                        values[i]);
+    ComponentSelectFunction<dim, RangeNumberType>::vector_value (points[i],
+        values[i]);
 }
 
 
 
-template <int dim, typename Number>
+template <int dim, typename RangeNumberType>
 std::size_t
-ComponentSelectFunction<dim, Number>::memory_consumption () const
+ComponentSelectFunction<dim, RangeNumberType>::memory_consumption () const
 {
   // No new complex data structure is introduced here, just evaluate how much
   // more memory is used *inside* the class via sizeof() and add that value to
   // parent class's memory_consumption()
-  return (sizeof(*this) - sizeof(ConstantFunction<dim, Number>)
-          + ConstantFunction<dim, Number>::memory_consumption());
+  return (sizeof(*this) - sizeof(ConstantFunction<dim, RangeNumberType>)
+          + ConstantFunction<dim, RangeNumberType>::memory_consumption());
 }
 
 //---------------------------------------------------------------------------
 
-template <int dim, typename Number>
-ScalarFunctionFromFunctionObject<dim, Number>::
-ScalarFunctionFromFunctionObject (const std::function<Number (const Point<dim> &)> &function_object)
+template <int dim, typename RangeNumberType>
+ScalarFunctionFromFunctionObject<dim, RangeNumberType>::
+ScalarFunctionFromFunctionObject (const std::function<RangeNumberType (const Point<dim> &)> &function_object)
   :
-  Function<dim, Number>(1),
+  Function<dim, RangeNumberType>(1),
   function_object (function_object)
 {}
 
 
 
-template <int dim, typename Number>
-Number
-ScalarFunctionFromFunctionObject<dim, Number>::value (const Point<dim> &p,
-                                                      const unsigned int component) const
+template <int dim, typename RangeNumberType>
+RangeNumberType
+ScalarFunctionFromFunctionObject<dim, RangeNumberType>::value (const Point<dim> &p,
+    const unsigned int component) const
 {
   (void)component;
   Assert (component == 0,
@@ -603,14 +603,14 @@ ScalarFunctionFromFunctionObject<dim, Number>::value (const Point<dim> &p,
 
 
 
-template <int dim, typename Number>
-VectorFunctionFromScalarFunctionObject<dim, Number>::
+template <int dim, typename RangeNumberType>
+VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::
 VectorFunctionFromScalarFunctionObject (
-  const std::function<Number (const Point<dim> &)> &function_object,
+  const std::function<RangeNumberType (const Point<dim> &)> &function_object,
   const unsigned int selected_component,
   const unsigned int n_components)
   :
-  Function<dim, Number>(n_components),
+  Function<dim, RangeNumberType>(n_components),
   function_object (function_object),
   selected_component (selected_component)
 {
@@ -620,9 +620,9 @@ VectorFunctionFromScalarFunctionObject (
 
 
 
-template <int dim, typename Number>
-Number
-VectorFunctionFromScalarFunctionObject<dim, Number>::value (
+template <int dim, typename RangeNumberType>
+RangeNumberType
+VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::value (
   const Point<dim> &p,
   const unsigned int component) const
 {
@@ -637,11 +637,11 @@ VectorFunctionFromScalarFunctionObject<dim, Number>::value (
 
 
 
-template <int dim, typename Number>
+template <int dim, typename RangeNumberType>
 void
-VectorFunctionFromScalarFunctionObject<dim, Number>::
+VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::
 vector_value (const Point<dim>   &p,
-              Vector<Number>     &values) const
+              Vector<RangeNumberType>     &values) const
 {
   AssertDimension(values.size(), this->n_components);
 
@@ -657,18 +657,18 @@ vector_value (const Point<dim>   &p,
  * The constructor for <tt>VectorFunctionFromTensorFunction</tt> which
  * initiates the return vector to be size <tt>n_components</tt>.
  */
-template <int dim, typename Number>
-VectorFunctionFromTensorFunction<dim, Number>::VectorFunctionFromTensorFunction (
-  const TensorFunction<1,dim,Number> &tensor_function,
+template <int dim, typename RangeNumberType>
+VectorFunctionFromTensorFunction<dim, RangeNumberType>::VectorFunctionFromTensorFunction (
+  const TensorFunction<1,dim,RangeNumberType> &tensor_function,
   const unsigned int selected_component,
   const unsigned int n_components)
   :
-  Function<dim, Number> (n_components),
+  Function<dim, RangeNumberType> (n_components),
   tensor_function (tensor_function),
   selected_component (selected_component)
 {
 
-  // Verify that the Tensor<1,dim,Number> will fit in the given length
+  // Verify that the Tensor<1,dim,RangeNumberType> will fit in the given length
   // selected_components and not hang over the end of the vector.
   Assert (selected_component + dim - 1 < this->n_components,
           ExcIndexRange (selected_component, 0, this->n_components));
@@ -676,9 +676,9 @@ VectorFunctionFromTensorFunction<dim, Number>::VectorFunctionFromTensorFunction 
 
 
 
-template <int dim, typename Number>
+template <int dim, typename RangeNumberType>
 inline
-Number VectorFunctionFromTensorFunction<dim, Number>::value (const Point<dim> &p,
+RangeNumberType VectorFunctionFromTensorFunction<dim, RangeNumberType>::value (const Point<dim> &p,
     const unsigned int component) const
 {
   Assert (component<this->n_components,
@@ -695,17 +695,17 @@ Number VectorFunctionFromTensorFunction<dim, Number>::value (const Point<dim> &p
   // placed at the <tt>selected_component</tt> to
   // <tt>selected_component + dim - 1</tt> elements of the <tt>Vector</tt>
   // values and pick the correct one
-  const Tensor<1,dim,Number> tensor_value = tensor_function.value (p);
+  const Tensor<1,dim,RangeNumberType> tensor_value = tensor_function.value (p);
 
   return tensor_value[component-selected_component];
 }
 
 
-template <int dim, typename Number>
+template <int dim, typename RangeNumberType>
 inline
-void VectorFunctionFromTensorFunction<dim, Number>::vector_value (
+void VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_value (
   const Point<dim> &p,
-  Vector<Number>   &values) const
+  Vector<RangeNumberType>   &values) const
 {
   Assert(values.size() == this->n_components,
          ExcDimensionMismatch(values.size(),this->n_components));
@@ -714,7 +714,7 @@ void VectorFunctionFromTensorFunction<dim, Number>::vector_value (
   // the <tt>selected_component</tt> to
   // <tt>selected_component + dim - 1</tt> elements of the <tt>Vector</tt>
   // values.
-  const Tensor<1,dim,Number> tensor_value = tensor_function.value (p);
+  const Tensor<1,dim,RangeNumberType> tensor_value = tensor_function.value (p);
 
   // First we make all elements of values = 0
   values = 0;
@@ -733,10 +733,10 @@ void VectorFunctionFromTensorFunction<dim, Number>::vector_value (
  * written so as to not replicate the function definition but passes each
  * point on to <tt>vector_value</tt> to be evaluated.
  */
-template <int dim, typename Number>
-void VectorFunctionFromTensorFunction<dim, Number>::vector_value_list (
+template <int dim, typename RangeNumberType>
+void VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_value_list (
   const std::vector<Point<dim> > &points,
-  std::vector<Vector<Number> > &value_list) const
+  std::vector<Vector<RangeNumberType> > &value_list) const
 {
   Assert (value_list.size() == points.size(),
           ExcDimensionMismatch (value_list.size(), points.size()));
@@ -744,8 +744,8 @@ void VectorFunctionFromTensorFunction<dim, Number>::vector_value_list (
   const unsigned int n_points = points.size();
 
   for (unsigned int p=0; p<n_points; ++p)
-    VectorFunctionFromTensorFunction<dim, Number>::vector_value(points[p],
-                                                                value_list[p]);
+    VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_value(points[p],
+        value_list[p]);
 }
 
 

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -35,7 +35,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 class BlockMask;
-template <int dim, typename Number> class Function;
+template <int dim, typename RangeNumberType> class Function;
 template <int dim, int spacedim> class FiniteElement;
 namespace hp
 {

--- a/include/deal.II/dofs/function_map.h
+++ b/include/deal.II/dofs/function_map.h
@@ -21,7 +21,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int spacedim, typename Number> class Function;
+template <int spacedim, typename RangeNumberType> class Function;
 
 
 

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -33,7 +33,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, typename Number> class Function;
+template <int dim, typename RangeNumberType> class Function;
 template <int dim> class Quadrature;
 template <int dim> class QGauss;
 template <int dim, typename number> class MatrixFree;


### PR DESCRIPTION
#526 makes some suggestions for a better interface to the `Function` class. Specifically, to introduce template parameters that describe the scalar type of the domain and range vector spaces. In this spirit, here is a patch that renames the `Number` template argument of the `Function` class to `ImageScalar` because it is the scalar type that underlies the image or range space. 

We can take it from there. Specifically, the following steps would be useful:
* Currently, the type for the *domain* scalar is always `double`. One could introduce a different template argument for that, to facilitate getting AD types into and out of that class.
* On the other hand, the current type used to denote the time variable in the `FunctionTime` base class is `Number` (now `ImageScalar`). This makes no sense -- it should really be the same as the *domain* scalar, or just a completely separate type altogether.

Question: Would people prefer `ImageScalar` or `RangeScalar`?

@luca-heltai ?