### PR TITLE
Fix Patterns::Tuple::description

### DIFF
--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1271,6 +1271,8 @@ namespace Patterns
     static_assert(is_base_of_all<PatternBase, PatternTypes...>::value,
                   "Not all of the input arguments of this function "
                   "are derived from PatternBase");
+    static_assert(sizeof...(ps) > 0,
+                  "The number of PatternTypes must be greater than zero!");
     auto pattern_pointers = { (static_cast<const PatternBase *>(&ps))... };
     for (auto p : pattern_pointers)
       patterns.push_back (p->clone());

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -1044,9 +1044,10 @@ namespace Patterns
             description << separator
                         << "[" << patterns[i]->description(style) << "]";
 
-            return description.str();
           }
+        return description.str();
       }
+
       default:
         AssertThrow(false, ExcNotImplemented());
       }

--- a/tests/base/patterns_12.cc
+++ b/tests/base/patterns_12.cc
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2005 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Check that the description of a patterns works for all OutputStyles
+// and number of PatternStyles.
+
+#include "../tests.h"
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/std_cxx14/memory.h>
+#include <memory>
+
+int main()
+{
+  initlog();
+
+  // one pattern
+  {
+    const auto &pattern = Patterns::Tuple(Patterns::Double());
+
+    deallog << pattern.description(Patterns::PatternBase::OutputStyle::Machine) << '\n'
+            << pattern.description(Patterns::PatternBase::OutputStyle::Text)    << '\n'
+            << pattern.description(Patterns::PatternBase::OutputStyle::LaTeX)   << '\n'
+            << std::endl;
+  }
+
+  // two patterns
+  {
+    const auto &pattern = Patterns::Tuple(Patterns::Double(),
+                                          Patterns::Anything());
+
+    deallog << pattern.description(Patterns::PatternBase::OutputStyle::Machine) << '\n'
+            << pattern.description(Patterns::PatternBase::OutputStyle::Text)    << '\n'
+            << pattern.description(Patterns::PatternBase::OutputStyle::LaTeX)   << '\n'
+            << std::endl;
+  }
+
+  // three patterns
+  {
+    const auto &pattern = Patterns::Tuple(Patterns::Double(),
+                                          Patterns::Anything(),
+                                          Patterns::Bool());
+
+    deallog << pattern.description(Patterns::PatternBase::OutputStyle::Machine) << '\n'
+            << pattern.description(Patterns::PatternBase::OutputStyle::Text)    << '\n'
+            << pattern.description(Patterns::PatternBase::OutputStyle::LaTeX)   << '\n'
+            << std::endl;
+  }
+}

--- a/tests/base/patterns_12.output
+++ b/tests/base/patterns_12.output
@@ -1,0 +1,13 @@
+
+DEAL::[Tuple of <1> elements <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]>]
+A Tuple of 1 elements  where each element is [A floating point number v such that -MAX_DOUBLE <= v <= MAX_DOUBLE]
+A Tuple of 1 elements  where each element is [A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$]
+
+DEAL::[Tuple of <2> elements <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]>, <[Anything]>]
+A Tuple of 2 elements  where each element is [A floating point number v such that -MAX_DOUBLE <= v <= MAX_DOUBLE],[Any string]
+A Tuple of 2 elements  where each element is [A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$],[Any string]
+
+DEAL::[Tuple of <3> elements <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]>, <[Anything]>, <[Bool]>]
+A Tuple of 3 elements  where each element is [A floating point number v such that -MAX_DOUBLE <= v <= MAX_DOUBLE],[Any string],[A boolean value (true or false)]
+A Tuple of 3 elements  where each element is [A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$],[Any string],[A boolean value (true or false)]
+


### PR DESCRIPTION
The return value in `Patterns::Tuple::description` was misplaced for `Patterns::PatternBase::Text` and `Patterns::PatternBase::LaTeX` resulting in wrong results whenever the number of patterns was not two.

Also make sure that the number of `PatternStyles` used is greater than zero.