### PR TITLE
Add math headers for AD numbers

### DIFF
--- a/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
+++ b/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
@@ -73,6 +73,8 @@
  *   use Adol-C numbers.
  * - adolc_product_types.h: Defines some product and scalar types that allow the use of
  *   Adol-C numbers in conjunction with the Tensor and SymmetricTensor classes.
+ * - sacado_math.h: Extension of the sacado math operations that allow these numbers to be used
+ *   consistently throughout the library.
  * - sacado_number_types.h: Implementation of the internal classes that define how we
  *   use the supported Sacado numbers.
  * - sacado_product_types.h: Defines some product and scalar types that allow the use of

--- a/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
+++ b/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
@@ -67,6 +67,8 @@
  *   provide a uniform interface to the classes through the NumberTraits and ADNumberTraits
  *   classes which are extensively used throughout of drivers. We also provide some mechanisms
  *   to easily query select properties of these numbers, i.e. some type traits.
+ * - adolc_math.h: Extension of the Adol-C math operations that allow these numbers to be used
+ *   consistently throughout the library.
  * - adolc_number_types.h: Implementation of the internal classes that define how we
  *   use Adol-C numbers.
  * - adolc_product_types.h: Defines some product and scalar types that allow the use of

--- a/include/deal.II/differentiation/ad.h
+++ b/include/deal.II/differentiation/ad.h
@@ -27,6 +27,7 @@
 #include <deal.II/differentiation/ad/adolc_number_types.h>
 #include <deal.II/differentiation/ad/adolc_product_types.h>
 
+#include <deal.II/differentiation/ad/sacado_math.h>
 #include <deal.II/differentiation/ad/sacado_number_types.h>
 #include <deal.II/differentiation/ad/sacado_product_types.h>
 

--- a/include/deal.II/differentiation/ad.h
+++ b/include/deal.II/differentiation/ad.h
@@ -23,6 +23,7 @@
 #include <deal.II/differentiation/ad/ad_number_types.h>
 #include <deal.II/differentiation/ad/ad_number_traits.h>
 
+#include <deal.II/differentiation/ad/adolc_math.h>
 #include <deal.II/differentiation/ad/adolc_number_types.h>
 #include <deal.II/differentiation/ad/adolc_product_types.h>
 

--- a/include/deal.II/differentiation/ad/adolc_math.h
+++ b/include/deal.II/differentiation/ad/adolc_math.h
@@ -1,0 +1,142 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_differentiation_ad_adolc_math_h
+#define dealii_differentiation_ad_adolc_math_h
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_ADOLC
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <adolc/internal/adolc_settings.h>
+#include <adolc/internal/adubfunc.h> // Taped double math functions
+
+#include <adolc/adouble.h> // Taped double
+#include <adolc/adtl.h>    // Tapeless double
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
+
+#ifndef DOXYGEN
+
+/**
+ * Import Adol-C math operations into standard namespace. This gives us the
+ * ability to use them within the Tensor class, and it also allows the user
+ * to write generic code and switch between AD number types.
+ *
+ * The math functions to be exposed come from the Adol-C's taped
+ * (anonymous) and tapeless namespaces.
+ */
+namespace std
+{
+
+  /**
+   * Make a unary function with one name available under a different name
+   */
+#define DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION_COPY(func_to, func_from) \
+  inline adouble func_to(const adouble &x) {return func_from(static_cast<const badouble &>(x));} \
+  inline adtl::adouble func_to(const adtl::adouble &x) {return adtl::func_from(x);}
+
+  /**
+   * Expose a unary function
+   */
+#define DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(func) \
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION_COPY(func,func)
+
+  /**
+   * Make a binary function with one name available under a different name
+   */
+#define DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY(func_to,func_from) \
+  inline adouble func_to(const adouble &x, const adouble &y) {return func_from(static_cast<const badouble &>(x),static_cast<const badouble &>(y));} \
+  inline adouble func_to(const double &x,  const adouble &y) {return func_from(x,static_cast<const badouble &>(y));} \
+  inline adouble func_to(const adouble &x, const double  &y) {return func_from(static_cast<const badouble &>(x),y);} \
+  inline adtl::adouble func_to(const adtl::adouble &x, const adtl::adouble &y) {return adtl::func_from(x,y);} \
+  inline adtl::adouble func_to(const double &x, const adtl::adouble &y) {return adtl::func_from(x,y);} \
+  inline adtl::adouble func_to(const adtl::adouble &x, const double &y) {return adtl::func_from(x,y);}
+
+  /**
+   * Expose a binary function
+   */
+#define DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION(func) \
+  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY(func,func)
+
+  /**
+   * Expose a binary function
+   */
+#define DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_2(func) \
+  inline adouble func(const adouble &x, const adouble &y) {return func(static_cast<const badouble &>(x),static_cast<const badouble &>(y));} \
+  inline adtl::adouble func(const adtl::adouble &x, const adtl::adouble &y) {return adtl::func(x,y);}
+
+  // See
+  // https://gitlab.com/adol-c/adol-c/blob/master/ADOL-C/include/adolc/adouble.h
+  // https://gitlab.com/adol-c/adol-c/blob/master/ADOL-C/include/adolc/internal/paramfunc.h
+
+  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION(pow)
+  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION(fmax)
+  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY(max,fmax)
+  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION(fmin)
+  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY(min,fmin)
+
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(exp)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(log)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(log10)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(sqrt)
+#if defined(DEAL_II_ADOLC_WITH_ATRIG_ERF)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(erf)
+  inline adouble erfc(const adouble &x)
+  {
+    return 1.0 - std::erf(x);
+  } \
+  inline adtl::adouble erfc(const adtl::adouble &x)
+  {
+    return 1.0 - std::erf(x);
+  }
+#endif
+
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(fabs)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION_COPY(abs,fabs)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(ceil)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(floor)
+
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(sin)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(cos)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(tan)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(asin)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(acos)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(atan)
+  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_2(atan2)
+
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(sinh)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(cosh)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(tanh)
+#if defined(DEAL_II_ADOLC_WITH_ATRIG_ERF)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(asinh)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(acosh)
+  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(atanh)
+#endif
+
+#undef DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_2
+#undef DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION
+#undef DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY
+#undef DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION
+#undef DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION_COPY
+
+} // namespace std
+
+#endif // DOXYGEN
+
+#endif // DEAL_II_WITH_ADOLC
+
+#endif

