### PR TITLE
Restructure DataOutFilter

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1214,7 +1214,9 @@ namespace DataOutBase
      * Filter duplicate vertices and associated values. This will drastically
      * reduce the output data size but will result in an output file that
      * does not faithfully represent the actual data if the data corresponds
-     * to discontinuous fields.
+     * to discontinuous fields. In particular, along subdomain boundaries
+     * the data will still be discontinuous, while it will look like a
+     * continuous field inside of the subdomain.
      */
     bool filter_duplicate_vertices;
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1890,7 +1890,10 @@ namespace DataOutBase
                        "produced by entirely different means), then the data in the "
                        "output file no longer faithfully represents the underlying data "
                        "because the discontinuous field has been replaced by a "
-                       "continuous one."
+                       "continuous one. Note also that the filtering can not occur "
+                       "on processor boundaries. Thus, a filtered discontinuous field "
+                       "looks like a continuous field inside of a subdomain, "
+                       "but like a discontinuous field at the subdomain boundary."
                        "\n\n"
                        "In any case, filtering results in drastically smaller output "
                        "files (smaller by about a factor of 2^dim).");

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -453,122 +453,219 @@ namespace DataOutBase
                 ExcInternalError());
     }
   }
+
+
+
+  DataOutFilter::DataOutFilter()
+    :
+    flags(false, true),
+    node_dim (numbers::invalid_unsigned_int),
+    vertices_per_cell (numbers::invalid_unsigned_int)
+  {}
+
+
+
+  DataOutFilter::DataOutFilter(const DataOutBase::DataOutFilterFlags &flags)
+    :
+    flags(flags),
+    node_dim (numbers::invalid_unsigned_int),
+    vertices_per_cell (numbers::invalid_unsigned_int)
+  {}
+
+
+
+  template <int dim>
+  void
+  DataOutFilter::write_point(const unsigned int index,
+                             const Point<dim> &p)
+  {
+    node_dim = dim;
+
+    Point<3> int_pt;
+    for (unsigned int d=0; d<dim; ++d)
+      int_pt(d) = p(d);
+
+    const Map3DPoint::const_iterator it = existing_points.find(int_pt);
+    unsigned int internal_ind;
+
+    // If the point isn't in the set, or we're not filtering duplicate points, add it
+    if (it == existing_points.end() || !flags.filter_duplicate_vertices)
+      {
+        internal_ind = existing_points.size();
+        existing_points.insert(std::make_pair(int_pt, internal_ind));
+      }
+    else
+      {
+        internal_ind = it->second;
+      }
+    // Now add the index to the list of filtered points
+    filtered_points[index] = internal_ind;
+  }
+
+
+
+  void
+  DataOutFilter::internal_add_cell(const unsigned int cell_index,
+                                   const unsigned int pt_index)
+  {
+    filtered_cells[cell_index] = filtered_points[pt_index];
+  }
+
+
+
+  void
+  DataOutFilter::fill_node_data(std::vector<double> &node_data) const
+  {
+    node_data.resize(existing_points.size()*node_dim);
+
+    for (Map3DPoint::const_iterator it=existing_points.begin(); it!=existing_points.end(); ++it)
+      {
+        for (unsigned int d=0; d<node_dim; ++d)
+          node_data[node_dim*it->second+d] = it->first(d);
+      }
+  }
+
+
+
+  void
+  DataOutFilter::fill_cell_data(const unsigned int local_node_offset,
+                                std::vector<unsigned int> &cell_data) const
+  {
+    cell_data.resize(filtered_cells.size());
+
+    for (std::map<unsigned int, unsigned int>::const_iterator it=filtered_cells.begin(); it!=filtered_cells.end(); ++it)
+      {
+        cell_data[it->first] = it->second+local_node_offset;
+      }
+  }
+
+
+
+  std::string
+  DataOutFilter::get_data_set_name(const unsigned int set_num) const
+  {
+    return data_set_names.at(set_num);
+  }
+
+
+
+  unsigned int
+  DataOutFilter::get_data_set_dim(const unsigned int set_num) const
+  {
+    return data_set_dims.at(set_num);
+  }
+
+
+
+  const double *
+  DataOutFilter::get_data_set(const unsigned int set_num) const
+  {
+    return &data_sets[set_num][0];
+  }
+
+
+
+  unsigned int
+  DataOutFilter::n_nodes() const
+  {
+    return existing_points.size();
+  }
+
+
+
+  unsigned int
+  DataOutFilter::n_cells() const
+  {
+    return filtered_cells.size()/vertices_per_cell;
+  }
+
+
+
+  unsigned int
+  DataOutFilter::n_data_sets() const
+  {
+    return data_set_names.size();
+  }
+
+
+
+  void
+  DataOutFilter::flush_points ()
+  {}
+
+
+
+  void
+  DataOutFilter::flush_cells ()
+  {}
+
+
+
+  template <int dim>
+  void
+  DataOutFilter::write_cell(const unsigned int index,
+                            const unsigned int start,
+                            const unsigned int d1,
+                            const unsigned int d2,
+                            const unsigned int d3)
+  {
+    const unsigned int base_entry = index * GeometryInfo<dim>::vertices_per_cell;
+    vertices_per_cell = GeometryInfo<dim>::vertices_per_cell;
+    internal_add_cell(base_entry+0, start);
+    if (dim>=1)
+      {
+        internal_add_cell(base_entry+1, start+d1);
+        if (dim>=2)
+          {
+            internal_add_cell(base_entry+2, start+d2+d1);
+            internal_add_cell(base_entry+3, start+d2);
+            if (dim>=3)
+              {
+                internal_add_cell(base_entry+4, start+d3);
+                internal_add_cell(base_entry+5, start+d3+d1);
+                internal_add_cell(base_entry+6, start+d3+d2+d1);
+                internal_add_cell(base_entry+7, start+d3+d2);
+              }
+          }
+      }
+  }
+
+
+
+  void DataOutFilter::write_data_set(const std::string &name,
+                                     const unsigned int dimension,
+                                     const unsigned int set_num,
+                                     const Table<2,double> &data_vectors)
+  {
+    unsigned int new_dim;
+
+    // HDF5/XDMF output only supports 1D or 3D output, so force rearrangement if needed
+    if (flags.xdmf_hdf5_output && dimension != 1)
+      new_dim = 3;
+    else
+      new_dim = dimension;
+
+    // Record the data set name, dimension, and allocate space for it
+    data_set_names.push_back(name);
+    data_set_dims.push_back(new_dim);
+    data_sets.emplace_back(new_dim * existing_points.size());
+
+    // TODO: averaging, min/max, etc for merged vertices
+    for (unsigned int i=0; i<filtered_points.size(); ++i)
+      {
+        const unsigned int r = filtered_points[i];
+
+        for (unsigned int d=0; d<new_dim; ++d)
+          {
+            if (d < dimension)
+              data_sets.back()[r*new_dim+d] = data_vectors(set_num+d, i);
+            else
+              data_sets.back()[r*new_dim+d] = 0;
+          }
+      }
+  }
 }
 
