### PR TITLE
Use std::unique_ptr for parallel::Vector::val

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1083,7 +1083,7 @@ namespace LinearAlgebra
       /**
        * Pointer to the array of local elements of this vector.
        */
-      Number         *val;
+      std::unique_ptr<Number[]> val;
 
       /**
        * For parallel loops with TBB, this member variable stores the affinity
@@ -1263,7 +1263,7 @@ namespace LinearAlgebra
     typename Vector<Number>::iterator
     Vector<Number>::begin ()
     {
-      return val;
+      return val.get();
     }
 
 
@@ -1273,7 +1273,7 @@ namespace LinearAlgebra
     typename Vector<Number>::const_iterator
     Vector<Number>::begin () const
     {
-      return val;
+      return val.get();
     }
 
 
@@ -1283,7 +1283,7 @@ namespace LinearAlgebra
     typename Vector<Number>::iterator
     Vector<Number>::end ()
     {
-      return val+partitioner->local_size();
+      return val.get()+partitioner->local_size();
     }
 
 
@@ -1293,7 +1293,7 @@ namespace LinearAlgebra
     typename Vector<Number>::const_iterator
     Vector<Number>::end () const
     {
-      return val+partitioner->local_size();
+      return val.get()+partitioner->local_size();
     }
 
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1083,7 +1083,7 @@ namespace LinearAlgebra
       /**
        * Pointer to the array of local elements of this vector.
        */
-      std::unique_ptr<Number[]> val;
+      std::unique_ptr<Number[]> values;
 
       /**
        * For parallel loops with TBB, this member variable stores the affinity
@@ -1263,7 +1263,7 @@ namespace LinearAlgebra
     typename Vector<Number>::iterator
     Vector<Number>::begin ()
     {
-      return val.get();
+      return values.get();
     }
 
 
@@ -1273,7 +1273,7 @@ namespace LinearAlgebra
     typename Vector<Number>::const_iterator
     Vector<Number>::begin () const
     {
-      return val.get();
+      return values.get();
     }
 
 
@@ -1283,7 +1283,7 @@ namespace LinearAlgebra
     typename Vector<Number>::iterator
     Vector<Number>::end ()
     {
-      return val.get()+partitioner->local_size();
+      return values.get()+partitioner->local_size();
     }
 
 
@@ -1293,7 +1293,7 @@ namespace LinearAlgebra
     typename Vector<Number>::const_iterator
     Vector<Number>::end () const
     {
-      return val.get()+partitioner->local_size();
+      return values.get()+partitioner->local_size();
     }
 
 
@@ -1312,7 +1312,7 @@ namespace LinearAlgebra
       Assert (partitioner->in_local_range (global_index) || vector_is_ghosted == true,
               ExcMessage("You tried to read a ghost element of this vector, "
                          "but it has not imported its ghost values."));
-      return val[partitioner->global_to_local(global_index)];
+      return values[partitioner->global_to_local(global_index)];
     }
 
 
@@ -1333,7 +1333,7 @@ namespace LinearAlgebra
       // (then, the compiler picks this method according to the C++ rule book
       // even if a human would pick the const method when this subsequent use
       // is just a read)
-      return val[partitioner->global_to_local (global_index)];
+      return values[partitioner->global_to_local (global_index)];
     }
 
 
@@ -1370,7 +1370,7 @@ namespace LinearAlgebra
       Assert (local_index < local_size() || vector_is_ghosted == true,
               ExcMessage("You tried to read a ghost element of this vector, "
                          "but it has not imported its ghost values."));
-      return val[local_index];
+      return values[local_index];
     }
 
 
@@ -1383,7 +1383,7 @@ namespace LinearAlgebra
       AssertIndexRange (local_index,
                         partitioner->local_size()+
                         partitioner->n_ghost_indices());
-      return val[local_index];
+      return values[local_index];
     }
 
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1082,8 +1082,12 @@ namespace LinearAlgebra
 
       /**
        * Pointer to the array of local elements of this vector.
+       *
+       * Because we allocate these arrays via Utilities::System::posix_memalign,
+       * we need to use a custom deleter for this object that does not call
+       * <code>delete[]</code>, but instead calls @p free().
        */
-      std::unique_ptr<Number[]> values;
+      std::unique_ptr<Number[], void (*)(void *)> values;
 
       /**
        * For parallel loops with TBB, this member variable stores the affinity

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1087,7 +1087,7 @@ namespace LinearAlgebra
        * we need to use a custom deleter for this object that does not call
        * <code>delete[]</code>, but instead calls @p free().
        */
-      std::unique_ptr<Number[], void (*)(void *)> values;
+      std::unique_ptr<Number[], decltype(&free)> values;
 
       /**
        * For parallel loops with TBB, this member variable stores the affinity

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -290,7 +290,6 @@ namespace LinearAlgebra
     inline
     Vector<Number>::~Vector ()
     {
-      resize_val(0);
       clear_mpi_requests();
     }
 

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -204,7 +204,7 @@ namespace LinearAlgebra
       :
       partitioner (new Utilities::MPI::Partitioner()),
       allocated_size (0),
-      values (nullptr)
+      values (nullptr, &free)
     {
       reinit(0);
     }
@@ -216,7 +216,7 @@ namespace LinearAlgebra
       :
       Subscriptor(),
       allocated_size (0),
-      values (nullptr),
+      values (nullptr, &free),
       vector_is_ghosted (false)
     {
       reinit (v, true);
@@ -240,7 +240,7 @@ namespace LinearAlgebra
                             const MPI_Comm  communicator)
       :
       allocated_size (0),
-      values (nullptr),
+      values (nullptr, &free),
       vector_is_ghosted (false)
     {
       reinit (local_range, ghost_indices, communicator);
@@ -253,7 +253,7 @@ namespace LinearAlgebra
                             const MPI_Comm  communicator)
       :
       allocated_size (0),
-      values (nullptr),
+      values (nullptr, &free),
       vector_is_ghosted (false)
     {
       reinit (local_range, communicator);
@@ -265,7 +265,7 @@ namespace LinearAlgebra
     Vector<Number>::Vector (const size_type size)
       :
       allocated_size (0),
-      values (nullptr),
+      values (nullptr, &free),
       vector_is_ghosted (false)
     {
       reinit (size, false);
@@ -278,7 +278,7 @@ namespace LinearAlgebra
     Vector (const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner)
       :
       allocated_size (0),
-      values (nullptr),
+      values (nullptr, &free),
       vector_is_ghosted (false)
     {
       reinit (partitioner);


### PR DESCRIPTION
This is the promised follow-up to #5268. While there, I took the liberty to also rename the `val` member variable to `values`, to keep with our habit of using long names.

@kronbichler -- can you take a look? I obviously had to wrap the call to `posix_memalign`, but that is in only one place and not too painful.