### PR TITLE
Instantiate everything also for complex-valued vectors.

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -12,6 +12,12 @@ REAL_SCALARS    := { double; float }
 COMPLEX_SCALARS := { std::complex<double>;
                      std::complex<float> }
 
+// real scalar floating point types
+REAL_AND_COMPLEX_SCALARS    := { double;
+                                 float; 
+                                 std::complex<double>;
+                                 std::complex<float> }
+
 // differentiable scalar types
 DIFFERENTIABLE_REAL_SCALARS := {
 		    @DEAL_II_EXPAND_TRILINOS_SACADO_TYPES@;
@@ -32,28 +38,45 @@ MPI_SCALARS     := { int;
                      unsigned long long int;
                      float;
                      double;
-                     long double }
+                     long double; 
+                     std::complex<double>;
+                     std::complex<float> }
 
 // template names for serial vectors that we can instantiate as T<S> where
 // S=REAL_SCALARS for example
 DEAL_II_VEC_TEMPLATES := { Vector; BlockVector }
 
-// Serial vector types
+// Serial vector types, based on real or complex scalars
 // TODO: why are parallel vectors in here?
 SERIAL_VECTORS := { Vector<double>;
                     Vector<float> ;
 
+                    Vector<std::complex<double> >;
+                    Vector<std::complex<float> >;
+
                     BlockVector<double>;
                     BlockVector<float>;
+
+                    BlockVector<std::complex<double> >;
+                    BlockVector<std::complex<float> >;
 
                     LinearAlgebra::Vector<double>;
                     LinearAlgebra::Vector<float> ;
 
+                    LinearAlgebra::Vector<std::complex<double> >;
+                    LinearAlgebra::Vector<std::complex<float> > ;
+
                     LinearAlgebra::distributed::Vector<double>;
                     LinearAlgebra::distributed::Vector<float> ;
 
+                    LinearAlgebra::distributed::Vector<std::complex<double> >;
+                    LinearAlgebra::distributed::Vector<std::complex<float> > ;
+
                     LinearAlgebra::distributed::BlockVector<double>;
                     LinearAlgebra::distributed::BlockVector<float> ;
+
+                    LinearAlgebra::distributed::BlockVector<std::complex<double> >;
+                    LinearAlgebra::distributed::BlockVector<std::complex<float> > ;
 
                     @DEAL_II_EXPAND_TRILINOS_MPI_VECTOR@;
                     @DEAL_II_EXPAND_EPETRA_VECTOR@;
@@ -63,7 +86,8 @@ SERIAL_VECTORS := { Vector<double>;
                     @DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR@;
                   }
 
-// same as SERIAL_VECTORS but only with real-valued PETSc vectors
+// same as SERIAL_VECTORS but only real-valued vectors (and only with PETSc 
+// vectors if the PETScScalar data type is real-valued)
 REAL_SERIAL_VECTORS := { Vector<double>;
                          Vector<float> ;
 

--- a/source/base/mpi.inst.in
+++ b/source/base/mpi.inst.in
@@ -13,14 +13,12 @@
 //
 // ---------------------------------------------------------------------
 
-for (S : REAL_SCALARS)
-{
-    template
-    void sum<S> (const LAPACKFullMatrix<S> &, const MPI_Comm &, LAPACKFullMatrix<S> &);
-}
 
 for (S : MPI_SCALARS)
 {
+    template
+    void sum<S> (const LAPACKFullMatrix<S> &, const MPI_Comm &, LAPACKFullMatrix<S> &);
+
     template
     void sum<S> (const Vector<S> &, const MPI_Comm &, Vector<S> &);
 
@@ -69,24 +67,6 @@ for (S : MPI_SCALARS)
             const ArrayView<S>    &);
 }
 
-
-for (S : COMPLEX_SCALARS)
-{
-    template
-    void sum<S> (const Vector<S> &, const MPI_Comm &, Vector<S> &);
-
-    template
-    void sum<S> (const FullMatrix<S> &, const MPI_Comm &, FullMatrix<S> &);
-
-    template
-    S sum<S> (const S &, const MPI_Comm &);
-
-    template
-    void sum<S> (const std::vector<S> &, const MPI_Comm &, std::vector<S> &);
-
-    template
-    void sum<S> (const ArrayView<const S> &, const MPI_Comm &, const ArrayView<S> &);
-}
 
 for (S : REAL_SCALARS; rank: RANKS; dim : SPACE_DIMENSIONS)
 {

--- a/source/base/partitioner.inst.in
+++ b/source/base/partitioner.inst.in
@@ -37,27 +37,3 @@ for (SCALAR : MPI_SCALARS)
             std::vector<MPI_Request> &) const;
 #endif
 }
