### PR TITLE
Fix VectorTools::interpolate for parallel computations

### DIFF
--- a/tests/mpi/interpolate_05.cc
+++ b/tests/mpi/interpolate_05.cc
@@ -1,0 +1,159 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// This is a modified copy from interpolate_01.cc.
+// VectorTools::interpolate used to accidentally read from non-owned
+// dofs when called with a component mask that excluded some components.
+// This triggered an assertion. Test that the solution,
+// namely skipping all non-local dofs that are not selected to be interpolated, works.
+
+#include "../tests.h"
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/function.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/grid/filtered_iterator.h>
+
+#include <deal.II/grid/tria.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+
+#include <sstream>
+
+
+template <int dim>
+void test()
+{
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+
+  // create a distributed mesh
+  parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube (tr);
+  tr.refine_global(2);
+
+  // Create a system with more than one component
+  FESystem<dim> fe(FE_Q<dim>(1),2);
+  DoFHandler<dim> dofh(tr);
+  dofh.distribute_dofs (fe);
+
+  IndexSet owned_set = dofh.locally_owned_dofs();
+  TrilinosWrappers::MPI::Vector x;
+
+  x.reinit(owned_set, MPI_COMM_WORLD);
+
+  // Select the first of the two components
+  std::vector<bool> components(2);
+  components[0] = true;
+
+  // This failed before this test was introduced.
+  // Interpolate onto the first component only.
+  VectorTools::interpolate(dofh,
+                           Functions::ConstantFunction<dim>(1,2),
+                           x,
+                           ComponentMask(components));
+
+  // Integrate the difference in the first component, if everything went
+  // well, this should be zero.
+  IndexSet relevant_set;
+  DoFTools::extract_locally_relevant_dofs (dofh, relevant_set);
+  TrilinosWrappers::MPI::Vector x_rel(relevant_set, MPI_COMM_WORLD);
+  x_rel = x;
+  Vector<double>  error (tr.n_active_cells());
+  ComponentSelectFunction<dim> right_component_select(0,2);
+  ComponentSelectFunction<dim> wrong_component_select(1,2);
+
+  VectorTools::integrate_difference (dofh,
+                                     x_rel,
+                                     Functions::ConstantFunction<dim>(1,2),
+                                     error,
+                                     QMidpoint<dim>(),
+                                     VectorTools::L2_norm,
+                                     &right_component_select);
+
+  double norm = VectorTools::compute_global_error(tr, error, VectorTools::L2_norm);
+
+  if (myid == 0)
+    deallog << dofh.n_locally_owned_dofs() << ' ' << dofh.n_dofs()
+            << std::endl
+            << "Error of interpolated component: " << norm
+            << std::endl;
+
+  // Integrate the difference in the second component. Since we did not interpolate
+  // the function into the finite element space, this should be equal to the
+  // integral of the ConstantFunction (=1) over the domain (unit square/cube).
+  // Thus the integral should be one.
+  VectorTools::integrate_difference (dofh,
+                                     x_rel,
+                                     Functions::ConstantFunction<dim>(1,2),
+                                     error,
+                                     QMidpoint<dim>(),
+                                     VectorTools::L2_norm,
+                                     &wrong_component_select);
+
+  norm = VectorTools::compute_global_error(tr, error, VectorTools::L2_norm);
+
+  if (myid == 0)
+    deallog << "Error of not interpolated component: " << norm
+            << std::endl;
+
+
+}
+
+
+int main(int argc, char *argv[])
+{
+#ifdef DEAL_II_WITH_MPI
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+#else
+  (void)argc;
+  (void)argv;
+  compile_time_error;
+#endif
+
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+
+
+  deallog.push(Utilities::int_to_string(myid));
+
+  if (myid == 0)
+    {
+      initlog();
+
+      deallog.push("2d");
+      test<2>();
+      deallog.pop();
+      deallog.push("3d");
+      test<3>();
+      deallog.pop();
+    }
+  else
+    {
+      test<2>();
+      test<3>();
+    }
+}

--- a/tests/mpi/interpolate_05.with_trilinos=true.mpirun=2.output
+++ b/tests/mpi/interpolate_05.with_trilinos=true.mpirun=2.output
@@ -1,0 +1,7 @@
+
+DEAL:0:2d::30 50
+DEAL:0:2d::Error of interpolated component: 0.00000
+DEAL:0:2d::Error of not interpolated component: 1.00000
+DEAL:0:3d::150 250
+DEAL:0:3d::Error of interpolated component: 0.00000
+DEAL:0:3d::Error of not interpolated component: 1.00000


