### PR TITLE
Fix undefined behavior in TridiagonalMatrix

### DIFF
--- a/source/lac/tridiagonal_matrix.cc
+++ b/source/lac/tridiagonal_matrix.cc
@@ -237,7 +237,7 @@ TridiagonalMatrix<double>::compute_eigenvalues()
 
   const int nn = n();
   int info;
-  stev (&N, &nn, &*diagonal.begin(), &*right.begin(), nullptr, &one, nullptr, &info);
+  stev (&N, &nn, diagonal.data(), right.data(), nullptr, &one, nullptr, &info);
   Assert(info == 0, ExcInternalError());
 
   state = LAPACKSupport::eigenvalues;


### PR DESCRIPTION
If `diagonal` or `right` are empty, `diagonal.begin()` resp. `right.begin()` are `nullptr` and dereferencing them is undefined behavior.