### PR TITLE
Use c++14's [[deprecated]] if possible

### DIFF
--- a/cmake/checks/check_01_compiler_features.cmake
+++ b/cmake/checks/check_01_compiler_features.cmake
@@ -300,8 +300,10 @@ ENDIF()
 #
 # GCC and some other compilers have an attribute of the form
 # __attribute__((deprecated)) that can be used to make the
-# compiler warn whenever a deprecated function is used. See
-# if this attribute is available.
+# compiler warn whenever a deprecated function is used. C++14
+# provides a standardized attribute of the form [[deprecated]
+# with the exact same functionality.
+# See if one of these attribute is available.
 #
 # If it is, set the variable DEAL_II_DEPRECATED to its value. If
 # it isn't, set it to an empty string (actually, to a single
@@ -315,7 +317,18 @@ ENDIF()
 # first see if the compiler accepts the attribute
 CHECK_CXX_SOURCE_COMPILES(
   "
-          int old_fn () __attribute__((deprecated));
+          [[deprecated]] int old_fn ();
+          int old_fn () { return 0; }
+          int (*fn_ptr)() = old_fn;
+
+          int main () {}
+  "
+  DEAL_II_COMPILER_HAS_CXX14_ATTRIBUTE_DEPRECATED
+  )
+
+CHECK_CXX_SOURCE_COMPILES(
+  "
+          __attribute__((deprecated)) int old_fn ();
           int old_fn () { return 0; }
           int (*fn_ptr)() = old_fn;
 
@@ -324,7 +337,9 @@ CHECK_CXX_SOURCE_COMPILES(
   DEAL_II_COMPILER_HAS_ATTRIBUTE_DEPRECATED
   )
 
-IF(DEAL_II_COMPILER_HAS_ATTRIBUTE_DEPRECATED)
+IF(DEAL_II_COMPILER_HAS_CXX14_ATTRIBUTE_DEPRECATED)
+  SET(DEAL_II_DEPRECATED "[[deprecated]]")
+ELSEIF(DEAL_II_COMPILER_HAS_ATTRIBUTE_DEPRECATED)
   SET(DEAL_II_DEPRECATED "__attribute__((deprecated))")
 ELSE()
   SET(DEAL_II_DEPRECATED " ")

--- a/include/deal.II/base/mg_level_object.h
+++ b/include/deal.II/base/mg_level_object.h
@@ -114,7 +114,8 @@ public:
    *
    * @deprecated Use clear_elements () instead
    */
-  void clear() DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  void clear();
 
   /**
    * Call @p clear on all objects stored by this object. This function

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -145,7 +145,8 @@ namespace numbers
    * @deprecated This function has been deprecated in favor of the C++11
    * function <code>std::isnan</code>.
    */
-  bool is_nan (const double x) DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  bool is_nan (const double x);
 
   /**
    * Return @p true if the given value is a finite floating point number, i.e.

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1266,10 +1266,11 @@ public:
    * @deprecated This function is deprecated because, even though it only
    *   outputs information, it is not a <code>const</code> function.
    */
+  DEAL_II_DEPRECATED
   void print_parameters_section (std::ostream       &out,
                                  const OutputStyle   style,
                                  const unsigned int  indent_level,
-                                 const bool          include_top_level_elements = false) DEAL_II_DEPRECATED;
+                                 const bool          include_top_level_elements = false);
 
   /**
    * Print parameters to a logstream. This function allows to print all

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -342,7 +342,8 @@ namespace Utilities
       /**
        * Return the MPI communicator underlying the partitioner object.
        */
-      const MPI_Comm &get_communicator() const DEAL_II_DEPRECATED;
+      DEAL_II_DEPRECATED
+      const MPI_Comm &get_communicator() const;
 
       /**
        * Return the MPI communicator underlying the partitioner object.

--- a/include/deal.II/base/table_indices.h
+++ b/include/deal.II/base/table_indices.h
@@ -123,6 +123,7 @@ public:
    * @deprecated Use the constructor with the appropriate number of arguments
    *   to initialize the @p N indices instead.
    */
+  DEAL_II_DEPRECATED
   TableIndices (const unsigned int index0,
                 const unsigned int index1,
                 const unsigned int index2,
@@ -131,7 +132,7 @@ public:
                 const unsigned int index5,
                 const unsigned int index6 = numbers::invalid_unsigned_int,
                 const unsigned int index7 = numbers::invalid_unsigned_int,
-                const unsigned int index8 = numbers::invalid_unsigned_int) DEAL_II_DEPRECATED;
+                const unsigned int index8 = numbers::invalid_unsigned_int);
 
   /**
    * Read-only access the value of the <tt>i</tt>th index.

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -148,10 +148,11 @@ template <bool, typename> struct constraint_and_return_value;
  *
  * @author Wolfgang Bangerth, 2003
  */
-template <typename T> struct constraint_and_return_value<true,T>
+template <typename T>
+struct DEAL_II_DEPRECATED constraint_and_return_value<true,T>
 {
   typedef T type;
-} DEAL_II_DEPRECATED;
+};
 
 
 
@@ -324,8 +325,8 @@ namespace internal
    * @author Wolfgang Bangerth, 2006
    */
   template <int N>
-  struct int2type
-  {} DEAL_II_DEPRECATED;
+  struct DEAL_II_DEPRECATED int2type
+  {};
 
 
   /**
@@ -336,8 +337,8 @@ namespace internal
    * @author Wolfgang Bangerth, 2009
    */
   template <bool B>
-  struct bool2type
-  {} DEAL_II_DEPRECATED;
+  struct DEAL_II_DEPRECATED bool2type
+  {};
 }
 
 
@@ -362,8 +363,8 @@ namespace internal
  * instead of this class.
  */
 template <typename T, typename U>
-struct types_are_equal : std::is_same<T,U>
-{} DEAL_II_DEPRECATED;
+struct DEAL_II_DEPRECATED types_are_equal : std::is_same<T,U>
+{};
 
 
 

--- a/include/deal.II/base/tensor_deprecated.h
+++ b/include/deal.II/base/tensor_deprecated.h
@@ -49,9 +49,10 @@ DeclException1 (ExcInvalidTensorContractionIndex,
  * @relates Tensor
  */
 template <int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 Number double_contract (const Tensor<2, dim, Number> &src1,
-                        const Tensor<2, dim, Number> &src2) DEAL_II_DEPRECATED;
+                        const Tensor<2, dim, Number> &src2);
 
 
 /**
@@ -64,10 +65,11 @@ Number double_contract (const Tensor<2, dim, Number> &src1,
  * @relates Tensor
  */
 template <int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 void double_contract (Tensor<2,dim,Number>       &dest,
                       const Tensor<4,dim,Number> &src1,
-                      const Tensor<2,dim,Number> &src2) DEAL_II_DEPRECATED;
+                      const Tensor<2,dim,Number> &src2);
 
 /**
  * Contract a tensor of rank 2 with a tensor of rank 2. The contraction is
@@ -80,12 +82,13 @@ void double_contract (Tensor<2,dim,Number>       &dest,
  * @relates Tensor
  */
 template <int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 void contract (Tensor<2,dim,Number>       &dest,
                const Tensor<2,dim,Number> &src1,
                const unsigned int          index1,
                const Tensor<2,dim,Number> &src2,
-               const unsigned int          index3) DEAL_II_DEPRECATED;
+               const unsigned int          index3);
 
 /**
  * Contract a tensor of rank 3 with a tensor of rank 1. The contraction is
@@ -97,11 +100,12 @@ void contract (Tensor<2,dim,Number>       &dest,
  * @relates Tensor
  */
 template <int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 void contract (Tensor<2,dim,Number>       &dest,
                const Tensor<3,dim,Number> &src1,
                const unsigned int          index1,
-               const Tensor<1,dim,Number> &src2) DEAL_II_DEPRECATED;
+               const Tensor<1,dim,Number> &src2);
 
 /**
  * Contract a tensor of rank 3 with a tensor of rank 2. The contraction is
@@ -114,12 +118,13 @@ void contract (Tensor<2,dim,Number>       &dest,
  * @relates Tensor
  */
 template <int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 void contract (Tensor<3,dim,Number>       &dest,
                const Tensor<3,dim,Number> &src1,
                const unsigned int          index1,
                const Tensor<2,dim,Number> &src2,
-               const unsigned int          index2) DEAL_II_DEPRECATED;
+               const unsigned int          index2);
 
 /**
  * Single contraction for tensors: contract the last index of a tensor @p src1
@@ -130,10 +135,11 @@ void contract (Tensor<3,dim,Number>       &dest,
  * @relates Tensor
  */
 template <int rank_1, int rank_2, int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 void contract (Tensor<rank_1 + rank_2 - 2, dim, Number> &dest,
                const Tensor<rank_1, dim, Number>        &src1,
-               const Tensor<rank_2, dim, Number>        &src2) DEAL_II_DEPRECATED;
+               const Tensor<rank_2, dim, Number>        &src2);
 
 /**
  * Contract a tensor of rank 1 with a tensor of rank 1 and return the result.
@@ -142,10 +148,11 @@ void contract (Tensor<rank_1 + rank_2 - 2, dim, Number> &dest,
  * @relates Tensor
  */
 template <int dim, typename Number, typename OtherNumber>
