### PR TITLE
change static_assert into Assert for CylindricalManifold to make it e…

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -330,13 +330,6 @@ private:
    */
   double tolerance;
 
-  // explicitly check for sensible template arguments, but not on windows
-  // because MSVC creates bogus warnings during normal compilation
-#ifndef DEAL_II_MSVC
-  static_assert (spacedim==3,
-                 "CylindricalManifold can only be used for spacedim==3!");
-#endif
-
 };
 
 

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -361,7 +361,13 @@ CylindricalManifold<dim, spacedim>::CylindricalManifold(const Point<spacedim> &d
               direction (direction_/direction_.norm()),
               point_on_axis (point_on_axis_),
               tolerance(tolerance)
-{}
+{
+  // do not use static_assert to make dimension-independent programming
+  // easier.
+  Assert (spacedim==3,
+          ExcMessage("CylindricalManifold can only be used for spacedim==3!"));
+
+}
 
 
 


### PR DESCRIPTION
…asier writing dimension independent code

Otherwise one has to do
```
void set_cylinder_manifold (parallel::distributed::Triangulation<2> &tria,
                            const types::manifold_id manifold_id,
                            const CylindricalManifold<3> & manifold)
{}

void set_cylinder_manifold (parallel::distributed::Triangulation<3> &tria,
                            const types::manifold_id manifold_id,
                            const CylindricalManifold<3> & manifold_cylinder)
{
  tria.set_manifold (manifold_id, manifold_cylinder);
}
```
to make dimension-independent code compile even if `CylindricalManifold` is only to be used in 3D.