### PR TITLE
Replace use of VectorView in library

### DIFF
--- a/doc/news/changes/minor/20171024MartinKronbichler
+++ b/doc/news/changes/minor/20171024MartinKronbichler
@@ -1,0 +1,6 @@
+New: The function
+LinearAlgebra::distributed::Vector::copy_locally_owned_data_from() can copy
+the locally owned range in a parallel vector without considering the ghost
+entries which might be different between the two vectors.
+<br>
+(MartinKronbichler, 2017/10/24)

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -513,6 +513,24 @@ namespace LinearAlgebra
        * @ref GlossGhostedVector "vectors with ghost elements"
        */
       bool has_ghost_elements() const;
+
+      /**
+       * This method copies the data in the locally owned range from another
+       * distributed vector @p src into the calling vector. As opposed to
+       * operator= that also includes ghost entries, this operation ignores
+       * the ghost range. The only prerequisite is that the local range on the
+       * calling vector and the given vector @p src are the same on all
+       * processors. It is explicitly allowed that the two vectors have
+       * different ghost elements that might or might not be related to each
+       * other.
+       *
+       * Since no data exchange is performed, make sure that neither @p src
+       * nor the calling vector have pending communications in order to obtain
+       * correct results.
+       */
+      template <typename Number2>
+      void copy_locally_owned_data_from(const Vector<Number2> &src);
+
       //@}
 
       /**

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -24,7 +24,6 @@
 
 #include <deal.II/lac/diagonal_matrix.h>
 #include <deal.II/lac/la_parallel_vector.h>
-#include <deal.II/lac/vector_view.h>
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 #include <deal.II/matrix_free/matrix_free.h>
 #include <deal.II/matrix_free/fe_evaluation.h>
@@ -1197,14 +1196,10 @@ namespace MatrixFreeOperators
 
         // copy the vector content to a temporary vector so that it does not get
         // lost
-        VectorView<Number> view_src_in(subblock(src,i).local_size(),
-                                       subblock(src,i).begin());
-        const Vector<Number> copy_vec = view_src_in;
+        LinearAlgebra::distributed::Vector<Number> copy_vec(subblock(src,i));
         subblock(const_cast<VectorType &>(src),i).
         reinit(data->get_dof_info(mf_component).vector_partitioner);
-        VectorView<Number> view_src_out(subblock(src,i).local_size(),
-                                        subblock(src,i).begin());
-        static_cast<Vector<Number>&>(view_src_out) = copy_vec;
+        subblock(const_cast<VectorType &>(src),i).copy_locally_owned_data_from(copy_vec);
       }
   }
 

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -448,6 +448,14 @@ protected:
   bool perform_plain_copy;
 
   /**
+   * Stores whether the copy operation from the global to the level vector is
+   * actually a plain copy to the finest level except for a renumbering within
+   * the finest level of the degrees of freedom. This means that the grid has
+   * no adaptive refinement.
+   */
+  bool perform_renumbered_plain_copy;
+
+  /**
    * The vector that stores what has been given to the
    * set_component_to_block_map() function.
    */

--- a/source/lac/la_parallel_vector.inst.in
+++ b/source/lac/la_parallel_vector.inst.in
@@ -34,6 +34,7 @@ for (S1, S2 : REAL_SCALARS)
     \{
     template void Vector<S1>::reinit<S2> (const Vector<S2>&,
                                           const bool);
+    template void Vector<S1>::copy_locally_owned_data_from<S2> (const Vector<S2>&);
     template S1 Vector<S1>::inner_product_local<S2> (const Vector<S2>&) const;
     \}
     \}
@@ -58,6 +59,7 @@ for (S1, S2 : COMPLEX_SCALARS)
     \{
     template void Vector<S1>::reinit<S2> (const Vector<S2>&,
                                           const bool);
+    template void Vector<S1>::copy_locally_owned_data_from<S2> (const Vector<S2>&);
     \}
     \}
 }

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -157,7 +157,7 @@ void MGTransferMatrixFree<dim,Number>
   AssertDimension(this->ghosted_level_vector[to_level-1].local_size(),
                   src.local_size());
 
-  this->ghosted_level_vector[to_level-1] = src;
+  this->ghosted_level_vector[to_level-1].copy_locally_owned_data_from(src);
   this->ghosted_level_vector[to_level-1].update_ghost_values();
   this->ghosted_level_vector[to_level] = 0.;
 
@@ -202,7 +202,7 @@ void MGTransferMatrixFree<dim,Number>
                           this->ghosted_level_vector[to_level-1]);
 
   this->ghosted_level_vector[to_level].compress(VectorOperation::add);
-  dst = this->ghosted_level_vector[to_level];
+  dst.copy_locally_owned_data_from(this->ghosted_level_vector[to_level]);
 }
 
 
@@ -221,7 +221,7 @@ void MGTransferMatrixFree<dim,Number>
   AssertDimension(this->ghosted_level_vector[from_level-1].local_size(),
                   dst.local_size());
 
-  this->ghosted_level_vector[from_level] = src;
+  this->ghosted_level_vector[from_level].copy_locally_owned_data_from(src);
   this->ghosted_level_vector[from_level].update_ghost_values();
   this->ghosted_level_vector[from_level-1] = 0.;
 


### PR DESCRIPTION
Relates to #5278.

This PR removes the use of `VectorView` from the library. I did this by introducing a new `copy_locally_owned_data` function to the distributed vector class for the use case where we wanted to ignore the ghost indices and simply copy locally owned data. I took the opportunity to make a small cleanup in the `MGTransferMatrixFree` class as well regarding unnecessary communication.