### PR TITLE
Clarify FE_Enriched::setup_data

### DIFF
--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -547,7 +547,7 @@ protected:
    */
   template <int dim_1>
   typename FiniteElement<dim,spacedim>::InternalDataBase *
-  setup_data (std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase> fes_data,
+  setup_data (std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase> &&fes_data,
               const UpdateFlags      flags,
               const Quadrature<dim_1> &quadrature) const;
 

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -289,18 +289,17 @@ FE_Enriched<dim,spacedim>::requires_update_flags (const UpdateFlags flags) const
 template <int dim, int spacedim>
 template <int dim_1>
 typename FiniteElement<dim,spacedim>::InternalDataBase *
-FE_Enriched<dim,spacedim>::setup_data (std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase> fes_data,
+FE_Enriched<dim,spacedim>::setup_data (std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase> &&fes_data,
                                        const UpdateFlags      flags,
                                        const Quadrature<dim_1> &quadrature) const
 {
   Assert ((dynamic_cast<typename FESystem<dim,spacedim>::InternalData *> (fes_data.get()) != nullptr),
           ExcInternalError());
-  typename FESystem<dim,spacedim>::InternalData *data_fesystem =
-    static_cast<typename FESystem<dim,spacedim>::InternalData *> (fes_data.get());
 
   // FESystem::InternalData will be aggregated (owned) by
   // our InternalData.
-  fes_data.release();
+  typename FESystem<dim,spacedim>::InternalData *data_fesystem =
+    static_cast<typename FESystem<dim,spacedim>::InternalData *> (fes_data.release());
   InternalData *data = new InternalData(std::unique_ptr<typename FESystem<dim,spacedim>::InternalData>(data_fesystem));
 
   // copy update_each from FESystem data:

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -296,8 +296,8 @@ FE_Enriched<dim,spacedim>::setup_data (std::unique_ptr<typename FiniteElement<di
   Assert ((dynamic_cast<typename FESystem<dim,spacedim>::InternalData *> (fes_data.get()) != nullptr),
           ExcInternalError());
 
-  // FESystem::InternalData will be aggregated (owned) by
-  // our InternalData.
+  // Pass ownership of the FiniteElement::InternalDataBase object
+  // that fes_data points to, to the new InternalData object.
   typename FESystem<dim,spacedim>::InternalData *data_fesystem =
     static_cast<typename FESystem<dim,spacedim>::InternalData *> (fes_data.release());
   InternalData *data = new InternalData(std::unique_ptr<typename FESystem<dim,spacedim>::InternalData>(data_fesystem));


### PR DESCRIPTION
- Using `std::unique_ptr::release` without using the return value looks suspicious so avoid it. Furthermore,  we can save a call to `get()` here.
- Clarify that we are going to steal the ownership of the stored data by passing by rvalue reference instead of by value.