### PR TITLE
New function: distributed compute point locations (and tests)

### DIFF
--- a/doc/news/changes/minor/20180119GiovanniAlzetta
+++ b/doc/news/changes/minor/20180119GiovanniAlzetta
@@ -1,0 +1,5 @@
+New: New function GridTools::distributed_compute_point_locations ; similarly to GridTools::compute_point_locations , given
+a vector of points, it returns vectors containing them, their reference position and the process owning them as it works
+with shared and distributed meshes.
+<br>
+(Giovanni Alzetta, 2018/01/19)

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -662,6 +662,62 @@ namespace GridTools
                               = typename Triangulation<dim, spacedim>::active_cell_iterator());
 
   /**
+   * Given a @p cache and a list of
+   * @p local_points for each process, find the points lying on the locally owned
+   * part of the mesh and compute the quadrature rules for them.
+   * Distributed compute point locations is a function similar to
+   * GridTools::compute_point_locations but working for parallel::Triangulation
+   * objects and, unlike its serial version, also for a distributed triangulation
+   * (see parallel::distributed::Triangulation).
+   *
+   * @param[in] cache a GridTools::Cache object
+   * @param[in] local_points the array of points owned by the current process. Every
+   *  process can have a different array of points which can be empty and not
+   *  contained within the locally owned part of the triangulation
+   * @param[in] local_bbox the description of the locally owned part of the mesh made
+   *  with bounding boxes. It can be obtained from
+   *  GridTools::compute_mesh_predicate_bounding_box
+   * @param[out] tuple containing the quadrature information
+   *
+   * The elements of the output tuple are:
+   * - cells : a vector of cells of the all cells containing at
+   *  least a point.
+   * - qpoints : a vector of vector of points; containing in @p qpoints[i]
+   *   the reference positions of all points that fall within the cell @P cells[i] .
+   * - maps : a vector of vector of integers, containing the mapping between
+   *  the numbering in qpoints (previous element of the tuple), and the vector
+   *  of local points of the process owning the points.
+   * - points : a vector of vector of points. @p points[i][j] is the point in the
+   *  real space corresponding.
+   *  to @p qpoints[i][j] . Notice @p points are the points lying on the locally
+   *  owned part of the mesh; thus these can be either copies of @p local_points
+   *  or points received from other processes i.e. local_points for other processes
+   * - owners : a vector of vectors; @p owners[i][j] contains the rank of
+   *  the process owning the point[i][j] (previous element of the tuple).
+   *
+   * The function uses the triangulation's mpi communicator: for this reason it
+   * throws an assert error if the Triangulation is not derived from
+   * parallel::Triangulation .
+   *
+   * In a serial execution the first three elements of the tuple are the same
+   * as in GridTools::compute_point_locations .
+   *
+   * @author Giovanni Alzetta, 2017-2018
+   */
+  template <int dim, int spacedim>
+  std::tuple<
+  std::vector< typename Triangulation<dim, spacedim>::active_cell_iterator >,
+      std::vector< std::vector< Point<dim> > >,
+      std::vector< std::vector< unsigned int > >,
+      std::vector< std::vector< Point<spacedim> > >,
+      std::vector< std::vector< unsigned int > >
+      >
+      distributed_compute_point_locations
+      (const GridTools::Cache<dim,spacedim>                &cache,
+       const std::vector<Point<spacedim> >                 &local_points,
+       const std::vector< BoundingBox<spacedim> >          &local_bbox);
+
+  /**
    * Return a map of index:Point<spacedim>, containing the used vertices of the
    * given `container`. The key of the returned map is the global index in the
    * triangulation. The used vertices are obtained by looping over all cells,

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -75,6 +75,19 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
     compute_point_locations(const Cache< deal_II_dimension, deal_II_space_dimension > &,
                             const std::vector< Point< deal_II_space_dimension > > &,
                             const typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator &);
+
+    template
+    std::tuple<
+        std::vector< typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator >,
+        std::vector< std::vector< Point<deal_II_dimension> > >,
+        std::vector< std::vector< unsigned int > >,
+        std::vector< std::vector< Point<deal_II_space_dimension> > >,
+        std::vector< std::vector< unsigned int > >
+        >
+    distributed_compute_point_locations
+    (const Cache< deal_II_dimension, deal_II_space_dimension >   &,
+     const std::vector< Point< deal_II_space_dimension > >       &,
+     const std::vector< BoundingBox< deal_II_space_dimension > > &);
     \}
 
 #endif

--- a/tests/grid/distributed_compute_point_locations_01.cc
+++ b/tests/grid/distributed_compute_point_locations_01.cc
@@ -1,0 +1,132 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017-2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Test GridTools::distributed_compute_point_locations for the serial case
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_tools_cache.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/fe/mapping_q.h>
+
+using namespace dealii;
+
+template <int dim>
+void test_compute_pt_loc(unsigned int n_points)
+{
+  MPI_Comm mpi_communicator = MPI_COMM_WORLD;
+  deallog << "Testing for dim = " << dim << std::endl;
+  deallog << "Testing on: " << n_points << " points." << std::endl;
+
+  // Creating a grid in the square [0,1]x[0,1]
+  parallel::distributed::Triangulation<dim> tria(mpi_communicator);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(std::max(6-dim,2));
+
+  // Creating the random points
+  std::vector<Point<dim>> points;
+
+  for (size_t i=0; i<n_points; ++i)
+    points.push_back(random_point<dim>());
+
+  // Initializing the cache
+  GridTools::Cache<dim,dim> cache(tria);
+
+  // Computing the description of the locally owned part of the mesh
+  IteratorFilters::LocallyOwnedCell locally_owned_cell_predicate;
+  std::vector< BoundingBox<dim> > local_bbox = GridTools::compute_mesh_predicate_bounding_box
+                                               (cache.get_triangulation(), locally_owned_cell_predicate,
+                                                1, true, 4); // These options should be passed
+  // Using the distributed version of compute point location
+
+  // Using the distributed version
+  auto output_tuple = distributed_compute_point_locations(cache,points,local_bbox);
+  // Testing in serial against the serial version
+  auto cell_qpoint_map = GridTools::compute_point_locations(cache,points);
+
+  auto &serial_cells = std::get<0>(cell_qpoint_map);
+  auto &serial_qpoints = std::get<1>(cell_qpoint_map);
+  size_t n_cells = std::get<0>(output_tuple).size();
+
+  deallog << "Points found in " << n_cells << " cells" << std::endl;
+
+  // testing if the result coincides with
+  // the serial one
+  for (unsigned int c=0; c<n_cells; ++c)
+    {
+      auto &cell = std::get<0>(output_tuple)[c];
+      auto &quad = std::get<1>(output_tuple)[c];
+      auto &local_map = std::get<2>(output_tuple)[c];
+      auto &original_points = std::get<3>(output_tuple)[c];
+      auto &ranks = std::get<4>(output_tuple)[c];
+
+      auto pos_cell = std::find(serial_cells.begin(),serial_cells.end(),cell);
+      for (auto r: ranks)
+        if (r!=0)
+          deallog << "ERROR: rank is not 0 but " << std::to_string(r) << std::endl;
+
+      if (pos_cell == serial_cells.end())
+        deallog << "ERROR: cell not found" << std::endl;
+      else
+        {
+          auto serial_cell_idx = pos_cell - serial_cells.begin();
+          if ( original_points.size() != serial_qpoints[serial_cell_idx].size())
+            deallog << "ERROR: in the number of points for cell" << std::to_string(serial_cell_idx) << std::endl;
+          if ( quad.size() != serial_qpoints[serial_cell_idx].size())
+            deallog << "ERROR: in the number of points for cell" << std::to_string(serial_cell_idx) << std::endl;
+
+          unsigned int pt_num = 0;
+          for (const auto &p_idx: local_map)
+            {
+              auto serial_pt_pos = std::find(local_map.begin(),local_map.end(),p_idx);
+              auto serial_pt_idx = serial_pt_pos-local_map.begin();
+              if ( serial_pt_pos == local_map.end())
+                deallog << "ERROR: point index not found for " << std::to_string(serial_pt_idx) << std::endl;
+              else
+                {
+                  if ( (original_points[pt_num] - points[p_idx]).norm() > 1e-12 )
+                    {
+                      deallog << "ERROR: Point in serial : " << points[p_idx] << " Point in distributed: " << original_points[pt_num] << std::endl;
+                    }
+
+                  if ( (quad[pt_num] - serial_qpoints[serial_cell_idx][serial_pt_idx]).norm() > 1e-10 )
+                    {
+                      deallog << " ERROR: Transformation of qpoint to point is not correct" << std::endl;
+                      deallog << "qpoint in serial : " << quad[pt_num] << " Point in distributed: " << serial_qpoints[serial_cell_idx][serial_pt_idx] << std::endl;
+                    }
+                }
+              ++pt_num;
+            }
+        }
+    }
+
+  deallog << "Test finished" << std::endl;
+}
+
+int main (int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+  MPILogInitAll log;
+
+  deallog << "Deal.II distributed_compute_point_locations:" << std::endl;
+  test_compute_pt_loc<2>(100);
+  test_compute_pt_loc<3>(200);
+}

--- a/tests/grid/distributed_compute_point_locations_01.mpirun=1.output
+++ b/tests/grid/distributed_compute_point_locations_01.mpirun=1.output
@@ -1,0 +1,10 @@
+
+DEAL:0::Deal.II distributed_compute_point_locations:
+DEAL:0::Testing for dim = 2
+DEAL:0::Testing on: 100 points.
+DEAL:0::Points found in 81 cells
+DEAL:0::Test finished
+DEAL:0::Testing for dim = 3
+DEAL:0::Testing on: 200 points.
+DEAL:0::Points found in 170 cells
+DEAL:0::Test finished

--- a/tests/grid/distributed_compute_point_locations_02.cc
+++ b/tests/grid/distributed_compute_point_locations_02.cc
@@ -1,0 +1,229 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017-2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Test GridTools::distributed_compute_point_locations for the parallel case:
+// Inside a distributed hypercube there's a shared sphere:
+// call distributed point locations on the sphere's cells centers and check
+// the result.
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_tools_cache.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/fe/mapping_q.h>
+
+using namespace dealii;
+
+template <int dim>
+void test_compute_pt_loc(unsigned int ref_cube, unsigned int ref_sphere)
+{
+  MPI_Comm mpi_communicator = MPI_COMM_WORLD;
+  unsigned int n_procs = Utilities::MPI::n_mpi_processes(mpi_communicator);
+  unsigned int my_rank = Utilities::MPI::this_mpi_process(mpi_communicator);
+
+  deallog << "Testing for dim = " << dim << " on " << n_procs << " processes" << std::endl;
+  deallog << "Cube refinements: " << ref_cube << std::endl;
+  deallog << "Sphere refinements:" << ref_sphere << std::endl;
+
+  // Initializing and refining meshes
+  parallel::distributed::Triangulation<dim> cube(mpi_communicator);
+  GridGenerator::hyper_cube(cube);
+  cube.refine_global(ref_cube);
+
+  parallel::shared::Triangulation<dim> sphere(mpi_communicator);
+  Point<dim> sphere_center;
+  // Defining center and radius
+  for (unsigned int i=0; i < dim; ++i)
+    sphere_center[i] = 0.47 - i*0.05;
+  double radius = 0.4 - dim*0.05;
+  GridGenerator::hyper_ball( sphere, sphere_center,radius);
+  static SphericalManifold<dim,dim> surface_description(sphere_center);
+  sphere.set_manifold(0, surface_description);
+  sphere.refine_global(ref_sphere);
+
+  deallog << "Sphere center:" << sphere_center << std::endl;
+  deallog << "Sphere radius:" << radius << std::endl;
+
+  // Initializing the cache
+  GridTools::Cache<dim,dim> cache(cube);
+
+  // Centers of locally owned cells
+  std::vector<Point<dim>> loc_owned_points;
+  // Building by hand the output of distributed points (see the function's
+  // description for more details, this is in fact compute point location
+  // code with the addition of rank storing)
+  std::vector< typename Triangulation<dim, dim>::active_cell_iterator > computed_cells;
+  std::vector< std::vector<Point<dim> > > computed_qpoints;
+  std::vector< std::vector<Point<dim> > > computed_points;
+  std::vector< std::vector< unsigned int > > computed_ranks;
+
+  unsigned int computed_pts = 0;
+  for (auto cell: sphere.active_cell_iterators())
+    {
+      // The points we consider are the cell centers
+      auto center_pt = cell->center();
+      // Store the point only if it is inside a locally owned sphere cell
+      if (cell->subdomain_id()==my_rank)
+        loc_owned_points.emplace_back(center_pt);
+      // Find the cube cell where center pt lies
+      auto my_pair = GridTools::find_active_cell_around_point
+                     (cache, center_pt);
+      // If it is inside a locally owned cell it shall be returned
+      // from distributed compute point locations
+      if ( my_pair.first->is_locally_owned() )
+        {
+          computed_pts++;
+          auto cells_it =
+            std::find(computed_cells.begin(),computed_cells.end(),my_pair.first);
+
+          if ( cells_it == computed_cells.end() )
+            {
+              // Cell not found: adding a new cell
+              computed_cells.emplace_back(my_pair.first);
+              computed_qpoints.emplace_back(1, my_pair.second);
+              computed_points.emplace_back(1, center_pt);
+              computed_ranks.emplace_back(1, cell->subdomain_id());
+            }
+          else
+            {
+              // Cell found: just adding the point index and qpoint to the list
+              unsigned int current_cell = cells_it - computed_cells.begin();
+              computed_qpoints[current_cell].emplace_back(my_pair.second);
+              computed_points[current_cell].emplace_back(center_pt);
+              computed_ranks[current_cell].emplace_back(cell->subdomain_id());
+            }
+        }
+    }
+
+  // Computing bounding boxes describing the locally owned part of the mesh
+  IteratorFilters::LocallyOwnedCell locally_owned_cell_predicate;
+  std::vector< BoundingBox<dim> > local_bbox = GridTools::compute_mesh_predicate_bounding_box
+                                               (cache.get_triangulation(), locally_owned_cell_predicate,
+                                                1, true, 4);
+
+  // Using the distributed version of compute point location
+  auto output_tuple = distributed_compute_point_locations
+                      (cache,loc_owned_points,local_bbox);
+  deallog << "Comparing results" << std::endl;
+  const auto &output_cells = std::get<0>(output_tuple);
+  const auto &output_qpoints = std::get<1>(output_tuple);
+  const auto &output_points = std::get<3>(output_tuple);
+  const auto &output_ranks = std::get<4>(output_tuple);
+
+  // Comparing the output with the previously computed computed result
+  bool test_passed = true;
+  if (output_cells.size() != computed_cells.size() )
+    {
+      test_passed = false;
+      deallog << "ERROR: non-matching number of cell found" << std::endl;
+    }
+
+  unsigned int output_computed_pts = 0;
+  for (unsigned int c=0; c< output_cells.size(); c++)
+    {
+      output_computed_pts += output_points[c].size();
+      const auto &cell = output_cells[c];
+      auto cell_it =
+        std::find(computed_cells.begin(),computed_cells.end(),cell);
+      if ( cell_it == computed_cells.end() )
+        {
+          deallog << "ERROR: active cell " << cell->active_cell_index() << " not found" << std::endl;
+          test_passed = false;
+        }
+      else
+        {
+          unsigned int c_cell = cell_it - computed_cells.begin();
+          if (output_points[c].size() != computed_points[c_cell].size() )
+            {
+              test_passed = false;
+              deallog << "ERROR: non-matching number of points for cell " << cell->active_cell_index() << std::endl;
+              deallog << "Distributed compute point location output:" << std::endl;
+              for (unsigned int pt_idx=0; pt_idx< output_points[c].size(); pt_idx++)
+                deallog << output_points[c][pt_idx] << " from process " << output_ranks[c][pt_idx] << " to " << my_rank << std::endl;
+              deallog << "Expected points:" << std::endl;
+              for (unsigned int pt_idx=0; pt_idx< computed_points[c_cell].size(); pt_idx++)
+                deallog << computed_points[c_cell][pt_idx] << std::endl;
+
+            }
+          else
+            {
+              // Checking if the points inside are the same
+              for (unsigned int pt_idx=0; pt_idx< output_points[c].size(); pt_idx++)
+                {
+                  const auto &pt = output_points[c][pt_idx];
+                  auto pt_it =
+                    std::find(computed_points[c_cell].begin(),computed_points[c_cell].end(),pt);
+                  if ( pt_it == computed_points[c_cell].end() )
+                    {
+                      deallog << "ERROR: point " << pt << " not found" << std::endl;
+                      test_passed = false;
+                    }
+                  else
+                    {
+                      unsigned int c_pt = pt_it - computed_points[c_cell].begin();
+                      // Checking the value of the transformed point
+                      if ( (output_qpoints[c][pt_idx] - computed_qpoints[c_cell][c_pt]).norm() > 1e-12 )
+                        {
+                          // Cell not found: adding a new cell
+                          deallog << "ERROR: qpoint " << c_pt << " not matching" << std::endl;
+                          test_passed = false;
+                        }
+                      // Checking the rank of the owner
+                      if ( output_ranks[c][pt_idx] != computed_ranks[c_cell][c_pt])
+                        {
+                          // Cell not found: adding a new cell
+                          deallog << "ERROR: rank of point " << c_pt << " not matching" << std::endl;
+                          test_passed = false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+
+  if (output_computed_pts != computed_pts)
+    {
+      deallog << "ERROR: the number of points is different from expected: " << std::endl;
+      deallog << "Number of locally computed points: " << computed_pts << std::endl;
+      deallog << "Number of points from distributed: " << output_computed_pts << std::endl;
+    }
+
+  if (test_passed)
+    deallog << "Test passed" << std::endl;
+  else
+    deallog << "Test FAILED" << std::endl;
+}
+
+int main (int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+  MPILogInitAll log;
+
+  deallog << "Deal.II distributed_compute_point_locations:" << std::endl;
+  deallog << "Test on parallel setting 2D:" << std::endl;
+  test_compute_pt_loc<2>(3,3);
+  deallog << "Test on parallel setting 3D:" << std::endl;
+  test_compute_pt_loc<3>(3,2);
+}

--- a/tests/grid/distributed_compute_point_locations_02.with_mpi=true.with_p4est=true.mpirun=2.output
+++ b/tests/grid/distributed_compute_point_locations_02.with_mpi=true.with_p4est=true.mpirun=2.output
@@ -1,0 +1,37 @@
+
+DEAL:0::Deal.II distributed_compute_point_locations:
+DEAL:0::Test on parallel setting 2D:
+DEAL:0::Testing for dim = 2 on 2 processes
+DEAL:0::Cube refinements: 3
+DEAL:0::Sphere refinements:3
+DEAL:0::Sphere center:0.470000 0.420000
+DEAL:0::Sphere radius:0.300000
+DEAL:0::Comparing results
+DEAL:0::Test passed
+DEAL:0::Test on parallel setting 3D:
+DEAL:0::Testing for dim = 3 on 2 processes
+DEAL:0::Cube refinements: 3
+DEAL:0::Sphere refinements:2
+DEAL:0::Sphere center:0.470000 0.420000 0.370000
+DEAL:0::Sphere radius:0.250000
+DEAL:0::Comparing results
+DEAL:0::Test passed
+
+DEAL:1::Deal.II distributed_compute_point_locations:
+DEAL:1::Test on parallel setting 2D:
+DEAL:1::Testing for dim = 2 on 2 processes
+DEAL:1::Cube refinements: 3
+DEAL:1::Sphere refinements:3
+DEAL:1::Sphere center:0.470000 0.420000
+DEAL:1::Sphere radius:0.300000
+DEAL:1::Comparing results
+DEAL:1::Test passed
+DEAL:1::Test on parallel setting 3D:
+DEAL:1::Testing for dim = 3 on 2 processes
+DEAL:1::Cube refinements: 3
+DEAL:1::Sphere refinements:2
+DEAL:1::Sphere center:0.470000 0.420000 0.370000
+DEAL:1::Sphere radius:0.250000
+DEAL:1::Comparing results
+DEAL:1::Test passed
+

--- a/tests/grid/distributed_compute_point_locations_02.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/grid/distributed_compute_point_locations_02.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,56 @@
+
+DEAL:0::Deal.II distributed_compute_point_locations:
+DEAL:0::Test on parallel setting 2D:
+DEAL:0::Testing for dim = 2 on 3 processes
+DEAL:0::Cube refinements: 3
+DEAL:0::Sphere refinements:3
+DEAL:0::Sphere center:0.470000 0.420000
+DEAL:0::Sphere radius:0.300000
+DEAL:0::Comparing results
+DEAL:0::Test passed
+DEAL:0::Test on parallel setting 3D:
+DEAL:0::Testing for dim = 3 on 3 processes
+DEAL:0::Cube refinements: 3
+DEAL:0::Sphere refinements:2
+DEAL:0::Sphere center:0.470000 0.420000 0.370000
+DEAL:0::Sphere radius:0.250000
+DEAL:0::Comparing results
+DEAL:0::Test passed
+
+DEAL:1::Deal.II distributed_compute_point_locations:
+DEAL:1::Test on parallel setting 2D:
+DEAL:1::Testing for dim = 2 on 3 processes
+DEAL:1::Cube refinements: 3
+DEAL:1::Sphere refinements:3
+DEAL:1::Sphere center:0.470000 0.420000
+DEAL:1::Sphere radius:0.300000
+DEAL:1::Comparing results
+DEAL:1::Test passed
+DEAL:1::Test on parallel setting 3D:
+DEAL:1::Testing for dim = 3 on 3 processes
+DEAL:1::Cube refinements: 3
+DEAL:1::Sphere refinements:2
+DEAL:1::Sphere center:0.470000 0.420000 0.370000
+DEAL:1::Sphere radius:0.250000
+DEAL:1::Comparing results
+DEAL:1::Test passed
+
+
+DEAL:2::Deal.II distributed_compute_point_locations:
+DEAL:2::Test on parallel setting 2D:
+DEAL:2::Testing for dim = 2 on 3 processes
+DEAL:2::Cube refinements: 3
+DEAL:2::Sphere refinements:3
+DEAL:2::Sphere center:0.470000 0.420000
+DEAL:2::Sphere radius:0.300000
+DEAL:2::Comparing results
+DEAL:2::Test passed
+DEAL:2::Test on parallel setting 3D:
+DEAL:2::Testing for dim = 3 on 3 processes
+DEAL:2::Cube refinements: 3
+DEAL:2::Sphere refinements:2
+DEAL:2::Sphere center:0.470000 0.420000 0.370000
+DEAL:2::Sphere radius:0.250000
+DEAL:2::Comparing results
+DEAL:2::Test passed
+


### PR DESCRIPTION
**Working version with tests**: now reviews are needed :)

It took me a while because there was a small bug with indices which resulted in a small number of wrong points in certain cases: it was difficult to understand where exactly the problem was.

The function currently asks for: cache, a vector of bounding boxes (the one describing the locally owned part of the mesh, so that its creation is up to the user) and a vector of points.

The mpi communicator is recovered from the cache's triangulation: I used dynamic casting and an assertion error is thrown if no "parallel::Triangulation" or derived object is used.

There are two tests:
1. Compares the result with the serial version of the code.
2. The points are taken from a shared triangulation: this means they can be computed "by hand" and then compared with the distributed compute point locations result.

The function's code is quite articulated: I tried to comment and organize as much as possible, but if some parts are unclear/too ugly please tell me and I shall try to improve them.