-
-
-for (SCALAR : COMPLEX_SCALARS)
-{
-#ifdef DEAL_II_WITH_MPI
-    template void Utilities::MPI::Partitioner::export_to_ghosted_array_start<SCALAR>(const unsigned int ,
-            const ArrayView<const SCALAR> &,
-            const ArrayView<SCALAR> &,
-            const ArrayView<SCALAR> &,
-            std::vector<MPI_Request> &) const;
-    template void Utilities::MPI::Partitioner::export_to_ghosted_array_finish<SCALAR>(const ArrayView<SCALAR> &,
-            std::vector<MPI_Request> &) const;
-    template void Utilities::MPI::Partitioner::import_from_ghosted_array_start<SCALAR>(const VectorOperation::values ,
-            const unsigned int ,
-            const ArrayView<SCALAR> &,
-            const ArrayView<SCALAR> &,
-            std::vector<MPI_Request> &) const;
-    template void Utilities::MPI::Partitioner::import_from_ghosted_array_finish<SCALAR>(const VectorOperation::values ,
-            const ArrayView<const SCALAR> &,
-            const ArrayView<SCALAR> &,
-            const ArrayView<SCALAR> &,
-            std::vector<MPI_Request> &) const;
-#endif
-}

--- a/source/lac/block_vector.inst.in
+++ b/source/lac/block_vector.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (S : REAL_SCALARS)
+for (S : REAL_AND_COMPLEX_SCALARS)
 {
     template class BlockVector<S>;
 }
@@ -26,13 +26,14 @@ for (S1, S2 : REAL_SCALARS)
             const bool);
 }
 
-
-for (S : COMPLEX_SCALARS)
+for (S1, S2 : COMPLEX_SCALARS)
 {
-    template class BlockVector<S>;
+    template void BlockVector<S1>::reinit<S2>(const BlockVector<S2>&,
+            const bool);
 }
 