### PR DESCRIPTION
This hopefully fixes the rest of the issues in geodynamics/aspect#1936 that are not addressed in #5313. I am not quite sure the fix is correct for all cases though (I am not familiar with exotic elements / hp / ...), so I would like to ask for a careful review. I can add a test when I am sure this is correct.

The error message that is fixed by this PR is:
```
1: --------------------------------------------------------
1: An error occurred in line <603> of file </home/fraters/deal.ii/deal.ii_2017-09-26/dealii/source/lac/trilinos_vector.cc> in function
1:     dealii::TrilinosScalar dealii::TrilinosWrappers::MPI::Vector::operator()(dealii::TrilinosWrappers::MPI::Vector::size_type) const
1: The violated condition was: 
1:     false
1: Additional information: 
1:     You tried to access element 30 of a distributed vector, but this element is not stored on the current processor. Note: There are 72 elements stored on the current processor from within the range 90 through 161 but Trilinos vectors need not store contiguous ranges on each processor, and not every element in this range may in fact be stored locally.
1: 
1: Stacktrace:
1: -----------
1: #0  /home/fraters/deal.ii/deal.ii_2017-09-26/dealii/build/lib/libdeal_II.g.so.9.0.0-pre: dealii::TrilinosWrappers::MPI::Vector::operator()(unsigned int) const
1: #1  /home/fraters/deal.ii/deal.ii_2017-09-26/dealii/build/lib/libdeal_II.g.so.9.0.0-pre: void dealii::VectorTools::interpolate<2, 2, dealii::TrilinosWrappers::MPI::BlockVector, dealii::DoFHandler>(dealii::Mapping<2, 2> const&, dealii::DoFHandler<2, 2> const&, dealii::Function<2, dealii::TrilinosWrappers::MPI::BlockVector::value_type> const&, dealii::TrilinosWrappers::MPI::BlockVector&, dealii::ComponentMask const&)
1: #2  /home/fraters/aspect/aspect_2017-09-26/aspect/build/aspect: aspect::Simulator<2>::set_initial_temperature_and_compositional_fields()
1: #3  /home/fraters/aspect/aspect_2017-09-26/aspect/build/aspect: aspect::Simulator<2>::run()
1: #4  /home/fraters/aspect/aspect_2017-09-26/aspect/build/aspect: main
1: --------------------------------------------------------
1: 
1: Calling MPI_Abort now.
1: To break execution in a GDB session, execute 'break MPI_Abort' before running. You can also put the following into your ~/.gdbinit:
1:   set breakpoint pending on
1:   break MPI_Abort
1:   set breakpoint pending auto
1: make[3]: *** [output-quick_mpi/screen-output] Error 255
1: make[2]: *** [CMakeFiles/quick_mpi.screen-output.diff.dir/all] Error 2
1: make[1]: *** [CMakeFiles/tests.quick_mpi.dir/rule] Error 2
1: make: *** [tests.quick_mpi] Error 2
1: *** "Test quick_mpi failed": ***
1: [ 22%] Built target quick_mpi
1: [ 33%] Generating output-quick_mpi/screen-output
1: CMakeFiles/quick_mpi.screen-output.diff.dir/build.make:76: recipe for target 'output-quick_mpi/screen-output' failed
1: CMakeFiles/Makefile2:164: recipe for target 'CMakeFiles/quick_mpi.screen-output.diff.dir/all' failed
1: CMakeFiles/Makefile2:107: recipe for target 'CMakeFiles/tests.quick_mpi.dir/rule' failed
1: Makefile:142: recipe for target 'tests.quick_mpi' failed
1: 
1: CMake Error at /home/fraters/aspect/aspect_2017-09-26/aspect/tests/run_test.cmake:14 (MESSAGE):
1:   *** Test aborted.
1: 
1: 
1/1 Test #1: quick_mpi ........................***Failed    0.43 sec
```

The problem here is that the interpolation in `VectorTools::interpolate` is only done for locally owned cells, but for all dofs on these cells. In some cases locally owned cells are associated with non locally owned dofs (e.g. at the boundary to ghost cells). This function currently tries to write into these dofs from both processes, which triggers an assertion of the parallel vector. Skipping these dofs should fix this, and should do no harm in many cases (they are interpolated on the owning process and then transferred during the call to `compress`). However, if the interpolated function is different on both cells for the same point, than this will lead to wrong results (there is no averaging of the values). I am not sure how to work around this though. @tamiko or somebody else, do you have an idea?