### PR TITLE
Disambiguate parallel::GridTools and GridTools.

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -704,7 +704,7 @@ namespace parallel
        */
       virtual void
       add_periodicity
-      (const std::vector<GridTools::PeriodicFacePair<cell_iterator> > &);
+      (const std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator> > &);
 
 
     private:

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -106,7 +106,7 @@ namespace parallel
             = IteratorFilters::SubdomainEqualTo(this->my_subdomain);
 
           const std::vector<typename parallel::shared::Triangulation<dim,spacedim>::active_cell_iterator>
-          active_halo_layer_vector = GridTools::compute_active_cell_halo_layer (*this, predicate);
+          active_halo_layer_vector = dealii::GridTools::compute_active_cell_halo_layer (*this, predicate);
           std::set<typename parallel::shared::Triangulation<dim,spacedim>::active_cell_iterator>
           active_halo_layer(active_halo_layer_vector.begin(), active_halo_layer_vector.end());
 
@@ -132,7 +132,7 @@ namespace parallel
                   true_level_subdomain_ids_of_cells[lvl].resize(this->n_cells(lvl));
 
                   const std::vector<typename parallel::shared::Triangulation<dim,spacedim>::cell_iterator>
-                  level_halo_layer_vector = GridTools::compute_cell_halo_layer_on_level (*this, predicate, lvl);
+                  level_halo_layer_vector = dealii::GridTools::compute_cell_halo_layer_on_level (*this, predicate, lvl);
                   std::set<typename parallel::shared::Triangulation<dim,spacedim>::cell_iterator>
                   level_halo_layer(level_halo_layer_vector.begin(), level_halo_layer_vector.end());
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1733,7 +1733,7 @@ namespace parallel
     Triangulation<dim,spacedim>::setup_coarse_cell_to_p4est_tree_permutation ()
     {
       DynamicSparsityPattern cell_connectivity;
-      GridTools::get_vertex_connectivity_of_cells (*this, cell_connectivity);
+      dealii::GridTools::get_vertex_connectivity_of_cells (*this, cell_connectivity);
       coarse_cell_to_p4est_tree_permutation.resize (this->n_cells(0));
       SparsityTools::
       reorder_hierarchical (cell_connectivity,
@@ -3054,7 +3054,7 @@ namespace parallel
 #ifdef DEBUG
       {
         const std::vector<bool> locally_owned_vertices
-          = GridTools::get_locally_owned_vertices (*this);
+          = dealii::GridTools::get_locally_owned_vertices (*this);
         for (unsigned int i=0; i<locally_owned_vertices.size(); ++i)
           Assert ((vertex_locally_moved[i] == false)
                   ||
@@ -3395,7 +3395,7 @@ namespace parallel
     template <int dim, int spacedim>
     void
     Triangulation<dim,spacedim>::add_periodicity
-    (const std::vector<GridTools::PeriodicFacePair<cell_iterator> > &
+    (const std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator> > &
      periodicity_vector)
     {
 #if DEAL_II_P4EST_VERSION_GTE(0,3,4,1)
@@ -3404,7 +3404,7 @@ namespace parallel
       Assert (this->n_levels() == 1,
               ExcMessage ("The triangulation is refined!"));
 
-      typedef std::vector<GridTools::PeriodicFacePair<cell_iterator> >
+      typedef std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator> >
       FaceVector;
       typename FaceVector::const_iterator it, periodic_end;
       it = periodicity_vector.begin();


### PR DESCRIPTION
I currently get a bunch of compilation failures in the unity build due to the new `parallel::GridTools` namespace. Without the extra namespace qualification the compiler tries to look up these functions in `parallel::GridTools` instead of `GridTools`.