### PR TITLE
Prefer using emplace_back

### DIFF
--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -373,8 +373,8 @@ namespace Utilities
       if (larger_ghost_index_set.size() == 0)
         {
           ghost_indices_subset_chunks_by_rank_data.clear();
-          ghost_indices_subset_data.push_back(std::make_pair(local_size(),
-                                                             local_size()+n_ghost_indices()));
+          ghost_indices_subset_data.emplace_back(local_size(),
+                                                 local_size()+n_ghost_indices());
           n_ghost_indices_in_larger_set = n_ghost_indices_data;
         }
       else

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -246,9 +246,8 @@ namespace internal
 
                 for (unsigned int i=0; i<receive_buffer.size(); ++i)
                   {
-                    copy_indices_level_mine[receive_buffer[i].level].push_back(
-                      std::make_pair (receive_buffer[i].global_dof_index, receive_buffer[i].level_dof_index)
-                    );
+                    copy_indices_level_mine[receive_buffer[i].level].emplace_back(
+                      receive_buffer[i].global_dof_index, receive_buffer[i].level_dof_index);
                   }
               }
           }


### PR DESCRIPTION
This is the result of `clang-tidy`s `modernize-use-emplace`.