### PR TITLE
Take IndexSet by const&

### DIFF
--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1433,7 +1433,7 @@ namespace FETools
           dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>(&dh.get_triangulation());
         Assert (parallel_tria != nullptr, ExcNotImplemented());
 
-        const IndexSet locally_owned_dofs = dh.locally_owned_dofs();
+        const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
         vector.reinit(locally_owned_dofs, parallel_tria->get_communicator());
       }
 #endif //DEAL_II_WITH_PETSC
@@ -1447,7 +1447,7 @@ namespace FETools
           dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>(&dh.get_triangulation());
         Assert (parallel_tria != nullptr, ExcNotImplemented());
 
-        const IndexSet locally_owned_dofs = dh.locally_owned_dofs();
+        const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
         vector.reinit(locally_owned_dofs, parallel_tria->get_communicator());
       }
 
@@ -1462,7 +1462,7 @@ namespace FETools
           dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>(&dh.get_triangulation());
         Assert (parallel_tria !=0, ExcNotImplemented());
 
-        const IndexSet locally_owned_dofs = dh.locally_owned_dofs();
+        const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
         vector.reinit(locally_owned_dofs, parallel_tria->get_communicator());
       }
 #endif
@@ -1476,7 +1476,7 @@ namespace FETools
           dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>(&dh.get_triangulation());
         Assert (parallel_tria != nullptr, ExcNotImplemented());
 
-        const IndexSet locally_owned_dofs = dh.locally_owned_dofs();
+        const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
         vector.reinit(locally_owned_dofs, parallel_tria->get_communicator());
       }
 
@@ -1497,7 +1497,7 @@ namespace FETools
         const parallel::distributed::Triangulation<dim,spacedim> *parallel_tria =
           dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>(&dh.get_triangulation());
         Assert(parallel_tria != nullptr, ExcNotImplemented());
-        const IndexSet  locally_owned_dofs = dh.locally_owned_dofs();
+        const IndexSet  &locally_owned_dofs = dh.locally_owned_dofs();
         IndexSet  locally_relevant_dofs;
         DoFTools::extract_locally_relevant_dofs (dh, locally_relevant_dofs);
         vector.reinit (locally_owned_dofs, locally_relevant_dofs,
@@ -1513,7 +1513,7 @@ namespace FETools
         const parallel::distributed::Triangulation<dim,spacedim> *parallel_tria =
           dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>(&dh.get_triangulation());
         Assert (parallel_tria != nullptr, ExcNotImplemented());
-        const IndexSet  locally_owned_dofs = dh.locally_owned_dofs();
+        const IndexSet  &locally_owned_dofs = dh.locally_owned_dofs();
         IndexSet  locally_relevant_dofs;
         DoFTools::extract_locally_relevant_dofs (dh, locally_relevant_dofs);
         vector.reinit (locally_owned_dofs, locally_relevant_dofs,
@@ -1528,7 +1528,7 @@ namespace FETools
         const parallel::distributed::Triangulation<dim,spacedim> *parallel_tria =
           dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>(&dh.get_triangulation());
         Assert (parallel_tria != nullptr, ExcNotImplemented());
-        const IndexSet  locally_owned_dofs = dh.locally_owned_dofs();
+        const IndexSet  &locally_owned_dofs = dh.locally_owned_dofs();
         IndexSet  locally_relevant_dofs;
         DoFTools::extract_locally_relevant_dofs (dh, locally_relevant_dofs);
         vector.reinit (locally_owned_dofs, locally_relevant_dofs,

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -217,7 +217,7 @@ namespace FETools
     // if we work on parallel distributed
     // vectors, we have to ensure, that we only
     // work on dofs this processor owns.
-    IndexSet  locally_owned_dofs = dof2.locally_owned_dofs();
+    const IndexSet  &locally_owned_dofs = dof2.locally_owned_dofs();
 
     // when a discontinuous element is
     // interpolated to a continuous
@@ -371,7 +371,7 @@ namespace FETools
         // if u1 is a parallel distributed PETSc vector, we create a
         // vector u2 with based on the sets of locally owned and relevant
         // dofs of dof2
-        IndexSet  dof2_locally_owned_dofs = dof2.locally_owned_dofs();
+        const IndexSet  &dof2_locally_owned_dofs = dof2.locally_owned_dofs();
         IndexSet  dof2_locally_relevant_dofs;
         DoFTools::extract_locally_relevant_dofs (dof2,
                                                  dof2_locally_relevant_dofs);
@@ -400,7 +400,7 @@ namespace FETools
         // if u1 is a parallel distributed Trilinos vector, we create a
         // vector u2 with based on the sets of locally owned and relevant
         // dofs of dof2
-        IndexSet  dof2_locally_owned_dofs = dof2.locally_owned_dofs();
+        const IndexSet  &dof2_locally_owned_dofs = dof2.locally_owned_dofs();
         IndexSet  dof2_locally_relevant_dofs;
         DoFTools::extract_locally_relevant_dofs (dof2,
                                                  dof2_locally_relevant_dofs);
@@ -425,7 +425,7 @@ namespace FETools
                              const ConstraintMatrix &constraints2,
                              LinearAlgebra::distributed::Vector<Number> &u1_interpolated)
       {
-        IndexSet dof2_locally_owned_dofs = dof2.locally_owned_dofs();
+        const IndexSet &dof2_locally_owned_dofs = dof2.locally_owned_dofs();
         IndexSet dof2_locally_relevant_dofs;
         DoFTools::extract_locally_relevant_dofs (dof2,
                                                  dof2_locally_relevant_dofs);

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -1202,7 +1202,7 @@ namespace VectorTools
                                      enforce_zero_boundary, q_boundary,
                                      project_to_boundary_first);
 
-      const IndexSet locally_owned_dofs = dof.locally_owned_dofs();
+      const IndexSet &locally_owned_dofs = dof.locally_owned_dofs();
       IndexSet::ElementIterator it = locally_owned_dofs.begin();
       for (; it!=locally_owned_dofs.end(); ++it)
         ::dealii::internal::ElementAccess<VectorType>::set(work_result(*it),
@@ -1348,7 +1348,7 @@ namespace VectorTools
 
       constraints.distribute (vec);
 
-      const IndexSet locally_owned_dofs = dof.locally_owned_dofs();
+      const IndexSet &locally_owned_dofs = dof.locally_owned_dofs();
       IndexSet::ElementIterator it = locally_owned_dofs.begin();
       for (; it!=locally_owned_dofs.end(); ++it)
         ::dealii::internal::ElementAccess<VectorType>::set(vec(*it), *it, vec_result);
@@ -1423,7 +1423,7 @@ namespace VectorTools
 
       constraints.distribute (vec);
 
-      const IndexSet locally_owned_dofs = dof.locally_owned_dofs();
+      const IndexSet &locally_owned_dofs = dof.locally_owned_dofs();
       IndexSet::ElementIterator it = locally_owned_dofs.begin();
       for (; it!=locally_owned_dofs.end(); ++it)
         ::dealii::internal::ElementAccess<VectorType>::set(vec(*it), *it, vec_result);

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -397,7 +397,7 @@ namespace DoFRenumbering
       }
     constraints.close ();
 
-    const IndexSet locally_owned = dof_handler.locally_owned_dofs();
+    const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
 
     // otherwise compute the Cuthill-McKee permutation
     DynamicSparsityPattern dsp (dof_handler.n_dofs(),


### PR DESCRIPTION
In all the cases below, there really is no reason to copy the `IndexSet` object.
In particular, `DoFTools::compute_Cuthill_McKee` only considers the locally owned degrees of freedom.