### PR TITLE
doxygen: fix deprecated function signatures

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -195,7 +195,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_NAMESPACE_CLOSE= \
                          DEAL_II_ENABLE_EXTRA_DIAGNOSTICS= \
                          DEAL_II_DISABLE_EXTRA_DIAGNOSTICS= \
-                         DEAL_II_DEPRECATED = \
+                         DEAL_II_DEPRECATED= \
                          DEAL_II_P4EST_VERSION_GTE=1 \
                          DEAL_II_TRILINOS_VERSION_GTE=1
 


### PR DESCRIPTION
Deprecated functions show up with a trailing "1". Fix this.

Example: has_generalized_face_support_points() in http://www.dealii.org/developer/doxygen/deal.II/classFiniteElement.html