### PR TITLE
Change argument of DoFRenumbering::downstream() to Tensor<1,dim>.

### DIFF
--- a/doc/news/changes/incompatibilities/20171023Bangerth
+++ b/doc/news/changes/incompatibilities/20171023Bangerth
@@ -1,0 +1,6 @@
+Changed: The direction argument of the DoFRenumbering::downstream()
+and related functions have been changed from a Point<dim> to a
+Tensor<1,dim> type, since that is the correct data type for a
+direction vector.
+<br>
+(Wolfgang Bangerth, 2017/10/23)

--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -831,9 +831,9 @@ namespace DoFRenumbering
    * numbering is performed cell-wise, otherwise it is performed based on the
    * location of the support points.
    *
-   * The cells are sorted such that the centers of higher numbers are further
+   * The cells are sorted such that the centers of cells numbered higher are further
    * downstream with respect to the constant vector @p direction than the
-   * centers of lower numbers. Even if this yields a downstream numbering with
+   * centers of of cells numbered lower. Even if this yields a downstream numbering with
    * respect to the flux on the edges for fairly general grids, this might not
    * be guaranteed for all meshes.
    *
@@ -852,48 +852,48 @@ namespace DoFRenumbering
    */
   template <typename DoFHandlerType>
   void
-  downstream (DoFHandlerType                               &dof_handler,
-              const Point<DoFHandlerType::space_dimension> &direction,
-              const bool                                    dof_wise_renumbering = false);
+  downstream (DoFHandlerType                                  &dof_handler,
+              const Tensor<1,DoFHandlerType::space_dimension> &direction,
+              const bool                                       dof_wise_renumbering = false);
 
 
   /**
    * Cell-wise downstream numbering with respect to a constant flow direction
-   * on one level. See the other function with the same name.
+   * on one level of a multigrid hierarchy. See the other function with the same name.
    */
   template <typename DoFHandlerType>
   void
-  downstream (DoFHandlerType                               &dof_handler,
-              const unsigned int                            level,
-              const Point<DoFHandlerType::space_dimension> &direction,
-              const bool                                    dof_wise_renumbering = false);
+  downstream (DoFHandlerType                                  &dof_handler,
+              const unsigned int                               level,
+              const Tensor<1,DoFHandlerType::space_dimension> &direction,
+              const bool                                       dof_wise_renumbering = false);
 
   /**
-   * Compute the renumbering vector needed by the downstream() function. Does
+   * Compute the set of renumbering indices needed by the downstream() function. Does
    * not perform the renumbering on the DoFHandler dofs but returns the
    * renumbering vector.
    */
   template <typename DoFHandlerType>
   void
-  compute_downstream (std::vector<types::global_dof_index>         &new_dof_indices,
-                      std::vector<types::global_dof_index>         &reverse,
-                      const DoFHandlerType                         &dof_handler,
-                      const Point<DoFHandlerType::space_dimension> &direction,
-                      const bool                                    dof_wise_renumbering);
+  compute_downstream (std::vector<types::global_dof_index>            &new_dof_indices,
+                      std::vector<types::global_dof_index>            &reverse,
+                      const DoFHandlerType                            &dof_handler,
+                      const Tensor<1,DoFHandlerType::space_dimension> &direction,
+                      const bool                                       dof_wise_renumbering);
 
   /**
-   * Compute the renumbering vector needed by the downstream() function. Does
+   * Compute the set of renumbering indices needed by the downstream() function. Does
    * not perform the renumbering on the DoFHandler dofs but returns the
    * renumbering vector.
    */
   template <typename DoFHandlerType>
   void
-  compute_downstream (std::vector<types::global_dof_index>         &new_dof_indices,
-                      std::vector<types::global_dof_index>         &reverse,
-                      const DoFHandlerType                         &dof_handler,
-                      const unsigned int                            level,
-                      const Point<DoFHandlerType::space_dimension> &direction,
-                      const bool                                    dof_wise_renumbering);
+  compute_downstream (std::vector<types::global_dof_index>            &new_dof_indices,
+                      std::vector<types::global_dof_index>            &reverse,
+                      const DoFHandlerType                            &dof_handler,
+                      const unsigned int                               level,
+                      const Tensor<1,DoFHandlerType::space_dimension> &direction,
+                      const bool                                       dof_wise_renumbering);
 
   /**
    * Cell-wise clockwise numbering.
@@ -910,8 +910,8 @@ namespace DoFRenumbering
                 const bool                                    counter = false);
 
   /**
-   * Cell-wise clockwise numbering on one level. See the other function with
-   * the same name.
+   * Cell-wise clockwise numbering on one level of a multigrid
+   * hierarchy. See the other function with the same name.
    */
   template <typename DoFHandlerType>
   void