-//----------------------------------------------------------------------//
-// DataOutFilter class member functions
-//----------------------------------------------------------------------//
-
-template <int dim>
-void DataOutBase::DataOutFilter::write_point(const unsigned int &index, const Point<dim> &p)
-{
-  Map3DPoint::const_iterator  it;
-  unsigned int      internal_ind;
-  Point<3>      int_pt;
-
-  for (int d=0; d<3; ++d) int_pt(d) = (d < dim ? p(d) : 0);
-  node_dim = dim;
-  it = existing_points.find(int_pt);
-
-  // If the point isn't in the set, or we're not filtering duplicate points, add it
-  if (it == existing_points.end() || !flags.filter_duplicate_vertices)
-    {
-      internal_ind = existing_points.size();
-      existing_points.insert(std::make_pair(int_pt, internal_ind));
-    }
-  else
-    {
-      internal_ind = it->second;
-    }
-  // Now add the index to the list of filtered points
-  filtered_points[index] = internal_ind;
-}
-
-void DataOutBase::DataOutFilter::internal_add_cell(const unsigned int &cell_index, const unsigned int &pt_index)
-{
-  filtered_cells[cell_index] = filtered_points[pt_index];
-}
-
-void DataOutBase::DataOutFilter::fill_node_data(std::vector<double> &node_data) const
-{
-  Map3DPoint::const_iterator  it;
-
-  node_data.resize(existing_points.size()*node_dim);
-
-  for (it=existing_points.begin(); it!=existing_points.end(); ++it)
-    {
-      for (unsigned int d=0; d<node_dim; ++d)
-        node_data[node_dim*it->second+d] = it->first(d);
-    }
-}
-
-void DataOutBase::DataOutFilter::fill_cell_data(const unsigned int &local_node_offset, std::vector<unsigned int> &cell_data) const
-{
-  std::map<unsigned int, unsigned int>::const_iterator  it;
-
-  cell_data.resize(filtered_cells.size());
-
-  for (it=filtered_cells.begin(); it!=filtered_cells.end(); ++it)
-    {
-      cell_data[it->first] = it->second+local_node_offset;
-    }
-}
-
-template <int dim>
-void
-DataOutBase::DataOutFilter::write_cell(
-  unsigned int index,
-  unsigned int start,
-  unsigned int d1,
-  unsigned int d2,
-  unsigned int d3)
-{
-  unsigned int base_entry = index * GeometryInfo<dim>::vertices_per_cell;
-  vertices_per_cell = GeometryInfo<dim>::vertices_per_cell;
-  internal_add_cell(base_entry+0, start);
-  if (dim>=1)
-    {
-      internal_add_cell(base_entry+1, start+d1);
-      if (dim>=2)
-        {
-          internal_add_cell(base_entry+2, start+d2+d1);
-          internal_add_cell(base_entry+3, start+d2);
-          if (dim>=3)
-            {
-              internal_add_cell(base_entry+4, start+d3);
-              internal_add_cell(base_entry+5, start+d3+d1);
-              internal_add_cell(base_entry+6, start+d3+d2+d1);
-              internal_add_cell(base_entry+7, start+d3+d2);
-            }
-        }
-    }
-}
-
-void DataOutBase::DataOutFilter::write_data_set(const std::string &name, const unsigned int &dimension, const unsigned int &set_num, const Table<2,double> &data_vectors)
-{
-  unsigned int    num_verts = existing_points.size();
-  unsigned int    i, r, d, new_dim;
-
-  // HDF5/XDMF output only supports 1D or 3D output, so force rearrangement if needed
-  if (flags.xdmf_hdf5_output && dimension != 1) new_dim = 3;
-  else new_dim = dimension;
-
-  // Record the data set name, dimension, and allocate space for it
-  data_set_names.push_back(name);
-  data_set_dims.push_back(new_dim);
-  data_sets.emplace_back(new_dim*num_verts);
-
-  // TODO: averaging, min/max, etc for merged vertices
-  for (i=0; i<filtered_points.size(); ++i)
-    {
-      for (d=0; d<new_dim; ++d)
-        {
-          r = filtered_points[i];
-          if (d < dimension) data_sets.back()[r*new_dim+d] = data_vectors(set_num+d, i);
-          else data_sets.back()[r*new_dim+d] = 0;
-        }
-    }
-}
 
 
 //----------------------------------------------------------------------//

