### PR TITLE
Implement more product types for AD numbers

### DIFF
--- a/cmake/configure/configure_2_trilinos.cmake
+++ b/cmake/configure/configure_2_trilinos.cmake
@@ -198,7 +198,11 @@ MACRO(FEATURE_TRILINOS_CONFIGURE_EXTERNAL)
       "Sacado::Fad::DFad<double>"
       "Sacado::Fad::DFad<float>"
       "Sacado::Fad::DFad<Sacado::Fad::DFad<double>>"
-      "Sacado::Fad::DFad<Sacado::Fad::DFad<float>>")
+      "Sacado::Fad::DFad<Sacado::Fad::DFad<float>>"
+      "Sacado::Rad::ADvar<double>"
+      "Sacado::Rad::ADvar<float>"
+      "Sacado::Rad::ADvar<Sacado::Fad::DFad<double>>"
+      "Sacado::Rad::ADvar<Sacado::Fad::DFad<float>>")
 
   IF (TRILINOS_WITH_MPI)
     SET(DEAL_II_EXPAND_EPETRA_VECTOR "LinearAlgebra::EpetraWrappers::Vector")

--- a/include/deal.II/differentiation/ad/adolc_product_types.h
+++ b/include/deal.II/differentiation/ad/adolc_product_types.h
@@ -1,0 +1,282 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_differentiation_ad_adolc_product_types_h
+#define dealii_differentiation_ad_adolc_product_types_h
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_ADOLC
+
+#include <deal.II/base/template_constraints.h>
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <adolc/adouble.h> // Taped double
+#include <adolc/adtl.h>    // Tapeless double
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
+DEAL_II_NAMESPACE_OPEN
+
+
+/* -------------- Adol-C taped (Differentiation::AD::NumberTypes::adolc_taped) -------------- */
+
+
+namespace internal
+{
+
+  template <>
+  struct ProductTypeImpl<adouble,adouble>
+  {
+    typedef adouble type;
+  };
+
+  // Typedefs for "adub"s are all thats necessary to ensure that no temporary Adol-C types
+  // "adub" are created when a scalar product is performed.
+  // If this is not done, then intermediate tensors are filled with unconstructable types.
+  template <>
+  struct ProductTypeImpl<adub,adouble>
+  {
+    typedef adouble type;
+  };
+
+  template <>
+  struct ProductTypeImpl<adouble,adub>
+  {
+    typedef adouble type;
+  };
+
+  /* --- Double --- */
+
+  template <>
+  struct ProductTypeImpl<double,adouble>
+  {
+    typedef adouble type;
+  };
+
+  template <>
+  struct ProductTypeImpl<adouble,double>
+  {
+    typedef adouble type;
+  };
+
+  template <>
+  struct ProductTypeImpl<double,adub>
+  {
+    typedef adouble type;
+  };
+
+  template <>
+  struct ProductTypeImpl<adub,double>
+  {
+    typedef adouble type;
+  };
+
+  /* --- Float --- */
+
+  template <>
+  struct ProductTypeImpl<float,adouble>
+  {
+    typedef adouble type;
+  };
+
+  template <>
+  struct ProductTypeImpl<adouble,float>
+  {
+    typedef adouble type;
+  };
+
+  template <>
+  struct ProductTypeImpl<float,adub>
+  {
+    typedef adouble type;
+  };
+
+  template <>
+  struct ProductTypeImpl<adub,float>
+  {
+    typedef adouble type;
+  };
+
+  /* --- Complex double --- */
+
+  template <>
+  struct ProductTypeImpl<std::complex<double> ,std::complex<adouble> >
+  {
+    typedef std::complex<adouble> type;
+  };
+
+  template <>
+  struct ProductTypeImpl<std::complex<adouble>, std::complex<double> >
+  {
+    typedef std::complex<adouble> type;
+  };
+
+  template <>
+  struct ProductTypeImpl< std::complex<adouble>, std::complex<adouble> >
+  {
+    typedef std::complex<adouble> type;
+  };
+
+  template <>
+  struct ProductTypeImpl<std::complex<adub> ,std::complex<adouble> >
+  {
+    typedef std::complex<adouble> type;
+  };
+
+  template <>
+  struct ProductTypeImpl<std::complex<adouble>, std::complex<adub> >
+  {
+    typedef std::complex<adouble> type;
+  };
+
+  /* --- Complex float --- */
+
+  template <>
+  struct ProductTypeImpl<std::complex<float> ,std::complex<adouble> >
+  {
+    typedef std::complex<adouble> type;
+  };
+
+  template <>
+  struct ProductTypeImpl<std::complex<adouble>, std::complex<float> >
+  {
+    typedef std::complex<adouble> type;
+  };
+
+}
+
+template <>
+struct EnableIfScalar<adouble>
+{
+  typedef adouble type;
+};
+
+template <>
+struct EnableIfScalar<std::complex<adouble> >
+{
+  typedef std::complex<adouble> type;
+};
+
+
+template <>
+struct EnableIfScalar<adub>
+{
+  typedef adouble type;
+};
+
+
+template <>
+struct EnableIfScalar<std::complex<adub> >
+{
+  typedef std::complex<adouble> type;
+};
+
+
+/* -------------- Adol-C tapeless (Differentiation::AD::NumberTypes::adolc_tapeless) -------------- */
+
+
+namespace internal
+{
+
+  /* --- Double --- */
+
+  template <>
+  struct ProductTypeImpl<double,adtl::adouble>
+  {
+    typedef adtl::adouble type;
+  };
+
+  template <>
+  struct ProductTypeImpl<adtl::adouble,double>
+  {
+    typedef adtl::adouble type;
+  };
+
+  template <>
+  struct ProductTypeImpl<adtl::adouble,adtl::adouble>
+  {
+    typedef adtl::adouble type;
+  };
+
+  /* --- Float --- */
+
+  template <>
+  struct ProductTypeImpl<float,adtl::adouble>
+  {
+    typedef adtl::adouble type;
+  };
+
+  template <>
+  struct ProductTypeImpl<adtl::adouble,float>
+  {
+    typedef adtl::adouble type;
+  };
+
+  /* --- Complex double --- */
+
+  template <>
+  struct ProductTypeImpl<std::complex<double>,std::complex<adtl::adouble> >
+  {
+    typedef std::complex<adtl::adouble> type;
+  };
+
+  template <>
+  struct ProductTypeImpl<std::complex<adtl::adouble>,std::complex<double> >
+  {
+    typedef std::complex<adtl::adouble> type;
+  };
+
+  template <>
+  struct ProductTypeImpl<std::complex<adtl::adouble>,std::complex<adtl::adouble> >
+  {
+    typedef std::complex<adtl::adouble> type;
+  };
+
+  /* --- Complex float --- */
+
+  template <>
+  struct ProductTypeImpl<std::complex<float>,std::complex<adtl::adouble> >
+  {
+    typedef std::complex<adtl::adouble> type;
+  };
+
+  template <>
+  struct ProductTypeImpl<std::complex<adtl::adouble>,std::complex<float> >
+  {
+    typedef std::complex<adtl::adouble> type;
+  };
+
+}
+
+
+template <>
+struct EnableIfScalar<adtl::adouble>
+{
+  typedef adtl::adouble type;
+};
+
+
+template <>
+struct EnableIfScalar<std::complex<adtl::adouble> >
+{
+  typedef std::complex<adtl::adouble> type;
+};
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_WITH_ADOLC
+
+#endif

