### PR TITLE
Avoid warnings about no return value in non-void functions.

### DIFF
--- a/include/deal.II/lac/lapack_templates.h
+++ b/include/deal.II/lac/lapack_templates.h
@@ -530,6 +530,7 @@ inline
 number lansy (const char *, const char *, const int *, const number *, const int *, number *)
 {
   Assert (false, ExcNotImplemented());
+  return number();
 }
 
 inline
@@ -576,6 +577,7 @@ inline
 number lange (const char *, const int *, const int *, const number *, const int *, number *)
 {
   Assert (false, ExcNotImplemented());
+  return number();
 }
 
 inline


### PR DESCRIPTION
We never saw this because this affects the general template for LAPACK functions
that we never call. But I want to instantiate functions that call them with
std::complex data types, and then we get into these functions.

Relates to #2033.