### PR TITLE
Corrected spelling in grid tool function

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -881,7 +881,7 @@ namespace GridTools
    * A version of the previous function that exploits an already existing
    * map between vertices and cells, constructed using the function
    * GridTools::vertex_to_cell_map, a map of vertex_to_cell_centers, obtained
-   * through GridTools::vertex_to_cells_center_directions, and a guess `cell_hint`.
+   * through GridTools::vertex_to_cell_centers_directions, and a guess `cell_hint`.
    *
    * @author Luca Heltai, Rene Gassmoeller, 2017
    */


### PR DESCRIPTION
Removing just a letter for a spelling error...but it was a bit fastidious since it broke the link to the function in the documentation...