### PR TITLE
Fix search for the cell of a vertex

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1623,7 +1623,10 @@ next_cell:
             vertex_to_point = p - mesh.get_vertices()[closest_vertex_index];
           }
 
-        vertex_to_point /= vertex_to_point.norm();
+        const double vertex_point_norm = vertex_to_point.norm();
+        if (vertex_point_norm > 0)
+          vertex_to_point /= vertex_point_norm;
+
         const unsigned int n_neighbor_cells = vertex_to_cells[closest_vertex_index].size();
 
         // Create a corresponding map of vectors from vertex to cell center


### PR DESCRIPTION
Something I noticed while working on #5125. If we look for the cell of a vertex location, we can not normalize the vector (closest vertex)->point, because it is 0. The algorithm will return a correct result anyway, since it will simply pick one of the cells adjacent to the vertex, this change just avoids the division by zero.