### PR TITLE
Add a check when comparing iterators.

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -120,7 +120,8 @@ TriaAccessorBase<structdim,dim,spacedim>::operator == (const TriaAccessorBase<st
 {
   Assert (tria == a.tria || tria == nullptr || a.tria == nullptr,
           TriaAccessorExceptions::ExcCantCompareIterators());
-  return ((present_level == a.present_level) &&
+  return ((tria == a.tria) &&
+          (present_level == a.present_level) &&
           (present_index == a.present_index));
 }
 
@@ -133,7 +134,8 @@ TriaAccessorBase<structdim,dim,spacedim>::operator != (const TriaAccessorBase<st
 {
   Assert (tria == a.tria || tria == nullptr || a.tria == nullptr,
           TriaAccessorExceptions::ExcCantCompareIterators());
-  return ((present_level != a.present_level) ||
+  return ((tria != a.tria) ||
+          (present_level != a.present_level) ||
           (present_index != a.present_index));
 }
 


### PR DESCRIPTION
Right now, comparing iterators only compares their level and index, but surprisingly
not the triangulation pointers. There is an assertion higher up that makes sure
that if the triangulation pointers of both objects are both non-nullptr, that they
are the same, but it is conceivable that one of the objects in invalid and the
other has a valid pointer. Internally, if that is the case, we have the invariant
that for iterators for which the triangulation pointer is nullptr, that the
level and index values are also invalid, and so nothing bad can happen (TM) with
the current code.

But it still seems prudent to also compare triangulation pointers, even if we know
that if one only of the pointers is nullptr, then the other comparisons for equality
must necessarily also fail because of the invariant -- we should just err on the
side of safety.

I've thought whether the pointers should be compared first or last. I put it first
because I think that the common case is to compare 'cell != endc', and in that
case one has a valid pointer and the other does not, so the first check will
already fail.