### PR TITLE
Fix unused variables, functions and parameters (with clang)

### DIFF
--- a/bundled/boost-1.62.0/include/boost/property_tree/ptree_serialization.hpp
+++ b/bundled/boost-1.62.0/include/boost/property_tree/ptree_serialization.hpp
@@ -41,7 +41,7 @@ namespace boost { namespace property_tree
     template<class Archive, class K, class D, class C>
     inline void save(Archive &ar,
                      const basic_ptree<K, D, C> &t,
-                     const unsigned int file_version)
+                     const unsigned int /*file_version*/)
     {
         using namespace boost::serialization;
         stl::save_collection<Archive, basic_ptree<K, D, C> >(ar, t);
@@ -99,7 +99,7 @@ namespace boost { namespace property_tree
     template<class Archive, class K, class D, class C>
     inline void load(Archive &ar,
                      basic_ptree<K, D, C> &t,
-                     const unsigned int file_version)
+                     const unsigned int /*file_version*/)
     {
         namespace bsl = boost::serialization;
 

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -94,7 +94,6 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unsupported-friend")
 
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-parameter")
-  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-variable")
 
   #
   # Disable a diagnostic that warns about potentially uninstantiated static
@@ -106,12 +105,18 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # Clang versions prior to 3.6 emit a lot of false positives wrt
   # "-Wunused-function". Also suppress warnings for Xcode older than 6.3
   # (which is equivalent to clang < 3.6).
+  # Policy CMP0025 allows to differentiate between Clang and AppleClang
+  # which admits a more fine-grained control. Otherwise, we are left
+  # with just disabling this feature for all versions between 4.0 and 6.3.
   #
-  # FIXME: I wait for the day with a clang version "4.0"... and I will
-  # curse the person that thought it is a _great_ idea to come up with
-  # independent version numbers for clang on Mac...
-  #
-  IF( CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.6" OR
+  IF (POLICY CMP0025)
+    IF( (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+         AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.6")
+        OR (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
+         AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.3"))
+      ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-function")
+    ENDIF()
+  ELSEIF(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.6" OR
       ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.0" AND
         CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.3") )
     ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-function")

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -229,7 +229,7 @@ void ParameterAcceptor::enter_my_subsection(ParameterHandler &prm=ParameterAccep
 void ParameterAcceptor::leave_my_subsection(ParameterHandler &prm=ParameterAcceptor::prm)
 {
   const auto sections = get_section_path();
-  for (const auto &sec : sections)
+  for (unsigned int i=0; i<sections.size(); ++i)
     {
       prm.leave_subsection();
     }

--- a/source/dummy.cc
+++ b/source/dummy.cc
@@ -21,4 +21,7 @@
  */
 
 const int global_symbol_42 = 42;
-
+void use_global_symbol_42()
+{
+  (void) global_symbol_42;
+}


### PR DESCRIPTION
Unless there are really good reasons to keep `-Wunused-variable` disabled, I would really like to remove this restriction. I guess everyone using `clang` for developing regularly introduces unused variables with just noticing when the code is tested afterwards with `gcc` or similar.

Also fix some unused parameters in the bundled boost, add more fine-grained control for `-Wunused-function` and circumvent declaring an unused variable in `ParameterAcceptor`.