+DEAL_II_DEPRECATED
 inline
 typename ProductType<Number,OtherNumber>::type
 contract (const Tensor<1,dim,Number> &src1,
-          const Tensor<1,dim,OtherNumber> &src2) DEAL_II_DEPRECATED;
+          const Tensor<1,dim,OtherNumber> &src2);
 
 
 /**
@@ -156,10 +163,11 @@ contract (const Tensor<1,dim,Number> &src1,
  * @relates Tensor
  */
 template <int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 void
 cross_product (Tensor<1,dim,Number>       &dst,
-               const Tensor<1,dim,Number> &src) DEAL_II_DEPRECATED;
+               const Tensor<1,dim,Number> &src);
 
 /**
  * The cross product of 2 vectors in 3d.
@@ -168,11 +176,12 @@ cross_product (Tensor<1,dim,Number>       &dst,
  * @relates Tensor
  */
 template <int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 void
 cross_product (Tensor<1,dim,Number>       &dst,
                const Tensor<1,dim,Number> &src1,
-               const Tensor<1,dim,Number> &src2) DEAL_II_DEPRECATED;
+               const Tensor<1,dim,Number> &src2);
 
 /**
  * Form the outer product of two tensors.
@@ -181,10 +190,11 @@ cross_product (Tensor<1,dim,Number>       &dst,
  * @relates Tensor
  */
 template <int rank_1, int rank_2, int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 void outer_product(Tensor<rank_1 + rank_2, dim, Number> &dst,
                    const Tensor<rank_1, dim, Number>    &src1,
-                   const Tensor<rank_2, dim, Number>    &src2) DEAL_II_DEPRECATED;
+                   const Tensor<rank_2, dim, Number>    &src2);
 
 /**
  * Multiply a Tensor<1,dim,Number> with a Number.
@@ -193,10 +203,11 @@ void outer_product(Tensor<rank_1 + rank_2, dim, Number> &dst,
  * @relates Tensor
  */
 template <int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 void outer_product (Tensor<1,dim,Number>       &dst,
                     const Number                src1,
-                    const Tensor<1,dim,Number> &src2) DEAL_II_DEPRECATED;
+                    const Tensor<1,dim,Number> &src2);
 
 /**
  * Multiply a Tensor<1,dim,Number> with a Number.
@@ -205,18 +216,20 @@ void outer_product (Tensor<1,dim,Number>       &dst,
  * @relates Tensor
  */
 template <int dim, typename Number>
+DEAL_II_DEPRECATED
 inline
 void outer_product (Tensor<1,dim,Number>       &dst,
                     const Tensor<1,dim,Number>  src1,
-                    const Number                src2) DEAL_II_DEPRECATED;
+                    const Number                src2);
 
 /**
  * @deprecated Do not use this function, evaluate the value manually.
  * @relates Tensor
  */
 template <int rank, typename Number>
+DEAL_II_DEPRECATED
 inline
-Number determinant (const Tensor<rank,1,Number> &t) DEAL_II_DEPRECATED;
+Number determinant (const Tensor<rank,1,Number> &t);
 
 
 /**
@@ -224,8 +237,9 @@ Number determinant (const Tensor<rank,1,Number> &t) DEAL_II_DEPRECATED;
  * @relates Tensor
  */
 template <typename Number>
+DEAL_II_DEPRECATED
 inline
-Number determinant (const Tensor<1,1,Number> &t) DEAL_II_DEPRECATED;
+Number determinant (const Tensor<1,1,Number> &t);
 
 //@}
 

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -147,7 +147,8 @@ public:
    * @deprecated Use Timer::get_last_lap_wall_time_data() instead, which
    * returns a reference to the same structure.
    */
-  const Utilities::MPI::MinMaxAvg &get_data() const DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  const Utilities::MPI::MinMaxAvg &get_data() const;
 
   /**
    * Return a reference to the data structure containing basic statistics on
@@ -166,7 +167,8 @@ public:
    * @deprecated Use Timer::get_accumulated_wall_time_data() instead, which
    * returns a reference the same structure.
    */
-  const Utilities::MPI::MinMaxAvg &get_total_data() const DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  const Utilities::MPI::MinMaxAvg &get_total_data() const;
 
   /**
    * Return a reference to the data structure containing basic statistics on
@@ -184,7 +186,8 @@ public:
    * prints the same information.
    */
   template <class StreamType>
-  void print_data(StreamType &stream) const DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  void print_data(StreamType &stream) const;
 
   /**
    * Print the data returned by Timer::get_last_lap_wall_time_data() to the
@@ -201,7 +204,8 @@ public:
    * prints the same information.
    */
   template <class StreamType>
-  void print_total_data(StreamType &stream) const DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  void print_total_data(StreamType &stream) const;
 
   /**
    * Print the data returned by Timer::get_accumulated_wall_time_data() to the
@@ -244,7 +248,8 @@ public:
    *
    * @deprecated Use cpu_time() instead.
    */
-  double operator() () const DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  double operator() () const;
 
   /**
    * Return the current accumulated wall time (including the current lap, if
@@ -279,7 +284,8 @@ public:
    *
    * @deprecated Use last_wall_time() instead.
    */
-  double get_lap_time () const DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  double get_lap_time () const;
 
 private:
   /**

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -315,7 +315,8 @@ public:
    *
    * @deprecated Use numbers::invalid_dof_index instead.
    */
-  static const types::global_dof_index invalid_dof_index DEAL_II_DEPRECATED = numbers::invalid_dof_index;
+  DEAL_II_DEPRECATED
+  static const types::global_dof_index invalid_dof_index = numbers::invalid_dof_index;
 
   /**
    * The default index of the finite element to be used on a given cell. Since
@@ -394,7 +395,8 @@ public:
    *
    * @deprecated Use the version without parameter instead.
    */
-  virtual void distribute_mg_dofs (const FiniteElement<dim, spacedim> &fe) DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  virtual void distribute_mg_dofs (const FiniteElement<dim, spacedim> &fe);
 
   /**
    * Distribute level degrees of freedom on each level for geometric

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -277,8 +277,9 @@ namespace DoFTools
    * @relates DoFHandler
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   unsigned int
-  max_dofs_per_cell (const DoFHandler<dim,spacedim> &dh) DEAL_II_DEPRECATED;
+  max_dofs_per_cell (const DoFHandler<dim,spacedim> &dh);
 
   /**
    * Maximal number of degrees of freedom on a cell.
@@ -288,8 +289,9 @@ namespace DoFTools
    * @relates hp::DoFHandler
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   unsigned int
-  max_dofs_per_cell (const hp::DoFHandler<dim,spacedim> &dh) DEAL_II_DEPRECATED;
+  max_dofs_per_cell (const hp::DoFHandler<dim,spacedim> &dh);
 
 
   /**
@@ -303,8 +305,9 @@ namespace DoFTools
    * @relates DoFHandler
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   unsigned int
-  max_dofs_per_face (const DoFHandler<dim,spacedim> &dh) DEAL_II_DEPRECATED;
+  max_dofs_per_face (const DoFHandler<dim,spacedim> &dh);
 
   /**
    * Maximal number of degrees of freedom on a face.
@@ -317,8 +320,9 @@ namespace DoFTools
    * @relates hp::DoFHandler
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   unsigned int
-  max_dofs_per_face (const hp::DoFHandler<dim,spacedim> &dh) DEAL_II_DEPRECATED;
+  max_dofs_per_face (const hp::DoFHandler<dim,spacedim> &dh);
 
   /**
    * Maximal number of degrees of freedom on a vertex.
@@ -331,8 +335,9 @@ namespace DoFTools
    * @relates DoFHandler
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   unsigned int
-  max_dofs_per_vertex (const DoFHandler<dim,spacedim> &dh) DEAL_II_DEPRECATED;
+  max_dofs_per_vertex (const DoFHandler<dim,spacedim> &dh);
 
   /**
    * Maximal number of degrees of freedom on a vertex.
@@ -345,8 +350,9 @@ namespace DoFTools
    * @relates hp::DoFHandler
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   unsigned int
-  max_dofs_per_vertex (const hp::DoFHandler<dim,spacedim> &dh) DEAL_II_DEPRECATED;
+  max_dofs_per_vertex (const hp::DoFHandler<dim,spacedim> &dh);
 
   /**
    * Number of vector components in the finite element object used by this
@@ -360,8 +366,9 @@ namespace DoFTools
    * @relates DoFHandler
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   unsigned int
-  n_components (const DoFHandler<dim,spacedim> &dh) DEAL_II_DEPRECATED;
+  n_components (const DoFHandler<dim,spacedim> &dh);
 
   /**
    * Number of vector components in the finite element object used by this
@@ -375,8 +382,9 @@ namespace DoFTools
    * @relates hp::DoFHandler
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   unsigned int
-  n_components (const hp::DoFHandler<dim,spacedim> &dh) DEAL_II_DEPRECATED;
+  n_components (const hp::DoFHandler<dim,spacedim> &dh);
 
   /**
    * Find out whether the first FiniteElement used by this DoFHandler is
@@ -390,8 +398,9 @@ namespace DoFTools
    * @relates DoFHandler
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   bool
-  fe_is_primitive (const DoFHandler<dim,spacedim> &dh) DEAL_II_DEPRECATED;
+  fe_is_primitive (const DoFHandler<dim,spacedim> &dh);
 
   /**
    * Find out whether the first FiniteElement used by this DoFHandler is primitive
@@ -405,8 +414,9 @@ namespace DoFTools
    * @relates hp::DoFHandler
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   bool
-  fe_is_primitive (const hp::DoFHandler<dim,spacedim> &dh) DEAL_II_DEPRECATED;
+  fe_is_primitive (const hp::DoFHandler<dim,spacedim> &dh);
 
   /**
    * @}
@@ -1559,9 +1569,10 @@ namespace DoFTools
    * function.
    */
   template <typename DoFHandlerType>
