### PR TITLE
lower the tolerance for full_matrix_10 test with float numbers

### DIFF
--- a/tests/full_matrix/full_matrix_10.cc
+++ b/tests/full_matrix/full_matrix_10.cc
@@ -41,7 +41,7 @@ void test()
         D(i,j) += A(i,k) * B(j,k);
   C.add(-1., D);
 
-  deallog << "Difference: " << filter_out_small_numbers(C.l1_norm(), std::numeric_limits<Number>::epsilon()*50.) << std::endl;
+  deallog << "Difference: " << filter_out_small_numbers(C.l1_norm(), std::numeric_limits<Number>::epsilon()*100.) << std::endl;
 }
 
 int main()


### PR DESCRIPTION
current value is something like `5.96046e-06` for `float`, whereas this failing test https://cdash.kyomu.43-1.org/testDetails.php?test=55471476&build=12925 ends up with `7.62939e-06` when using `MKL`.