@@ -1099,28 +1099,6 @@ namespace DoFRenumbering
    */
   DeclException0 (ExcNotDGFEM);
 }
-
-/* ------------------------- inline functions -------------- */
-
-#ifndef DOXYGEN
-namespace DoFRenumbering
-{
-  template <typename DoFHandlerType>
-  void
-  inline
-  downstream (DoFHandlerType                               &dof,
-              const Point<DoFHandlerType::space_dimension> &direction,
-              const bool                                    dof_wise_renumbering)
-  {
-    std::vector<types::global_dof_index> renumbering(dof.n_dofs());
-    std::vector<types::global_dof_index> reverse(dof.n_dofs());
-    compute_downstream(renumbering, reverse, dof, direction,
-                       dof_wise_renumbering);
-
-    dof.renumber_dofs(renumbering);
-  }
-}
-#endif
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1487,18 +1487,30 @@ namespace DoFRenumbering
 
 
 
+  template <typename DoFHandlerType>
+  void
+  downstream (DoFHandlerType                                  &dof,
+              const Tensor<1,DoFHandlerType::space_dimension> &direction,
+              const bool                                       dof_wise_renumbering)
+  {
+    std::vector<types::global_dof_index> renumbering(dof.n_dofs());
+    std::vector<types::global_dof_index> reverse(dof.n_dofs());
+    compute_downstream(renumbering, reverse, dof, direction,
+                       dof_wise_renumbering);
 
+    dof.renumber_dofs(renumbering);
+  }
 
 
 
   template <typename DoFHandlerType>
   void
   compute_downstream
