### PR TITLE
Fix undefined behavior in DoFHandler

### DIFF
--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -552,96 +552,96 @@ namespace internal
       types::global_dof_index
       get_dof_index (
         const DoFHandler<1, spacedim> &dof_handler,
-        internal::DoFHandler::DoFLevel<1> &mg_level,
-        internal::DoFHandler::DoFFaces<1> &,
+        const std::unique_ptr<internal::DoFHandler::DoFLevel<1> > &mg_level,
+        const std::unique_ptr<internal::DoFHandler::DoFFaces<1> > &,
         const unsigned int obj_index,
         const unsigned int fe_index,
         const unsigned int local_index,
         const std::integral_constant<int, 1>)
       {
-        return mg_level.dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
+        return mg_level->dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
 
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &, internal::DoFHandler::DoFFaces<2> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 1>)
+      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<2> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<2> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 1>)
       {
-        return mg_faces.lines.get_dof_index (dof_handler, obj_index, fe_index, local_index);
+        return mg_faces->lines.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
 
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &mg_level, internal::DoFHandler::DoFFaces<2> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 2>)
+      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<2> > &mg_level, const std::unique_ptr<internal::DoFHandler::DoFFaces<2> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 2>)
       {
-        return mg_level.dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
+        return mg_level->dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
 
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 1>)
+      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 1>)
       {
-        return mg_faces.lines.get_dof_index (dof_handler, obj_index, fe_index, local_index);
+        return mg_faces->lines.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
 
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 2>)
+      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 2>)
       {
-        return mg_faces.quads.get_dof_index (dof_handler, obj_index, fe_index, local_index);
+        return mg_faces->quads.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
 
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &mg_level, internal::DoFHandler::DoFFaces<3> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 3>)
+      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &mg_level, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 3>)
       {
-        return mg_level.dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
+        return mg_level->dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<1, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<1> &mg_level, internal::DoFHandler::DoFFaces<1> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
+      void set_dof_index (const DoFHandler<1, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<1> > &mg_level, const std::unique_ptr<internal::DoFHandler::DoFFaces<1> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
       {
-        mg_level.dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
+        mg_level->dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &, internal::DoFHandler::DoFFaces<2> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
+      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<2> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<2> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
       {
-        mg_faces.lines.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
+        mg_faces->lines.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &mg_level, internal::DoFHandler::DoFFaces<2> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 2>)
+      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<2> > &mg_level, const std::unique_ptr<internal::DoFHandler::DoFFaces<2> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 2>)
       {
-        mg_level.dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
+        mg_level->dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
+      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
       {
-        mg_faces.lines.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
+        mg_faces->lines.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 2>)
+      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 2>)
       {
-        mg_faces.quads.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
+        mg_faces->quads.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &mg_level, internal::DoFHandler::DoFFaces<3> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 3>)
+      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &mg_level, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 3>)
       {
-        mg_level.dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
+        mg_level->dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
     };
   }
@@ -1215,8 +1215,8 @@ DoFHandler<dim, spacedim>::get_dof_index (const unsigned int obj_level,
                                           const unsigned int fe_index,
                                           const unsigned int local_index) const
 {
-  return internal::DoFHandler::Implementation::get_dof_index (*this, *this->mg_levels[obj_level],
-                                                              *this->mg_faces, obj_index,
+  return internal::DoFHandler::Implementation::get_dof_index (*this, this->mg_levels[obj_level],
+                                                              this->mg_faces, obj_index,
                                                               fe_index, local_index,
                                                               std::integral_constant<int, structdim> ());
 }
@@ -1232,8 +1232,8 @@ void DoFHandler<dim, spacedim>::set_dof_index (const unsigned int obj_level,
                                                const types::global_dof_index global_index) const
 {
   internal::DoFHandler::Implementation::set_dof_index (*this,
-                                                       *this->mg_levels[obj_level],
-                                                       *this->mg_faces,
+                                                       this->mg_levels[obj_level],
+                                                       this->mg_faces,
                                                        obj_index,
                                                        fe_index,
                                                        local_index,


### PR DESCRIPTION
In `DoFHandler<dim, spacedim>::set_dof_index` we are dereferencing `this->mg_levels[obj_level]` and `this->mg_faces` which might be nullptr. At the moment, the derefenced values are not actually used.

We can circumvent the undefined behavior by passing by `const std::unique_ptr &` instead of by value.