### PR TITLE
Remove unnecessary #include statements.

### DIFF
--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -24,15 +24,14 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/thread_management.h>
-#include <deal.II/lac/vector_view.h>
 #include <deal.II/lac/vector_operation.h>
 
 #include <cstring>
 #include <iomanip>
 
 #ifdef DEAL_II_WITH_TRILINOS
-#include <deal.II/lac/trilinos_epetra_communication_pattern.h>
-#include <deal.II/lac/trilinos_epetra_vector.h>
+#  include <deal.II/lac/trilinos_epetra_communication_pattern.h>
+#  include <deal.II/lac/trilinos_epetra_vector.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_MultiVector.h>

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -27,7 +27,6 @@
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/trilinos_vector.h>
 #  include <deal.II/lac/trilinos_epetra_vector.h>
-#  include <deal.II/lac/vector_view.h>
 #  include <deal.II/lac/vector_memory.h>
 #include <deal.II/lac/vector_operation.h>
 

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/mpi.h>
+
 #ifdef DEAL_II_WITH_SUNDIALS
 
 #include <deal.II/base/logstream.h>
@@ -26,11 +27,10 @@
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/mpi.h>
 #ifdef DEAL_II_WITH_PETSC
-#include <deal.II/lac/petsc_parallel_block_vector.h>
-#include <deal.II/lac/petsc_parallel_vector.h>
+#  include <deal.II/lac/petsc_parallel_block_vector.h>
+#  include <deal.II/lac/petsc_parallel_vector.h>
 #endif
 #include <deal.II/lac/vector.h>
-#include <deal.II/lac/vector_view.h>
 #include <deal.II/lac/vector_memory.h>
 
 
@@ -38,7 +38,7 @@
 #include <arkode/arkode_impl.h>
 #include <nvector/nvector_serial.h>
 #ifdef DEAL_II_WITH_MPI
-#include <nvector/nvector_parallel.h>
+#  include <nvector/nvector_parallel.h>
 #endif
 #include <sundials/sundials_math.h>
 #include <sundials/sundials_types.h>

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -26,11 +26,10 @@
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/mpi.h>
 #ifdef DEAL_II_WITH_PETSC
-#include <deal.II/lac/petsc_parallel_block_vector.h>
-#include <deal.II/lac/petsc_parallel_vector.h>
+#  include <deal.II/lac/petsc_parallel_block_vector.h>
+#  include <deal.II/lac/petsc_parallel_vector.h>
 #endif
 #include <deal.II/lac/vector.h>
-#include <deal.II/lac/vector_view.h>
 #include <deal.II/lac/vector_memory.h>
 
 

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -25,7 +25,6 @@
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/lac/vector.h>
-#include <deal.II/lac/vector_view.h>
 #include <deal.II/lac/vector_memory.h>
 
 #include <kinsol/kinsol.h>


### PR DESCRIPTION
These are all in files that don't actually make use of the classes so #included.
I noticed this because I had to recompile a *lot* of files everytime I made
a change to VectorView, even though the class is barely used in the library.

See also #5278.