+  DEAL_II_DEPRECATED
   void
   extract_locally_owned_dofs (const DoFHandlerType &dof_handler,
-                              IndexSet             &dof_set) DEAL_II_DEPRECATED;
+                              IndexSet             &dof_set);
 
 
   /**

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -2066,8 +2066,9 @@ public:
    * subset of generalized support points describing degrees of freedom for
    * a given face. Don't use this function
    */
+  DEAL_II_DEPRECATED
   const std::vector<Point<dim-1> > &
-  get_generalized_face_support_points () const DEAL_II_DEPRECATED;
+  get_generalized_face_support_points () const;
 
   /**
    * Return whether a finite element has defined generalized support points on
@@ -2081,8 +2082,9 @@ public:
    * subset of generalized support points describing degrees of freedom for
    * a given face. Don't use this function
    */
+  DEAL_II_DEPRECATED
   bool
-  has_generalized_face_support_points () const DEAL_II_DEPRECATED;
+  has_generalized_face_support_points () const;
 
   /**
    * For a given degree of freedom, return whether it is logically associated

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -1234,8 +1234,9 @@ namespace FETools
    * @deprecated Use get_fe_by_name() with two template parameters instead
    */
   template <int dim>
+  DEAL_II_DEPRECATED
   FiniteElement<dim,dim> *
-  get_fe_from_name (const std::string &name) DEAL_II_DEPRECATED;
+  get_fe_from_name (const std::string &name);
 
 
   /**

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2738,7 +2738,8 @@ public:
    * @deprecated Use get_normal_vectors() instead, which returns the exact
    * same thing.
    */
-  const std::vector<Tensor<1,spacedim> > &get_all_normal_vectors () const DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  const std::vector<Tensor<1,spacedim> > &get_all_normal_vectors () const;
 
   /**
    * Return the normal vectors at the quadrature points. For a face, these are

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -100,9 +100,10 @@ namespace Manifolds
    *   <code>cell-@>face(f)</code> or <code>cell-@>line(l)</code>.
    */
   template <typename MeshIteratorType>
+  DEAL_II_DEPRECATED
   Quadrature<MeshIteratorType::AccessorType::space_dimension>
   get_default_quadrature(const MeshIteratorType &iterator,
-                         const bool              with_laplace = false) DEAL_II_DEPRECATED;
+                         const bool              with_laplace = false);
 
   /**
    * Given a general mesh iterator, construct arrays of quadrature points and

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1262,7 +1262,8 @@ public:
    * @deprecated This member variable has been deprecated in favor of creating
    * an independent FlatManifold.
    */
-  static const StraightBoundary<dim,spacedim> straight_boundary DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  static const StraightBoundary<dim,spacedim> straight_boundary;
 
   /**
    * Declare some symbolic names for mesh smoothing algorithms. The meaning of
@@ -1722,8 +1723,9 @@ public:
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
+  DEAL_II_DEPRECATED
   void set_boundary (const types::manifold_id   number,
-                     const Boundary<dim,spacedim> &boundary_object) DEAL_II_DEPRECATED;
+                     const Boundary<dim,spacedim> &boundary_object);
 
 
   /**
@@ -1740,7 +1742,8 @@ public:
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  void set_boundary (const types::manifold_id number) DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  void set_boundary (const types::manifold_id number);
 
   /**
    * Assign a manifold object to a certain part of the triangulation. If
@@ -1828,7 +1831,8 @@ public:
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  const Boundary<dim,spacedim> &get_boundary (const types::manifold_id number) const DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  const Boundary<dim,spacedim> &get_boundary (const types::manifold_id number) const;
 
   /**
    * Return a constant reference to a Manifold object used for this

--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -81,7 +81,7 @@ DEAL_II_NAMESPACE_OPEN
  * Luca Heltai, 2014
  */
 template <int dim, int spacedim=dim>
-class Boundary : public FlatManifold<dim, spacedim>
+class DEAL_II_DEPRECATED Boundary : public FlatManifold<dim, spacedim>
 {
 public:
 
@@ -219,7 +219,7 @@ private:
    * Mutex for protecting the points array.
    */
   mutable Threads::Mutex mutex;
-} DEAL_II_DEPRECATED;
+};
 
 
 
@@ -241,7 +241,7 @@ private:
  * @author Wolfgang Bangerth, 1998, 2001, Ralf Hartmann, 2001
  */
 template <int dim, int spacedim=dim>
-class StraightBoundary : public Boundary<dim,spacedim>
+class DEAL_II_DEPRECATED StraightBoundary : public Boundary<dim,spacedim>
 {
 public:
   /**
@@ -367,7 +367,7 @@ public:
   Point<spacedim>
   project_to_surface (const typename Triangulation<dim,spacedim>::hex_iterator &hex,
                       const Point<spacedim> &candidate) const;
-} DEAL_II_DEPRECATED;
+};
 
 
 

--- a/include/deal.II/grid/tria_boundary_lib.h
+++ b/include/deal.II/grid/tria_boundary_lib.h
@@ -50,7 +50,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Guido Kanschat, 2001, Wolfgang Bangerth, 2007
  */
 template <int dim, int spacedim = dim>
-class CylinderBoundary : public StraightBoundary<dim,spacedim>
+class DEAL_II_DEPRECATED CylinderBoundary : public StraightBoundary<dim,spacedim>
 {
 public:
   /**
@@ -159,7 +159,7 @@ private:
    * Given a number for the axis, return a vector that denotes this direction.
    */
   static Point<spacedim> get_axis_vector (const unsigned int axis);
-} DEAL_II_DEPRECATED;
+};
 
 
 
@@ -200,7 +200,7 @@ private:
  * @author Markus B&uuml;rg, 2009
  */
 template <int dim>
-class ConeBoundary : public StraightBoundary<dim>
+class DEAL_II_DEPRECATED ConeBoundary : public StraightBoundary<dim>
 {
 public:
   /**
@@ -315,7 +315,7 @@ private:
   get_intermediate_points_between_points (const Point<dim> &p0,
                                           const Point<dim> &p1,
                                           std::vector<Point<dim> > &points) const;
-} DEAL_II_DEPRECATED;
+};
 
 
 
@@ -341,7 +341,7 @@ private:
  * @author Wolfgang Bangerth, 1998, Ralf Hartmann, 2001
  */
 template <int dim, int spacedim=dim>
-class HyperBallBoundary : public StraightBoundary<dim,spacedim>
+class DEAL_II_DEPRECATED HyperBallBoundary : public StraightBoundary<dim,spacedim>
 {
 public:
   /**
@@ -462,7 +462,7 @@ private:
    */
   void get_intermediate_points_between_points (const Point<spacedim> &p0, const Point<spacedim> &p1,
                                                std::vector<Point<spacedim> > &points) const;
-} DEAL_II_DEPRECATED;
+};
 
 
 
@@ -483,7 +483,7 @@ private:
  * @author Wolfgang Bangerth, 1999, 2001
  */
 template <int dim>
