### PR TITLE
Error corrected: removed extra #ifdef MPI in distributed/grid_tools.cc

### DIFF
--- a/source/distributed/grid_tools.cc
+++ b/source/distributed/grid_tools.cc
@@ -20,8 +20,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-#ifdef DEAL_II_WITH_MPI
-
 namespace parallel
 {
   namespace GridTools
@@ -107,5 +105,4 @@ namespace parallel
 // explicit instantiations
 #include "grid_tools.inst"
 
-#endif // DEAL_II_WITH_MPI
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Hi!
 I'm sorry but in the pull request, I did as @Rombur  asked me (adding the #ifndef mpi inside etc.) but forgot to remove the "ifdef mpi" outside (in practise nothing changed...) and the error slipped away. This should fix it.
Thanks,
Giovanni