### PR TITLE
add a boolean flag to MatrixFreeOperators::Base::compute_diagonal() t…

### DIFF
--- a/doc/news/changes/minor/20171019DenisDavydov
+++ b/doc/news/changes/minor/20171019DenisDavydov
@@ -1,0 +1,5 @@
+New: MatrixFreeOperators::Base now also stores the diagonal of the operator that
+shall be populated in derived class in compute_diagonal() method. The read access
+is provided by MatrixFreeOperators::Base::get_matrix_diagonal().
+<br>
+(Denis Davydov, 2017/10/19)


### PR DESCRIPTION
…o switch between the diagonal and its inverse

This is useful if one works with a linear combination of matrix-free operators, i.e. `A+c*B`. In this case I want to keep actual diagonals in `A` and `B` and manually do their linear combination and inversion in a wrapper class around `A,B`.

I am not particularly happy about the approach in this PR, as users would have to adjust derived classes to implement `virtual void compute_diagonal (const bool invert = true) = 0;`. 

Alternatives could be to (2) introduce `void invert()` function to the `Base` class and do inversion there, but it might be even worse as users would need to call it within their current code.

Yet another alternative is to (3) leave things as-is but introduce write access to the diagonal object so that one can invert the inverted diagonal elements. This is also not particularly neat. But it's the least intrusive approach.

TODO:

- [x] run matrix-free tests once we agree on the interface.