-class HalfHyperBallBoundary : public HyperBallBoundary<dim>
+class DEAL_II_DEPRECATED HalfHyperBallBoundary : public HyperBallBoundary<dim>
 {
 public:
   /**
@@ -533,7 +533,7 @@ public:
   virtual void
   get_normals_at_vertices (const typename Triangulation<dim>::face_iterator &face,
                            typename Boundary<dim>::FaceVertexNormals &face_vertex_normals) const;
-} DEAL_II_DEPRECATED;
+};
 
 
 
@@ -551,7 +551,7 @@ public:
  * @author Wolfgang Bangerth, 1999
  */
 template <int dim>
-class HyperShellBoundary : public HyperBallBoundary<dim>
+class DEAL_II_DEPRECATED HyperShellBoundary : public HyperBallBoundary<dim>
 {
 public:
   /**
@@ -561,7 +561,7 @@ public:
    * radius as argument. This radius will be ignored
    */
   HyperShellBoundary (const Point<dim> &center = Point<dim>());
-} DEAL_II_DEPRECATED;
+};
 
 
 
@@ -582,7 +582,7 @@ public:
  * @author Wolfgang Bangerth, 2000, 2009
  */
 template <int dim>
-class HalfHyperShellBoundary : public HyperShellBoundary<dim>
+class DEAL_II_DEPRECATED HalfHyperShellBoundary : public HyperShellBoundary<dim>
 {
 public:
   /**
@@ -644,7 +644,7 @@ private:
    */
   const double inner_radius;
   const double outer_radius;
-} DEAL_II_DEPRECATED;
+};
 
 
 /**
@@ -659,7 +659,7 @@ private:
  * TorusManifold class.
  */
 template <int dim, int spacedim>
-class TorusBoundary : public Boundary<dim,spacedim>
+class DEAL_II_DEPRECATED TorusBoundary : public Boundary<dim,spacedim>
 {
 public:
   /**
@@ -741,7 +741,7 @@ private:
    */
   const double R;
   const double r;
-} DEAL_II_DEPRECATED;
+};
 
 
 

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -237,7 +237,8 @@ namespace hp
      *
      * @deprecated Use numbers::invalid_dof_index instead.
      */
-    static const types::global_dof_index invalid_dof_index DEAL_II_DEPRECATED = numbers::invalid_dof_index;
+    DEAL_II_DEPRECATED
+    static const types::global_dof_index invalid_dof_index = numbers::invalid_dof_index;
 
     /**
      * The default index of the finite element to be used on a given cell. For
@@ -648,7 +649,8 @@ namespace hp
      *
      * @deprecated Use get_fe_collection() instead.
      */
-    const hp::FECollection<dim,spacedim> &get_fe () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    const hp::FECollection<dim,spacedim> &get_fe () const;
 
     /**
      * Return a constant reference to the indexth finite element object that is

--- a/include/deal.II/integrators/divergence.h
+++ b/include/deal.II/integrators/divergence.h
@@ -427,10 +427,11 @@ namespace LocalIntegrators
      * @deprecated Use LocalIntegrators::GradDiv::cell_matrix() instead.
      */
     template <int dim>
+    DEAL_II_DEPRECATED
     void grad_div_matrix (
       FullMatrix<double> &M,
       const FEValuesBase<dim> &fe,
-      const double factor = 1.) DEAL_II_DEPRECATED;
+      const double factor = 1.);
 
     template <int dim>
     void grad_div_matrix (
@@ -445,11 +446,12 @@ namespace LocalIntegrators
      * @deprecated Use LocalIntegrators::GradDiv::cell_residual() instead.
      */
     template <int dim, typename number>
+    DEAL_II_DEPRECATED
     void grad_div_residual (
       Vector<number> &result,
       const FEValuesBase<dim> &fetest,
       const VectorSlice<const std::vector<std::vector<Tensor<1,dim> > > > &input,
-      const double factor = 1.) DEAL_II_DEPRECATED;
+      const double factor = 1.);
 
     template <int dim, typename number>
     void grad_div_residual (

--- a/include/deal.II/lac/block_matrix_array.h
+++ b/include/deal.II/lac/block_matrix_array.h
@@ -113,7 +113,7 @@ DEAL_II_NAMESPACE_OPEN
  * @date 2000-2005, 2010
  */
 template <typename number = double, typename BlockVectorType=BlockVector<number> >
-class BlockMatrixArray : public Subscriptor
+class DEAL_II_DEPRECATED BlockMatrixArray : public Subscriptor
 {
 public:
   /**
@@ -345,7 +345,7 @@ private:
    * number of blocks per row.
    */
   unsigned int block_cols;
-} DEAL_II_DEPRECATED;
+};
 
 /*@}*/
 
@@ -407,7 +407,7 @@ private:
  * @author Guido Kanschat, 2001, 2005
  */
 template <typename number = double, typename BlockVectorType = BlockVector<number> >
-class BlockTrianglePrecondition
+class DEAL_II_DEPRECATED BlockTrianglePrecondition
   : private BlockMatrixArray<number,BlockVectorType>
 {
 public:
@@ -521,7 +521,7 @@ private:
    * Flag for backward insertion.
    */
   bool backward;
-} DEAL_II_DEPRECATED;
+};
 
 
 #ifndef DOXYGEN

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -633,7 +633,8 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet arguments instead.
      */
-    BlockSparsityPattern (const std::vector<Epetra_Map> &parallel_partitioning) DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    BlockSparsityPattern (const std::vector<Epetra_Map> &parallel_partitioning);
 
     /**
      * Initialize the pattern with an array of index sets that specifies both
@@ -680,7 +681,8 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet arguments instead.
      */
-    void reinit (const std::vector<Epetra_Map> &parallel_partitioning) DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    void reinit (const std::vector<Epetra_Map> &parallel_partitioning);
 
     /**
      * Resize the matrix to a square tensor product of matrices. See the

--- a/include/deal.II/lac/filtered_matrix.h
+++ b/include/deal.II/lac/filtered_matrix.h
@@ -192,7 +192,7 @@ template <class VectorType> class FilteredMatrixBlock;
  * constrained_linear_operator().
  */
 template <typename VectorType>
-class FilteredMatrix : public Subscriptor
+class DEAL_II_DEPRECATED FilteredMatrix : public Subscriptor
 {
 public:
   class const_iterator;
@@ -413,8 +413,9 @@ public:
    * the second parameter to @p true to use a faster algorithm. Note: This
    * method is deprecated as matrix_is_symmetric parameter is no longer used.
    */
+  DEAL_II_DEPRECATED
   void apply_constraints (VectorType &v,
-                          const bool matrix_is_symmetric) const DEAL_II_DEPRECATED;
+                          const bool matrix_is_symmetric) const;
   /**
    * Apply the constraints to a right hand side vector. This needs to be done
    * before starting to solve with the filtered matrix.
@@ -542,7 +543,7 @@ private:
    * FilteredMatrixBlock accesses pre_filter() and post_filter().
    */
   friend class FilteredMatrixBlock<VectorType>;
-} DEAL_II_DEPRECATED;
+};
 
 /*@}*/
 /*---------------------- Inline functions -----------------------------------*/

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -345,19 +345,21 @@ namespace LinearAlgebra
        *
        * This function is deprecated.
        */
+      DEAL_II_DEPRECATED
       void equ (const Number a, const BlockVector<Number> &u,
-                const Number b, const BlockVector<Number> &v) DEAL_II_DEPRECATED;
+                const Number b, const BlockVector<Number> &v);
 
       /**
        * Scaling and multiple addition.
        *
        * This function is deprecated.
        */
+      DEAL_II_DEPRECATED
       void sadd (const Number               s,
                  const Number               a,
                  const BlockVector<Number> &V,
                  const Number               b,
-                 const BlockVector<Number> &W) DEAL_II_DEPRECATED;
+                 const BlockVector<Number> &W);
 
       /**
        * Return whether the vector contains only elements with value zero.

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -359,8 +359,9 @@ namespace LinearAlgebra
        * This function is deprecated. Use the interface through
        * ReadWriteVector instead.
        */
+      DEAL_II_DEPRECATED
       Vector<Number> &
-      operator = (const PETScWrappers::MPI::Vector &petsc_vec) DEAL_II_DEPRECATED;
+      operator = (const PETScWrappers::MPI::Vector &petsc_vec);
 #endif
 
 #ifdef DEAL_II_WITH_TRILINOS
@@ -375,8 +376,9 @@ namespace LinearAlgebra
        * This function is deprecated. Use the interface through
        * ReadWriteVector instead.
        */
+      DEAL_II_DEPRECATED
       Vector<Number> &
-      operator = (const TrilinosWrappers::MPI::Vector &trilinos_vec) DEAL_II_DEPRECATED;
+      operator = (const TrilinosWrappers::MPI::Vector &trilinos_vec);
 #endif
       //@}
 
@@ -737,19 +739,21 @@ namespace LinearAlgebra
        *
        * This function is deprecated.
        */
