### PR TITLE
Generalize the numbering in the Cuthill-McKee algorithm.

### DIFF
--- a/doc/news/changes/minor/20171116Bangerth
+++ b/doc/news/changes/minor/20171116Bangerth
@@ -1,0 +1,5 @@
+New: In parallel, the starting indices of
+DoFRenumbering::Cuthill_McKee() can now also be locally active
+indices. They no longer need to be locally owned DoF indices.
+<br>
+(Wolfgang Bangerth, 2017/11/16)

--- a/tests/mpi/renumber_cuthill_mckee_03.cc
+++ b/tests/mpi/renumber_cuthill_mckee_03.cc
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test that DofRenumbering::Cuthill_McKee works in parallel also when
+// a set of starting indices is given.
+//
+// this set of starting indices may also contain locally active DoFs,
+// even though they will not be part of the renumbering on each
+// cell. verify that this works by using as starting indices the ones
+// that are located on processor boundaries
+
+
+#include "../tests.h"
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi.templates.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/fe/mapping_q1.h>
+#include <deal.II/fe/fe_q.h>
+
+
+
+template <int dim>
+void test()
+{
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+  unsigned int nprocs = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
+
+  parallel::distributed::Triangulation<dim> tr (MPI_COMM_WORLD);
+
+  GridGenerator::hyper_cube (tr, -1.0, 1.0);
+  tr.refine_global (2);
+
+  const FE_Q<dim> fe (1);
+  DoFHandler<dim> dofh (tr);
+  dofh.distribute_dofs (fe);
+
+  deallog << "Before:" << std::endl;
+  for (const auto &cell : dofh.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        deallog << "locally owned cell: " << cell << std::endl;
+        deallog << "       dof indices: ";
+
+        std::vector<types::global_dof_index> cell_dofs (cell->get_fe().dofs_per_cell);
+        cell->get_dof_indices (cell_dofs);
+
+        for (auto i : cell_dofs)
+          deallog << i << ' ';
+        deallog << std::endl;
+      }
+
+  std::set<types::global_dof_index> starting_indices;
+  for (const auto &cell : dofh.active_cell_iterators())
+    if (cell->is_locally_owned())
+      for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+        if (!cell->at_boundary(f)
+            &&
+            cell->neighbor(f)->is_ghost())
+          {
+            // we've identified a subdomain interface. use these DoFs
+            // as starting indices
+            std::vector<types::global_dof_index> face_dofs (cell->get_fe().dofs_per_face);
+            cell->face(f)->get_dof_indices (face_dofs);
+            for (auto i : face_dofs)
+              starting_indices.insert (i);
+          }
+
+  DoFRenumbering::Cuthill_McKee (dofh, false, false,
+                                 std::vector<types::global_dof_index>(starting_indices.begin(),
+                                     starting_indices.end()));
+
+  // output the renumbered DoF indices
+  deallog << "After:" << std::endl;
+  for (const auto &cell : dofh.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        deallog << "locally owned cell: " << cell << std::endl;
+        deallog << "       dof indices: ";
+
+        std::vector<types::global_dof_index> cell_dofs (cell->get_fe().dofs_per_cell);
+        cell->get_dof_indices (cell_dofs);
+
+        for (auto i : cell_dofs)
+          deallog << i << ' ';
+        deallog << std::endl;
+      }
+
+  std::map<types::global_dof_index, Point<dim> > support_points;
+  DoFTools::map_dofs_to_support_points (MappingQ1<dim>(), dofh, support_points);
+  DoFTools::write_gnuplot_dof_support_point_info (deallog.get_file_stream(),
+                                                  support_points);
+
+}
+
+
+int main (int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+  MPILogInitAll log;
+
+  deallog.push ("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push ("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/mpi/renumber_cuthill_mckee_03.mpirun=2.output
+++ b/tests/mpi/renumber_cuthill_mckee_03.mpirun=2.output
@@ -1,0 +1,571 @@
+
+DEAL:0:2d::Before:
+DEAL:0:2d::locally owned cell: 2.0
+DEAL:0:2d::       dof indices: 0 1 2 3 
+DEAL:0:2d::locally owned cell: 2.1
+DEAL:0:2d::       dof indices: 1 4 3 5 
+DEAL:0:2d::locally owned cell: 2.2
+DEAL:0:2d::       dof indices: 2 3 6 7 
+DEAL:0:2d::locally owned cell: 2.3
+DEAL:0:2d::       dof indices: 3 5 7 8 
+DEAL:0:2d::locally owned cell: 2.4
+DEAL:0:2d::       dof indices: 4 9 5 10 
+DEAL:0:2d::locally owned cell: 2.5
+DEAL:0:2d::       dof indices: 9 11 10 12 
+DEAL:0:2d::locally owned cell: 2.6
+DEAL:0:2d::       dof indices: 5 10 8 13 
+DEAL:0:2d::locally owned cell: 2.7
+DEAL:0:2d::       dof indices: 10 12 13 14 
+DEAL:0:2d::After:
+DEAL:0:2d::locally owned cell: 2.0
+DEAL:0:2d::       dof indices: 10 12 5 7 
+DEAL:0:2d::locally owned cell: 2.1
+DEAL:0:2d::       dof indices: 12 13 7 8 
+DEAL:0:2d::locally owned cell: 2.2
+DEAL:0:2d::       dof indices: 5 7 0 1 
+DEAL:0:2d::locally owned cell: 2.3
+DEAL:0:2d::       dof indices: 7 8 1 2 
+DEAL:0:2d::locally owned cell: 2.4
+DEAL:0:2d::       dof indices: 13 14 8 9 
+DEAL:0:2d::locally owned cell: 2.5
+DEAL:0:2d::       dof indices: 14 11 9 6 
+DEAL:0:2d::locally owned cell: 2.6
+DEAL:0:2d::       dof indices: 8 9 2 3 
+DEAL:0:2d::locally owned cell: 2.7
+DEAL:0:2d::       dof indices: 9 6 3 4 
+-1.00000 -1.00000 "10"
+-1.00000 -0.500000 "5"
+-1.00000 0.00000 "0"
+-1.00000 0.500000 "15"
+-0.500000 -1.00000 "12"
+-0.500000 -0.500000 "7"
+-0.500000 0.00000 "1"
+-0.500000 0.500000 "17"
+0.00000 -1.00000 "13"
+0.00000 -0.500000 "8"
+0.00000 0.00000 "2"
+0.00000 0.500000 "18"
+0.500000 -1.00000 "14"
+0.500000 -0.500000 "9"
+0.500000 0.00000 "3"
+0.500000 0.500000 "19"
+1.00000 -1.00000 "11"
+1.00000 -0.500000 "6"
+1.00000 0.00000 "4"
+1.00000 0.500000 "16"
+DEAL:0:3d::Before:
+DEAL:0:3d::locally owned cell: 2.0
+DEAL:0:3d::       dof indices: 0 1 2 3 4 5 6 7 
+DEAL:0:3d::locally owned cell: 2.1
+DEAL:0:3d::       dof indices: 1 8 3 9 5 10 7 11 
+DEAL:0:3d::locally owned cell: 2.2
+DEAL:0:3d::       dof indices: 2 3 12 13 6 7 14 15 
+DEAL:0:3d::locally owned cell: 2.3
+DEAL:0:3d::       dof indices: 3 9 13 16 7 11 15 17 
+DEAL:0:3d::locally owned cell: 2.4
+DEAL:0:3d::       dof indices: 4 5 6 7 18 19 20 21 
+DEAL:0:3d::locally owned cell: 2.5
+DEAL:0:3d::       dof indices: 5 10 7 11 19 22 21 23 
+DEAL:0:3d::locally owned cell: 2.6
+DEAL:0:3d::       dof indices: 6 7 14 15 20 21 24 25 
+DEAL:0:3d::locally owned cell: 2.7
+DEAL:0:3d::       dof indices: 7 11 15 17 21 23 25 26 
+DEAL:0:3d::locally owned cell: 2.8
+DEAL:0:3d::       dof indices: 8 27 9 28 10 29 11 30 
+DEAL:0:3d::locally owned cell: 2.9
+DEAL:0:3d::       dof indices: 27 31 28 32 29 33 30 34 
+DEAL:0:3d::locally owned cell: 2.10
+DEAL:0:3d::       dof indices: 9 28 16 35 11 30 17 36 
+DEAL:0:3d::locally owned cell: 2.11
+DEAL:0:3d::       dof indices: 28 32 35 37 30 34 36 38 
+DEAL:0:3d::locally owned cell: 2.12
+DEAL:0:3d::       dof indices: 10 29 11 30 22 39 23 40 
+DEAL:0:3d::locally owned cell: 2.13
+DEAL:0:3d::       dof indices: 29 33 30 34 39 41 40 42 
+DEAL:0:3d::locally owned cell: 2.14
+DEAL:0:3d::       dof indices: 11 30 17 36 23 40 26 43 
+DEAL:0:3d::locally owned cell: 2.15
+DEAL:0:3d::       dof indices: 30 34 36 38 40 42 43 44 
+DEAL:0:3d::locally owned cell: 2.16
+DEAL:0:3d::       dof indices: 12 13 45 46 14 15 47 48 
+DEAL:0:3d::locally owned cell: 2.17
+DEAL:0:3d::       dof indices: 13 16 46 49 15 17 48 50 
+DEAL:0:3d::locally owned cell: 2.18
+DEAL:0:3d::       dof indices: 45 46 51 52 47 48 53 54 
+DEAL:0:3d::locally owned cell: 2.19
+DEAL:0:3d::       dof indices: 46 49 52 55 48 50 54 56 
+DEAL:0:3d::locally owned cell: 2.20
+DEAL:0:3d::       dof indices: 14 15 47 48 24 25 57 58 
+DEAL:0:3d::locally owned cell: 2.21
+DEAL:0:3d::       dof indices: 15 17 48 50 25 26 58 59 
+DEAL:0:3d::locally owned cell: 2.22
+DEAL:0:3d::       dof indices: 47 48 53 54 57 58 60 61 
+DEAL:0:3d::locally owned cell: 2.23
+DEAL:0:3d::       dof indices: 48 50 54 56 58 59 61 62 
+DEAL:0:3d::locally owned cell: 2.24
+DEAL:0:3d::       dof indices: 16 35 49 63 17 36 50 64 
+DEAL:0:3d::locally owned cell: 2.25
+DEAL:0:3d::       dof indices: 35 37 63 65 36 38 64 66 
+DEAL:0:3d::locally owned cell: 2.26
+DEAL:0:3d::       dof indices: 49 63 55 67 50 64 56 68 
+DEAL:0:3d::locally owned cell: 2.27
+DEAL:0:3d::       dof indices: 63 65 67 69 64 66 68 70 
+DEAL:0:3d::locally owned cell: 2.28
+DEAL:0:3d::       dof indices: 17 36 50 64 26 43 59 71 
+DEAL:0:3d::locally owned cell: 2.29
+DEAL:0:3d::       dof indices: 36 38 64 66 43 44 71 72 
+DEAL:0:3d::locally owned cell: 2.30
+DEAL:0:3d::       dof indices: 50 64 56 68 59 71 62 73 
+DEAL:0:3d::locally owned cell: 2.31
+DEAL:0:3d::       dof indices: 64 66 68 70 71 72 73 74 
+DEAL:0:3d::After:
+DEAL:0:3d::locally owned cell: 2.0
+DEAL:0:3d::       dof indices: 50 54 55 66 25 29 30 41 
+DEAL:0:3d::locally owned cell: 2.1
+DEAL:0:3d::       dof indices: 54 56 66 67 29 31 41 42 
+DEAL:0:3d::locally owned cell: 2.2
+DEAL:0:3d::       dof indices: 55 66 57 68 30 41 32 43 
+DEAL:0:3d::locally owned cell: 2.3
+DEAL:0:3d::       dof indices: 66 67 68 69 41 42 43 44 
+DEAL:0:3d::locally owned cell: 2.4
+DEAL:0:3d::       dof indices: 25 29 30 41 0 1 2 3 
+DEAL:0:3d::locally owned cell: 2.5
+DEAL:0:3d::       dof indices: 29 31 41 42 1 4 3 5 
+DEAL:0:3d::locally owned cell: 2.6
+DEAL:0:3d::       dof indices: 30 41 32 43 2 3 6 7 
+DEAL:0:3d::locally owned cell: 2.7
+DEAL:0:3d::       dof indices: 41 42 43 44 3 5 7 8 
+DEAL:0:3d::locally owned cell: 2.8
+DEAL:0:3d::       dof indices: 56 58 67 70 31 33 42 45 
+DEAL:0:3d::locally owned cell: 2.9
+DEAL:0:3d::       dof indices: 58 51 70 59 33 26 45 34 
+DEAL:0:3d::locally owned cell: 2.10
+DEAL:0:3d::       dof indices: 67 70 69 71 42 45 44 46 
+DEAL:0:3d::locally owned cell: 2.11
+DEAL:0:3d::       dof indices: 70 59 71 60 45 34 46 35 
+DEAL:0:3d::locally owned cell: 2.12
+DEAL:0:3d::       dof indices: 31 33 42 45 4 9 5 10 
+DEAL:0:3d::locally owned cell: 2.13
+DEAL:0:3d::       dof indices: 33 26 45 34 9 11 10 12 
+DEAL:0:3d::locally owned cell: 2.14
+DEAL:0:3d::       dof indices: 42 45 44 46 5 10 8 13 
+DEAL:0:3d::locally owned cell: 2.15
+DEAL:0:3d::       dof indices: 45 34 46 35 10 12 13 14 
+DEAL:0:3d::locally owned cell: 2.16
+DEAL:0:3d::       dof indices: 57 68 61 72 32 43 36 47 
+DEAL:0:3d::locally owned cell: 2.17
+DEAL:0:3d::       dof indices: 68 69 72 73 43 44 47 48 
+DEAL:0:3d::locally owned cell: 2.18
+DEAL:0:3d::       dof indices: 61 72 52 62 36 47 27 37 
+DEAL:0:3d::locally owned cell: 2.19
+DEAL:0:3d::       dof indices: 72 73 62 63 47 48 37 38 
+DEAL:0:3d::locally owned cell: 2.20
+DEAL:0:3d::       dof indices: 32 43 36 47 6 7 15 16 
+DEAL:0:3d::locally owned cell: 2.21
+DEAL:0:3d::       dof indices: 43 44 47 48 7 8 16 17 
+DEAL:0:3d::locally owned cell: 2.22
+DEAL:0:3d::       dof indices: 36 47 27 37 15 16 18 19 
+DEAL:0:3d::locally owned cell: 2.23
+DEAL:0:3d::       dof indices: 47 48 37 38 16 17 19 20 
+DEAL:0:3d::locally owned cell: 2.24
+DEAL:0:3d::       dof indices: 69 71 73 74 44 46 48 49 
+DEAL:0:3d::locally owned cell: 2.25
+DEAL:0:3d::       dof indices: 71 60 74 64 46 35 49 39 
+DEAL:0:3d::locally owned cell: 2.26
+DEAL:0:3d::       dof indices: 73 74 63 65 48 49 38 40 
+DEAL:0:3d::locally owned cell: 2.27
+DEAL:0:3d::       dof indices: 74 64 65 53 49 39 40 28 
+DEAL:0:3d::locally owned cell: 2.28
+DEAL:0:3d::       dof indices: 44 46 48 49 8 13 17 21 
+DEAL:0:3d::locally owned cell: 2.29
+DEAL:0:3d::       dof indices: 46 35 49 39 13 14 21 22 
+DEAL:0:3d::locally owned cell: 2.30
+DEAL:0:3d::       dof indices: 48 49 38 40 17 21 20 23 
+DEAL:0:3d::locally owned cell: 2.31
+DEAL:0:3d::       dof indices: 49 39 40 28 21 22 23 24 
+-1.00000 -1.00000 -1.00000 "50"
+-1.00000 -1.00000 -0.500000 "25"
+-1.00000 -1.00000 0.00000 "0"
+-1.00000 -1.00000 0.500000 "75"
+-1.00000 -0.500000 -1.00000 "55"
+-1.00000 -0.500000 -0.500000 "30"
+-1.00000 -0.500000 0.00000 "2"
+-1.00000 -0.500000 0.500000 "80"
+-1.00000 0.00000 -1.00000 "57"
+-1.00000 0.00000 -0.500000 "32"
+-1.00000 0.00000 0.00000 "6"
+-1.00000 0.00000 0.500000 "82"
+-1.00000 0.500000 -1.00000 "61"
+-1.00000 0.500000 -0.500000 "36"
+-1.00000 0.500000 0.00000 "15"
+-1.00000 0.500000 0.500000 "86"
+-1.00000 1.00000 -1.00000 "52"
+-1.00000 1.00000 -0.500000 "27"
+-1.00000 1.00000 0.00000 "18"
+-1.00000 1.00000 0.500000 "77"
+-0.500000 -1.00000 -1.00000 "54"
+-0.500000 -1.00000 -0.500000 "29"
+-0.500000 -1.00000 0.00000 "1"
+-0.500000 -1.00000 0.500000 "79"
+-0.500000 -0.500000 -0.500000 "41"
+-0.500000 -0.500000 0.500000 "91"
+-0.500000 -0.500000 -1.00000 "66"
+-0.500000 -0.500000 3.46945e-18 "3"
+-0.500000 0.00000 -1.00000 "68"
+-0.500000 0.00000 -0.500000 "43"
+-0.500000 0.00000 6.93889e-18 "7"
+-0.500000 0.00000 0.500000 "93"
+-0.500000 0.500000 -1.00000 "72"
+-0.500000 0.500000 3.46945e-18 "16"
+-0.500000 0.500000 -0.500000 "47"
+-0.500000 0.500000 0.500000 "97"
+-0.500000 1.00000 -1.00000 "62"
+-0.500000 1.00000 -0.500000 "37"
+-0.500000 1.00000 0.00000 "19"
+-0.500000 1.00000 0.500000 "87"
+0.00000 -1.00000 -1.00000 "56"
+0.00000 -1.00000 -0.500000 "31"
+0.00000 -1.00000 0.00000 "4"
+0.00000 -1.00000 0.500000 "81"
+0.00000 -0.500000 -1.00000 "67"
+0.00000 -0.500000 -0.500000 "42"
+0.00000 -0.500000 6.93889e-18 "5"
+0.00000 -0.500000 0.500000 "92"
+0.00000 0.00000 -1.00000 "69"
+0.00000 0.00000 -0.500000 "44"
+0.00000 0.00000 1.38778e-17 "8"
+0.00000 0.00000 0.500000 "94"
+0.00000 0.500000 -1.00000 "73"
+0.00000 0.500000 -0.500000 "48"
+0.00000 0.500000 6.93889e-18 "17"
+0.00000 0.500000 0.500000 "98"
+0.00000 1.00000 -1.00000 "63"
+0.00000 1.00000 -0.500000 "38"
+0.00000 1.00000 0.00000 "20"
+0.00000 1.00000 0.500000 "88"
+0.500000 -1.00000 -1.00000 "58"
+0.500000 -1.00000 -0.500000 "33"
+0.500000 -1.00000 0.00000 "9"
+0.500000 -1.00000 0.500000 "83"
+0.500000 -0.500000 -0.500000 "45"
+0.500000 -0.500000 0.500000 "95"
+0.500000 -0.500000 -1.00000 "70"
+0.500000 -0.500000 3.46945e-18 "10"
+0.500000 0.00000 -1.00000 "71"
+0.500000 0.00000 -0.500000 "46"
+0.500000 0.00000 6.93889e-18 "13"
+0.500000 0.00000 0.500000 "96"
+0.500000 0.500000 -1.00000 "74"
+0.500000 0.500000 3.46945e-18 "21"
+0.500000 0.500000 -0.500000 "49"
+0.500000 0.500000 0.500000 "99"
+0.500000 1.00000 -1.00000 "65"
+0.500000 1.00000 -0.500000 "40"
+0.500000 1.00000 0.00000 "23"
+0.500000 1.00000 0.500000 "90"
+1.00000 -1.00000 -1.00000 "51"
+1.00000 -1.00000 -0.500000 "26"
+1.00000 -1.00000 0.00000 "11"
+1.00000 -1.00000 0.500000 "76"
+1.00000 -0.500000 -1.00000 "59"
+1.00000 -0.500000 -0.500000 "34"
+1.00000 -0.500000 0.00000 "12"
+1.00000 -0.500000 0.500000 "84"
+1.00000 0.00000 -1.00000 "60"
+1.00000 0.00000 -0.500000 "35"
+1.00000 0.00000 0.00000 "14"
+1.00000 0.00000 0.500000 "85"
+1.00000 0.500000 -1.00000 "64"
+1.00000 0.500000 -0.500000 "39"
+1.00000 0.500000 0.00000 "22"
+1.00000 0.500000 0.500000 "89"
+1.00000 1.00000 -1.00000 "53"
+1.00000 1.00000 -0.500000 "28"
+1.00000 1.00000 0.00000 "24"
+1.00000 1.00000 0.500000 "78"
+
+DEAL:1:2d::Before:
+DEAL:1:2d::locally owned cell: 2.8
+DEAL:1:2d::       dof indices: 6 7 15 16 
+DEAL:1:2d::locally owned cell: 2.9
+DEAL:1:2d::       dof indices: 7 8 16 17 
+DEAL:1:2d::locally owned cell: 2.10
+DEAL:1:2d::       dof indices: 15 16 18 19 
+DEAL:1:2d::locally owned cell: 2.11
+DEAL:1:2d::       dof indices: 16 17 19 20 
+DEAL:1:2d::locally owned cell: 2.12
+DEAL:1:2d::       dof indices: 8 13 17 21 
+DEAL:1:2d::locally owned cell: 2.13
+DEAL:1:2d::       dof indices: 13 14 21 22 
+DEAL:1:2d::locally owned cell: 2.14
+DEAL:1:2d::       dof indices: 17 21 20 23 
+DEAL:1:2d::locally owned cell: 2.15
+DEAL:1:2d::       dof indices: 21 22 23 24 
+DEAL:1:2d::After:
+DEAL:1:2d::locally owned cell: 2.8
+DEAL:1:2d::       dof indices: 0 1 15 17 
+DEAL:1:2d::locally owned cell: 2.9
+DEAL:1:2d::       dof indices: 1 2 17 18 
+DEAL:1:2d::locally owned cell: 2.10
+DEAL:1:2d::       dof indices: 15 17 20 22 
+DEAL:1:2d::locally owned cell: 2.11
+DEAL:1:2d::       dof indices: 17 18 22 23 
+DEAL:1:2d::locally owned cell: 2.12
+DEAL:1:2d::       dof indices: 2 3 18 19 
+DEAL:1:2d::locally owned cell: 2.13
+DEAL:1:2d::       dof indices: 3 4 19 16 
+DEAL:1:2d::locally owned cell: 2.14
+DEAL:1:2d::       dof indices: 18 19 23 24 
+DEAL:1:2d::locally owned cell: 2.15
+DEAL:1:2d::       dof indices: 19 16 24 21 
+-1.00000 -0.500000 "5"
+-1.00000 0.00000 "0"
+-1.00000 0.500000 "15"
+-1.00000 1.00000 "20"
+-0.500000 -0.500000 "7"
+-0.500000 0.00000 "1"
+-0.500000 0.500000 "17"
+-0.500000 1.00000 "22"
+0.00000 -0.500000 "8"
+0.00000 0.00000 "2"
+0.00000 0.500000 "18"
+0.00000 1.00000 "23"
+0.500000 -0.500000 "9"
+0.500000 0.00000 "3"
+0.500000 0.500000 "19"
+0.500000 1.00000 "24"
+1.00000 -0.500000 "6"
+1.00000 0.00000 "4"
+1.00000 0.500000 "16"
+1.00000 1.00000 "21"
+DEAL:1:3d::Before:
+DEAL:1:3d::locally owned cell: 2.32
+DEAL:1:3d::       dof indices: 18 19 20 21 75 76 77 78 
+DEAL:1:3d::locally owned cell: 2.33
+DEAL:1:3d::       dof indices: 19 22 21 23 76 79 78 80 
+DEAL:1:3d::locally owned cell: 2.34
+DEAL:1:3d::       dof indices: 20 21 24 25 77 78 81 82 
+DEAL:1:3d::locally owned cell: 2.35
+DEAL:1:3d::       dof indices: 21 23 25 26 78 80 82 83 
+DEAL:1:3d::locally owned cell: 2.36
+DEAL:1:3d::       dof indices: 75 76 77 78 84 85 86 87 
+DEAL:1:3d::locally owned cell: 2.37
+DEAL:1:3d::       dof indices: 76 79 78 80 85 88 87 89 
+DEAL:1:3d::locally owned cell: 2.38
+DEAL:1:3d::       dof indices: 77 78 81 82 86 87 90 91 
+DEAL:1:3d::locally owned cell: 2.39
+DEAL:1:3d::       dof indices: 78 80 82 83 87 89 91 92 
+DEAL:1:3d::locally owned cell: 2.40
+DEAL:1:3d::       dof indices: 22 39 23 40 79 93 80 94 
+DEAL:1:3d::locally owned cell: 2.41
+DEAL:1:3d::       dof indices: 39 41 40 42 93 95 94 96 
+DEAL:1:3d::locally owned cell: 2.42
+DEAL:1:3d::       dof indices: 23 40 26 43 80 94 83 97 
+DEAL:1:3d::locally owned cell: 2.43
+DEAL:1:3d::       dof indices: 40 42 43 44 94 96 97 98 
+DEAL:1:3d::locally owned cell: 2.44
+DEAL:1:3d::       dof indices: 79 93 80 94 88 99 89 100 
+DEAL:1:3d::locally owned cell: 2.45
+DEAL:1:3d::       dof indices: 93 95 94 96 99 101 100 102 
+DEAL:1:3d::locally owned cell: 2.46
+DEAL:1:3d::       dof indices: 80 94 83 97 89 100 92 103 
+DEAL:1:3d::locally owned cell: 2.47
+DEAL:1:3d::       dof indices: 94 96 97 98 100 102 103 104 
+DEAL:1:3d::locally owned cell: 2.48
+DEAL:1:3d::       dof indices: 24 25 57 58 81 82 105 106 
+DEAL:1:3d::locally owned cell: 2.49
+DEAL:1:3d::       dof indices: 25 26 58 59 82 83 106 107 
+DEAL:1:3d::locally owned cell: 2.50
+DEAL:1:3d::       dof indices: 57 58 60 61 105 106 108 109 
+DEAL:1:3d::locally owned cell: 2.51
+DEAL:1:3d::       dof indices: 58 59 61 62 106 107 109 110 
+DEAL:1:3d::locally owned cell: 2.52
+DEAL:1:3d::       dof indices: 81 82 105 106 90 91 111 112 
+DEAL:1:3d::locally owned cell: 2.53
+DEAL:1:3d::       dof indices: 82 83 106 107 91 92 112 113 
+DEAL:1:3d::locally owned cell: 2.54
+DEAL:1:3d::       dof indices: 105 106 108 109 111 112 114 115 
+DEAL:1:3d::locally owned cell: 2.55
+DEAL:1:3d::       dof indices: 106 107 109 110 112 113 115 116 
+DEAL:1:3d::locally owned cell: 2.56
+DEAL:1:3d::       dof indices: 26 43 59 71 83 97 107 117 
+DEAL:1:3d::locally owned cell: 2.57
+DEAL:1:3d::       dof indices: 43 44 71 72 97 98 117 118 
+DEAL:1:3d::locally owned cell: 2.58
+DEAL:1:3d::       dof indices: 59 71 62 73 107 117 110 119 
+DEAL:1:3d::locally owned cell: 2.59
+DEAL:1:3d::       dof indices: 71 72 73 74 117 118 119 120 
+DEAL:1:3d::locally owned cell: 2.60
+DEAL:1:3d::       dof indices: 83 97 107 117 92 103 113 121 
+DEAL:1:3d::locally owned cell: 2.61
+DEAL:1:3d::       dof indices: 97 98 117 118 103 104 121 122 
+DEAL:1:3d::locally owned cell: 2.62
+DEAL:1:3d::       dof indices: 107 117 110 119 113 121 116 123 
+DEAL:1:3d::locally owned cell: 2.63
+DEAL:1:3d::       dof indices: 117 118 119 120 121 122 123 124 
+DEAL:1:3d::After:
+DEAL:1:3d::locally owned cell: 2.32
+DEAL:1:3d::       dof indices: 0 1 2 3 75 79 80 91 
+DEAL:1:3d::locally owned cell: 2.33
+DEAL:1:3d::       dof indices: 1 4 3 5 79 81 91 92 
+DEAL:1:3d::locally owned cell: 2.34
+DEAL:1:3d::       dof indices: 2 3 6 7 80 91 82 93 
+DEAL:1:3d::locally owned cell: 2.35
+DEAL:1:3d::       dof indices: 3 5 7 8 91 92 93 94 
+DEAL:1:3d::locally owned cell: 2.36
+DEAL:1:3d::       dof indices: 75 79 80 91 100 104 105 116 
+DEAL:1:3d::locally owned cell: 2.37
+DEAL:1:3d::       dof indices: 79 81 91 92 104 106 116 117 
+DEAL:1:3d::locally owned cell: 2.38
+DEAL:1:3d::       dof indices: 80 91 82 93 105 116 107 118 
+DEAL:1:3d::locally owned cell: 2.39
+DEAL:1:3d::       dof indices: 91 92 93 94 116 117 118 119 
+DEAL:1:3d::locally owned cell: 2.40
+DEAL:1:3d::       dof indices: 4 9 5 10 81 83 92 95 
+DEAL:1:3d::locally owned cell: 2.41
+DEAL:1:3d::       dof indices: 9 11 10 12 83 76 95 84 
+DEAL:1:3d::locally owned cell: 2.42
+DEAL:1:3d::       dof indices: 5 10 8 13 92 95 94 96 
+DEAL:1:3d::locally owned cell: 2.43
+DEAL:1:3d::       dof indices: 10 12 13 14 95 84 96 85 
+DEAL:1:3d::locally owned cell: 2.44
+DEAL:1:3d::       dof indices: 81 83 92 95 106 108 117 120 
+DEAL:1:3d::locally owned cell: 2.45
+DEAL:1:3d::       dof indices: 83 76 95 84 108 101 120 109 
+DEAL:1:3d::locally owned cell: 2.46
+DEAL:1:3d::       dof indices: 92 95 94 96 117 120 119 121 
+DEAL:1:3d::locally owned cell: 2.47
+DEAL:1:3d::       dof indices: 95 84 96 85 120 109 121 110 
+DEAL:1:3d::locally owned cell: 2.48
+DEAL:1:3d::       dof indices: 6 7 15 16 82 93 86 97 
+DEAL:1:3d::locally owned cell: 2.49
+DEAL:1:3d::       dof indices: 7 8 16 17 93 94 97 98 
+DEAL:1:3d::locally owned cell: 2.50
+DEAL:1:3d::       dof indices: 15 16 18 19 86 97 77 87 
+DEAL:1:3d::locally owned cell: 2.51
+DEAL:1:3d::       dof indices: 16 17 19 20 97 98 87 88 
+DEAL:1:3d::locally owned cell: 2.52
+DEAL:1:3d::       dof indices: 82 93 86 97 107 118 111 122 
+DEAL:1:3d::locally owned cell: 2.53
+DEAL:1:3d::       dof indices: 93 94 97 98 118 119 122 123 
+DEAL:1:3d::locally owned cell: 2.54
+DEAL:1:3d::       dof indices: 86 97 77 87 111 122 102 112 
+DEAL:1:3d::locally owned cell: 2.55
+DEAL:1:3d::       dof indices: 97 98 87 88 122 123 112 113 
+DEAL:1:3d::locally owned cell: 2.56
+DEAL:1:3d::       dof indices: 8 13 17 21 94 96 98 99 
+DEAL:1:3d::locally owned cell: 2.57
+DEAL:1:3d::       dof indices: 13 14 21 22 96 85 99 89 
+DEAL:1:3d::locally owned cell: 2.58
+DEAL:1:3d::       dof indices: 17 21 20 23 98 99 88 90 
+DEAL:1:3d::locally owned cell: 2.59
+DEAL:1:3d::       dof indices: 21 22 23 24 99 89 90 78 
+DEAL:1:3d::locally owned cell: 2.60
+DEAL:1:3d::       dof indices: 94 96 98 99 119 121 123 124 
+DEAL:1:3d::locally owned cell: 2.61
+DEAL:1:3d::       dof indices: 96 85 99 89 121 110 124 114 
+DEAL:1:3d::locally owned cell: 2.62
+DEAL:1:3d::       dof indices: 98 99 88 90 123 124 113 115 
+DEAL:1:3d::locally owned cell: 2.63
+DEAL:1:3d::       dof indices: 99 89 90 78 124 114 115 103 
+-1.00000 -1.00000 -0.500000 "25"
+-1.00000 -1.00000 0.00000 "0"
+-1.00000 -1.00000 0.500000 "75"
+-1.00000 -1.00000 1.00000 "100"
+-1.00000 -0.500000 -0.500000 "30"
+-1.00000 -0.500000 0.00000 "2"
+-1.00000 -0.500000 0.500000 "80"
+-1.00000 -0.500000 1.00000 "105"
+-1.00000 0.00000 -0.500000 "32"
+-1.00000 0.00000 0.00000 "6"
+-1.00000 0.00000 0.500000 "82"
+-1.00000 0.00000 1.00000 "107"
+-1.00000 0.500000 -0.500000 "36"
+-1.00000 0.500000 0.00000 "15"
+-1.00000 0.500000 0.500000 "86"
+-1.00000 0.500000 1.00000 "111"
+-1.00000 1.00000 -0.500000 "27"
+-1.00000 1.00000 0.00000 "18"
+-1.00000 1.00000 0.500000 "77"
+-1.00000 1.00000 1.00000 "102"
+-0.500000 -1.00000 -0.500000 "29"
+-0.500000 -1.00000 0.00000 "1"
+-0.500000 -1.00000 0.500000 "79"
+-0.500000 -1.00000 1.00000 "104"
+-0.500000 -0.500000 -0.500000 "41"
+-0.500000 -0.500000 0.500000 "91"
+-0.500000 -0.500000 3.46945e-18 "3"
+-0.500000 -0.500000 1.00000 "116"
+-0.500000 0.00000 -0.500000 "43"
+-0.500000 0.00000 6.93889e-18 "7"
+-0.500000 0.00000 0.500000 "93"
+-0.500000 0.00000 1.00000 "118"
+-0.500000 0.500000 3.46945e-18 "16"
+-0.500000 0.500000 1.00000 "122"
+-0.500000 0.500000 -0.500000 "47"
+-0.500000 0.500000 0.500000 "97"
+-0.500000 1.00000 -0.500000 "37"
+-0.500000 1.00000 0.00000 "19"
+-0.500000 1.00000 0.500000 "87"
+-0.500000 1.00000 1.00000 "112"
+0.00000 -1.00000 -0.500000 "31"
+0.00000 -1.00000 0.00000 "4"
+0.00000 -1.00000 0.500000 "81"
+0.00000 -1.00000 1.00000 "106"
+0.00000 -0.500000 -0.500000 "42"
+0.00000 -0.500000 6.93889e-18 "5"
+0.00000 -0.500000 0.500000 "92"
+0.00000 -0.500000 1.00000 "117"
+0.00000 0.00000 -0.500000 "44"
+0.00000 0.00000 1.38778e-17 "8"
+0.00000 0.00000 0.500000 "94"
+0.00000 0.00000 1.00000 "119"
+0.00000 0.500000 -0.500000 "48"
+0.00000 0.500000 6.93889e-18 "17"
+0.00000 0.500000 0.500000 "98"
+0.00000 0.500000 1.00000 "123"
+0.00000 1.00000 -0.500000 "38"
+0.00000 1.00000 0.00000 "20"
+0.00000 1.00000 0.500000 "88"
+0.00000 1.00000 1.00000 "113"
+0.500000 -1.00000 -0.500000 "33"
+0.500000 -1.00000 0.00000 "9"
+0.500000 -1.00000 0.500000 "83"
+0.500000 -1.00000 1.00000 "108"
+0.500000 -0.500000 -0.500000 "45"
+0.500000 -0.500000 0.500000 "95"
+0.500000 -0.500000 3.46945e-18 "10"
+0.500000 -0.500000 1.00000 "120"
+0.500000 0.00000 -0.500000 "46"
+0.500000 0.00000 6.93889e-18 "13"
+0.500000 0.00000 0.500000 "96"
+0.500000 0.00000 1.00000 "121"
+0.500000 0.500000 3.46945e-18 "21"
+0.500000 0.500000 1.00000 "124"
+0.500000 0.500000 -0.500000 "49"
+0.500000 0.500000 0.500000 "99"
+0.500000 1.00000 -0.500000 "40"
+0.500000 1.00000 0.00000 "23"
+0.500000 1.00000 0.500000 "90"
+0.500000 1.00000 1.00000 "115"
+1.00000 -1.00000 -0.500000 "26"
+1.00000 -1.00000 0.00000 "11"
+1.00000 -1.00000 0.500000 "76"
+1.00000 -1.00000 1.00000 "101"
+1.00000 -0.500000 -0.500000 "34"
+1.00000 -0.500000 0.00000 "12"
+1.00000 -0.500000 0.500000 "84"
+1.00000 -0.500000 1.00000 "109"
+1.00000 0.00000 -0.500000 "35"
+1.00000 0.00000 0.00000 "14"
+1.00000 0.00000 0.500000 "85"
+1.00000 0.00000 1.00000 "110"
+1.00000 0.500000 -0.500000 "39"
+1.00000 0.500000 0.00000 "22"
+1.00000 0.500000 0.500000 "89"
+1.00000 0.500000 1.00000 "114"
+1.00000 1.00000 -0.500000 "28"
+1.00000 1.00000 0.00000 "24"
+1.00000 1.00000 0.500000 "78"
+1.00000 1.00000 1.00000 "103"
+

--- a/tests/mpi/step-40_cuthill_mckee.cc
+++ b/tests/mpi/step-40_cuthill_mckee.cc
@@ -1,0 +1,444 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// A lightly adapted version of the step-40 tutorial program
+//
+// like the step-40 test, but using a Cuthill-McKee renumbering
+// algorithm for DoFs that includes starting indices that are not
+// locally owned but only locally active
+
+#include "../tests.h"
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+
+#include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#include <deal.II/lac/petsc_parallel_vector.h>
+#include <deal.II/lac/petsc_solver.h>
+#include <deal.II/lac/petsc_precondition.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/error_estimator.h>
+
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/grid_refinement.h>
+
+#include <iostream>
+
+namespace Step40
+{
+  using namespace dealii;
+
+
+  template <int dim>
+  class LaplaceProblem
+  {
+  public:
+    LaplaceProblem ();
+    ~LaplaceProblem ();
+
+    void run ();
+
+  private:
+    void setup_system ();
+    void assemble_system ();
+    void solve ();
+    void refine_grid ();
+
+    MPI_Comm mpi_communicator;
+
+    parallel::distributed::Triangulation<dim>   triangulation;
+
+    DoFHandler<dim>      dof_handler;
+    FE_Q<dim>            fe;
+
+    IndexSet             locally_owned_dofs;
+    IndexSet             locally_relevant_dofs;
+
+    ConstraintMatrix     constraints;
+
+    PETScWrappers::MPI::SparseMatrix system_matrix;
+    PETScWrappers::MPI::Vector locally_relevant_solution;
+    PETScWrappers::MPI::Vector system_rhs;
+
+    ConditionalOStream                pcout;
+  };
+
+
+
+
+  template <int dim>
+  LaplaceProblem<dim>::LaplaceProblem ()
+    :
+    mpi_communicator (MPI_COMM_WORLD),
+    triangulation (mpi_communicator,
+                   typename Triangulation<dim>::MeshSmoothing
+                   (Triangulation<dim>::smoothing_on_refinement |
+                    Triangulation<dim>::smoothing_on_coarsening)),
+    dof_handler (triangulation),
+    fe (2),
+    pcout (Utilities::MPI::this_mpi_process(mpi_communicator)
+           == 0
+           ?
+           deallog.get_file_stream()
+           :
+           std::cout,
+           (Utilities::MPI::this_mpi_process(mpi_communicator)
+            == 0))
+  {}
+
+
+
+  template <int dim>
+  LaplaceProblem<dim>::~LaplaceProblem ()
+  {
+    dof_handler.clear ();
+  }
+
+
+
+  template <int dim>
+  void LaplaceProblem<dim>::setup_system ()
+  {
+    dof_handler.distribute_dofs (fe);
+    locally_owned_dofs = dof_handler.locally_owned_dofs();
+    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+
+    {
+      std::vector<types::global_dof_index> starting_indices;
+
+
+      const QGauss<dim - 1> face_quadrature_formula(fe.degree + 1);
+      FEFaceValues<dim> fe_face_values(fe, face_quadrature_formula,
+                                       update_values | update_quadrature_points | update_normal_vectors |
+                                       update_JxW_values);
+
+      Tensor<1, dim> u;
+      Point<dim> down {0,-1};
+      std::vector< types::global_dof_index >dof_indices (fe.n_dofs_per_face(), 0);
+
+
+      for (const auto &cell: dof_handler.active_cell_iterators())
+        {
+          if (cell->is_locally_owned())
+            {
+
+              for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+                {
+                  if ((cell->face(face)->at_boundary())
+                      || (cell->neighbor(face)->active() && cell->neighbor(face)->is_ghost()))
+                    {
+                      fe_face_values.reinit(cell, face);
+                      //for Q_2 this is in middle of face, dim=2 or what quadrature point to give?
+                      u=fe_face_values.normal_vector(1);
+                      if (u*down< 0)
+                        {
+                          cell->face(face)->get_dof_indices(dof_indices);
+                          starting_indices.insert(std::end(starting_indices),
+                                                  std::begin(dof_indices), std::end(dof_indices));
+                        }
+                    }
+                }
+            }
+        }
+
+      // remove duplicates by creating a set
+      std::set<types::global_dof_index> no_duplicates_please (starting_indices.begin(),
+                                                              starting_indices.end());
+      // back to vector for the DoFRenumbering function
+      starting_indices.clear();
+      starting_indices.assign(no_duplicates_please.begin(), no_duplicates_please.end());
+
+      DoFRenumbering::Cuthill_McKee(dof_handler,false, true, starting_indices);
+
+      locally_owned_dofs = dof_handler.locally_owned_dofs();
+      DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    }
+
+    locally_relevant_solution.reinit (locally_owned_dofs,
+                                      locally_relevant_dofs,
+                                      mpi_communicator);
+    system_rhs.reinit (locally_owned_dofs, mpi_communicator);
+    system_rhs = PetscScalar();
+
+    constraints.clear ();
+    constraints.reinit (locally_relevant_dofs);
+    DoFTools::make_hanging_node_constraints (dof_handler, constraints);
+    VectorTools::interpolate_boundary_values (dof_handler,
+                                              0,
+                                              Functions::ZeroFunction<dim>(),
+                                              constraints);
+    constraints.close ();
+
+    DynamicSparsityPattern csp (dof_handler.n_dofs(),
+                                dof_handler.n_dofs(),
+                                locally_relevant_dofs);
+    DoFTools::make_sparsity_pattern (dof_handler,
+                                     csp,
+                                     constraints, false);
+    SparsityTools::distribute_sparsity_pattern (csp,
+                                                dof_handler.n_locally_owned_dofs_per_processor(),
+                                                mpi_communicator,
+                                                locally_relevant_dofs);
+    system_matrix.reinit (mpi_communicator,
+                          csp,
+                          dof_handler.n_locally_owned_dofs_per_processor(),
+                          dof_handler.n_locally_owned_dofs_per_processor(),
+                          Utilities::MPI::this_mpi_process(mpi_communicator));
+  }
+
+
+
+
+  template <int dim>
+  void LaplaceProblem<dim>::assemble_system ()
+  {
+    const QGauss<dim>  quadrature_formula(3);
+
+    FEValues<dim> fe_values (fe, quadrature_formula,
+                             update_values    |  update_gradients |
+                             update_quadrature_points |
+                             update_JxW_values);
+
+    const unsigned int   dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int   n_q_points    = quadrature_formula.size();
+
+    FullMatrix<PetscScalar>   cell_matrix (dofs_per_cell, dofs_per_cell);
+    Vector<PetscScalar>       cell_rhs (dofs_per_cell);
+
+    std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
+
+    typename DoFHandler<dim>::active_cell_iterator
+    cell = dof_handler.begin_active(),
+    endc = dof_handler.end();
+    for (; cell!=endc; ++cell)
+      if (cell->is_locally_owned())
+        {
+          cell_matrix = PetscScalar();
+          cell_rhs = PetscScalar();
+
+          fe_values.reinit (cell);
+
+          for (unsigned int q_point=0; q_point<n_q_points; ++q_point)
+            {
+              const double
+              rhs_value
+                = (fe_values.quadrature_point(q_point)[1]
+                   >
+                   0.5+0.25*std::sin(4.0 * numbers::PI *
+                                     fe_values.quadrature_point(q_point)[0])
+                   ? 1 : -1);
+
+              for (unsigned int i=0; i<dofs_per_cell; ++i)
+                {
+                  for (unsigned int j=0; j<dofs_per_cell; ++j)
+                    cell_matrix(i,j) += (fe_values.shape_grad(i,q_point) *
+                                         fe_values.shape_grad(j,q_point) *
+                                         fe_values.JxW(q_point));
+
+                  cell_rhs(i) += (rhs_value *
+                                  fe_values.shape_value(i,q_point) *
+                                  fe_values.JxW(q_point));
+                }
+            }
+
+          cell->get_dof_indices (local_dof_indices);
+          constraints.distribute_local_to_global (cell_matrix,
+                                                  cell_rhs,
+                                                  local_dof_indices,
+                                                  system_matrix,
+                                                  system_rhs);
+        }
+
+    system_matrix.compress (VectorOperation::add);
+    system_rhs.compress (VectorOperation::add);
+  }
+
+
+
+
+  template <int dim>
+  void LaplaceProblem<dim>::solve ()
+  {
+    PETScWrappers::MPI::Vector
+    completely_distributed_solution (mpi_communicator,
+                                     dof_handler.n_dofs(),
+                                     dof_handler.n_locally_owned_dofs());
+
+    SolverControl solver_control (dof_handler.n_dofs(), 1e-12);
+
+    PETScWrappers::SolverCG solver(solver_control, mpi_communicator);
+
+#ifndef PETSC_USE_COMPLEX
+    PETScWrappers::PreconditionBoomerAMG
+    preconditioner(system_matrix,
+                   PETScWrappers::PreconditionBoomerAMG::AdditionalData(true));
+
+    check_solver_within_range(
+      solver.solve (system_matrix, completely_distributed_solution, system_rhs,
+                    preconditioner),
+      solver_control.last_step(), 11, 11);
+#else
+    check_solver_within_range(
+      solver.solve (system_matrix, completely_distributed_solution, system_rhs,
+                    PETScWrappers::PreconditionJacobi(system_matrix)),
+      solver_control.last_step(), 120, 260);
+#endif
+
+    pcout << "   Solved in " << solver_control.last_step()
+          << " iterations." << std::endl;
+
+    constraints.distribute (completely_distributed_solution);
+
+    locally_relevant_solution = completely_distributed_solution;
+  }
+
+
+
+
+  template <int dim>
+  void LaplaceProblem<dim>::refine_grid ()
+  {
+    triangulation.refine_global (1);
+  }
+
+
+
+
+  template <int dim>
+  void LaplaceProblem<dim>::run ()
+  {
+    const unsigned int n_cycles = 2;
+    for (unsigned int cycle=0; cycle<n_cycles; ++cycle)
+      {
+        pcout << "Cycle " << cycle << ':' << std::endl;
+
+        if (cycle == 0)
+          {
+            GridGenerator::hyper_cube (triangulation);
+            triangulation.refine_global (5);
+          }
+        else
+          refine_grid ();
+
+        setup_system ();
+
+        pcout << "   Number of active cells:       "
+              << triangulation.n_global_active_cells()
+              << std::endl
+              << "      ";
+        for (unsigned int i=0; i<Utilities::MPI::n_mpi_processes(mpi_communicator); ++i)
+          pcout << triangulation.n_locally_owned_active_cells_per_processor()[i]
+                << '+';
+        pcout << std::endl;
+
+        pcout << "   Number of degrees of freedom: "
+              << dof_handler.n_dofs()
+              << std::endl
+              << "      ";
+        for (unsigned int i=0; i<Utilities::MPI::n_mpi_processes(mpi_communicator); ++i)
+          pcout << dof_handler.n_locally_owned_dofs_per_processor()[i]
+                << '+';
+        pcout << std::endl;
+
+        assemble_system ();
+        solve ();
+
+        pcout << std::endl;
+      }
+  }
+}
+
+
+int test_mpi ()
+{
+
+  try
+    {
+      using namespace dealii;
+      using namespace Step40;
+
+
+      {
+        LaplaceProblem<2> laplace_problem_2d;
+        laplace_problem_2d.run ();
+      }
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+
+  return 0;
+}
+
+
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+
+  if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
+    {
+      initlog();
+
+      deallog.push("mpi");
+      test_mpi();
+      deallog.pop();
+    }
+  else
+    test_mpi();
+}

--- a/tests/mpi/step-40_cuthill_mckee.with_petsc_with_hypre=true.mpirun=4.output
+++ b/tests/mpi/step-40_cuthill_mckee.with_petsc_with_hypre=true.mpirun=4.output
@@ -1,0 +1,17 @@
+
+Cycle 0:
+   Number of active cells:       1024
+      256+256+256+256+
+   Number of degrees of freedom: 4225
+      1089+1056+1056+1024+
+DEAL:mpi::Solver stopped after 10 iterations
+   Solved in 10 iterations.
+
+Cycle 1:
+   Number of active cells:       4096
+      1024+1024+1024+1024+
+   Number of degrees of freedom: 16641
+      4225+4160+4160+4096+
+DEAL:mpi::Solver stopped within 11 - 11 iterations
+   Solved in 11 iterations.
+


### PR DESCRIPTION
Specifically, allow locally active, not only locally owned DoF indices as starting points. The reasoning for this is given in #5407.

Fixes #5407.