### PR TITLE
Add header to tests using Sacado::Rad.

### DIFF
--- a/tests/sacado/basic_01a.cc
+++ b/tests/sacado/basic_01a.cc
@@ -23,6 +23,7 @@
 #include "../tests.h"
 
 #include <Sacado.hpp>
+#include <Sacado_trad.hpp>
 
 // The function to differentiate
 template <typename NumberType>

--- a/tests/sacado/basic_01b.cc
+++ b/tests/sacado/basic_01b.cc
@@ -25,6 +25,7 @@
 #include "../tests.h"
 
 #include <Sacado.hpp>
+#include <Sacado_trad.hpp>
 
 // The functions to differentiate
 template <typename NumberType>

--- a/tests/sacado/basic_02a.cc
+++ b/tests/sacado/basic_02a.cc
@@ -26,6 +26,7 @@
 #include "../tests.h"
 
 #include <Sacado.hpp>
+#include <Sacado_trad.hpp>
 
 // The function to differentiate
 template <typename NumberType, typename NumberType2>

--- a/tests/sacado/basic_02b.cc
+++ b/tests/sacado/basic_02b.cc
@@ -29,6 +29,7 @@
 #include "../tests.h"
 
 #include <Sacado.hpp>
+#include <Sacado_trad.hpp>
 
 // The function to differentiate
 template <typename NumberType, typename NumberType2>


### PR DESCRIPTION
For some older versions of Trilinos, the header for templated
Sacado::Rad numbers is missing from Sacado.hpp.

Fixes #5455 