### PR TITLE
Prefer using nullptr over 0 or NULL

### DIFF
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -446,7 +446,7 @@ namespace internal
            typename std::enable_if<
            !std::is_same<typename std::decay<T>::type,typename std::decay<F>::type>::value &&
            std::is_constructible<T,F>::value
-           >::type * = 0)
+           >::type * = nullptr)
     {
       return T(f);
     }

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1460,7 +1460,7 @@ namespace FETools
       {
         const parallel::distributed::Triangulation<dim,spacedim> *parallel_tria =
           dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>(&dh.get_triangulation());
-        Assert (parallel_tria !=0, ExcNotImplemented());
+        Assert (parallel_tria !=nullptr, ExcNotImplemented());
 
         const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
         vector.reinit(locally_owned_dofs, parallel_tria->get_communicator());

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -511,10 +511,10 @@ public:
    * semantic sense, and we generate an exception when such an object is
    * actually generated.
    */
-  InvalidAccessor (const Triangulation<dim,spacedim> *parent     =  0,
-                   const int                 level      = -1,
-                   const int                 index      = -1,
-                   const AccessorData       *local_data =  0);
+  InvalidAccessor (const Triangulation<dim,spacedim> *parent     =  nullptr,
+                   const int                          level      = -1,
+                   const int                          index      = -1,
+                   const AccessorData                *local_data =  nullptr);
 
   /**
    * Copy constructor.  This class is used for iterators that do not make

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -296,7 +296,7 @@ namespace LinearAlgebra
     BlockVector<Number>::reinit(const VectorSpaceVector<Number> &V,
                                 const bool omit_zeroing_entries)
     {
-      Assert(dynamic_cast<const BlockVector<Number> *>(&V)!=NULL,
+      Assert(dynamic_cast<const BlockVector<Number> *>(&V)!=nullptr,
              ExcVectorTypeNotCompatible());
       const BlockVector<Number> &down_V = dynamic_cast<const BlockVector<Number> &>(V);
       reinit(down_V, omit_zeroing_entries);

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -742,7 +742,7 @@ namespace LinearAlgebra
                                 const bool omit_zeroing_entries)
     {
       // Downcast. Throws an exception if invalid.
-      Assert(dynamic_cast<const Vector<Number> *>(&V)!=NULL,
+      Assert(dynamic_cast<const Vector<Number> *>(&V)!=nullptr,
              ExcVectorTypeNotCompatible());
       const Vector<Number> &down_V = dynamic_cast<const Vector<Number> &>(V);
 

--- a/include/deal.II/lac/la_vector.templates.h
+++ b/include/deal.II/lac/la_vector.templates.h
@@ -58,7 +58,7 @@ namespace LinearAlgebra
                               const bool omit_zeroing_entries)
   {
     // Check that casting will work.
-    Assert(dynamic_cast<const Vector<Number>*>(&V)!=NULL, ExcVectorTypeNotCompatible());
+    Assert(dynamic_cast<const Vector<Number>*>(&V)!=nullptr, ExcVectorTypeNotCompatible());
 
     // Downcast V. If fails, throws an exception.
     const Vector<Number> &down_V = dynamic_cast<const Vector<Number>&>(V);

--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -467,7 +467,7 @@ namespace internal
           p4est_iterate (reinterpret_cast<dealii::internal::p4est::types<2>::forest *>(parallel_forest),
                          reinterpret_cast<dealii::internal::p4est::types<2>::ghost *>(parallel_ghost),
                          static_cast<void *>(&fg),
-                         NULL, find_ghosts_face<2,spacedim>, find_ghosts_corner<2,spacedim>);
+                         nullptr, find_ghosts_face<2,spacedim>, find_ghosts_corner<2,spacedim>);
           break;
 
         case 3:


### PR DESCRIPTION
The last PR related to this run of `clang-tidy`. This is the result of `clang-tidy`s `modernize-use-nullptr`
