### PR TITLE
Make sure to not call memset with a nullptr

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -237,9 +237,14 @@ namespace LinearAlgebra
       reinit (v, true);
 
       thread_loop_partitioner = v.thread_loop_partitioner;
-      dealii::internal::VectorOperations::Vector_copy<Number,Number> copier(v.val, val);
-      internal::VectorOperations::parallel_for(copier, 0, partitioner->local_size(),
-                                               thread_loop_partitioner);
+
+      const size_type this_size = local_size();
+      if (this_size>0)
+        {
+          dealii::internal::VectorOperations::Vector_copy<Number,Number> copier(v.val, val);
+          internal::VectorOperations::parallel_for(copier, 0, partitioner->local_size(),
+                                                   thread_loop_partitioner);
+        }
     }
 
 
@@ -378,9 +383,14 @@ namespace LinearAlgebra
         must_update_ghost_values |= vector_is_ghosted;
 
       thread_loop_partitioner = c.thread_loop_partitioner;
-      dealii::internal::VectorOperations::Vector_copy<Number,Number2> copier(c.val, val);
-      internal::VectorOperations::parallel_for(copier, 0, partitioner->local_size(),
-                                               thread_loop_partitioner);
+
+      const size_type this_size = local_size();
+      if (this_size>0)
+        {
+          dealii::internal::VectorOperations::Vector_copy<Number,Number2> copier(c.val, val);
+          internal::VectorOperations::parallel_for(copier, 0, this_size,
+                                                   thread_loop_partitioner);
+        }
 
       if (must_update_ghost_values)
         update_ghost_values();
@@ -930,10 +940,14 @@ namespace LinearAlgebra
     Vector<Number> &
     Vector<Number>::operator = (const Number s)
     {
-      internal::VectorOperations::Vector_set<Number> setter(s, val);
+      const size_type this_size = local_size();
+      if (this_size>0)
+        {
+          internal::VectorOperations::Vector_set<Number> setter(s, val);
 
-      internal::VectorOperations::parallel_for(setter, 0, partitioner->local_size(),
-                                               thread_loop_partitioner);
+          internal::VectorOperations::parallel_for(setter, 0, this_size,
+                                                   thread_loop_partitioner);
+        }
 
       // if we call Vector::operator=0, we want to zero out all the entries
       // plus ghosts.

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -220,8 +220,12 @@ namespace LinearAlgebra
     Assert(s==static_cast<Number>(0), ExcMessage("Only 0 can be assigned to a vector."));
     (void)s;
 
-    dealii::internal::VectorOperations::Vector_set<Number> setter(Number(), val);
-    dealii::internal::VectorOperations::parallel_for(setter, 0, n_elements(), thread_loop_partitioner);
+    const size_type this_size = n_elements();
+    if (this_size>0)
+      {
+        dealii::internal::VectorOperations::Vector_set<Number> setter(Number(), val);
+        dealii::internal::VectorOperations::parallel_for(setter, 0, this_size, thread_loop_partitioner);
+      }
 
     return *this;
   }

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -205,8 +205,11 @@ Vector<Number>::operator= (const Vector<Number> &v)
   if (vec_size != v.vec_size)
     reinit (v, true);
 
-  dealii::internal::VectorOperations::Vector_copy<Number,Number> copier(v.val, val);
-  internal::VectorOperations::parallel_for(copier,0,vec_size,thread_loop_partitioner);
+  if (vec_size>0)
+    {
+      dealii::internal::VectorOperations::Vector_copy<Number,Number> copier(v.val, val);
+      internal::VectorOperations::parallel_for(copier,0,vec_size,thread_loop_partitioner);
+    }
 
   return *this;
 }
@@ -358,9 +361,11 @@ Vector<Number>::operator= (const Number s)
   if (s != Number())
     Assert (vec_size!=0, ExcEmptyObject());
 
-  internal::VectorOperations::Vector_set<Number> setter(s, val);
-
-  internal::VectorOperations::parallel_for(setter,0,vec_size,thread_loop_partitioner);
+  if (vec_size>0)
+    {
+      internal::VectorOperations::Vector_set<Number> setter(s, val);
+      internal::VectorOperations::parallel_for(setter,0,vec_size,thread_loop_partitioner);
+    }
 
   return *this;
 }

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -203,18 +203,22 @@ namespace internal
         :
         value(value),
         dst(dst)
-      {}
+      {
+        Assert(dst != nullptr, ExcInternalError());
+      }
 
       void operator() (const size_type begin, const size_type end) const
       {
+        Assert (end>=begin, ExcInternalError());
+
         if (value == Number())
           std::memset (dst+begin,0,(end-begin)*sizeof(Number));
         else
           std::fill (dst+begin, dst+end, value);
       }
 
-      Number value;
-      Number *dst;
+      const Number value;
+      Number *const dst;
     };
 
     template <typename Number, typename OtherNumber>
@@ -224,10 +228,15 @@ namespace internal
         :
         src(src),
         dst(dst)
-      {}
+      {
+        Assert(src!=nullptr, ExcInternalError());
+        Assert(dst!=nullptr, ExcInternalError());
+      }
 
       void operator() (const size_type begin, const size_type end) const
       {
+        Assert (end>=begin, ExcInternalError());
+
         if (std::is_same<Number,OtherNumber>::value)
           std::memcpy(dst+begin, src+begin, (end-begin)*sizeof(Number));
         else
@@ -238,8 +247,8 @@ namespace internal
           }
       }
 
-      const OtherNumber *src;
-      Number *dst;
+      const OtherNumber *const src;
+      Number *const dst;
     };
 
     template <typename Number>


### PR DESCRIPTION
If we are calling `Vector_copy` or `Vector_set` with an empty object, the pointers passed are often  `nullptr`. Hence, we were calling `std::memset` with a `nullptr` as first argument.

At least the implementation of `std::memset` I am using is declared as
```
void *memset (void *__s, int __c, size_t __n) __THROW __nonnull ((1));
```
and doesn't allow the first argument `__s` to be a `nullptr` which makes sense.
Something similar holds for `std::memcpy` which is declared as
```
void *memcpy (void *__restrict __dest, const void *__restrict __src,
              size_t __n) __THROW __nonnull ((1, 2));
```