+      DEAL_II_DEPRECATED
       void sadd (const Number          s,
                  const Number          a,
                  const Vector<Number> &V,
                  const Number          b,
-                 const Vector<Number> &W) DEAL_II_DEPRECATED;
+                 const Vector<Number> &W);
 
       /**
        * Assignment <tt>*this = a*u + b*v</tt>.
        *
        * This function is deprecated.
        */
+      DEAL_II_DEPRECATED
       void equ (const Number a, const Vector<Number> &u,
-                const Number b, const Vector<Number> &v) DEAL_II_DEPRECATED;
+                const Number b, const Vector<Number> &v);
 
       //@}
 
@@ -772,7 +776,8 @@ namespace LinearAlgebra
        *
        * This function is deprecated.
        */
-      std::pair<size_type, size_type> local_range () const DEAL_II_DEPRECATED;
+      DEAL_II_DEPRECATED
+      std::pair<size_type, size_type> local_range () const;
 
       /**
        * Return true if the given global index is in the local range of this
@@ -780,14 +785,16 @@ namespace LinearAlgebra
        *
        * This function is deprecated.
        */
-      bool in_local_range (const size_type global_index) const DEAL_II_DEPRECATED;
+      DEAL_II_DEPRECATED
+      bool in_local_range (const size_type global_index) const;
 
       /**
        * Return the number of ghost elements present on the vector.
        *
        * This function is deprecated.
        */
-      size_type n_ghost_entries () const DEAL_II_DEPRECATED;
+      DEAL_II_DEPRECATED
+      size_type n_ghost_entries () const;
 
       /**
        * Return an index set that describes which elements of this vector are
@@ -796,7 +803,8 @@ namespace LinearAlgebra
        *
        * This function is deprecated.
        */
-      const IndexSet &ghost_elements() const DEAL_II_DEPRECATED;
+      DEAL_II_DEPRECATED
+      const IndexSet &ghost_elements() const;
 
       /**
        * Return whether the given global index is a ghost index on the
@@ -805,7 +813,8 @@ namespace LinearAlgebra
        *
        * This function is deprecated.
        */
-      bool is_ghost_entry (const types::global_dof_index global_index) const DEAL_II_DEPRECATED;
+      DEAL_II_DEPRECATED
+      bool is_ghost_entry (const types::global_dof_index global_index) const;
 
       /**
        * Make the @p Vector class a bit like the <tt>vector<></tt> class of

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -146,7 +146,7 @@ extern "C" {
  * @author Denis Davydov, 2015, 2017
  */
 template <typename VectorType>
-class PArpackSolver : public Subscriptor
+class  DEAL_II_DEPRECATED PArpackSolver : public Subscriptor
 {
 public:
   /**
@@ -256,7 +256,7 @@ public:
     const MatrixType &B;
     const double sigma;
 
-  } DEAL_II_DEPRECATED;
+  };
 
   /**
    * Standardized data struct to pipe additional data to the solver, should it

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -708,8 +708,9 @@ namespace PETScWrappers
      * matrix.
      * @deprecated Use the function with order of arguments reversed instead.
      */
+    DEAL_II_DEPRECATED
     MatrixBase &add (const MatrixBase &other,
-                     const PetscScalar factor) DEAL_II_DEPRECATED;
+                     const PetscScalar factor);
 
     /**
      * Matrix-vector multiplication: let <i>dst = M*src</i> with <i>M</i>

--- a/include/deal.II/lac/petsc_parallel_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_parallel_sparse_matrix.h
@@ -175,6 +175,7 @@ namespace PETScWrappers
        * @deprecated This constructor is deprecated: please use the
        * constructor with a sparsity pattern argument instead.
        */
+      DEAL_II_DEPRECATED
       SparseMatrix (const MPI_Comm  &communicator,
                     const size_type  m,
                     const size_type  n,
@@ -182,7 +183,7 @@ namespace PETScWrappers
                     const size_type  local_columns,
                     const size_type  n_nonzero_per_row,
                     const bool       is_symmetric = false,
-                    const size_type  n_offdiag_nonzero_per_row = 0) DEAL_II_DEPRECATED;
+                    const size_type  n_offdiag_nonzero_per_row = 0);
 
       /**
        * Initialize a rectangular matrix with @p m rows and @p n columns. The
@@ -207,6 +208,7 @@ namespace PETScWrappers
        * @deprecated This constructor is deprecated: please use the
        * constructor with a sparsity pattern argument instead.
        */
+      DEAL_II_DEPRECATED
       SparseMatrix (const MPI_Comm               &communicator,
                     const size_type               m,
                     const size_type               n,
@@ -214,7 +216,7 @@ namespace PETScWrappers
                     const size_type               local_columns,
                     const std::vector<size_type> &row_lengths,
                     const bool                    is_symmetric = false,
-                    const std::vector<size_type> &offdiag_row_lengths = std::vector<size_type>()) DEAL_II_DEPRECATED;
+                    const std::vector<size_type> &offdiag_row_lengths = std::vector<size_type>());
 
       /**
        * Initialize using the given sparsity pattern with communication
@@ -272,6 +274,7 @@ namespace PETScWrappers
        * @deprecated This overload of <code>reinit</code> is deprecated:
        * please use the overload with a sparsity pattern argument instead.
        */
+      DEAL_II_DEPRECATED
       void reinit (const MPI_Comm     &communicator,
                    const size_type m,
                    const size_type n,
@@ -279,7 +282,7 @@ namespace PETScWrappers
                    const size_type local_columns,
                    const size_type n_nonzero_per_row,
                    const bool      is_symmetric = false,
-                   const size_type n_offdiag_nonzero_per_row = 0) DEAL_II_DEPRECATED;
+                   const size_type n_offdiag_nonzero_per_row = 0);
 
       /**
        * Throw away the present matrix and generate one that has the same
@@ -289,6 +292,7 @@ namespace PETScWrappers
        * @deprecated This overload of <code>reinit</code> is deprecated:
        * please use the overload with a sparsity pattern argument instead.
        */
+      DEAL_II_DEPRECATED
       void reinit (const MPI_Comm               &communicator,
                    const size_type               m,
                    const size_type               n,
@@ -296,7 +300,7 @@ namespace PETScWrappers
                    const size_type               local_columns,
                    const std::vector<size_type> &row_lengths,
                    const bool                    is_symmetric = false,
-                   const std::vector<size_type> &offdiag_row_lengths = std::vector<size_type>()) DEAL_II_DEPRECATED;
+                   const std::vector<size_type> &offdiag_row_lengths = std::vector<size_type>());
 
       /**
        * Initialize using the given sparsity pattern with communication
@@ -419,13 +423,14 @@ namespace PETScWrappers
        * @deprecated This overload of <code>do_reinit</code> is deprecated:
        * please use the overload with a sparsity pattern argument instead.
        */
+      DEAL_II_DEPRECATED
       void do_reinit (const size_type m,
                       const size_type n,
                       const size_type local_rows,
                       const size_type local_columns,
                       const size_type n_nonzero_per_row,
                       const bool      is_symmetric = false,
-                      const size_type n_offdiag_nonzero_per_row = 0) DEAL_II_DEPRECATED;
+                      const size_type n_offdiag_nonzero_per_row = 0);
 
       /**
        * Same as previous function.
@@ -433,13 +438,14 @@ namespace PETScWrappers
        * @deprecated This overload of <code>do_reinit</code> is deprecated:
        * please use the overload with a sparsity pattern argument instead.
        */
+      DEAL_II_DEPRECATED
       void do_reinit (const size_type               m,
                       const size_type               n,
                       const size_type               local_rows,
                       const size_type               local_columns,
                       const std::vector<size_type> &row_lengths,
                       const bool                    is_symmetric = false,
-                      const std::vector<size_type> &offdiag_row_lengths = std::vector<size_type>()) DEAL_II_DEPRECATED;
+                      const std::vector<size_type> &offdiag_row_lengths = std::vector<size_type>());
 
       /**
        * Same as previous functions.

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -217,9 +217,10 @@ namespace PETScWrappers
        * @deprecated The use of objects that are explicitly of type VectorBase
        * is deprecated: use PETScWrappers::MPI::Vector instead.
        */
+      DEAL_II_DEPRECATED
       explicit Vector (const MPI_Comm     &communicator,
                        const VectorBase   &v,
-                       const size_type     local_size) DEAL_II_DEPRECATED;
+                       const size_type     local_size);
 
       /**
        * Construct a new parallel ghosted PETSc vector from an IndexSet.

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -163,17 +163,6 @@ namespace PETScWrappers
      */
     void initialize(const PreconditionerBase &preconditioner);
 
-    /**
-     * Exception.
-     *
-     * @deprecated This function has been deprecated in favor of the more
-     * general LACExceptions::ExcPETScError exception class.
-     */
-    DeclException1 (ExcPETScError,
-                    int,
-                    << "An error with error number " << arg1
-                    << " occurred while calling a PETSc function") DEAL_II_DEPRECATED;
-
   protected:
 
     /**

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -648,8 +648,9 @@ namespace PETScWrappers
      * If any of the <tt>b[i]</tt> is zero, the result is undefined. No
      * attempt is made to catch such situations.
      */
