### PR TITLE
Update documentation of manifolds

### DIFF
--- a/doc/doxygen/headers/manifold.h
+++ b/doc/doxygen/headers/manifold.h
@@ -88,7 +88,7 @@
  * object (derived from Manifold). Notice that Triangulation uses only
  * the Manifold interface, not the Boundary interface. Other tools,
  * however, might need to compute exact normals at quadrature points,
- * and therefore a wrapper to query Boundary objects is provided. 
+ * and therefore a wrapper to query Boundary objects is provided.
  *
  *
  * <h3>An example</h3>
@@ -136,7 +136,7 @@
  *  const HyperShellBoundary<2> boundary_description(center);
  *  triangulation.set_boundary (0, boundary_description);
  *
- *  triangulation.refine_global (3); 
+ *  triangulation.refine_global (3);
  * @endcode
  * This code is better, producing the following mesh:
  *
@@ -171,8 +171,8 @@
  *    cell = triangulation.begin_active(),
  *    endc = triangulation.end();
  *  for (; cell!=endc; ++cell)
- *    cell->set_all_manifold_ids (0);  
- *  
+ *    cell->set_all_manifold_ids (0);
+ *
  *  triangulation.refine_global (3);
  * @endcode
  * This leads to the following mesh:
@@ -206,7 +206,7 @@
  *  const HyperShellBoundary<2> boundary_description(center);
  *  triangulation.set_boundary (0, boundary_description);
  *
- *  triangulation.refine_global (3); 
+ *  triangulation.refine_global (3);
  * @endcode
  *
  * @image html hypershell-boundary-only-4.png ""
@@ -245,8 +245,8 @@
  *    cell = triangulation.begin_active(),
  *    endc = triangulation.end();
  *  for (; cell!=endc; ++cell)
- *    cell->set_all_manifold_ids (0);  
- *  
+ *    cell->set_all_manifold_ids (0);
+ *
  *  triangulation.refine_global (3);
  * @endcode
  *
@@ -258,7 +258,14 @@
  * in the context of what GridGenerator::hyper_shell() produces in 3d
  * (see the documentation of this function). It is also germane to the
  * cases discussed in the @ref GlossDistorted "glossary entry on distorted cells".
- * 
+ *
+ * Another example where the manifold description not just at the boundary but
+ * also in the interior of the domain matters is for high-order methods. When
+ * using cubic or even higher degrees of the polynomials, full convergence is
+ * typically only obtained if a curved description at a boundary transitions
+ * into a straight description inside the domain (for example when meshing a
+ * ball including the origin) over a layer of finite thickness. This is
+ * realized by the class TransfiniteInterpolationManifold.
  *
  * @see @ref GlossManifoldIndicator "Glossary entry on manifold indicators"
  *

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -117,6 +117,7 @@ private:
 };
 
 
+
 /**
  * Manifold description for a spherical space coordinate system.
  *
@@ -161,9 +162,11 @@ private:
  * connecting points on the surface of the sphere. In the examples above,
  * the PolarManifold class implements the first way of connecting two
  * points on the surface of a sphere, while SphericalManifold implements
- * the second way, i.e., if the codimension of the Manifold is one,
- * than this Manifold connects points using geodesics. In all other cases
- * it is a continuus extension of the codimension one case.
+ * the second way, i.e., this Manifold connects points using geodesics.
+ * If more than two points are involved through a
+ * SphericalManifold::get_new_points() call, a so-called spherical average is
+ * used where the final point minimizes the weighted distance to all other
+ * points via geodesics.
  *
  * In particular, this class implements a Manifold that joins any two
  * points in space by first projecting them onto the surface of a
@@ -190,13 +193,16 @@ private:
  * points across the center, they would travel on spherical
  * coordinates, avoiding the center.
  *
- * The ideal geometry for this Manifold is an HyperShell. If you plan
- * to use this Manifold on a HyperBall, you have to make sure you do
- * not attach this Manifold to the cell containing the center.
+ * The ideal geometry for this Manifold is an HyperShell. If you plan to use
+ * this Manifold on a HyperBall, you have to make sure you do not attach this
+ * Manifold to the cell containing the center. It is advisable to combine this
+ * class with TransfiniteInterpolationManifold to ensure a smooth transition
+ * from a curved shape to the straight coordinate system in the center of the
+ * ball.
  *
  * @ingroup manifold
  *
- * @author Mauro Bardelloni, Luca Heltai, 2016
+ * @author Mauro Bardelloni, Luca Heltai, Daniel Arndt, 2016, 2017
  */
 template <int dim, int spacedim = dim>
 class SphericalManifold : public Manifold<dim, spacedim>
@@ -243,6 +249,7 @@ public:
    */
   const Point<spacedim> center;
 };
