### PR TITLE
Add support for AD calculations to FEValues functions 

### DIFF
--- a/include/deal.II/differentiation/ad.h
+++ b/include/deal.II/differentiation/ad.h
@@ -18,8 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-#if defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_WITH_TRILINOS)
-
 #include <deal.II/differentiation/ad/ad_number_types.h>
 #include <deal.II/differentiation/ad/ad_number_traits.h>
 
@@ -54,7 +52,5 @@ namespace Differentiation
 }
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif
 
 #endif

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -16,8 +16,10 @@
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/multithread_info.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/signaling_nan.h>
+#include <deal.II/differentiation/ad.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/la_vector.h>
@@ -40,8 +42,6 @@
 #include <memory>
 #include <type_traits>
 
-#include <deal.II/differentiation/ad/adolc_product_types.h>
-#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include <boost/container/small_vector.hpp>
 
@@ -480,8 +480,12 @@ namespace FEValuesViews
         if (shape_function_data[shape_function].is_nonzero_shape_function_component)
           {
             const Number &value = dof_values[shape_function];
-            if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-              continue;
+            // For auto-differentiable numbers, the fact that a DoF value is zero
+            // does not imply that its derivatives are zero as well. So we
+            // can't filter by value for these number types.
+            if (!Differentiation::AD::is_ad_number<Number>::value)
+              if (value == dealii::internal::NumberType<Number>::value(0.0) )
+                continue;
 
             const double *shape_value_ptr =
               &shape_values(shape_function_data[shape_function].row_index, 0);
@@ -514,8 +518,12 @@ namespace FEValuesViews
         if (shape_function_data[shape_function].is_nonzero_shape_function_component)
           {
             const Number &value = dof_values[shape_function];
-            if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-              continue;
+            // For auto-differentiable numbers, the fact that a DoF value is zero
+            // does not imply that its derivatives are zero as well. So we
+            // can't filter by value for these number types.
+            if (!Differentiation::AD::is_ad_number<Number>::value)
+              if (value == dealii::internal::NumberType<Number>::value(0.0) )
+                continue;
 
             const dealii::Tensor<order,spacedim> *shape_derivative_ptr =
               &shape_derivatives[shape_function_data[shape_function].row_index][0];
@@ -547,8 +555,12 @@ namespace FEValuesViews
         if (shape_function_data[shape_function].is_nonzero_shape_function_component)
           {
             const Number &value = dof_values[shape_function];
-            if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-              continue;
+            // For auto-differentiable numbers, the fact that a DoF value is zero
+            // does not imply that its derivatives are zero as well. So we
+            // can't filter by value for these number types.
+            if (!Differentiation::AD::is_ad_number<Number>::value)
+              if (value == dealii::internal::NumberType<Number>::value(0.0))
+                continue;
 
             const dealii::Tensor<2,spacedim> *shape_hessian_ptr =
               &shape_hessians[shape_function_data[shape_function].row_index][0];
@@ -585,8 +597,12 @@ namespace FEValuesViews
             continue;
 
           const Number &value = dof_values[shape_function];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (snc != -1)
             {
@@ -635,8 +651,12 @@ namespace FEValuesViews
             continue;
 
           const Number &value = dof_values[shape_function];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (snc != -1)
             {
@@ -689,8 +709,12 @@ namespace FEValuesViews
             continue;
 
           const Number &value = dof_values[shape_function];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (snc != -1)
             {
@@ -742,8 +766,12 @@ namespace FEValuesViews
             continue;
 
           const Number &value = dof_values[shape_function];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (snc != -1)
             {
@@ -804,8 +832,12 @@ namespace FEValuesViews
 
               const Number &value = dof_values[shape_function];
 
-              if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-                continue;
+              // For auto-differentiable numbers, the fact that a DoF value is zero
+              // does not imply that its derivatives are zero as well. So we
+              // can't filter by value for these number types.
+              if (!Differentiation::AD::is_ad_number<Number>::value)
+                if (value == dealii::internal::NumberType<Number>::value(0.0))
+                  continue;
 
               if (snc != -1)
                 {
@@ -864,8 +896,12 @@ namespace FEValuesViews
 
               const Number &value = dof_values[shape_function];
 
-              if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-                continue;
+              // For auto-differentiable numbers, the fact that a DoF value is zero
+              // does not imply that its derivatives are zero as well. So we
+              // can't filter by value for these number types.
+              if (!Differentiation::AD::is_ad_number<Number>::value)
+                if (value == dealii::internal::NumberType<Number>::value(0.0))
+                  continue;
 
               if (snc != -1)
                 {
@@ -986,8 +1022,12 @@ namespace FEValuesViews
             continue;
 
           const Number &value = dof_values[shape_function];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (snc != -1)
             {
@@ -1040,8 +1080,12 @@ namespace FEValuesViews
             continue;
 
           const Number &value = dof_values[shape_function];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (snc != -1)
             {
@@ -1094,8 +1138,12 @@ namespace FEValuesViews
             continue;
 
           const Number &value = dof_values[shape_function];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (snc != -1)
             {
@@ -1182,8 +1230,12 @@ namespace FEValuesViews
             continue;
 
           const Number &value = dof_values[shape_function];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (snc != -1)
             {
@@ -1238,8 +1290,12 @@ namespace FEValuesViews
             continue;
 
           const Number &value = dof_values[shape_function];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (snc != -1)
             {
@@ -2687,8 +2743,12 @@ namespace internal
     for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
       {
         const Number2 value = dof_values_ptr[shape_func];
-        if (value == Number2())
-          continue;
+        // For auto-differentiable numbers, the fact that a DoF value is zero
+        // does not imply that its derivatives are zero as well. So we
+        // can't filter by value for these number types.
+        if (!Differentiation::AD::is_ad_number<Number2>::value)
+          if (value == dealii::internal::NumberType<Number2>::value(0.0))
+            continue;
 
         const double *shape_value_ptr = &shape_values(shape_func, 0);
         for (unsigned int point=0; point<n_quadrature_points; ++point)
@@ -2744,8 +2804,12 @@ namespace internal
       for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
         {
           const Number &value = dof_values_ptr[shape_func+mc*dofs_per_cell];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (fe.is_primitive(shape_func))
             {
@@ -2819,8 +2883,12 @@ namespace internal
     for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
       {
         const Number &value = dof_values_ptr[shape_func];
-        if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-          continue;
+        // For auto-differentiable numbers, the fact that a DoF value is zero
+        // does not imply that its derivatives are zero as well. So we
+        // can't filter by value for these number types.
+        if (!Differentiation::AD::is_ad_number<Number>::value)
+          if (value == dealii::internal::NumberType<Number>::value(0.0))
+            continue;
 
         const Tensor<order,spacedim> *shape_derivative_ptr
           = &shape_derivatives[shape_func][0];
@@ -2878,8 +2946,12 @@ namespace internal
       for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
         {
           const Number &value = dof_values_ptr[shape_func+mc*dofs_per_cell];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (fe.is_primitive(shape_func))
             {
@@ -2947,8 +3019,12 @@ namespace internal
     for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
       {
         const Number2 value = dof_values_ptr[shape_func];
-        if (value == Number2())
-          continue;
+        // For auto-differentiable numbers, the fact that a DoF value is zero
+        // does not imply that its derivatives are zero as well. So we
+        // can't filter by value for these number types.
+        if (!Differentiation::AD::is_ad_number<Number2>::value)
+          if (value == dealii::internal::NumberType<Number2>::value(0.0))
+            continue;
 
         const Tensor<2,spacedim> *shape_hessian_ptr
           = &shape_hessians[shape_func][0];
@@ -3005,8 +3081,12 @@ namespace internal
       for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
         {
           const Number &value = dof_values_ptr[shape_func+mc*dofs_per_cell];
-          if (value == dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0))
-            continue;
+          // For auto-differentiable numbers, the fact that a DoF value is zero
+          // does not imply that its derivatives are zero as well. So we
+          // can't filter by value for these number types.
+          if (!Differentiation::AD::is_ad_number<Number>::value)
+            if (value == dealii::internal::NumberType<Number>::value(0.0))
+              continue;
 
           if (fe.is_primitive(shape_func))
             {

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -473,7 +473,7 @@ namespace FEValuesViews
       AssertDimension (values.size(), n_quadrature_points);
 
       std::fill (values.begin(), values.end(),
-                 dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0));
+                 dealii::internal::NumberType<Number>::value(0.0));
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
@@ -529,7 +529,7 @@ namespace FEValuesViews
               &shape_derivatives[shape_function_data[shape_function].row_index][0];
             for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
               derivatives[q_point] += value *
-                                      typename ProductType<Number,dealii::Tensor<order,spacedim> >::type(*shape_derivative_ptr++);
+                                      dealii::Tensor<order,spacedim>(*shape_derivative_ptr++);
           }
     }
 
@@ -666,7 +666,7 @@ namespace FEValuesViews
                 &shape_derivatives[snc][0];
               for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
                 derivatives[q_point][comp] += value *
-                                              typename ProductType<Number,dealii::Tensor<order,spacedim> >::type(*shape_derivative_ptr++);
+                                              dealii::Tensor<order,spacedim>(*shape_derivative_ptr++);
             }
           else
             for (unsigned int d=0; d<spacedim; ++d)
@@ -677,7 +677,7 @@ namespace FEValuesViews
                                        row_index[d]][0];
                   for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
                     derivatives[q_point][d] += value *
-                                               typename ProductType<Number,dealii::Tensor<order,spacedim> >::type(*shape_derivative_ptr++);
+                                               dealii::Tensor<order,spacedim>(*shape_derivative_ptr++);
                 }
         }
     }
@@ -724,7 +724,7 @@ namespace FEValuesViews
                 &shape_gradients[snc][0];
               for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
                 symmetric_gradients[q_point] += value *
-                                                typename ProductType<Number,dealii::SymmetricTensor<2,spacedim> >::type (symmetrize_single_row(comp, *shape_gradient_ptr++));
+                                                dealii::SymmetricTensor<2,spacedim> (symmetrize_single_row(comp, *shape_gradient_ptr++));
             }
           else
             for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
@@ -831,7 +831,6 @@ namespace FEValuesViews
                 continue;
 
               const Number &value = dof_values[shape_function];
-
               // For auto-differentiable numbers, the fact that a DoF value is zero
               // does not imply that its derivatives are zero as well. So we
               // can't filter by value for these number types.
@@ -895,7 +894,6 @@ namespace FEValuesViews
                 continue;
 
               const Number &value = dof_values[shape_function];
-
               // For auto-differentiable numbers, the fact that a DoF value is zero
               // does not imply that its derivatives are zero as well. So we
               // can't filter by value for these number types.
@@ -2731,7 +2729,7 @@ namespace internal
 
     // initialize with zero
     std::fill_n (values.begin(), n_quadrature_points,
-                 dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0));
+                 dealii::internal::NumberType<Number>::value(0.0));
 
     // add up contributions of trial functions. note that here we deal with
     // scalar finite elements, so no need to check for non-primitivity of
@@ -3011,7 +3009,7 @@ namespace internal
 
     // initialize with zero
     std::fill_n (laplacians.begin(), n_quadrature_points,
-                 dealii::internal::NumberType<typename std::decay<Number>::type>::value(0.0));
+                 dealii::internal::NumberType<Number>::value(0.0));
 
     // add up contributions of trial functions. note that here we deal with
     // scalar finite elements and also note that the Laplacian is

--- a/tests/sacado/zero_val_nonzero_deriv_01.cc
+++ b/tests/sacado/zero_val_nonzero_deriv_01.cc
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Tests the computation of the first derivatives of a function with zero
+// input can have a non-zero first derivative.
+
+
+#include "../tests.h"
+
+#include <deal.II/grid/tria.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/fe_values_extractors.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/differentiation/ad.h>
+#include <Sacado.hpp>
+
+int main()
+{
+  initlog();
+
+  const unsigned int dim = 2;
+  Triangulation<dim> triangulation;
+  FE_Q<dim>          fe (1);
+  QGauss<dim>        quadrature_formula(2);
+  DoFHandler<dim>    dof_handler (triangulation);
+  Vector<double>     zero_solution;
+
+  FEValues<dim> fe_values (fe, quadrature_formula,
+                           update_values | update_gradients | update_JxW_values);
+
+  GridGenerator::hyper_cube (triangulation, -1, 1);
+  dof_handler.distribute_dofs (fe);
+  zero_solution.reinit (dof_handler.n_dofs());
+
+  const FEValuesExtractors::Scalar extractor_sclr(0);
+
+  typedef Sacado::Fad::DFad<double> ad_type;
+  DoFHandler<dim>::active_cell_iterator cell = dof_handler.begin_active();
+  DoFHandler<dim>::active_cell_iterator endc = dof_handler.end();
+  for (; cell!=endc; ++cell)
+    {
+      fe_values.reinit (cell);
+
+      // Extract (zero'd) DoF values
+      Vector<double> local_dof_values(cell->get_fe().dofs_per_cell);
+      cell->get_dof_values(zero_solution, local_dof_values);
+
+      // Configure AD-equivalent DoF values. These
+      // are the independent variables "x".
+      std::vector<ad_type> local_ad_dof_values (fe.n_dofs_per_cell());
+      for (unsigned int i=0; i<fe.n_dofs_per_cell(); ++i)
+        local_ad_dof_values[i] = ad_type(fe.n_dofs_per_cell(), i, local_dof_values[i]);
+
+      // Get solution values while tracking the influence
+      // that perturbing the DoF values may have on the
+      // derivative of the dependent variable "f(x)".
+      std::vector<ad_type> local_qp_soln_values_ad (fe.n_dofs_per_cell());
+      fe_values[extractor_sclr].get_function_values_from_local_dof_values(local_ad_dof_values,local_qp_soln_values_ad);
+
+      // Compute the dependent variable "f(x)".
+      ad_type f_x = 0.0;
+      for (unsigned int i=0; i<fe.n_dofs_per_cell(); ++i)
+        f_x += local_qp_soln_values_ad[i];
+
+      deallog << "f(x): " << f_x.val() << std::endl;
+      for (unsigned int i=0; i<fe.n_dofs_per_cell(); ++i)
+        deallog << "df/dx_" << i << ": " << f_x.dx(i) << std::endl;
+
+    }
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/zero_val_nonzero_deriv_01.output
+++ b/tests/sacado/zero_val_nonzero_deriv_01.output
@@ -1,0 +1,7 @@
+
+DEAL::f(x): 0.00000
+DEAL::df/dx_0: 1.00000
+DEAL::df/dx_1: 1.00000
+DEAL::df/dx_2: 1.00000
+DEAL::df/dx_3: 1.00000
+DEAL::OK


### PR DESCRIPTION
When using AD to automatically compute the linearisation of a residual, one cannot _a priori_ assume no sensitivity with respect to zero-valued degrees-of-freedom. The first commit in this PR ensures that this calculation shortcut is not taken for AD numbers.

Furthermore, with the current functionality my application of these two features in the FEValues function is now overly defensive. So the second commit effectively reverts some of the changes made in #4951, as #4893 makes some use of `ProductType` unnecessary and #5251 ensures compatible conversions between numbers of all CV qualifications.