-for (S1, S2 : COMPLEX_SCALARS)
+
+for (S1 : COMPLEX_SCALARS; S2 : REAL_SCALARS)
 {
     template void BlockVector<S1>::reinit<S2>(const BlockVector<S2>&,
             const bool);

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -76,8 +76,3 @@ for (Vec : SERIAL_VECTORS)
 {
     template void ConstraintMatrix::distribute<Vec>(Vec &) const;
 }
-
-for (S: COMPLEX_SCALARS; T : DEAL_II_VEC_TEMPLATES)
-{
-    template void ConstraintMatrix::distribute<T<S> >(T<S> &) const;
-}

--- a/source/lac/full_matrix.cc
+++ b/source/lac/full_matrix.cc
@@ -32,9 +32,6 @@ template void FullMatrix<long double>::vmult<long double>(Vector<long double> &,
 template void FullMatrix<long double>::Tvmult<long double>(Vector<long double> &, const Vector<long double> &, bool) const;
 template void FullMatrix<long double>::add<long double> (const long double, const FullMatrix<long double> &);
 
-// This is needed if PETSc was compiled with complex, though, it may
-// be used elsewhere too.
-template void dealii::FullMatrix<double>::vmult<std::complex<double> >(dealii::Vector<std::complex<double> > &, dealii::Vector<std::complex<double> > const &, bool) const;
 
 // do a few functions that currently don't fit the scheme because they have
 // two template arguments that need to be different (the case of same

--- a/source/lac/full_matrix.inst.in
+++ b/source/lac/full_matrix.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (S : REAL_SCALARS)
+for (S : REAL_AND_COMPLEX_SCALARS)
 {
     template class FullMatrix<S>;
 
@@ -32,7 +32,11 @@ for (S : REAL_SCALARS)
 
     template void FullMatrix<S>::copy_from<3>(
         const Tensor<2,3>&, const size_type, const size_type, const size_type, const size_type, const size_type, const size_type);
+}
 
+
+for (S : REAL_SCALARS)
+{
     template void FullMatrix<S>::copy_to<1>(
         Tensor<2,1>&, const size_type, const size_type, const size_type, const size_type, const size_type, const size_type) const;
 
@@ -42,6 +46,7 @@ for (S : REAL_SCALARS)
     template void FullMatrix<S>::copy_to<3>(
         Tensor<2,3>&, const size_type, const size_type, const size_type, const size_type, const size_type, const size_type) const;
 }
+
 
 for (S1, S2 : REAL_SCALARS)
 {
@@ -98,6 +103,19 @@ for (S1, S2 : REAL_SCALARS)
         const FullMatrix<S2>&,
         const std::vector<size_type>&,
         const std::vector<size_type>&);
+
+    template
+    void FullMatrix<S1>::cholesky<S2> (const FullMatrix<S2>&);
+
+    template
+    void FullMatrix<S1>::outer_product<S2> (const Vector<S2>&,
+                                            const Vector<S2>&);
+}
+
+
+// real matrices can be multiplied by real or complex vectors
+for (S1 : REAL_SCALARS; S2 : REAL_AND_COMPLEX_SCALARS)
+{
     template
     void FullMatrix<S1>::vmult<S2>(
         Vector<S2>&, const Vector<S2>&, bool) const;
@@ -120,14 +138,37 @@ for (S1, S2 : REAL_SCALARS)
     template
     void FullMatrix<S1>::precondition_Jacobi<S2> (
         Vector<S2> &, const Vector<S2> &, const S1) const;
-
-    template
-    void FullMatrix<S1>::cholesky<S2> (const FullMatrix<S2>&);
-
-    template
-    void FullMatrix<S1>::outer_product<S2> (const Vector<S2>&,
-                                            const Vector<S2>&);
 }
+
+
+// complex matrices can be multiplied only by complex vectors
+for (S1 : COMPLEX_SCALARS; S2 : COMPLEX_SCALARS)
+{
+    template
+    void FullMatrix<S1>::vmult<S2>(
+        Vector<S2>&, const Vector<S2>&, bool) const;
+    template
+    void FullMatrix<S1>::Tvmult<S2>(
+        Vector<S2>&, const Vector<S2>&, bool) const;
+    template
+    S2 FullMatrix<S1>::matrix_norm_square<S2> (
+        const Vector<S2> &) const;
+    template
+    S2 FullMatrix<S1>::matrix_scalar_product<S2>(
+        const Vector<S2>&, const Vector<S2>&) const;
+    template
+    void FullMatrix<S1>::forward<S2>(
+        Vector<S2>&, const Vector<S2>&) const;
+    template
+    void FullMatrix<S1>::backward<S2>(
+        Vector<S2>&, const Vector<S2>&) const;
+
+    template
+    void FullMatrix<S1>::precondition_Jacobi<S2> (
+        Vector<S2> &, const Vector<S2> &, const S1) const;
+}
+
+
 
 for (S1, S2, S3 : REAL_SCALARS)
 {
@@ -139,20 +180,6 @@ for (S1, S2, S3 : REAL_SCALARS)
 }
 
 
-
-
-
-// same for complex scalars
-
-for (S : COMPLEX_SCALARS)
-{
-    template class FullMatrix<S>;
-
-    template void FullMatrix<S>::print(
-        LogStream&, const unsigned int, const unsigned int) const;
-    template void FullMatrix<S>::print(
-        std::ostream&, const unsigned int, const unsigned int) const;
-}
 
 for (S1, S2 : COMPLEX_SCALARS)
 {
@@ -203,28 +230,6 @@ for (S1, S2 : COMPLEX_SCALARS)
         const FullMatrix<S2>&,
         const std::vector<size_type>&,
         const std::vector<size_type>&);
-    template
-    void FullMatrix<S1>::vmult<S2>(
-        Vector<S2>&, const Vector<S2>&, bool) const;
-    template
-    void FullMatrix<S1>::Tvmult<S2>(
-        Vector<S2>&, const Vector<S2>&, bool) const;
-    template
-    S2 FullMatrix<S1>::matrix_norm_square<S2> (
-        const Vector<S2> &) const;
-    template
-    S2 FullMatrix<S1>::matrix_scalar_product<S2>(
-        const Vector<S2>&, const Vector<S2>&) const;
-    template
-    void FullMatrix<S1>::forward<S2>(
-        Vector<S2>&, const Vector<S2>&) const;
-    template
-    void FullMatrix<S1>::backward<S2>(
-        Vector<S2>&, const Vector<S2>&) const;
-
-    template
-    void FullMatrix<S1>::precondition_Jacobi<S2> (
-        Vector<S2> &, const Vector<S2> &, const S1) const;
 }
 
 for (S1, S2, S3 : COMPLEX_SCALARS)