+
 
 
 /**
@@ -331,6 +338,7 @@ private:
   double tolerance;
 
 };
+
 
 
 /**
@@ -471,6 +479,7 @@ private:
 };
 
 
+
 /**
  * Manifold description for the surface of a Torus in three dimensions. The
  * Torus is assumed to be in the x-z plane. The reference coordinate system
@@ -609,13 +618,14 @@ private:
  * two vertices using the weights 0.25 and 0.75 for the two vertices should
  * give the same result as first computing the mid point at 0.5 and then again
  * compute the midpoint between the first vertex and coarse mid point. This is
- * the case for PolarManifold but not for Spherical manifold, so be careful
- * when using the latter. In case the quality of the manifold is not good
- * enough, upon mesh refinement it may happen that the transformation to a
- * chart inside the get_new_point() or get_new_points() methods produces
- * points that are outside the unit cell. Then this class throws an exception
- * of type Mapping::ExcTransformationFailed. In that case, the mesh should be
- * refined before attaching this class, as done in the following example:
+ * the case for most of the manifold classes provided by deal.II, such as
+ * SphericalManifold or PolarManifold, but it might be violated by naive
+ * implementations. In case the quality of the manifold is not good enough,
+ * upon mesh refinement it may happen that the transformation to a chart
+ * inside the get_new_point() or get_new_points() methods produces points that
+ * are outside the unit cell. Then this class throws an exception of type
+ * Mapping::ExcTransformationFailed. In that case, the mesh should be refined
+ * before attaching this class, as done in the following example:
  *
  * @code
  * SphericalManifold<dim> spherical_manifold;
@@ -625,7 +635,7 @@ private:
  *
  * triangulation.set_all_manifold_ids(1);
  * triangulation.set_all_manifold_ids_on_boundary(0);
- * triangulation.set_manifold (0, polar_manifold);
+ * triangulation.set_manifold (0, spherical_manifold);
  * inner_manifold.initialize(triangulation);
  * triangulation.set_manifold (1, inner_manifold);
  * triangulation.refine_global(1);

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -92,6 +92,7 @@ namespace internal
 }
 
 
+
 // ============================================================
 // PolarManifold
 // ============================================================
@@ -101,6 +102,8 @@ PolarManifold<dim,spacedim>::PolarManifold(const Point<spacedim> center):
   ChartManifold<dim,spacedim,spacedim>(PolarManifold<dim,spacedim>::get_periodicity()),
   center(center)
 {}
+
+
 
 template <int dim, int spacedim>
 Tensor<1,spacedim>
@@ -115,6 +118,8 @@ PolarManifold<dim,spacedim>::get_periodicity()
   periodicity[spacedim-1] = 2*numbers::PI;
   return periodicity;
 }
+
+
 
 template <int dim, int spacedim>
 Point<spacedim>
@@ -146,6 +151,8 @@ PolarManifold<dim,spacedim>::push_forward(const Point<spacedim> &spherical_point
       }
   return p+center;
 }
+
+
 
 template <int dim, int spacedim>
 Point<spacedim>
@@ -182,6 +189,8 @@ PolarManifold<dim,spacedim>::pull_back(const Point<spacedim> &space_point) const
     }
   return p;
 }
+
+
 
 template <int dim, int spacedim>
 DerivativeForm<1,spacedim,spacedim>
@@ -228,6 +237,8 @@ PolarManifold<dim,spacedim>::push_forward_gradient(const Point<spacedim> &spheri
   return DX;
 }
 
+
+
 // ============================================================
 // SphericalManifold
 // ============================================================
@@ -236,6 +247,8 @@ template <int dim, int spacedim>
 SphericalManifold<dim,spacedim>::SphericalManifold(const Point<spacedim> center):
   center(center)
 {}
+
+
 
 template <int dim, int spacedim>
 Point<spacedim>
@@ -298,6 +311,8 @@ get_intermediate_point (const Point<spacedim> &p1,
   return Point<spacedim>(center + (w*r2+(1.0-w)*r1)*P);
 }
 
+
+
 template <int dim, int spacedim>
 Tensor<1,spacedim>
 SphericalManifold<dim,spacedim>::
@@ -339,6 +354,7 @@ get_tangent_vector (const Point<spacedim> &p1,
 
   return (r1-r2)*e1 + r1*gamma*tg;
 }
+
 
 
 // The main part of the implementation uses the ideas in the publication
@@ -497,6 +513,8 @@ get_new_point (const ArrayView<const Point<spacedim>> &vertices,
   return center + rho*candidate;
 }
 
+
+
 // ============================================================
 // CylindricalManifold
 // ============================================================
@@ -525,7 +543,6 @@ CylindricalManifold<dim, spacedim>::CylindricalManifold(const Point<spacedim> &d
   // easier.
   Assert (spacedim==3,
           ExcMessage("CylindricalManifold can only be used for spacedim==3!"));
-
 }
 
 
@@ -726,6 +743,9 @@ FunctionManifold<dim,spacedim,chartdim>::pull_back(const Point<spacedim> &space_
 
 
 
+// ============================================================
+// TorusManifold
+// ============================================================
 template <int dim>
 Point<3>
 TorusManifold<dim>::pull_back(const Point<3> &p) const
@@ -797,6 +817,9 @@ TorusManifold<dim>::push_forward_gradient(const Point<3> &chart_point) const
 
 
 
+// ============================================================
+// TransfiniteInterpolationManifold
+// ============================================================
 template <int dim, int spacedim>
 TransfiniteInterpolationManifold<dim,spacedim>::TransfiniteInterpolationManifold()
   :
@@ -934,7 +957,7 @@ namespace
   // this is replicated from GeometryInfo::face_to_cell_vertices since we need
   // it very often in compute_transfinite_interpolation and the function is
   // performance critical
-  unsigned int
+  static constexpr unsigned int
   face_to_cell_vertices_3d[6][4] =
   {
     {0, 2, 4, 6},
@@ -948,7 +971,8 @@ namespace
   // this is replicated from GeometryInfo::face_to_cell_lines since we need it
   // very often in compute_transfinite_interpolation and the function is
   // performance critical
-  unsigned int face_to_cell_lines_3d[6][4] =
+  static constexpr unsigned int
+  face_to_cell_lines_3d[6][4] =
   {
     {8,10, 0, 4},
     {9,11, 1, 5},


### PR DESCRIPTION
This cleans up some things after #5374 and adds some documentation on #5368. Furthermore, I noticed that we should also mention `TransfiniteInterpolationManifold` in the manifold group documentation.