### PR TITLE
Deprecate BlockTrianglePrecondition and BlockMatrixArray.

### DIFF
--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -122,6 +122,39 @@ block_back_substitution(const BlockLinearOperator<Range, Domain, BlockPayload> &
  * const auto block_op_a = block_operator(A);
  * @endcode
  *
+ * Alternatively, there are several helper functions available for creating
+ * instances from multiple independent matrices of possibly different types.
+ * Here is an example of a block diagonal matrix created from a FullMatrix and
+ * a SparseMatrixEZ:
+ *
+ * @code
+ * FullMatrix<double> top_left(2, 2);
+ * top_left(0, 0) = 2.0;
+ * top_left(0, 1) = -1.0;
+ * top_left(1, 0) = -1.0;
+ * top_left(1, 1) = 2.0;
+ *
+ * SparseMatrixEZ<double> bottom_right(4, 4, 4);
+ * for (std::size_t row_n = 0; row_n < 4; ++row_n)
+ *   {
+ *     bottom_right.add(row_n, row_n, 1.0);
+ *     if (row_n < 3)
+ *       bottom_right.add(row_n, row_n + 1, -1.0);
+ *   }
+ *
+ * auto top_left_op = linear_operator(top_left);
+ * auto bottom_right_op = linear_operator(bottom_right);
+ * std::array<decltype(top_left_op), 2> operators {{top_left_op, bottom_right_op}};
+ * auto block_op = block_diagonal_operator (operators);
+ *
+ * std::vector<BlockVector<double>::size_type> block_sizes {2, 4};
+ * BlockVector<double> src(block_sizes);
+ * src = 2.0;
+ * BlockVector<double> dst(block_sizes);
+ * block_op.vmult(dst, src); // now equal to 2, 2, 0, 0, 0, 2
+ * @endcode
+ *
+ *
  * A BlockLinearOperator can be sliced to a LinearOperator at any time. This
  * removes all information about the underlying block structure (because above
  * <code>std::function</code> objects are no longer available) - the linear

--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -123,12 +123,12 @@ block_back_substitution(const BlockLinearOperator<Range, Domain, BlockPayload> &
  * @endcode
  *
  * A BlockLinearOperator can be sliced to a LinearOperator at any time. This
- * removes all information about the underlying block structure (beacuse above
+ * removes all information about the underlying block structure (because above
  * <code>std::function</code> objects are no longer available) - the linear
  * operator interface, however, remains intact.
  *
  * @note This class makes heavy use of <code>std::function</code> objects and
- * lambda functions. This flexibiliy comes with a run-time penalty. Only use
+ * lambda functions. This flexibility comes with a run-time penalty. Only use
  * this object to encapsulate object with medium to large individual block
  * sizes, and small block structure (as a rule of thumb, matrix blocks greater
  * than $1000\times1000$).
@@ -378,9 +378,9 @@ namespace internal
      * subblocks.
      *
      * This is the Payload class typically associated with deal.II's native
-     * BlockSparseMatrix. To use Trilinos and PETSc BlockSparseMatrices it is
-     * necessary to initialize a BlockLinearOperator with their associated
-     * BlockPayload.
+     * BlockSparseMatrix. To use either TrilinosWrappers::BlockSparseMatrix or
+     * PETScWrappers::BlockSparseMatrix one must initialize a
+     * BlockLinearOperator with their associated BlockPayload.
      *
      * @author Jean-Paul Pelteret, Matthias Maier, 2016
      *
@@ -472,7 +472,7 @@ block_operator(const BlockMatrixType &block_matrix)
  *
  * A variant of above function that encapsulates a given collection @p ops of
  * LinearOperators into a block structure. Here, it is assumed that Range and
- * Domain are blockvectors, i.e., derived from
+ * Domain are block vectors, i.e., derived from
  * @ref BlockVectorBase.
  * The individual linear operators in @p ops must act on the underlying vector
  * type of the block vectors, i.e., on Domain::BlockType yielding a result in

--- a/include/deal.II/lac/block_matrix_array.h
+++ b/include/deal.II/lac/block_matrix_array.h
@@ -105,6 +105,8 @@ DEAL_II_NAMESPACE_OPEN
  * The remaining code of this sample program concerns preconditioning and is
  * described in the documentation of BlockTrianglePrecondition.
  *
+ * @deprecated This class has been superseded by BlockLinearOperator.
+ *
  * @see
  * @ref GlossBlockLA "Block (linear algebra)"
  * @author Guido Kanschat
@@ -343,7 +345,7 @@ private:
    * number of blocks per row.
    */
   unsigned int block_cols;
-};
+} DEAL_II_DEPRECATED;
 
 /*@}*/
 
@@ -398,6 +400,8 @@ private:
  * for solving.
  * @until Error
  *
+ * @deprecated This class has been superseded by block_back_substitution and
+ * block_forward_substitution, which build on BlockLinearOperator.
  *
  * @ingroup Preconditioners
  * @author Guido Kanschat, 2001, 2005
@@ -517,7 +521,7 @@ private:
    * Flag for backward insertion.
    */
   bool backward;
-};
+} DEAL_II_DEPRECATED;
 
 
 #ifndef DOXYGEN

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -119,12 +119,12 @@ null_operator(const LinearOperator<Range, Domain, Payload> &);
  * in conjunction with the LinearOperator class, it is necessary to extend the
  * functionality of the LinearOperator class by means of an additional Payload.
  *
