### PR TITLE
Make sure to actually zero the ghost entries in partitioner import call.

### DIFF
--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -402,9 +402,7 @@ namespace Utilities
 
       // clear the ghost array in case we did not yet do that in the _start
       // function
-      if (n_ghost_indices_in_larger_set == n_ghost_indices() ||
-          ghost_array.size() != n_ghost_indices_in_larger_set)
-        std::memset(ghost_array.begin(), 0, sizeof(Number)*n_ghost_indices());
+      std::memset(ghost_array.begin(), 0, sizeof(Number)*n_ghost_indices());
 
       // clear the compress requests
       requests.resize(0);

--- a/tests/mpi/parallel_partitioner_07.cc
+++ b/tests/mpi/parallel_partitioner_07.cc
@@ -97,6 +97,9 @@ void test ()
                                            temp_array.size()),
                                        make_array_view(locally_owned_array),
                                        make_array_view(ghosts), requests);
+    // check that the ghost entries are zeroed out in these calls
+    for (unsigned int i=0; i<v.n_ghost_indices(); ++i)
+      AssertDimension(ghosts[i], 0);
   }
   deallog << "From all ghosts: ";
   for (unsigned int i=0; i<locally_owned_array.size(); ++i)
@@ -117,6 +120,10 @@ void test ()
                                            temp_array.size()),
                                        make_array_view(locally_owned_array),
                                        make_array_view(ghosts), requests);
+
+    // check that the ghost entries are zeroed out in these calls
+    for (unsigned int i=0; i<w.n_ghost_indices(); ++i)
+      AssertDimension(ghosts[i], 0);
   }
   deallog << "From reduced ghosts 1: ";
   for (unsigned int i=0; i<locally_owned_array.size(); ++i)
@@ -137,6 +144,10 @@ void test ()
                                            temp_array.size()),
                                        make_array_view(locally_owned_array),
                                        make_array_view(ghosts), requests);
+
+    // check that the ghost entries are zeroed out in these calls
+    for (unsigned int i=0; i<x.n_ghost_indices(); ++i)
+      AssertDimension(ghosts[i], 0);
   }
   deallog << "From reduced ghosts 2: ";
   for (unsigned int i=0; i<locally_owned_array.size(); ++i)


### PR DESCRIPTION
The new function `Utilities::MPI::Partitioner::import_from_ghosted_array_finish` from #5259 claims to zero the ghost array when leaving the function. Make sure that is actually happens in the test. 