### PR TITLE
 escape characters in LaTeX format of ParameterHandler

### DIFF
--- a/doc/news/changes/incompatibilities/20171103TimoHeister
+++ b/doc/news/changes/incompatibilities/20171103TimoHeister
@@ -1,0 +1,4 @@
+Changed: ParameterHandler::print_parameters() in LaTeX format now correctly
+escapes special characters. As a consequence, the names of labels changed because they are now mangled. See the documentation for more details.
+<br>
+(Timo Heister, 2017/11/03)

--- a/doc/news/changes/incompatibilities/20171103TimoHeister
+++ b/doc/news/changes/incompatibilities/20171103TimoHeister
@@ -1,4 +1,5 @@
 Changed: ParameterHandler::print_parameters() in LaTeX format now correctly
-escapes special characters. As a consequence, the names of labels changed because they are now mangled. See the documentation for more details.
+escapes special characters. As a consequence, the names of labels changed
+because they are now mangled. See the documentation for more details.
 <br>
 (Timo Heister, 2017/11/03)

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1233,7 +1233,7 @@ public:
    * and <code>parameters:section1/subsection1/someentry</code>. Because
    * special characters can appear in the section and entry names, these
    * will be "mangled". Here, all characters except <code>[a-zA-Z0-9]</code>
-   * are replaced by <code>_XX</code>, where <code>XX</code> is the digit
+   * are replaced by <code>_XX</code>, where <code>XX</code> is the two-digit
    * ascii code of the character in hexadecimal encoding (so a space becomes
    * <code>_20</code> for example).
    *

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1227,6 +1227,22 @@ public:
    * parameters. The various sections of parameters are then represented by
    * latex section and subsection commands as well as by nested enumerations.
    *
+   * You can reference specific parameter sections and individual parameters
+   * by the labels that are generated automatically for each entry. The
+   * labels have the format <code>parameters:section1/subsection1</code>
+   * and <code>parameters:section1/subsection1/someentry</code>. Because
+   * special characters can appear in the section and entry names, these
+   * will be "mangled". Here, all characters except <code>[a-zA-Z0-9]</code>
+   * are replaced by <code>_XX</code>, where <code>XX</code> is the digit
+   * ascii code of the character in hexadecimal encoding (so a space becomes
+   * <code>_20</code> for example).
+   *
+   * While this function escapes special LaTeX-specific characters (backslash,
+   * underscore, etc.) in most of the output (names, default values, etc.),
+   * the documentation string is passed as-is. This means you can use math
+   * environments and other formatting in the description, but you need
+   * to escape quotes, backslashes, underscores, etc. yourself.
+   *
    * In addition, all parameter names are listed with <code>@\index</code>
    * statements in two indices called <code>prmindex</code> (where the name of
    * each parameter is listed in the index) and <code>prmindexfull</code>

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -148,13 +148,16 @@ namespace Patterns
    */
   std::unique_ptr<PatternBase> pattern_factory (const std::string &description);
 