--- a/include/deal.II/differentiation/ad/sacado_product_types.h
+++ b/include/deal.II/differentiation/ad/sacado_product_types.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 by the deal.II authors
+// Copyright (C) 2015, 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -25,9 +25,20 @@
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Sacado.hpp>
+// It appears that some versions of Trilinos do not directly or indirectly
+// include all the headers for all forward and reverse Sacado AD types.
+// So we directly include these both here as a precaution.
+// Standard forward AD classes (templated)
+#  include <Sacado_Fad_DFad.hpp>
+// Reverse AD classes (templated)
+#  include <Sacado_trad.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
+
+
+/* -------------- Sacado::Fad::DFad (Differentiation::AD::NumberTypes::[sacado_fad/sacado_fad_fad]) -------------- */
+
 
 namespace internal
 {
@@ -71,15 +82,139 @@ namespace internal
   template <typename T, typename U>
   struct ProductTypeImpl<Sacado::Fad::DFad<T>, Sacado::Fad::DFad<U> >
   {
-    typedef Sacado::Fad::DFad<typename ProductType<T,U>::type > type;
+    typedef Sacado::Fad::DFad<typename ProductType<T,U>::type> type;
   };
 
 }
+
 
 template <typename T>
 struct EnableIfScalar<Sacado::Fad::DFad<T> >
 {
   typedef Sacado::Fad::DFad<T> type;
+};
+
+
+/* -------------- Sacado::Rad::ADvar (Differentiation::AD::NumberTypes::[sacado_rad/sacado_rad_fad]) -------------- */
+
+
+namespace internal
+{
+
+  template <typename T>
+  struct ProductTypeImpl<Sacado::Rad::ADvar<T>, float>
+  {
+    typedef Sacado::Rad::ADvar<T> type;
+  };
+
+  template <typename T>
+  struct ProductTypeImpl<float, Sacado::Rad::ADvar<T> >
+  {
+    typedef Sacado::Rad::ADvar<T> type;
+  };
+
+  template <typename T>
+  struct ProductTypeImpl<Sacado::Rad::ADvar<T>, double>
+  {
+    typedef Sacado::Rad::ADvar<T> type;
+  };
+
+  template <typename T>
+  struct ProductTypeImpl<double, Sacado::Rad::ADvar<T> >
+  {
+    typedef Sacado::Rad::ADvar<T> type;
+  };
+
+  template <typename T>
+  struct ProductTypeImpl<Sacado::Rad::ADvar<T>, int>
+  {
+    typedef Sacado::Rad::ADvar<T> type;
+  };
+
+  template <typename T>
+  struct ProductTypeImpl<int, Sacado::Rad::ADvar<T> >
+  {
+    typedef Sacado::Rad::ADvar<T> type;
+  };
+
+  template <typename T, typename U>
+  struct ProductTypeImpl<Sacado::Rad::ADvar<T>, Sacado::Rad::ADvar<U> >
+  {
+    typedef Sacado::Rad::ADvar<typename ProductType<T,U>::type> type;
+  };
+
+  /* --- Sacado::Rad::ADvar: Temporary type --- */
+
+  template <typename T>
+  struct ProductTypeImpl<Sacado::Rad::ADvari<T>, float>
+  {
+    typedef Sacado::Rad::ADvari<T> type;
+  };
+
+  template <typename T>
+  struct ProductTypeImpl<float, Sacado::Rad::ADvari<T> >
+  {
+    typedef Sacado::Rad::ADvari<T> type;
+  };
+
+  template <typename T>
+  struct ProductTypeImpl<Sacado::Rad::ADvari<T>, double>
+  {
+    typedef Sacado::Rad::ADvari<T> type;
+  };
+
+  template <typename T>
+  struct ProductTypeImpl<double, Sacado::Rad::ADvari<T> >
+  {
+    typedef Sacado::Rad::ADvari<T> type;
+  };
+
+  template <typename T>
+  struct ProductTypeImpl<Sacado::Rad::ADvari<T>, int>
+  {
+    typedef Sacado::Rad::ADvari<T> type;
+  };
+
+  template <typename T>
+  struct ProductTypeImpl<int, Sacado::Rad::ADvari<T> >
+  {
+    typedef Sacado::Rad::ADvari<T> type;
+  };
+
+  template <typename T, typename U>
+  struct ProductTypeImpl<Sacado::Rad::ADvari<T>, Sacado::Rad::ADvari<U> >
+  {
+    typedef Sacado::Rad::ADvari<typename ProductType<T,U>::type> type;
+  };
+
+  /* --- Sacado::Rad::ADvar: Main and temporary type --- */
+
+  template <typename T, typename U>
+  struct ProductTypeImpl<Sacado::Rad::ADvar<T>, Sacado::Rad::ADvari<U> >
+  {
+    typedef Sacado::Rad::ADvar<typename ProductType<T,U>::type> type;
+  };
+
+  template <typename T, typename U>
+  struct ProductTypeImpl<Sacado::Rad::ADvari<T>, Sacado::Rad::ADvar<U> >
+  {
+    typedef Sacado::Rad::ADvar<typename ProductType<T,U>::type> type;
+  };
+
+}
+
+
+template <typename T>
+struct EnableIfScalar<Sacado::Rad::ADvar<T> >
+{
+  typedef Sacado::Rad::ADvar<T> type;
+};
+
+
+template <typename T>
+struct EnableIfScalar<Sacado::Rad::ADvari<T> >
+{
+  typedef Sacado::Rad::ADvari<T> type;
 };
 
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -40,6 +40,7 @@
 #include <memory>
 #include <type_traits>
 
+#include <deal.II/differentiation/ad/adolc_product_types.h>
 #include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include <boost/container/small_vector.hpp>


### PR DESCRIPTION
This allows for these AD number types to be used in `Tensor` and `SymmetricTensor` operations.

~~Blocked by #5382~~