### PR TITLE
Rename class groups in template-arguments.in.

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -58,9 +58,8 @@ MPI_SCALARS     := { int;
 // S=REAL_SCALARS for example
 DEAL_II_VEC_TEMPLATES := { Vector; BlockVector }
 
-// Serial vector types, based on real or complex scalars
-// TODO: why are parallel vectors in here?
-SERIAL_VECTORS := { Vector<double>;
+// All vector types, based on real or complex scalars
+VECTOR_TYPES := {   Vector<double>;
                     Vector<float> ;
 
                     Vector<std::complex<double> >;
@@ -98,9 +97,9 @@ SERIAL_VECTORS := { Vector<double>;
                     @DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR@;
                   }
 
-// same as SERIAL_VECTORS but only real-valued vectors (and only with PETSc 
+// same as VECTOR_TYPES but only real-valued vectors (and only with PETSc 
 // vectors if the PETScScalar data type is real-valued)
-REAL_SERIAL_VECTORS := { Vector<double>;
+REAL_VECTOR_TYPES  := {  Vector<double>;
                          Vector<float> ;
 
                          BlockVector<double>;

--- a/source/algorithms/operator.inst.in
+++ b/source/algorithms/operator.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS)
+for (VEC : VECTOR_TYPES)
 {
     template class OutputOperator<VEC>;
     template class Newton<VEC>;

--- a/source/dofs/dof_accessor_get.inst.in
+++ b/source/dofs/dof_accessor_get.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; lda : BOOL)
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; lda : BOOL)
 {
     template
     void
@@ -46,7 +46,7 @@ for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; lda : BOOL)
 }
 
 
-for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; lda : BOOL)
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; lda : BOOL)
 {
     template
     void

--- a/source/dofs/dof_accessor_set.inst.in
+++ b/source/dofs/dof_accessor_set.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; lda : BOOL)
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; lda : BOOL)
 {
     template
     void
@@ -46,7 +46,7 @@ for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; lda : BOOL)
 }
 
 
