### PR TITLE
Add some missing instantiations.

### DIFF
--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1554,11 +1554,14 @@ namespace DoFTools
    * processor. For regular DoFHandler objects, this set is the complete set
    * with all DoF indices. In either case, it equals what
    * DoFHandler::locally_owned_dofs() returns.
+   *
+   * @deprecated Use DoFHandler::locally_owned_dofs() directly instead of this
+   * function.
    */
   template <typename DoFHandlerType>
   void
   extract_locally_owned_dofs (const DoFHandlerType &dof_handler,
-                              IndexSet             &dof_set);
+                              IndexSet             &dof_set) DEAL_II_DEPRECATED;
 
 
   /**
@@ -1742,10 +1745,11 @@ namespace DoFTools
    * processor. Note that this includes the ones that this subdomain "owns"
    * (i.e. the ones for which get_subdomain_association() returns a value
    * equal to the subdomain given here and that are selected by the
-   * extract_locally_owned_dofs() function) but also all of those that sit on
-   * the boundary between the given subdomain and other subdomain. In essence,
-   * degrees of freedom that sit on boundaries between subdomain will be in
-   * the index sets returned by this function for more than one subdomain.
+   * DoFHandler::locally_owned_dofs() function) but also all of those that sit
+   * on the boundary between the given subdomain and other subdomain. In
+   * essence, degrees of freedom that sit on boundaries between subdomain will
+   * be in the index sets returned by this function for more than one
+   * subdomain.
    *
    * Note that this function is of questionable use for DoFHandler objects
    * built on parallel::distributed::Triangulation since in that case

--- a/include/deal.II/grid/intergrid_map.h
+++ b/include/deal.II/grid/intergrid_map.h
@@ -143,12 +143,12 @@ public:
   void clear ();
 
   /**
-   * Return a pointer to the source grid.
+   * Return a reference to the source grid.
    */
   const MeshType &get_source_grid () const;
 
   /**
-   * Return a pointer to the destination grid.
+   * Return a reference to the destination grid.
    */
   const MeshType &get_destination_grid () const;
 

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2699,14 +2699,14 @@ namespace DoFTools
                 // Nothing bad happened: the user used serial Triangulation
               }
 
-            IndexSet locally_owned_dofs, locally_relevant_dofs;
-            DoFTools::extract_locally_owned_dofs
-            (coarse_to_fine_grid_map.get_destination_grid (), locally_owned_dofs);
+
+            IndexSet locally_relevant_dofs;
             DoFTools::extract_locally_relevant_dofs
             (coarse_to_fine_grid_map.get_destination_grid (), locally_relevant_dofs);
 
             copy_data.global_parameter_representation[i].reinit
-            (locally_owned_dofs, locally_relevant_dofs, communicator);
+            (coarse_to_fine_grid_map.get_destination_grid().locally_owned_dofs(),
+             locally_relevant_dofs, communicator);
 #else
             const types::global_dof_index n_fine_dofs = weight_mapping.size();
             copy_data.global_parameter_representation[i].reinit (n_fine_dofs);

--- a/source/dofs/dof_tools_constraints.inst.in
+++ b/source/dofs/dof_tools_constraints.inst.in
@@ -72,52 +72,48 @@ for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
 #endif
 }
 
-for (deal_II_dimension : DIMENSIONS)
+for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 {
+#if deal_II_dimension <= deal_II_space_dimension
     template
     void
     DoFTools::make_zero_boundary_constraints
-    (const DoFHandler<deal_II_dimension> &,
-     ConstraintMatrix                    &,
-     const ComponentMask             &);
+    (const DH<deal_II_dimension, deal_II_space_dimension> &,
+     ConstraintMatrix                                     &,
+     const ComponentMask                                  &);
 
     template
     void
     DoFTools::make_zero_boundary_constraints
-    (const DoFHandler<deal_II_dimension> &,
+    (const DH<deal_II_dimension, deal_II_space_dimension> &,
      const types::boundary_id,
-     ConstraintMatrix                    &,
-     const ComponentMask             &);
+     ConstraintMatrix                                     &,
+     const ComponentMask                                  &);
+#endif
+}
 
+// intergrid transfer is not yet implemented for hp::DoFHandler
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+{
+#if deal_II_dimension <= deal_II_space_dimension
     template
     void
-    DoFTools::make_zero_boundary_constraints
-    (const hp::DoFHandler<deal_II_dimension> &,
-     ConstraintMatrix                        &,
-     const ComponentMask                 &);
-
-    template
-    void
-    DoFTools::make_zero_boundary_constraints
-    (const hp::DoFHandler<deal_II_dimension> &,
-     const types::boundary_id,
-     ConstraintMatrix                        &,
-     const ComponentMask                 &);
-
-    template
-    void
-    DoFTools::compute_intergrid_constraints<deal_II_dimension> (
-        const DoFHandler<deal_II_dimension> &, const unsigned int,
-        const DoFHandler<deal_II_dimension> &, const unsigned int,
-        const InterGridMap<DoFHandler<deal_II_dimension> > &,
-        ConstraintMatrix&);
+    DoFTools::compute_intergrid_constraints
+    (const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+     const unsigned int,
+     const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+     const unsigned int,
+     const InterGridMap<DoFHandler<deal_II_dimension, deal_II_space_dimension> > &,
+     ConstraintMatrix &);
 
     template
     void
     DoFTools::compute_intergrid_transfer_representation<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &, const unsigned int,
-     const DoFHandler<deal_II_dimension> &, const unsigned int,
-     const InterGridMap<DoFHandler<deal_II_dimension> > &,
+    (const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+     const unsigned int,
+     const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+     const unsigned int,
+     const InterGridMap<DoFHandler<deal_II_dimension, deal_II_space_dimension> > &,
      std::vector<std::map<types::global_dof_index, float> > &);
-
+#endif
 }


### PR DESCRIPTION
A partial fix to #5246: I added instantiations of `DoFTools::make_zero_boundary_constraints` for the nonzero codimension case.

I made two small changes along the way: I deprecated the seldom-used `extract_locally_owned_dofs` (all this function does is call `dof_handler.locally_owned_dofs`) and fixed some wrong comments. Deprecating `extract_locally_owned_dofs` is relevant to the current patch since that function is also only instantiated for the codimension zero case (i.e., it currently causes linker errors).

This patch is just the right size with these changes, so I hope no one minds me sticking them in here :)