### PR TITLE
Use bool literals instead of integer values

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -126,7 +126,7 @@ namespace
 
       switch (state_in->step)
         {
-          while (1)
+          while (true)
             {
               DEAL_II_FALLTHROUGH;
             case step_A:

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -125,7 +125,7 @@ TableHandler::Column::Column(const std::string &tex_caption)
   tex_caption(tex_caption),
   tex_format("c"),
   precision(4),
-  scientific(0),
+  scientific(false),
   flag(0),
   max_length(0)
 {}
@@ -137,7 +137,7 @@ TableHandler::Column::Column()
   tex_caption(),
   tex_format("c"),
   precision(4),
-  scientific(0),
+  scientific(false),
   flag(0),
   max_length(0)
 {}

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -3091,7 +3091,7 @@ namespace internal
 
               // right child
               neighbor = neighbor->child(1);
-              while (1)
+              while (true)
                 {
                   Assert (neighbor->neighbor(1) == cell->child(0),
                           ExcInternalError());
@@ -3119,7 +3119,7 @@ namespace internal
 
               // left child
               neighbor = neighbor->child(0);
-              while (1)
+              while (true)
                 {
                   Assert (neighbor->neighbor(0) == cell->child(1),
                           ExcInternalError());

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -425,7 +425,7 @@ void MGTransferBlockBase::build_matrices (
             {
               const types::global_dof_index n_dofs = prolongation_matrices[level]->block(block, block).m();
               constraints_per_block[block].resize(0);
-              constraints_per_block[block].resize(n_dofs, 0);
+              constraints_per_block[block].resize(n_dofs, false);
               for (types::global_dof_index i=0; i<n_dofs; ++i, ++index)
                 constraints_per_block[block][i] = (constrain_indices[index] == 1);
 

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -365,12 +365,12 @@ namespace OpenCASCADE
             {
               Handle(Geom_Curve) curve = intersections[i];
               Handle(Geom_BoundedCurve) bcurve = Handle(Geom_BoundedCurve)::DownCast(curve);
-              check = convert_bspline.Add(bcurve,tolerance,0,1,0);
+              check = convert_bspline.Add(bcurve,tolerance,false,true,0);
               if (check == false)  // If we failed, try again with the reversed curve
                 {
                   curve->Reverse();
                   Handle(Geom_BoundedCurve) bcurve = Handle(Geom_BoundedCurve)::DownCast(curve);
-                  check = convert_bspline.Add(bcurve,tolerance,0,1,0);
+                  check = convert_bspline.Add(bcurve,tolerance,false,true,0);
                 }
               one_failed = one_failed || (check == false);
               one_added = one_added || (check == true);


### PR DESCRIPTION
This is the result of `clang-tidy`s `modernize-use-bool-literals`.