--- a/tests/numerics/data_out_filter_01.cc
+++ b/tests/numerics/data_out_filter_01.cc
@@ -1,0 +1,94 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// This test shows the ability of DataOutFilter to merge vertex duplicates taking
+// into account floating point inprecision.
+// The test creates a distorted triangulation with vertices very close to each other
+// that are subsequently merged by the DataOutFilter class.
+// Note that while the test case will likely never happen, there are cases
+// in which vertices during mesh output have slightly different positions
+// that would not be merged if the points would simply be compared for equality.
+
+#include "../tests.h"
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/numerics/data_out.h>
+
+
+
+
+template <int dim>
+void
+test ()
+{
+  Triangulation<dim> tria(Triangulation<dim>::MeshSmoothing::none,true);
+  GridGenerator::hyper_cube(tria, 1., 1. + 1000.0 * std::numeric_limits<double>::epsilon());
+
+  FE_Q<dim> fe1(1);
+
+  DoFHandler<dim> dof1(tria);
+  dof1.distribute_dofs(fe1);
+
+  Vector<double> v1(dof1.n_dofs());
+  for (unsigned int i=0; i<v1.size(); ++i) v1(i) = i;
+
+  DataOut<dim> data_out;
+  data_out.add_data_vector (dof1, v1, "linear");
+  data_out.build_patches ();
+
+  DataOutBase::DataOutFilter data_filter
+  (DataOutBase::DataOutFilterFlags (true, false));
+
+  data_out.write_filtered_data (data_filter);
+
+  deallog << "Number of filtered nodes: " << data_filter.n_nodes() << std::endl;
+
+  Triangulation<dim> tria2(Triangulation<dim>::MeshSmoothing::none,true);
+  GridGenerator::hyper_cube(tria2, 1., 1 + 10.0 * std::numeric_limits<double>::epsilon());
+
+  FE_Q<dim> fe2(1);
+
+  DoFHandler<dim> dof2(tria2);
+  dof2.distribute_dofs(fe2);
+
+  Vector<double> v2(dof2.n_dofs());
+  for (unsigned int i=0; i<v2.size(); ++i) v2(i) = i;
+
+  DataOut<dim> data_out2;
+  data_out2.add_data_vector (dof2, v2, "linear");
+  data_out2.build_patches ();
+
+  DataOutBase::DataOutFilter data_filter2
+  (DataOutBase::DataOutFilterFlags (true, false));
+
+  data_out2.write_filtered_data (data_filter2);
+
+  deallog << "Number of filtered nodes: " << data_filter2.n_nodes() << std::endl;
+
+  deallog << "ok" << std::endl;
+}
+
+
+int main(int argc, char *argv[])
+{
+  initlog();
+  test<2>();
+  test<3>();
+
+  return 0;
+}

--- a/tests/numerics/data_out_filter_01.with_hdf5=true.output
+++ b/tests/numerics/data_out_filter_01.with_hdf5=true.output
@@ -1,0 +1,7 @@
+
+DEAL::Number of filtered nodes: 4
+DEAL::Number of filtered nodes: 1
+DEAL::ok
+DEAL::Number of filtered nodes: 8
+DEAL::Number of filtered nodes: 1
+DEAL::ok


### PR DESCRIPTION
Originally, the purpose of this PR is to fix a bug in `DataOutFilter` discussed in geodynamics/aspect#1958. 
When I started working on the class I realized it must have been merged before code review was in place so I had to do some restructuring. The two commits of this PR can be reviewed independently, the first one only adjusts the code structure to our usual conventions, but should not change functionality. The second commit contains the real change, comparing points for equality with some tolerance to account for floating-point precision. I also added the first test case for this class. The test checks that points that are sufficiently close (<1e-10 relative difference in each coordinate) are merged, while points that are farther apart are not merged.