### PR TITLE
extend example of user projects testsuite to contain header files

### DIFF
--- a/doc/users/testsuite.html
+++ b/doc/users/testsuite.html
@@ -173,6 +173,8 @@ src/CMakeLists.txt
 src/step.cc
 src/support.cc
 
+include/support.h
+
 tests/step/CMakeLists
 tests/step/my_test_1.prm
 tests/step/my_test_1.output
@@ -199,6 +201,8 @@ FIND_PACKAGE(deal.II 9.0.0 REQUIRED
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 PROJECT(step)
 ENABLE_TESTING()
+
+INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include)
 
 ADD_SUBDIRECTORY(src)
 ADD_SUBDIRECTORY(tests/step)

--- a/doc/users/testsuite.html
+++ b/doc/users/testsuite.html
@@ -165,7 +165,11 @@ Total Test time (real) =   1.72 sec</pre>
       as a second example a project is presented that consists of a support
       library "support" and an executable "step". The task shall be to
       provide unit tests for the library "support" and simple configuration
-      type tests for "step". In detail:
+      type tests for "step". We shall assume that all the
+      functions and classes are declared in a single header <code>support.h</code>
+      to be included <code>#include &lt;support.h&gt;</code> from the executable "step"
+      and units tests for the library.
+      In detail the directory and file layout is as follows:
       <pre>
 CMakeLists.txt
 


### PR DESCRIPTION
the user in  https://groups.google.com/forum/?fromgroups#!topic/dealii/6YgunmMhva0 tried to follow the documentation but could not figure out how to setup includes. So adjust code snippets and directory structure to contain `support.h` to hopefully make the example complete.