### PR TITLE
Allow DataEntry functions to return either the real or imaginary part.

### DIFF
--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -146,6 +146,35 @@ namespace internal
   namespace DataOut
   {
     /**
+     * The DataEntry classes abstract away the concrete data type of vectors
+     * users can attach to DataOut (and similar) objects and allow the underlying
+     * DataOut functions to query for individual elements of solution vectors
+     * without having to know the concrete vector type. This avoids that
+     * DataOut has to know what vectors are being used, but it has the downside
+     * that DataOut also doesn't know the underlying scalar type of these vectors.
+     *
+     * If the underlying scalar types all represent real numbers (in the
+     * mathematical sense -- i.e., the scalar type would be @p float,
+     * @p double, etc) then that is not a problem -- DataOut simply
+     * receives the values of individual vector components as @p double
+     * objects. On the other hand, if the vector type uses a std::complex
+     * scalar type, then DataEntry returning a @p double for a vector
+     * entry is not sufficient -- we need to provide DataOut with a way
+     * to query both the real and the imaginary part, so that they can
+     * be written into output files separately.
+     *
+     * This enum allows DataOut to tell a DataEntry function which component
+     * of a vector entry it wants to query, i.e., whether it wants the real
+     * or the imaginary part of a vector entry.
+     */
+    enum class ComponentExtractor
+    {
+      real_part,
+      imaginary_part
+    };
+
+
+    /**
      * For each vector that has been added through the add_data_vector()
      * functions, we need to keep track of a pointer to it, and allow data
      * extraction from it when we generate patches. Unfortunately, we need to
@@ -190,7 +219,8 @@ namespace internal
        */
       virtual
       double
-      get_cell_data_value (const unsigned int cell_number) const = 0;
+      get_cell_data_value (const unsigned int cell_number,
+                           const ComponentExtractor extract_component) const = 0;
 
       /**
        * Given a FEValuesBase object, extract the values on the present cell
@@ -200,6 +230,7 @@ namespace internal
       void
       get_function_values
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
+       const ComponentExtractor extract_component,
        std::vector<double> &patch_values) const = 0;
 
       /**
@@ -211,6 +242,7 @@ namespace internal
       void
       get_function_values
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
+       const ComponentExtractor extract_component,
        std::vector<dealii::Vector<double> > &patch_values_system) const = 0;
 
       /**
@@ -221,6 +253,7 @@ namespace internal
       void
       get_function_gradients
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
+       const ComponentExtractor extract_component,
        std::vector<Tensor<1,DoFHandlerType::space_dimension> > &patch_gradients) const = 0;
 
       /**
@@ -232,6 +265,7 @@ namespace internal
       void
       get_function_gradients
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
+       const ComponentExtractor extract_component,
        std::vector<std::vector<Tensor<1,DoFHandlerType::space_dimension> > > &patch_gradients_system) const = 0;
 
       /**
@@ -242,6 +276,7 @@ namespace internal
       void
       get_function_hessians
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
+       const ComponentExtractor extract_component,
        std::vector<Tensor<2,DoFHandlerType::space_dimension> > &patch_hessians) const = 0;
 
       /**
@@ -253,6 +288,7 @@ namespace internal
       void
       get_function_hessians
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
+       const ComponentExtractor extract_component,
        std::vector<std::vector< Tensor<2,DoFHandlerType::space_dimension> > > &patch_hessians_system) const = 0;
 
       /**

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -156,12 +156,15 @@ build_one_patch
                   // gradient etc.
                   if (update_flags & update_values)
                     this->dof_data[dataset]->get_function_values (this_fe_patch_values,
+                                                                  internal::DataOut::ComponentExtractor::real_part,
                                                                   scratch_data.patch_values_scalar.solution_values);
                   if (update_flags & update_gradients)
                     this->dof_data[dataset]->get_function_gradients (this_fe_patch_values,
+                                                                     internal::DataOut::ComponentExtractor::real_part,
                                                                      scratch_data.patch_values_scalar.solution_gradients);
                   if (update_flags & update_hessians)
                     this->dof_data[dataset]->get_function_hessians (this_fe_patch_values,
+                                                                    internal::DataOut::ComponentExtractor::real_part,
                                                                     scratch_data.patch_values_scalar.solution_hessians);
 
                   if (update_flags & update_quadrature_points)
@@ -185,12 +188,15 @@ build_one_patch
                   // derivative...
                   if (update_flags & update_values)
                     this->dof_data[dataset]->get_function_values (this_fe_patch_values,
+                                                                  internal::DataOut::ComponentExtractor::real_part,
                                                                   scratch_data.patch_values_system.solution_values);
                   if (update_flags & update_gradients)
                     this->dof_data[dataset]->get_function_gradients (this_fe_patch_values,
+                                                                     internal::DataOut::ComponentExtractor::real_part,
                                                                      scratch_data.patch_values_system.solution_gradients);
                   if (update_flags & update_hessians)
                     this->dof_data[dataset]->get_function_hessians (this_fe_patch_values,
+                                                                    internal::DataOut::ComponentExtractor::real_part,
                                                                     scratch_data.patch_values_system.solution_hessians);
 
                   if (update_flags & update_quadrature_points)
@@ -221,6 +227,7 @@ build_one_patch
             if (n_components == 1)
               {
                 this->dof_data[dataset]->get_function_values (this_fe_patch_values,
+                                                              internal::DataOut::ComponentExtractor::real_part,
                                                               scratch_data.patch_values_scalar.solution_values);
                 for (unsigned int q=0; q<n_q_points; ++q)
                   patch.data(offset,q) = scratch_data.patch_values_scalar.solution_values[q];
@@ -229,6 +236,7 @@ build_one_patch
               {
                 scratch_data.resize_system_vectors(n_components);
                 this->dof_data[dataset]->get_function_values (this_fe_patch_values,
+                                                              internal::DataOut::ComponentExtractor::real_part,
                                                               scratch_data.patch_values_system.solution_values);
                 for (unsigned int component=0; component<n_components;
                      ++component)
@@ -250,7 +258,8 @@ build_one_patch
           for (unsigned int dataset=0; dataset<this->cell_data.size(); ++dataset)
             {
               const double value
-                = this->cell_data[dataset]->get_cell_data_value (cell_and_index->second);
+                = this->cell_data[dataset]->get_cell_data_value (cell_and_index->second,
+                                                                 internal::DataOut::ComponentExtractor::real_part);
               for (unsigned int q=0; q<n_q_points; ++q)
                 patch.data(offset+dataset,q) = value;
             }

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -155,12 +155,15 @@ build_one_patch (const FaceDescriptor *cell_and_face,
                   // gradient etc.
                   if (update_flags & update_values)
                     this->dof_data[dataset]->get_function_values (this_fe_patch_values,
+                                                                  internal::DataOut::ComponentExtractor::real_part,
                                                                   data.patch_values_scalar.solution_values);
                   if (update_flags & update_gradients)
                     this->dof_data[dataset]->get_function_gradients (this_fe_patch_values,
+                                                                     internal::DataOut::ComponentExtractor::real_part,
                                                                      data.patch_values_scalar.solution_gradients);
                   if (update_flags & update_hessians)
                     this->dof_data[dataset]->get_function_hessians (this_fe_patch_values,
+                                                                    internal::DataOut::ComponentExtractor::real_part,
                                                                     data.patch_values_scalar.solution_hessians);
 
                   if (update_flags & update_quadrature_points)
@@ -186,12 +189,15 @@ build_one_patch (const FaceDescriptor *cell_and_face,
                   data.resize_system_vectors(n_components);
                   if (update_flags & update_values)
                     this->dof_data[dataset]->get_function_values (this_fe_patch_values,
+                                                                  internal::DataOut::ComponentExtractor::real_part,
                                                                   data.patch_values_system.solution_values);
                   if (update_flags & update_gradients)
                     this->dof_data[dataset]->get_function_gradients (this_fe_patch_values,
+                                                                     internal::DataOut::ComponentExtractor::real_part,
                                                                      data.patch_values_system.solution_gradients);
                   if (update_flags & update_hessians)
                     this->dof_data[dataset]->get_function_hessians (this_fe_patch_values,
+                                                                    internal::DataOut::ComponentExtractor::real_part,
                                                                     data.patch_values_system.solution_hessians);
 
                   if (update_flags & update_quadrature_points)
@@ -224,6 +230,7 @@ build_one_patch (const FaceDescriptor *cell_and_face,
             if (n_components == 1)
               {
                 this->dof_data[dataset]->get_function_values (this_fe_patch_values,
+                                                              internal::DataOut::ComponentExtractor::real_part,
                                                               data.patch_values_scalar.solution_values);
                 for (unsigned int q=0; q<n_q_points; ++q)
                   patch.data(offset,q) = data.patch_values_scalar.solution_values[q];
@@ -232,6 +239,7 @@ build_one_patch (const FaceDescriptor *cell_and_face,
               {
                 data.resize_system_vectors(n_components);
                 this->dof_data[dataset]->get_function_values (this_fe_patch_values,
+                                                              internal::DataOut::ComponentExtractor::real_part,
                                                               data.patch_values_system.solution_values);
                 for (unsigned int component=0; component<n_components;
                      ++component)
@@ -258,7 +266,8 @@ build_one_patch (const FaceDescriptor *cell_and_face,
                              typename Triangulation<dimension,space_dimension>::active_cell_iterator(cell_and_face->first));
 
           const double value
-            = this->cell_data[dataset]->get_cell_data_value (cell_number);
+            = this->cell_data[dataset]->get_cell_data_value (cell_number,
+                                                             internal::DataOut::ComponentExtractor::real_part);
           for (unsigned int q=0; q<n_q_points; ++q)
             patch.data(dataset+offset,q) = value;
         }

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -204,12 +204,15 @@ build_one_patch (const cell_iterator                                            
                       // value, gradient etc.
                       if (update_flags & update_values)
                         this->dof_data[dataset]->get_function_values (fe_patch_values,
+                                                                      internal::DataOut::ComponentExtractor::real_part,
                                                                       data.patch_values_scalar.solution_values);
                       if (update_flags & update_gradients)
                         this->dof_data[dataset]->get_function_gradients (fe_patch_values,
+                                                                         internal::DataOut::ComponentExtractor::real_part,
                                                                          data.patch_values_scalar.solution_gradients);
                       if (update_flags & update_hessians)
                         this->dof_data[dataset]->get_function_hessians (fe_patch_values,
+                                                                        internal::DataOut::ComponentExtractor::real_part,
                                                                         data.patch_values_scalar.solution_hessians);
 
                       if (update_flags & update_quadrature_points)
@@ -233,12 +236,15 @@ build_one_patch (const cell_iterator                                            
                       // its derivative...
                       if (update_flags & update_values)
                         this->dof_data[dataset]->get_function_values (fe_patch_values,
+                                                                      internal::DataOut::ComponentExtractor::real_part,
                                                                       data.patch_values_system.solution_values);
                       if (update_flags & update_gradients)
                         this->dof_data[dataset]->get_function_gradients (fe_patch_values,
+                                                                         internal::DataOut::ComponentExtractor::real_part,
                                                                          data.patch_values_system.solution_gradients);
                       if (update_flags & update_hessians)
                         this->dof_data[dataset]->get_function_hessians (fe_patch_values,
+                                                                        internal::DataOut::ComponentExtractor::real_part,
                                                                         data.patch_values_system.solution_hessians);
 
                       if (update_flags & update_quadrature_points)
@@ -288,6 +294,7 @@ build_one_patch (const cell_iterator                                            
               else if (n_components == 1)
                 {
                   this->dof_data[dataset]->get_function_values (fe_patch_values,
+                                                                internal::DataOut::ComponentExtractor::real_part,
                                                                 data.patch_values_scalar.solution_values);
 
                   switch (dimension)
@@ -320,6 +327,7 @@ build_one_patch (const cell_iterator                                            
                 {
                   data.resize_system_vectors(n_components);
                   this->dof_data[dataset]->get_function_values (fe_patch_values,
+                                                                internal::DataOut::ComponentExtractor::real_part,
                                                                 data.patch_values_system.solution_values);
 
                   for (unsigned int component=0; component<n_components;
@@ -366,7 +374,8 @@ build_one_patch (const cell_iterator                                            
                 = std::distance (this->triangulation->begin_active(),
                                  typename Triangulation<dimension,space_dimension>::active_cell_iterator(*cell));
               const double value
-                = this->cell_data[dataset]->get_cell_data_value (cell_number);
+                = this->cell_data[dataset]->get_cell_data_value (cell_number,
+                                                                 internal::DataOut::ComponentExtractor::real_part);
               switch (dimension)
                 {
                 case 1:


### PR DESCRIPTION
This is the next step in addressing #1894, and a follow-up to #5333: The classes that wrap vectors to be output via `DataOut` (i.e., the `DataEntry` classes) have functions to return the values, gradients, and Hessians of a field described by a solution vector, but they only worked if the scalar underlying the solution vector was float, double, or some other real number type. They would fail if the vector is based on a `std::complex` data type.

This patch provides these functions with the ability to select between the real and imaginary parts of the values, gradients, and Hessians, since these are what we can output.

I wrote this so that in principle one could extend it beyond just scalar numbers, in case we ever wanted to solve PDEs based on octonions. (If you can do octonions, then quaternions seem like so yesterday and boring.) I have no intention of implementing this, though :-)

Right now, I'm not making use of this ability. That's the next step for #1894.