-  /**
-   * Escape the string @p input for the specified @p style so that characters
-   * will appear as intended. For example, characters like _ can not be
-   * written as is in LateX and have to be escaped as \_.
-   */
-  std::string escape(const std::string &input, const PatternBase::OutputStyle style);
+  namespace internal
+  {
+    /**
+     * Escape the string @p input for the specified @p style so that characters
+     * will appear as intended. For example, characters like _ can not be
+     * written as is in LateX and have to be escaped as \_.
+     */
+    std::string escape(const std::string &input, const PatternBase::OutputStyle style);
 
+  }
 
   /**
    * Test for the string being an integer. If bounds are given to the

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -149,6 +149,14 @@ namespace Patterns
   std::unique_ptr<PatternBase> pattern_factory (const std::string &description);
 
   /**
+   * Escape the string @p input for the specified @p style so that characters
+   * will appear as intended. For example, characters like _ can not be
+   * written as is in LateX and have to be escaped as \_.
+   */
+  std::string escape(const std::string &input, const PatternBase::OutputStyle style);
+
+
+  /**
    * Test for the string being an integer. If bounds are given to the
    * constructor, then the integer given also needs to be within the interval
    * specified by these bounds. Note that unlike common convention in the C++

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1141,8 +1141,8 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
                 out << "\\item {\\it Parameter name:} {\\tt "
                     << escape(demangle(p->first)) << "}\n"
                     << "\\phantomsection";
-                // labels are not to be escaped but mangled:
                 {
+                  // create label: labels are not to be escaped but mangled
                   std::string label = "parameters:";
                   for (unsigned int i=0; i<target_subsection_path.size(); ++i)
                     {
@@ -1150,11 +1150,11 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
                       label.append("/");
                     }
                   label.append(p->first);
-                  out << "\\label{" << label << "}\n";
-                  // Backwards-compatibility. Also output label without
+                  // Backwards-compatibility. Output the label with and without
                   // escaping whitespace:
                   if (label.find("_20")!=std::string::npos)
                     out << "\\label{" << Utilities::replace_in_string(label,"_20", " ") << "}\n";
+                  out << "\\label{" << label << "}\n";
                 }
                 out << "\n\n";
 
@@ -1197,13 +1197,23 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
                 // print name
                 out << "\\item {\\it Parameter name:} {\\tt "
                     << escape(demangle(p->first)) << "}\n"
-                    << "\\phantomsection\\label{parameters:";
-                // do not escape but mangle labels:
-                for (unsigned int i=0; i<target_subsection_path.size(); ++i)
-                  out << mangle(target_subsection_path[i]) << "/";
-                out << p->first;
-                out << "}\n\n"
-                    << '\n';
+                    << "\\phantomsection";
+                {
+                  // create label: labels are not to be escaped but mangled
+                  std::string label = "parameters:";
+                  for (unsigned int i=0; i<target_subsection_path.size(); ++i)
+                    {
+                      label.append(mangle(target_subsection_path[i]));
+                      label.append("/");
+                    }
+                  label.append(p->first);
+                  // Backwards-compatibility. Output the label with and without
+                  // escaping whitespace:
+                  if (label.find("_20")!=std::string::npos)
+                    out << "\\label{" << Utilities::replace_in_string(label,"_20", " ") << "}\n";
+                  out << "\\label{" << label << "}\n";
+                }
+                out << "\n\n";
 
                 out << "\\index[prmindex]{"
                     << escape(demangle(p->first))

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1140,13 +1140,23 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
                 // print name
                 out << "\\item {\\it Parameter name:} {\\tt "
                     << escape(demangle(p->first)) << "}\n"
-                    << "\\phantomsection\\label{parameters:";
+                    << "\\phantomsection";
                 // labels are not to be escaped but mangled:
-                for (unsigned int i=0; i<target_subsection_path.size(); ++i)
-                  out << mangle(target_subsection_path[i]) << "/";
-                out << p->first;
-                out << "}\n\n"
-                    << '\n';
+                {
+                  std::string label = "parameters:";
+                  for (unsigned int i=0; i<target_subsection_path.size(); ++i)
+                    {
+                      label.append(mangle(target_subsection_path[i]));
+                      label.append("/");
+                    }
+                  label.append(p->first);
+                  out << "\\label{" << label << "}\n";
+                  // Backwards-compatibility. Also output label without
+                  // escaping whitespace:
+                  if (label.find("_20")!=std::string::npos)
+                    out << "\\label{" << Utilities::replace_in_string(label,"_20", " ") << "}\n";
+                }
+                out << "\n\n";
 
                 out << "\\index[prmindex]{"
                     << escape(demangle(p->first))

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1106,7 +1106,7 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
     {
       auto escape = [] (const std::string &input)
       {
-        return Patterns::escape(input, Patterns::PatternBase::LaTeX);
+        return Patterns::internal::escape(input, Patterns::PatternBase::LaTeX);
       };
 
       // if there are any parameters in this section then print them
@@ -1347,7 +1347,7 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
           {
             auto escape = [] (const std::string &input)
             {
-              return Patterns::escape(input, Patterns::PatternBase::LaTeX);
+              return Patterns::internal::escape(input, Patterns::PatternBase::LaTeX);
             };
 
             out << '\n'
@@ -1577,7 +1577,7 @@ ParameterHandler::print_parameters_section (std::ostream      &out,
     {
       auto escape = [] (const std::string &input)
       {
-        return Patterns::escape(input, Patterns::PatternBase::LaTeX);
+        return Patterns::internal::escape(input, Patterns::PatternBase::LaTeX);
       };
 
       // if there are any parameters in this section then print them
@@ -1796,7 +1796,7 @@ ParameterHandler::print_parameters_section (std::ostream      &out,
               {
                 auto escape = [] (const std::string &input)
                 {
-                  return Patterns::escape(input, Patterns::PatternBase::LaTeX);
+                  return Patterns::internal::escape(input, Patterns::PatternBase::LaTeX);
                 };
 
                 out << std::endl

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1104,6 +1104,11 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
 
     case LaTeX:
     {
+      auto escape = [] (const std::string &input)
+      {
+        return Patterns::escape(input, Patterns::PatternBase::LaTeX);
+      };
+
       // if there are any parameters in this section then print them
       // as an itemized list
       bool parameters_exist_here = false;
@@ -1133,37 +1138,42 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
                 const std::string value = p->second.get<std::string>("value");
 
                 // print name
-                out << "\\item {\\it Parameter name:} {\\tt " << demangle(p->first) << "}\n"
+                out << "\\item {\\it Parameter name:} {\\tt "
+                    << escape(demangle(p->first)) << "}\n"
                     << "\\phantomsection\\label{parameters:";
+                // labels are not to be escaped but mangled:
                 for (unsigned int i=0; i<target_subsection_path.size(); ++i)
-                  out << target_subsection_path[i] << "/";
-                out << demangle(p->first);
+                  out << mangle(target_subsection_path[i]) << "/";
+                out << p->first;
                 out << "}\n\n"
                     << '\n';
 
                 out << "\\index[prmindex]{"
-                    << demangle(p->first)
+                    << escape(demangle(p->first))
                     << "}\n";
                 out << "\\index[prmindexfull]{";
                 for (unsigned int i=0; i<target_subsection_path.size(); ++i)
-                  out << target_subsection_path[i] << "!";
-                out << demangle(p->first)
+                  out << escape(target_subsection_path[i]) << "!";
+                out << escape(demangle(p->first))
                     << "}\n";
 
                 // finally print value and default
-                out << "{\\it Value:} " << value << "\n\n"
+                out << "{\\it Value:} " << escape(value) << "\n\n"
                     << '\n'
                     << "{\\it Default:} "
-                    << p->second.get<std::string>("default_value") << "\n\n"
+                    << escape(p->second.get<std::string>("default_value"))
+                    << "\n\n"
                     << '\n';
 
-                // if there is a documenting string, print it as well
+                // if there is a documenting string, print it as well but
+                // don't escape to allow formatting/formulas
                 if (!p->second.get<std::string>("documentation").empty())
                   out << "{\\it Description:} "
                       << p->second.get<std::string>("documentation") << "\n\n"
                       << '\n';
 
-                // also output possible values
+                // also output possible values, do not escape because the
+                // description internally will use LaTeX formatting
                 const unsigned int pattern_index = p->second.get<unsigned int> ("pattern");
                 const std::string desc_str = patterns[pattern_index]->description (Patterns::PatternBase::LaTeX);
                 out << "{\\it Possible values:} "
@@ -1175,26 +1185,28 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
                 const std::string alias = p->second.get<std::string>("alias");
 
                 // print name
-                out << "\\item {\\it Parameter name:} {\\tt " << demangle(p->first) << "}\n"
+                out << "\\item {\\it Parameter name:} {\\tt "
+                    << escape(demangle(p->first)) << "}\n"
                     << "\\phantomsection\\label{parameters:";
+                // do not escape but mangle labels:
                 for (unsigned int i=0; i<target_subsection_path.size(); ++i)
-                  out << target_subsection_path[i] << "/";
-                out << demangle(p->first);
+                  out << mangle(target_subsection_path[i]) << "/";
+                out << p->first;
                 out << "}\n\n"
                     << '\n';
 
                 out << "\\index[prmindex]{"
-                    << demangle(p->first)
+                    << escape(demangle(p->first))
                     << "}\n";
                 out << "\\index[prmindexfull]{";
                 for (unsigned int i=0; i<target_subsection_path.size(); ++i)
-                  out << target_subsection_path[i] << "!";
-                out << demangle(p->first)
+                  out << escape(target_subsection_path[i]) << "!";
+                out << escape(demangle(p->first))
                     << "}\n";
 
                 // finally print alias and indicate if it is deprecated
                 out << "This parameter is an alias for the parameter ``\\texttt{"
-                    << alias << "}''."
+                    << escape(alias) << "}''."
                     << (p->second.get<std::string>("deprecation_status") == "true"
                         ?
                         " Its use is deprecated."
@@ -1313,14 +1325,19 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
 
           case LaTeX:
           {
+            auto escape = [] (const std::string &input)
+            {
+              return Patterns::escape(input, Patterns::PatternBase::LaTeX);
+            };
+
             out << '\n'
                 << "\\subsection{Parameters in section \\tt ";
 
             // find the path to the current section so that we can
             // print it in the \subsection{...} heading
             for (unsigned int i=0; i<target_subsection_path.size(); ++i)
-              out << target_subsection_path[i] << "/";
-            out << demangle(p->first);
+              out << escape(target_subsection_path[i]) << "/";
+            out << escape(demangle(p->first));
 
             out << "}" << '\n';
             out << "\\label{parameters:";
@@ -1538,6 +1555,11 @@ ParameterHandler::print_parameters_section (std::ostream      &out,
 
     case LaTeX:
     {
+      auto escape = [] (const std::string &input)
+      {
+        return Patterns::escape(input, Patterns::PatternBase::LaTeX);
+      };
+
       // if there are any parameters in this section then print them
       // as an itemized list
       bool parameters_exist_here = false;
@@ -1567,28 +1589,28 @@ ParameterHandler::print_parameters_section (std::ostream      &out,
                 const std::string value = p->second.get<std::string>("value");
 
                 // print name
-                out << "\\item {\\it Parameter name:} {\\tt " << demangle(p->first) << "}\n"
+                out << "\\item {\\it Parameter name:} {\\tt " << escape(demangle(p->first)) << "}\n"
                     << "\\phantomsection\\label{parameters:";
                 for (unsigned int i=0; i<subsection_path.size(); ++i)
-                  out << subsection_path[i] << "/";
-                out << demangle(p->first);
+                  out << mangle(subsection_path[i]) << "/";
+                out << p->first;
                 out << "}\n\n"
                     << std::endl;
 
                 out << "\\index[prmindex]{"
-                    << demangle(p->first)
+                    << escape(demangle(p->first))
                     << "}\n";
                 out << "\\index[prmindexfull]{";
                 for (unsigned int i=0; i<subsection_path.size(); ++i)
-                  out << subsection_path[i] << "!";
-                out << demangle(p->first)
+                  out << escape(subsection_path[i]) << "!";
+                out << escape(demangle(p->first))
                     << "}\n";
 
                 // finally print value and default
-                out << "{\\it Value:} " << value << "\n\n"
+                out << "{\\it Value:} " << escape(value) << "\n\n"
                     << std::endl
                     << "{\\it Default:} "
-                    << p->second.get<std::string>("default_value") << "\n\n"
+                    << escape(p->second.get<std::string>("default_value")) << "\n\n"
                     << std::endl;
 
                 // if there is a documenting string, print it as well
@@ -1609,26 +1631,26 @@ ParameterHandler::print_parameters_section (std::ostream      &out,
                 const std::string alias = p->second.get<std::string>("alias");
 
                 // print name
-                out << "\\item {\\it Parameter name:} {\\tt " << demangle(p->first) << "}\n"
+                out << "\\item {\\it Parameter name:} {\\tt " << escape(demangle(p->first)) << "}\n"
                     << "\\phantomsection\\label{parameters:";
                 for (unsigned int i=0; i<subsection_path.size(); ++i)
-                  out << subsection_path[i] << "/";
-                out << demangle(p->first);
+                  out << mangle(subsection_path[i]) << "/";
+                out << p->first;
                 out << "}\n\n"
                     << std::endl;
 
                 out << "\\index[prmindex]{"
-                    << demangle(p->first)
+                    << escape(demangle(p->first))
                     << "}\n";
                 out << "\\index[prmindexfull]{";
                 for (unsigned int i=0; i<subsection_path.size(); ++i)
-                  out << subsection_path[i] << "!";
-                out << demangle(p->first)
+                  out << escape(subsection_path[i]) << "!";
+                out << escape(demangle(p->first))
                     << "}\n";
 
                 // finally print alias and indicate if it is deprecated
                 out << "This parameter is an alias for the parameter ``\\texttt{"
-                    << alias << "}''."
+                    << escape(alias) << "}''."
                     << (p->second.get<std::string>("deprecation_status") == "true"
                         ?
                         " Its use is deprecated."
@@ -1752,14 +1774,19 @@ ParameterHandler::print_parameters_section (std::ostream      &out,
                 break;
               case LaTeX:
               {
+                auto escape = [] (const std::string &input)
+                {
+                  return Patterns::escape(input, Patterns::PatternBase::LaTeX);
+                };
+
                 out << std::endl
                     << "\\subsection{Parameters in section \\tt ";
 
                 // find the path to the current section so that we can
                 // print it in the \subsection{...} heading
                 for (unsigned int i=0; i<subsection_path.size(); ++i)
-                  out << subsection_path[i] << "/";
-                out << demangle(p->first);
+                  out << escape(subsection_path[i]) << "/";
+                out << escape(demangle(p->first));
 
                 out << "}" << std::endl;
                 out << "\\label{parameters:";

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -48,6 +48,66 @@ DEAL_II_NAMESPACE_OPEN
 namespace Patterns
 {
 
+
+  namespace internal
+  {
+
+
+    std::string escape(const std::string &input, const PatternBase::OutputStyle style)
+    {
+      switch (style)
+        {
+        case PatternBase::Machine:
+        case PatternBase::Text:
+          return input;
+        case PatternBase::LaTeX:
+        {
+          std::string u;
+          u.reserve (input.size());
+          for (auto c : input)
+            {
+              switch (c)
+                {
+                case '#':
+                case '$':
+                case '%':
+                case '&':
+                case '_':
+                case '{':
+                case '}':
+                  // simple escaping:
+                  u.push_back('\\');
+                  u.push_back(c);
+                  break;
+
+                case '\\':
+                  u.append("\\textbackslash{}");
+                  break;
+
+                case '^':
+                  u.append("\\^{}");
+                  break;
+
+                case '~':
+                  u.append("\\~{}");
+                  break;
+
+                default:
+                  // all other chars are just copied:
+                  u.push_back(c);
+                }
+            }
+          return u;
+        }
+        default:
+          Assert(false, ExcNotImplemented());
+        }
+      return "";
+    }
+
+  }
+
+
   namespace
   {
     /**
@@ -72,60 +132,6 @@ namespace Patterns
         }
       return true;
     }
-  }
-
-
-
-  std::string escape(const std::string &input, const PatternBase::OutputStyle style)
-  {
-    switch (style)
-      {
-      case PatternBase::Machine:
-      case PatternBase::Text:
-        return input;
-      case PatternBase::LaTeX:
-      {
-        std::string u;
-        u.reserve (input.size());
-        for (auto c : input)
-          {
-            switch (c)
-              {
-              case '#':
-              case '$':
-              case '%':
-              case '&':
-              case '_':
-              case '{':
-              case '}':
-                // simple escaping:
-                u.push_back('\\');
-                u.push_back(c);
-                break;
-
-              case '\\':
-                u.append("\\textbackslash{}");
-                break;
-
-              case '^':
-                u.append("\\^{}");
-                break;
-
-              case '~':
-                u.append("\\~{}");
-                break;
-
-              default:
-                // all other chars are just copied:
-                u.push_back(c);
-              }
-          }
-        return u;
-      }
-      default:
-        Assert(false, ExcNotImplemented());
-      }
-    return "";
   }
 
 
@@ -571,7 +577,7 @@ namespace Patterns
         std::ostringstream description;
 
         description << "Any one of "
-                    << escape(Utilities::replace_in_string(sequence,"|",", "), style);
+                    << internal::escape(Utilities::replace_in_string(sequence,"|",", "), style);
 
         return description.str();
       }
@@ -711,7 +717,7 @@ namespace Patterns
                     << " elements ";
         if (separator != ",")
           description << "separated by <"
-                      << escape(separator, style)
+                      << internal::escape(separator, style)
                       << "> ";
         description  << "where each element is ["
                      << pattern->description(style)
@@ -884,12 +890,12 @@ namespace Patterns
         std::ostringstream description;
 
         description << "A key"
-                    << escape(key_value_separator, style)
+                    << internal::escape(key_value_separator, style)
                     << "value map of "
                     << min_elements << " to " << max_elements
                     << " elements ";
         if (separator != ",")
-          description << " separated by <" << escape(separator, style) << "> ";
+          description << " separated by <" << internal::escape(separator, style) << "> ";
         description << " where each key is ["
                     << key_pattern->description(style)
                     << "]"
@@ -1091,13 +1097,13 @@ namespace Patterns
                     << patterns.size()
                     << " elements ";
         if (separator != ":")
-          description << " separated by <" << escape(separator, style) << "> ";
+          description << " separated by <" << internal::escape(separator, style) << "> ";
         description << " where each element is ["
                     <<  patterns[0]->description(style)
                     << "]";
         for (unsigned int i=1; i<patterns.size(); ++i)
           {
-            description << escape(separator, style)
+            description << internal::escape(separator, style)
                         << "[" << patterns[i]->description(style) << "]";
 
           }
@@ -1290,7 +1296,7 @@ namespace Patterns
         std::ostringstream description;
 
         description << "A comma-separated list of any of "
-                    << escape(Utilities::replace_in_string(sequence,"|",", "), style);
+                    << internal::escape(Utilities::replace_in_string(sequence,"|",", "), style);
 
         return description.str();
       }

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -76,6 +76,60 @@ namespace Patterns
 
 
 
+  std::string escape(const std::string &input, const PatternBase::OutputStyle style)
+  {
+    switch (style)
+      {
+      case PatternBase::Machine:
+      case PatternBase::Text:
+        return input;
+      case PatternBase::LaTeX:
+      {
+        std::string u;
+        u.reserve (input.size());
+        for (auto c : input)
+          {
+            switch (c)
+              {
+              case '#':
+              case '$':
+              case '%':
+              case '&':
+              case '_':
+              case '{':
+              case '}':
+                // simple escaping:
+                u.push_back('\\');
+                u.push_back(c);
+                break;
+
+              case '\\':
+                u.append("\\textbackslash{}");
+                break;
+
+              case '^':
+                u.append("\\^{}");
+                break;
+
+              case '~':
+                u.append("\\~{}");
+                break;
+
+              default:
+                // all other chars are just copied:
+                u.push_back(c);
+              }
+          }
+        return u;
+      }
+      default:
+        Assert(false, ExcNotImplemented());
+      }
+    return "";
+  }
+
+
+
   std::unique_ptr<PatternBase> pattern_factory(const std::string &description)
   {
     std::unique_ptr<PatternBase> p;
@@ -517,7 +571,7 @@ namespace Patterns
         std::ostringstream description;
 
         description << "Any one of "
-                    << Utilities::replace_in_string(sequence,"|",", ");
+                    << escape(Utilities::replace_in_string(sequence,"|",", "), style);
 
         return description.str();
       }
@@ -656,7 +710,9 @@ namespace Patterns
                     << min_elements << " to " << max_elements
                     << " elements ";
         if (separator != ",")
-          description << "separated by <" << separator << "> ";
+          description << "separated by <"
+                      << escape(separator, style)
+                      << "> ";
         description  << "where each element is ["
                      << pattern->description(style)
                      << "]";
@@ -828,12 +884,12 @@ namespace Patterns
         std::ostringstream description;
 
         description << "A key"
-                    << key_value_separator
+                    << escape(key_value_separator, style)
                     << "value map of "
                     << min_elements << " to " << max_elements
                     << " elements ";
         if (separator != ",")
-          description << " separated by <" << separator << "> ";
+          description << " separated by <" << escape(separator, style) << "> ";
         description << " where each key is ["
                     << key_pattern->description(style)
                     << "]"
@@ -1035,13 +1091,13 @@ namespace Patterns
                     << patterns.size()
                     << " elements ";
         if (separator != ":")
-          description << " separated by <" << separator << "> ";
+          description << " separated by <" << escape(separator, style) << "> ";
         description << " where each element is ["
                     <<  patterns[0]->description(style)
                     << "]";
         for (unsigned int i=1; i<patterns.size(); ++i)
           {
-            description << separator
+            description << escape(separator, style)
                         << "[" << patterns[i]->description(style) << "]";
 
           }
@@ -1234,7 +1290,7 @@ namespace Patterns
         std::ostringstream description;
 
         description << "A comma-separated list of any of "
-                    << Utilities::replace_in_string(sequence,"|",", ");
+                    << escape(Utilities::replace_in_string(sequence,"|",", "), style);
 
         return description.str();
       }

--- a/tests/parameter_handler/parameter_acceptor_06.output
+++ b/tests/parameter_handler/parameter_acceptor_06.output
@@ -18,7 +18,7 @@ DEAL::\label{parameters:First_20Class}
 DEAL::
 DEAL::\begin{itemize}
 DEAL::\item {\it Parameter name:} {\tt First bool}
-DEAL::\phantomsection\label{parameters:First Class/First bool}
+DEAL::\phantomsection\label{parameters:First_20Class/First_20bool}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First bool}
@@ -31,7 +31,7 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} A boolean value (true or false)
 DEAL::\item {\it Parameter name:} {\tt First double}
-DEAL::\phantomsection\label{parameters:First Class/First double}
+DEAL::\phantomsection\label{parameters:First_20Class/First_20double}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First double}
@@ -44,7 +44,7 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 DEAL::\item {\it Parameter name:} {\tt First int}
-DEAL::\phantomsection\label{parameters:First Class/First int}
+DEAL::\phantomsection\label{parameters:First_20Class/First_20int}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First int}
@@ -57,7 +57,7 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 DEAL::\item {\it Parameter name:} {\tt First string}
-DEAL::\phantomsection\label{parameters:First Class/First string}
+DEAL::\phantomsection\label{parameters:First_20Class/First_20string}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First string}
@@ -76,7 +76,7 @@ DEAL::\label{parameters:Second_20Class}
 DEAL::
 DEAL::\begin{itemize}
 DEAL::\item {\it Parameter name:} {\tt Second bool}
-DEAL::\phantomsection\label{parameters:Second Class/Second bool}
+DEAL::\phantomsection\label{parameters:Second_20Class/Second_20bool}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second bool}
@@ -89,7 +89,7 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} A boolean value (true or false)
 DEAL::\item {\it Parameter name:} {\tt Second double}
-DEAL::\phantomsection\label{parameters:Second Class/Second double}
+DEAL::\phantomsection\label{parameters:Second_20Class/Second_20double}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second double}
@@ -102,7 +102,7 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 DEAL::\item {\it Parameter name:} {\tt Second int}
-DEAL::\phantomsection\label{parameters:Second Class/Second int}
+DEAL::\phantomsection\label{parameters:Second_20Class/Second_20int}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second int}
@@ -115,7 +115,7 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 DEAL::\item {\it Parameter name:} {\tt Second string}
-DEAL::\phantomsection\label{parameters:Second Class/Second string}
+DEAL::\phantomsection\label{parameters:Second_20Class/Second_20string}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second string}

--- a/tests/parameter_handler/parameter_acceptor_06.output
+++ b/tests/parameter_handler/parameter_acceptor_06.output
@@ -19,6 +19,7 @@ DEAL::
 DEAL::\begin{itemize}
 DEAL::\item {\it Parameter name:} {\tt First bool}
 DEAL::\phantomsection\label{parameters:First_20Class/First_20bool}
+DEAL::\label{parameters:First Class/First bool}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First bool}
@@ -32,6 +33,7 @@ DEAL::
 DEAL::{\it Possible values:} A boolean value (true or false)
 DEAL::\item {\it Parameter name:} {\tt First double}
 DEAL::\phantomsection\label{parameters:First_20Class/First_20double}
+DEAL::\label{parameters:First Class/First double}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First double}
@@ -45,6 +47,7 @@ DEAL::
 DEAL::{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 DEAL::\item {\it Parameter name:} {\tt First int}
 DEAL::\phantomsection\label{parameters:First_20Class/First_20int}
+DEAL::\label{parameters:First Class/First int}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First int}
@@ -58,6 +61,7 @@ DEAL::
 DEAL::{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 DEAL::\item {\it Parameter name:} {\tt First string}
 DEAL::\phantomsection\label{parameters:First_20Class/First_20string}
+DEAL::\label{parameters:First Class/First string}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First string}
@@ -77,6 +81,7 @@ DEAL::
 DEAL::\begin{itemize}
 DEAL::\item {\it Parameter name:} {\tt Second bool}
 DEAL::\phantomsection\label{parameters:Second_20Class/Second_20bool}
+DEAL::\label{parameters:Second Class/Second bool}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second bool}
@@ -90,6 +95,7 @@ DEAL::
 DEAL::{\it Possible values:} A boolean value (true or false)
 DEAL::\item {\it Parameter name:} {\tt Second double}
 DEAL::\phantomsection\label{parameters:Second_20Class/Second_20double}
+DEAL::\label{parameters:Second Class/Second double}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second double}
@@ -103,6 +109,7 @@ DEAL::
 DEAL::{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 DEAL::\item {\it Parameter name:} {\tt Second int}
 DEAL::\phantomsection\label{parameters:Second_20Class/Second_20int}
+DEAL::\label{parameters:Second Class/Second int}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second int}
@@ -116,6 +123,7 @@ DEAL::
 DEAL::{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 DEAL::\item {\it Parameter name:} {\tt Second string}
 DEAL::\phantomsection\label{parameters:Second_20Class/Second_20string}
+DEAL::\label{parameters:Second Class/Second string}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second string}

--- a/tests/parameter_handler/parameter_acceptor_06.output
+++ b/tests/parameter_handler/parameter_acceptor_06.output
@@ -18,8 +18,8 @@ DEAL::\label{parameters:First_20Class}
 DEAL::
 DEAL::\begin{itemize}
 DEAL::\item {\it Parameter name:} {\tt First bool}
-DEAL::\phantomsection\label{parameters:First_20Class/First_20bool}
-DEAL::\label{parameters:First Class/First bool}
+DEAL::\phantomsection\label{parameters:First Class/First bool}
+DEAL::\label{parameters:First_20Class/First_20bool}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First bool}
@@ -32,8 +32,8 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} A boolean value (true or false)
 DEAL::\item {\it Parameter name:} {\tt First double}
-DEAL::\phantomsection\label{parameters:First_20Class/First_20double}
-DEAL::\label{parameters:First Class/First double}
+DEAL::\phantomsection\label{parameters:First Class/First double}
+DEAL::\label{parameters:First_20Class/First_20double}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First double}
@@ -46,8 +46,8 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 DEAL::\item {\it Parameter name:} {\tt First int}
-DEAL::\phantomsection\label{parameters:First_20Class/First_20int}
-DEAL::\label{parameters:First Class/First int}
+DEAL::\phantomsection\label{parameters:First Class/First int}
+DEAL::\label{parameters:First_20Class/First_20int}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First int}
@@ -60,8 +60,8 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 DEAL::\item {\it Parameter name:} {\tt First string}
-DEAL::\phantomsection\label{parameters:First_20Class/First_20string}
-DEAL::\label{parameters:First Class/First string}
+DEAL::\phantomsection\label{parameters:First Class/First string}
+DEAL::\label{parameters:First_20Class/First_20string}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{First string}
@@ -80,8 +80,8 @@ DEAL::\label{parameters:Second_20Class}
 DEAL::
 DEAL::\begin{itemize}
 DEAL::\item {\it Parameter name:} {\tt Second bool}
-DEAL::\phantomsection\label{parameters:Second_20Class/Second_20bool}
-DEAL::\label{parameters:Second Class/Second bool}
+DEAL::\phantomsection\label{parameters:Second Class/Second bool}
+DEAL::\label{parameters:Second_20Class/Second_20bool}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second bool}
@@ -94,8 +94,8 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} A boolean value (true or false)
 DEAL::\item {\it Parameter name:} {\tt Second double}
-DEAL::\phantomsection\label{parameters:Second_20Class/Second_20double}
-DEAL::\label{parameters:Second Class/Second double}
+DEAL::\phantomsection\label{parameters:Second Class/Second double}
+DEAL::\label{parameters:Second_20Class/Second_20double}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second double}
@@ -108,8 +108,8 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 DEAL::\item {\it Parameter name:} {\tt Second int}
-DEAL::\phantomsection\label{parameters:Second_20Class/Second_20int}
-DEAL::\label{parameters:Second Class/Second int}
+DEAL::\phantomsection\label{parameters:Second Class/Second int}
+DEAL::\label{parameters:Second_20Class/Second_20int}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second int}
@@ -122,8 +122,8 @@ DEAL::
 DEAL::
 DEAL::{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 DEAL::\item {\it Parameter name:} {\tt Second string}
-DEAL::\phantomsection\label{parameters:Second_20Class/Second_20string}
-DEAL::\label{parameters:Second Class/Second string}
+DEAL::\phantomsection\label{parameters:Second Class/Second string}
+DEAL::\label{parameters:Second_20Class/Second_20string}
 DEAL::
 DEAL::
 DEAL::\index[prmindex]{Second string}

--- a/tests/parameter_handler/parameter_handler_4.output
+++ b/tests/parameter_handler/parameter_handler_4.output
@@ -38,8 +38,8 @@
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list}
-\phantomsection\label{parameters:Testing/string_20list}
-\label{parameters:Testing/string list}
+\phantomsection\label{parameters:Testing/string list}
+\label{parameters:Testing/string_20list}
 
 
 \index[prmindex]{string list}

--- a/tests/parameter_handler/parameter_handler_4.output
+++ b/tests/parameter_handler/parameter_handler_4.output
@@ -39,6 +39,7 @@
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list}
 \phantomsection\label{parameters:Testing/string_20list}
+\label{parameters:Testing/string list}
 
 
 \index[prmindex]{string list}

--- a/tests/parameter_handler/parameter_handler_4.output
+++ b/tests/parameter_handler/parameter_handler_4.output
@@ -38,7 +38,7 @@
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list}
-\phantomsection\label{parameters:Testing/string list}
+\phantomsection\label{parameters:Testing/string_20list}
 
 
 \index[prmindex]{string list}

--- a/tests/parameter_handler/parameter_handler_4a.output
+++ b/tests/parameter_handler/parameter_handler_4a.output
@@ -38,8 +38,8 @@
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list}
-\phantomsection\label{parameters:Testing/string_20list}
-\label{parameters:Testing/string list}
+\phantomsection\label{parameters:Testing/string list}
+\label{parameters:Testing/string_20list}
 
 
 \index[prmindex]{string list}
@@ -63,8 +63,8 @@
 
 \begin{itemize}
 \item {\it Parameter name:} {\tt double 2}
-\phantomsection\label{parameters:Testing/Testing_202/double_202}
-\label{parameters:Testing/Testing 2/double 2}
+\phantomsection\label{parameters:Testing/Testing 2/double 2}
+\label{parameters:Testing/Testing_202/double_202}
 
 
 \index[prmindex]{double 2}
@@ -80,8 +80,8 @@
 
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
-\phantomsection\label{parameters:Testing/Testing_202/int_202}
-\label{parameters:Testing/Testing 2/int 2}
+\phantomsection\label{parameters:Testing/Testing 2/int 2}
+\label{parameters:Testing/Testing_202/int_202}
 
 
 \index[prmindex]{int 2}
@@ -94,8 +94,8 @@
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
-\phantomsection\label{parameters:Testing/Testing_202/string_20list_202}
-\label{parameters:Testing/Testing 2/string list 2}
+\phantomsection\label{parameters:Testing/Testing 2/string list 2}
+\label{parameters:Testing/Testing_202/string_20list_202}
 
 
 \index[prmindex]{string list 2}

--- a/tests/parameter_handler/parameter_handler_4a.output
+++ b/tests/parameter_handler/parameter_handler_4a.output
@@ -38,7 +38,7 @@
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list}
-\phantomsection\label{parameters:Testing/string list}
+\phantomsection\label{parameters:Testing/string_20list}
 
 
 \index[prmindex]{string list}
@@ -62,7 +62,7 @@
 
 \begin{itemize}
 \item {\it Parameter name:} {\tt double 2}
-\phantomsection\label{parameters:Testing/Testing 2/double 2}
+\phantomsection\label{parameters:Testing/Testing_202/double_202}
 
 
 \index[prmindex]{double 2}
@@ -78,7 +78,7 @@
 
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
-\phantomsection\label{parameters:Testing/Testing 2/int 2}
+\phantomsection\label{parameters:Testing/Testing_202/int_202}
 
 
 \index[prmindex]{int 2}
@@ -91,7 +91,7 @@
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
-\phantomsection\label{parameters:Testing/Testing 2/string list 2}
+\phantomsection\label{parameters:Testing/Testing_202/string_20list_202}
 
 
 \index[prmindex]{string list 2}

--- a/tests/parameter_handler/parameter_handler_4a.output
+++ b/tests/parameter_handler/parameter_handler_4a.output
@@ -39,6 +39,7 @@
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list}
 \phantomsection\label{parameters:Testing/string_20list}
+\label{parameters:Testing/string list}
 
 
 \index[prmindex]{string list}
@@ -63,6 +64,7 @@
 \begin{itemize}
 \item {\it Parameter name:} {\tt double 2}
 \phantomsection\label{parameters:Testing/Testing_202/double_202}
+\label{parameters:Testing/Testing 2/double 2}
 
 
 \index[prmindex]{double 2}
@@ -79,6 +81,7 @@
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
 \phantomsection\label{parameters:Testing/Testing_202/int_202}
+\label{parameters:Testing/Testing 2/int 2}
 
 
 \index[prmindex]{int 2}
@@ -92,6 +95,7 @@
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
 \phantomsection\label{parameters:Testing/Testing_202/string_20list_202}
+\label{parameters:Testing/Testing 2/string list 2}
 
 
 \index[prmindex]{string list 2}

--- a/tests/parameter_handler/parameter_handler_4a_with_alias.output
+++ b/tests/parameter_handler/parameter_handler_4a_with_alias.output
@@ -24,12 +24,12 @@
 
 
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
-\item {\it Parameter name:} {\tt double_alias}
-\phantomsection\label{parameters:Testing/double_alias}
+\item {\it Parameter name:} {\tt double\_alias}
+\phantomsection\label{parameters:Testing/double_5falias}
 
 
-\index[prmindex]{double_alias}
-\index[prmindexfull]{Testing!double_alias}
+\index[prmindex]{double\_alias}
+\index[prmindexfull]{Testing!double\_alias}
 This parameter is an alias for the parameter ``\texttt{double}''.
 
 
@@ -46,17 +46,17 @@ This parameter is an alias for the parameter ``\texttt{double}''.
 
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
-\item {\it Parameter name:} {\tt int_alias}
-\phantomsection\label{parameters:Testing/int_alias}
+\item {\it Parameter name:} {\tt int\_alias}
+\phantomsection\label{parameters:Testing/int_5falias}
 
 
-\index[prmindex]{int_alias}
-\index[prmindexfull]{Testing!int_alias}
+\index[prmindex]{int\_alias}
+\index[prmindexfull]{Testing!int\_alias}
 This parameter is an alias for the parameter ``\texttt{int}''.
 
 
 \item {\it Parameter name:} {\tt string list}
-\phantomsection\label{parameters:Testing/string list}
+\phantomsection\label{parameters:Testing/string_20list}
 
 
 \index[prmindex]{string list}
@@ -80,7 +80,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 \begin{itemize}
 \item {\it Parameter name:} {\tt double 2}
-\phantomsection\label{parameters:Testing/Testing 2/double 2}
+\phantomsection\label{parameters:Testing/Testing_202/double_202}
 
 
 \index[prmindex]{double 2}
@@ -96,7 +96,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
-\phantomsection\label{parameters:Testing/Testing 2/int 2}
+\phantomsection\label{parameters:Testing/Testing_202/int_202}
 
 
 \index[prmindex]{int 2}
@@ -109,7 +109,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
-\phantomsection\label{parameters:Testing/Testing 2/string list 2}
+\phantomsection\label{parameters:Testing/Testing_202/string_20list_202}
 
 
 \index[prmindex]{string list 2}

--- a/tests/parameter_handler/parameter_handler_4a_with_alias.output
+++ b/tests/parameter_handler/parameter_handler_4a_with_alias.output
@@ -57,6 +57,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 \item {\it Parameter name:} {\tt string list}
 \phantomsection\label{parameters:Testing/string_20list}
+\label{parameters:Testing/string list}
 
 
 \index[prmindex]{string list}
@@ -81,6 +82,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 \begin{itemize}
 \item {\it Parameter name:} {\tt double 2}
 \phantomsection\label{parameters:Testing/Testing_202/double_202}
+\label{parameters:Testing/Testing 2/double 2}
 
 
 \index[prmindex]{double 2}
@@ -97,6 +99,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
 \phantomsection\label{parameters:Testing/Testing_202/int_202}
+\label{parameters:Testing/Testing 2/int 2}
 
 
 \index[prmindex]{int 2}
@@ -110,6 +113,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
 \phantomsection\label{parameters:Testing/Testing_202/string_20list_202}
+\label{parameters:Testing/Testing 2/string list 2}
 
 
 \index[prmindex]{string list 2}

--- a/tests/parameter_handler/parameter_handler_4a_with_alias.output
+++ b/tests/parameter_handler/parameter_handler_4a_with_alias.output
@@ -56,8 +56,8 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 
 \item {\it Parameter name:} {\tt string list}
-\phantomsection\label{parameters:Testing/string_20list}
-\label{parameters:Testing/string list}
+\phantomsection\label{parameters:Testing/string list}
+\label{parameters:Testing/string_20list}
 
 
 \index[prmindex]{string list}
@@ -81,8 +81,8 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 \begin{itemize}
 \item {\it Parameter name:} {\tt double 2}
-\phantomsection\label{parameters:Testing/Testing_202/double_202}
-\label{parameters:Testing/Testing 2/double 2}
+\phantomsection\label{parameters:Testing/Testing 2/double 2}
+\label{parameters:Testing/Testing_202/double_202}
 
 
 \index[prmindex]{double 2}
@@ -98,8 +98,8 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
-\phantomsection\label{parameters:Testing/Testing_202/int_202}
-\label{parameters:Testing/Testing 2/int 2}
+\phantomsection\label{parameters:Testing/Testing 2/int 2}
+\label{parameters:Testing/Testing_202/int_202}
 
 
 \index[prmindex]{int 2}
@@ -112,8 +112,8 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
-\phantomsection\label{parameters:Testing/Testing_202/string_20list_202}
-\label{parameters:Testing/Testing 2/string list 2}
+\phantomsection\label{parameters:Testing/Testing 2/string list 2}
+\label{parameters:Testing/Testing_202/string_20list_202}
 
 
 \index[prmindex]{string list 2}

--- a/tests/parameter_handler/parameter_handler_4a_with_alias_deprecated.output
+++ b/tests/parameter_handler/parameter_handler_4a_with_alias_deprecated.output
@@ -57,6 +57,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 \item {\it Parameter name:} {\tt string list}
 \phantomsection\label{parameters:Testing/string_20list}
+\label{parameters:Testing/string list}
 
 
 \index[prmindex]{string list}
@@ -81,6 +82,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 \begin{itemize}
 \item {\it Parameter name:} {\tt double 2}
 \phantomsection\label{parameters:Testing/Testing_202/double_202}
+\label{parameters:Testing/Testing 2/double 2}
 
 
 \index[prmindex]{double 2}
@@ -97,6 +99,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
 \phantomsection\label{parameters:Testing/Testing_202/int_202}
+\label{parameters:Testing/Testing 2/int 2}
 
 
 \index[prmindex]{int 2}
@@ -110,6 +113,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
 \phantomsection\label{parameters:Testing/Testing_202/string_20list_202}
+\label{parameters:Testing/Testing 2/string list 2}
 
 
 \index[prmindex]{string list 2}

--- a/tests/parameter_handler/parameter_handler_4a_with_alias_deprecated.output
+++ b/tests/parameter_handler/parameter_handler_4a_with_alias_deprecated.output
@@ -56,8 +56,8 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 
 \item {\it Parameter name:} {\tt string list}
-\phantomsection\label{parameters:Testing/string_20list}
-\label{parameters:Testing/string list}
+\phantomsection\label{parameters:Testing/string list}
+\label{parameters:Testing/string_20list}
 
 
 \index[prmindex]{string list}
@@ -81,8 +81,8 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 \begin{itemize}
 \item {\it Parameter name:} {\tt double 2}
-\phantomsection\label{parameters:Testing/Testing_202/double_202}
-\label{parameters:Testing/Testing 2/double 2}
+\phantomsection\label{parameters:Testing/Testing 2/double 2}
+\label{parameters:Testing/Testing_202/double_202}
 
 
 \index[prmindex]{double 2}
@@ -98,8 +98,8 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
-\phantomsection\label{parameters:Testing/Testing_202/int_202}
-\label{parameters:Testing/Testing 2/int 2}
+\phantomsection\label{parameters:Testing/Testing 2/int 2}
+\label{parameters:Testing/Testing_202/int_202}
 
 
 \index[prmindex]{int 2}
@@ -112,8 +112,8 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
-\phantomsection\label{parameters:Testing/Testing_202/string_20list_202}
-\label{parameters:Testing/Testing 2/string list 2}
+\phantomsection\label{parameters:Testing/Testing 2/string list 2}
+\label{parameters:Testing/Testing_202/string_20list_202}
 
 
 \index[prmindex]{string list 2}

--- a/tests/parameter_handler/parameter_handler_4a_with_alias_deprecated.output
+++ b/tests/parameter_handler/parameter_handler_4a_with_alias_deprecated.output
@@ -24,12 +24,12 @@
 
 
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
-\item {\it Parameter name:} {\tt double_alias}
-\phantomsection\label{parameters:Testing/double_alias}
+\item {\it Parameter name:} {\tt double\_alias}
+\phantomsection\label{parameters:Testing/double_5falias}
 
 
-\index[prmindex]{double_alias}
-\index[prmindexfull]{Testing!double_alias}
+\index[prmindex]{double\_alias}
+\index[prmindexfull]{Testing!double\_alias}
 This parameter is an alias for the parameter ``\texttt{double}''. Its use is deprecated.
 
 
@@ -46,17 +46,17 @@ This parameter is an alias for the parameter ``\texttt{double}''. Its use is dep
 
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
-\item {\it Parameter name:} {\tt int_alias}
-\phantomsection\label{parameters:Testing/int_alias}
+\item {\it Parameter name:} {\tt int\_alias}
+\phantomsection\label{parameters:Testing/int_5falias}
 
 
-\index[prmindex]{int_alias}
-\index[prmindexfull]{Testing!int_alias}
+\index[prmindex]{int\_alias}
+\index[prmindexfull]{Testing!int\_alias}
 This parameter is an alias for the parameter ``\texttt{int}''.
 
 
 \item {\it Parameter name:} {\tt string list}
-\phantomsection\label{parameters:Testing/string list}
+\phantomsection\label{parameters:Testing/string_20list}
 
 
 \index[prmindex]{string list}
@@ -80,7 +80,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 \begin{itemize}
 \item {\it Parameter name:} {\tt double 2}
-\phantomsection\label{parameters:Testing/Testing 2/double 2}
+\phantomsection\label{parameters:Testing/Testing_202/double_202}
 
 
 \index[prmindex]{double 2}
@@ -96,7 +96,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 {\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
-\phantomsection\label{parameters:Testing/Testing 2/int 2}
+\phantomsection\label{parameters:Testing/Testing_202/int_202}
 
 
 \index[prmindex]{int 2}
@@ -109,7 +109,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 
 {\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
-\phantomsection\label{parameters:Testing/Testing 2/string list 2}
+\phantomsection\label{parameters:Testing/Testing_202/string_20list_202}
 
 
 \index[prmindex]{string list 2}

--- a/tests/parameter_handler/write_latex_01.cc
+++ b/tests/parameter_handler/write_latex_01.cc
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test escaping of underscores in ParameterHandler::print_parameters(LaTeX)
+
+#include "../tests.h"
+#include <deal.II/base/parameter_handler.h>
+
+
+int main ()
+{
+  initlog();
+
+  // latex header to make it easy to check the .tex output:
+  deallog.get_file_stream() << "\\documentclass{article}\n"
+                            "\\usepackage{amsmath}\n"
+                            "\\usepackage{imakeidx}\n"
+                            "\\makeindex[name=prmindex, title=Index of run-time parameter entries]\n"
+                            "\\makeindex[name=prmindexfull, title=Index of run-time parameters with section names]\n"
+                            "\\usepackage[colorlinks,linkcolor=blue,urlcolor=blue,citecolor=blue,baseurl=../]{hyperref}\n"
+                            "\\begin{document}\n" << std::endl;
+
+  ParameterHandler prm;
+  prm.enter_subsection ("section_1");
+  {
+    prm.enter_subsection ("section_2&3");
+    {
+      prm.declare_entry ("list",
+                         "default_1",
+                         Patterns::List(Patterns::Selection("default_1|b|c|d|e|f|g|h")),
+                         "docs 1");
+      prm.declare_entry ("int_hello",
+                         "1",
+                         Patterns::Integer());
+      prm.declare_entry ("text",
+                         "default text with _ ~ \\ # & { }",
+                         Patterns::Anything(),
+                         "documentation with formulas: $x_3$");
+    }
+    prm.leave_subsection ();
+    prm.declare_entry ("some other entry with {%}",
+                       "3.1415926",
+                       Patterns::Double(),
+                       "documentation");
+  }
+  prm.leave_subsection ();
+
+  prm.print_parameters (deallog.get_file_stream(), ParameterHandler::LaTeX);
+
+  deallog.get_file_stream() << "\n\n"
+                            "\\printindex[prmindex]\n"
+                            "\\printindex[prmindexfull]\n"
+                            "\\end{document}" << std::endl;
+}

--- a/tests/parameter_handler/write_latex_01.cc
+++ b/tests/parameter_handler/write_latex_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2016 by the deal.II authors
+// Copyright (C) 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/parameter_handler/write_latex_01.output
+++ b/tests/parameter_handler/write_latex_01.output
@@ -17,8 +17,8 @@
 
 \begin{itemize}
 \item {\it Parameter name:} {\tt some other entry with \{\%\}}
-\phantomsection\label{parameters:section_5f1/some_20other_20entry_20with_20_7b_25_7d}
-\label{parameters:section_5f1/some other entry with _7b_25_7d}
+\phantomsection\label{parameters:section_5f1/some other entry with _7b_25_7d}
+\label{parameters:section_5f1/some_20other_20entry_20with_20_7b_25_7d}
 
 
 \index[prmindex]{some other entry with \{\%\}}

--- a/tests/parameter_handler/write_latex_01.output
+++ b/tests/parameter_handler/write_latex_01.output
@@ -1,0 +1,93 @@
+
+\documentclass{article}
+\usepackage{amsmath}
+\usepackage{imakeidx}
+\makeindex[name=prmindex, title=Index of run-time parameter entries]
+\makeindex[name=prmindexfull, title=Index of run-time parameters with section names]
+\usepackage[colorlinks,linkcolor=blue,urlcolor=blue,citecolor=blue,baseurl=../]{hyperref}
+\begin{document}
+
+\subsection{Global parameters}
+\label{parameters:global}
+
+
+
+\subsection{Parameters in section \tt section\_1}
+\label{parameters:section_5f1}
+
+\begin{itemize}
+\item {\it Parameter name:} {\tt some other entry with \{\%\}}
+\phantomsection\label{parameters:section_5f1/some_20other_20entry_20with_20_7b_25_7d}
+
+
+\index[prmindex]{some other entry with \{\%\}}
+\index[prmindexfull]{section\_1!some other entry with \{\%\}}
+{\it Value:} 3.1415926
+
+
+{\it Default:} 3.1415926
+
+
+{\it Description:} documentation
+
+
+{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
+\end{itemize}
+
+
+
+\subsection{Parameters in section \tt section\_1/section\_2\&3}
+\label{parameters:section_5f1/section_5f2_263}
+
+\begin{itemize}
+\item {\it Parameter name:} {\tt int\_hello}
+\phantomsection\label{parameters:section_5f1/section_5f2_263/int_5fhello}
+
+
+\index[prmindex]{int\_hello}
+\index[prmindexfull]{section\_1!section\_2\&3!int\_hello}
+{\it Value:} 1
+
+
+{\it Default:} 1
+
+
+{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
+\item {\it Parameter name:} {\tt list}
+\phantomsection\label{parameters:section_5f1/section_5f2_263/list}
+
+
+\index[prmindex]{list}
+\index[prmindexfull]{section\_1!section\_2\&3!list}
+{\it Value:} default\_1
+
+
+{\it Default:} default\_1
+
+
+{\it Description:} docs 1
+
+
+{\it Possible values:} A list of 0 to 4294967295 elements where each element is [Any one of default\_1, b, c, d, e, f, g, h]
+\item {\it Parameter name:} {\tt text}
+\phantomsection\label{parameters:section_5f1/section_5f2_263/text}
+
+
+\index[prmindex]{text}
+\index[prmindexfull]{section\_1!section\_2\&3!text}
+{\it Value:} default text with \_ \~{} \textbackslash{} \# \& \{ \}
+
+
+{\it Default:} default text with \_ \~{} \textbackslash{} \# \& \{ \}
+
+
+{\it Description:} documentation with formulas: $x_3$
+
+
+{\it Possible values:} Any string
+\end{itemize}
+
+
+\printindex[prmindex]
+\printindex[prmindexfull]
+\end{document}

--- a/tests/parameter_handler/write_latex_01.output
+++ b/tests/parameter_handler/write_latex_01.output
@@ -18,6 +18,7 @@
 \begin{itemize}
 \item {\it Parameter name:} {\tt some other entry with \{\%\}}
 \phantomsection\label{parameters:section_5f1/some_20other_20entry_20with_20_7b_25_7d}
+\label{parameters:section_5f1/some other entry with _7b_25_7d}
 
 
 \index[prmindex]{some other entry with \{\%\}}


### PR DESCRIPTION
- escape special latex characters (_, \, %, ...)
- mangle label names
- document more details about print_parameters()
- update tests
- closes #5378 