+    DEAL_II_DEPRECATED
     void ratio (const VectorBase &a,
-                const VectorBase &b) DEAL_II_DEPRECATED;
+                const VectorBase &b);
 
     /**
      * Prints the PETSc vector object values using PETSc internal vector

--- a/include/deal.II/lac/pointer_matrix.h
+++ b/include/deal.II/lac/pointer_matrix.h
@@ -50,7 +50,7 @@ template <typename number, typename BlockVectorType> class BlockMatrixArray;
  * @author Guido Kanschat, 2000, 2001, 2002
  */
 template <typename VectorType>
-class PointerMatrixBase : public Subscriptor
+class DEAL_II_DEPRECATED PointerMatrixBase : public Subscriptor
 {
 public:
   /**
@@ -98,7 +98,7 @@ public:
    */
   virtual void Tvmult_add (VectorType       &dst,
                            const VectorType &src) const = 0;
-} DEAL_II_DEPRECATED;
+};
 
 
 /**
@@ -114,7 +114,7 @@ public:
  * @author Guido Kanschat 2000, 2001, 2002
  */
 template <typename MatrixType, typename VectorType>
-class PointerMatrix : public PointerMatrixBase<VectorType>
+class DEAL_II_DEPRECATED PointerMatrix : public PointerMatrixBase<VectorType>
 {
 public:
   /**
@@ -196,7 +196,7 @@ private:
    * The pointer to the actual matrix.
    */
   SmartPointer<const MatrixType,PointerMatrix<MatrixType,VectorType> > m;
-} DEAL_II_DEPRECATED;
+};
 
 
 /**
@@ -216,7 +216,7 @@ private:
  * @author Guido Kanschat 2006
  */
 template <typename MatrixType, typename VectorType>
-class PointerMatrixAux : public PointerMatrixBase<VectorType>
+class DEAL_II_DEPRECATED PointerMatrixAux : public PointerMatrixBase<VectorType>
 {
 public:
   /**
@@ -318,7 +318,7 @@ private:
    * The pointer to the actual matrix.
    */
   SmartPointer<const MatrixType,PointerMatrixAux<MatrixType,VectorType> > m;
-} DEAL_II_DEPRECATED;
+};
 
 
 
@@ -335,7 +335,7 @@ private:
  * @author Guido Kanschat, 2006
  */
 template <typename number>
-class PointerMatrixVector : public PointerMatrixBase<Vector<number> >
+class DEAL_II_DEPRECATED PointerMatrixVector : public PointerMatrixBase<Vector<number> >
 {
 public:
   /**
@@ -431,7 +431,7 @@ private:
    * The pointer to the actual matrix.
    */
   SmartPointer<const Vector<number>,PointerMatrixVector<number> > m;
-} DEAL_II_DEPRECATED;
+};
 
 
 

--- a/include/deal.II/lac/slepc_solver.h
+++ b/include/deal.II/lac/slepc_solver.h
@@ -208,9 +208,10 @@ namespace SLEPcWrappers
     /**
      * Set the initial vector for the solver.
      */
+    DEAL_II_DEPRECATED
     void
     set_initial_vector
-    (const PETScWrappers::VectorBase &this_initial_vector) DEAL_II_DEPRECATED;
+    (const PETScWrappers::VectorBase &this_initial_vector);
 
     /**
      * Set the initial vector space for the solver.

--- a/include/deal.II/lac/swappable_vector.h
+++ b/include/deal.II/lac/swappable_vector.h
@@ -55,7 +55,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Wolfgang Bangerth, 1999, 2000
  */
 template <typename number>
-class SwappableVector : public Vector<number>
+class DEAL_II_DEPRECATED SwappableVector : public Vector<number>
 {
 public:
   /**
@@ -212,7 +212,7 @@ private:
    * to signal success itself if this is required.
    */
   void reload_vector (const bool set_flag);
-} DEAL_II_DEPRECATED;
+};
 
 /*@}*/
 /*----------------------------   swappable_vector.h     ---------------------------*/

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -183,9 +183,10 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet arguments instead.
      */
+    DEAL_II_DEPRECATED
     void reinit (const std::vector<Epetra_Map>             &input_maps,
                  const ::dealii::BlockSparseMatrix<double> &deal_ii_sparse_matrix,
-                 const double                               drop_tolerance=1e-13) DEAL_II_DEPRECATED;
+                 const double                               drop_tolerance=1e-13);
 
     /**
      * This function initializes the Trilinos matrix using the deal.II sparse
@@ -238,7 +239,8 @@ namespace TrilinosWrappers
      * @deprecated Use the methods of the individual matrices based on
      * IndexSet arguments.
      */
-    std::vector<Epetra_Map> domain_partitioner () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    std::vector<Epetra_Map> domain_partitioner () const;
 
     /**
      * Return a vector of the underlying Trilinos Epetra_Map that sets the
@@ -249,7 +251,8 @@ namespace TrilinosWrappers
      * @deprecated Use the methods of the individual matrices based on
      * IndexSet arguments.
      */
-    std::vector<Epetra_Map> range_partitioner () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    std::vector<Epetra_Map> range_partitioner () const;
 
     /**
      * Return the partitioning of the domain space for the individual blocks of

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -666,8 +666,9 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     SparseMatrix (const Epetra_Map  &parallel_partitioning,
-                  const size_type    n_max_entries_per_row = 0) DEAL_II_DEPRECATED;
+                  const size_type    n_max_entries_per_row = 0);
 
     /**
      * Same as before, but now set a value of nonzeros for each matrix row.
@@ -678,8 +679,9 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     SparseMatrix (const Epetra_Map                &parallel_partitioning,
-                  const std::vector<unsigned int> &n_entries_per_row) DEAL_II_DEPRECATED;
+                  const std::vector<unsigned int> &n_entries_per_row);
 
     /**
      * This constructor is similar to the one above, but it now takes two
@@ -699,9 +701,10 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     SparseMatrix (const Epetra_Map &row_parallel_partitioning,
                   const Epetra_Map &col_parallel_partitioning,
-                  const size_type   n_max_entries_per_row = 0) DEAL_II_DEPRECATED;
+                  const size_type   n_max_entries_per_row = 0);
 
     /**
      * This constructor is similar to the one above, but it now takes two
@@ -719,9 +722,10 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     SparseMatrix (const Epetra_Map                &row_parallel_partitioning,
                   const Epetra_Map                &col_parallel_partitioning,
-                  const std::vector<unsigned int> &n_entries_per_row) DEAL_II_DEPRECATED;
+                  const std::vector<unsigned int> &n_entries_per_row);
 
     /**
      * This function is initializes the Trilinos Epetra matrix according to
@@ -750,9 +754,10 @@ namespace TrilinosWrappers
      * @deprecated Use the respective method with IndexSet argument instead.
      */
     template <typename SparsityPatternType>
+    DEAL_II_DEPRECATED
     void reinit (const Epetra_Map          &parallel_partitioning,
                  const SparsityPatternType &sparsity_pattern,
-                 const bool                 exchange_data = false) DEAL_II_DEPRECATED;
+                 const bool                 exchange_data = false);
 
     /**
      * This function is similar to the other initialization function above,
@@ -769,10 +774,11 @@ namespace TrilinosWrappers
      * @deprecated Use the respective method with IndexSet argument instead.
      */
     template <typename SparsityPatternType>
+    DEAL_II_DEPRECATED
     void reinit (const Epetra_Map          &row_parallel_partitioning,
                  const Epetra_Map          &col_parallel_partitioning,
                  const SparsityPatternType &sparsity_pattern,
-                 const bool                 exchange_data = false) DEAL_II_DEPRECATED;
+                 const bool                 exchange_data = false);
 
     /**
      * This function initializes the Trilinos matrix using the deal.II sparse
@@ -793,11 +799,12 @@ namespace TrilinosWrappers
      * @deprecated Use the respective method with IndexSet argument instead.
      */
     template <typename number>
+    DEAL_II_DEPRECATED
     void reinit (const Epetra_Map                     &parallel_partitioning,
                  const ::dealii::SparseMatrix<number> &dealii_sparse_matrix,
                  const double                          drop_tolerance=1e-13,
                  const bool                            copy_values=true,
-                 const ::dealii::SparsityPattern      *use_this_sparsity=nullptr) DEAL_II_DEPRECATED;
+                 const ::dealii::SparsityPattern      *use_this_sparsity=nullptr);
 
     /**
      * This function is similar to the other initialization function with
@@ -815,12 +822,13 @@ namespace TrilinosWrappers
      * @deprecated Use the respective method with IndexSet argument instead.
      */
     template <typename number>
