### PR TITLE
Fix boost iostreams

### DIFF
--- a/cmake/configure/configure_boost.cmake
+++ b/cmake/configure/configure_boost.cmake
@@ -86,8 +86,7 @@ MACRO(FEATURE_BOOST_FIND_EXTERNAL var)
       #
       RESET_CMAKE_REQUIRED()
       PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
-      PUSH_CMAKE_REQUIRED("-L${Boost_LIBRARY_DIRS}")
-      SET(CMAKE_REQUIRED_LIBRARIES "-lboost_iostreams")
+      SET(CMAKE_REQUIRED_LIBRARIES "${BOOST_LIBRARIES}")
       CHECK_CXX_SOURCE_COMPILES(
         "
         #include <string>
@@ -116,6 +115,10 @@ MACRO(FEATURE_BOOST_FIND_EXTERNAL var)
                 "with zlib support but a simple test failed! "
                 "Therefore, the bundled boost package is used."
                )
+        SET(BOOST_ADDITIONAL_ERROR_STRING
+            "DEAL_II_WITH_ZLIB=ON requires Boost.Iostreams to be compiled "
+            "with zlib support but a simple test failed! "
+           )
         SET(${var} FALSE)
       ENDIF()
       RESET_CMAKE_REQUIRED()

--- a/cmake/configure/configure_boost.cmake
+++ b/cmake/configure/configure_boost.cmake
@@ -79,6 +79,48 @@ MACRO(FEATURE_BOOST_FIND_EXTERNAL var)
 
   IF(BOOST_FOUND)
     SET(${var} TRUE)
+
+    IF(DEAL_II_WITH_ZLIB)
+      #
+      # Test that Boost.Iostreams is usuable.
+      #
+      RESET_CMAKE_REQUIRED()
+      PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
+      PUSH_CMAKE_REQUIRED("-L${Boost_LIBRARY_DIRS}")
+      SET(CMAKE_REQUIRED_LIBRARIES "-lboost_iostreams")
+      CHECK_CXX_SOURCE_COMPILES(
+        "
+        #include <string>
+        #include <boost/iostreams/device/back_inserter.hpp>
+        #include <boost/iostreams/filter/gzip.hpp>
+        #include <boost/iostreams/filtering_stream.hpp>
+
+        int main()
+        {
+          std::string decompressed_buffer;
+          char test[1] = {'c'};
+
+          boost::iostreams::filtering_ostream decompressing_stream;
+          decompressing_stream.push(boost::iostreams::gzip_decompressor());
+          decompressing_stream.push(boost::iostreams::back_inserter(decompressed_buffer));
+          decompressing_stream.write (test, 1);
+        }
+        "
+        _boost_iostreams_usuable
+        )
+      IF(${_boost_iostreams_usuable})
+        MESSAGE(STATUS "Boost.Iostreams is usuable.")
+      ELSE()
+        MESSAGE(STATUS
+                "DEAL_II_WITH_ZLIB=ON requires Boost.Iostreams to be compiled "
+                "with zlib support but a simple test failed! "
+                "Therefore, the bundled boost package is used."
+               )
+        SET(${var} FALSE)
+      ENDIF()
+      RESET_CMAKE_REQUIRED()
+    ENDIF()
+
   ENDIF()
 ENDMACRO()
 

--- a/cmake/modules/FindBOOST.cmake
+++ b/cmake/modules/FindBOOST.cmake
@@ -78,6 +78,51 @@ IF(Boost_FOUND)
   SET(BOOST_VERSION
     "${BOOST_VERSION_MAJOR}.${BOOST_VERSION_MINOR}.${BOOST_VERSION_SUBMINOR}"
     )
