### PR TITLE
Fix TransfiniteInterpolationManifold on complex geometry

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -731,15 +731,16 @@ public:
 private:
   /**
    * Internal function to identify the most suitable cells (=charts) where the
-   * given surrounding points are located. We use a cheap algorithm to identify
-   * the cells and rank the cells by probability before we actually do the
-   * search inside the relevant cells. The cells are sorted by the distance of
-   * a Q1 approximation of the inverse mapping to the unit cell of the
-   * surrounding points. We expect at most 10 cells (it should be less than 8
-   * candidates even in 3D, typically only two or three), so get an array with
-   * 10 entries of a the indices <tt>cell->index()</tt>.
+   * given surrounding points are located. We use a cheap algorithm to
+   * identify the cells and rank the cells by probability before we actually
+   * do the search inside the relevant cells. The cells are sorted by the
+   * distance of a Q1 approximation of the inverse mapping to the unit cell of
+   * the surrounding points. We expect at most 20 cells (it should be up to 8
+   * candidates on a 3D structured mesh and a bit more on unstructured ones,
+   * typically we only get two or three), so get an array with 20 entries of a
+   * the indices <tt>cell->index()</tt>.
    */
-  std::array<unsigned int, 10>
+  std::array<unsigned int, 20>
   get_possible_cells_around_points(const ArrayView<const Point<spacedim>> &surrounding_points) const;
 
   /**

--- a/tests/manifold/transfinite_manifold_05.cc
+++ b/tests/manifold/transfinite_manifold_05.cc
@@ -1,0 +1,65 @@
+//-------------------------------------------------------------------
+//    Copyright (C) 2017 by the deal.II authors.
+//
+//    This file is subject to LGPL and may not be  distributed
+//    without copyright and license information. Please refer
+//    to the file deal.II/doc/license.html for the  text  and
+//    further information on this license.
+//
+//-------------------------------------------------------------------
+
+
+// Test that transfinite interpolation manifold works properly for creating a
+// particular point on a somewhat more complicated geometry. We used to
+// restrict the search too much in an initial version of the manifold
+
+#include "../tests.h"
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/manifold_lib.h>
+
+
+int main ()
+{
+  initlog();
+
+  const int dim = 3;
+  Triangulation<dim> tria1, tria2, tria;
+  GridGenerator::hyper_shell(tria1, Point<dim>(), 0.4, std::sqrt(dim), 6);
+  GridGenerator::hyper_ball(tria2, Point<dim>(), 0.4);
+  GridGenerator::merge_triangulations(tria1, tria2, tria);
+  tria.set_all_manifold_ids(0);
+  for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
+       cell != tria.end(); ++cell)
+    {
+      for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+        {
+          bool face_at_sphere_boundary = true;
+          for (unsigned int v=0; v<GeometryInfo<dim-1>::vertices_per_cell; ++v)
+            if (std::abs(cell->face(f)->vertex(v).norm()-0.4) > 1e-12)
+              face_at_sphere_boundary = false;
+          if (face_at_sphere_boundary)
+            cell->face(f)->set_all_manifold_ids(1);
+        }
+    }
+  static const SphericalManifold<dim> spherical_manifold;
+  tria.set_manifold(1, spherical_manifold);
+  static TransfiniteInterpolationManifold<dim> transfinite;
+  transfinite.initialize(tria);
+  tria.set_manifold(0, transfinite);
+
+  const std::array<Point<3>, 2> points({{Point<3>(0, 0.360566, 0), Point<3>(0, 0.321132, 0)}});
+  const std::array<double, 2> weights({{0.4, 0.6}});
+  deallog << "Interpolate between points " << points[0] << " and "
+          << points[1] << " with weights " << weights[0] << " and "
+          << weights[1] << ": " << transfinite.get_new_point(make_array_view(points.begin(),
+                                                             points.end()),
+                                                             make_array_view(weights.begin(),
+                                                                 weights.end()))
+          << std::endl;
+
+  return 0;
+}

--- a/tests/manifold/transfinite_manifold_05.output
+++ b/tests/manifold/transfinite_manifold_05.output
@@ -1,0 +1,2 @@
+
+DEAL::Interpolate between points 0.00000 0.360566 0.00000 and 0.00000 0.321132 0.00000 with weights 0.400000 and 0.600000: 0.00000 0.336906 0.00000


### PR DESCRIPTION
It turned out that returning only 10 candidates for further checking in `TransfiniteInterpolationManifold` can be too little for complex meshes as demonstrated by the given test case (ball with curved boundary inside a cube). The reason is that the candidates are based on an affine approximation that is inaccurate on strongly curved meshes. In that case, the right candidate was not beyond the first 10. It should not be much more, because we expect 8 cells around a point on a 3D Cartesian mesh, so 2.5 that number should suffice.

To ease future debugging and help users in the case the mapping fails, this PR also adds some more debugging information.