### PR TITLE
Update the GDB pretty-printer.

### DIFF
--- a/contrib/utilities/dotgdbinit.py
+++ b/contrib/utilities/dotgdbinit.py
@@ -25,7 +25,7 @@
 # slightly older versions of GDB (the Python interface was added in 7.0,
 # released in 2009).
 #
-# Authors: Wolfgang Bangerth, 2015, David Wells, 2015
+# Authors: Wolfgang Bangerth, 2015, David Wells, 2015 - 2017
 #
 set print pretty 1
 
@@ -99,7 +99,7 @@ class VectorPrinter(object):
         # The first entry (see the "Pretty Printing API" documentation of GDB)
         # in the tuple should be a name for the child, which should be nothing
         # (an empty string) here.
-        return (("", (self.val['val'] + count).dereference())
+        return (("", (self.val['values'] + count).dereference())
                 for count in range(int(self.val['vec_size'])))
 
     def to_string(self):


### PR DESCRIPTION
The data array variable was renamed from 'val' to 'values' in 2faae204c26.

Fixes #5432.