### PR TITLE
Fix undefined behavior in tests

### DIFF
--- a/tests/bits/error_estimator_01.cc
+++ b/tests/bits/error_estimator_01.cc
@@ -66,15 +66,6 @@ get_q_face (Function<dim> &)
 }
 
 
-Quadrature<0> &
-get_q_face (Function<1> &)
-{
-  Quadrature<0> *q = nullptr;
-  return *q;
-}
-
-
-
 template <int dim>
 void make_mesh (Triangulation<dim> &tria)
 {

--- a/tests/bits/error_estimator_02.cc
+++ b/tests/bits/error_estimator_02.cc
@@ -66,15 +66,6 @@ get_q_face (Function<dim> &)
 }
 
 
-Quadrature<0> &
-get_q_face (Function<1> &)
-{
-  Quadrature<0> *q = nullptr;
-  return *q;
-}
-
-
-
 template <int dim>
 void make_mesh (Triangulation<dim> &tria)
 {

--- a/tests/codim_one/error_estimator_01.cc
+++ b/tests/codim_one/error_estimator_01.cc
@@ -65,14 +65,6 @@ get_q_face ()
   return q;
 }
 
-template <>
-Quadrature<0> &
-get_q_face <1>()
-{
-  Quadrature<0> *q = nullptr;
-  return *q;
-}
-
 template <int dim, int spacedim>
 void make_mesh (Triangulation<dim,spacedim> &tria)
 {

--- a/tests/codim_one/error_estimator_02.cc
+++ b/tests/codim_one/error_estimator_02.cc
@@ -93,13 +93,7 @@ get_q_face ()
   return q;
 }
 
-template <>
-Quadrature<0> &
-get_q_face <1>()
-{
-  Quadrature<0> *q = nullptr;
-  return *q;
-}
+
 
 template <int dim, int spacedim>
 void make_mesh (Triangulation<dim,spacedim> &tria)

--- a/tests/numerics/boundaries.cc
+++ b/tests/numerics/boundaries.cc
@@ -67,14 +67,6 @@ boundary_q (const DoFHandler<dim> &)
 }
 
 
-const Quadrature<0> &
-boundary_q (const DoFHandler<1> &)
-{
-  static const Quadrature<0> *q = nullptr;
-  return *q;
-}
-
-
 void write_map (const std::map<types::global_dof_index,double> &bv)
 {
   for (std::map<types::global_dof_index,double>::const_iterator

--- a/tests/numerics/error_estimator.cc
+++ b/tests/numerics/error_estimator.cc
@@ -66,16 +66,6 @@ get_q_face (Function<dim> &)
 }
 
 
-Quadrature<0> &
-get_q_face (Function<1> &)
-{
-  Quadrature<0> *q = nullptr;
-  return *q;
-}
-
-
-
-
 template <int dim>
 void
 check ()


### PR DESCRIPTION
For some reason we are explicitly dereferencing a `nullptr` in these tests.
May be this was done, to make sure that the value is actually not used. But using undefined behavior seems not to be helpful.