### PR TITLE
Added new compute point locations to GridTools

### DIFF
--- a/doc/news/changes/minor/20171024GiovanniAlzetta
+++ b/doc/news/changes/minor/20171024GiovanniAlzetta
@@ -1,0 +1,3 @@
+Added: Function GridTools::compute_point_locations and a test for it. The function uses the recently added Cache to improve performance.
+<br>
+(Giovanni Alzetta, 2017/10/24)

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -606,6 +606,41 @@ namespace GridTools
   /*@{*/
 
   /**
+   * Given a @p cache and a list of @p points create the quadrature rules. This
+   * function returns a tuple containing the following elements:
+   * - The first ( get<0>), call it cells, is a vector of a vector cells of the all cells
+   *  that contain at least one of the @p points
+   * - The second a vector qpoints of vector of points, containing in qpoints[i]
+   *  the reference positions of all points that fall within the cell cells[i]
+   * - The third a vector indices of vector of integers, containing the mapping between
+   *  local numbering in qpoints, and global index in points
+   *
+   * If points[a] and points[b] are the only two points that fall in cells[c], then
+   * qpoints[c][0] and qpoints[c][1] are the reference positions of points[a] and points[b]
+   * in cells[c], and indices[c][0] = a, indices[c][1] = b. The function
+   * Mapping::tansform_unit_to_real(qpoints[c][0]) returns points[a].
+   *
+   * The algorithm assumes it's easier to look for a point in the cell that was used previously.
+   * For this reason random points are, computationally speaking, the worst case scenario while
+   * points grouped by the cell to which they belong are the best case.
+   * Pre-sorting points, trying to minimize distances, can make the algorithm much faster.
+   *
+   * Notice: given the center of a cell, points at distance greater then
+   * @p distance_factor * cell.diameter() are considered outside the cell. In some cases, such
+   * as curved meshes, this leads to cell's repetitions in the output tuple.
+   * To avoid this either enlarge @p distance_factor (depending on the regularity of the
+   * triangulation) and/or merge the repetitions contained in the output.
+   */
+  template <int dim, int spacedim>
+  std::tuple<
+  std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator >,
+      std::vector< std::vector< Point<dim> > >,
+      std::vector< std::vector<unsigned int> > >
+      compute_point_locations(const Cache<dim,spacedim>                                         &cache,
+                              const std::vector<Point<spacedim> >                               &points,
+                              const double                                                      &distance_factor=0.5);
+
+  /**
    * Return a map of index:Point<spacedim>, containing the used vertices of the
    * given `container`. The key of the returned map is the global index in the
    * triangulation. The used vertices are obtained by looping over all cells,

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -139,8 +139,13 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
                                       const typename Triangulation<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator &,
                                       const std::vector<bool>  &);
 
-
-                       \}
+        template
+        std::tuple< std::vector< typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator >,
+                    std::vector< std::vector< Point< deal_II_dimension > > >, std::vector< std::vector< unsigned int > > >
+        compute_point_locations(const Cache< deal_II_dimension, deal_II_space_dimension > &,
+                                const std::vector< Point< deal_II_space_dimension > > &,
+                                const double &);
+                                                                                                      \}
 
 #endif
 }

--- a/tests/grid/compute_point_locations_01.cc
+++ b/tests/grid/compute_point_locations_01.cc
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Test Functions::FEFieldFunction::compute_point_locations
+
+#include "../tests.h"
+#include <iostream>
+
+#include <deal.II/grid/tria.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_tools_cache.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/numerics/fe_field_function.h>
+
+#include <deal.II/fe/mapping_q.h>
+
+using namespace dealii;
+
+template <int dim>
+void test_compute_pt_loc(unsigned int n_points)
+{
+  deallog << "Testing for dim = " << dim << std::endl;
+  deallog << "Testing on: " << n_points << " points." << std::endl;
+
+  // Creating a grid in the square [0,1]x[0,1]
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(std::max(6-dim,2));
+
+  //Creating the finite elements needed:
+  FE_Q<dim> fe(1);
+  DoFHandler<dim> dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+
+  // Creating the random points
+  std::vector<Point<dim>> points;
+
+  for (size_t i=0; i<n_points; ++i)
+    {
+      Point<dim> p;
+      for (unsigned int d=0; d<dim; ++d)
+        p[d] = double(Testing::rand())/RAND_MAX; //Normalizing the value
+      points.push_back(p);
+    }
+
+  // Initializing the cache
+  GridTools::Cache<dim,dim> cache(tria);
+
+  std::tuple< std::vector<typename Triangulation<dim, dim>::active_cell_iterator >, std::vector< std::vector< Point<dim> > >, std::vector<std::vector<unsigned int> > >
+  cell_qpoint_map = GridTools::compute_point_locations(cache,points);
+  size_t n_cells = std::get<0>(cell_qpoint_map).size();
+
+  deallog << "Points found in " << n_cells << " cells" << std::endl;
+
+  // testing if the transformation is correct:
+  // For each cell check if the quadrature points in the i-th FE
+  // are the same as std::get<2>(cell_qpoint_map)[i]
+  for (unsigned int i=0; i<std::get<0>(cell_qpoint_map).size(); ++i)
+    {
+      auto &cell = std::get<0>(cell_qpoint_map)[i];
+      auto &quad = std::get<1>(cell_qpoint_map)[i];
+      auto &local_map = std::get<2>(cell_qpoint_map)[i];
+
+      // Given the std::get<1>(cell_qpoint_map) of the current cell, compute the real points
+      FEValues<dim> fev(fe, quad, update_quadrature_points);
+      fev.reinit(cell);
+      const auto &real_quad = fev.get_quadrature_points();
+
+      for (unsigned int q=0; q<real_quad.size(); ++q)
+        {
+          // Check if points are the same as real points
+          if (real_quad[q].distance(points[local_map[q]]) > 1e-10)
+            deallog << "Error on cell : " << cell
+                    << " at local point " << i
+                    << ", corresponding to real point "
+                    << points[local_map[q]]
+                    << ", that got transformed to "
+                    << real_quad[q]
+                    << " instead." << std::endl;
+        }
+    }
+  deallog << "Test finished" << std::endl;
+}
+
+int main()
+{
+  initlog();
+
+  deallog << "Deal.II compute_pt_loc:" << std::endl;
+  test_compute_pt_loc<2>(100);
+  test_compute_pt_loc<3>(200);
+}

--- a/tests/grid/compute_point_locations_01.output
+++ b/tests/grid/compute_point_locations_01.output
@@ -1,0 +1,10 @@
+
+DEAL::Deal.II compute_pt_loc:
+DEAL::Testing for dim = 2
+DEAL::Testing on: 100 points.
+DEAL::Points found in 81 cells
+DEAL::Test finished
+DEAL::Testing for dim = 3
+DEAL::Testing on: 200 points.
+DEAL::Points found in 170 cells
+DEAL::Test finished


### PR DESCRIPTION
Adding a new function " compute point locations" to GridTools.

This version uses the Cache (and related new functions). Moreover it avoids unnecessarily calling transform real to unit cell by computing the distance cell's center / point to discard points which are far aways.

In the tests I've made (1x1 square grid with random points), with a 4k points/cells the speedup was 120/130: this can change depending on the point disposition, but I'm sure this version is much better.

The only problem comes with curved meshes: in this case using half the diameter it's not ok and thus, as an option, I included the possibility of enlarging the cutoff distance.
What might happen, if the radius is too short compared with the cell, is that we have more times the same cell in the output. Personally I believe this is enough. There are other options for this case you might like:
- at the end of the algorithm checking if there are repetitions (and "merge" them) from within the function 
- adding a call flag and, if it's true, check every time find_cell_around_point is called if the cell is new (otherwise add the current point to the previous cell)
- adding a flag to use another algorithm (see afterwards): this works with every sort of mapping and has a much cleaner code than the one I'm proposing. The main problem is that it is slower (roughly 5-10% slower on my benchmark test) than the current version. (If with the new developments of find cell around point it shall become faster than this shall be my choice, clearly...)
What do you think?

This is the main part of the other algorithm (I'm using cells, qpoints and maps which are the get<0>, get<1> and get<2> respectively...):

```
 for(unsigned int p=0; p< np; ++p)
      {
        const std::pair<typename dealii::internal::ActiveCellIterator
        <dim, spacedim, MeshType<dim,spacedim>>::type, Point<dim> >
                                        my_pair  = GridTools::find_active_cell_around_point
                                                   (mapping, tria, points[p],vertex_to_cell_map,vertex_to_cell_centers);

        // Check if the cell has already been found
        typename std::vector<typename MeshType<dim,spacedim>::active_cell_iterator >::iterator
            cells_it = std::find(cells.begin(),cells.end(),my_pair.first);

        if ( cells_it == cells.end() ) {
          // Cell not found: adding a new cell
            cells.push_back(my_pair.first);
            qpoints.emplace_back(1,my_pair.second);
            maps.emplace_back(1,p);
        } else {
            unsigned int current_cell = cells_it - cells.begin();
          // Cell found: just adding the point index and qpoint to the list
            maps[current_cell].push_back(p);
            qpoints[current_cell].push_back(my_pair.second);
        }
      }
```
