### PR TITLE
Update bundled boost to allow to compile with clang-9.0

### DIFF
--- a/bundled/boost-1.62.0/include/boost/config/compiler/nvcc.hpp
+++ b/bundled/boost-1.62.0/include/boost/config/compiler/nvcc.hpp
@@ -11,6 +11,13 @@
 #  define BOOST_COMPILER "NVIDIA CUDA C++ Compiler"
 #endif
 
+#if defined(__CUDACC_VER_MAJOR__) && defined(__CUDACC_VER_MINOR__) && defined(__CUDACC_VER_BUILD__)
+#  define BOOST_CUDA_VERSION __CUDACC_VER_MAJOR__ * 1000000 + __CUDACC_VER_MINOR__ * 10000 + __CUDACC_VER_BUILD__
+#else
+// We don't really know what the CUDA version is, but it's definitely before 7.5:
+#  define BOOST_CUDA_VERSION 7000000
+#endif
+
 // NVIDIA Specific support
 // BOOST_GPU_ENABLED : Flag a function or a method as being enabled on the host and device
 #define BOOST_GPU_ENABLED __host__ __device__
@@ -19,6 +26,32 @@
 // https://svn.boost.org/trac/boost/ticket/11897
 // This is fixed in 7.5. As the following version macro was introduced in 7.5 an existance
 // check is enough to detect versions < 7.5
-#if !defined(__CUDACC_VER__) || (__CUDACC_VER__ < 70500)
+#if BOOST_CUDA_VERSION < 7050000
 #   define BOOST_NO_CXX11_VARIADIC_TEMPLATES
+#endif
+// The same bug is back again in 8.0:
+#if (BOOST_CUDA_VERSION > 8000000) && (BOOST_CUDA_VERSION < 8010000)
+#   define BOOST_NO_CXX11_VARIADIC_TEMPLATES
+#endif
+// Most recent CUDA (8.0) has no constexpr support in msvc mode:
+#if defined(_MSC_VER)
+#  define BOOST_NO_CXX11_CONSTEXPR
+#endif
+
+#ifdef __CUDACC__
+//
+// When compiing .cu files, there's a bunch of stuff that doesn't work with msvc:
+//
+#if defined(_MSC_VER)
+#  define BOOST_NO_CXX14_DIGIT_SEPARATORS
+#  define BOOST_NO_CXX11_UNICODE_LITERALS
+#endif
+//
+// And this one effects the NVCC front end,
+// See https://svn.boost.org/trac/boost/ticket/13049
+//
+#if (BOOST_CUDA_VERSION >= 8000000) && (BOOST_CUDA_VERSION < 8010000)
+#  define BOOST_NO_CXX11_NOEXCEPT
+#endif
+
 #endif


### PR DESCRIPTION
Even if this does not fix all the problems I currently have using `cuda-9.0`(#5336), this is at least progress and should address the failing [CDash builds](https://cdash.kyomu.43-1.org/viewBuildError.php?buildid=12661).

I updated the file to a version currently used in `boost`.