### PR TITLE
suppress use of ROL for older versions of Trilinos

### DIFF
--- a/cmake/configure/configure_2_trilinos.cmake
+++ b/cmake/configure/configure_2_trilinos.cmake
@@ -66,6 +66,15 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
       ENDIF()
     ENDFOREACH()
 
+    IF(${DEAL_II_TRILINOS_WITH_ROL})
+      IF(TRILINOS_VERSION VERSION_LESS 12.6.1)
+        MESSAGE(STATUS "ROL interface is disabled."
+          "deal.II will not support ROL interface if Trilinos version is less "
+          "than 12.6.1. Trilinos version found: \"${TRILINOS_VERSION}\".")
+          SET(DEAL_II_TRILINOS_WITH_ROL OFF)
+      ENDIF()
+    ENDIF()
+
     IF((TRILINOS_VERSION_MAJOR EQUAL 11 AND
         NOT (TRILINOS_VERSION_MINOR LESS 14))
        OR

--- a/doc/external-libs/trilinos.html
+++ b/doc/external-libs/trilinos.html
@@ -64,6 +64,7 @@
         <li> Ifpack,
         <li> ML,
         <li> MueLu (if using Trilinos 11.14 or newer),
+        <li> ROL,
         <li> Sacado, and
         <li> Teuchos.
       </ul>
@@ -86,6 +87,7 @@
     -DTrilinos_ENABLE_Teuchos=ON                     \
     -DTrilinos_ENABLE_MueLu=ON                       \
     -DTrilinos_ENABLE_ML=ON                          \
+    -DTrilinos_ENABLE_ROL=ON                         \
     -DTrilinos_VERBOSE_CONFIGURE=OFF                 \
     -DTPL_ENABLE_MPI=ON                              \
     -DBUILD_SHARED_LIBS=ON                           \


### PR DESCRIPTION
To fix #5456 