### PR TITLE
pass std::function by const reference

### DIFF
--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -893,7 +893,7 @@ namespace Threads
        * The function that runs on the thread.
        */
       static
-      void thread_entry_point (const std::function<RT ()> function,
+      void thread_entry_point (const std::function<RT ()> &function,
                                std::shared_ptr<return_value<RT> > ret_val)
       {
         // call the function in question. since an exception that is

--- a/include/deal.II/base/time_stepping.h
+++ b/include/deal.II/base/time_stepping.h
@@ -165,8 +165,8 @@ namespace TimeStepping
      * evolve_one_time_step returns the time at the end of the time step.
      */
     virtual double evolve_one_time_step
-    (std::function<VectorType (const double, const VectorType &)>               f,
-     std::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
+    (const std::function<VectorType (const double, const VectorType &)>               &f,
+     const std::function<VectorType (const double, const double, const VectorType &)> &id_minus_tau_J_inverse,
      double                                                                     t,
      double                                                                     delta_t,
      VectorType                                                                 &y) = 0;
@@ -234,8 +234,8 @@ namespace TimeStepping
      * end of the time step.
      */
     double evolve_one_time_step
-    (std::function<VectorType (const double, const VectorType &)>                f,
-     std::function<VectorType (const double, const double, const VectorType &)>  id_minus_tau_J_inverse,
+    (const std::function<VectorType (const double, const VectorType &)>                &f,
+     const std::function<VectorType (const double, const double, const VectorType &)>  &id_minus_tau_J_inverse,
      double                                                                      t,
      double                                                                      delta_t,
      VectorType                                                                  &y);
@@ -248,7 +248,7 @@ namespace TimeStepping
      * step.
      */
     double evolve_one_time_step
-    (std::function<VectorType (const double, const VectorType &)> f,
+    (const std::function<VectorType (const double, const VectorType &)> &f,
      double                                                       t,
      double                                                       delta_t,
      VectorType                                                   &y);
@@ -276,7 +276,7 @@ namespace TimeStepping
      * Compute the different stages needed.
      */
     void compute_stages
-    (std::function<VectorType (const double, const VectorType &)> f,
+    (const std::function<VectorType (const double, const VectorType &)> &f,
      const double                                                 t,
      const double                                                 delta_t,
      const VectorType                                             &y,
@@ -333,11 +333,11 @@ namespace TimeStepping
      * returns the time at the end of the time step.
      */
     double evolve_one_time_step
-    (std::function<VectorType (const double, const VectorType &)>               f,
-     std::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
-     double                                                                     t,
-     double                                                                     delta_t,
-     VectorType                                                                 &y);
+    (const std::function<VectorType (const double, const VectorType &)>               &f,
+     const std::function<VectorType (const double, const double, const VectorType &)> &id_minus_tau_J_inverse,
+     double                                                                           t,
+     double                                                                           delta_t,
+     VectorType                                                                       &y);
 
     /**
      * Set the maximum number of iterations and the tolerance used by the
@@ -374,30 +374,30 @@ namespace TimeStepping
      * Compute the different stages needed.
      */
     void compute_stages
-    (std::function<VectorType (const double, const VectorType &)>               f,
-     std::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
-     double                                                                     t,
-     double                                                                     delta_t,
-     VectorType                                                                 &y,
+    (const std::function<VectorType (const double, const VectorType &)>               &f,
+     const std::function<VectorType (const double, const double, const VectorType &)> &id_minus_tau_J_inverse,
+     double                                                                           t,
+     double                                                                           delta_t,
+     VectorType                                                                       &y,
      std::vector<VectorType> &f_stages);
 
     /**
      * Newton solver used for the implicit stages.
      */
-    void newton_solve(std::function<void (const VectorType &,VectorType &)> get_residual,
-                      std::function<VectorType (const VectorType &)>        id_minus_tau_J_inverse,
-                      VectorType                                            &y);
+    void newton_solve(const std::function<void (const VectorType &,VectorType &)> &get_residual,
+                      const std::function<VectorType (const VectorType &)>        &id_minus_tau_J_inverse,
+                      VectorType                                                  &y);
 
     /**
      * Compute the residual needed by the Newton solver.
      */
-    void compute_residual(std::function<VectorType (const double, const VectorType &)> f,
-                          double                                                       t,
-                          double                                                       delta_t,
-                          const VectorType                                             &new_y,
-                          const VectorType                                             &y,
-                          VectorType                                                   &tendency,
-                          VectorType                                                   &residual) const;
+    void compute_residual(const std::function<VectorType (const double, const VectorType &)> &f,
+                          double                                                             t,
+                          double                                                             delta_t,
+                          const VectorType                                                   &new_y,
+                          const VectorType                                                   &y,
+                          VectorType                                                         &tendency,
+                          VectorType                                                         &residual) const;
 
     /**
      * When using SDIRK, there is no need to compute the linear combination of
@@ -483,8 +483,8 @@ namespace TimeStepping
      * at the end of the time step.
      */
     double evolve_one_time_step
-    (std::function<VectorType (const double, const VectorType &)>               f,
-     std::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
+    (const std::function<VectorType (const double, const VectorType &)>               &f,
+     const std::function<VectorType (const double, const double, const VectorType &)> &id_minus_tau_J_inverse,
      double                                                                     t,
      double                                                                     delta_t,
      VectorType &y);
@@ -497,7 +497,7 @@ namespace TimeStepping
      * step.
      */
     double evolve_one_time_step
-    (std::function<VectorType (const double, const VectorType &)> f,
+    (const std::function<VectorType (const double, const VectorType &)> &f,
      double                                                       t,
      double                                                       delta_t,
      VectorType &y);
@@ -536,7 +536,7 @@ namespace TimeStepping
     /**
      * Compute the different stages needed.
      */
-    void compute_stages(std::function<VectorType (const double, const VectorType &)> f,
+    void compute_stages(const std::function<VectorType (const double, const VectorType &)> &f,
                         const double                                                 t,
                         const double                                                 delta_t,
                         const VectorType                                             &y,

--- a/include/deal.II/base/time_stepping.templates.h
+++ b/include/deal.II/base/time_stepping.templates.h
@@ -138,8 +138,8 @@ namespace TimeStepping
 
   template <typename VectorType>
   double ExplicitRungeKutta<VectorType>::evolve_one_time_step
-  (std::function<VectorType (const double, const VectorType &)> f,
-   std::function<VectorType (const double, const double, const VectorType &)> /*id_minus_tau_J_inverse*/,
+  (const std::function<VectorType (const double, const VectorType &)> &f,
+   const std::function<VectorType (const double, const double, const VectorType &)> &/*id_minus_tau_J_inverse*/,
    double                                                             t,
    double                                                             delta_t,
    VectorType                                                         &y)
@@ -151,7 +151,7 @@ namespace TimeStepping
 
   template <typename VectorType>
   double ExplicitRungeKutta<VectorType>::evolve_one_time_step
-  (std::function<VectorType (const double, const VectorType &)> f,
+  (const std::function<VectorType (const double, const VectorType &)> &f,
    double                                                             t,
    double                                                             delta_t,
    VectorType                                                         &y)
@@ -179,7 +179,7 @@ namespace TimeStepping
 
   template <typename VectorType>
   void ExplicitRungeKutta<VectorType>::compute_stages
-  (std::function<VectorType (const double, const VectorType &)> f,
+  (const std::function<VectorType (const double, const VectorType &)> &f,
    const double                                                       t,
    const double                                                       delta_t,
    const VectorType                                                   &y,
@@ -281,8 +281,8 @@ namespace TimeStepping
 
   template <typename VectorType>
   double ImplicitRungeKutta<VectorType>::evolve_one_time_step
-  (std::function<VectorType (const double, const VectorType &)> f,
-   std::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
+  (const std::function<VectorType (const double, const VectorType &)> &f,
+   const std::function<VectorType (const double, const double, const VectorType &)> &id_minus_tau_J_inverse,
    double                                                             t,
    double                                                             delta_t,
    VectorType                                                         &y)
@@ -324,8 +324,8 @@ namespace TimeStepping
 
   template <typename VectorType>
   void ImplicitRungeKutta<VectorType>::compute_stages(
-    std::function<VectorType (const double, const VectorType &)> f,
-    std::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
+    const std::function<VectorType (const double, const VectorType &)> &f,
+    const std::function<VectorType (const double, const double, const VectorType &)> &id_minus_tau_J_inverse,
     double t,
     double delta_t,
     VectorType &y,
@@ -351,8 +351,8 @@ namespace TimeStepping
 
   template <typename VectorType>
   void ImplicitRungeKutta<VectorType>::newton_solve(
-    std::function<void (const VectorType &,VectorType &)> get_residual,
-    std::function<VectorType (const VectorType &)> id_minus_tau_J_inverse,
+    const std::function<void (const VectorType &,VectorType &)> &get_residual,
+    const std::function<VectorType (const VectorType &)> &id_minus_tau_J_inverse,
     VectorType &y)
   {
     VectorType residual(y);
@@ -377,7 +377,7 @@ namespace TimeStepping
 
   template <typename VectorType>
   void ImplicitRungeKutta<VectorType>::compute_residual
-  (std::function<VectorType (const double, const VectorType &)> f,
+  (const std::function<VectorType (const double, const VectorType &)> &f,
    double                                                             t,
    double                                                             delta_t,
    const VectorType                                                   &old_y,
@@ -675,8 +675,8 @@ namespace TimeStepping
 
   template <typename VectorType>
   double EmbeddedExplicitRungeKutta<VectorType>::evolve_one_time_step(
-    std::function<VectorType (const double, const VectorType &)> f,
-    std::function<VectorType (const double, const double, const VectorType &)> /*id_minus_tau_J_inverse*/,
+    const std::function<VectorType (const double, const VectorType &)> &f,
+    const std::function<VectorType (const double, const double, const VectorType &)> &/*id_minus_tau_J_inverse*/,
     double t,
     double delta_t,
     VectorType &y)
@@ -688,7 +688,7 @@ namespace TimeStepping
 
   template <typename VectorType>
   double EmbeddedExplicitRungeKutta<VectorType>::evolve_one_time_step(
-    std::function<VectorType (const double, const VectorType &)> f,
+    const std::function<VectorType (const double, const VectorType &)> &f,
     double t, double delta_t, VectorType &y)
   {
     bool done = false;
@@ -804,7 +804,7 @@ namespace TimeStepping
 
   template <typename VectorType>
   void EmbeddedExplicitRungeKutta<VectorType>::compute_stages(
-    std::function<VectorType (const double, const VectorType &)> f,
+    const std::function<VectorType (const double, const VectorType &)> &f,
     const double t,
     const double delta_t,
     const VectorType &y,

--- a/include/deal.II/distributed/grid_tools.h
+++ b/include/deal.II/distributed/grid_tools.h
@@ -128,8 +128,8 @@ namespace parallel
     template <typename DataType, typename MeshType>
     void
     exchange_cell_data_to_ghosts (const MeshType &mesh,
-                                  std::function<boost::optional<DataType> (const typename MeshType::active_cell_iterator &)> pack,
-                                  std::function<void (const typename MeshType::active_cell_iterator &, const DataType &)> unpack);
+                                  const std::function<boost::optional<DataType> (const typename MeshType::active_cell_iterator &)> &pack,
+                                  const std::function<void (const typename MeshType::active_cell_iterator &, const DataType &)> &unpack);
   }
 
 
@@ -260,8 +260,8 @@ namespace parallel
     template <typename DataType, typename MeshType>
     void
     exchange_cell_data_to_ghosts (const MeshType &mesh,
-                                  std::function<boost::optional<DataType> (const typename MeshType::active_cell_iterator &)> pack,
-                                  std::function<void (const typename MeshType::active_cell_iterator &, const DataType &)> unpack)
+                                  const std::function<boost::optional<DataType> (const typename MeshType::active_cell_iterator &)> &pack,
+                                  const std::function<void (const typename MeshType::active_cell_iterator &, const DataType &)> &unpack)
     {
 #ifndef DEAL_II_WITH_MPI
       (void)mesh;

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -897,7 +897,7 @@ namespace VectorTools
                 const DoFHandler<dim,spacedim> &dof,
                 const ConstraintMatrix         &constraints,
                 const Quadrature<dim>          &quadrature,
-                const std::function< typename VectorType::value_type (const typename DoFHandler<dim, spacedim>::active_cell_iterator &, const unsigned int)> func,
+                const std::function< typename VectorType::value_type (const typename DoFHandler<dim, spacedim>::active_cell_iterator &, const unsigned int)> &func,
                 VectorType                     &vec_result);
 
   /**
@@ -924,7 +924,7 @@ namespace VectorTools
   void project (std::shared_ptr<const MatrixFree<dim,typename VectorType::value_type> > data,
                 const ConstraintMatrix &constraints,
                 const unsigned int n_q_points_1d,
-                const std::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> func,
+                const std::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> &func,
                 VectorType &vec_result);
 
   /**
@@ -933,7 +933,7 @@ namespace VectorTools
   template <int dim, typename VectorType>
   void project (std::shared_ptr<const MatrixFree<dim,typename VectorType::value_type> > data,
                 const ConstraintMatrix &constraints,
-                const std::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> func,
+                const std::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> &func,
                 VectorType &vec_result);
 
   /**

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -1262,7 +1262,7 @@ namespace VectorTools
                            const DoFHandler<dim,spacedim> &dof,
                            const ConstraintMatrix         &constraints,
                            const Quadrature<dim>          &quadrature,
-                           const std::function< typename VectorType::value_type (const typename DoFHandler<dim, spacedim>::active_cell_iterator &, const unsigned int)> func,
+                           const std::function< typename VectorType::value_type (const typename DoFHandler<dim, spacedim>::active_cell_iterator &, const unsigned int)> &func,
                            VectorType                     &vec_result)
     {
       typedef typename VectorType::value_type Number;
@@ -1360,7 +1360,7 @@ namespace VectorTools
     template <int dim, typename VectorType, int spacedim, int fe_degree, int n_q_points_1d>
     void project_parallel (std::shared_ptr<const MatrixFree<dim,typename VectorType::value_type> > matrix_free,
                            const ConstraintMatrix &constraints,
-                           const std::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> func,
+                           const std::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> &func,
                            VectorType &vec_result)
     {
       const DoFHandler<dim,spacedim> &dof = matrix_free->get_dof_handler();
@@ -1438,7 +1438,7 @@ namespace VectorTools
                 const DoFHandler<dim,spacedim> &dof,
                 const ConstraintMatrix         &constraints,
                 const Quadrature<dim>          &quadrature,
-                const std::function< typename VectorType::value_type (const typename DoFHandler<dim, spacedim>::active_cell_iterator &, const unsigned int)> func,
+                const std::function< typename VectorType::value_type (const typename DoFHandler<dim, spacedim>::active_cell_iterator &, const unsigned int)> &func,
                 VectorType                     &vec_result)
   {
     switch (dof.get_fe().degree)
@@ -1463,7 +1463,7 @@ namespace VectorTools
   void project (std::shared_ptr<const MatrixFree<dim,typename VectorType::value_type> > matrix_free,
                 const ConstraintMatrix &constraints,
                 const unsigned int n_q_points_1d,
-                const std::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> func,
+                const std::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> &func,
                 VectorType &vec_result)
   {
     (void) n_q_points_1d;
@@ -1493,7 +1493,7 @@ namespace VectorTools
   template <int dim, typename VectorType>
   void project (std::shared_ptr<const MatrixFree<dim,typename VectorType::value_type> > matrix_free,
                 const ConstraintMatrix &constraints,
-                const std::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> func,
+                const std::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> &func,
                 VectorType &vec_result)
   {
     project (matrix_free,

--- a/source/numerics/vector_tools_project_qp.inst.in
+++ b/source/numerics/vector_tools_project_qp.inst.in
@@ -23,7 +23,7 @@ for (VEC: REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
         const DoFHandler<deal_II_dimension,deal_II_dimension> &,
         const ConstraintMatrix &,
         const Quadrature<deal_II_dimension> &,
-        const std::function<VEC::value_type (const DoFHandler<deal_II_dimension, deal_II_dimension>::active_cell_iterator &, const unsigned int)>,
+        const std::function<VEC::value_type (const DoFHandler<deal_II_dimension, deal_II_dimension>::active_cell_iterator &, const unsigned int)> &,
         VEC &);
 
     \}

--- a/source/numerics/vector_tools_project_qpmf.inst.in
+++ b/source/numerics/vector_tools_project_qpmf.inst.in
@@ -23,7 +23,7 @@ for (VEC: REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
     void project<deal_II_dimension, VEC>(
         std::shared_ptr<const MatrixFree<deal_II_dimension,VEC::value_type> > matrix_free,
         const ConstraintMatrix &constraints,
-        const std::function< VectorizedArray<VEC::value_type> (const unsigned int, const unsigned int)>,
+        const std::function< VectorizedArray<VEC::value_type> (const unsigned int, const unsigned int)> &,
         VEC &);
 
     template
@@ -31,7 +31,7 @@ for (VEC: REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
         std::shared_ptr<const MatrixFree<deal_II_dimension,VEC::value_type> > matrix_free,
         const ConstraintMatrix &constraints,
         const unsigned int,
-        const std::function< VectorizedArray<VEC::value_type> (const unsigned int, const unsigned int)>,
+        const std::function< VectorizedArray<VEC::value_type> (const unsigned int, const unsigned int)> &,
         VEC &);
 
     \}


### PR DESCRIPTION
I think a std::function should be passed by const reference, unless we
are planning on storing a copy (then by value and move). Fix a few places.