-for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; lda : BOOL)
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; lda : BOOL)
 {
     template
     void

--- a/source/fe/fe_tools_extrapolate.inst.in
+++ b/source/fe/fe_tools_extrapolate.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; VEC : SERIAL_VECTORS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; VEC : VECTOR_TYPES)
 {
     namespace FETools
     \{

--- a/source/fe/fe_tools_interpolate.inst.in
+++ b/source/fe/fe_tools_interpolate.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; Vector : SERIAL_VECTORS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; Vector : VECTOR_TYPES)
 {
     namespace FETools
     \{
@@ -64,7 +64,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     \}
 }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; VEC : SERIAL_VECTORS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; VEC : VECTOR_TYPES)
 {
     namespace FETools
     \{

--- a/source/fe/fe_values.decl.1.inst.in
+++ b/source/fe/fe_values.decl.1.inst.in
@@ -18,7 +18,7 @@
 // Declarations of member functions of FEValuesBase::CellIteratorBase
 // and derived classes
 
-for (VEC : SERIAL_VECTORS)
+for (VEC : VECTOR_TYPES)
 {
     /// Call
     /// @p get_interpolated_dof_values

--- a/source/fe/fe_values.decl.2.inst.in
+++ b/source/fe/fe_values.decl.2.inst.in
@@ -18,7 +18,7 @@
 // Declarations of member functions of FEValuesBase::CellIteratorBase
 // and derived classes
 
-for (VEC : SERIAL_VECTORS)
+for (VEC : VECTOR_TYPES)
 {
     /// Call
     /// @p get_interpolated_dof_values

--- a/source/fe/fe_values.impl.1.inst.in
+++ b/source/fe/fe_values.impl.1.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS)
+for (VEC : VECTOR_TYPES)
 {
     template <int dim, int spacedim>
     template <typename CI>

--- a/source/fe/fe_values.impl.2.inst.in
+++ b/source/fe/fe_values.impl.2.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS)
+for (VEC : VECTOR_TYPES)
 {
     template <int dim, int spacedim>
     void

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -61,7 +61,7 @@ for (dof_handler : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II
 
 
 
-for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     template
@@ -239,7 +239,7 @@ for (VEC : GENERAL_CONTAINER_TYPES;
 }
 
 
-for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
 

--- a/source/fe/mapping_fe_field.inst.in
+++ b/source/fe/mapping_fe_field.inst.in
@@ -16,7 +16,7 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; VEC : REAL_SERIAL_VECTORS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; VEC : REAL_VECTOR_TYPES)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     template class MappingFEField<deal_II_dimension, deal_II_space_dimension,  VEC,

--- a/source/fe/mapping_q1_eulerian.inst.in
+++ b/source/fe/mapping_q1_eulerian.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; VEC : REAL_SERIAL_VECTORS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; VEC : REAL_VECTOR_TYPES)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     template class MappingQ1Eulerian<deal_II_dimension, VEC, deal_II_space_dimension>;

--- a/source/fe/mapping_q_eulerian.inst.in
+++ b/source/fe/mapping_q_eulerian.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; VEC : REAL_SERIAL_VECTORS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; VEC : REAL_VECTOR_TYPES)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     template class MappingQEulerian<deal_II_dimension, VEC, deal_II_space_dimension>;

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -72,7 +72,7 @@ for (S1 : COMPLEX_SCALARS)
 }
 
 
-for (Vec : SERIAL_VECTORS)
+for (Vec : VECTOR_TYPES)
 {
     template void ConstraintMatrix::distribute<Vec>(Vec &) const;
 }

--- a/source/lac/solver.inst.in
+++ b/source/lac/solver.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (S : SERIAL_VECTORS)
+for (S : VECTOR_TYPES)
 {
     template class Solver<S>;
 }

--- a/source/lac/vector_memory.inst.in
+++ b/source/lac/vector_memory.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (VECTOR : SERIAL_VECTORS)
+for (VECTOR : VECTOR_TYPES)
 {
     template class VectorMemory<VECTOR>;
     template class GrowingVectorMemory<VECTOR>;

--- a/source/lac/vector_memory_release.inst.in
+++ b/source/lac/vector_memory_release.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (VECTOR : SERIAL_VECTORS)
+for (VECTOR : VECTOR_TYPES)
 {
     dealii::GrowingVectorMemory<dealii::VECTOR>::release_unused_memory();
 }

--- a/source/meshworker/mesh_worker_vector_selector.inst.in
+++ b/source/meshworker/mesh_worker_vector_selector.inst.in
@@ -25,7 +25,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     \}
 }
 
