### PR TITLE
Use unique_ptr instead of raw pointers in distributed::Vector.

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1093,10 +1093,10 @@ namespace LinearAlgebra
 
       /**
        * Temporary storage that holds the data that is sent to this processor
-       * in @p compress() or sent from this processor in @p
-       * update_ghost_values.
+       * in @p compress() or sent from this processor in
+       * @p update_ghost_values.
        */
-      mutable Number *import_data;
+      mutable std::unique_ptr<Number[]> import_data;
 
       /**
        * Stores whether the vector currently allows for reading ghost elements


### PR DESCRIPTION
This is a follow-up I noticed while reading through #5259: We use plain pointers there, but could use a `std::unique_ptr` instead.

I'm current resetting these pointers via
```
  data_import.reset (new T[n]);
```
instead of using `std_cxx14::make_unique()`. That's because for array types `T[]`, one needs to use a different variant of that function:
  http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
We currently don't provide in namespace `std_cxx14`. I thought about adding it, but it's not actually particularly easy to do so because, as that page states, one would need to distinguish between array types and non-array types. So I suspect that some sort of internal dispatch is necessary, which I thought is more than I was going for here.

@kronbichler -- as the author of the original code, any comments?