### PR TITLE
Support sundials-3.0.0

### DIFF
--- a/doc/news/changes/minor/20171103DanielArndt
+++ b/doc/news/changes/minor/20171103DanielArndt
@@ -1,0 +1,3 @@
+Improved: Both Sundials-2.7.0 and Sundials-3.0.0 are supported.
+<br>
+(Daniel Arndt, 2017/11/03)

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -216,6 +216,31 @@
     (major)*1000000 + (minor)*10000 + (subminor)*100 + (patch))
 #endif
 
+ /*
+  * SUNDIALS:
+  *
+  *  Note: The following definitions will be set in sundials_config.h,
+  *        so we don't repeat them here.
+  *
+  *  SUNDIALS_VERSION_MAJOR
+  *  SUNDIALS_VERSION_MINOR
+  *  SUNDIALS_VERSION_PATCH
+  */
+
+ #define DEAL_II_SUNDIALS_VERSION_GTE(major,minor,subminor) \
+   ((SUNDIALS_VERSION_MAJOR * 10000 + \
+     SUNDIALS_VERSION_MINOR * 100 + \
+     SUNDIALS_VERSION_SUBMINOR) \
+     >=  \
+     (major)*10000 + (minor)*100 + (subminor))
+
+ #define DEAL_II_SUNDIALS_VERSION_LT(major,minor,subminor) \
+   ((SUNDIALS_VERSION_MAJOR * 10000 + \
+     SUNDIALS_VERSION_MINOR * 100 + \
+     SUNDIALS_VERSION_SUBMINOR) \
+     <  \
+     (major)*10000 + (minor)*100 + (subminor))
+
 /*
  * PETSc:
  *

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -35,9 +35,12 @@
 
 #include <ida/ida.h>
 #include <ida/ida_spils.h>
-#include <ida/ida_spgmr.h>
-#include <ida/ida_spbcgs.h>
-#include <ida/ida_sptfqmr.h>
+#include <sundials/sundials_config.h>
+#if DEAL_II_SUNDIALS_VERSION_LT(3,0,0)
+#  include <ida/ida_spgmr.h>
+#  include <ida/ida_spbcgs.h>
+#  include <ida/ida_sptfqmr.h>
+#endif
 #include <nvector/nvector_serial.h>
 #include <sundials/sundials_math.h>
 #include <sundials/sundials_types.h>

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -32,6 +32,8 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/sundials/copy.h>
 
+#include <sundials/sundials_config.h>
+
 #include <iostream>
 #include <iomanip>
 #include <arkode/arkode_impl.h>
@@ -137,7 +139,9 @@ namespace SUNDIALS
     template<typename VectorType>
     int t_arkode_solve_jacobian(ARKodeMem arkode_mem,
                                 N_Vector b,
+#if DEAL_II_SUNDIALS_VERSION_LT(3,0,0)
                                 N_Vector,
+#endif
                                 N_Vector ycur,
                                 N_Vector fcur)
     {
@@ -186,8 +190,13 @@ namespace SUNDIALS
 
     template<typename VectorType>
     int t_arkode_solve_mass(ARKodeMem arkode_mem,
+#if DEAL_II_SUNDIALS_VERSION_LT(3,0,0)
                             N_Vector b,
-                            N_Vector)
+                            N_Vector
+#else
+                            N_Vector b
+#endif
+                           )
     {
       ARKode<VectorType> &solver = *static_cast<ARKode<VectorType> *>(arkode_mem->ark_user_data);
       GrowingVectorMemory<VectorType> mem;
@@ -424,7 +433,9 @@ namespace SUNDIALS
         if (setup_jacobian)
           {
             ARKode_mem->ark_lsetup = t_arkode_setup_jacobian<VectorType>;
+#if DEAL_II_SUNDIALS_VERSION_LT(3,0,0)
             ARKode_mem->ark_setupNonNull = true;
+#endif
           }
       }
     else
@@ -441,7 +452,9 @@ namespace SUNDIALS
         if (setup_mass)
           {
             ARKode_mem->ark_msetup = t_arkode_setup_mass<VectorType>;
+#if DEAL_II_SUNDIALS_VERSION_LT(3,0,0)
             ARKode_mem->ark_MassSetupNonNull = true;
+#endif
           }
       }
 

--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -387,7 +387,9 @@ namespace SUNDIALS
 
     IDA_mem->ida_lsetup = t_dae_lsetup<VectorType>;
     IDA_mem->ida_lsolve = t_dae_solve<VectorType>;
+#if DEAL_II_SUNDIALS_VERSION_LT(3,0,0)
     IDA_mem->ida_setupNonNull = true;
+#endif
 
     status = IDASetMaxOrd(ida_mem, data.maximum_order);
     AssertIDA(status);


### PR DESCRIPTION
Fixes #5372.

Lots of variables were removed and interfaces changed. The only major change is
 the replacement of `KINDense` by  `SUNDenseMatrix`, `SUNDenseLinearSolver` and `KINDlsSetLinearSolver` which is adapted from `examples/kinsol/serial/kinFerTron_dns.c`.