### PR TITLE
Make fe_field_function compute::point locations use the gridtools version

### DIFF
--- a/doc/news/changes/minor/20171106GiovanniAlzetta
+++ b/doc/news/changes/minor/20171106GiovanniAlzetta
@@ -1,0 +1,4 @@
+Modified: Function Functions::FEFieldFunction::compute_point_locations now calls GridTools::compute_point_locations
+Modified: Function GridTools::compute_point_locations now accepts a cell hint (a test for this hint has been added)
+<br>
+(Giovanni Alzetta, 2017/11/06)

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -657,7 +657,9 @@ namespace GridTools
       std::vector< std::vector< Point<dim> > >,
       std::vector< std::vector<unsigned int> > >
       compute_point_locations(const Cache<dim,spacedim>                                         &cache,
-                              const std::vector<Point<spacedim> >                               &points);
+                              const std::vector<Point<spacedim> >                               &points,
+                              const typename Triangulation<dim, spacedim>::active_cell_iterator &cell_hint
+                              = typename Triangulation<dim, spacedim>::active_cell_iterator());
 
   /**
    * Return a map of index:Point<spacedim>, containing the used vertices of the

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/thread_local_storage.h>
+#include <deal.II/grid/grid_tools_cache.h>
 
 #include <deal.II/lac/vector.h>
 
@@ -413,6 +414,10 @@ namespace Functions
      * @return This function returns the number of cells that
      *   collectively contain the set of points give as @p
      *   points. This also equals the lengths of the output arrays.
+     *
+     * This function simply calls GridTools::compute_point_locations :
+     * using the original function avoids computing a
+     * new Cache at every function call.
      */
     unsigned int
     compute_point_locations
@@ -443,6 +448,11 @@ namespace Functions
      * A reference to the mapping being used.
      */
     const Mapping<dim> &mapping;
+
+    /**
+     * The Cache object
+     */
+    GridTools::Cache<dim,DoFHandlerType::space_dimension> cache;
 
     /**
      * The latest cell hint.

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5176,8 +5176,9 @@ next_cell:
   std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator >,
       std::vector< std::vector< Point<dim> > >,
       std::vector< std::vector<unsigned int> > >
-      compute_point_locations(const Cache<dim,spacedim>                &cache,
-                              const std::vector<Point<spacedim> >      &points)
+      compute_point_locations(const Cache<dim,spacedim>                 &cache,
+                              const std::vector<Point<spacedim> >       &points,
+                              const typename Triangulation<dim, spacedim>::active_cell_iterator &cell_hint)
   {
     // How many points are here?
     const unsigned int np = points.size();
@@ -5193,8 +5194,13 @@ next_cell:
 
     // We begin by finding the cell/transform of the first point
     std::pair<typename Triangulation<dim, spacedim>::active_cell_iterator, Point<dim> >
-    my_pair  = GridTools::find_active_cell_around_point
-               (cache, points[0]);
+    my_pair;
+    if (cell_hint.state() == IteratorState::valid)
+      my_pair = GridTools::find_active_cell_around_point
+                (cache, points[0],cell_hint);
+    else
+      my_pair = GridTools::find_active_cell_around_point
+                (cache, points[0]);
 
     std::get<0>(cell_qpoint_map).emplace_back(my_pair.first);
     std::get<1>(cell_qpoint_map).emplace_back(1, my_pair.second);

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -156,7 +156,8 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
         std::tuple< std::vector< typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator >,
                     std::vector< std::vector< Point< deal_II_dimension > > >, std::vector< std::vector< unsigned int > > >
         compute_point_locations(const Cache< deal_II_dimension, deal_II_space_dimension > &,
-                                const std::vector< Point< deal_II_space_dimension > > &);
+                                const std::vector< Point< deal_II_space_dimension > > &,
+                                const typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator &);
                                                                                                       \}
 
 #endif

--- a/tests/grid/compute_point_locations_02.cc
+++ b/tests/grid/compute_point_locations_02.cc
@@ -56,12 +56,19 @@ void test_compute_pt_loc(unsigned int n_points)
   std::vector<Point<dim>> points;
 
   for (size_t i=0; i<n_points; ++i)
-    points.push_back(random_point<dim>());
+    {
+      Point<dim> p;
+      for (unsigned int d=0; d<dim; ++d)
+        p[d] = double(Testing::rand())/RAND_MAX; //Normalizing the value
+      points.push_back(p);
+    }
 
   // Initializing the cache
   GridTools::Cache<dim,dim> cache(tria);
-
-  auto cell_qpoint_map = GridTools::compute_point_locations(cache,points);
+  // Finding the first cell and giving it as hint
+  auto my_pair = GridTools::find_active_cell_around_point
+                 (cache, points[0]);
+  auto cell_qpoint_map = GridTools::compute_point_locations(cache,points,my_pair.first);
   size_t n_cells = std::get<0>(cell_qpoint_map).size();
 
   deallog << "Points found in " << n_cells << " cells" << std::endl;

--- a/tests/grid/compute_point_locations_02.output
+++ b/tests/grid/compute_point_locations_02.output
@@ -1,0 +1,10 @@
+
+DEAL::Deal.II compute_pt_loc:
+DEAL::Testing for dim = 2
+DEAL::Testing on: 100 points.
+DEAL::Points found in 81 cells
+DEAL::Test finished
+DEAL::Testing for dim = 3
+DEAL::Testing on: 200 points.
+DEAL::Points found in 170 cells
+DEAL::Test finished


### PR DESCRIPTION
After creating the function compute point locations I'm making the one in FEFieldFunction use the one in GridTools.

This should bring a performance boost, also to many other functions. The only caveat: there might be problems with curved meshes which are very deformed, as reported in the documentation of GridTools::compute_point_locations.

Best,
Giovanni