### PR TITLE
Add an assertion to provide a nicer error message.

### DIFF
--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1512,6 +1512,11 @@ namespace DoFRenumbering
    const Tensor<1,DoFHandlerType::space_dimension> &direction,
    const bool                                       dof_wise_renumbering)
   {
+    Assert ((dynamic_cast<const parallel::Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*>
+             (&dof.get_triangulation())
+             == nullptr),
+            ExcNotImplemented());
+
     if (dof_wise_renumbering == false)
       {
         std::vector<typename DoFHandlerType::active_cell_iterator> ordered_cells;


### PR DESCRIPTION
Right now, as observed by @stmcgovern, we run into some obscure assertions with
non-locally-owned cells somewhere further down that really don't describe
what the problem is.