### PR TITLE
CMake: Fix info string about bundled libraries

### DIFF
--- a/cmake/configure/configure_boost.cmake
+++ b/cmake/configure/configure_boost.cmake
@@ -17,7 +17,7 @@
 # Configuration for the boost library:
 #
 
-IF(NOT FEATURE_ZLIB_PROCESSED)                                     
+IF(NOT FEATURE_ZLIB_PROCESSED)
   MESSAGE(FATAL_ERROR "\n"
     "Internal build system error: The configuration of "
     "DEAL_II_WITH_BOOST depends on "

--- a/cmake/macros/macro_configure_feature.cmake
+++ b/cmake/macros/macro_configure_feature.cmake
@@ -114,7 +114,8 @@ or set the relevant variables by hand in ccmake."
     ${${_feature}_ADDITIONAL_ERROR_STRING}
     "Please ensure that a suitable ${_feature_lowercase} library is installed on your computer.\n"
     "If the library is not at a default location, either provide some hints "
-    "for autodetection,${_hint_snippet}${_bundled_snippet}"
+    "for autodetection,${_hint_snippet}"
+    ${_bundled_snippet}
     )
 ENDMACRO()
 


### PR DESCRIPTION
Two very small changes:
 - remove trailing whitespace (as discovered by Denis in #5375)
 - print the info string for bundled libraries correctly

In reference to #5375