+    DEAL_II_DEPRECATED
     void reinit (const Epetra_Map                      &row_parallel_partitioning,
                  const Epetra_Map                      &col_parallel_partitioning,
                  const ::dealii::SparseMatrix<number>  &dealii_sparse_matrix,
                  const double                           drop_tolerance=1e-13,
                  const bool                             copy_values=true,
-                 const ::dealii::SparsityPattern      *use_this_sparsity=nullptr) DEAL_II_DEPRECATED;
+                 const ::dealii::SparsityPattern      *use_this_sparsity=nullptr);
 //@}
     /**
      * @name Constructors and initialization using an IndexSet description
@@ -1727,7 +1735,8 @@ namespace TrilinosWrappers
      *
      * @deprecated Use locally_owned_domain_indices() instead.
      */
-    const Epetra_Map &domain_partitioner ()  const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    const Epetra_Map &domain_partitioner ()  const;
 
     /**
      * Return a const reference to the underlying Trilinos Epetra_Map that
@@ -1737,7 +1746,8 @@ namespace TrilinosWrappers
      *
      * @deprecated Use locally_owned_range_indices() instead.
      */
-    const Epetra_Map &range_partitioner () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    const Epetra_Map &range_partitioner () const;
 
     /**
      * Return a const reference to the underlying Trilinos Epetra_Map that
@@ -1746,7 +1756,8 @@ namespace TrilinosWrappers
      *
      * @deprecated Use locally_owned_range_indices() instead.
      */
-    const Epetra_Map &row_partitioner () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    const Epetra_Map &row_partitioner () const;
 
     /**
      * Return a const reference to the underlying Trilinos Epetra_Map that
@@ -1757,7 +1768,8 @@ namespace TrilinosWrappers
      * @deprecated Usually not necessary. If desired, access it via the
      * Epetra_CrsMatrix.
      */
-    const Epetra_Map &col_partitioner () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    const Epetra_Map &col_partitioner () const;
 //@}
 
     /**

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -419,8 +419,9 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     SparsityPattern (const Epetra_Map &parallel_partitioning,
-                     const size_type   n_entries_per_row = 0) DEAL_II_DEPRECATED;
+                     const size_type   n_entries_per_row = 0);
 
     /**
      * Same as before, but now use the exact number of nonzeros in each m row.
@@ -434,8 +435,9 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     SparsityPattern (const Epetra_Map             &parallel_partitioning,
-                     const std::vector<size_type> &n_entries_per_row) DEAL_II_DEPRECATED;
+                     const std::vector<size_type> &n_entries_per_row);
 
     /**
      * This constructor is similar to the one above, but it now takes two
@@ -455,9 +457,10 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     SparsityPattern (const Epetra_Map   &row_parallel_partitioning,
                      const Epetra_Map   &col_parallel_partitioning,
-                     const size_type     n_entries_per_row = 0) DEAL_II_DEPRECATED;
+                     const size_type     n_entries_per_row = 0);
 
     /**
      * This constructor is similar to the one above, but it now takes two
@@ -472,9 +475,10 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     SparsityPattern (const Epetra_Map             &row_parallel_partitioning,
                      const Epetra_Map             &col_parallel_partitioning,
-                     const std::vector<size_type> &n_entries_per_row) DEAL_II_DEPRECATED;
+                     const std::vector<size_type> &n_entries_per_row);
 
     /**
      * Reinitialization function for generating a square sparsity pattern
@@ -492,9 +496,10 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     void
     reinit (const Epetra_Map &parallel_partitioning,
-            const size_type   n_entries_per_row = 0) DEAL_II_DEPRECATED;
+            const size_type   n_entries_per_row = 0);
 
     /**
      * Same as before, but now use the exact number of nonzeros in each m row.
@@ -508,9 +513,10 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     void
     reinit (const Epetra_Map             &parallel_partitioning,
-            const std::vector<size_type> &n_entries_per_row) DEAL_II_DEPRECATED;
+            const std::vector<size_type> &n_entries_per_row);
 
     /**
      * This reinit function is similar to the one above, but it now takes two
@@ -530,10 +536,11 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     void
     reinit (const Epetra_Map   &row_parallel_partitioning,
             const Epetra_Map   &col_parallel_partitioning,
-            const size_type     n_entries_per_row = 0) DEAL_II_DEPRECATED;
+            const size_type     n_entries_per_row = 0);
 
     /**
      * This reinit function is similar to the one above, but it now takes two
@@ -548,10 +555,11 @@ namespace TrilinosWrappers
      *
      * @deprecated Use the respective method with IndexSet argument instead.
      */
+    DEAL_II_DEPRECATED
     void
     reinit (const Epetra_Map             &row_parallel_partitioning,
             const Epetra_Map             &col_parallel_partitioning,
-            const std::vector<size_type> &n_entries_per_row) DEAL_II_DEPRECATED;
+            const std::vector<size_type> &n_entries_per_row);
 
     /**
      * Reinit function. Takes one of the deal.II sparsity patterns and a
@@ -564,11 +572,12 @@ namespace TrilinosWrappers
      * @deprecated Use the respective method with IndexSet argument instead.
      */
     template <typename SparsityPatternType>
+    DEAL_II_DEPRECATED
     void
     reinit (const Epetra_Map          &row_parallel_partitioning,
             const Epetra_Map          &col_parallel_partitioning,
             const SparsityPatternType &nontrilinos_sparsity_pattern,
-            const bool                 exchange_data = false) DEAL_II_DEPRECATED;
+            const bool                 exchange_data = false);
 
     /**
      * Reinit function. Takes one of the deal.II sparsity patterns and a
@@ -581,10 +590,11 @@ namespace TrilinosWrappers
      * @deprecated Use the respective method with IndexSet argument instead.
      */
     template <typename SparsityPatternType>
+    DEAL_II_DEPRECATED
     void
     reinit (const Epetra_Map          &parallel_partitioning,
             const SparsityPatternType &nontrilinos_sparsity_pattern,
-            const bool                 exchange_data = false) DEAL_II_DEPRECATED;
+            const bool                 exchange_data = false);
 //@}
     /**
      * @name Constructors and initialization using an IndexSet description
@@ -949,7 +959,8 @@ namespace TrilinosWrappers
      *
      * @deprecated Use locally_owned_domain_indices() instead.
      */
-    const Epetra_Map &domain_partitioner () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    const Epetra_Map &domain_partitioner () const;
 
     /**
      * Return a const reference to the underlying Trilinos Epetra_Map that
@@ -959,7 +970,8 @@ namespace TrilinosWrappers
      *
      * @deprecated Use locally_owned_range_indices() instead.
      */
-    const Epetra_Map &range_partitioner () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    const Epetra_Map &range_partitioner () const;
 
     /**
      * Return a const reference to the underlying Trilinos Epetra_Map that
@@ -968,7 +980,8 @@ namespace TrilinosWrappers
      *
      * @deprecated Use locally_owned_range_indices() instead.
      */
-    const Epetra_Map &row_partitioner () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    const Epetra_Map &row_partitioner () const;
 
     /**
      * Return a const reference to the underlying Trilinos Epetra_Map that
@@ -979,14 +992,16 @@ namespace TrilinosWrappers
      * @deprecated Usually not necessary. If desired, access via the
      * Epetra_FECrsGraph.
      */
-    const Epetra_Map &col_partitioner () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    const Epetra_Map &col_partitioner () const;
 
     /**
      * Return a const reference to the communicator used for this object.
      *
      * @deprecated Use get_mpi_communicator instead.
      */
-    const Epetra_Comm &trilinos_communicator () const DEAL_II_DEPRECATED;
+    DEAL_II_DEPRECATED
+    const Epetra_Comm &trilinos_communicator () const;
 
     /**
      * Return the MPI communicator object in use with this matrix.

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -728,8 +728,9 @@ public:
    *
    * @dealiiOperationIsMultithreaded
    */
+  DEAL_II_DEPRECATED
   void ratio (const Vector<Number> &a,
-              const Vector<Number> &b) DEAL_II_DEPRECATED;
+              const Vector<Number> &b);
 
   /**
    * This function does nothing but exists for compatibility with the @p
@@ -749,7 +750,8 @@ public:
    *
    * This function is deprecated.
    */
-  void print (const char *format = nullptr) const DEAL_II_DEPRECATED;
+  DEAL_II_DEPRECATED
+  void print (const char *format = nullptr) const;
 
   /**
    * Print to a stream. @p precision denotes the desired precision with which
@@ -770,9 +772,10 @@ public:
    *
    * This function is deprecated.
    */
