### PR TITLE
Use PolarManifold in 2D SphericalManifold

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -248,6 +248,13 @@ public:
    * The center of the spherical coordinate system.
    */
   const Point<spacedim> center;
+
+private:
+
+  /**
+   * A manifold description to be used for get_new_point in 2D.
+   **/
+  const PolarManifold<spacedim> polar_manifold;
 };
 
 

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -245,7 +245,8 @@ PolarManifold<dim,spacedim>::push_forward_gradient(const Point<spacedim> &spheri
 
 template <int dim, int spacedim>
 SphericalManifold<dim,spacedim>::SphericalManifold(const Point<spacedim> center):
-  center(center)
+  center(center),
+  polar_manifold(center)
 {}
 
 
@@ -403,8 +404,10 @@ get_new_point (const ArrayView<const Point<spacedim>> &vertices,
     rho /= total_weights;
   }
 
-  if (spacedim<2)
-    return center + rho*candidate;
+  // If not in 3D, just use the implementation from PolarManifold
+  // after we verified that the candidate is not the center.
+  if (spacedim<3)
+    return polar_manifold.get_new_point(vertices, weights);
 
   // Step 2:
   // Do Newton-style iterations to improve the estimate.


### PR DESCRIPTION
As discussed in #5368, we want to use the faster implementation of `PolarManifold::get_new_point` in `SphericalManifold::get_new_point` in case `spacedim!=3`.