### PR TITLE
Fix numerics/project_03

### DIFF
--- a/tests/numerics/project_03.cc
+++ b/tests/numerics/project_03.cc
@@ -40,6 +40,8 @@ template <int dim>
 class F : public Function<dim>
 {
 public:
+  F () {};
+
   virtual double value (const Point<dim> &p,
                         const unsigned int = 0) const
   {


### PR DESCRIPTION
Fixes the failing test `numerics/project_03` on [clang-3.7.0](https://cdash.kyomu.43-1.org/testDetails.php?test=56915431&build=13205).
This bases on the [core language issue 253](http://open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#253).
