### PR TITLE
Speed up SphericalManifold::get_new_point

### DIFF
--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -461,6 +461,22 @@ get_new_point (const ArrayView<const Point<spacedim>> &vertices,
 
     const unsigned int n_merged_points = directions.size();
 
+    // check if we only have two points now, in which case we can use the
+    // get_intermediate_point function
+    if (n_merged_points == 2)
+      {
+        SphericalManifold<3,3> unit_manifold;
+        Assert(std::abs(merged_weights[0] + merged_weights[1] - 1.0) < 1e-13,
+               ExcMessage("Weights do not sum up to 1"));
+        Point<3> intermediate = unit_manifold.get_intermediate_point
+                                (Point<3>(directions[0]), Point<3>(directions[1]), merged_weights[1]);
+        // copy back to spacedim-point
+        Point<spacedim> p;
+        for (unsigned int d=0; d<spacedim; ++d)
+          p[d] = intermediate[d];
+        return center + rho * p;
+      }
+
     Tensor<1,3> vPerp;
     Tensor<2,2> Hessian;
     Tensor<1,2> gradient;


### PR DESCRIPTION
This PR adds an additional check in the selection of points in `SphericalManifold` that checks whether some of the direction vectors are the same. This happens quite frequently on volume manifolds where points that only differ in radial direction coincide after the initial normalization of vectors. Thus, we can save on the expensive trigonometric calls by finding equal points. The search involved is currently not very sophisticated. It simply does linear search and results in quadratic complexity in the number of points but I believe it won't matter much: The end result of points is most often a 2D set of points, so usually not more than 9 points. Unless we have skew cells or lots of points to interpolate from, this should help - otherwise a profiler will tell us at some point.