### PR TITLE
fix illegal character (<F6> instead of oe)

### DIFF
--- a/tests/lac/eigen.cc
+++ b/tests/lac/eigen.cc
@@ -41,7 +41,7 @@ int main()
    * Compute minimal and maximal
    * eigenvalues of the 5-point
    * stencil matrix
-   * (Hackbusch:Iterative Lösung...,
+   * (Hackbusch:Iterative Loesung...,
    * Satz 4.1.1)
    */
   const double h = 1./size;


### PR DESCRIPTION
Locally I see
```
$ git diff
diff --git a/tests/lac/eigen.cc b/tests/lac/eigen.cc
index 4f376b7f3d..35842bee5e 100644
--- a/tests/lac/eigen.cc
+++ b/tests/lac/eigen.cc
@@ -41,7 +41,7 @@ int main()
    * Compute minimal and maximal
    * eigenvalues of the 5-point
    * stencil matrix
-   * (Hackbusch:Iterative L<F6>sung...,
+   * (Hackbusch:Iterative Loesung...,
    * Satz 4.1.1)
    */
   const double h = 1./size;
```
Indentation script was also broken
```
tr: Illegal byte sequence
```