--- a/source/lac/la_parallel_block_vector.inst.in
+++ b/source/lac/la_parallel_block_vector.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (SCALAR : REAL_SCALARS)
+for (SCALAR : REAL_AND_COMPLEX_SCALARS)
 {
     namespace LinearAlgebra
     \{
@@ -32,7 +32,23 @@ for (SCALAR : REAL_SCALARS)
     \}
 }
 
-for (S1, S2 : REAL_SCALARS)
+for (S1 : REAL_AND_COMPLEX_SCALARS; S2 : REAL_SCALARS)
+{
+    namespace LinearAlgebra
+    \{
+    namespace distributed
+    \{
+    template void BlockVector<S1>::reinit<S2> (const BlockVector<S2>&,
+            const bool);
+    template void BlockVector<S1>::add<S2> (const std::vector<size_type> &,
+                                            const ::dealii::Vector<S2>&);
+    \}
+    \}
+}
+
+
+
+for (S1, S2 : COMPLEX_SCALARS)
 {
     namespace LinearAlgebra
     \{

--- a/source/lac/la_parallel_vector.inst.in
+++ b/source/lac/la_parallel_vector.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (SCALAR : REAL_SCALARS)
+for (SCALAR : REAL_AND_COMPLEX_SCALARS)
 {
     namespace LinearAlgebra
     \{
@@ -26,7 +26,7 @@ for (SCALAR : REAL_SCALARS)
     \}
 }
 
-for (S1, S2 : REAL_SCALARS)
+for (S1 : REAL_AND_COMPLEX_SCALARS; S2 : REAL_SCALARS)
 {
     namespace LinearAlgebra
     \{
@@ -34,22 +34,12 @@ for (S1, S2 : REAL_SCALARS)
     \{
     template void Vector<S1>::reinit<S2> (const Vector<S2>&,
                                           const bool);
-    template void Vector<S1>::copy_locally_owned_data_from<S2> (const Vector<S2>&);
     template S1 Vector<S1>::inner_product_local<S2> (const Vector<S2>&) const;
+    template void Vector<S1>::copy_locally_owned_data_from<S2> (const Vector<S2>&);
     \}
     \}
 }
 
-for (SCALAR : COMPLEX_SCALARS)
-{
-    namespace LinearAlgebra
-    \{
-    namespace distributed
-    \{
-    template class Vector<SCALAR>;
-    \}
-    \}
-}
 
 for (S1, S2 : COMPLEX_SCALARS)
 {
@@ -59,7 +49,9 @@ for (S1, S2 : COMPLEX_SCALARS)
     \{
     template void Vector<S1>::reinit<S2> (const Vector<S2>&,
                                           const bool);
+    template S1 Vector<S1>::inner_product_local<S2> (const Vector<S2>&) const;
     template void Vector<S1>::copy_locally_owned_data_from<S2> (const Vector<S2>&);
     \}
     \}
 }
+

--- a/source/lac/lapack_full_matrix.inst.in
+++ b/source/lac/lapack_full_matrix.inst.in
@@ -15,13 +15,13 @@
 
 
 
-for (S : REAL_SCALARS)
+for (S : REAL_AND_COMPLEX_SCALARS)
 {
     template class LAPACKFullMatrix<S>;
     template class PreconditionLU<S>;
 }
 
-for (S1, S2 : REAL_SCALARS)
+for (S1 : REAL_AND_COMPLEX_SCALARS; S2 : REAL_SCALARS)
 {
     template LAPACKFullMatrix<S1> &
     LAPACKFullMatrix<S1>::operator = (const FullMatrix<S2> &M);

--- a/source/lac/vector.inst.in
+++ b/source/lac/vector.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (SCALAR : REAL_SCALARS)
+for (SCALAR : REAL_AND_COMPLEX_SCALARS)
 {
     template class Vector<SCALAR>;
 }
@@ -32,13 +32,6 @@ for (S1, S2 : REAL_SCALARS)
     void Vector<S1>::reinit<S2>(const Vector<S2>&, const bool);
 }
 
-
-
-for (SCALAR : COMPLEX_SCALARS)
-{
-    template class Vector<SCALAR>;
-}
-
 for (S1, S2 : COMPLEX_SCALARS)
 {
     template
@@ -51,8 +44,10 @@ for (S1, S2 : COMPLEX_SCALARS)
     void Vector<S1>::reinit<S2>(const Vector<S2>&, const bool);
 }
 
-for (S1: REAL_SCALARS; S2: COMPLEX_SCALARS)
+for (S1: COMPLEX_SCALARS; S2: REAL_SCALARS)
 {
     template
-    Vector<S2>& Vector<S2>::operator=<S1> (const Vector<S1> &);
+    Vector<S1>& Vector<S1>::operator=<S2> (const Vector<S2> &);
+    template
+    void Vector<S1>::reinit<S2>(const Vector<S2>&, const bool);
 }

--- a/source/lac/vector_memory.inst.in
+++ b/source/lac/vector_memory.inst.in
@@ -20,12 +20,3 @@ for (VECTOR : SERIAL_VECTORS)
     template class VectorMemory<VECTOR>;
     template class GrowingVectorMemory<VECTOR>;
 }