--- a/include/deal.II/differentiation/ad/sacado_math.h
+++ b/include/deal.II/differentiation/ad/sacado_math.h
@@ -1,0 +1,96 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_differentiation_ad_sacado_math_h
+#define dealii_differentiation_ad_sacado_math_h
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_TRILINOS
+
+#include <deal.II/base/numbers.h>
+#include <deal.II/differentiation/ad/ad_number_traits.h>
+#include <deal.II/differentiation/ad/sacado_number_types.h>
+
+
+#ifndef DOXYGEN
+
+/**
+ * Define some missing fundamental math functions
+ */
+namespace std
+{
+
+  /**
+   * Implementation of the error function for real-valued Sacado numbers.
+   */
+  template<typename ADNumberType, typename = typename std::enable_if<
+             dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value &&
+             dealii::Differentiation::AD::is_real_valued_ad_number<ADNumberType>::value
+             >::type>
+  inline ADNumberType erf(ADNumberType x)
+  {
+    // Reference:
+    // Handbook of Mathematical Functions: with Formulas, Graphs, and Mathematical Tables
+    // Abramowitz, M. and Stegun, I.
+    // Dover Books on Mathematics. 1972.
+    //
+    // Current implementation source:
+    // https://www.johndcook.com/blog/cpp_erf/
+    // https://www.johndcook.com/blog/2009/01/19/stand-alone-error-function-erf/
+    //
+    // Note: This implementation has a reported maximum round-off error of 1.5e-7.
+
+    // Constants
+    const double a1 =  0.254829592;
+    const double a2 = -0.284496736;
+    const double a3 =  1.421413741;
+    const double a4 = -1.453152027;
+    const double a5 =  1.061405429;
+    const double p  =  0.3275911;
+
+    // Save the sign of x
+    const bool neg_val = (x < dealii::internal::NumberType<ADNumberType>::value(0.0) ? true : false);
+    x = std::fabs(x);
+
+    // Abramowitz1972a equation 7.1.26
+    const ADNumberType t = 1.0/(1.0 + p*x);
+    const ADNumberType y = 1.0 - (((((a5*t + a4)*t) + a3)*t + a2)*t + a1)*t*std::exp(-x*x);
+
+    if (!neg_val)
+      return y;
+    else
+      return -y;
+  }
+
+
+  /**
+   * Implementation of the complementary error function for Sacado numbers.
+   */
+  template<typename ADNumberType, typename = typename std::enable_if<
+             dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value
+             >::type>
+  inline ADNumberType erfc(const ADNumberType &x)
+  {
+    return 1.0 - std::erf(x);
+  }
+
+} // namespace std
+
+#endif // DOXYGEN
+
+#endif // DEAL_II_WITH_TRILINOS
+
+#endif


### PR DESCRIPTION
Extension of some math operations for AD numbers. In the case of Adol-C numbers, we also import the math operations into the standard namespace (like Sacado does).