### PR TITLE
Avoid numdiff check race condition in test

### DIFF
--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -149,10 +149,11 @@ MACRO(DEAL_II_PICKUP_TESTS)
   #
   STRING(FIND "${NUMDIFF_EXECUTABLE}" "numdiff" _found_numdiff_binary)
   IF(NOT "${_found_numdiff_binary}" STREQUAL "-1")
+    STRING(RANDOM _suffix)
     SET(_first_test_file_name
-      "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/numdiff-test-1.txt")
+      "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/numdiff-test-${_suffix}-1.txt")
     SET(_second_test_file_name
-      "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/numdiff-test-2.txt")
+      "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/numdiff-test-${_suffix}-2.txt")
     FILE(WRITE "${_first_test_file_name}" "0.99999999998\n2.0\n1.0\n")
     FILE(WRITE "${_second_test_file_name}" "1.00000000001\n2.0\n1.0\n")
 

--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -164,10 +164,11 @@ MACRO(DEAL_II_PICKUP_TESTS)
       RESULT_VARIABLE _numdiff_tolerance_test_status
       )
 
-    # Note: We do not remove the test files to avoid a race condition if 
-    # cmake decides to rerun in a concurrent situation:
-    # FILE(REMOVE ${_first_test_file_name})
-    # FILE(REMOVE ${_second_test_file_name})
+    #
+    # Tidy up:
+    #
+    FILE(REMOVE ${_first_test_file_name})
+    FILE(REMOVE ${_second_test_file_name})
 
     IF(NOT "${_numdiff_tolerance_test_status}" STREQUAL "0")
       MESSAGE(FATAL_ERROR


### PR DESCRIPTION
Use randomly generated file names for collision free (concurrent) checks
for numdiff support.

Otherwise, if a test subproject is configured concurrently (which might
happen if ctest accidentally triggers a reconfigure due to changed files in
the main project), the following error might occur:
   "The detected numdiff executable was not able to pass a simple relative
   tolerance test."

In reference to #5323