### PR TITLE
Fix memory leak in DoFHandler

### DIFF
--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1083,7 +1083,7 @@ template <int dim, int spacedim>
 void DoFHandler<dim,spacedim>::clear ()
 {
   // release lock to old fe
-  fe_collection.release();
+  fe_collection.reset();
 
   // release memory
   clear_space ();


### PR DESCRIPTION
`std::unique_ptr::release()` doesn't delete the underlying object. So this should have been `reset()`.