### PR TITLE
re-declare update_number_cache() as protected

### DIFF
--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -278,13 +278,15 @@ namespace parallel
        */
       bool with_artificial_cells() const;
 
-    private:
+    protected:
 
       /**
        * Override the function to update the number cache so we can fill data
        * like @p level_ghost_owners.
        */
       virtual void update_number_cache ();
+
+    private:
 
       /**
        * Settings


### PR DESCRIPTION
`parallel::Triangulation::update_number_cache()` is a virtual protected member. It would be better to make it virtual **protected** member in `parallel::shared::Triangulation` as well. #5114 made it a private member.