+  DEAL_II_DEPRECATED
   void print (LogStream &out,
               const unsigned int width = 6,
-              const bool across = true) const DEAL_II_DEPRECATED;
+              const bool across = true) const;
 
   /**
    * Write the vector en bloc to a file. This is done in a binary mode, so the

--- a/include/deal.II/lac/vector_view.h
+++ b/include/deal.II/lac/vector_view.h
@@ -130,7 +130,7 @@ DEAL_II_NAMESPACE_OPEN
  * @deprecated Use ArrayView instead.
  */
 template <typename Number>
-class VectorView : public Vector<Number>
+class DEAL_II_DEPRECATED VectorView : public Vector<Number>
 {
 public:
 
@@ -225,7 +225,7 @@ public:
    * called, and will throw an exception if you try to do so.
    */
   virtual void swap (Vector<Number> &v);
-} DEAL_II_DEPRECATED;
+};
 
 
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -333,12 +333,13 @@ public:
    * one provided by DoFHandler::locally_owned_dofs().
    */
   template <typename DoFHandlerType, typename QuadratureType>
+  DEAL_II_DEPRECATED
   void reinit (const Mapping<dim>     &mapping,
                const DoFHandlerType   &dof_handler,
                const ConstraintMatrix &constraint,
                const IndexSet         &locally_owned_dofs,
                const QuadratureType   &quad,
-               const AdditionalData    additional_data = AdditionalData()) DEAL_II_DEPRECATED;
+               const AdditionalData    additional_data = AdditionalData());
 
   /**
    * Extracts the information needed to perform loops over cells. The
@@ -385,12 +386,13 @@ public:
    * one provided by DoFHandler::locally_owned_dofs().
    */
   template <typename DoFHandlerType, typename QuadratureType>
+  DEAL_II_DEPRECATED
   void reinit (const Mapping<dim>                          &mapping,
                const std::vector<const DoFHandlerType *>   &dof_handler,
                const std::vector<const ConstraintMatrix *> &constraint,
                const std::vector<IndexSet>                 &locally_owned_set,
                const std::vector<QuadratureType>           &quad,
-               const AdditionalData                        additional_data = AdditionalData()) DEAL_II_DEPRECATED;
+               const AdditionalData                        additional_data = AdditionalData());
 
   /**
    * Initializes the data structures. Same as before, but now the index set

--- a/include/deal.II/multigrid/mg_block_smoother.h
+++ b/include/deal.II/multigrid/mg_block_smoother.h
@@ -54,12 +54,13 @@ public:
    *
    * Constructor. Sets memory and smoothing parameters.
    */
+  DEAL_II_DEPRECATED
   MGSmootherBlock (VectorMemory<BlockVector<number> > &mem,
                    const unsigned int                   steps     = 1,
                    const bool                           variable  = false,
                    const bool                           symmetric = false,
                    const bool                           transpose = false,
-                   const bool                           reverse   = false) DEAL_II_DEPRECATED;
+                   const bool                           reverse   = false);
 
   /**
    * Constructor.

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -87,7 +87,7 @@ private:
  * @author Guido Kanschat, 1999, Ralf Hartmann, 2002.
  */
 template <typename SolverType, class VectorType = Vector<double> >
-class MGCoarseGridLACIteration :  public MGCoarseGridBase<VectorType>
+class DEAL_II_DEPRECATED MGCoarseGridLACIteration :  public MGCoarseGridBase<VectorType>
 {
 public:
   /**
@@ -153,7 +153,7 @@ private:
    */
   LinearOperator<VectorType> precondition;
 
-} DEAL_II_DEPRECATED;
+};
 
 
 

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -74,9 +74,10 @@ public:
    * @deprecated Use initialize() followed by make_zero_boundary_constraints() instead
    */
   template <int dim, int spacedim>
+  DEAL_II_DEPRECATED
   void initialize(const DoFHandler<dim,spacedim> &dof,
                   const typename FunctionMap<dim>::type &function_map,
-                  const ComponentMask &component_mask = ComponentMask()) DEAL_II_DEPRECATED;
+                  const ComponentMask &component_mask = ComponentMask());
 
   /**
    * Fill the internal data structures with information

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -528,8 +528,9 @@ public:
    *
    * @deprecated @p constraints is unused.
    */
+  DEAL_II_DEPRECATED
   MGTransferPrebuilt (const ConstraintMatrix &constraints,
-                      const MGConstrainedDoFs &mg_constrained_dofs) DEAL_II_DEPRECATED;
+                      const MGConstrainedDoFs &mg_constrained_dofs);
 
   /**
    * Destructor.
@@ -546,8 +547,9 @@ public:
    *
    * @deprecated @p constraints is unused.
    */
+  DEAL_II_DEPRECATED
   void initialize_constraints (const ConstraintMatrix &constraints,
-                               const MGConstrainedDoFs &mg_constrained_dofs) DEAL_II_DEPRECATED;
+                               const MGConstrainedDoFs &mg_constrained_dofs);
 
   /**
    * Reset the object to the state it had right after the default constructor.

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -76,8 +76,9 @@ public:
    *
    * @deprecated @p constraints is unused.
    */
+  DEAL_II_DEPRECATED
   MGTransferBlockBase (const ConstraintMatrix &constraints,
-                       const MGConstrainedDoFs &mg_constrained_dofs) DEAL_II_DEPRECATED;
+                       const MGConstrainedDoFs &mg_constrained_dofs);
 
   /**
    * Memory used by this object.
@@ -319,8 +320,9 @@ public:
    *
    * @deprecated @p constraints is unused.
    */
+  DEAL_II_DEPRECATED
   MGTransferBlockSelect (const ConstraintMatrix &constraints,
-                         const MGConstrainedDoFs &mg_constrained_dofs) DEAL_II_DEPRECATED;
+                         const MGConstrainedDoFs &mg_constrained_dofs);
 
   /**
    * Destructor.

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -93,6 +93,7 @@ public:
    * The DoFHandler is actually not needed.
    */
   template <int dim>
+  DEAL_II_DEPRECATED
   Multigrid(const DoFHandler<dim>              &mg_dof_handler,
             const MGMatrixBase<VectorType>     &matrix,
             const MGCoarseGridBase<VectorType> &coarse,
@@ -101,7 +102,7 @@ public:
             const MGSmootherBase<VectorType>   &post_smooth,
             const unsigned int                 minlevel = 0,
             const unsigned int                 maxlevel = numbers::invalid_unsigned_int,
-            Cycle                              cycle = v_cycle) DEAL_II_DEPRECATED;
+            Cycle                              cycle = v_cycle);
 
   /**
    * Constructor. <tt>transfer</tt> is an object performing prolongation and

--- a/include/deal.II/opencascade/boundary_lib.h
+++ b/include/deal.II/opencascade/boundary_lib.h
@@ -66,7 +66,7 @@ namespace OpenCASCADE
    * @author Luca Heltai, Andrea Mola, 2011--2014.
    */
   template <int dim, int spacedim>
-  class NormalProjectionBoundary : public Boundary<dim,spacedim>
+  class DEAL_II_DEPRECATED NormalProjectionBoundary : public Boundary<dim,spacedim>
   {
   public:
 
@@ -107,7 +107,7 @@ namespace OpenCASCADE
      * Relative tolerance used by this class to compute distances.
      */
     const double tolerance;
-  } DEAL_II_DEPRECATED;
+  };
 
   /**
    * A Boundary object based on OpenCASCADE TopoDS_Shape where new points are
@@ -134,7 +134,7 @@ namespace OpenCASCADE
    * @author Luca Heltai, Andrea Mola, 2011--2014.
    */
   template <int dim, int spacedim>
-  class DirectionalProjectionBoundary : public Boundary<dim,spacedim>
+  class DEAL_II_DEPRECATED DirectionalProjectionBoundary : public Boundary<dim,spacedim>
   {
   public:
     /**
@@ -176,7 +176,7 @@ namespace OpenCASCADE
      * Relative tolerance used by this class to compute distances.
      */
     const double tolerance;
-  } DEAL_II_DEPRECATED;
+  };
 
 
   /**
@@ -227,7 +227,7 @@ namespace OpenCASCADE
    * @author Luca Heltai, Andrea Mola, 2011--2014.
    */
   template <int dim, int spacedim>
-  class NormalToMeshProjectionBoundary : public Boundary<dim,spacedim>
+  class DEAL_II_DEPRECATED NormalToMeshProjectionBoundary : public Boundary<dim,spacedim>
   {
   public:
     /**
@@ -261,7 +261,7 @@ namespace OpenCASCADE
      * Relative tolerance used by this class to compute distances.
      */
     const double tolerance;
-  } DEAL_II_DEPRECATED;
+  };
 
   /**
    * A Boundary object based on OpenCASCADE TopoDS_Shape objects which have


### PR DESCRIPTION
C++14 provides using the attribute `[[deprecated]]` a standardized way of deprecating code.
For compatibility with `__attribute__ ((deprecated))` we used before, we need to move the location
of `DEAL_II_DEPRECATED` for classes and functions.