### PR TITLE
Fix warnings regarding extra';' and unused parameters

### DIFF
--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1469,28 +1469,28 @@ namespace Patterns
       constexpr int max_list_rank()
       {
         return RankInfo<T>::list_rank;
-      };
+      }
 
       template <class T1, class T2, class... Types>
       constexpr int max_list_rank()
       {
         return std_cxx14::max(RankInfo<T1>::list_rank,
                               max_list_rank<T2,Types...>());
-      };
+      }
 
       // Helper function for map_rank
       template <class T>
       constexpr int max_map_rank()
       {
         return RankInfo<T>::map_rank;
-      };
+      }
 
       template <class T1, class T2, class... Types>
       constexpr int max_map_rank()
       {
         return std_cxx14::max(RankInfo<T1>::map_rank,
                               max_map_rank<T2,Types...>());
-      };
+      }
 
       // Rank of vector types
       template <class T>

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -4468,6 +4468,7 @@ namespace internal
           Implementation::renumber_mg_dofs (ghosted_new_numbers, relevant_dofs,
                                             *dof_handler, level, true);
 #else
+        (void) new_numbers;
         Assert(false, ExcNotImplemented());
 #endif
 


### PR DESCRIPTION
Fixes the warnings in https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=12710
and https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=12723