-  (std::vector<types::global_dof_index>         &new_indices,
-   std::vector<types::global_dof_index>         &reverse,
-   const DoFHandlerType                         &dof,
-   const Point<DoFHandlerType::space_dimension> &direction,
-   const bool                                    dof_wise_renumbering)
+  (std::vector<types::global_dof_index>            &new_indices,
+   std::vector<types::global_dof_index>            &reverse,
+   const DoFHandlerType                            &dof,
+   const Tensor<1,DoFHandlerType::space_dimension> &direction,
+   const bool                                       dof_wise_renumbering)
   {
     if (dof_wise_renumbering == false)
       {
@@ -1583,10 +1595,10 @@ namespace DoFRenumbering
 
 
   template <typename DoFHandlerType>
-  void downstream (DoFHandlerType                               &dof,
-                   const unsigned int                            level,
-                   const Point<DoFHandlerType::space_dimension> &direction,
-                   const bool                                    dof_wise_renumbering)
+  void downstream (DoFHandlerType                                  &dof,
+                   const unsigned int                               level,
+                   const Tensor<1,DoFHandlerType::space_dimension> &direction,
+                   const bool                                       dof_wise_renumbering)
   {
     std::vector<types::global_dof_index> renumbering(dof.n_dofs(level));
     std::vector<types::global_dof_index> reverse(dof.n_dofs(level));
@@ -1601,12 +1613,12 @@ namespace DoFRenumbering
   template <typename DoFHandlerType>
   void
   compute_downstream
-  (std::vector<types::global_dof_index>         &new_indices,
-   std::vector<types::global_dof_index>         &reverse,
-   const DoFHandlerType                         &dof,
-   const unsigned int                            level,
-   const Point<DoFHandlerType::space_dimension> &direction,
-   const bool                                    dof_wise_renumbering)
+  (std::vector<types::global_dof_index>            &new_indices,
+   std::vector<types::global_dof_index>            &reverse,
+   const DoFHandlerType                            &dof,
+   const unsigned int                               level,
+   const Tensor<1,DoFHandlerType::space_dimension> &direction,
+   const bool                                       dof_wise_renumbering)
   {
     if (dof_wise_renumbering == false)
       {

--- a/source/dofs/dof_renumbering.inst.in
+++ b/source/dofs/dof_renumbering.inst.in
@@ -198,7 +198,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     template void
     compute_downstream<DoFHandler<deal_II_dimension> >
     (std::vector<types::global_dof_index>&,std::vector<types::global_dof_index>&,
-     const DoFHandler<deal_II_dimension>&, const Point<deal_II_dimension>&,
+     const DoFHandler<deal_II_dimension>&, const Tensor<1,deal_II_dimension>&,
      const bool);
 
     template
@@ -229,7 +229,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     compute_downstream<hp::DoFHandler<deal_II_dimension> >
     (std::vector<types::global_dof_index>&,std::vector<types::global_dof_index>&,
      const hp::DoFHandler<deal_II_dimension>&,
-     const Point<deal_II_dimension>&,
+     const Tensor<1,deal_II_dimension>&,
      const bool);
 
     template
@@ -252,7 +252,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     void downstream
     (DoFHandler<deal_II_dimension>&,
      const unsigned int,
-     const Point<deal_II_dimension>&,
+     const Tensor<1,deal_II_dimension>&,
      const bool);
 
     template

--- a/source/dofs/dof_renumbering.inst.in
+++ b/source/dofs/dof_renumbering.inst.in
@@ -198,7 +198,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     template void
     compute_downstream<DoFHandler<deal_II_dimension> >
     (std::vector<types::global_dof_index>&,std::vector<types::global_dof_index>&,
-     const DoFHandler<deal_II_dimension>&, const Tensor<1,deal_II_dimension>&,
+     const DoFHandler<deal_II_dimension>&, const Tensor<1,DoFHandler<deal_II_dimension>::space_dimension>&,
      const bool);
 
     template
@@ -229,7 +229,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     compute_downstream<hp::DoFHandler<deal_II_dimension> >
     (std::vector<types::global_dof_index>&,std::vector<types::global_dof_index>&,
      const hp::DoFHandler<deal_II_dimension>&,
-     const Tensor<1,deal_II_dimension>&,
+     const Tensor<1,hp::DoFHandler<deal_II_dimension>::space_dimension>&,
      const bool);
 
     template
@@ -246,13 +246,19 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
      const Point<deal_II_dimension>&,
      const bool);
 
+    template
+    void downstream
+    (DoFHandler<deal_II_dimension>&,
+     const Tensor<1,DoFHandler<deal_II_dimension>::space_dimension>&,
+     const bool);
+
 // MG
 
     template
     void downstream
     (DoFHandler<deal_II_dimension>&,
      const unsigned int,
-     const Tensor<1,deal_II_dimension>&,
+     const Tensor<1,DoFHandler<deal_II_dimension>::space_dimension>&,
      const bool);
 
     template

--- a/tests/dofs/dof_renumbering.cc
+++ b/tests/dofs/dof_renumbering.cc
@@ -83,9 +83,9 @@ check_renumbering(DoFHandler<dim> &mgdof, bool discontinuous)
   std::vector<unsigned int> order(element.n_components());
   for (unsigned int i=0; i<order.size(); ++i) order[i] = order.size()-i-1;
 
-  Point<dim> direction;
+  Tensor<1,dim> direction;
   for (unsigned int i=0; i<dim; ++i)
-    direction(i) = std::pow(10.,static_cast<double>(i));
+    direction[i] = std::pow(10.,static_cast<double>(i));
 
   // Check global ordering
   print_dofs (dof);

--- a/tests/dofs/dof_renumbering_02.cc
+++ b/tests/dofs/dof_renumbering_02.cc
@@ -113,9 +113,9 @@ check_renumbering(DoFHandler<dim> &mgdof)
   std::vector<unsigned int> order(element.n_components());
   for (unsigned int i=0; i<order.size(); ++i) order[i] = order.size()-i-1;
 
-  Point<dim> direction;
+  Tensor<1,dim> direction;
   for (unsigned int i=0; i<dim; ++i)
-    direction(i) = -5.0001+i;
+    direction[i] = -5.0001+i;
 
   deallog << std::endl << "Downstream numbering cell-wise" << std::endl;
   DoFRenumbering::downstream(dof, direction);

--- a/tests/multigrid/transfer_compare_01.cc
+++ b/tests/multigrid/transfer_compare_01.cc
@@ -130,7 +130,7 @@ void check_block(const FiniteElement<dim> &fe)
 
   // Make sure all orderings are the
   // same
-  Point<dim> direction;
+  Tensor<1,dim> direction;
   for (unsigned int d=0; d<dim; ++d)
     direction[d] = d*d*d;
   DoFRenumbering::downstream(dof, direction);


### PR DESCRIPTION
That's because this kind of argument indicates a *direction*, not a point, and
for the former Tensor<1,dim> is the correct data type.