### PR TITLE
Make some things work for complex-valued vectors.

### DIFF
--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1341,7 +1341,7 @@ namespace FETools
       // not owned patch cells
       // are computed, start
       // the interpolation
-      u2 = 0;
+      u2 = typename OutVector::value_type(0.);
 
       std::queue<WorkPackage> queue;
       {

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -641,7 +641,7 @@ namespace FETools
     FullMatrix<double> matrix(n2,n1);
     get_projection_matrix(dof1.get_fe(), dof2.get_fe(), matrix);
 
-    u2 = 0;
+    u2 = typename OutVector::value_type(0.);
     while (cell2 != end)
       {
         cell1->get_dof_values(u1, u1_local);

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -127,9 +127,9 @@ namespace FETools
     std::vector<types::global_dof_index> dofs;
     dofs.reserve (DoFTools::max_dofs_per_cell (dof2));
 
-    u2 = 0;
+    u2 = typename OutVector::value_type(0.);
     OutVector touch_count(u2);
-    touch_count = 0;
+    touch_count = typename OutVector::value_type(0.);
 
     // for distributed triangulations,
     // we can only interpolate u1 on

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -18,6 +18,7 @@
 
 
 #include <deal.II/base/config.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/memory_consumption.h>
@@ -1693,9 +1694,9 @@ BlockVectorBase<VectorType>::mean_value () const
   value_type sum = 0.;
   // need to do static_cast as otherwise it won't work with value_type=complex<T>
   for (size_type i=0; i<n_blocks(); ++i)
-    sum += components[i].mean_value() * static_cast<double>(components[i].size());
+    sum += components[i].mean_value() * (typename numbers::NumberTraits<value_type>::real_type(components[i].size()));
 
-  return sum/static_cast<double>(size());
+  return sum/(typename numbers::NumberTraits<value_type>::real_type(size()));
 }
 
 

--- a/include/deal.II/multigrid/multigrid.templates.h
+++ b/include/deal.II/multigrid/multigrid.templates.h
@@ -223,7 +223,7 @@ Multigrid<VectorType>::level_step(const unsigned int level,
   // Combine the defect from the initial copy_to_mg with the one that has come
   // from the finer level by the transfer
   defect2[level] += defect[level];
-  defect[level] = 0;
+  defect[level] = typename VectorType::value_type(0.);
 
   if (debug>2)
     deallog << cychar << "-cycle defect norm     " << defect2[level].l2_norm()
@@ -264,7 +264,7 @@ Multigrid<VectorType>::level_step(const unsigned int level,
   if (edge_down != nullptr)
     edge_down->vmult(level, defect2[level-1], solution[level]);
   else
-    defect2[level-1] = 0;
+    defect2[level-1] = typename VectorType::value_type(0.);
 
   transfer->restrict_and_add (level, defect2[level-1], t[level]);
 

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -8210,7 +8210,7 @@ namespace VectorTools
                                         Vector<Number> (dof.get_fe(0).n_components()));
 
     Number mean = Number();
-    double area = 0.;
+    typename numbers::NumberTraits<Number>::real_type area = 0.;
     // Compute mean value
     for (cell = dof.begin_active(); cell != dof.end(); ++cell)
       if (cell->is_locally_owned())

--- a/source/multigrid/mg_base.cc
+++ b/source/multigrid/mg_base.cc
@@ -33,7 +33,7 @@ MGSmootherBase<VectorType>::apply (const unsigned int level,
                                    VectorType         &u,
                                    const VectorType   &rhs) const
 {
-  u = 0;
+  u = typename VectorType::value_type(0.);
   smooth(level, u, rhs);
 }
 


### PR DESCRIPTION
I want to eventually instantiate things also for complex-valued vectors, but
there are *many* places where this currently leads to compiler errors.

This patch fixes a few of those.