### PR TITLE
Fix missing include file in multigrid/interface_matrix_entry_01

### DIFF
--- a/tests/multigrid/interface_matrix_entry_01.cc
+++ b/tests/multigrid/interface_matrix_entry_01.cc
@@ -42,6 +42,7 @@
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 #include <deal.II/multigrid/multigrid.h>
 
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/generic_linear_algebra.h>
 


### PR DESCRIPTION
Fixes a [test](https://cdash.kyomu.43-1.org/testDetails.php?test=56492459&build=13127) failing for `Intel-18`.