-for (VECTOR : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VECTOR : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
     namespace MeshWorker
     \{

--- a/source/multigrid/mg_base.inst.in
+++ b/source/multigrid/mg_base.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS)
+for (VEC : VECTOR_TYPES)
 {
     template class MGTransferBase< VEC >;
     template class MGMatrixBase< VEC >;

--- a/source/multigrid/multigrid.inst.in
+++ b/source/multigrid/multigrid.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS)
+for (VEC : VECTOR_TYPES)
 {
     template class Multigrid< VEC >;
 }

--- a/source/numerics/data_out_dof_data.inst.in
+++ b/source/numerics/data_out_dof_data.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS; DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
+for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
 {
     template void
     DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension,deal_II_dimension>::

--- a/source/numerics/data_out_dof_data_codim.inst.in
+++ b/source/numerics/data_out_dof_data_codim.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_SERIAL_VECTORS; DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
+for (VEC : REAL_VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
 {
 #if deal_II_dimension < deal_II_space_dimension
     template void

--- a/source/numerics/derivative_approximation.inst.in
+++ b/source/numerics/derivative_approximation.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS ; VEC : REAL_SERIAL_VECTORS ; DH : DOFHANDLER_TEMPLATES)
+for (deal_II_dimension : DIMENSIONS ; VEC : REAL_VECTOR_TYPES ; DH : DOFHANDLER_TEMPLATES)
 {
     namespace DerivativeApproximation
     \{

--- a/source/numerics/dof_output_operator.inst.in
+++ b/source/numerics/dof_output_operator.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
 {
     template class DoFOutputOperator<VEC, deal_II_dimension, deal_II_dimension>;
 }

--- a/source/numerics/error_estimator.inst.in
+++ b/source/numerics/error_estimator.inst.in
@@ -21,7 +21,7 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
 #endif
 }
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; DH : DOFHANDLER_TEMPLATES )
+for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; DH : DOFHANDLER_TEMPLATES )
 {
 #if deal_II_dimension != 1 && deal_II_dimension <= deal_II_space_dimension
 

--- a/source/numerics/error_estimator_1d.inst.in
+++ b/source/numerics/error_estimator_1d.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; DH : DOFHANDLER_TEMPLATES )
+for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; DH : DOFHANDLER_TEMPLATES )
 {
 #if deal_II_dimension == 1 && deal_II_dimension <= deal_II_space_dimension
 

--- a/source/numerics/fe_field_function.inst.in
+++ b/source/numerics/fe_field_function.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (VECTOR : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VECTOR : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
 {
     template class FEFieldFunction<deal_II_dimension,
                                    DoFHandler<deal_II_dimension>,

--- a/source/numerics/point_value_history.inst.in
+++ b/source/numerics/point_value_history.inst.in
@@ -21,7 +21,7 @@ for (deal_II_dimension : DIMENSIONS)
 }
 
 
-for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
 {
     template
     void PointValueHistory<deal_II_dimension>::evaluate_field
@@ -30,7 +30,7 @@ for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
 }
 
 
-for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
 {
     template
     void PointValueHistory<deal_II_dimension>::evaluate_field_at_requested_location
@@ -38,7 +38,7 @@ for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
      const VEC &);
 }
 
-for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
 {
     template
     void PointValueHistory<deal_II_dimension>::evaluate_field
@@ -48,7 +48,7 @@ for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
      const Quadrature<deal_II_dimension> &);
 }
 
-for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
 {
     template
     void PointValueHistory<deal_II_dimension>::evaluate_field

--- a/source/numerics/solution_transfer.inst.in
+++ b/source/numerics/solution_transfer.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     template class SolutionTransfer<deal_II_dimension, VEC, DoFHandler<deal_II_dimension, deal_II_space_dimension> >;

--- a/source/numerics/vector_tools_integrate_difference.inst.in
+++ b/source/numerics/vector_tools_integrate_difference.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace VectorTools \{

--- a/source/numerics/vector_tools_interpolate.inst.in
+++ b/source/numerics/vector_tools_interpolate.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace VectorTools \{
@@ -57,7 +57,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
 
 //TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension, deal_II_space_dimension>
 // where applicable and move to codimension cases above also when applicable
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension == deal_II_space_dimension
 
@@ -96,7 +96,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
 }
 
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace VectorTools \{

--- a/source/numerics/vector_tools_mean_value.inst.in
+++ b/source/numerics/vector_tools_mean_value.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace VectorTools \{
@@ -40,7 +40,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
 
 
 
-for (VEC : SERIAL_VECTORS)
+for (VEC : VECTOR_TYPES)
 {
     namespace VectorTools \{
     template

--- a/source/numerics/vector_tools_point_gradient.inst.in
+++ b/source/numerics/vector_tools_point_gradient.inst.in
@@ -13,7 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension == deal_II_space_dimension
 

--- a/source/numerics/vector_tools_point_value.inst.in
+++ b/source/numerics/vector_tools_point_value.inst.in
@@ -16,7 +16,7 @@
 
 //TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension, deal_II_space_dimension>
 // where applicable and move to codimension cases above also when applicable
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension == deal_II_space_dimension
 

--- a/source/numerics/vector_tools_project.inst.in
+++ b/source/numerics/vector_tools_project.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension == deal_II_space_dimension
     namespace VectorTools \{

--- a/source/numerics/vector_tools_project_codim.inst.in
+++ b/source/numerics/vector_tools_project_codim.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension < deal_II_space_dimension
     namespace VectorTools \{

--- a/source/numerics/vector_tools_project_hp.inst.in
+++ b/source/numerics/vector_tools_project_hp.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace VectorTools \{

--- a/source/numerics/vector_tools_rhs.inst.in
+++ b/source/numerics/vector_tools_rhs.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace VectorTools \{


### PR DESCRIPTION
The previous name no longer adequately represented what these classes were. Fix this.

See #3922.