+
+  IF(DEAL_II_WITH_ZLIB)
+    #
+    # Test that Boost.Iostreams is usuable.
+    #
+    RESET_CMAKE_REQUIRED()
+    PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
+    PUSH_CMAKE_REQUIRED("-L${Boost_LIBRARY_DIRS}")
+    SET(CMAKE_REQUIRED_LIBRARIES "-lboost_iostreams")
+    CHECK_CXX_SOURCE_COMPILES(
+      "
+      #include <string>
+      #include <boost/iostreams/device/back_inserter.hpp>
+      #include <boost/iostreams/filter/gzip.hpp>
+      #include <boost/iostreams/filtering_stream.hpp>
+
+      int main()
+      {
+        std::string decompressed_buffer;
+        char test[1] = {'c'};
+
+        boost::iostreams::filtering_ostream decompressing_stream;
+        decompressing_stream.push(boost::iostreams::gzip_decompressor());
+        decompressing_stream.push(boost::iostreams::back_inserter(decompressed_buffer));
+        decompressing_stream.write (test, 1);
+      }
+      "
+      DEAL_II_BOOST_IOSTREAMS_USUABLE
+      )
+    MESSAGE(STATUS "${DEAL_II_BOOST_IOSTREAMS_USUABLE}")
+    IF(${DEAL_II_BOOST_IOSTREAMS_USUABLE})
+      MESSAGE(STATUS "Boost.Iostreams is usuable.")
+    ELSE()
+      MESSAGE(STATUS
+              "DEAL_II_WITH_ZLIB=ON requires Boost.Iostreams to be compiled "
+              "with zlib support but a simple test failed! "
+              "Therefore, the bundled boost package is used."
+             )
+      SET(Boost_FOUND FALSE)
+      SET(Boost_LIBRARIES "")
+      SET(Boost_INCLUDE_DIRS "")
+    ENDIF()
+    RESET_CMAKE_REQUIRED()
+  ENDIF()
+
 ENDIF()
 
 DEAL_II_PACKAGE_HANDLE(BOOST
@@ -85,7 +130,7 @@ DEAL_II_PACKAGE_HANDLE(BOOST
   INCLUDE_DIRS REQUIRED Boost_INCLUDE_DIRS
   USER_INCLUDE_DIRS Boost_INCLUDE_DIRS
   CLEAR
-    Boost_DIR Boost_INCLUDE_DIR Boost_IOSTREAMS_LIBRARY_DEBUG
+    Boost_DIR Boost_INCLUDE_DIRS Boost_IOSTREAMS_LIBRARY_DEBUG
     Boost_IOSTREAMS_LIBRARY_RELEASE Boost_LIBRARY_DIR
     Boost_SERIALIZATION_LIBRARY_DEBUG Boost_SERIALIZATION_LIBRARY_RELEASE
     Boost_SYSTEM_LIBRARY_DEBUG Boost_SYSTEM_LIBRARY_RELEASE

--- a/cmake/modules/FindBOOST.cmake
+++ b/cmake/modules/FindBOOST.cmake
@@ -78,51 +78,6 @@ IF(Boost_FOUND)
   SET(BOOST_VERSION
     "${BOOST_VERSION_MAJOR}.${BOOST_VERSION_MINOR}.${BOOST_VERSION_SUBMINOR}"
     )
-
-  IF(DEAL_II_WITH_ZLIB)
-    #
-    # Test that Boost.Iostreams is usuable.
-    #
-    RESET_CMAKE_REQUIRED()
-    PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
-    PUSH_CMAKE_REQUIRED("-L${Boost_LIBRARY_DIRS}")
-    SET(CMAKE_REQUIRED_LIBRARIES "-lboost_iostreams")
-    CHECK_CXX_SOURCE_COMPILES(
-      "
-      #include <string>
-      #include <boost/iostreams/device/back_inserter.hpp>
-      #include <boost/iostreams/filter/gzip.hpp>
-      #include <boost/iostreams/filtering_stream.hpp>
-
-      int main()
-      {
-        std::string decompressed_buffer;
-        char test[1] = {'c'};
-
-        boost::iostreams::filtering_ostream decompressing_stream;
-        decompressing_stream.push(boost::iostreams::gzip_decompressor());
-        decompressing_stream.push(boost::iostreams::back_inserter(decompressed_buffer));
-        decompressing_stream.write (test, 1);
-      }
-      "
-      DEAL_II_BOOST_IOSTREAMS_USUABLE
-      )
-    MESSAGE(STATUS "${DEAL_II_BOOST_IOSTREAMS_USUABLE}")
-    IF(${DEAL_II_BOOST_IOSTREAMS_USUABLE})
-      MESSAGE(STATUS "Boost.Iostreams is usuable.")
-    ELSE()
-      MESSAGE(STATUS
-              "DEAL_II_WITH_ZLIB=ON requires Boost.Iostreams to be compiled "
-              "with zlib support but a simple test failed! "
-              "Therefore, the bundled boost package is used."
-             )
-      SET(Boost_FOUND FALSE)
-      SET(Boost_LIBRARIES "")
-      SET(Boost_INCLUDE_DIRS "")
-    ENDIF()
-    RESET_CMAKE_REQUIRED()
-  ENDIF()
-
 ENDIF()
 
 DEAL_II_PACKAGE_HANDLE(BOOST


### PR DESCRIPTION
Fixes #5289, fixes #5317.

This PR checks that for an externally provided boost dependency, Boost.Iostreams is usuable using a
typical example from our codebase. If this is not the case we fall back to use the bundled boost version.

For the bundled version we want to be able to use Boost.Iostreams which requires for our use case ZLIB.
Therefore, it's a fatal error if we try to use the bundled Boost without `DEAL_II_WITH_ZLIB=ON`.