### PR TITLE
Relax requirements for external BOOST for DEAL_WITH_ZLIB=OFF

### DIFF
--- a/cmake/configure/configure_boost.cmake
+++ b/cmake/configure/configure_boost.cmake
@@ -17,6 +17,16 @@
 # Configuration for the boost library:
 #
 
+IF(NOT FEATURE_ZLIB_PROCESSED)                                     
+  MESSAGE(FATAL_ERROR "\n"
+    "Internal build system error: The configuration of "
+    "DEAL_II_WITH_BOOST depends on "
+    "DEAL_II_WITH_ZLIB, but CONFIGURE_FEATURE(BOOST) "
+    "was called before CONFIGURE_FEATURE(ZLIB).\n\n"
+    )
+ENDIF()
+
+
 SET(DEAL_II_WITH_BOOST ON # Always true. We need it :-]
   CACHE BOOL "Build deal.II with support for boost." FORCE
   )

--- a/cmake/modules/FindBOOST.cmake
+++ b/cmake/modules/FindBOOST.cmake
@@ -46,9 +46,15 @@ ENDIF()
 
 # temporarily disable ${CMAKE_SOURCE_DIR}/cmake/modules for module lookup
 LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
-FIND_PACKAGE(Boost 1.59 COMPONENTS
-  iostreams serialization system thread
-  )
+IF(DEAL_II_WITH_ZLIB)
+  FIND_PACKAGE(Boost 1.59 COMPONENTS
+    iostreams serialization system thread
+    )
+ELSE()
+  FIND_PACKAGE(Boost 1.59 COMPONENTS
+    serialization system thread
+    )
+ENDIF()
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 
 #
@@ -59,7 +65,11 @@ IF(NOT Boost_FOUND AND Boost_USE_STATIC_LIBS)
 
   # temporarily disable ${CMAKE_SOURCE_DIR}/cmake/modules for module lookup
   LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
-  FIND_PACKAGE(Boost 1.59 COMPONENTS iostreams serialization system thread)
+  IF(DEAL_II_WITH_ZLIB)
+    FIND_PACKAGE(Boost 1.59 COMPONENTS iostreams serialization system thread)
+  ELSE()
+    FIND_PACKAGE(Boost 1.59 COMPONENTS serialization system thread)
+  ENDIF()
   LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 ENDIF()
 


### PR DESCRIPTION
In response to https://github.com/dealii/dealii/pull/5318#issuecomment-339378078
we should just relax requirements for an externally `boost` dependency in case we don't use `ZLIB` at all.

@tamiko Is this fine with the philosophy on what we are allowed to do in `Find*.cmake` files or do you have a better suggestion?

Depends (weakly) on #5322.
