### PR TITLE
Performance improvement for transfinite interpolation manifold.

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -780,12 +780,12 @@ private:
    * Push forward operation.
    *
    * @note This internal function is currently not compatible with the
-   * ChartManifold::pull_back() function because the given class represents an
-   * atlas of charts, not a single chart. Thus, the pull_back() operation is
-   * only valid with the additional information of the chart, given by a cell
-   * on the coarse grid. An alternative implementation could shift the index
-   * depending on the coarse cell for a 1-to-1 relation between the chart space
-   * and the image space.
+   * ChartManifold::push_forward() function because the given class represents
+   * an atlas of charts, not a single chart. Thus, the push_forward()
+   * operation is only valid with the additional information of the chart,
+   * given by a cell on the coarse grid. An alternative implementation could
+   * shift the index depending on the coarse cell for a 1-to-1 relation
+   * between the chart space and the image space.
    */
   Point<spacedim>
   push_forward(const typename Triangulation<dim,spacedim>::cell_iterator &cell,
@@ -793,10 +793,18 @@ private:
 
   /**
    * Gradient of the push_forward method.
+   *
+   * @note This internal function is not compatible with the
+   * ChartManifold::pull_back() function because the given class represents an
+   * atlas of charts, not a single chart. Furthermore, this private function
+   * also requires the user to provide the result of the push_forward() call
+   * on the chart point for the use case of this function, namely inside a
+   * Newton iteration where the gradient is computed by finite differences.
    */
   DerivativeForm<1,dim,spacedim>
   push_forward_gradient(const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                        const Point<dim> &chart_point) const;
+                        const Point<dim>      &chart_point,
+                        const Point<spacedim> &pushed_forward_chart_point) const;
 
   /**
    * The underlying triangulation.

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -805,11 +805,12 @@ private:
    * Gradient of the push_forward method.
    *
    * @note This internal function is not compatible with the
-   * ChartManifold::pull_back() function because the given class represents an
-   * atlas of charts, not a single chart. Furthermore, this private function
-   * also requires the user to provide the result of the push_forward() call
-   * on the chart point for the use case of this function, namely inside a
-   * Newton iteration where the gradient is computed by finite differences.
+   * ChartManifold::push_forward_gradient() function because the given class
+   * represents an atlas of charts, not a single chart. Furthermore, this
+   * private function also requires the user to provide the result of the
+   * push_forward() call on the chart point for the single use case of this
+   * function, namely inside a Newton iteration where the gradient is computed
+   * by finite differences.
    */
   DerivativeForm<1,dim,spacedim>
   push_forward_gradient(const typename Triangulation<dim,spacedim>::cell_iterator &cell,

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -685,6 +685,10 @@ public:
    * this class is that the input triangulation is uniformly refined and the
    * manifold is later attached to the same triangulation.
    *
+   * Whenever the assignment of manifold ids changes on the level of the
+   * triangulation which this class was initialized with, initialize() must be
+   * called again to update the manifold ids connected to the coarse cells.
+   *
    * @note The triangulation used to construct the manifold must not be
    * destroyed during the usage of this object.
    */
@@ -764,6 +768,11 @@ private:
   /**
    * Pull back operation into the unit coordinates on the given coarse cell.
    *
+   * This method is currently based on a Newton-like iteration to find the
+   * point in the origin. One may speed up the iteration by providing a good
+   * initial guess as the third argument. If no better point is known, use
+   * cell->real_to_unit_cell_affine_approximation(p)
+   *
    * @note This internal function is currently not compatible with the
    * ChartManifold::pull_back() function because the given class represents an
    * atlas of charts, not a single chart. Thus, the pull_back() operation is
@@ -774,7 +783,8 @@ private:
    */
   Point<dim>
   pull_back(const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-            const Point<spacedim> &p) const;
+            const Point<spacedim> &p,
+            const Point<dim>      &initial_guess) const;
 
   /**
    * Push forward operation.


### PR DESCRIPTION
Pass initial point along to the push_forward_gradient call rather than re-computing it.
Use quasi-Newton method (Broyden's method) rather than full Newton with finite differences to reduce number of calls to the compute_transfinite_interpolation.