- * For example, in order to construct an InverseOperator a call to a solver is
- * required. Naturally these solvers don't have an interface to the
- * LinearOperator (which, for example, may represent a composite operation).
- * The TrilinosWrappers::internal::LinearOperator::TrilinosPayload therefore
- * provides an interface extension to the LinearOperator so that it can be
- * passed to the solver and used by the solver as if it were a Trilinos
+ * For example: LinearOperator instances representing matrix inverses usually
+ * require calling some linear solver. These solvers may not have interfaces
+ * to the LinearOperator (which, for example, may represent a composite
+ * operation). The TrilinosWrappers::internal::LinearOperator::TrilinosPayload
+ * therefore provides an interface extension to the LinearOperator so that it
+ * can be passed to the solver and used by the solver as if it were a Trilinos
  * operator. This implies that all of the necessary functionality of the
  * specific Trilinos operator has been overloaded within the Payload class.
  * This includes operator-vector multiplication and inverse operator-vector

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -140,7 +140,7 @@ null_operator(const LinearOperator<Range, Domain, Payload> &);
  *
  * @note To ensure that the correct payload is provided, wrapper functions
  * for linear operators have been provided within the respective
- * TrilinosWrappers (and, in the future, PetscWrappers) namespaces.
+ * TrilinosWrappers (and, in the future, PETScWrappers) namespaces.
  *
  * @author Luca Heltai, Matthias Maier, 2015; Jean-Paul Pelteret, 2016
  *
@@ -782,7 +782,7 @@ identity_operator(const std::function<void(Range &, bool)> &reinit_vector)
  * Return a LinearOperator that is the identity of the vector space @p Range.
  *
  * The function takes a LinearOperator @p op and uses its range initializer
- * to create an identiy operator. In contrast to the function above, this
+ * to create an identity operator. In contrast to the function above, this
  * function also ensures that the underlying Payload matches that of the
  * input @p op.
  *
@@ -913,8 +913,8 @@ namespace internal
      * facilitate the operations of the matrix.
      *
      * This is the Payload class typically associated with deal.II's native
-     * SparseMatrix. To use Trilinos and PETSc SparseMatrices it is necessary
-     * to initialize a LinearOperator with their associated Payload.
+     * SparseMatrix. To use Trilinos and PETSc sparse matrix classes it is
+     * necessary to initialize a LinearOperator with their associated Payload.
      *
      * @author Jean-Paul Pelteret, Matthias Maier, 2016
      *


### PR DESCRIPTION
Closing #3733 reminded me that we still need to deprecate these two classes.

I made some small improvements to the documentation along the way: in particular, I found it hard to figure out how to set up a `BlockLinearOperator` with multiple matrix types so I added a little example up front.