-
-for (SCALAR : COMPLEX_SCALARS)
-{
-    template class VectorMemory<Vector<SCALAR> >;
-    template class GrowingVectorMemory<Vector<SCALAR> >;
-
-    template class VectorMemory<BlockVector<SCALAR> >;
-    template class GrowingVectorMemory<BlockVector<SCALAR> >;
-}

--- a/source/lac/vector_memory_release.inst.in
+++ b/source/lac/vector_memory_release.inst.in
@@ -19,9 +19,3 @@ for (VECTOR : SERIAL_VECTORS)
 {
     dealii::GrowingVectorMemory<dealii::VECTOR>::release_unused_memory();
 }
-
-for (SCALAR : COMPLEX_SCALARS)
-{
-    dealii::GrowingVectorMemory<dealii::Vector<SCALAR> >::release_unused_memory();
-    dealii::GrowingVectorMemory<dealii::BlockVector<SCALAR> >::release_unused_memory();
-}

--- a/source/numerics/data_out_dof_data.inst.in
+++ b/source/numerics/data_out_dof_data.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_SERIAL_VECTORS; DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
+for (VEC : SERIAL_VECTORS; DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
 {
     template void
     DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension,deal_II_dimension>::


### PR DESCRIPTION
After all of the previous patches (see the links in #2033), this finally makes it
possible to instantiate everything also for complex-valued vectors. Do so.