### PR TITLE
Add dummy functions to parallel::distributed::Triangulation<1,spacedim>

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -935,6 +935,24 @@ namespace parallel
       communicate_locally_moved_vertices (const std::vector<bool> &vertex_locally_moved);
 
       /**
+       * This function is not implemented, but needs to be present for the compiler.
+       */
+      unsigned int
+      register_data_attach (const std::size_t size,
+                            const std::function<void (const typename dealii::Triangulation<1,spacedim>::cell_iterator &,
+                                                      const typename dealii::Triangulation<1,spacedim>::CellStatus,
+                                                      void *)> &pack_callback);
+
+      /**
+       * This function is not implemented, but needs to be present for the compiler.
+       */
+      void
+      notify_ready_to_unpack (const unsigned int offset,
+                              const std::function<void (const typename dealii::Triangulation<1,spacedim>::cell_iterator &,
+                                                        const typename dealii::Triangulation<1,spacedim>::CellStatus,
+                                                        const void *)> &unpack_callback);
+
+      /**
        * Dummy arrays. This class isn't usable but the compiler wants to see
        * these variables at a couple places anyway.
        */

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3741,6 +3741,31 @@ namespace parallel
     }
 
 
+
+    template <int spacedim>
+    unsigned int
+    Triangulation<1,spacedim>::register_data_attach (const std::size_t /*size*/,
+                                                     const std::function<void (const typename dealii::Triangulation<1,spacedim>::cell_iterator &,
+                                                         const typename dealii::Triangulation<1,spacedim>::CellStatus,
+                                                         void *)> &/*pack_callback*/)
+    {
+      Assert (false, ExcNotImplemented());
+      return 0;
+    }
+
+
+
+    template <int spacedim>
+    void
+    Triangulation<1,spacedim>::notify_ready_to_unpack (const unsigned int /*offset*/,
+                                                       const std::function<void (const typename dealii::Triangulation<1,spacedim>::cell_iterator &,
+                                                           const typename dealii::Triangulation<1,spacedim>::CellStatus,
+                                                           const void *)> &/*unpack_callback*/)
+    {
+      Assert (false, ExcNotImplemented());
+    }
+
+
     template <int spacedim>
     const std::vector<types::global_dof_index> &
     Triangulation<1,spacedim>::get_p4est_tree_to_coarse_cell_permutation() const


### PR DESCRIPTION
#5125 calls some functions from `parallel::distributed::Triangulation<dim,spacedim>` that are not implemented in ` parallel::distributed::Triangulation<1,spacedim>`. Add some dummy functions so that the compiler does not complain. 