### PR TITLE
Move VectorOperation into its own header.

### DIFF
--- a/doc/news/changes/minor/20171020DavidWells
+++ b/doc/news/changes/minor/20171020DavidWells
@@ -1,0 +1,3 @@
+Changed: The <code>enum</code> VectorOperation is now declared in its own header instead of the header for Vector.
+<br>
+(David Wells, 2017/10/20)

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -23,8 +23,10 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/array_view.h>
-#include <deal.II/lac/vector.h>
+
 #include <deal.II/lac/communication_pattern_base.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_operation.h>
 
 #include <limits>
 

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -28,6 +28,7 @@
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/matrix_iterator.h>
 #include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_operation.h>
 
 #include <cmath>
 

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/lac/block_indices.h>
 #include <deal.II/lac/block_vector_base.h>
+#include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_type_traits.h>
 
 #include <cstdio>

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -24,6 +24,8 @@
 #include <deal.II/lac/exceptions.h>
 #include <deal.II/lac/block_indices.h>
 #include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_operation.h>
+
 #include <vector>
 #include <iterator>
 #include <cmath>

--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/lac/vector_space_vector.h>
-
+#include <deal.II/lac/vector_operation.h>
 
 #ifdef DEAL_II_WITH_CUDA
 

--- a/include/deal.II/lac/diagonal_matrix.h
+++ b/include/deal.II/lac/diagonal_matrix.h
@@ -18,6 +18,7 @@
 
 
 #include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_operation.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -22,8 +22,8 @@
 #include <deal.II/lac/block_indices.h>
 #include <deal.II/lac/block_vector_base.h>
 #include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_type_traits.h>
-
 
 #include <cstdio>
 #include <vector>

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -22,6 +22,7 @@
 #include <deal.II/lac/petsc_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/lapack_support.h>
+#include <deal.II/lac/vector.h>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/partitioner.h>
 #include <deal.II/base/thread_management.h>
+#include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_space_vector.h>
 #include <deal.II/lac/vector_type_traits.h>
 

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_space_vector.h>
 #include <deal.II/lac/vector_type_traits.h>
 

--- a/include/deal.II/lac/la_vector.templates.h
+++ b/include/deal.II/lac/la_vector.templates.h
@@ -17,6 +17,7 @@
 #define dealii_la_vector_templates_h
 
 #include <deal.II/lac/la_vector.h>
+#include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_operations_internal.h>
 #include <iostream>
 #include <iomanip>

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -17,11 +17,13 @@
 #define dealii_parpack_solver_h
 
 #include <deal.II/base/config.h>
+#include <deal.II/base/index_set.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/memory_consumption.h>
+
 #include <deal.II/lac/solver_control.h>
-#include <deal.II/lac/vector.h>
-#include <deal.II/base/index_set.h>
+#include <deal.II/lac/vector_operation.h>
+
 
 #include <cstring>
 

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -25,7 +25,7 @@
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/full_matrix.h>
 #  include <deal.II/lac/petsc_compatibility.h>
-#  include <deal.II/lac/vector.h>
+#  include <deal.II/lac/vector_operation.h>
 
 #  include <petscmat.h>
 

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -24,6 +24,7 @@
 #  include <deal.II/base/subscriptor.h>
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/vector.h>
+#  include <deal.II/lac/vector_operation.h>
 #  include <deal.II/lac/petsc_vector_base.h>
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/lac/vector_type_traits.h>

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -24,6 +24,7 @@
 #  include <deal.II/base/subscriptor.h>
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/vector.h>
+#  include <deal.II/lac/vector_operation.h>
 
 #  include <vector>
 #  include <utility>

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -25,6 +25,7 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/lac/vector_view.h>
+#include <deal.II/lac/vector_operation.h>
 
 #include <cstring>
 #include <iomanip>

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -23,7 +23,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/identity_matrix.h>
 #include <deal.II/lac/exceptions.h>
-#include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_operation.h>
 
 #include <memory>
 

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -24,7 +24,9 @@
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/lac/trilinos_epetra_communication_pattern.h>
+#include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_space_vector.h>
+#include <deal.II/lac/vector_type_traits.h>
 #include <memory>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -29,6 +29,7 @@
 #  include <deal.II/lac/trilinos_epetra_vector.h>
 #  include <deal.II/lac/vector_view.h>
 #  include <deal.II/lac/vector_memory.h>
+#include <deal.II/lac/vector_operation.h>
 
 #  include <type_traits>
 #  include <vector>

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -26,6 +26,7 @@
 #  include <deal.II/base/mpi.h>
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/vector.h>
+#  include <deal.II/lac/vector_operation.h>
 #  include <deal.II/lac/vector_type_traits.h>
 
 #  include <vector>

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/index_set.h>
+#include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_type_traits.h>
 
 // boost::serialization::make_array used to be in array.hpp, but was
@@ -78,37 +79,6 @@ namespace parallel
 /*! @addtogroup Vectors
  *@{
  */
-
-/**
- * This enum keeps track of the current operation in parallel linear algebra
- * objects like Vectors and Matrices.
- *
- * It is used in the various compress() functions. They also exist in serial
- * codes for compatibility and are empty there.
- *
- * See
- * @ref GlossCompress "Compressing distributed objects"
- * for more information.
- */
-struct VectorOperation
-{
-  enum values
-  {
-    /**
-     * The current operation is unknown.
-     */
-    unknown,
-    /**
-     * The current operation is an insertion.
-     */
-    insert,
-    /**
-     * The current operation is an addition.
-     */
-    add
-  };
-};
-
 
 /**
  * Numerical vector of data.  For this class there are different types of

--- a/include/deal.II/lac/vector_operation.h
+++ b/include/deal.II/lac/vector_operation.h
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_lac_vector_operation_h
+#define dealii_lac_vector_operation_h
+
+#include <deal.II/base/config.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+/*! @addtogroup Vectors
+ *@{
+ */
+
+/**
+ * This enum keeps track of the current operation in parallel linear algebra
+ * objects like Vectors and Matrices.
+ *
+ * It is used in the various compress() functions. They also exist in serial
+ * codes for compatibility and are empty there.
+ *
+ * See
+ * @ref GlossCompress "Compressing distributed objects"
+ * for more information.
+ */
+struct VectorOperation
+{
+  enum values
+  {
+    /**
+     * The current operation is unknown.
+     */
+    unknown,
+    /**
+     * The current operation is an insertion.
+     */
+    insert,
+    /**
+     * The current operation is an addition.
+     */
+    add
+  };
+};
+
+/*@}*/
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/numbers.h>
-#include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_operation.h>
 
 #include <memory>
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -32,6 +32,7 @@
 #include <deal.II/matrix_free/tensor_product_kernels.h>
 #include <deal.II/matrix_free/evaluation_selector.h>
 
+#include <deal.II/lac/vector_operation.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -27,7 +27,7 @@
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/mapping.h>
 #include <deal.II/fe/mapping_q1.h>
-#include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/block_vector_base.h>
 #include <deal.II/lac/constraint_matrix.h>


### PR DESCRIPTION
This commit moves the `VectorOperation` enum into its own file. This is backwards compatible since `vector.h`, which previously contained the declaration, `#include`s this new header.

This should fix the extra test failures in #5288 that seemed to be caused by removing `#include <deal.II/lac/vector_view.h>` (which `#include`d `vector.h`).