### PR TITLE
 Implement a uniform interface to automatic differentiation libraries

### DIFF
--- a/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
+++ b/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
@@ -59,6 +59,8 @@
  * A summary of the files that implement the interface to the supported auto-differentiable
  * numbers is as follows:
  *
+ * - ad_helpers.h: Provides a set of classes to help perform automatic differentiation in a
+ *   number of different contexts. These are detailed in \ref auto_diff_1_3.
  * - ad_number_types.h: Introduces an enumeration (called a type code) for the
  *   auto-differentiable number combinations that will be supported by the driver classes.
  *   The rationale behind the use of this somewhat restrictive mechanism is discussed below.
@@ -97,5 +99,11 @@
  * @subsubsection auto_diff_1_3 User interface to the automatic differentiation libraries
  *
  * @todo Summarize driver classes 
+ * - %Quadrature point level
+ *   - Scalar mode
+ *   - %Vector mode
+ * - Cell level functions
+ *   - Variational formulations
+ *   - Residual linearisation
  *
  */

--- a/doc/news/changes/major/20171116Jean-PaulPelteret
+++ b/doc/news/changes/major/20171116Jean-PaulPelteret
@@ -1,0 +1,5 @@
+New: A new collection of classes and functions have been implemented in the
+Differentiation::AD namespace that provide an interface to the Adol-C and
+Sacado (a part of Trilinos) automatic differentiation libraries.
+<br>
+(Jean-Paul Pelteret, 2017/11/16)

--- a/include/deal.II/differentiation/ad.h
+++ b/include/deal.II/differentiation/ad.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/differentiation/ad/ad_helpers.h>
 #include <deal.II/differentiation/ad/ad_number_types.h>
 #include <deal.II/differentiation/ad/ad_number_traits.h>
 

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -1,0 +1,2716 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_differentiation_ad_ad_helpers_h
+#define dealii_differentiation_ad_ad_helpers_h
+
+#include <deal.II/base/config.h>
+
+#if defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_WITH_TRILINOS)
+
+#include <deal.II/base/numbers.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/symmetric_tensor.h>
+
+#include <deal.II/differentiation/ad/ad_number_traits.h>
+#include <deal.II/differentiation/ad/adolc_number_types.h>
+#include <deal.II/differentiation/ad/adolc_product_types.h>
+#include <deal.II/differentiation/ad/sacado_number_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
+
+#include <deal.II/fe/fe_values_extractors.h>
+
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#ifdef DEAL_II_WITH_ADOLC
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <adolc/drivers/drivers.h>
+#include <adolc/taping.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
+#endif // DEAL_II_WITH_ADOLC
+
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <set>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace Differentiation
+{
+  namespace AD
+  {
+
+    namespace internal
+    {
+      namespace
+      {
+        // --- Define a whole bunch of helper structs to assist with getting data
+        //     related to FEExtractors ---
+        template <int dim, typename ExtractorType>
+        struct Extractor;
+
+        template <int dim>
+        struct Extractor<dim,FEValuesExtractors::Scalar>
+        {
+          static const unsigned int rank = 0;
+          static const unsigned int n_components = 1;
+          static bool symmetric_component (const unsigned int idx)
+          {
+            return false;
+          }
+
+          template<typename NumberType>
+          using tensor_type = Tensor<rank,dim,NumberType>; // NumberType;
+
+          // Note: FEValuesViews::Scalar::tensor_type is double, so we can't
+          // use it (FEValuesViews) in this context.
+          // In fact, sadly, all FEValuesViews objects expect doubles as value
+          // types
+          template<typename NumberType>
+          using value_type = NumberType;
+
+          template<typename NumberType>
+          using gradient_type = Tensor<rank+1,dim,NumberType>; // NumberType;
+
+          template<typename NumberType, typename IndexType = unsigned int, int rank_in>
+          static IndexType
+          local_component(const TableIndices<rank_in> &table_indices,
+                          const unsigned int           column_offset)
+          {
+            return 0;
+          }
+        };
+
+        template <int dim>
+        struct Extractor<dim,FEValuesExtractors::Vector>
+        {
+          static const unsigned int rank = 1; // Tensor<1,dim>::rank;
+          static const unsigned int n_components = dim; // Tensor<1,dim>::n_independent_components
+          static bool symmetric_component (const unsigned int idx)
+          {
+            return false;
+          }
+
+          template<typename NumberType>
+          using tensor_type = Tensor<rank,dim,NumberType>;
+
+          template<typename NumberType>
+          using value_type = tensor_type<NumberType>;
+
+          template<typename NumberType>
+          using gradient_type = Tensor<rank+1,dim,NumberType>;
+
+          template<int rank_in>
+          static TableIndices<rank>
+          table_index_view (const TableIndices<rank_in> &table_indices,
+                            const unsigned int           column_offset)
+          {
+            Assert(0+column_offset < rank_in, ExcInternalError());
+            return TableIndices<rank>(table_indices[0+column_offset]);
+          }
+
+          template<typename NumberType, typename IndexType = unsigned int, int rank_in>
+          static IndexType
+          local_component(const TableIndices<rank_in> &table_indices,
+                          const unsigned int           column_offset)
+          {
+            typedef tensor_type<NumberType> TensorType;
+            return TensorType::component_to_unrolled_index(table_index_view(table_indices,
+                                                           column_offset));
+          }
+        };
+
+        template <int dim>
+        struct Extractor< dim,FEValuesExtractors::Tensor<1> >
+        {
+          static const unsigned int rank = Tensor<1,dim>::rank;
+          static const unsigned int n_components = Tensor<1,dim>::n_independent_components;
+          static bool symmetric_component (const unsigned int idx)
+          {
+            return false;
+          }
+
+          template<typename NumberType>
+          using tensor_type = Tensor<rank,dim,NumberType>;
+
+          template<typename NumberType>
+          using value_type = tensor_type<NumberType>;
+
+          template<typename NumberType>
+          using gradient_type = Tensor<rank+1,dim,NumberType>;
+
+          template<int rank_in>
+          static TableIndices<rank>
+          table_index_view (const TableIndices<rank_in> &table_indices,
+                            const unsigned int           column_offset)
+          {
+            Assert(column_offset < rank_in, ExcInternalError());
+            return TableIndices<rank>(table_indices[column_offset]);
+          }
+
+          template<typename NumberType, typename IndexType = unsigned int, int rank_in>
+          static IndexType
+          local_component(const TableIndices<rank_in> &table_indices,
+                          const unsigned int           column_offset)
+          {
+            typedef tensor_type<NumberType> TensorType;
+            return TensorType::component_to_unrolled_index(table_index_view(table_indices,
+                                                           column_offset));
+          }
+        };
+
+        template <int dim>
+        struct Extractor< dim,FEValuesExtractors::Tensor<2> >
+        {
+          static const unsigned int rank = Tensor<2,dim>::rank;
+          static const unsigned int n_components = Tensor<2,dim>::n_independent_components;
+          static bool symmetric_component (const unsigned int idx)
+          {
+            return false;
+          }
+
+          template<typename NumberType>
+          using tensor_type = Tensor<rank,dim,NumberType>;
+
+          template<typename NumberType>
+          using value_type = tensor_type<NumberType>;
+
+          template<typename NumberType>
+          using gradient_type = Tensor<rank+1,dim,NumberType>;
+
+          template<int rank_in>
+          static TableIndices<rank>
+          table_index_view (const TableIndices<rank_in> &table_indices,
+                            const unsigned int           column_offset)
+          {
+            Assert(column_offset < rank_in, ExcInternalError());
+            Assert(1+column_offset < rank_in, ExcInternalError());
+            return TableIndices<rank>(table_indices[column_offset],
+                                      table_indices[1+column_offset]);
+          }
+
+          template<typename NumberType, typename IndexType = unsigned int, int rank_in>
+          static IndexType
+          local_component(const TableIndices<rank_in> &table_indices,
+                          const unsigned int           column_offset)
+          {
+            typedef tensor_type<NumberType> TensorType;
+            return TensorType::component_to_unrolled_index(table_index_view(table_indices,
+                                                           column_offset));
+          }
+        };
+
+        template <int dim>
+        struct Extractor< dim,FEValuesExtractors::SymmetricTensor<2> >
+        {
+          static const unsigned int rank = SymmetricTensor<2,dim>::rank;
+          static const unsigned int n_components = SymmetricTensor<2,dim>::n_independent_components;
+          static bool symmetric_component (const unsigned int idx)
+          {
+            static const  SymmetricTensor<2,dim> t;
+            const TableIndices<2> table_indices = t.unrolled_to_component_indices(idx);
+            return table_indices[0] != table_indices[1];
+          }
+
+          template<typename NumberType>
+          using tensor_type = SymmetricTensor<rank,dim,NumberType>;
+
+          template<typename NumberType>
+          using value_type = tensor_type<NumberType>;
+
+          template<typename NumberType>
+          using gradient_type = Tensor<rank+1,dim,NumberType>;
+
+          template<int rank_in>
+          static TableIndices<rank>
+          table_index_view (const TableIndices<rank_in> &table_indices,
+                            const unsigned int           column_offset)
+          {
+            Assert(column_offset < rank_in, ExcInternalError());
+            Assert(1+column_offset < rank_in, ExcInternalError());
+            return TableIndices<rank>(table_indices[column_offset],
+                                      table_indices[1+column_offset]);
+          }
+
+          template<typename NumberType, typename IndexType = unsigned int, int rank_in>
+          static IndexType
+          local_component(const TableIndices<rank_in> &table_indices,
+                          const unsigned int           column_offset)
+          {
+            typedef tensor_type<NumberType> TensorType;
+            return TensorType::component_to_unrolled_index(table_index_view(table_indices,
+                                                           column_offset));
+          }
+        };
+
+        // --- Define the return types for Gradient calculations ---
+        template <int dim, typename NumberType, typename ExtractorType>
+        struct Gradient
+        {
+          typedef typename Extractor<dim,ExtractorType>::template tensor_type<NumberType> type;
+        };
+
+        // --- Define the return types for Hessian calculations ---
+
+        // TODO: Can this be made more elegant?
+        template<typename ExtractorType_Row,typename ExtractorType_Col>
+        struct HessianType
+        {
+          // Note: We set the return type for
+          // HessianType<FEExtractor::Vector,FEExtractor::Vector>
+          // as a normal Tensor. This is because if one has two vector components,
+          // the coupling tensor (i.e. hessian component<FE::V_1,FE::V_2>) is in
+          // general not symmetric.
+          template<int rank, int dim, typename NumberType>
+          using type = Tensor<rank,dim,NumberType>;
+        };
+        template<>
+        struct HessianType<FEValuesExtractors::SymmetricTensor<2>, FEValuesExtractors::Scalar>
+        {
+          template<int /*rank*/, int dim, typename NumberType>
+          using type = SymmetricTensor<2 /*rank*/,dim,NumberType>;
+        };
+        template<>
+        struct HessianType< FEValuesExtractors::Scalar, FEValuesExtractors::SymmetricTensor<2> >
+        {
+          template<int /*rank*/, int dim, typename NumberType>
+          using type = SymmetricTensor<2 /*rank*/,dim,NumberType>;
+        };
+        template<>
+        struct HessianType< FEValuesExtractors::SymmetricTensor<2>, FEValuesExtractors::SymmetricTensor<2> >
+        {
+          template<int /*rank*/, int dim, typename NumberType>
+          using type = SymmetricTensor<4 /*rank*/,dim,NumberType>;
+        };
+
+        template <int dim,typename NumberType,
+                  typename ExtractorType_Row,typename ExtractorType_Col>
+        struct Hessian
+        {
+          static const int rank
+            = Extractor<dim,ExtractorType_Row>::rank
+              + Extractor<dim,ExtractorType_Col>::rank;
+
+          typedef typename HessianType<ExtractorType_Row,ExtractorType_Col>
+          ::template type<rank,dim,NumberType> type;
+
+          // typedef typename HessianType<ExtractorType_Row,ExtractorType_Col>::template
+          //          type< Extractor<dim,ExtractorType_Row>::rank
+          //               +Extractor<dim,ExtractorType_Col>::rank,
+          //                dim,NumberType> type;
+        };
+
+        // --- Generic functions (Many of these could be integrated into the
+        //     extractors helper structs) --
+
+        static inline
+        unsigned int
+        first_component (const FEValuesExtractors::Scalar &extractor)
+        {
+          return extractor.component;
+        }
+        static inline
+        unsigned int
+        first_component (const FEValuesExtractors::Vector &extractor)
+        {
+          return extractor.first_vector_component;
+        }
+        static inline
+        unsigned int
+        first_component (const FEValuesExtractors::Tensor<1> &extractor)
+        {
+          return extractor.first_tensor_component;
+        }
+        static inline
+        unsigned int
+        first_component (const FEValuesExtractors::Tensor<2> &extractor)
+        {
+          return extractor.first_tensor_component;
+        }
+        static inline
+        unsigned int
+        first_component (const FEValuesExtractors::SymmetricTensor<2> &extractor)
+        {
+          return extractor.first_tensor_component;
+        }
+
+        template<int dim, typename IndexType = unsigned int, typename ExtractorType>
+        std::vector<IndexType>
+        extract_index_set (const ExtractorType &extractor,
+                           const bool           /*ignore_symmetries*/ = true)
+        {
+          const IndexType n_components = internal::Extractor<dim,ExtractorType>::n_components;
+          const IndexType comp_first = first_component(extractor);
+          // const unsigned int comp_last = comp_begin + n_components;
+          std::vector<IndexType> indices (n_components);
+          std::iota(indices.begin(), indices.end(), comp_first);
+          return indices;
+        }
+
+        template<int dim, typename IndexType = unsigned int>
+        std::vector<IndexType>
+        extract_index_set (const FEValuesExtractors::SymmetricTensor<dim> &extractor_symm_tensor,
+                           const bool                                      ignore_symmetries = true)
+        {
+          const IndexType n_components = internal::Extractor<dim,FEValuesExtractors::SymmetricTensor<dim> >::n_components;
+          if (ignore_symmetries == true)
+            {
+              const IndexType comp_first = first_component(extractor_symm_tensor);
+              std::vector<IndexType> indices (n_components);
+              std::iota(indices.begin(), indices.end(), comp_first);
+              return indices;
+            }
+          else
+            {
+              // First get all of the indices of the non-symmetric tensor
+              const FEValuesExtractors::Tensor<dim> extractor_tensor (extractor_symm_tensor.first_tensor_component);
+              std::vector<IndexType> indices = extract_index_set<dim>(extractor_tensor, true);
+
+              // Then we overwrite any illegal entries with the equivalent indices
+              // from the symmetric tensor
+              for (unsigned int i=0; i<indices.size(); ++i)
+                {
+                  if (indices[i] >= n_components)
+                    {
+                      const TableIndices<2> ti_tensor = Tensor<2,dim>::unrolled_to_component_indices(indices[i]);
+                      const IndexType sti_new_index = SymmetricTensor<2,dim>::component_to_unrolled_index(ti_tensor);
+                      indices[i] = sti_new_index;
+                    }
+                }
+
+              return indices;
+            }
+        }
+
+        template<int rank, int dim, typename NumberType>
+        TableIndices<rank>
+        get_table_indices (const Tensor<rank,dim,NumberType> &t,
+                           const unsigned int                &idx)
+        {
+          return t.unrolled_to_component_indices(idx);
+        }
+
+        template<int rank, int dim, typename NumberType>
+        TableIndices<rank>
+        get_table_indices (const SymmetricTensor<rank,dim,NumberType> &t,
+                           const unsigned int                         &idx)
+        {
+          return t.unrolled_to_component_indices(idx);
+        }
+
+        template<typename TensorType, typename NumberType>
+        void
+        set_tensor_entry(TensorType         &t,
+                         const unsigned int &idx,
+                         const NumberType   &value)
+        {
+          // Where possible, set values using TableIndices
+          Assert(idx < t.n_independent_components,
+                 ExcMessage("Index out of range"));
+          t[get_table_indices(t,idx)] = value;
+        }
+
+        template<int dim, typename NumberType>
+        void
+        set_tensor_entry(SymmetricTensor<4,dim,NumberType> &t,
+                         const unsigned int                &idx_row,
+                         const unsigned int                &idx_col,
+                         const NumberType                  &value)
+        {
+          // Fourth order symmetric tensors require a specialized interface
+          // to extract values.
+          // NOTE: Don't templatize this on NumberType
+          // We have to get rid of all instances of adtl::adouble
+          // before calling adtl::setNumDir.
+          static const SymmetricTensor<2,dim,double> dummy = SymmetricTensor<2,dim,double>();
+          Assert(idx_row < dummy.n_independent_components,
+                 ExcMessage("Index out of range"));
+          Assert(idx_col < dummy.n_independent_components,
+                 ExcMessage("Index out of range"));
+          const TableIndices<2> indices_row = get_table_indices(dummy,idx_row);
+          const TableIndices<2> indices_col = get_table_indices(dummy,idx_col);
+          t[indices_row[0]][indices_row[1]][indices_col[0]][indices_col[1]] = value;
+        }
+
+        // Specialisations
+        template<int dim, typename NumberType>
+        void
+        set_tensor_entry(Tensor<0,dim,NumberType> &t,
+                         const unsigned int       &idx,
+                         const NumberType         &value)
+        {
+          Assert(idx==0,
+                 ExcMessage("Index for rank-0 tensor out of range"));
+          (void) idx;
+          t = value;
+        }
+
+        template<typename NumberType>
+        void
+        set_tensor_entry(NumberType         &t,
+                         const unsigned int &idx,
+                         const NumberType   &value)
+        {
+          Assert(idx==0,
+                 ExcMessage("Index for scalar value out of range"));
+          (void) idx;
+          t = value;
+        }
+
+        template<int rank, int dim, typename NumberType,
+                 template<int, int, typename> class TensorType>
+        NumberType
+        get_tensor_entry(const TensorType<rank,dim,NumberType> &t,
+                         const unsigned int                    &idx)
+        {
+          // Where possible, get values using TableIndices
+          Assert(idx < t.n_independent_components,
+                 ExcMessage("Index out of range"));
+          return t[get_table_indices(t,idx)];
+        }
+
+        template<int dim, typename NumberType,
+                 template<int, int, typename> class TensorType>
+        NumberType
+        get_tensor_entry(const TensorType<0,dim,NumberType> &t,
+                         const unsigned int                 &idx)
+        {
+          Assert(idx==0,
+                 ExcMessage("Index for rank-0 tensor out of range"));
+          return t;
+        }
+
+        template<typename NumberType>
+        const NumberType &
+        get_tensor_entry(const NumberType   &t,
+                         const unsigned int &idx)
+        {
+          Assert(idx==0,
+                 ExcMessage("Index for scalar value out of range"));
+          return t;
+        }
+
+        template<int rank, int dim, typename NumberType,
+                 template<int, int, typename> class TensorType>
+        NumberType &
+        get_tensor_entry(TensorType<rank,dim,NumberType> &t,
+                         const unsigned int              &idx)
+        {
+          // Where possible, get values using TableIndices
+          Assert(idx < t.n_independent_components,
+                 ExcMessage("Index out of range"));
+          return t[get_table_indices(t,idx)];
+        }
+
+        template<int dim, typename NumberType,
+                 template<int, int, typename> class TensorType>
+        NumberType &
+        get_tensor_entry(TensorType<0,dim,NumberType> &t,
+                         const unsigned int           &idx)
+        {
+          Assert(idx==0,
+                 ExcMessage("Index for rank-0 tensor out of range"));
+          (void) idx;
+          return t;
+        }
+
+        template<typename NumberType>
+        NumberType &
+        get_tensor_entry(NumberType         &t,
+                         const unsigned int &idx)
+        {
+          Assert(idx==0,
+                 ExcMessage("Index for scalar value out of range"));
+          (void) idx;
+          return t;
+        }
+
+      }
+    } // namespace internal
+
+
+
+    /**
+     * A base helper class that facilitates the evaluation of the derivitive
+     * of a number of user-defined dependent variables $\mathbf{f}(\mathbf{X})$
+     * with respect to a set of independent variables $\mathbf{X}$.
+     *
+     * @warning Adol-C does not support the standard threading models used by
+     * deal.II, so this class should \b not be embedded within a multithreaded
+     * function. It is, however, suitable for use in both serial and MPI routines.
+     *
+     * In addition to the dimension @p dim, this class is templated on the
+     * floating point type @p scalar_type of the number that we'd like to
+     * differentiate, as well as an enumeration indicating the @p ADNumberTypeCode .
+     *
+     * @author Jean-Paul Pelteret, 2016, 2017
+     */
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType = double>
+    class ADHelperBase
+    {
+    public:
+
+      /**
+      * Type definition for the floating point number type that are used in, and
+      * result from, all computations.
+      */
+      typedef typename AD::NumberTraits<ScalarType,ADNumberTypeCode>::scalar_type scalar_type;
+
+      /**
+      * Type definition for the auto-differentiation number type that is used
+      * in all computations.
+      */
+      typedef typename AD::NumberTraits<ScalarType,ADNumberTypeCode>::ad_type     ad_type;
+
+      /**
+       * @name Constructor / destructor
+       */
+//@{
+
+      /**
+      * The constructor for the class.
+      *
+      * @param[in] n_independent_variables The number of independent variables
+      * that will be used in the definition of the functions with which one
+      * desires to compute the sensitivities of.
+      * @param[in] n_dependent_variables Number of scalar functions defined
+      * with a sensitivity to the given independent variables.
+      */
+      ADHelperBase(const unsigned int n_independent_variables,
+                   const unsigned int n_dependent_variables);
+
+      /**
+      * Destructor
+      */
+      virtual
+      ~ADHelperBase();
+
+//@}
+
+      /**
+       * @name Interrogation of internal information
+       */
+//@{
+
+      /**
+      * Returns the number of independent variables that this object expects to
+      * work with.
+      */
+      std::size_t
+      n_independent_variables() const;
+
+      /**
+      * Returns the number of dependent variables that this object expects to
+      * operate on.
+      */
+      std::size_t
+      n_dependent_variables() const;
+
+      /**
+      * Returns the tape number which is currently activated for recording or
+      * reading.
+      */
+      int
+      active_tape() const;
+
+      /**
+      * Prints the values currently assigned to the independent variables.
+      *
+      * @param[in] stream The output stream to which the values are to be written.
+      */
+      void
+      print_values(std::ostream &stream) const;
+
+      /**
+      * Prints the statistics regarding the usage of the tapes.
+      *
+      * @param[in] stream The output stream to which the values are to be written.
+      */
+      void
+      print_tape_stats(std::ostream &stream,
+                       const unsigned int &tape_index) const;
+
+//@}
+
+      /**
+       * @name Recording tapes
+       */
+//@{
+
+      /**
+      * Reset the state of the helper class.
+      *
+      * When an instance of an ADHelperBase is stored as a class member object
+      * with the intention to reuse its instance, it is necessary to reset the
+      * state of the object before use. This is because, internally, there is
+      * error checking performed to ensure that the correct auto-differentiable
+      * data is being tracked and used only when appropriate. This function
+      * clears all member data and, therefore, allows the state of all internal
+      * flags to be safely reset to their initial state.
+      *
+      * In the rare case that the number of independent or dependent variables
+      * has changed, this can also reconfigured by passing in the appropriate
+      * arguments to the function.
+      *
+      * @note This also resets the active tape number to an invalid number, and
+      * deactivates the recording mode for taped variables.
+      */
+      virtual void
+      reset (const unsigned int n_independent_variables = 0,
+             const unsigned int n_dependent_variables   = 0);
+
+      /**
+      * Specify the number of @p independent_variables to be used in tapeless
+      * mode.
+      *
+      * Although this function is called internally in the ADHelperBase
+      * constructor, there may be occasions when adtl::adoubles are created
+      * before an instance of this class is created. This function therefore
+      * allows one to declare at the earliest possible instance how many
+      * directional derivatives will be considered in tapeless mode.
+      *
+      * @warning Calling this function leaves the set number of directional
+      * derivatives in a persistent state, so it will not be possible to
+      * further modify during course of the program's execution.
+      */
+      static void
+      configure_tapeless_mode (const unsigned int &n_independent_variables);
+
+      /**
+      * Select a tape to record to or read from.
+      *
+      * @param[in] tape_index The index of the tape to be written
+      *
+      * @note The chosen tape index must be greater than zero and less than
+      * max_tape_index.
+      */
+      void
+      activate_tape(const unsigned int &tape_index);
+
+      /**
+      * Enable recording mode for a given tape.
+      *
+      * The operations that take place between this function call and that
+      * of disable_record_sensitivities are recorded to the tape and can
+      * be replayed and reevaluated as necessary.
+      *
+      * The typical set of operations to be performed during this phase are:
+      *   - Definition of some dummy independent variables via
+      *     register_independent_variable(). These define the branch of operations
+      *     tracked by the tape
+      *   - Extraction of a set of independent variables of auto-differentiable
+      *     type using get_sensitive_variables(). These are then tracked during
+      *     later computations.
+      *   - Defining the dependent variables via register_dependent_variable().
+      *     These are the
+      *
+      * @param[in] tape_index The index of the tape to be written
+      * @param[in] overwrite_tape Express whether tapes are allowed to be reused
+      * @param[in] keep Determines whether the numerical values of all independent
+      *                 variables are recorded in the tape buffer. If true, then
+      *                 tape can be immediately used to perform computations after
+      *                 recording is complete.
+      *
+      * @note During the recording phase, no value(), gradient() or hessian()
+      *       operations can be performed.
+      */
+      bool
+      enable_record_sensitivities(const unsigned int &tape_index,
+                                  const bool          overwrite_tape = false,
+                                  const bool          keep = true);
+
+      /**
+      * Disable recording mode for a given tape.
+      *
+      * @note After this functiom call, the tape is considered ready for use and
+      * operations such as value(), gradient() or hessian() can be executed.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      void
+      disable_record_sensitivities(const bool write_tapes_to_file = false);
+
+    protected:
+
+      /**
+       * @name Taping
+       */
+//@{
+
+      /**
+      * A tape index that is, in general, reserved by Adol-C and unusable to be
+      * safely used under all conditions.
+      *
+      * Adol-C doesn't allow us to record to this tape (i.e. can't write it to
+      * file), so we can safely use it as an invalidation case. In general, we
+      * want the user to be able to record to a tape if they'd like.
+      */
+      static const int invalid_tape_index = 0;
+
+      /**
+      * The maximum number of tapes that can be written on one process
+      */
+      static const int max_tape_index = 32; // TODO: Double check whether this is the maximum number of tapes allowed
+
+      /*-
+      * Index of the tape that is currently in use. It is this tape that will be
+      * recorded to or read from when performing computations.
+      */
+      int              active_tape_index;
+
+      /*-
+      * A collection of tapes that have been recorded to on this process.
+      *
+      * It is important to keep track of this so that one doesn't accidentally
+      * record over a tape (unless specifically instructed to) and that one
+      * doesn't try to use a tape that doesn't exist.
+      */
+      std::set<int>    registered_tapes;
+
+      /**
+      * Mark whether we're we're going to tell Adol-C to keep the values stored
+      * on the tape so that they can be evaluated again at a later stage.
+      */
+      bool             keep_values;
+
+      /**
+      * Mark whether we're currently recording a tape. Dependent on the state of
+      * this flag, only a restricted set of operations are allowable.
+      */
+      bool             is_recording;
+
+//@}
+
+      /**
+       * @name Independent variables
+       */
+//@{
+
+      /**
+      * A set of independent variables $\mathbf{X}$ that we will be performing
+      * symbolic differentiation with respect to.
+      *
+      * The gradients and hessians of dependent variables will be computed
+      * at these finite values.
+      */
+      mutable std::vector<scalar_type> independent_variable_values;
+
+      /**
+      * A set of sensitive independent variables $\mathbf{X}$ that we will be
+      * performing symbolic differentiation with respect to.
+      *
+      * The gradients and hessians of dependent variables will be computed
+      * using these configured AD numbers. Note that only reverse-mode AD
+      * requires that the sensitive independent variables be stored.
+      */
+      mutable std::vector<ad_type>     independent_variables;
+
+      /**
+      * Registered independent variables that have been manipulated for a given
+      * set of operations.
+      */
+      std::vector<bool>                touched_independent_variables;
+
+      /**
+      * Registered independent variables that have been extracted and their
+      * sensitivities marked.
+      */
+      mutable std::vector<bool>        touched_marked_independent_variables;
+
+      /**
+      * Reset the boolean vector that indicates which independent varaibles
+      * we've been manipulating for the current set of operations
+      */
+      void
+      reset_touched_independent_variables ();
+
+      /**
+      * Set the actual value of the independent variable $X_{i}$.
+      *
+      * @param[in] value The value to set the index'd independent variable to.
+      * @param[in] index The index in the vector of independent variables.
+      */
+      void
+      set_sensitivity_value (const scalar_type    &value,
+                             const unsigned int  index);
+
+      /**
+      * Initialise an independent variable $X_{i}$ and record it to the tape.
+      *
+      * @note Care must be taken to mark each independent variable only once.
+      *
+      * @note The order in which the independent variables are marked defined the
+      * order of all future internal operations. They must be manipulated in the
+      * same order as that in which they are first marked. If not then Adol-C
+      * won't throw an error, but rather it might complain nonsensically during
+      * later computations or produce garbage results.
+      *
+      * @param[out] out An auto-differentiable number that is ready for use in
+      * computations. The operations that are performed with it are recorded on
+      * the tape and will be considered in the computation of dependent variable
+      * values.
+      * @param[in] index The index in the vector of independent variables.
+      */
+      void
+      mark_independent_variable (ad_type            &out,
+                                 const unsigned int  index) const;
+
+      /**
+       * Finalize the state of the independent variables before use.
+       *
+       * This step and the storage of the independent variables is done
+       * separately because some derived classes may offer the capability
+       * to add independent varialbes in a staggered manner. This function
+       * is to be triggered when these values are considered finalized
+       * and we can safely initialize the sensitive equivalents of those
+       * values.
+       */
+      void
+      finalize_sensitive_independent_variables() const;
+
+      /**
+      * Initialise an independent variable $X_{i}$.
+      *
+      * @param[out] out An auto-differentiable number that is ready for use in
+      * standard computations. The operations that are performed with it are not
+      * recorded on the tape, and so should only be used when not in recording
+      * mode.
+      * @param[in] index The index in the vector of independent variables.
+      */
+      void
+      get_independent_variable (ad_type            &out,
+                                const unsigned int  index) const;
+
+      /**
+      * The number of independent variables that have been manipulated within a
+      * set of operations.
+      */
+      unsigned int
+      n_touched_independent_variables () const;
+//@}
+
+      /**
+       * @name Dependent variables
+       */
+//@{
+
+      /**
+      * A set of dependent variables $\mathbolsymbol{\Psi}(\mathbf{X})$ for which
+      * we wish to compute the derivatives of.
+      *
+      * The gradients and hessians of these dependent variables will be computed
+      * at the values $\mathbf{X}$ set with the set_sensitivity_value function.
+      *
+      * @note These are stored as an @p ad_type so that we can use them to
+      * compute function values and directional derivatives in the case that
+      * tapeless numbers are used
+      */
+      std::vector<ad_type> dependent_variables;
+
+      /**
+      * A list of dependent variables.
+      */
+      std::vector<bool>    touched_dependent_variables;
+
+      /**
+      * The number of dependent variables that have been registered.
+      */
+      unsigned int
+      n_touched_dependent_variables () const;
+
+      /**
+      * Register the definition of the index'th dependent variable
+      * $\Psi(\mathbf{X})$.
+      *
+      * @param[in] func The recorded function that defines a dependent variable.
+      * @param[in] index The index of the entry in the global list of dependent
+      * variables that this function belongs to.
+      *
+      * @note Each dependent variable must only be registered once
+      */
+      void
+      register_dependent_variable (const ad_type      &func,
+                                   const unsigned int  index);
+//@}
+
+    }; // class ADHelperBase
+
+
+
+    /**
+     * A base helper class that facilitates the evaluation of point-wise defined
+     * functions. This class is not complete for use since no derivative
+     * computations have been implemeneted. What can be computed and how the
+     * computed values are interpreted depends on the number of dependent variables
+     * to be considered.
+     *
+     * @author Jean-Paul Pelteret, 2016
+     */
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType = double>
+    class ADHelperPointLevelFunctionsBase
+      : public ADHelperBase<dim,ADNumberTypeCode,ScalarType>
+    {
+    public:
+
+      /**
+      * Type definition for the floating point number type that are used in, and
+      * result from, all computations.
+      */
+      using scalar_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::scalar_type;
+
+      /**
+      * Type definition for the auto-differentiation number type that is used
+      * in all computations.
+      */
+      using ad_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::ad_type;
+
+      /**
+       * @name Constructor / destructor
+       */
+      //@{
+
+      /**
+      * The constructor for the class.
+      *
+      * @param[in] n_independent_variables The number of independent variables
+      * that the scalar function is sensitive to.
+      */
+      ADHelperPointLevelFunctionsBase(const unsigned int n_independent_variables,
+                                      const unsigned int n_dependent_variables);
+
+      /**
+      * Destructor
+      */
+      virtual
+      ~ADHelperPointLevelFunctionsBase();
+
+      //@}
+
+      /**
+       * @name Recording tapes
+       */
+      //@{
+
+      /**
+      * Reset the state of the helper class.
+      *
+      * When an instance of an ADHelperBase is stored as a class member object
+      * with the intention to reuse its instance, it is necessary to reset the
+      * state of the object before use. This is because, internally, there is
+      * error checking performed to ensure that the correct auto-differentiable
+      * data is being tracked and used only when appropriate. This function
+      * clears all member data and, therefore, allows the state of all internal
+      * flags to be safely reset to their initial state.
+      *
+      * In the rare case that the number of independent or dependent variables
+      * has changed, this can also reconfigured by passing in the appropriate
+      * arguments to the function.
+      *
+      * @note This also resets the active tape number to an invalid number, and
+      * deactivates the recording mode for taped variables.
+      */
+      virtual void
+      reset (const unsigned int n_independent_variables = 0,
+             const unsigned int n_dependent_variables   = 0);
+
+      /**
+      * Register the complete set of independent variables $\mathbf{X}$.
+      *
+      * @param[in] values A field that defines the values of all independent
+      * variables. To avoid potential issues with branch switching, it may be a
+      * good idea to choose the field's values close to those that will be later
+      * evaluated.
+      *
+      * @note The input value type must correspond to this class's number type.
+      * So if this class is templated on type double then the number type
+      * associated with value must also be of type double.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      void
+      register_independent_variables (const std::vector<scalar_type> &values);
+
+      /**
+      * Register the subset of independent variables
+      * $\mathbf{A} \in \mathbf{X}$.
+      *
+      * @param[in] value A field that defines a number of independent variables.
+      * To avoid potential issues with branch switching, it may be a good idea
+      * to choose the field's values close to those that will be later
+      * evaluated.
+      * @param[in] extractor An extractor associated with the input field
+      * variables. This effectively defines which components of the global set
+      * of independent variables this field is associated with.
+      *
+      * @note The input value type must correspond to this class's number type.
+      * So if this class is templated on type double then the number type
+      * associated with value must also be of type double.
+      *
+      * @note The input extractor must correspond to the input value type.
+      * So, for example, if a value is a rank-1 tensor, then the extractor must
+      * be an FEValuesExtractors::Vector or FEValuesExtractors::Tensor<1>.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      template<typename ValueType, typename ExtractorType>
+      void
+      register_independent_variable (const ValueType     &value,
+                                     const ExtractorType &extractor);
+
+      /**
+      * The complete set of independent variables of auto-differentiable type.
+      * It is indicated to Adol-C that operations performed with these numbers
+      * are to be tracked, so they are considered "sensitive" variables.
+      * The values of the components of the returned object are initialised to
+      * the values set with register_independent_variable().
+      *
+      * @return An object of auto-differentiable type numbers.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      const std::vector<ad_type> &
+      get_sensitive_variables ();
+
+      /*
+      * Extract of a set of independent variables of auto-differentiable type.
+      * It is indicated to Adol-C that operations performed with these numbers
+      * are to be tracked, so they are considered "sensitive" variables.
+      * The values of the components of the returned object are initialised to
+      * the values set with register_independent_variable().
+      *
+      * @param[in] extractor An extractor associated with the input field
+      * variables. This effectively defines which components of the global set
+      * of independent variables this field is associated with.
+      * @return An object of auto-differentiable type numbers. The return type is
+      * based on the input extractor, and will be either a scalar, Tensor<1,dim>,
+      * Tensor<2,dim>, or SymmetricTensor<2,dim>.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      template<typename ExtractorType>
+      typename internal::Extractor<dim,ExtractorType>::template tensor_type<ad_type>
+      get_sensitive_variables (const ExtractorType &extractor);
+
+      //@}
+
+      /**
+       * @name Post-processing tapes
+       */
+      //@{
+
+      /*
+      * Extract of a set of independent variables of auto-differentiable type.
+      * Operations performed with these numbers are not tracked by Adol-C,
+      * so they are considered "non-sensitive" variables.
+      * The values of the components of the returned object are initialised to
+      * the values set with register_independent_variable().
+      *
+      * @param[in] extractor An extractor associated with the input field
+      * variables. This effectively defines which components of the global set
+      * of independent variables this field is associated with.
+      * @return An object of auto-differentiable type numbers. The return type is
+      * based on the input extractor, and will be either a scalar, Tensor<1,dim>,
+      * Tensor<2,dim>, or SymmetricTensor<2,dim>.
+      *
+      * @note This function is not typically used within the context of automatic
+      * differentation computations, but can make performing substitutions in
+      * symbolic computations easier.
+      *
+      * @note This operation is only valid outside recording mode.
+      */
+      template<typename ExtractorType>
+      typename internal::Extractor<dim,ExtractorType>::template tensor_type<ad_type>
+      get_non_sensitive_variables (const ExtractorType &extractor);
+
+      //@}
+
+      /**
+       * @name Computations using the recorded tape at the point defined by the
+       * set independent variable values
+       */
+      //@{
+
+      /**
+      * Set the values for the independent variables $\mathbf{X}$.
+      *
+      * @param[in] values A vector field that defines the values of all
+      * independent variables.
+      *
+      * @note The input value type must correspond to this class's number type.
+      * So if this class is templated on type double then the number type
+      * associated with value must also be of type double.
+      *
+      * @note If the keep flag has been set when enable_record_sensitivities() is
+      * called, the tape is immediately used after creation, and the values of
+      * the independent variables set by register_independent_variable() are those
+      * at which the function is to be evaluated, then a call to this function
+      * is not strictly necessary.
+      */
+      void
+      set_independent_variables (const std::vector<scalar_type> &values);
+
+      /**
+      * Set the values for a subset of independent variables
+      * $\mathbf{A} \in \mathbf{X}$.
+      *
+      * @param[in] value A field that defines the values of a number of
+      * independent variables.
+      * @param[in] extractor An extractor associated with the input field
+      * variables. This effectively defines which components of the global set
+      * of independent variables this field is associated with.
+      *
+      * @note The input value type must correspond to this class's number type.
+      * So if this class is templated on type double then the number type
+      * associated with value must also be of type double.
+      *
+      * @note The input extractor must correspond to the input value type.
+      * So, for example, if a value is a rank-1 tensor, then the extractor must
+      * be an FEValuesExtractors::Vector or FEValuesExtractors::Tensor<1>.
+      *
+      * @note If the keep flag has been set when enable_record_sensitivities() is
+      * called, the tape is immediately used after creation, and the values of
+      * the independent variables set by register_independent_variable() are those
+      * at which the function is to be evaluated, then a call to this function
+      * is not strictly necessary.
+      */
+      template<typename ValueType, typename ExtractorType>
+      void
+      set_independent_variable (const ValueType     &value,
+                                const ExtractorType &extractor);
+
+      //@}
+
+    protected:
+
+      /**
+       * @name Independent variables
+       */
+      //@{
+
+      /**
+      * Set the actual value of the independent variable $X_{i}$.
+      *
+      * @param[in] value The value to set the index'd independent variable to.
+      * @param[in] index The index in the vector of independent variables.
+      * @param[in] symmetric_dof mark whether this index relates to a component
+      * of a symmetric field.
+      */
+      void
+      set_sensitivity_value (const scalar_type  &value,
+                             const unsigned int  index,
+                             const bool          symmetric_dof);
+
+      /**
+      * The independent variables for which we must take into account symmetry
+      * when extracting their gradient or hessian values.
+      */
+      bool
+      is_symmetric_independent_variable (const unsigned int index) const;
+
+      /**
+      * The number of independent variables that have been marked as being
+      * components of a symmetric field
+      */
+      unsigned int
+      n_symmetric_independent_variables () const;
+
+
+      //@}
+
+    private:
+
+      /**
+       * @name Independent variables
+       */
+      //@{
+
+      /**
+      * The independent variables for which we must take into account symmetry
+      * when extracting their gradient or hessian values.
+      */
+      std::vector<bool> symmetric_independent_variables;
+
+      //@}
+
+    }; // class ADHelperPointLevelFunctionsBase
+
+
+
+    /**
+     * A helper class that facilitates the evaluation of a scalar function,
+     * its first and second derivatives (gradient and hessian). This class
+     * would typically be used to compute the first and second derivatives
+     * of a <b>stored energy function<\b> defined at a quadrature point.
+     * It can also be used to compute derivatives of any other scalar field
+     * so long as all its dependence on the independent variables are explicit
+     * (that is to say, no independent variables may have some implicit
+     * dependence on one another).
+     *
+     * An example of its usage in the case of a multi-field constitutive laws
+     * might be as follows:
+     * @code
+     * // Define a tape; this pre-records the steps necessary to perform AD
+     * // computations. Reusing it may be be a time-saver in some scenarios.
+     * // Instead of having to perform these operations each time a AD helper is
+     * // used, one could run them once up front and then recall a set of taped
+     * // operations as necessary.
+     * const int tape_no = 1;
+     * const bool is_recording = ad_helper.enable_record_sensitivities(tape_no, //  material_id
+     *                                                                 true,    // overwrite_tape
+     *                                                                 true);   // keep
+     *
+     * // Define some extractors that will help us set independent variables and
+     * // and later get the computed values related to the dependent variables
+     * const FEValuesExtractors::SymmetricTensor<2> C_dofs (0);
+     * const FEValuesExtractors::Vector             H_dofs (dealii::SymmetricTensor<2,dim>::n_independent_components);
+     * const unsigned int n_independent_variables = SymmetricTensor<2,dim>::n_independent_components
+     *                                            + Tensor<1,dim>::n_independent_components;
+     *
+     * // Define the helper that we will use in the AD computations for our scalar
+     * // energy function. Note that we expect it to return values of type double.
+     * ADHelperPointLevelFunctionsBase<dim,double> ad_helper (n_independent_variables);
+     *
+     * // Fields that provide the independent values.
+     * // When the tape is being played, these should be set to Something
+     * // meaningful.
+     * const Tensor<1,dim> H = ...;
+     * const SymmetricTensor<2,dim> C = ...;
+     *
+     * if (is_recording == true)
+     * {
+     *   // These could happily be set to anything, unless the function will
+     *   // be evaluated along a branch not otherwise traversed during later
+     *   // use. For this reason, in this example instead of using some dummy
+     *   // values, we'll actually map out the function at the same point around
+     *   // which we'll later linearise it.
+     *   ad_helper.register_independent_variable(H, H_dofs);
+     *   ad_helper.register_independent_variable(C, C_dofs);
+     *
+     *   // NOTE: We have to extract the sensitivities in the order we wish to
+     *   //       introduce them. So this means we have to do it by logical order
+     *   //       of the extractors that we've created.
+     *   const SymmetricTensor<2,dim,ADNumberType> C_AD = ad_helper.get_sensitive_variables(C_dofs);
+     *   const Tensor<1,dim,ADNumberType>          H_AD = ad_helper.get_sensitive_variables(H_dofs);
+     *
+     *   // Here we define the material stored energy function.
+     *   // Insert your own fancy function here...
+     *   ADNumberType psi = 0.5*(1.0+(H_AD*H_AD)/100.0)*(trace(C_AD) - dim);
+     *
+     *   ad_helper.register_dependent_variable(psi_CH);
+     *   ad_helper.disable_record_sensitivities(false); // write_tapes_to_file
+     * }
+     * else
+     * {
+     *   Assert(is_recording==true, ExcInternalError());
+     * }
+     *
+     * // Now we do some work...
+     * // First we activate a tape and set the values of the
+     * // independent variables. Note that since we've set the keep
+     * // flag and their values have not changed, it is not strictly
+     * // necessary to reset the values of the independent variables.
+     * ad_helper.activate_tape(tape_no);
+     * ad_helper.set_independent_variable(C, C_dofs);
+     * ad_helper.set_independent_variable(H, H_dofs);
+     *
+     * // Play the tape and record the output function value, its gradient and
+     * // linearisation. These are expensive to compute, so we'll do this once
+     * // and extract the desired values from tme
+     * const double psi               = ad_helper.compute_value();
+     * const Vector<double> Dpsi      = ad_helper.compute_gradient();
+     * const FullMatrix<double> D2psi = ad_helper.compute_hessian();
+     *
+     * // Extract the desired components of the gradient vector and Hessian matrix
+     * const SymmetricTensor<2,dim> S = 2.0*ad_helper.extract_gradient_component(Dpsi,C_dofs);
+     * const SymmetricTensor<4,dim> H = 4.0*ad_helper.extract_hessian_component(D2psi,C_dofs,C_dofs);
+     * @endcode
+     *
+     * @warning Adol-C does not support the standard threading models used by
+     * deal.II, so this class should \b not be embedded within a multithreaded
+     * function. It is, however, suitable for use in both serial and MPI routines.
+     *
+     * @author Jean-Paul Pelteret, 2016
+     */
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType = double>
+    class ADHelperScalarFunction
+      : public ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>
+    {
+    public:
+
+      /**
+      * Type definition for the floating point number type that are used in, and
+      * result from, all computations.
+      */
+      using scalar_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::scalar_type;
+
+      /**
+      * Type definition for the auto-differentiation number type that is used
+      * in all computations.
+      */
+      using ad_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::ad_type;
+
+      /**
+       * @name Constructor / destructor
+       */
+//@{
+
+      /**
+      * The constructor for the class.
+      *
+      * @param[in] n_independent_variables The number of independent variables
+      * that the scalar function is sensitive to.
+      */
+      ADHelperScalarFunction(const unsigned int n_independent_variables);
+
+      /**
+      * Destructor
+      */
+      virtual
+      ~ADHelperScalarFunction();
+
+//@}
+
+      /**
+       * @name Dependent variables
+       */
+//@{
+
+      /**
+      * Register the definition of the scalar field $\Psi(\mathbf{X})$.
+      *
+      * @param[in] func The recorded function that defines a dependent variable.
+      *
+      * @note For this class that expects only one dependent variable, this
+      * function must only be called once per tape.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      void
+      register_dependent_variable (const ad_type &func);
+
+//@}
+
+      /**
+       * @name Computations using the recorded tape at the point defined by the
+       * set independent variable values
+       */
+//@{
+
+      /**
+      * Computes the value of the scalar field $\Psi(\mathbf{X})$ using the tape
+      * as opposed to executing the source code.
+      *
+      * @return A scalar object with the value for the scalar field evaluated
+      * at the point defined by the independent variable values.
+      */
+      scalar_type
+      compute_value() const;
+
+      /**
+      * Computes the gradient (first derivative) of the scalar field with respect
+      * to all independent variables, i.e.
+      * @f[
+      *   \frac{\partial\Psi(\mathbf{X})}{\partial\mathbf{X}}
+      * @f]
+      *
+      * @return A Vector with the values for the scalar field gradient evaluated
+      * at the point defined by the independent variable values.
+      */
+      Vector<scalar_type>
+      compute_gradient() const;
+
+      /**
+      * Computes the hessian (second derivative)  of the scalar field with respect
+      * to all independent variables, i.e.
+      * @f[
+      *   \frac{\partial^{2}\Psi(\mathbf{X})}{\partial\mathbf{X} \otimes \partial\mathbf{X}}
+      * @f]
+      *
+      * @return A FullMatrix with the values for the scalar field gradient evaluated
+      * at the point defined by the independent variable values.
+      */
+      FullMatrix<scalar_type>
+      compute_hessian() const;
+
+      /**
+      * Extract the function gradient for a subset of independent variables
+      * $\mathbf{A} \in \mathbf{X}$, i.e.
+      * @f[
+      *   \frac{\partial\Psi(\mathbf{X})}{\partial\mathbf{A}}
+      * @f]
+      *
+      * @param[in] gradient The gradient of the scalar function with respect to
+      * all independent variables, i.e. that returned by compute_gradient().
+      * @param[in] extractor_row An extractor associated with the input field
+      * variables. This effectively defines which components of the global set
+      * of independent variables this field is associated with.
+      */
+      template<typename ExtractorType_Row>
+      typename internal::Gradient<dim,scalar_type,ExtractorType_Row>::type
+      extract_gradient_component(const Vector<scalar_type> &gradient,
+                                 const ExtractorType_Row   &extractor_row) const;
+
+      /**
+      * Extract the function hessian for a subset of independent variables
+      * $\mathbf{A},\mathbf{B} \in \mathbf{X}$, i.e.
+      * @f[
+      *   \frac{}{\partial\mathbf{B}} \left[ \frac{\partial\Psi(\mathbf{X})}{\partial\mathbf{A}} \right]
+      *   = \frac{\partial^{2}\Psi(\mathbf{X})}{\partial\mathbf{B} \otimes \partial\mathbf{A}}
+      * @f]
+      *
+      * @param[in] hessian The hessian of the scalar function with respect to
+      * all independent variables, i.e. that returned by compute_hessian().
+      * @param[in] extractor_row An extractor associated with the input field
+      * variables for which the first index of the hessian is extracted.
+      * @param[in] extractor_col An extractor associated with the input field
+      * variables for which the second index of the hessian is extracted.
+      */
+      template<typename ExtractorType_Row, typename ExtractorType_Col>
+      typename internal::Hessian<dim,scalar_type,ExtractorType_Row,ExtractorType_Col>::type
+      extract_hessian_component(const FullMatrix<scalar_type> &hessian,
+                                const ExtractorType_Row       &extractor_row,
+                                const ExtractorType_Col       &extractor_col) const;
+
+      /**
+      * Extract the function hessian for a subset of independent variables
+      * $\mathbf{A},\mathbf{B} \in \mathbf{X}$, i.e.
+      * @f[
+      *   \frac{}{\partial\mathbf{B}} \left[ \frac{\partial\Psi(\mathbf{X})}{\partial\mathbf{A}} \right]
+      * @f]
+      *
+      * This function is a specialisation of the above for rank-0 tensors (scalars)
+      */
+      Tensor<0,dim,scalar_type>
+      extract_hessian_component(const FullMatrix<scalar_type>    &hessian,
+                                const FEValuesExtractors::Scalar &extractor_row,
+                                const FEValuesExtractors::Scalar &extractor_col) const;
+
+      /**
+      * Extract the function hessian for a subset of independent variables
+      * $\mathbf{A},\mathbf{B} \in \mathbf{X}$, i.e.
+      * @f[
+      *   \frac{}{\partial\mathbf{B}} \left[ \frac{\partial\Psi(\mathbf{X})}{\partial\mathbf{A}} \right]
+      * @f]
+      *
+      * This function is a specialisation of the above for rank-4 symmetric tensors
+      */
+      SymmetricTensor<4,dim,scalar_type>
+      extract_hessian_component(const FullMatrix<scalar_type>                &hessian,
+                                const FEValuesExtractors::SymmetricTensor<2> &extractor_row,
+                                const FEValuesExtractors::SymmetricTensor<2> &extractor_col) const;
+
+//@}
+
+    }; // class ADHelperScalarFunction
+
+
+
+    /**
+     * A helper class that facilitates the evaluation of a vector of functions,
+     * typically one that represents a collection of coupled, multi-dimensional
+     * fields.
+     * This class would typically be used to compute the linearisation a set of
+     * kinetic field variables defined at the quadrature point level.
+     *
+     * An example of its usage in the case of a quadrature point data linearisation
+     * might be as follows:
+     * @code
+     * @endcode
+     *
+     * @warning Adol-C does not support the standard threading models used by
+     * deal.II, so this class should \b not be embedded within a multithreaded
+     * function. It is, however, suitable for use in both serial and MPI routines.
+     *
+     * @author Jean-Paul Pelteret, 2016
+     */
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType = double>
+    class ADHelperVectorFunction
+      : public ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>
+    {
+    public:
+
+      /**
+      * Type definition for the floating point number type that are used in, and
+      * result from, all computations.
+      */
+      using scalar_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::scalar_type;
+
+      /**
+      * Type definition for the auto-differentiation number type that is used
+      * in all computations.
+      */
+      using ad_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::ad_type;
+
+      /**
+       * @name Constructor / destructor
+       */
+//@{
+
+      /**
+      * The constructor for the class.
+      *
+      * @param[in] n_independent_variables The number of independent variables
+      * that the scalar function is sensitive to.
+      */
+      ADHelperVectorFunction(const unsigned int n_independent_variables,
+                             const unsigned int n_dependent_variables);
+
+      /**
+      * Destructor
+      */
+      virtual
+      ~ADHelperVectorFunction();
+
+//@}
+
+      /**
+       * @name Dependent variables
+       */
+//@{
+
+      /**
+      * Register the definition of the vector field $\boldsymbol{\Psi}(\mathbf{X})$.
+      *
+      * @param[in] func A vector of recorded functions that defines the dependent
+      * variables.
+      *
+      * @note For this class that expects only vector field of dependent
+      * variables, this function must only be called once per tape.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      void
+      register_dependent_variables (const std::vector<ad_type> &funcs);
+
+      /**
+      * Register the definition of the scalar field $\Psi(\mathbf{X})$.
+      *
+      * @param[in] funcs The recorded functions that define a set of dependent variable.
+      * @param[in] extractor An extractor associated with the input field
+      * variables. This effectively defines which components of the global set
+      * of dependent variables this field is associated with.
+      *
+      * @note The input extractor must correspond to the input value type.
+      * So, for example, if a value is a rank-1 tensor, then the extractor must
+      * be an FEValuesExtractors::Vector or FEValuesExtractors::Tensor<1>.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      template<typename ValueType, typename ExtractorType>
+      void
+      register_dependent_variable (const ValueType     &funcs,
+                                   const ExtractorType &extractor);
+
+//@}
+
+      /**
+       * @name Computations using the recorded tape at the point defined by the
+       * set independent variable values
+       */
+//@{
+
+      /**
+      * Computes the value of the vector field $\mathbf{f} = \boldsymbol{\Psi}(\mathbf{X})$
+      * using the tape as opposed to executing the source code.
+      *
+      * @return A Vector object with the value for each component of the vector
+      * field evaluated at the point defined by the independent variable values.
+      */
+      Vector<scalar_type>
+      compute_values() const;
+
+      /**
+      * Computes the jacobian (first derivative) of the vector field with respect
+      * to all independent variables, i.e.
+      * @f[
+      *   \mathbf{J}(\boldsymbol{\Psi})
+      *      = \frac{\partial\boldsymbol{\Psi}(\mathbf{X})}{\partial\mathbf{X}}
+      * @f]
+      *
+      * @return A FullMatrix with the gradient of each component of the vector
+      * field evaluated at the point defined by the independent variable values.
+      */
+      FullMatrix<scalar_type>
+      compute_jacobian() const;
+
+
+      /**
+      * Extract the set of function' values for a subset of independent variables
+      * $\mathbf{A} \in \mathbf{X}$, i.e.
+      * @f[
+      *   \mathbf{f}(\boldsymbol{\Psi})
+      *      = \frac{\partial\boldsymbol{\Psi}(\mathbf{X})}{\partial\mathbf{A}}
+      * @f]
+      *
+      * @param[in] gradient The gradient of the scalar function with respect to
+      * all independent variables, i.e. that returned by compute_gradient().
+      * @param[in] extractor_row An extractor associated with the input field
+      * variables. This effectively defines which components of the global set
+      * of independent variables this field is associated with.
+      */
+      template<typename ExtractorType_Row>
+      typename internal::Gradient<dim,scalar_type,ExtractorType_Row>::type
+      extract_value_component(const Vector<scalar_type> &values,
+                              const ExtractorType_Row   &extractor_row) const;
+
+      /**
+      * Extract the set of functions' jacobian for a subset of independent
+      * variables $\mathbf{A} \in \mathbf{X}$, i.e.
+      * @f[
+      *   \mathbf{J}(\boldsymbol{\Psi})
+      *      = \frac{\partial\boldsymbol{\Psi}(\mathbf{X})}{\partial\mathbf{A}}
+      * @f]
+      *
+      * @param[in] jacobian The jacobian of the vector function with respect to
+      * all independent variables, i.e. that returned by compute_jacobian().
+      * @param[in] extractor_row An extractor associated with the input field
+      * variables for which the first index of the jacobian is extracted.
+      * @param[in] extractor_col An extractor associated with the input field
+      * variables for which the second index of the jacobian is extracted.
+      */
+      template<typename ExtractorType_Row, typename ExtractorType_Col>
+      typename internal::Hessian<dim,scalar_type,ExtractorType_Row,ExtractorType_Col>::type
+      extract_jacobian_component(const FullMatrix<scalar_type> &jacobian,
+                                 const ExtractorType_Row       &extractor_row,
+                                 const ExtractorType_Col       &extractor_col) const;
+
+      /**
+      * Extract the set of functions' jacobian for a subset of independent
+      * variables $\mathbf{A},\mathbf{B} \in \mathbf{X}$, i.e.
+      * @f[
+      *   \mathbf{J}(\boldsymbol{\Psi})
+      *      = \frac{}{\partial\mathbf{B}} \left[ \frac{\partial\boldsymbol{\Psi}(\mathbf{X})}{\partial\mathbf{A}} \right]
+      * @f]
+      *
+      * This function is a specialisation of the above for rank-0 tensors (scalars)
+      */
+      Tensor<0,dim,scalar_type>
+      extract_jacobian_component(const FullMatrix<scalar_type>    &jacobian,
+                                 const FEValuesExtractors::Scalar &extractor_row,
+                                 const FEValuesExtractors::Scalar &extractor_col) const;
+
+      /**
+      * Extract the set of functions' jacobian for a subset of independent
+      * variables $\mathbf{A},\mathbf{B} \in \mathbf{X}$, i.e.
+      * @f[
+      *   \mathbf{J}(\boldsymbol{\Psi})
+      *      = \frac{}{\partial\mathbf{B}} \left[ \frac{\partial\boldsymbol{\Psi}(\mathbf{X})}{\partial\mathbf{A}} \right]
+      * @f]
+      *
+      * This function is a specialisation of the above for rank-4 symmetric tensors
+      */
+      SymmetricTensor<4,dim,scalar_type>
+      extract_jacobian_component(const FullMatrix<scalar_type>                &jacobian,
+                                 const FEValuesExtractors::SymmetricTensor<2> &extractor_row,
+                                 const FEValuesExtractors::SymmetricTensor<2> &extractor_col) const;
+
+//@}
+
+    }; // class ADHelperVectorFunction
+
+
+
+    /**
+     * A general helper class that facilitates the evaluation of a vector of
+     * functions, as well as its first derivatives (their Jacobian).
+     * This class would typically be used to compute the linearisation of a
+     * set of local nonlinear equations, but can also be used as the basis of
+     * the linearisation of the residual vector defined on the level of a finite
+     * element.
+     *
+     * @note When using the cell-level AD methods in 3d and/or with higher
+     * order elements, it is incredibly easy to exceed the tape buffer size.
+     * These buffer variables dictate the amount of memory allocated to a tape
+     * before it is written to file (at a significant performance loss).
+     * Therefore, as stated by the manual, it may be desirable to create a file
+     * ".adolcrc" in the program run directory and set the buffer size therein.
+     * For example, the following settings increase the default buffer size by
+     * 128 times:
+     * <code>
+       "OBUFSIZE" "67108864"
+       "LBUFSIZE" "67108864"
+       "VBUFSIZE" "67108864"
+    "     TBUFSIZE" "67108864"
+     * </code>
+     * Note that the quotation marks are mandatory.
+     *
+     * @warning Adol-C does not support the standard threading models used by
+     * deal.II, so this class should \b not be embedded within a multithreaded
+     * function. It is, however, suitable for use in both serial and MPI routines.
+     *
+     * @author Jean-Paul Pelteret, 2016
+     */
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType = double>
+    class ADHelperCellLevelBase
+      : public ADHelperBase<dim,ADNumberTypeCode,ScalarType>
+    {
+    public:
+
+      /**
+      * Type definition for the floating point number type that are used in, and
+      * result from, all computations.
+      */
+      using scalar_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::scalar_type;
+
+      /**
+      * Type definition for the auto-differentiation number type that is used
+      * in all computations.
+      */
+      using ad_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::ad_type;
+
+      /**
+       * @name Constructor / destructor
+       */
+//@{
+
+      /**
+      * The constructor for the class.
+      *
+      * @param[in] n_independent_variables The number of independent variables
+      * that the vector of functions is sensitive to.
+      * @param[in] n_dependent_variables The number of dependent variables, i.e.
+      * the number of functions in the vector that one wishes to compute the
+      * sensitivities of.
+      */
+      ADHelperCellLevelBase(const unsigned int n_independent_variables,
+                            const unsigned int n_dependent_variables);
+
+      /**
+      * Destructor
+      */
+      virtual
+      ~ADHelperCellLevelBase();
+
+//@}
+
+      /**
+       * @name Recording tapes
+       */
+//@{
+
+      /**
+      * Register the complete set of independent variables $\mathbf{X}$ that
+      * represent the local degree-of-freedom values.
+      *
+      * @param[in] values A field that defines the values of all degrees-of-freedom.
+      * To avoid potential issues with branch switching, it may be a good idea to
+      * choose these values close to those that will be later evaluated and linearized
+      * around.
+      *
+      * @note The input value type must correspond to this class's number type.
+      * So if this class is templated on type double then the number type
+      * associated with value must also be of type double.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      void
+      register_dof_values (const std::vector<scalar_type> &dof_values);
+
+      /**
+      * Register the complete set of independent variables $\mathbf{X}$ that
+      * represent the local degree-of-freedom values.
+      *
+      * @param[in] values A global field from which the values of all independent
+      * variables will be extracted. This typically will be the solution vector
+      * around at which point a residual vector is to be computed and around which
+      * linearisation is to occur. To avoid potential issues with branch
+      * switching, it may be a good idea to choose the field's values close to
+      * those that will be later evaluated.
+      * @param[in] local_dof_indices A vector of degree of freedom indices from
+      * which to extract the local degree of freedom values.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      template<typename VectorType>
+      void
+      register_dof_values (const VectorType                           &values,
+                           const std::vector<types::global_dof_index> &local_dof_indices);
+
+      /**
+      * The complete set of DoF values of auto-differentiable type.
+      * It is indicated to Adol-C that operations performed with these numbers
+      * are to be tracked, so they are considered "sensitive" variables.
+      * The values of the components of the returned object are initialised to
+      * the values set with register_independent_variable().
+      *
+      * @return An object of auto-differentiable type numbers.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      const std::vector<ad_type> &
+      get_sensitive_dof_values ();
+
+//@}
+
+      /**
+       * @name Post-processing tapes
+       */
+//@{
+
+      /*
+      * The complete set of DoF values of auto-differentiable type.
+      * Operations performed with these numbers are not tracked by Adol-C,
+      * so they are considered "non-sensitive" variables.
+      * The values of the components of the returned object are initialised to
+      * the values set with register_independent_variable().
+      *
+      * @return An object of auto-differentiable type numbers.
+      *
+      *
+      * @note This function is not typically used within the context of automatic
+      * differentation computations, but can make performing substutitions in
+      * symbolic computations easier.
+      *
+      * @note This operation is only valid outside recording mode.
+      */
+      std::vector<ad_type>
+      get_non_sensitive_dof_values ();
+
+//@}
+
+      /**
+       * @name Computations using the recorded tape at the point defined by the
+       * set independent variable values
+       */
+//@{
+
+      /**
+      * Set the values for the independent variables $\mathbf{X}$.
+      *
+      * @param[in] values A vector field that defines the values of all
+      * independent variables.
+      *
+      * @note The input value type must correspond to this class's number type.
+      * So if this class is templated on type double then the number type
+      * associated with value must also be of type double.
+      *
+      * @note If the keep flag has been set when enable_record_sensitivities() is
+      * called, the tape is immediately used after creation, and the values of
+      * the independent variables set by register_independent_variable() are those
+      * at which the function is to be evaluated, then a call to this function
+      * is not strictly necessary.
+      */
+      void
+      set_dof_values (const std::vector<scalar_type> &values);
+
+      /**
+      * Set the values for the independent variables $\mathbf{X}$.
+      *
+      * @param[in] values A vector field from which the values of all
+      * independent variables is to be extracted.
+      * @param[in] local_dof_indices A vector of degree of freedom indices from
+      * which to extract the local degree of freedom values.
+      *
+      * @note If the keep flag has been set when enable_record_sensitivities() is
+      * called, the tape is immediately used after creation, and the values of
+      * the independent variables set by register_independent_variable() are those
+      * at which the function is to be evaluated, then a call to this function
+      * is not strictly necessary.
+      */
+      template<typename VectorType>
+      void
+      set_dof_values (const VectorType                           &values,
+                      const std::vector<types::global_dof_index> &local_dof_indices);
+
+      /**
+      * Computes the value of the vector field $\boldsymbol{\Psi}(\mathbf{X})$
+      * using the tape as opposed to executing the source code.
+      *
+      * @return A Vector object with the value for each component of the vector
+      * field evaluated at the point defined by the independent variable values.
+      */
+      virtual Vector<scalar_type>
+      compute_residual() const = 0;
+
+      /**
+      * Computes the gradient (first derivative) of the vector field with respect
+      * to all independent variables, i.e.
+      * @f[
+      *   \frac{\partial\boldsymbol{\Psi}(\mathbf{X})}{\partial\mathbf{X}}
+      * @f]
+      *
+      * @return A FullMatrix with the gradient of each component of the vector
+      * field evaluated at the point defined by the independent variable values.
+      */
+      virtual FullMatrix<scalar_type>
+      compute_linearization() const = 0;
+
+      //@}
+
+    protected:
+
+      /**
+       * @name Dependent variables
+       */
+//@{
+
+      /**
+      * Register the definition of the vector field $\boldsymbol{\Psi}(\mathbf{X})$.
+      *
+      * @param[in] func A vector of recorded functions that defines the dependent
+      * variables.
+      *
+      * @note For this class that expects only vector field of dependent
+      * variables, this function must only be called once per tape.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      void
+      register_dependent_variables (const std::vector<ad_type> &funcs);
+
+//@}
+
+    }; // class ADHelperCellLevelBase
+
+
+
+    /**
+       * A helper class that facilitates the implementation of a generic (incremental)
+       * variational formulation from which the computation of the residual vector, as
+       * well as its linearisation, is automated. This class would typically be used to
+       * derive the residual vector and tangent matrix, defined on the level of a finite
+       * element, or a linearized system of equations, starting from a scalar energy
+       * functional.
+       *
+       * An example of its usage in the case of a residual and tangent computations
+       * might be as follows:
+       * @code
+       * @endcode
+       *
+       * @warning Adol-C does not support the standard threading models used by
+       * deal.II, so this class should \b not be embedded within a multithreaded
+       * function. It is, however, suitable for use in both serial and MPI routines.
+       *
+       * @author Jean-Paul Pelteret, 2016
+       */
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType = double>
+    class ADHelperVariationalFormulation
+      : public ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>
+    {
+    public:
+
+      /**
+      * Type definition for the floating point number type that are used in, and
+      * result from, all computations.
+      */
+      using scalar_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::scalar_type;
+
+      /**
+      * Type definition for the auto-differentiation number type that is used
+      * in all computations.
+      */
+      using ad_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::ad_type;
+
+      /**
+       * @name Constructor / destructor
+       */
+      //@{
+
+      /**
+      * The constructor for the class.
+      *
+      * @param[in] n_independent_variables The number of independent variables
+      * that the vector of functions is sensitive to.
+      *
+      * @note These is only one dependent variable associated with the total
+      * energy attributed to the local finite element.
+      */
+      ADHelperVariationalFormulation(const unsigned int n_independent_variables);
+
+      /**
+      * Destructor
+      */
+      virtual
+      ~ADHelperVariationalFormulation();
+
+      //@}
+
+      /**
+       * @name Dependent variables
+       */
+      //@{
+
+      /**
+      * Register the definition of the total potential $\boldsymbol{\Psi}(\mathbf{X})$.
+      *
+      * @param[in] func A vector of recorded functions that defines the residual.
+      * The components of this vector represents the dependent variables.
+      *
+      * @note For this class that expects only a single scalar dependent
+      * variable, this function must only be called once per tape.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      void
+      register_energy_functional (const ad_type &energy);
+
+      //@}
+
+      /**
+       * @name Computations using the recorded tape at the point defined by the
+       * set independent variable values
+       */
+      //@{
+
+      /**
+      * Evaluation of the residual for a chosen set of degree-of-freedom values.
+      * Underlying this is the computation of the gradient (first derivative) of
+      * the scalar energy field with respect to all independent variables, i.e.
+      * @f[
+      *   \mathbf{r}(\mathbf{X}) = \frac{\partial\boldsymbol{\Psi}(\mathbf{X})}{\partial\mathbf{X}}
+      * @f]
+      *
+      * @return A Vector object, for which the value for each entry represents the
+      * residual value for the corresponding local degree-of freedom.
+      */
+      virtual Vector<scalar_type>
+      compute_residual() const;
+
+      /**
+      * Computes the linearization the residual vector around a chosen set of
+      * degree-of-freedom values.
+      * Underlying this is the computation of the hessian (second derivative) of
+      * the vector field with respect to all independent variables, i.e.
+      * @f[
+      *   \frac{\partial\mathbf{r}(\mathbf{X})}{\partial\mathbf{X}}
+      *     = \frac{\partial^{2}\boldsymbol{\Psi}(\mathbf{X})}{\partial\mathbf{X} \otimes \partial\mathbf{X}}
+      * @f]
+      *
+      * @return A FullMatrix representing the linearization of the residual vector.
+      */
+      virtual FullMatrix<scalar_type>
+      compute_linearization() const;
+
+      //@}
+
+    }; // class ADHelperVariationalFormulation
+
+
+
+    /**
+     * A helper class that facilitates the evaluation of a vector of functions,
+     * that represent the local degree-of-freedom values corresponding to the
+     * residual vector, as well as its linearisation. This class
+     * would typically be used to compute the linearisation of a residual vector
+     * defined on the level of a finite element, or for local nonlinear equations.
+     *
+     * An example of its usage in the case of a residual linearisation
+     * might be as follows:
+     * @code
+     * @endcode
+     *
+     * @warning Adol-C does not support the standard threading models used by
+     * deal.II, so this class should \b not be embedded within a multithreaded
+     * function. It is, however, suitable for use in both serial and MPI routines.
+     *
+     * @author Jean-Paul Pelteret, 2016
+     */
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType = double>
+    class ADHelperResidualLinearisation
+      : public ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>
+    {
+    public:
+
+      /**
+      * Type definition for the floating point number type that are used in, and
+      * result from, all computations.
+      */
+      using scalar_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::scalar_type;
+
+      /**
+      * Type definition for the auto-differentiation number type that is used
+      * in all computations.
+      */
+      using ad_type = typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::ad_type;
+
+      /**
+       * @name Constructor / destructor
+       */
+//@{
+
+      /**
+      * The constructor for the class.
+      *
+      * @param[in] n_independent_variables The number of independent variables
+      * that the vector of functions is sensitive to.
+      * @param[in] n_dependent_variables The number of dependent variables, i.e.
+      * the number of functions in the vector that one wishes to compute the
+      * sensitivities of.
+      */
+      ADHelperResidualLinearisation(const unsigned int n_independent_variables,
+                                    const unsigned int n_dependent_variables);
+
+      /**
+      * Destructor
+      */
+      virtual
+      ~ADHelperResidualLinearisation();
+
+//@}
+
+      /**
+       * @name Dependent variables
+       */
+//@{
+
+      /**
+      * Register the definition of the residual vector field $\mathbf{r}(\mathbf{X})$.
+      *
+      * @param[in] func A vector of recorded functions that defines the residual.
+      * The components of this vector represents the dependent variables.
+      *
+      * @note For this class that expects only vector field of dependent
+      * variables, this function must only be called once per tape.
+      *
+      * @note This operation is only valid in recording mode.
+      */
+      void
+      register_residual_vector (const std::vector<ad_type> &residual);
+
+//@}
+
+      /**
+       * @name Computations using the recorded tape at the point defined by the
+       * set independent variable values
+       */
+//@{
+
+      /**
+      * Evaluation of the residual for a chosen set of degree-of-freedom values.
+      * This corresponds to the computation the vector-valued residual field
+      * $\mathbf{r}(\mathbf{X})$ using the tape as opposed to executing the source code.
+      *
+      * @return A Vector object, for which the value for each entry represents the
+      * residual value for the corresponding local degree-of freedom.
+      */
+      virtual Vector<scalar_type>
+      compute_residual() const;
+
+      /**
+      * Computes the linearization the residual vector around a chosen set of
+      * degree-of-freedom values.
+      * Underlying this is the computation of the gradient (first derivative) of
+      * the vector field with respect to all independent variables, i.e.
+      * @f[
+      *   \frac{\partial\mathbf{r}(\mathbf{X})}{\partial\mathbf{X}}
+      * @f]
+      *
+      * @return A FullMatrix representing the linearization of the residual vector.
+      */
+      virtual FullMatrix<scalar_type>
+      compute_linearization() const;
+
+//@}
+
+    }; // class ADHelperResidualLinearisation
+
+
+  } // namespace AD
+} // namespace Differentiation
+
+
+/* --------------------------- inline and template functions ------------------------- */
+
+
+#ifndef DOXYGEN
+
+namespace Differentiation
+{
+  namespace AD
+  {
+
+    namespace internal
+    {
+      namespace
+      {
+
+        template<typename ADNumberType>
+        static typename std::enable_if<
+        ADNumberTraits<ADNumberType>::is_taped>
+        ::type
+        configure_adtl (const unsigned int)
+        {
+
+        }
+
+#ifdef DEAL_II_WITH_ADOLC
+
+        template<typename ADNumberType>
+        static typename std::enable_if<
+        ADNumberTraits<ADNumberType>::is_tapeless &&
+        !is_adolc_number<ADNumberType>::value>
+        ::type
+        configure_adtl (const unsigned int)
+        {
+
+        }
+
+        template<typename ADNumberType>
+        static typename std::enable_if<
+        ADNumberTraits<ADNumberType>::is_tapeless &&
+        is_adolc_number<ADNumberType>::value>
+        ::type
+        configure_adtl (const unsigned int n_directional_derivatives)
+        {
+          // Enable vector mode
+          // See Adol-C manual section 7.1
+          // NOTE: It is critical that this is done for tapeless mode BEFORE
+          // any adtl::adouble are created. If this is not done, then we see
+          // this scary warning:
+          //
+          // ADOL-C Warning: Tapeless: Setting numDir could change memory
+          // allocation of derivatives in existing adoubles and may lead to
+          // erronious results or memory corruption
+          //
+          // So we use this dummy function to configure this setting before
+          // we create and initialize our class data
+          const std::size_t n_live_variables = adtl::refcounter::getNumLiveVar();
+          if (n_live_variables == 0)
+            {
+              adtl::setNumDir(n_directional_derivatives);
+            }
+          else
+            {
+              // So there are some live active variables floating around. Here we
+              // check if we ask to increase the number of number of computable
+              // directional derivatives. If this really is necessary then its
+              // absolutely vital that there exist no live variables before doing
+              // so.
+              const std::size_t n_set_directional_derivatives = adtl::getNumDir();
+              if (n_directional_derivatives > n_set_directional_derivatives)
+                AssertThrow(n_live_variables == 0,
+                            ExcMessage("There are currently " +
+                                       Utilities::to_string(n_live_variables) + " "
+                                       "live adtl::adouble variables in existence. They currently "
+                                       "assume " +
+                                       Utilities::to_string(n_set_directional_derivatives) + " directional derivatives "
+                                       "but you wish to increase this to " +
+                                       Utilities::to_string(n_directional_derivatives) + ". \n"
+                                       "To safely change (or more specifically in this case, "
+                                       "increase) the number of directional derivatives, there "
+                                       "must be no tapeless doubles in local/global scope."));
+            }
+        }
+
+#else
+
+        template<typename ad_type>
+        static typename std::enable_if<
+        ADNumberTraits<ad_type>::is_tapeless>
+        ::type
+        configure_adtl (const unsigned int)
+        {
+
+        }
+
+#endif
+
+        template<typename ADNumberType>
+        static int
+        configure_adtl_and_return_tape_index (const unsigned int n_independent_variables,
+                                              const int invalid_tape_index)
+        {
+          configure_adtl<ADNumberType>(n_independent_variables);
+          return invalid_tape_index;
+        }
+
+
+        /**
+         * Define the active dependent variable when using reverse-mode AD.
+         *
+         * If there are multiple dependent variables then it is necessary to
+         * inform the independent variables, from which the adjoints are computed,
+         * which dependent variable they are computing the gradients with respect
+         * to. This function broadcasts this information.
+         */
+        template<typename ADNumberType>
+        static typename std::enable_if<
+        is_sacado_rad_number<ADNumberType>::value
+        >
+        ::type
+        reverse_mode_dependent_variable_activation (ADNumberType &dependent_variable)
+        {
+          // Compute all gradients (adjoints) for this
+          // reverse-mode Sacado dependent variable.
+          // For reverse-mode Sacado numbers it is necessary to broadcast to
+          // all independent variables that it is time to compute gradients.
+          // For one dependent variable one would just need to all
+          // ad_type::Gradcomp(), but since we have a more
+          // generic implementation for vectors of dependent variables
+          // (vector mode) we default to the complex case.
+          ADNumberType::Outvar_Gradcomp(dependent_variable);
+        }
+
+
+        template<typename ADNumberType>
+        static typename std::enable_if<
+        !is_sacado_rad_number<ADNumberType>::value>
+        ::type
+        reverse_mode_dependent_variable_activation (ADNumberType &)
+        {
+
+        }
+
+      }
+    } // namespace internal
+
+
+
+// -------------------------- ADHelperBase ----------------------
+
+// -------------------------- ADHelperPointLevelFunctionsBase ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename ValueType, typename ExtractorType>
+    void
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::register_independent_variable (
+      const ValueType     &value,
+      const ExtractorType &extractor)
+    {
+      // This is actually the same thing the set_independent_variable function,
+      // in the sense that we simply populate our array of independent values
+      // with a meaningful number. However, in this case we need to double check
+      // that we're not registering these variables twice
+#ifdef DEBUG
+      const std::vector<unsigned int> index_set (internal::extract_index_set<dim>(extractor));
+      for (unsigned int i=0; i<index_set.size(); ++i)
+        {
+          Assert(this->touched_independent_variables[index_set[i]] == false,
+                 ExcMessage("Overlapping indices for independent variables."));
+        }
+#endif
+      set_independent_variable(value,extractor);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename ValueType, typename ExtractorType>
+    void
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::set_independent_variable (
+      const ValueType     &value,
+      const ExtractorType &extractor)
+    {
+      if (ADNumberTraits<ad_type>::is_tapeless == true)
+        {
+          Assert(this->is_recording==true,
+                 ExcMessage("Cannot change the value of an independent variable "
+                            "of the tapeless variety."));
+        }
+      if (ADNumberTraits<ad_type>::is_taped == true)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+        }
+
+      const std::vector<unsigned int> index_set (internal::extract_index_set<dim>(extractor));
+      for (unsigned int i=0; i<index_set.size(); ++i)
+        {
+          set_sensitivity_value(internal::get_tensor_entry(value,i),
+                                index_set[i],
+                                internal::Extractor<dim,ExtractorType>::symmetric_component(i));
+        }
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename ExtractorType>
+    typename internal::Extractor<dim,ExtractorType>::template tensor_type<typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::ad_type>
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::get_sensitive_variables (const ExtractorType &extractor)
+    {
+      if (ADNumberTraits<ad_type>::is_taped == true)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+        }
+
+      // If necessary, finalize the internally stored vector of
+      // AD numbers that represents the independent variables
+      this->finalize_sensitive_independent_variables();
+      Assert(this->independent_variables.size()==this->n_independent_variables(),
+             ExcInternalError());
+
+      const std::vector<unsigned int> index_set (internal::extract_index_set<dim>(extractor));
+      typename internal::Extractor<dim,ExtractorType>::template tensor_type<ad_type> out;
+
+      for (unsigned int i=0; i<index_set.size(); ++i)
+        {
+          const unsigned int index = index_set[i];
+          Assert(index < this->n_independent_variables(), ExcInternalError());
+          Assert(this->touched_independent_variables[index] == true, ExcInternalError());
+          internal::get_tensor_entry(out,i) = this->independent_variables[index];
+        }
+
+      return out;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename ExtractorType>
+    typename internal::Extractor<dim,ExtractorType>::template tensor_type<typename ADHelperBase<dim,ADNumberTypeCode,ScalarType>::ad_type>
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::get_non_sensitive_variables (const ExtractorType &extractor)
+    {
+      if (ADNumberTraits<ad_type>::is_taped == true)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+        }
+
+      const std::vector<unsigned int> index_set (internal::extract_index_set<dim>(extractor));
+      typename internal::Extractor<dim,ExtractorType>::template tensor_type<ad_type> out;
+
+      for (unsigned int i=0; i<index_set.size(); ++i)
+        this->get_independent_variable(internal::get_tensor_entry(out,i),
+                                       index_set[i]);
+
+      return out;
+    }
+
+
+
+// -------------------------- ADHelperScalarFunction ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename ExtractorType_Row>
+    typename internal::Gradient<dim,typename ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type,ExtractorType_Row>::type
+    ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::extract_gradient_component(
+      const Vector<scalar_type>  &gradient,
+      const ExtractorType_Row  &extractor_row) const
+    {
+      // NOTE: The order of components must be consistently defined throughout this class.
+      typename internal::Gradient<dim,scalar_type,ExtractorType_Row>::type out;
+
+      // Get indexsets for the subblock from which we wish to extract the gradient values
+      const std::vector<unsigned int> row_index_set (internal::extract_index_set<dim>(extractor_row));
+      Assert(out.n_independent_components == row_index_set.size(),
+             ExcMessage("Not all tensor components have been extracted!"));
+      for (unsigned int r=0; r<row_index_set.size(); ++r)
+        internal::set_tensor_entry(out, r,
+                                   gradient[row_index_set[r]]);
+
+      return out;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename ExtractorType_Row, typename ExtractorType_Col>
+    typename internal::Hessian<dim,typename ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type,ExtractorType_Row,ExtractorType_Col>::type
+    ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::extract_hessian_component(
+      const FullMatrix<scalar_type>  &hessian,
+      const ExtractorType_Row      &extractor_row,
+      const ExtractorType_Col      &extractor_col) const
+    {
+      typedef internal::Hessian<dim,scalar_type,ExtractorType_Row,ExtractorType_Col> InternalHessian;
+      typedef internal::Extractor<dim,ExtractorType_Row> InternalExtractorRow;
+      typedef internal::Extractor<dim,ExtractorType_Col> InternalExtractorCol;
+      typedef typename InternalHessian::type HessianType;
+
+      // NOTE: The order of components must be consistently defined throughout this class.
+      HessianType out;
+
+      // Get indexsets for the subblocks from which we wish to extract the hessian values
+      // NOTE: Here we have to do some clever accounting when the one extractor is a symmetric Tensor
+      // and the other is not, e.g. <SymmTensor,Vector>. In this scenario the return type is a
+      // non-symmetric Tensor<3,dim> but we have to fetch information from a SymmTensor row/column
+      // that has too few entries to fill the output tensor. So we must duplicate the relevant
+      // entries in the row/column indexset to fetch off-diagonal components that are Otherwise
+      // non-existent in a SymmTensor.
+      const std::vector<unsigned int> row_index_set (internal::extract_index_set<dim>(extractor_row,false /*ignore_symmetries*/));
+      const std::vector<unsigned int> col_index_set (internal::extract_index_set<dim>(extractor_col,false /*ignore_symmetries*/));
+
+      for (unsigned int idx=0; idx<HessianType::n_independent_components; ++idx)
+        {
+          const TableIndices<HessianType::rank> ti_out = HessianType::unrolled_to_component_indices(idx);
+          const unsigned int r = InternalExtractorRow::template local_component<scalar_type>(ti_out, 0);
+          const unsigned int c = InternalExtractorCol::template local_component<scalar_type>(ti_out, InternalExtractorRow::rank);
+
+          internal::set_tensor_entry(out, idx,
+                                     hessian[row_index_set[r]][col_index_set[c]]);
+        }
+
+      return out;
+    }
+
+
+
+// -------------------------- ADHelperVectorFunction ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename ValueType, typename ExtractorType>
+    void
+    ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::register_dependent_variable (
+      const ValueType     &funcs,
+      const ExtractorType &extractor)
+    {
+      const std::vector<unsigned int> index_set (internal::extract_index_set<dim>(extractor));
+      for (unsigned int i=0; i<index_set.size(); ++i)
+        {
+          Assert(this->touched_dependent_variables[index_set[i]] == false,
+                 ExcMessage("Overlapping indices for independent variables."));
+          ADHelperBase<dim,ADNumberTypeCode,ScalarType>::register_dependent_variable(
+            internal::get_tensor_entry(funcs,i),
+            index_set[i]);
+        }
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename ExtractorType_Row>
+    typename internal::Gradient<dim,typename ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type,ExtractorType_Row>::type
+    ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::extract_value_component(
+      const Vector<scalar_type>  &values,
+      const ExtractorType_Row  &extractor_row) const
+    {
+      // NOTE: The order of components must be consistently defined throughout this class.
+      typename internal::Gradient<dim,scalar_type,ExtractorType_Row>::type out;
+
+      // Get indexsets for the subblock from which we wish to extract the gradient values
+      const std::vector<unsigned int> row_index_set (internal::extract_index_set<dim>(extractor_row));
+      Assert(out.n_independent_components == row_index_set.size(),
+             ExcMessage("Not all tensor components have been extracted!"));
+      for (unsigned int r=0; r<row_index_set.size(); ++r)
+        internal::set_tensor_entry(out, r,
+                                   values[row_index_set[r]]);
+
+      return out;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename ExtractorType_Row, typename ExtractorType_Col>
+    typename internal::Hessian<dim,typename ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type,ExtractorType_Row,ExtractorType_Col>::type
+    ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::extract_jacobian_component(
+      const FullMatrix<scalar_type>  &jacobian,
+      const ExtractorType_Row      &extractor_row,
+      const ExtractorType_Col      &extractor_col) const
+    {
+      typedef internal::Hessian<dim,scalar_type,ExtractorType_Row,ExtractorType_Col> InternalHessian;
+      typedef internal::Extractor<dim,ExtractorType_Row> InternalExtractorRow;
+      typedef internal::Extractor<dim,ExtractorType_Col> InternalExtractorCol;
+      typedef typename InternalHessian::type HessianType;
+
+      // NOTE: The order of components must be consistently defined throughout this class.
+      HessianType out;
+
+      // Get indexsets for the subblocks from which we wish to extract the hessian values
+      // NOTE: Here we have to do some clever accounting when the one extractor is a symmetric Tensor
+      // and the other is not, e.g. <SymmTensor,Vector>. In this scenario the return type is a
+      // non-symmetric Tensor<3,dim> but we have to fetch information from a SymmTensor row/column
+      // that has too few entries to fill the output tensor. So we must duplicate the relevant
+      // entries in the row/column indexset to fetch off-diagonal components that are Otherwise
+      // non-existent in a SymmTensor.
+      const std::vector<unsigned int> row_index_set (internal::extract_index_set<dim>(extractor_row,false /*ignore_symmetries*/));
+      const std::vector<unsigned int> col_index_set (internal::extract_index_set<dim>(extractor_col,false /*ignore_symmetries*/));
+
+      for (unsigned int idx=0; idx<HessianType::n_independent_components; ++idx)
+        {
+          const TableIndices<HessianType::rank> ti_out = HessianType::unrolled_to_component_indices(idx);
+          const unsigned int r = InternalExtractorRow::template local_component<scalar_type>(ti_out, 0);
+          const unsigned int c = InternalExtractorCol::template local_component<scalar_type>(ti_out, InternalExtractorRow::rank);
+
+          internal::set_tensor_entry(out, idx,
+                                     jacobian[row_index_set[r]][col_index_set[c]]);
+        }
+
+      return out;
+    }
+
+
+
+// -------------------------- ADHelperCellLevelBase ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename VectorType>
+    void
+    ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>::register_dof_values (
+      const VectorType                           &values,
+      const std::vector<types::global_dof_index> &local_dof_indices)
+    {
+      // This is actually the same thing the set_dof_values function,
+      // in the sense that we simply populate our array of independent values
+      // with a meaningful number. However, in this case we need to double check
+      // that we're not registering these variables twice
+      Assert(local_dof_indices.size() == this->n_independent_variables(),
+             ExcMessage("DoF index vector size does not match number of independent variables"));
+#ifdef DEBUG
+      for (unsigned int i=0; i<this->n_independent_variables(); ++i)
+        {
+          Assert(this->touched_independent_variables[i] == false,
+                 ExcMessage("Independent variables already registered."));
+        }
+#endif
+      set_dof_values(values, local_dof_indices);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    template<typename VectorType>
+    void
+    ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>::set_dof_values (
+      const VectorType                           &values,
+      const std::vector<types::global_dof_index> &local_dof_indices)
+    {
+      if (ADNumberTraits<ad_type>::is_taped == true)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+        }
+      Assert(local_dof_indices.size() == this->n_independent_variables(),
+             ExcMessage("Vector size does not match number of independent variables"));
+      for (unsigned int i=0; i<this->n_independent_variables(); ++i)
+        ADHelperBase<dim,ADNumberTypeCode,ScalarType>::set_sensitivity_value(values[local_dof_indices[i]], i);
+    }
+
+
+
+// -------------------------- ADHelperVariationalFormulation ----------------------
+
+
+
+// -------------------------- ADHelperResidualLinearisation ----------------------
+
+
+
+  } // namespace AD
+} // namespace Differentiation
+
+
+#endif // DOXYGEN
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_WITH_TRILINOS)
+
+#endif // dealii__adolc_helpers_h

--- a/source/differentiation/ad/CMakeLists.txt
+++ b/source/differentiation/ad/CMakeLists.txt
@@ -16,11 +16,14 @@
 INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
 SET(_src
+  ad_helpers.cc
   adolc_number_types.cc
   sacado_number_types.cc
   )
 
 SET(_inst
+  ad_helpers.inst1.in
+  ad_helpers.inst2.in
   adolc_number_types.inst.in
   sacado_number_types.inst1.in
   sacado_number_types.inst2.in

--- a/source/differentiation/ad/ad_helpers.cc
+++ b/source/differentiation/ad/ad_helpers.cc
@@ -1,0 +1,1815 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#if defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_WITH_TRILINOS)
+
+#include <deal.II/differentiation/ad/ad_helpers.h>
+
+#include <type_traits>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+
+namespace Differentiation
+{
+  namespace AD
+  {
+
+// -------------------------- ADHelperBase ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::ADHelperBase(
+      const unsigned int n_independent_variables,
+      const unsigned int n_dependent_variables)
+      :
+      active_tape_index(internal::configure_adtl_and_return_tape_index<ad_type>(n_independent_variables, invalid_tape_index)),
+      keep_values(true),
+      is_recording(false),
+      independent_variable_values(n_independent_variables,
+                                  dealii::internal::NumberType<scalar_type>::value(0.0)),
+      touched_independent_variables(n_independent_variables,false),
+      touched_marked_independent_variables(n_independent_variables,false),
+      dependent_variables(n_dependent_variables,
+                          dealii::internal::NumberType<ad_type>::value(0.0)),
+      touched_dependent_variables(n_dependent_variables,false)
+    {
+      // TODO: Tapeless: Create some sort of shared static mutex to ensure
+      // that only one ADHelperBase can exist in scope at a time?
+      // Bad things will happen in the case that adtl::setNumDir is called with
+      // different values during the course of tracking some tapeless variables.
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::~ADHelperBase()
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::reset_touched_independent_variables ()
+    {
+      for (typename std::vector<bool>::iterator
+           it = touched_independent_variables.begin();
+           it != touched_independent_variables.end(); ++it)
+        *it = false;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::set_sensitivity_value (
+      const scalar_type    &value,
+      const unsigned int  index)
+    {
+      Assert(index < n_independent_variables(),
+             ExcMessage("Trying to set the value of a non-existent independent variable."));
+      independent_variable_values[index]           = value;
+      touched_independent_variables[index]   = true;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::mark_independent_variable (
+      ad_type       &out,
+      const unsigned int  index) const
+    {
+      Assert(index < n_independent_variables(), ExcInternalError());
+      Assert(touched_independent_variables[index] == true, ExcInternalError());
+
+      if (index > 0)
+        {
+          Assert(touched_marked_independent_variables[index-1] == true,
+                 ExcMessage("Need to extract sensitivities in the order they're created."));
+        }
+
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(active_tape()!=invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(is_recording==true,
+                 ExcMessage("Only valid during recording"));
+        }
+
+      internal::Marking<ad_type>::independent_variable(
+        independent_variable_values[index], index,
+        this->n_independent_variables(), out);
+      touched_marked_independent_variables[index] = true;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::finalize_sensitive_independent_variables () const
+    {
+      // Double check that we've actually touched all DoFs
+      Assert(n_touched_independent_variables() == n_independent_variables(),
+             ExcMessage("Not all values of sensitivities have been recorded!"));
+
+      // This should happen only once
+      if (this->independent_variables.size() == 0)
+        {
+          this->independent_variables = std::vector<ad_type> (this->n_independent_variables(), dealii::internal::NumberType<ad_type>::value(0.0));
+
+          // Indicate the sensitivity that each entry represents
+          for (unsigned int i=0; i<this->n_independent_variables(); ++i)
+            this->mark_independent_variable(this->independent_variables[i], i);
+        }
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::get_independent_variable (
+      ad_type       &out,
+      const unsigned int  index) const
+    {
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(active_tape()!=invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+        }
+      Assert(is_recording==false,
+             ExcMessage("Only valid outside of recording"));
+
+      Assert(index < n_independent_variables(), ExcInternalError());
+      Assert(touched_independent_variables[index] == true, ExcInternalError());
+
+      out = independent_variable_values[index];
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    unsigned int
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::n_touched_independent_variables () const
+    {
+      return std::accumulate(touched_independent_variables.begin(),
+                             touched_independent_variables.end(), 0u);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    std::size_t
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::n_independent_variables() const
+    {
+      return independent_variable_values.size();
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    unsigned int
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::n_touched_dependent_variables () const
+    {
+      return std::accumulate(touched_dependent_variables.begin(),
+                             touched_dependent_variables.end(), 0u);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    std::size_t
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::n_dependent_variables() const
+    {
+      return dependent_variables.size();
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    int
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::active_tape() const
+    {
+      return active_tape_index;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::print_values(std::ostream &stream) const
+    {
+      for (unsigned int i=0; i<n_independent_variables(); i++)
+        stream
+            << independent_variable_values[i]
+            << (i<(n_independent_variables()-1) ? "," : "")
+            << std::flush;
+      stream << std::endl;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode,typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::print_tape_stats(
+      std::ostream       &stream,
+      const unsigned int &tape_index) const
+    {
+      if (ADNumberTraits<ad_type>::is_tapeless == true)
+        return;
+
+      Assert(registered_tapes.find(tape_index) != registered_tapes.end(),
+             ExcMessage("Tape number not registered"));
+
+#ifdef DEAL_II_WITH_ADOLC
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          // See Adol-C manual section 2.1
+          // and adolc/taping.h
+          std::vector<std::size_t> counts (STAT_SIZE);
+          ::tapestats(tape_index, counts.data());
+          Assert(counts.size() >= 18, ExcInternalError());
+          stream
+              << "Tape index: " << tape_index << "\n"
+              << "Number of independent variables: " << counts[0] << "\n"
+              << "Number of dependent variables:   " << counts[1] << "\n"
+              << "Max number of live, active variables: " << counts[2] << "\n"
+              << "Size of taylor stack (number of overwrites): " << counts[3] << "\n"
+              << "Operations buffer size: " << counts[4] << "\n"
+              << "Total number of recorded operations: " << counts[5] << "\n"
+              << "Operations file written or not: " << counts[6] << "\n"
+              << "Overall number of locations: " << counts[7] << "\n"
+              << "Locations file written or not: " << counts[8] << "\n"
+              << "Overall number of values: " << counts[9] << "\n"
+              << "Values file written or not: " << counts[10] << "\n"
+              << "Locations buffer size: " << counts[11] << "\n"
+              << "Values buffer size: " << counts[12] << "\n"
+              << "Taylor buffer size: " << counts[13] << "\n"
+              << "Number of eq_*_prod for sparsity pattern: " << counts[14] << "\n"
+              << "Use of 'min_op', deferred to 'abs_op' for piecewise calculations: " << counts[15] << "\n"
+              << "Number of 'abs' calls that can switch branch: " << counts[16] << "\n"
+              << "Number of parameters (doubles) interchangable without retaping: " << counts[17] << "\n";
+        }
+#endif
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::reset (const unsigned int n_independent_variables,
+                                                          const unsigned int n_dependent_variables)
+    {
+      active_tape_index = internal::configure_adtl_and_return_tape_index<ad_type>(n_independent_variables, invalid_tape_index);
+      registered_tapes.clear();
+      is_recording = false;
+
+      const unsigned int new_n_independent_variables =
+        (n_independent_variables != 0 ? n_independent_variables : this->n_independent_variables());
+
+      independent_variable_values =  std::vector<scalar_type>(new_n_independent_variables,
+                                                              dealii::internal::NumberType<scalar_type>::value(0.0));
+      touched_independent_variables = std::vector<bool>(new_n_independent_variables,false);
+      touched_marked_independent_variables = std::vector<bool>(new_n_independent_variables,false);
+
+      const unsigned int new_n_dependent_variables =
+        (n_dependent_variables != 0 ? n_dependent_variables : this->n_dependent_variables());
+
+      dependent_variables = std::vector<ad_type>(new_n_dependent_variables,
+                                                 dealii::internal::NumberType<ad_type>::value(0.0));
+      touched_dependent_variables = std::vector<bool>(new_n_dependent_variables,false);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::configure_tapeless_mode (const unsigned int &n_independent_variables)
+    {
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_tapeless)
+        {
+          internal::configure_adtl<ad_type>(n_independent_variables);
+          // In order to ensure that the settings remain for the entire duration of the simulation,
+          // we create a global live variable that doesn't go out of scope.
+          static ad_type num = 0.0;
+        }
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::activate_tape(const unsigned int &tape_index)
+    {
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(tape_index!=invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(tape_index<max_tape_index,
+                 ExcMessage("Tape index exceeds maximum allowable value"));
+          Assert(registered_tapes.find(tape_index) != registered_tapes.end(),
+                 ExcMessage("Tape number not registered"));
+          active_tape_index = tape_index;
+          reset_touched_independent_variables();
+        }
+      else
+        {
+          Assert(ADNumberTraits<ad_type>::is_tapeless == true, ExcInternalError());
+          active_tape_index = 1; // Some dummy value
+        }
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    bool
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::enable_record_sensitivities(
+      const unsigned int &tape_index,
+      const bool          overwrite_tape,
+      const bool          keep)
+    {
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          if (overwrite_tape != true)
+            {
+              Assert(is_recording == false,
+                     ExcMessage("Already recording..."));
+            }
+          if (registered_tapes.find(tape_index) == registered_tapes.end() ||
+              overwrite_tape == true)
+            {
+              registered_tapes.insert(tape_index);
+              activate_tape(tape_index);
+              trace_on(active_tape(),keep);
+              reset_touched_independent_variables();
+              keep_values = keep;
+              is_recording = true;
+            }
+        }
+      else
+        {
+          // Tapeless mode
+          is_recording = true;
+          activate_tape(tape_index);
+        }
+
+      return is_recording;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::disable_record_sensitivities(
+      const bool write_tapes_to_file)
+    {
+      Assert(is_recording == true,
+             ExcMessage("Not currently recording..."));
+
+      // Double check that we've actually touched all DoFs
+      Assert(n_touched_independent_variables() == n_independent_variables(),
+             ExcMessage("Not all values of sensitivities have been recorded!"));
+
+      if (ADNumberTraits<ad_type>::is_tapeless == true)
+        {
+          // Double check that we've actually touched dependent variables
+          Assert(n_touched_dependent_variables() == n_dependent_variables(),
+                 ExcMessage("Not all dependent variables have been set!"));
+
+          // By changing this flag, we ensure that the we can no longer
+          // alter the values of the dependent variables using
+          // set_independent_variable(). This is important because the value of
+          // the tapeless independent variables are set and finalized when
+          // mark_independent_variable() is called. So we cannot allow this to
+          // be done when not in the "recording" phase
+          is_recording = false;
+          active_tape_index = invalid_tape_index;
+          return;
+        }
+      else
+        {
+#ifdef DEAL_II_WITH_ADOLC
+          if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+            {
+              if (write_tapes_to_file)
+                {
+                  trace_off(active_tape()); // Slow
+
+                  std::vector<std::size_t> counts (STAT_SIZE);
+                  ::tapestats(active_tape(), counts.data());
+                }
+              else
+                trace_off(); // Fast(er)
+            }
+#endif
+
+          // Now that we've turned tracing off, we've definitely
+          // stopped all tape recording.
+          is_recording = false;
+
+          // If the keep_values flag is set, then we expect the user to use this tape
+          // immediately after recording it. There is therefore no need to invalidate
+          // it. However, there is now also no way to double-check that the newly
+          // recorded tape is indeed the active tape.
+          if (keep_values == false)
+            active_tape_index = invalid_tape_index;
+        }
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperBase<dim,ADNumberTypeCode,ScalarType>::register_dependent_variable (
+      const ad_type &func,
+      const unsigned int  index)
+    {
+      Assert(index<n_dependent_variables(),
+             ExcMessage("Index out of range"));
+      Assert(touched_dependent_variables[index] == false,
+             ExcMessage("This dependent variable has already been registered."));
+
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(active_tape()!=invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(is_recording == true,
+                 ExcMessage("Must be recording when registering dependent variables."));
+        }
+
+      // See Adol-C manual section 1.4
+      // Note: Even though it appears that we're doing nothing in particular here,
+      // the following steps are in fact being recorded on the Adol-C tape.
+      internal::Marking<ad_type>::dependent_variable(dependent_variables[index], func);
+      touched_dependent_variables[index] = true;
+    }
+
+
+
+// -------------------------- ADHelperPointLevelFunctionsBase ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::ADHelperPointLevelFunctionsBase(
+      const unsigned int n_independent_variables,
+      const unsigned int n_dependent_variables)
+      :
+      ADHelperBase<dim,ADNumberTypeCode,ScalarType>(n_independent_variables, n_dependent_variables),
+      symmetric_independent_variables(n_independent_variables,false)
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::~ADHelperPointLevelFunctionsBase()
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::reset (
+      const unsigned int n_independent_variables,
+      const unsigned int n_dependent_variables)
+    {
+      ADHelperBase<dim,ADNumberTypeCode,ScalarType>::reset(n_independent_variables,n_dependent_variables);
+
+      const unsigned int new_n_independent_variables =
+        (n_independent_variables != 0 ? n_independent_variables : this->n_independent_variables());
+      symmetric_independent_variables = std::vector<bool>(new_n_independent_variables,false);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    bool
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::is_symmetric_independent_variable (const unsigned int index) const
+    {
+      Assert(index<symmetric_independent_variables.size(),
+             ExcInternalError());
+      return symmetric_independent_variables[index];
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    unsigned int
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::n_symmetric_independent_variables () const
+    {
+      return std::accumulate(symmetric_independent_variables.begin(),
+                             symmetric_independent_variables.end(), 0u);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::register_independent_variables (const std::vector<scalar_type> &values)
+    {
+      // This is actually the same thing the set_independent_variable function,
+      // in the sense that we simply populate our array of independent values
+      // with a meaningful number. However, in this case we need to double check
+      // that we're not registering these variables twice
+      Assert(values.size() == this->n_independent_variables(),
+             ExcMessage("Vector size does not match number of independent variables"));
+#ifdef DEBUG
+      for (unsigned int i=0; i<this->n_independent_variables(); ++i)
+        {
+          Assert(this->touched_independent_variables[i] == false,
+                 ExcMessage("Independent variables already registered."));
+        }
+#endif
+      set_independent_variables(values);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    const std::vector<typename ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::ad_type> &
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::get_sensitive_variables ()
+    {
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+        }
+
+      // If necessary, initialize the internally stored vector of
+      // AD numbers that represents the independent variables
+      this->finalize_sensitive_independent_variables();
+      Assert(this->independent_variables.size()==this->n_independent_variables(),
+             ExcInternalError());
+
+      return this->independent_variables;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::set_sensitivity_value (
+      const scalar_type    &value,
+      const unsigned int  index,
+      const bool          symmetric_dof)
+    {
+      ADHelperBase<dim,ADNumberTypeCode,ScalarType>::set_sensitivity_value(value,index);
+      Assert(index < this->n_independent_variables(),
+             ExcMessage("Trying to set the symmetry flag of a non-existent independent variable."));
+      Assert(index < symmetric_independent_variables.size(),
+             ExcInternalError());
+      symmetric_independent_variables[index] = symmetric_dof;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>::set_independent_variables (const std::vector<scalar_type> &values)
+    {
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+        }
+      Assert(values.size() == this->n_independent_variables(),
+             ExcMessage("Vector size does not match number of independent variables"));
+      for (unsigned int i=0; i<this->n_independent_variables(); ++i)
+        ADHelperBase<dim,ADNumberTypeCode,ScalarType>::set_sensitivity_value(values[i], i);
+    }
+
+
+
+    // -------------------------- Internal functions ----------------------
+
+
+
+    namespace internal
+    {
+      namespace
+      {
+        /**
+         * Adol-C only has drivers for doubles, and so floats are not intrinsically
+         * supported. This wrapper struct works around the issue when necessary.
+         */
+        template<typename ScalarType>
+        struct AdolCTapedDrivers;
+
+        template<>
+        struct AdolCTapedDrivers<double>
+        {
+          typedef double scalar_type;
+
+          // === Scalar drivers ===
+
+          static scalar_type
+          value (const unsigned int             &active_tape,
+                 const unsigned int             &n_independent_variables,
+                 const std::vector<scalar_type> &independent_variables)
+          {
+            double *f = new double();
+            ::function(active_tape,
+                       1, // Only one dependent variable
+                       n_independent_variables,
+                       const_cast<double *>(independent_variables.data()),
+                       f);
+
+            const double value = f[0];
+
+            // Cleanup :-/
+            delete f;
+            f = nullptr;
+
+            return value;
+          }
+
+          static void
+          gradient (Vector<scalar_type>            &gradient,
+                    const unsigned int             &active_tape,
+                    const unsigned int             &n_independent_variables,
+                    const std::vector<scalar_type> &independent_variables)
+          {
+            Assert(gradient.size() == n_independent_variables,
+                   ExcMessage("The length of the gradient vector must be equal "
+                              "to the number of independent variables."));
+
+            scalar_type *g = new scalar_type[n_independent_variables]; // Use smart pointers or std_cxx11::array?
+            ::gradient(active_tape,
+                       n_independent_variables,
+                       const_cast<scalar_type *>(independent_variables.data()),
+                       g);
+
+            for (unsigned int i=0; i<n_independent_variables; ++i)
+              gradient[i] = g[i];
+
+            // Cleanup :-/
+            delete[] g;
+            g = nullptr;
+          }
+
+          static void
+          hessian (FullMatrix<scalar_type>        &hessian,
+                   const unsigned int             &active_tape,
+                   const unsigned int             &n_independent_variables,
+                   const std::vector<scalar_type> &independent_variables)
+          {
+            Assert(hessian.m() == n_independent_variables,
+                   ExcMessage("The hessian row length must be equal "
+                              "to the number of independent variables."));
+
+            Assert(hessian.n() == n_independent_variables,
+                   ExcMessage("The hessian column length must be equal "
+                              "to the number of independent variables."));
+
+            scalar_type **H = new scalar_type*[n_independent_variables]; // Use smart pointers or std_cxx11::array?
+            for (unsigned int i=0; i<n_independent_variables; ++i)
+              H[i] = new scalar_type[i+1]; // Symmetry
+
+            ::hessian(active_tape,
+                      n_independent_variables,
+                      const_cast<scalar_type *>(independent_variables.data()),
+                      H);
+
+            for (unsigned int i=0; i<n_independent_variables; i++)
+              for (unsigned int j=0; j<i+1; j++)
+                {
+                  hessian[i][j] = H[i][j];
+                  if (i != j)
+                    hessian[j][i] = H[i][j]; // Symmetry
+                }
+
+            // Cleanup :-/
+            for (unsigned int i=0; i<n_independent_variables; i++)
+              delete[] H[i];
+            delete[] H;
+            H = nullptr;
+          }
+
+          // === Vector drivers ===
+
+          static void
+          values (Vector<scalar_type>            &values,
+                  const unsigned int             &active_tape,
+                  const unsigned int             &n_dependent_variables,
+                  const unsigned int             &n_independent_variables,
+                  const std::vector<scalar_type> &independent_variables)
+          {
+            Assert(values.size() == n_dependent_variables,
+                   ExcMessage("The length of the dependent function vector must "
+                              " be equal to the number of dependent variables."));
+
+            scalar_type *f = new scalar_type[n_dependent_variables]; // Use smart pointers or std_cxx11::array?
+            ::function(active_tape,
+                       n_dependent_variables,
+                       n_independent_variables,
+                       const_cast<scalar_type *>(independent_variables.data()),
+                       f);
+
+            for (unsigned int i=0; i<n_dependent_variables; i++)
+              values[i] = f[i];
+
+            // Cleanup :-/
+            delete[] f;
+            f = nullptr;
+          }
+
+          static void
+          jacobian (FullMatrix<scalar_type>        &jacobian,
+                    const unsigned int             &active_tape,
+                    const unsigned int             &n_dependent_variables,
+                    const unsigned int             &n_independent_variables,
+                    const std::vector<scalar_type> &independent_variables)
+          {
+            scalar_type **J = new scalar_type*[n_dependent_variables]; // Use smart pointers or std_cxx11::array?
+            for (unsigned int i=0; i<n_dependent_variables; ++i)
+              J[i] = new scalar_type[n_independent_variables];
+
+            ::jacobian(active_tape,
+                       n_dependent_variables,
+                       n_independent_variables,
+                       independent_variables.data(),
+                       J);
+
+            for (unsigned int i=0; i<n_dependent_variables; i++)
+              for (unsigned int j=0; j<n_independent_variables; j++)
+                jacobian[i][j] = J[i][j];
+
+            // Cleanup :-/
+            for (unsigned int i=0; i<n_dependent_variables; i++)
+              delete[] J[i];
+            delete[] J;
+            J = nullptr;
+          }
+        };
+
+
+        template<>
+        struct AdolCTapedDrivers<float>
+        {
+          typedef float scalar_type;
+
+          static std::vector<double>
+          vector_float_to_double (const std::vector<float> &in)
+          {
+            std::vector<double> out (in.size());
+            std::copy(in.begin(), in.end(), out.begin());
+            return out;
+          }
+
+          // === Scalar drivers ===
+
+          static scalar_type
+          value (const unsigned int             &active_tape,
+                 const unsigned int             &n_independent_variables,
+                 const std::vector<scalar_type> &independent_variables)
+          {
+
+            return AdolCTapedDrivers<double>::value(
+                     active_tape,
+                     n_independent_variables,
+                     vector_float_to_double(independent_variables));
+          }
+
+          static void
+          gradient (Vector<scalar_type>            &gradient,
+                    const unsigned int             &active_tape,
+                    const unsigned int             &n_independent_variables,
+                    const std::vector<scalar_type> &independent_variables)
+          {
+            Vector<double> gradient_double (gradient.size());
+            AdolCTapedDrivers<double>::gradient(
+              gradient_double,
+              active_tape,
+              n_independent_variables,
+              vector_float_to_double(independent_variables));
+            gradient = gradient_double;
+          }
+
+          static void
+          hessian (FullMatrix<scalar_type>        &hessian,
+                   const unsigned int             &active_tape,
+                   const unsigned int             &n_independent_variables,
+                   const std::vector<scalar_type> &independent_variables)
+          {
+            FullMatrix<double> hessian_double (hessian.m(), hessian.n());
+            AdolCTapedDrivers<double>::hessian(
+              hessian_double,
+              active_tape,
+              n_independent_variables,
+              vector_float_to_double(independent_variables));
+            hessian = hessian_double;
+          }
+
+          // === Vector drivers ===
+
+          static void
+          values (Vector<scalar_type>            &values,
+                  const unsigned int             &active_tape,
+                  const unsigned int             &n_dependent_variables,
+                  const unsigned int             &n_independent_variables,
+                  const std::vector<scalar_type> &independent_variables)
+          {
+            Vector<double> values_double (values.size());
+            AdolCTapedDrivers<double>::values(
+              values_double,
+              active_tape,
+              n_dependent_variables,
+              n_independent_variables,
+              vector_float_to_double(independent_variables));
+            values = values_double;
+          }
+
+          static void
+          jacobian (FullMatrix<scalar_type>        &jacobian,
+                    const unsigned int             &active_tape,
+                    const unsigned int             &n_dependent_variables,
+                    const unsigned int             &n_independent_variables,
+                    const std::vector<scalar_type> &independent_variables)
+          {
+            FullMatrix<double> jacobian_double (jacobian.m(), jacobian.n());
+            AdolCTapedDrivers<double>::jacobian(
+              jacobian_double,
+              active_tape,
+              n_dependent_variables,
+              n_independent_variables,
+              vector_float_to_double(independent_variables));
+            jacobian = jacobian_double;
+          }
+        };
+
+      }
+    }
+
+
+
+    // -------------------------- ADHelperScalarFunction ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::ADHelperScalarFunction(const unsigned int n_independent_variables)
+      :
+      ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>(n_independent_variables, 1)
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::~ADHelperScalarFunction()
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::register_dependent_variable (const ad_type &func)
+    {
+      Assert(this->n_dependent_variables() == 1, ExcInternalError());
+      ADHelperBase<dim,ADNumberTypeCode,ScalarType>::register_dependent_variable(func,0);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    typename ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type
+    ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::compute_value() const
+    {
+      if (this->keep_values == false ||
+          ADNumberTraits<ad_type>::is_tapeless == true)
+        {
+          Assert(this->n_touched_independent_variables() == this->n_independent_variables(),
+                 ExcMessage("Not all values of sensitivities have been registered or subsequently set!"));
+        }
+      Assert(this->n_touched_dependent_variables() == this->n_dependent_variables(),
+             ExcMessage("Not all dependent variables have been registered."));
+
+      Assert(this->n_dependent_variables() == 1,
+             ExcMessage("Only valid for one dependent variable."));
+
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(this->is_recording == false,
+                 ExcMessage("Cannot compute values while tape is being recorded."));
+
+          // This is a work-around for the fact that Adol-C does not perform
+          // calculations with floats (only doubles)
+          return internal::AdolCTapedDrivers<scalar_type>::value(
+                   this->active_tape(),
+                   this->n_independent_variables(),
+                   this->independent_variable_values);
+        }
+      else
+        {
+          Assert(ADNumberTraits<ad_type>::is_tapeless == true, ExcInternalError());
+          return ADNumberTraits<ad_type>::get_scalar_value(this->dependent_variables[0]);
+        }
+    }
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    Vector<typename ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::compute_gradient() const
+    {
+      if (this->keep_values == false ||
+          ADNumberTraits<ad_type>::is_tapeless == true)
+        {
+          Assert(this->n_touched_independent_variables() == this->n_independent_variables(),
+                 ExcMessage("Not all values of sensitivities have been registered or subsequently set!"));
+        }
+      Assert(this->n_touched_dependent_variables() == this->n_dependent_variables(),
+             ExcMessage("Not all dependent variables have been registered."));
+
+      Assert(this->n_dependent_variables() == 1,
+             ExcMessage("Only valid for one dependent variable."));
+
+      Vector<scalar_type> gradient (this->n_independent_variables());
+
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(this->is_recording == false,
+                 ExcMessage("Cannot compute gradient while tape is being recorded."));
+
+          internal::AdolCTapedDrivers<scalar_type>::gradient(
+            gradient,
+            this->active_tape(),
+            this->n_independent_variables(),
+            this->independent_variable_values);
+        }
+      else if (ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_rad ||
+               ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_rad_dfad)
+        {
+          Assert(this->independent_variables.size() == this->n_independent_variables(), ExcInternalError());
+          // In reverse mode, the gradients are computed from the
+          // independent variables (i.e. the adjoint)
+          internal::reverse_mode_dependent_variable_activation(const_cast<ad_type &>(this->dependent_variables[0]));
+          for (unsigned int i=0; i<this->n_independent_variables(); i++)
+            gradient[i] = internal::NumberType<scalar_type>::value(ADNumberTraits<ad_type>::get_directional_derivative(
+                                                                     this->independent_variables[i],
+                                                                     0 /*This number doesn't really matter*/));
+        }
+      else
+        {
+          Assert((ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_tapeless ||
+                  ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_dfad ||
+                  ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_dfad_dfad),
+                 ExcMessage("An unexpected AD type has fallen through to the default case."));
+          // In forward mode, the gradients are computed from the
+          // dependent variables
+          for (unsigned int i=0; i<this->n_independent_variables(); i++)
+            gradient[i] = internal::NumberType<scalar_type>::value(ADNumberTraits<ad_type>::get_directional_derivative(
+                                                                     this->dependent_variables[0], i));
+        }
+
+      // Account for symmetries of tensor components
+      for (unsigned int i=0; i<this->n_independent_variables(); i++)
+        {
+          if (this->is_symmetric_independent_variable(i) == true)
+            gradient[i] *= 0.5;
+        }
+
+      return gradient;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    FullMatrix<typename ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::compute_hessian() const
+    {
+      AssertThrow(AD::ADNumberTraits<ad_type>::n_supported_derivative_levels >= 2,
+                  ExcMessage("Cannot computed function Hessian: AD number type does not support the calculation of second order derivatives."));
+
+      if (this->keep_values == false)
+        {
+          Assert(this->n_touched_independent_variables() == this->n_independent_variables(),
+                 ExcMessage("Not all values of sensitivities have been registered or subsequently set!"));
+        }
+      Assert(this->n_touched_dependent_variables() == this->n_dependent_variables(),
+             ExcMessage("Not all dependent variables have been registered."));
+
+      Assert(this->n_dependent_variables() == 1,
+             ExcMessage("Only valid for one dependent variable."));
+
+      FullMatrix<scalar_type> hessian (this->n_independent_variables(),
+                                       this->n_independent_variables());
+
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(this->is_recording == false,
+                 ExcMessage("Cannot compute hessian while tape is being recorded."));
+
+          internal::AdolCTapedDrivers<scalar_type>::hessian(
+            hessian,
+            this->active_tape(),
+            this->n_independent_variables(),
+            this->independent_variable_values);
+        }
+      else if (ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_rad_dfad)
+        {
+          Assert(this->independent_variables.size() == this->n_independent_variables(), ExcInternalError());
+          // In reverse mode, the gradients are computed from the
+          // independent variables (i.e. the adjoint)
+          internal::reverse_mode_dependent_variable_activation(const_cast<ad_type &>(this->dependent_variables[0]));
+          for (unsigned int i=0; i<this->n_independent_variables(); i++)
+            {
+              typedef typename ADNumberTraits<ad_type>::derivative_type derivative_type;
+              const derivative_type gradient_i
+                = ADNumberTraits<ad_type>::get_directional_derivative(this->independent_variables[i], i);
+
+              for (unsigned int j=0; j <= i; ++j) // Symmetry
+                {
+                  // Extract higher-order directional derivatives. Depending on the AD number type,
+                  // the result may be another AD number or a floating point value.
+                  const scalar_type hessian_ij = internal::NumberType<scalar_type>::value(
+                                                   ADNumberTraits<derivative_type>::get_directional_derivative(gradient_i, j));
+                  hessian[i][j] = hessian_ij;
+                  if (i != j)
+                    hessian[j][i] = hessian_ij;  // Symmetry
+                }
+            }
+        }
+      else
+        {
+          Assert((ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_dfad_dfad),
+                 ExcMessage("An unexpected AD type has fallen through to the default case."));
+          // In forward mode, the gradients are computed from the
+          // dependent variables
+          for (unsigned int i=0; i<this->n_independent_variables(); i++)
+            {
+              typedef typename ADNumberTraits<ad_type>::derivative_type derivative_type;
+              const derivative_type gradient_i
+                = ADNumberTraits<ad_type>::get_directional_derivative(this->dependent_variables[0], i);
+
+              for (unsigned int j=0; j <= i; ++j) // Symmetry
+                {
+                  const scalar_type hessian_ij = internal::NumberType<scalar_type>::value(
+                                                   ADNumberTraits<derivative_type>::get_directional_derivative(gradient_i, j));
+                  hessian[i][j] = hessian_ij;
+                  if (i != j)
+                    hessian[j][i] = hessian_ij;  // Symmetry
+                }
+            }
+        }
+
+      // Account for symmetries of tensor components
+      for (unsigned int i=0; i<this->n_independent_variables(); i++)
+        for (unsigned int j=0; j<i+1; j++)
+          {
+            if (this->is_symmetric_independent_variable(i) == true &&
+                this->is_symmetric_independent_variable(j) == true)
+              {
+                hessian[i][j] *= 0.25;
+                if (i != j)
+                  hessian[j][i] *= 0.25;
+              }
+            else if ((this->is_symmetric_independent_variable(i) == true &&
+                      this->is_symmetric_independent_variable(j) == false) ||
+                     (this->is_symmetric_independent_variable(j) == true &&
+                      this->is_symmetric_independent_variable(i) == false))
+              {
+                hessian[i][j] *= 0.5;
+                if (i != j)
+                  hessian[j][i] *= 0.5;
+              }
+          }
+
+      return hessian;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    Tensor<0,dim,typename ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::extract_hessian_component(
+      const FullMatrix<scalar_type>      &hessian,
+      const FEValuesExtractors::Scalar &extractor_row,
+      const FEValuesExtractors::Scalar &extractor_col) const
+    {
+      // NOTE: It is necessary to make special provision for the case when the HessianType
+      //       is scalar. Unfortunately Tensor<0,dim> does not provide the function
+      //       unrolled_to_component_indices!
+      // NOTE: The order of components must be consistently defined throughout this class.
+      Tensor<0,dim,scalar_type> out;
+
+      // Get indexsets for the subblocks from which we wish to extract the matrix values
+      const std::vector<unsigned int> row_index_set (internal::extract_index_set<dim>(extractor_row));
+      const std::vector<unsigned int> col_index_set (internal::extract_index_set<dim>(extractor_col));
+      Assert(row_index_set.size() == 1, ExcInternalError());
+      Assert(col_index_set.size() == 1, ExcInternalError());
+
+      internal::set_tensor_entry(out, 0,
+                                 hessian[row_index_set[0]][col_index_set[0]]);
+
+      return out;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    SymmetricTensor<4,dim,typename ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperScalarFunction<dim,ADNumberTypeCode,ScalarType>::extract_hessian_component(
+      const FullMatrix<scalar_type>                   &hessian,
+      const FEValuesExtractors::SymmetricTensor<2>  &extractor_row,
+      const FEValuesExtractors::SymmetricTensor<2>  &extractor_col) const
+    {
+      // NOTE: The order of components must be consistently defined throughout this class.
+      // NOTE: We require a specialisation for rank-4 symmetric tensors because they
+      //       do not define their rank, and setting data using TableIndices is somewhat
+      //       specialised as well.
+      SymmetricTensor<4,dim,scalar_type> out;
+
+      // Get indexsets for the subblocks from which we wish to extract the matrix values
+      const std::vector<unsigned int> row_index_set (internal::extract_index_set<dim>(extractor_row));
+      const std::vector<unsigned int> col_index_set (internal::extract_index_set<dim>(extractor_col));
+
+      for (unsigned int r=0; r<row_index_set.size(); ++r)
+        for (unsigned int c=0; c<col_index_set.size(); ++c)
+          {
+            internal::set_tensor_entry(out, r, c,
+                                       hessian[row_index_set[r]][col_index_set[c]]);
+          }
+
+      return out;
+    }
+
+
+
+// -------------------------- ADHelperVectorFunction ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::ADHelperVectorFunction(
+      const unsigned int n_independent_variables,
+      const unsigned int n_dependent_variables)
+      :
+      ADHelperPointLevelFunctionsBase<dim,ADNumberTypeCode,ScalarType>(n_independent_variables,
+          n_dependent_variables)
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::~ADHelperVectorFunction()
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::register_dependent_variables (const std::vector<ad_type> &funcs)
+    {
+      Assert(funcs.size() == this->n_dependent_variables(),
+             ExcMessage("Vector size does not match number of dependent variables"));
+      for (unsigned int i=0; i<this->n_dependent_variables(); ++i)
+        ADHelperBase<dim,ADNumberTypeCode,ScalarType>::register_dependent_variable(funcs[i],i);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    Vector<typename ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::compute_values() const
+    {
+      if (this->keep_values == false ||
+          ADNumberTraits<ad_type>::is_tapeless == true)
+        {
+          Assert(this->n_touched_independent_variables() == this->n_independent_variables(),
+                 ExcMessage("Not all values of sensitivities have been registered or subsequently set!"));
+        }
+      Assert(this->n_touched_dependent_variables() == this->n_dependent_variables(),
+             ExcMessage("Not all dependent variables have been registered."));
+
+      Vector<scalar_type> values (this->n_dependent_variables());
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(this->is_recording == false,
+                 ExcMessage("Cannot compute values while tape is being recorded."));
+
+          internal::AdolCTapedDrivers<scalar_type>::values(
+            values,
+            this->active_tape(),
+            this->n_dependent_variables(),
+            this->n_independent_variables(),
+            this->independent_variable_values);
+        }
+      else
+        {
+          Assert(ADNumberTraits<ad_type>::is_tapeless == true, ExcInternalError());
+          for (unsigned int i=0; i<this->n_dependent_variables(); i++)
+            values[i] = ADNumberTraits<ad_type>::get_scalar_value(this->dependent_variables[i]);
+        }
+
+      return values;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    FullMatrix<typename ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::compute_jacobian() const
+    {
+      if (this->keep_values == false ||
+          ADNumberTraits<ad_type>::is_tapeless == true)
+        {
+          Assert(this->n_touched_independent_variables() == this->n_independent_variables(),
+                 ExcMessage("Not all values of sensitivities have been registered or subsequently set!"));
+        }
+      Assert(this->n_touched_dependent_variables() == this->n_dependent_variables(),
+             ExcMessage("Not all dependent variables have been registered."));
+
+      FullMatrix<scalar_type> jacobian (this->n_dependent_variables(),
+                                        this->n_independent_variables());
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(this->is_recording == false,
+                 ExcMessage("Cannot compute jacobian while tape is being recorded."));
+
+          internal::AdolCTapedDrivers<scalar_type>::jacobian(
+            jacobian,
+            this->active_tape(),
+            this->n_dependent_variables(),
+            this->n_independent_variables(),
+            this->independent_variable_values);
+        }
+      else if (ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_rad ||
+               ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_rad_dfad)
+        {
+          Assert(this->independent_variables.size() == this->n_independent_variables(), ExcInternalError());
+          // In reverse mode, the gradients are computed from the
+          // independent variables (i.e. the adjoint).
+          // For a demonstration of why this accumulation process is
+          // required, see the unit tests
+          // sacado/basic_01b.cc and sacado/basic_02b.cc
+          // Here we also take into consideration the derivative type:
+          // The Sacado number may be of the nested variety, in which
+          // case the effect of the accumulation process on the
+          // sensitivities of the nested number need to be accounted for.
+          typedef typename ADNumberTraits<ad_type>::derivative_type AccumulationType;
+          std::vector<AccumulationType> rad_accumulation (
+            this->n_independent_variables(),
+            dealii::internal::NumberType<AccumulationType>::value(0.0));
+          for (unsigned int i=0; i<this->n_dependent_variables(); i++)
+            {
+              internal::reverse_mode_dependent_variable_activation(const_cast<ad_type &>(this->dependent_variables[i]));
+              for (unsigned int j=0; j<this->n_independent_variables(); j++)
+                {
+                  const AccumulationType df_i_dx_j
+                    = ADNumberTraits<ad_type>::get_directional_derivative(
+                        this->independent_variables[j], i /*This number doesn't really matter*/)
+                      - rad_accumulation[j];
+                  jacobian[i][j] = internal::NumberType<scalar_type>::value(df_i_dx_j);
+                  rad_accumulation[j] += df_i_dx_j;
+                }
+            }
+        }
+      else
+        {
+          Assert((ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_tapeless ||
+                  ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_dfad ||
+                  ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_dfad_dfad),
+                 ExcMessage("An unexpected AD type has fallen through to the default case."));
+          // In forward mode, the gradients are computed from the
+          // dependent variables
+          for (unsigned int i=0; i<this->n_dependent_variables(); i++)
+            for (unsigned int j=0; j<this->n_independent_variables(); j++)
+              jacobian[i][j] = internal::NumberType<scalar_type>::value(ADNumberTraits<ad_type>::get_directional_derivative(
+                                                                          this->dependent_variables[i], j));
+        }
+
+      for (unsigned int i=0; i<this->n_dependent_variables(); i++)
+        for (unsigned int j=0; j<this->n_independent_variables(); j++)
+          // Because we perform just a single differentiation
+          // operation with respect to the "column" variables,
+          // we only need to consider them for symmetry conditions.
+          if (this->is_symmetric_independent_variable(j) == true)
+            jacobian[i][j] *= 0.5;
+
+      return jacobian;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    Tensor<0,dim,typename ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::extract_jacobian_component(
+      const FullMatrix<scalar_type>      &jacobian,
+      const FEValuesExtractors::Scalar &extractor_row,
+      const FEValuesExtractors::Scalar &extractor_col) const
+    {
+      // NOTE: It is necessary to make special provision for the case when the HessianType
+      //       is scalar. Unfortunately Tensor<0,dim> does not provide the function
+      //       unrolled_to_component_indices!
+      // NOTE: The order of components must be consistently defined throughout this class.
+      Tensor<0,dim,scalar_type> out;
+
+      // Get indexsets for the subblocks from which we wish to extract the matrix values
+      const std::vector<unsigned int> row_index_set (internal::extract_index_set<dim>(extractor_row));
+      const std::vector<unsigned int> col_index_set (internal::extract_index_set<dim>(extractor_col));
+      Assert(row_index_set.size() == 1, ExcInternalError());
+      Assert(col_index_set.size() == 1, ExcInternalError());
+
+      internal::set_tensor_entry(out, 0,
+                                 jacobian[row_index_set[0]][col_index_set[0]]);
+
+      return out;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    SymmetricTensor<4,dim,typename ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperVectorFunction<dim,ADNumberTypeCode,ScalarType>::extract_jacobian_component(
+      const FullMatrix<scalar_type>                   &jacobian,
+      const FEValuesExtractors::SymmetricTensor<2>  &extractor_row,
+      const FEValuesExtractors::SymmetricTensor<2>  &extractor_col) const
+    {
+      // NOTE: The order of components must be consistently defined throughout this class.
+      // NOTE: We require a specialisation for rank-4 symmetric tensors because they
+      //       do not define their rank, and setting data using TableIndices is somewhat
+      //       specialised as well.
+      SymmetricTensor<4,dim,scalar_type> out;
+
+      // Get indexsets for the subblocks from which we wish to extract the matrix values
+      const std::vector<unsigned int> row_index_set (internal::extract_index_set<dim>(extractor_row));
+      const std::vector<unsigned int> col_index_set (internal::extract_index_set<dim>(extractor_col));
+
+      for (unsigned int r=0; r<row_index_set.size(); ++r)
+        for (unsigned int c=0; c<col_index_set.size(); ++c)
+          {
+            internal::set_tensor_entry(out, r, c,
+                                       jacobian[row_index_set[r]][col_index_set[c]]);
+          }
+
+      return out;
+    }
+
+
+
+// -------------------------- ADHelperCellLevelBase ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>::ADHelperCellLevelBase(
+      const unsigned int n_independent_variables,
+      const unsigned int n_dependent_variables)
+      :
+      ADHelperBase<dim,ADNumberTypeCode,ScalarType>(n_independent_variables,
+                                                    n_dependent_variables)
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>::~ADHelperCellLevelBase()
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>::register_dof_values (const std::vector<scalar_type> &dof_values)
+    {
+      // This is actually the same thing the set_independent_variable function,
+      // in the sense that we simply populate our array of independent values
+      // with a meaningful number. However, in this case we need to double check
+      // that we're not registering these variables twice
+      Assert(dof_values.size() == this->n_independent_variables(),
+             ExcMessage("Vector size does not match number of independent variables"));
+#ifdef DEBUG
+      for (unsigned int i=0; i<this->n_independent_variables(); ++i)
+        {
+          Assert(this->touched_independent_variables[i] == false,
+                 ExcMessage("Independent variables already registered."));
+        }
+#endif
+      set_dof_values(dof_values);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    const std::vector<typename ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>::ad_type> &
+    ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>::get_sensitive_dof_values ()
+    {
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+        }
+
+      // If necessary, initialize the internally stored vector of
+      // AD numbers that represents the independent variables
+      this->finalize_sensitive_independent_variables();
+      Assert(this->independent_variables.size()==this->n_independent_variables(),
+             ExcInternalError());
+
+      return this->independent_variables;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    std::vector<typename ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>::ad_type>
+    ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>::get_non_sensitive_dof_values ()
+    {
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+        }
+
+      std::vector<ad_type> out (this->n_independent_variables(), dealii::internal::NumberType<ad_type>::value(0.0));
+      for (unsigned int i=0; i<this->n_independent_variables(); ++i)
+        this->get_independent_variable(out[i], i);
+
+      return out;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>::set_dof_values (const std::vector<scalar_type> &values)
+    {
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+        }
+      Assert(values.size() == this->n_independent_variables(),
+             ExcMessage("Vector size does not match number of independent variables"));
+      for (unsigned int i=0; i<this->n_independent_variables(); ++i)
+        ADHelperBase<dim,ADNumberTypeCode,ScalarType>::set_sensitivity_value(values[i], i);
+    }
+
+
+
+    // -------------------------- ADHelperVariationalFormulation ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperVariationalFormulation<dim,ADNumberTypeCode,ScalarType>::ADHelperVariationalFormulation(
+      const unsigned int n_independent_variables)
+      :
+      ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>(n_independent_variables,1)
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperVariationalFormulation<dim,ADNumberTypeCode,ScalarType>::~ADHelperVariationalFormulation()
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperVariationalFormulation<dim,ADNumberTypeCode,ScalarType>::register_energy_functional (const ad_type &energy)
+    {
+      Assert(this->n_dependent_variables() == 1, ExcInternalError());
+      ADHelperBase<dim,ADNumberTypeCode,ScalarType>::register_dependent_variable(energy,0);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    Vector<typename ADHelperVariationalFormulation<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperVariationalFormulation<dim,ADNumberTypeCode,ScalarType>::compute_residual() const
+    {
+      if (this->keep_values == false ||
+          ADNumberTraits<ad_type>::is_tapeless == true)
+        {
+          Assert(this->n_touched_independent_variables() == this->n_independent_variables(),
+                 ExcMessage("Not all values of sensitivities have been registered or subsequently set!"));
+        }
+      Assert(this->n_touched_dependent_variables() == this->n_dependent_variables(),
+             ExcMessage("Not all dependent variables have been registered."));
+
+      Assert(this->n_dependent_variables() == 1,
+             ExcMessage("Only valid for one dependent variable."));
+
+      Vector<scalar_type> gradient (this->n_independent_variables());
+
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(this->is_recording == false,
+                 ExcMessage("Cannot compute gradient while tape is being recorded."));
+
+          internal::AdolCTapedDrivers<scalar_type>::gradient(
+            gradient,
+            this->active_tape(),
+            this->n_independent_variables(),
+            this->independent_variable_values);
+        }
+      else if (ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_rad ||
+               ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_rad_dfad)
+        {
+          Assert(this->independent_variables.size() == this->n_independent_variables(), ExcInternalError());
+          // In reverse mode, the gradients are computed from the
+          // independent variables (i.e. the adjoint)
+          internal::reverse_mode_dependent_variable_activation(const_cast<ad_type &>(this->dependent_variables[0]));
+          for (unsigned int i=0; i<this->n_independent_variables(); i++)
+            gradient[i] = internal::NumberType<scalar_type>::value(ADNumberTraits<ad_type>::get_directional_derivative(
+                                                                     this->independent_variables[i],
+                                                                     0 /*This number doesn't really matter*/));
+        }
+      else
+        {
+
+          Assert((ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_tapeless ||
+                  ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_dfad ||
+                  ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_dfad_dfad),
+                 ExcMessage("An unexpected AD type has fallen through to the default case."));
+          // In forward mode, the gradients are computed from the
+          // dependent variables
+          for (unsigned int i=0; i<this->n_independent_variables(); i++)
+            gradient[i] = internal::NumberType<scalar_type>::value(ADNumberTraits<ad_type>::get_directional_derivative(
+                                                                     this->dependent_variables[0], i));
+        }
+
+      return gradient;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    FullMatrix<typename ADHelperVariationalFormulation<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperVariationalFormulation<dim,ADNumberTypeCode,ScalarType>::compute_linearization() const
+    {
+      AssertThrow(AD::ADNumberTraits<ad_type>::n_supported_derivative_levels >= 2,
+                  ExcMessage("Cannot computed functional linearization: AD number type does not support the calculation of second order derivatives."));
+
+      if (this->keep_values == false)
+        {
+          Assert(this->n_touched_independent_variables() == this->n_independent_variables(),
+                 ExcMessage("Not all values of sensitivities have been registered or subsequently set!"));
+        }
+      Assert(this->n_touched_dependent_variables() == this->n_dependent_variables(),
+             ExcMessage("Not all dependent variables have been registered."));
+
+      Assert(this->n_dependent_variables() == 1,
+             ExcMessage("Only valid for one dependent variable."));
+
+      FullMatrix<scalar_type> hessian (this->n_independent_variables(),
+                                       this->n_independent_variables());
+
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(this->is_recording == false,
+                 ExcMessage("Cannot compute hessian while tape is being recorded."));
+
+          internal::AdolCTapedDrivers<scalar_type>::hessian(
+            hessian,
+            this->active_tape(),
+            this->n_independent_variables(),
+            this->independent_variable_values);
+        }
+      else if (ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_rad_dfad)
+        {
+          Assert(this->independent_variables.size() == this->n_independent_variables(), ExcInternalError());
+          // In reverse mode, the gradients are computed from the
+          // independent variables (i.e. the adjoint)
+          internal::reverse_mode_dependent_variable_activation(const_cast<ad_type &>(this->dependent_variables[0]));
+          for (unsigned int i=0; i<this->n_independent_variables(); i++)
+            {
+              typedef typename ADNumberTraits<ad_type>::derivative_type derivative_type;
+              const derivative_type gradient_i
+                = ADNumberTraits<ad_type>::get_directional_derivative(this->independent_variables[i], i);
+
+              for (unsigned int j=0; j <= i; ++j) // Symmetry
+                {
+                  const scalar_type hessian_ij = internal::NumberType<scalar_type>::value(
+                                                   ADNumberTraits<derivative_type>::get_directional_derivative(gradient_i, j));
+                  hessian[i][j] = hessian_ij;
+                  if (i != j)
+                    hessian[j][i] = hessian_ij;  // Symmetry
+                }
+            }
+        }
+      else
+        {
+          Assert((ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_dfad_dfad),
+                 ExcMessage("An unexpected AD type has fallen through to the default case."));
+          // In forward mode, the gradients are computed from the
+          // dependent variables
+          for (unsigned int i=0; i<this->n_independent_variables(); i++)
+            {
+              typedef typename ADNumberTraits<ad_type>::derivative_type derivative_type;
+              const derivative_type gradient_i
+                = ADNumberTraits<ad_type>::get_directional_derivative(this->dependent_variables[0], i);
+
+              for (unsigned int j=0; j <= i; ++j) // Symmetry
+                {
+                  const scalar_type hessian_ij = internal::NumberType<scalar_type>::value(
+                                                   ADNumberTraits<derivative_type>::get_directional_derivative(gradient_i, j));
+                  hessian[i][j] = hessian_ij;
+                  if (i != j)
+                    hessian[j][i] = hessian_ij;  // Symmetry
+                }
+            }
+        }
+
+      return hessian;
+    }
+
+
+// -------------------------- ADHelperResidualLinearisation ----------------------
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperResidualLinearisation<dim,ADNumberTypeCode,ScalarType>::ADHelperResidualLinearisation(
+      const unsigned int n_independent_variables,
+      const unsigned int n_dependent_variables)
+      :
+      ADHelperCellLevelBase<dim,ADNumberTypeCode,ScalarType>(n_independent_variables,
+                                                             n_dependent_variables)
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    ADHelperResidualLinearisation<dim,ADNumberTypeCode,ScalarType>::~ADHelperResidualLinearisation()
+    { }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    void
+    ADHelperResidualLinearisation<dim,ADNumberTypeCode,ScalarType>::register_residual_vector (const std::vector<ad_type> &residual)
+    {
+      Assert(residual.size() == this->n_dependent_variables(),
+             ExcMessage("Vector size does not match number of dependent variables"));
+      for (unsigned int i=0; i<this->n_dependent_variables(); ++i)
+        ADHelperBase<dim,ADNumberTypeCode,ScalarType>::register_dependent_variable(residual[i],i);
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    Vector<typename ADHelperResidualLinearisation<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperResidualLinearisation<dim,ADNumberTypeCode,ScalarType>::compute_residual() const
+    {
+      if (this->keep_values == false ||
+          ADNumberTraits<ad_type>::is_tapeless == true)
+        {
+          Assert(this->n_touched_independent_variables() == this->n_independent_variables(),
+                 ExcMessage("Not all values of sensitivities have been registered or subsequently set!"));
+        }
+      Assert(this->n_touched_dependent_variables() == this->n_dependent_variables(),
+             ExcMessage("Not all dependent variables have been registered."));
+
+      Vector<scalar_type> values (this->n_dependent_variables());
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(this->is_recording == false,
+                 ExcMessage("Cannot compute values while tape is being recorded."));
+
+          internal::AdolCTapedDrivers<scalar_type>::values(
+            values,
+            this->active_tape(),
+            this->n_dependent_variables(),
+            this->n_independent_variables(),
+            this->independent_variable_values);
+        }
+      else
+        {
+          Assert(ADNumberTraits<ad_type>::is_tapeless == true, ExcInternalError());
+          for (unsigned int i=0; i<this->n_dependent_variables(); i++)
+            values[i] = ADNumberTraits<ad_type>::get_scalar_value(this->dependent_variables[i]);
+        }
+
+      return values;
+    }
+
+
+
+    template<int dim, enum AD::NumberTypes ADNumberTypeCode, typename ScalarType>
+    FullMatrix<typename ADHelperResidualLinearisation<dim,ADNumberTypeCode,ScalarType>::scalar_type>
+    ADHelperResidualLinearisation<dim,ADNumberTypeCode,ScalarType>::compute_linearization() const
+    {
+      if (this->keep_values == false ||
+          ADNumberTraits<ad_type>::is_tapeless == true)
+        {
+          Assert(this->n_touched_independent_variables() == this->n_independent_variables(),
+                 ExcMessage("Not all values of sensitivities have been registered or subsequently set!"));
+        }
+      Assert(this->n_touched_dependent_variables() == this->n_dependent_variables(),
+             ExcMessage("Not all dependent variables have been registered."));
+
+      FullMatrix<scalar_type> jacobian (this->n_dependent_variables(),
+                                        this->n_independent_variables());
+      if (ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_taped)
+        {
+          Assert(this->active_tape()!=this->invalid_tape_index,
+                 ExcMessage("Invalid tape index"));
+          Assert(this->is_recording == false,
+                 ExcMessage("Cannot compute hessian while tape is being recorded."));
+
+          internal::AdolCTapedDrivers<scalar_type>::jacobian(
+            jacobian,
+            this->active_tape(),
+            this->n_dependent_variables(),
+            this->n_independent_variables(),
+            this->independent_variable_values);
+        }
+      else if (ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_rad ||
+               ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_rad_dfad)
+        {
+          Assert(this->independent_variables.size() == this->n_independent_variables(), ExcInternalError());
+          // In reverse mode, the gradients are computed from the
+          // independent variables (i.e. the adjoint).
+          // For a demonstration of why this accumulation process is
+          // required, see the unit tests
+          // sacado/basic_01b.cc and sacado/basic_02b.cc
+          // Here we also take into consideration the derivative type:
+          // The Sacado number may be of the nested variety, in which
+          // case the effect of the accumulation process on the
+          // sensitivities of the nested number need to be accounted for.
+          typedef typename ADNumberTraits<ad_type>::derivative_type AccumulationType;
+          std::vector<AccumulationType> rad_accumulation (
+            this->n_independent_variables(),
+            dealii::internal::NumberType<AccumulationType>::value(0.0));
+          for (unsigned int i=0; i<this->n_dependent_variables(); i++)
+            {
+              internal::reverse_mode_dependent_variable_activation(const_cast<ad_type &>(this->dependent_variables[i]));
+              for (unsigned int j=0; j<this->n_independent_variables(); j++)
+                {
+                  const AccumulationType df_i_dx_j
+                    = ADNumberTraits<ad_type>::get_directional_derivative(
+                        this->independent_variables[j], i /*This number doesn't really matter*/)
+                      - rad_accumulation[j];
+                  jacobian[i][j] = internal::NumberType<scalar_type>::value(df_i_dx_j);
+                  rad_accumulation[j] += df_i_dx_j;
+                }
+            }
+        }
+      else
+        {
+          Assert((ADNumberTraits<ad_type>::type_code == NumberTypes::adolc_tapeless ||
+                  ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_dfad ||
+                  ADNumberTraits<ad_type>::type_code == NumberTypes::sacado_dfad_dfad),
+                 ExcMessage("An unexpected AD type has fallen through to the default case."));
+          // In forward mode, the gradients are computed from the
+          // dependent variables
+          for (unsigned int i=0; i<this->n_dependent_variables(); i++)
+            for (unsigned int j=0; j<this->n_independent_variables(); j++)
+              jacobian[i][j] = internal::NumberType<scalar_type>::value(ADNumberTraits<ad_type>::get_directional_derivative(
+                                                                          this->dependent_variables[i], j));
+        }
+
+      return jacobian;
+    }
+
+
+  } // namespace AD
+} // namespace Differentiation
+
+
+/* --- Explicit instantiations --- */
+#ifdef DEAL_II_WITH_ADOLC
+#include "ad_helpers.inst1"
+#endif
+#ifdef DEAL_II_WITH_TRILINOS
+#include "ad_helpers.inst2"
+#endif
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_WITH_TRILINOS)

--- a/source/differentiation/ad/ad_helpers.inst1.in
+++ b/source/differentiation/ad/ad_helpers.inst1.in
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// TODO: Include complex types
+
+for (deal_II_dimension : DIMENSIONS ; number : REAL_SCALARS)
+{
+  namespace Differentiation
+  \{
+  namespace AD
+  \{
+    // -------------------------- ADHelperBase ----------------------
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::adolc_taped,number>;
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::adolc_tapeless,number>;
+
+    // -------------------------- ADHelperPointLevelFunctionsBase ----------------------
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::adolc_taped,number>;
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::adolc_tapeless,number>;
+
+    // -------------------------- ADHelperScalarFunction ----------------------
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::adolc_taped,number>;
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::adolc_tapeless,number>;
+
+    // -------------------------- ADHelperVectorFunction ----------------------
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::adolc_taped,number>;
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::adolc_tapeless,number>;
+
+    // -------------------------- ADHelperCellLevelBase ----------------------
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::adolc_taped,number>;
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::adolc_tapeless,number>;
+
+    // -------------------------- ADHelperVariationalFormulation ----------------------
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::adolc_taped,number>;
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::adolc_tapeless,number>;
+
+    // -------------------------- ADHelperResidualLinearisation ----------------------
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::adolc_taped,number>;
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::adolc_tapeless,number>;
+
+    \}
+    \}
+}
+
+// Instantiations for NumberTraits for which the underlying number type is fixed
+for (deal_II_dimension : DIMENSIONS)
+{
+    namespace Differentiation
+    \{
+    namespace AD
+    \{
+
+    // -------------------------- ADHelperBase ----------------------
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::adolc_taped,typename NumberTraits<double,NumberTypes::adolc_taped>::ad_type>;
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::adolc_tapeless,typename NumberTraits<double,NumberTypes::adolc_tapeless>::ad_type>;
+
+    // -------------------------- ADHelperPointLevelFunctionsBase ----------------------
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::adolc_taped,typename NumberTraits<double,NumberTypes::adolc_taped>::ad_type>;
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::adolc_tapeless,typename NumberTraits<double,NumberTypes::adolc_tapeless>::ad_type>;
+
+    // -------------------------- ADHelperScalarFunction ----------------------
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::adolc_taped,typename NumberTraits<double,NumberTypes::adolc_taped>::ad_type>;
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::adolc_tapeless,typename NumberTraits<double,NumberTypes::adolc_tapeless>::ad_type>;
+
+    // -------------------------- ADHelperVectorFunction ----------------------
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::adolc_taped,typename NumberTraits<double,NumberTypes::adolc_taped>::ad_type>;
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::adolc_tapeless,typename NumberTraits<double,NumberTypes::adolc_tapeless>::ad_type>;
+
+    // -------------------------- ADHelperCellLevelBase ----------------------
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::adolc_taped,typename NumberTraits<double,NumberTypes::adolc_taped>::ad_type>;
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::adolc_tapeless,typename NumberTraits<double,NumberTypes::adolc_tapeless>::ad_type>;
+
+    // -------------------------- ADHelperVariationalFormulation ----------------------
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::adolc_taped,typename NumberTraits<double,NumberTypes::adolc_taped>::ad_type>;
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::adolc_tapeless,typename NumberTraits<double,NumberTypes::adolc_tapeless>::ad_type>;
+
+    // -------------------------- ADHelperResidualLinearisation ----------------------
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::adolc_taped,typename NumberTraits<double,NumberTypes::adolc_taped>::ad_type>;
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::adolc_tapeless,typename NumberTraits<double,NumberTypes::adolc_tapeless>::ad_type>;
+
+    \}
+    \}
+}

--- a/source/differentiation/ad/ad_helpers.inst2.in
+++ b/source/differentiation/ad/ad_helpers.inst2.in
@@ -1,0 +1,234 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// TODO: Include complex types
+
+for (deal_II_dimension : DIMENSIONS ; number : REAL_SCALARS)
+{
+  namespace Differentiation
+  \{
+  namespace AD
+  \{
+    // -------------------------- ADHelperBase ----------------------
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::sacado_dfad_dfad,number>;
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::sacado_dfad,number>;
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::sacado_rad,number>;
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::sacado_rad_dfad,number>;
+
+    // -------------------------- ADHelperPointLevelFunctionsBase ----------------------
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::sacado_dfad_dfad,number>;
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::sacado_dfad,number>;
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::sacado_rad,number>;
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::sacado_rad_dfad,number>;
+
+    // -------------------------- ADHelperScalarFunction ----------------------
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::sacado_dfad_dfad,number>;
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::sacado_dfad,number>;
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::sacado_rad,number>;
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::sacado_rad_dfad,number>;
+
+    // -------------------------- ADHelperVectorFunction ----------------------
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::sacado_dfad_dfad,number>;
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::sacado_dfad,number>;
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::sacado_rad,number>;
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::sacado_rad_dfad,number>;
+
+    // -------------------------- ADHelperCellLevelBase ----------------------
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::sacado_dfad_dfad,number>;
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::sacado_dfad,number>;
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::sacado_rad,number>;
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::sacado_rad_dfad,number>;
+
+    // -------------------------- ADHelperVariationalFormulation ----------------------
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::sacado_dfad_dfad,number>;
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::sacado_dfad,number>;
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::sacado_rad,number>;
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::sacado_rad_dfad,number>;
+
+    // -------------------------- ADHelperResidualLinearisation ----------------------
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::sacado_dfad_dfad,number>;
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::sacado_dfad,number>;
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::sacado_rad,number>;
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::sacado_rad_dfad,number>;
+
+    \}
+    \}
+}
+
+// Instantiations for NumberTraits for which the underlying number type is fixed
+for (deal_II_dimension : DIMENSIONS)
+{
+    namespace Differentiation
+    \{
+    namespace AD
+    \{
+
+    // -------------------------- ADHelperBase ----------------------
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::sacado_dfad_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad_dfad>::ad_type>;
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::sacado_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad>::ad_type>;
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::sacado_rad,typename NumberTraits<double,NumberTypes::sacado_rad>::ad_type>;
+
+    template
+    class ADHelperBase<deal_II_dimension,NumberTypes::sacado_rad_dfad,typename NumberTraits<double,NumberTypes::sacado_rad_dfad>::ad_type>;
+
+    // -------------------------- ADHelperPointLevelFunctionsBase ----------------------
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::sacado_dfad_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad_dfad>::ad_type>;
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::sacado_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad>::ad_type>;
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::sacado_rad,typename NumberTraits<double,NumberTypes::sacado_rad>::ad_type>;
+
+    template
+    class ADHelperPointLevelFunctionsBase<deal_II_dimension,NumberTypes::sacado_rad_dfad,typename NumberTraits<double,NumberTypes::sacado_rad_dfad>::ad_type>;
+
+    // -------------------------- ADHelperScalarFunction ----------------------
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::sacado_dfad_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad_dfad>::ad_type>;
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::sacado_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad>::ad_type>;
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::sacado_rad,typename NumberTraits<double,NumberTypes::sacado_rad>::ad_type>;
+
+    template
+    class ADHelperScalarFunction<deal_II_dimension,NumberTypes::sacado_rad_dfad,typename NumberTraits<double,NumberTypes::sacado_rad_dfad>::ad_type>;
+
+    // -------------------------- ADHelperVectorFunction ----------------------
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::sacado_dfad_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad_dfad>::ad_type>;
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::sacado_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad>::ad_type>;
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::sacado_rad,typename NumberTraits<double,NumberTypes::sacado_rad>::ad_type>;
+
+    template
+    class ADHelperVectorFunction<deal_II_dimension,NumberTypes::sacado_rad_dfad,typename NumberTraits<double,NumberTypes::sacado_rad_dfad>::ad_type>;
+
+    // -------------------------- ADHelperCellLevelBase ----------------------
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::sacado_dfad_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad_dfad>::ad_type>;
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::sacado_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad>::ad_type>;
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::sacado_rad,typename NumberTraits<double,NumberTypes::sacado_rad>::ad_type>;
+
+    template
+    class ADHelperCellLevelBase<deal_II_dimension,NumberTypes::sacado_rad_dfad,typename NumberTraits<double,NumberTypes::sacado_rad_dfad>::ad_type>;
+
+    // -------------------------- ADHelperVariationalFormulation ----------------------
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::sacado_dfad_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad_dfad>::ad_type>;
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::sacado_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad>::ad_type>;
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::sacado_rad,typename NumberTraits<double,NumberTypes::sacado_rad>::ad_type>;
+
+    template
+    class ADHelperVariationalFormulation<deal_II_dimension,NumberTypes::sacado_rad_dfad,typename NumberTraits<double,NumberTypes::sacado_rad_dfad>::ad_type>;
+
+    // -------------------------- ADHelperResidualLinearisation ----------------------
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::sacado_dfad_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad_dfad>::ad_type>;
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::sacado_dfad,typename NumberTraits<double,NumberTypes::sacado_dfad>::ad_type>;
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::sacado_rad,typename NumberTraits<double,NumberTypes::sacado_rad>::ad_type>;
+
+    template
+    class ADHelperResidualLinearisation<deal_II_dimension,NumberTypes::sacado_rad_dfad,typename NumberTraits<double,NumberTypes::sacado_rad_dfad>::ad_type>;
+
+    \}
+    \}
+}

--- a/tests/adolc/helper_scalar_coupled_3_components_01.cc
+++ b/tests/adolc/helper_scalar_coupled_3_components_01.cc
@@ -1,0 +1,375 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Evaluation of a coupled system (tensor + vector + scalar components)
+// using a helper class
+
+#include "../tests.h"
+#include <deal.II/differentiation/ad.h>
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/fe/fe_values_extractors.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#include <fstream>
+#include <iomanip>
+
+using namespace dealii;
+namespace AD = dealii::Differentiation::AD;
+
+// Function and its derivatives
+template<int dim, typename NumberType>
+struct FunctionsTestTensorVectorScalarCoupled
+{
+  static NumberType
+  det_t(const Tensor<2,dim,NumberType> &t)
+  {
+    return determinant(t);
+  }
+
+  static Tensor<2,dim,NumberType>
+  ddet_t_dt(const Tensor<2,dim,NumberType> &t)
+  {
+    return det_t(t)*transpose(invert(t));
+  }
+
+  static Tensor<4,dim,NumberType>
+  d2det_t_dt_dt(const Tensor<2,dim,NumberType> &t)
+  {
+    const Tensor<2,dim,NumberType> t_inv = invert(t);
+    Tensor<4,dim,NumberType> dt_inv_trans_dt;
+    // https://en.wikiversity.org/wiki/Introduction_to_Elasticity/Tensors#Derivative_of_the_determinant_of_a_tensor
+    for (unsigned int i=0; i<dim; ++i)
+      for (unsigned int j=0; j<dim; ++j)
+        for (unsigned int k=0; k<dim; ++k)
+          for (unsigned int l=0; l<dim; ++l)
+            dt_inv_trans_dt[i][j][k][l] = -t_inv[l][i]*t_inv[j][k];
+
+    return det_t(t)*outer_product(transpose(t_inv),transpose(t_inv))
+           + det_t(t)*dt_inv_trans_dt;
+  }
+
+  static NumberType
+  v_squ(const Tensor<1,dim,NumberType> &v)
+  {
+    return v*v;
+  }
+
+  static Tensor<1,dim,NumberType>
+  dv_squ_dv(const Tensor<1,dim,NumberType> &v)
+  {
+    return 2.0*v;
+  }
+
+  static Tensor<2,dim,NumberType>
+  d2v_squ_dv_dv(const Tensor<1,dim,NumberType> &v)
+  {
+    static const Tensor<2,dim,NumberType> I (unit_symmetric_tensor<dim>());
+    return 2.0*I;
+  }
+
+  // --------
+
+  static const double sf;
+
+  static NumberType
+  psi (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return pow(det_t(t),2)*pow(v_squ(v),3)*pow(s,sf);
+  };
+
+  static Tensor<2,dim,NumberType>
+  dpsi_dt (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return 2.0*pow(det_t(t),1)*ddet_t_dt(t)*pow(v_squ(v),3)*pow(s,sf);
+  };
+
+  static Tensor<1,dim,NumberType>
+  dpsi_dv (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return pow(det_t(t),2)*3.0*pow(v_squ(v),2)*dv_squ_dv(v)*pow(s,sf);
+  };
+
+  static NumberType
+  dpsi_ds (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return pow(det_t(t),2)*pow(v_squ(v),3)*sf*pow(s,sf-1.0);
+  };
+
+  static Tensor<4,dim,NumberType>
+  d2psi_dt_dt (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return 2.0*pow(v_squ(v),3)*
+           (pow(det_t(t),0)*outer_product(ddet_t_dt(t),ddet_t_dt(t))
+            + pow(det_t(t),1)*d2det_t_dt_dt(t))*pow(s,sf);
+  };
+
+  static Tensor<3,dim,NumberType>
+  d2psi_dv_dt (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return 2.0*pow(det_t(t),1)*3.0*pow(v_squ(v),2)*outer_product(ddet_t_dt(t),dv_squ_dv(v))*pow(s,sf);
+  };
+
+  static Tensor<2,dim,NumberType>
+  d2psi_ds_dt (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return 2.0*pow(det_t(t),1)*ddet_t_dt(t)*pow(v_squ(v),3)*sf*pow(s,sf-1.0);
+  };
+
+  static Tensor<3,dim,NumberType>
+  d2psi_dt_dv (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return 2.0*pow(det_t(t),1)*3.0*pow(v_squ(v),2)*outer_product(dv_squ_dv(v),ddet_t_dt(t))*pow(s,sf);
+  };
+
+  static Tensor<2,dim,NumberType>
+  d2psi_dv_dv (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return pow(det_t(t),2)*3.0*
+           (2.0*pow(v_squ(v),1)*outer_product(dv_squ_dv(v),dv_squ_dv(v))
+            + pow(v_squ(v),2)*d2v_squ_dv_dv(v))*pow(s,sf);
+  };
+
+  static Tensor<1,dim,NumberType>
+  d2psi_ds_dv (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return pow(det_t(t),2)*3.0*pow(v_squ(v),2)*dv_squ_dv(v)*sf*pow(s,sf-1.0);
+  };
+
+  static Tensor<2,dim,NumberType>
+  d2psi_dt_ds (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return 2.0*pow(det_t(t),1)*ddet_t_dt(t)*pow(v_squ(v),3)*sf*pow(s,sf-1.0);
+  };
+
+  static Tensor<1,dim,NumberType>
+  d2psi_dv_ds (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return pow(det_t(t),2)*3.0*pow(v_squ(v),2)*dv_squ_dv(v)*sf*pow(s,sf-1.0);
+  };
+
+  static NumberType
+  d2psi_ds_ds (const Tensor<2,dim,NumberType> &t, const Tensor<1,dim,NumberType> &v, const NumberType &s)
+  {
+    return pow(det_t(t),2)*pow(v_squ(v),3)*sf*(sf-1.0)*pow(s,sf-2.0);
+  };
+};
+
+template<int dim, typename NumberType>
+const double
+FunctionsTestTensorVectorScalarCoupled<dim,NumberType>::sf = 2.2;
+
+template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+void test_tensor_vector_scalar_coupled ()
+{
+  typedef AD::ADHelperScalarFunction<dim,ad_type_code,number_t> ADHelper;
+  typedef typename ADHelper::ad_type ADNumberType;
+
+  const unsigned int this_mpi_process = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+  ConditionalOStream pcout (deallog.get_console(), this_mpi_process==0);
+
+  pcout
+      << "*** Test variables: Tensor + Vector + Scalar (coupled), "
+      << (AD::ADNumberTraits<ADNumberType>::is_taped == true ? "Taped" : "Tapeless")
+      << std::endl;
+
+  // Values computed from the AD energy function
+  double psi;
+  Vector<double> Dpsi;
+  FullMatrix<double> D2psi;
+
+  // Function and its derivatives
+  typedef FunctionsTestTensorVectorScalarCoupled<dim,ADNumberType> func_ad;
+
+  // Setup the variable components and choose a value at which to
+  // evaluate the tape
+  const FEValuesExtractors::Tensor<2> t_dof (0);
+  const FEValuesExtractors::Vector    v_dof (Tensor<2,dim>::n_independent_components);
+  const FEValuesExtractors::Scalar    s_dof (Tensor<2,dim>::n_independent_components
+                                             + Tensor<1,dim>::n_independent_components);
+  const unsigned int n_AD_components = Tensor<2,dim>::n_independent_components
+                                       + Tensor<1,dim>::n_independent_components
+                                       + 1;
+  ADHelper ad_helper (n_AD_components);
+  Tensor<2,dim> t = unit_symmetric_tensor<dim>();
+  for (unsigned int i=0; i<t.n_independent_components; ++i)
+    t[t.unrolled_to_component_indices(i)] += 0.11*(i+0.125);
+  Tensor<1,dim> v;
+  double s = 0.57;
+  for (unsigned int i=0; i<dim; ++i)
+    v[i] = 0.275*(1.0+i);
+
+  const int tape_no = 1;
+  const bool is_recording = ad_helper.enable_record_sensitivities(tape_no /*material_id*/,
+                            true /*overwrite_tape*/,
+                            true /*keep*/);
+  if (is_recording == true)
+    {
+      ad_helper.register_independent_variable(t, t_dof);
+      ad_helper.register_independent_variable(v, v_dof);
+      ad_helper.register_independent_variable(s, s_dof);
+
+      const Tensor<2,dim,ADNumberType> t_ad = ad_helper.get_sensitive_variables(t_dof);
+      const Tensor<1,dim,ADNumberType> v_ad = ad_helper.get_sensitive_variables(v_dof);
+      ADNumberType s_ad = ad_helper.get_sensitive_variables(s_dof);
+
+      const ADNumberType psi (func_ad::psi(t_ad,v_ad,s_ad));
+
+      ad_helper.register_dependent_variable(psi);
+      ad_helper.disable_record_sensitivities(false /*write_tapes_to_file*/);
+
+      pcout << "Recorded data..." << std::endl;
+      pcout << "independent variable values: " << std::flush;
+      if (this_mpi_process == 0)
+        ad_helper.print_values(pcout.get_stream());
+      pcout << "t_ad: " << t_ad << std::endl;
+      pcout << "v_ad: " << v_ad << std::endl;
+      pcout << "s_ad: " << s_ad << std::endl;
+      pcout << "psi: " << psi << std::endl;
+      pcout << std::endl;
+    }
+  else
+    {
+      Assert(is_recording==true, ExcInternalError());
+    }
+
+  // Do some work :-)
+  // Set a new evaluation point
+  if (AD::ADNumberTraits<ADNumberType>::is_taped == true)
+    {
+      pcout << "Using tape with different values for independent variables..." << std::endl;
+      ad_helper.activate_tape(tape_no);
+      t *= 0.9;
+      v *= 0.63;
+      s *= 1.21;
+      ad_helper.set_independent_variable(t, t_dof);
+      ad_helper.set_independent_variable(v, v_dof);
+      ad_helper.set_independent_variable(s, s_dof);
+    }
+
+  pcout << "independent variable values: " << std::flush;
+  if (this_mpi_process == 0)
+    ad_helper.print_values(pcout.get_stream());
+
+  // Compute the function value, gradient and hessian for the new evaluation point
+  psi = ad_helper.compute_value();
+  Dpsi = ad_helper.compute_gradient();
+  if (AD::ADNumberTraits<ADNumberType>::is_taped == true)
+    {
+      D2psi = ad_helper.compute_hessian();
+    }
+
+  // Output the full stored function, gradient vector and hessian matrix
+  pcout << "psi: " << psi << std::endl;
+  pcout << "Dpsi: \n";
+  if (this_mpi_process == 0)
+    Dpsi.print(pcout.get_stream());
+  if (AD::ADNumberTraits<ADNumberType>::is_taped == true)
+    {
+      pcout << "D2psi: \n";
+      if (this_mpi_process == 0)
+        D2psi.print_formatted(pcout.get_stream(),3,true,0,"0.0");
+    }
+
+  // Extract components of the solution
+  const Tensor<2,dim,double> dpsi_dt = ad_helper.extract_gradient_component(Dpsi,t_dof);
+  const Tensor<1,dim,double> dpsi_dv = ad_helper.extract_gradient_component(Dpsi,v_dof);
+  const Tensor<0,dim,double> dpsi_ds = ad_helper.extract_gradient_component(Dpsi,s_dof);
+  pcout
+      << "extracted Dpsi (t): " << dpsi_dt << "\n"
+      << "extracted Dpsi (v): " << dpsi_dv << "\n"
+      << "extracted Dpsi (s): " << dpsi_ds << "\n";
+
+  // Verify the result
+  typedef FunctionsTestTensorVectorScalarCoupled<dim,double> func;
+  static const double tol = 1e-12;
+  Assert(std::abs(psi - func::psi(t,v,s)) < tol, ExcMessage("No match for function value."));
+  Assert(std::abs((dpsi_dt - func::dpsi_dt(t,v,s)).norm()) < tol, ExcMessage("No match for first derivative."));
+  Assert(std::abs((dpsi_dv - func::dpsi_dv(t,v,s)).norm()) < tol, ExcMessage("No match for first derivative."));
+  Assert(std::abs( dpsi_ds - func::dpsi_ds(t,v,s))         < tol, ExcMessage("No match for first derivative."));
+  if (AD::ADNumberTraits<ADNumberType>::is_taped == true)
+    {
+      const Tensor<4,dim,double> d2psi_dt_dt = ad_helper.extract_hessian_component(D2psi,t_dof,t_dof);
+      const Tensor<3,dim,double> d2psi_dv_dt = ad_helper.extract_hessian_component(D2psi,t_dof,v_dof);
+      const Tensor<2,dim,double> d2psi_ds_dt = ad_helper.extract_hessian_component(D2psi,t_dof,s_dof);
+      const Tensor<3,dim,double> d2psi_dt_dv = ad_helper.extract_hessian_component(D2psi,v_dof,t_dof);
+      const Tensor<2,dim,double> d2psi_dv_dv = ad_helper.extract_hessian_component(D2psi,v_dof,v_dof);
+      const Tensor<1,dim,double> d2psi_ds_dv = ad_helper.extract_hessian_component(D2psi,v_dof,s_dof);
+      const Tensor<2,dim,double> d2psi_dt_ds = ad_helper.extract_hessian_component(D2psi,s_dof,t_dof);
+      const Tensor<1,dim,double> d2psi_dv_ds = ad_helper.extract_hessian_component(D2psi,s_dof,v_dof);
+      const Tensor<0,dim,double> d2psi_ds_ds = ad_helper.extract_hessian_component(D2psi,s_dof,s_dof);
+      pcout
+          << "extracted Dpsi (t): " << dpsi_dt << "\n"
+          << "extracted Dpsi (v): " << dpsi_dv << "\n"
+          << "extracted Dpsi (s): " << dpsi_ds << "\n"
+          << "extracted D2psi (t,t): " << d2psi_dt_dt << "\n"
+          << "extracted D2psi (t,v): " << d2psi_dv_dt << "\n"
+          << "extracted D2psi (t,s): " << d2psi_ds_dt << "\n"
+          << "extracted D2psi (v,t): " << d2psi_dt_dv << "\n"
+          << "extracted D2psi (v,v): " << d2psi_dv_dv << "\n"
+          << "extracted D2psi (v,s): " << d2psi_ds_dv << "\n"
+          << "extracted D2psi (s,t): " << d2psi_dt_ds << "\n"
+          << "extracted D2psi (s,v): " << d2psi_dv_ds << "\n"
+          << "extracted D2psi (s,s): " << d2psi_ds_ds << "\n"
+          << std::endl;
+      Assert(std::abs((d2psi_dt_dt - func::d2psi_dt_dt(t,v,s)).norm()) < tol, ExcMessage("No match for second derivative."));
+      Assert(std::abs((d2psi_dv_dt - func::d2psi_dv_dt(t,v,s)).norm()) < tol, ExcMessage("No match for second derivative."));
+      Assert(std::abs((d2psi_ds_dt - func::d2psi_ds_dt(t,v,s)).norm()) < tol, ExcMessage("No match for second derivative."));
+      Assert(std::abs((d2psi_dt_dv - func::d2psi_dt_dv(t,v,s)).norm()) < tol, ExcMessage("No match for second derivative."));
+      Assert(std::abs((d2psi_dv_dv - func::d2psi_dv_dv(t,v,s)).norm()) < tol, ExcMessage("No match for second derivative."));
+      Assert(std::abs((d2psi_ds_dv - func::d2psi_ds_dv(t,v,s)).norm()) < tol, ExcMessage("No match for second derivative."));
+      Assert(std::abs((d2psi_dt_ds - func::d2psi_dt_ds(t,v,s)).norm()) < tol, ExcMessage("No match for second derivative."));
+      Assert(std::abs((d2psi_dv_ds - func::d2psi_dv_ds(t,v,s)).norm()) < tol, ExcMessage("No match for second derivative."));
+      Assert(std::abs( d2psi_ds_ds - func::d2psi_ds_ds(t,v,s))         < tol, ExcMessage("No match for second derivative."));
+    }
+}
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+
+  const unsigned int this_mpi_process = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+
+  if (this_mpi_process == 0)
+    {
+      initlog();
+
+      // --- Taped ---
+      test_tensor_vector_scalar_coupled<2,double,AD::NumberTypes::adolc_taped>();
+      test_tensor_vector_scalar_coupled<3,double,AD::NumberTypes::adolc_taped>();
+      deallog << "Taped OK" << std::endl;
+
+      // --- Tapeless ---
+      test_tensor_vector_scalar_coupled<2,double,AD::NumberTypes::adolc_tapeless>();
+      test_tensor_vector_scalar_coupled<3,double,AD::NumberTypes::adolc_tapeless>();
+      deallog << "Tapeless OK" << std::endl;
+
+      deallog << "OK" << std::endl;
+    }
+  else
+    {
+      // --- Taped ---
+      test_tensor_vector_scalar_coupled<2,double,AD::NumberTypes::adolc_taped>();
+      test_tensor_vector_scalar_coupled<3,double,AD::NumberTypes::adolc_taped>();
+
+      // --- Tapeless ---
+      test_tensor_vector_scalar_coupled<2,double,AD::NumberTypes::adolc_tapeless>();
+      test_tensor_vector_scalar_coupled<3,double,AD::NumberTypes::adolc_tapeless>();
+    }
+}

--- a/tests/adolc/helper_scalar_coupled_3_components_01.output
+++ b/tests/adolc/helper_scalar_coupled_3_components_01.output
@@ -1,0 +1,4 @@
+
+DEAL::Taped OK
+DEAL::Tapeless OK
+DEAL::OK

--- a/tests/adolc/helper_scalar_coupled_3_components_01.with_mpi=true.mpirun=2.output
+++ b/tests/adolc/helper_scalar_coupled_3_components_01.with_mpi=true.mpirun=2.output
@@ -1,0 +1,4 @@
+
+DEAL::Taped OK
+DEAL::Tapeless OK
+DEAL::OK

--- a/tests/adolc/helper_vector_2_indep_2_dep_vars.cc
+++ b/tests/adolc/helper_vector_2_indep_2_dep_vars.cc
@@ -1,0 +1,208 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Evaluation of a vector of 2 dependent and 2 independent variables
+// using a helper class
+
+#include "../tests.h"
+#include <deal.II/differentiation/ad.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/fe/fe_values_extractors.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#include <fstream>
+#include <iomanip>
+
+using namespace dealii;
+namespace AD = dealii::Differentiation::AD;
+
+// Function and its derivatives
+template<int dim, typename NumberType>
+struct FunctionsTestSquare
+{
+  static NumberType
+  f0 (const NumberType &s0, const NumberType &s1)
+  {
+    return 2.0*pow(s0,4)*pow(s1,3);
+  };
+
+  static NumberType
+  df0_ds0 (const NumberType &s0, const NumberType &s1)
+  {
+    return 8.0*pow(s0,3)*pow(s1,3);
+  };
+
+  static NumberType
+  df0_ds1 (const NumberType &s0, const NumberType &s1)
+  {
+    return 6.0*pow(s0,4)*pow(s1,2);
+  };
+
+  static NumberType
+  f1 (const NumberType &s0, const NumberType &s1)
+  {
+    return 3.0*pow(s0,2)*pow(s1,4);
+  };
+
+  static NumberType
+  df1_ds0 (const NumberType &s0, const NumberType &s1)
+  {
+    return 6.0*pow(s0,1)*pow(s1,4);
+  };
+
+  static NumberType
+  df1_ds1 (const NumberType &s0, const NumberType &s1)
+  {
+    return 12.0*pow(s0,2)*pow(s1,3);
+  };
+};
+
+template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+void test_AD_vector_jacobian ()
+{
+  typedef AD::ADHelperVectorFunction<dim,ad_type_code,number_t> ADHelper;
+  typedef typename ADHelper::ad_type ADNumberType;
+
+  std::cout
+      << "*** Test variables: Variables: 2 independent, 2 dependent, "
+      << (AD::ADNumberTraits<ADNumberType>::is_taped == true ? "Taped" : "Tapeless")
+      << std::endl;
+
+  // Function and its derivatives
+  typedef FunctionsTestSquare<dim,ADNumberType> func_ad;
+
+  // Setup the variable components and choose a value at which to
+  // evaluate the tape
+  const unsigned int n_vars_indep = 2;
+  const unsigned int n_vars_dep = 2;
+  ADHelper ad_helper (n_vars_indep, n_vars_dep);
+  std::vector<double> s (n_vars_indep);
+  s[0] = 3.1;
+  s[1] = 5.9;
+
+  // Configure tape
+  const int tape_no = 1;
+  const bool is_recording = ad_helper.enable_record_sensitivities(tape_no /*material_id*/,
+                            true /*overwrite_tape*/,
+                            true /*keep*/);
+  if (is_recording == true)
+    {
+      ad_helper.register_independent_variables(s);
+
+      const std::vector<ADNumberType> s_ad = ad_helper.get_sensitive_variables();
+
+      std::vector<ADNumberType> f_ad (n_vars_dep, ADNumberType());
+      f_ad[0] = func_ad::f0(s_ad[0],s_ad[1]);
+      f_ad[1] = func_ad::f1(s_ad[0],s_ad[1]);
+
+      ad_helper.register_dependent_variables(f_ad);
+      ad_helper.disable_record_sensitivities(false /*write_tapes_to_file*/);
+
+      std::cout << "Taped data..." << std::endl;
+      std::cout << "independent variable values: " << std::flush;
+      ad_helper.print_values(std::cout);
+      std::cout << "s_ad: ";
+      for (unsigned int i=0; i<n_vars_indep; ++i)
+        std::cout << s_ad[i] << (i<(n_vars_indep-1) ? "," : "");
+      std::cout << std::endl;
+      std::cout << "f_ad: ";
+      for (unsigned int i=0; i<n_vars_dep; ++i)
+        std::cout << f_ad[i] << (i<(n_vars_dep-1) ? "," : "");
+      std::cout << std::endl;
+    }
+  else
+    {
+      Assert(is_recording==true, ExcInternalError());
+    }
+
+  // Do some work :-)
+  // Set a new evaluation point
+  if (AD::ADNumberTraits<ADNumberType>::is_taped == true)
+    {
+      std::cout << "Using tape with different values for independent variables..." << std::endl;
+      s[0] = 4.9;
+      s[1] = 0.87;
+      ad_helper.activate_tape(tape_no);
+      ad_helper.set_independent_variables(s);
+
+      std::cout << "independent variable values: " << std::flush;
+      ad_helper.print_values(std::cout);
+    }
+
+  // Compute the function values and their jacobian for the new evaluation point
+  const Vector<double> funcs      = ad_helper.compute_values();
+  const FullMatrix<double> Dfuncs = ad_helper.compute_jacobian();
+
+  // Output the full stored function, gradient vector and hessian matrix
+  std::cout << "funcs: \n";
+  funcs.print(std::cout);
+  std::cout << "Dfuncs: \n";
+  Dfuncs.print_formatted(std::cout,3,true,0,"0.0");
+
+  // Verify the result
+  typedef FunctionsTestSquare<dim,double> func;
+  static const double tol = 1e-6;
+  std::cout
+      << "funcs[0]: " << funcs[0]
+      << "\t func::f0(s[0],s[1])): " << func::f0(s[0],s[1])
+      << std::endl;
+  std::cout
+      << "funcs[1]: " << funcs[1]
+      << "\t func::f1(s[0],s[1])): " << func::f1(s[0],s[1])
+      << std::endl;
+  std::cout
+      << "Dfuncs[0][0]: " << Dfuncs[0][0]
+      << "\t func::df0_ds0(s[0],s[1])): " << func::df0_ds0(s[0],s[1])
+      << std::endl;
+  std::cout
+      << "Dfuncs[0][1]: " << Dfuncs[0][1]
+      << "\t func::df0_ds1(s[0],s[1])): " << func::df0_ds1(s[0],s[1])
+      << std::endl;
+  std::cout
+      << "Dfuncs[1][0]: " << Dfuncs[1][0]
+      << "\t func::df1_ds0(s[0],s[1])): " << func::df1_ds0(s[0],s[1])
+      << std::endl;
+  std::cout
+      << "Dfuncs[1][1]: " << Dfuncs[1][1]
+      << "\t func::df1_ds1(s[0],s[1])): " << func::df1_ds1(s[0],s[1])
+      << std::endl;
+  Assert(std::abs(funcs[0] - func::f0(s[0],s[1])) < tol, ExcMessage("No match for function 1 value."));
+  Assert(std::abs(funcs[1] - func::f1(s[0],s[1])) < tol, ExcMessage("No match for function 2 value."));
+  Assert(std::abs(Dfuncs[0][0] - func::df0_ds0(s[0],s[1])) < tol, ExcMessage("No match for function 1 first derivative.."));
+  Assert(std::abs(Dfuncs[0][1] - func::df0_ds1(s[0],s[1])) < tol, ExcMessage("No match for function 1 first derivative.."));
+  Assert(std::abs(Dfuncs[1][0] - func::df1_ds0(s[0],s[1])) < tol, ExcMessage("No match for function 2 first derivative.."));
+  Assert(std::abs(Dfuncs[1][1] - func::df1_ds1(s[0],s[1])) < tol, ExcMessage("No match for function 2 first derivative.."));
+}
+
+int main ()
+{
+  initlog();
+
+  // --- Taped ---
+  test_AD_vector_jacobian<2,double,AD::NumberTypes::adolc_taped>();
+  test_AD_vector_jacobian<3,double,AD::NumberTypes::adolc_taped>();
+  deallog << "Taped OK" << std::endl;
+
+  // --- Tapeless ---
+  test_AD_vector_jacobian<2,double,AD::NumberTypes::adolc_tapeless>();
+  test_AD_vector_jacobian<3,double,AD::NumberTypes::adolc_tapeless>();
+  deallog << "Tapeless OK" << std::endl;
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/helper_vector_2_indep_2_dep_vars.output
+++ b/tests/adolc/helper_vector_2_indep_2_dep_vars.output
@@ -1,0 +1,4 @@
+
+DEAL::Taped OK
+DEAL::Tapeless OK
+DEAL::OK

--- a/tests/adolc/step-44-helper_res_lin_01.cc
+++ b/tests/adolc/step-44-helper_res_lin_01.cc
@@ -1,0 +1,1663 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// This is a modified version of step-44, which tests the implementation of
+// cell-level auto-differentiation (linearisation of a residual vector).
+// The AD number type used is Adol-C (taped).
+
+#include "../tests.h"
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/timer.h>
+#include <deal.II/base/work_stream.h>
+#include <deal.II/differentiation/ad.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/base/quadrature_point_data.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/fe/fe_dgp_monomial.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_tools.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q_eulerian.h>
+#include <deal.II/lac/block_sparse_matrix.h>
+#include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/precondition_selector.h>
+#include <deal.II/lac/solver_selector.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/linear_operator.h>
+#include <deal.II/lac/packaged_operation.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <iostream>
+#include <fstream>
+#include <functional>
+namespace Step44
+{
+  using namespace dealii;
+  namespace AD = dealii::Differentiation::AD;
+  namespace Parameters
+  {
+    struct FESystem
+    {
+      unsigned int poly_degree;
+      unsigned int quad_order;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void FESystem::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Finite element system");
+      {
+        prm.declare_entry("Polynomial degree", "2",
+                          Patterns::Integer(0),
+                          "Displacement system polynomial order");
+        prm.declare_entry("Quadrature order", "3",
+                          Patterns::Integer(0),
+                          "Gauss quadrature order");
+      }
+      prm.leave_subsection();
+    }
+    void FESystem::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Finite element system");
+      {
+        poly_degree = prm.get_integer("Polynomial degree");
+        quad_order = prm.get_integer("Quadrature order");
+      }
+      prm.leave_subsection();
+    }
+    struct Geometry
+    {
+      unsigned int global_refinement;
+      double       scale;
+      double       p_p0;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void Geometry::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        prm.declare_entry("Global refinement", "2",
+                          Patterns::Integer(0),
+                          "Global refinement level");
+        prm.declare_entry("Grid scale", "1e-3",
+                          Patterns::Double(0.0),
+                          "Global grid scaling factor");
+        prm.declare_entry("Pressure ratio p/p0", "100",
+                          Patterns::Selection("20|40|60|80|100"),
+                          "Ratio of applied pressure to reference pressure");
+      }
+      prm.leave_subsection();
+    }
+    void Geometry::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        global_refinement = prm.get_integer("Global refinement");
+        scale = prm.get_double("Grid scale");
+        p_p0 = prm.get_double("Pressure ratio p/p0");
+      }
+      prm.leave_subsection();
+    }
+    struct Materials
+    {
+      double nu;
+      double mu;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void Materials::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Material properties");
+      {
+        prm.declare_entry("Poisson's ratio", "0.4999",
+                          Patterns::Double(-1.0,0.5),
+                          "Poisson's ratio");
+        prm.declare_entry("Shear modulus", "80.194e6",
+                          Patterns::Double(),
+                          "Shear modulus");
+      }
+      prm.leave_subsection();
+    }
+    void Materials::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Material properties");
+      {
+        nu = prm.get_double("Poisson's ratio");
+        mu = prm.get_double("Shear modulus");
+      }
+      prm.leave_subsection();
+    }
+    struct LinearSolver
+    {
+      std::string type_lin;
+      double      tol_lin;
+      double      max_iterations_lin;
+      bool        use_static_condensation;
+      std::string preconditioner_type;
+      double      preconditioner_relaxation;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void LinearSolver::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Linear solver");
+      {
+        prm.declare_entry("Solver type", "CG",
+                          Patterns::Selection("CG|Direct"),
+                          "Type of solver used to solve the linear system");
+        prm.declare_entry("Residual", "1e-6",
+                          Patterns::Double(0.0),
+                          "Linear solver residual (scaled by residual norm)");
+        prm.declare_entry("Max iteration multiplier", "1",
+                          Patterns::Double(0.0),
+                          "Linear solver iterations (multiples of the system matrix size)");
+        prm.declare_entry("Use static condensation", "true",
+                          Patterns::Bool(),
+                          "Solve the full block system or a reduced problem");
+        prm.declare_entry("Preconditioner type", "ssor",
+                          Patterns::Selection("jacobi|ssor"),
+                          "Type of preconditioner");
+        prm.declare_entry("Preconditioner relaxation", "0.65",
+                          Patterns::Double(0.0),
+                          "Preconditioner relaxation value");
+      }
+      prm.leave_subsection();
+    }
+    void LinearSolver::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Linear solver");
+      {
+        type_lin = prm.get("Solver type");
+        tol_lin = prm.get_double("Residual");
+        max_iterations_lin = prm.get_double("Max iteration multiplier");
+        use_static_condensation = prm.get_bool("Use static condensation");
+        preconditioner_type = prm.get("Preconditioner type");
+        preconditioner_relaxation = prm.get_double("Preconditioner relaxation");
+      }
+      prm.leave_subsection();
+    }
+    struct NonlinearSolver
+    {
+      unsigned int max_iterations_NR;
+      double       tol_f;
+      double       tol_u;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void NonlinearSolver::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Nonlinear solver");
+      {
+        prm.declare_entry("Max iterations Newton-Raphson", "10",
+                          Patterns::Integer(0),
+                          "Number of Newton-Raphson iterations allowed");
+        prm.declare_entry("Tolerance force", "1.0e-9",
+                          Patterns::Double(0.0),
+                          "Force residual tolerance");
+        prm.declare_entry("Tolerance displacement", "1.0e-6",
+                          Patterns::Double(0.0),
+                          "Displacement error tolerance");
+      }
+      prm.leave_subsection();
+    }
+    void NonlinearSolver::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Nonlinear solver");
+      {
+        max_iterations_NR = prm.get_integer("Max iterations Newton-Raphson");
+        tol_f = prm.get_double("Tolerance force");
+        tol_u = prm.get_double("Tolerance displacement");
+      }
+      prm.leave_subsection();
+    }
+    struct Time
+    {
+      double delta_t;
+      double end_time;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void Time::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Time");
+      {
+        prm.declare_entry("End time", "1",
+                          Patterns::Double(),
+                          "End time");
+        prm.declare_entry("Time step size", "0.1",
+                          Patterns::Double(),
+                          "Time step size");
+      }
+      prm.leave_subsection();
+    }
+    void Time::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Time");
+      {
+        end_time = prm.get_double("End time");
+        delta_t = prm.get_double("Time step size");
+      }
+      prm.leave_subsection();
+    }
+    struct AllParameters : public FESystem,
+      public Geometry,
+      public Materials,
+      public LinearSolver,
+      public NonlinearSolver,
+      public Time
+    {
+      AllParameters(const std::string &input_file);
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    AllParameters::AllParameters(const std::string &input_file)
+    {
+      ParameterHandler prm;
+      declare_parameters(prm);
+      prm.parse_input(input_file);
+      parse_parameters(prm);
+    }
+    void AllParameters::declare_parameters(ParameterHandler &prm)
+    {
+      FESystem::declare_parameters(prm);
+      Geometry::declare_parameters(prm);
+      Materials::declare_parameters(prm);
+      LinearSolver::declare_parameters(prm);
+      NonlinearSolver::declare_parameters(prm);
+      Time::declare_parameters(prm);
+    }
+    void AllParameters::parse_parameters(ParameterHandler &prm)
+    {
+      FESystem::parse_parameters(prm);
+      Geometry::parse_parameters(prm);
+      Materials::parse_parameters(prm);
+      LinearSolver::parse_parameters(prm);
+      NonlinearSolver::parse_parameters(prm);
+      Time::parse_parameters(prm);
+    }
+  }
+  template<int dim>
+  class StandardTensors
+  {
+  public:
+    static const SymmetricTensor<2, dim> I;
+    static const SymmetricTensor<4, dim> IxI;
+    static const SymmetricTensor<4, dim> II;
+    static const SymmetricTensor<4, dim> dev_P;
+  };
+  template<int dim>
+  const SymmetricTensor<2, dim>
+  StandardTensors<dim>::I = unit_symmetric_tensor<dim>();
+  template<int dim>
+  const SymmetricTensor<4, dim>
+  StandardTensors<dim>::IxI = outer_product(I, I);
+  template<int dim>
+  const SymmetricTensor<4, dim>
+  StandardTensors<dim>::II = identity_tensor<dim>();
+  template<int dim>
+  const SymmetricTensor<4, dim>
+  StandardTensors<dim>::dev_P = deviator_tensor<dim>();
+  class Time
+  {
+  public:
+    Time (const double time_end,
+          const double delta_t)
+      :
+      timestep(0),
+      time_current(0.0),
+      time_end(time_end),
+      delta_t(delta_t)
+    {}
+    virtual ~Time()
+    {}
+    double current() const
+    {
+      return time_current;
+    }
+    double end() const
+    {
+      return time_end;
+    }
+    double get_delta_t() const
+    {
+      return delta_t;
+    }
+    unsigned int get_timestep() const
+    {
+      return timestep;
+    }
+    void increment()
+    {
+      time_current += delta_t;
+      ++timestep;
+    }
+  private:
+    unsigned int timestep;
+    double       time_current;
+    const double time_end;
+    const double delta_t;
+  };
+  template<int dim>
+  class Material_Compressible_Neo_Hook_Three_Field
+  {
+  public:
+    Material_Compressible_Neo_Hook_Three_Field(const double mu,
+                                               const double nu)
+      :
+      kappa((2.0 * mu * (1.0 + nu)) / (3.0 * (1.0 - 2.0 * nu))),
+      c_1(mu / 2.0)
+    {
+      Assert(kappa > 0, ExcInternalError());
+    }
+    ~Material_Compressible_Neo_Hook_Three_Field()
+    {}
+
+    template<typename NumberType>
+    SymmetricTensor<2, dim, NumberType>
+    get_tau(const Tensor<2, dim, NumberType> &F,
+            const NumberType                 &p_tilde) const
+    {
+      return get_tau_iso(F) + get_tau_vol(F,p_tilde);
+    }
+    template<typename NumberType>
+    NumberType
+    get_dPsi_vol_dJ(const NumberType &J_tilde) const
+    {
+      return (kappa / 2.0) * (J_tilde - 1.0 / J_tilde);
+    }
+
+  protected:
+    const double kappa;
+    const double c_1;
+
+    template<typename NumberType>
+    SymmetricTensor<2, dim, NumberType>
+    get_tau_vol(const Tensor<2, dim, NumberType> &F,
+                const NumberType                 &p_tilde) const
+    {
+      const NumberType det_F = determinant(F);
+      // return p_tilde * det_F * StandardTensors<dim>::I;
+      SymmetricTensor<2, dim, NumberType> tau_vol (StandardTensors<dim>::I);
+      tau_vol *= p_tilde * det_F;
+      return tau_vol;
+    }
+    template<typename NumberType>
+    SymmetricTensor<2, dim, NumberType>
+    get_tau_iso(const Tensor<2, dim, NumberType> &F) const
+    {
+      // return StandardTensors<dim>::dev_P * get_tau_bar(F);
+
+      const SymmetricTensor<2, dim, NumberType> tau_bar = get_tau_bar(F);
+      SymmetricTensor<2, dim, NumberType> tau_iso;
+      for (unsigned int i=0; i<dim; ++i)
+        for (unsigned int j=i; j<dim; ++j)
+          for (unsigned int k=0; k<dim; ++k)
+            for (unsigned int l=0; l<dim; ++l)
+              tau_iso[i][j] += StandardTensors<dim>::dev_P[i][j][k][l] * tau_bar[k][l];
+
+      return tau_iso;
+    }
+    template<typename NumberType>
+    SymmetricTensor<2, dim, NumberType>
+    get_tau_bar(const Tensor<2, dim, NumberType> &F) const
+    {
+      using adtl::pow;
+      using std::pow;
+
+      const NumberType det_F = determinant(F);
+      SymmetricTensor<2,dim,NumberType> b_bar = symmetrize(F * transpose(F));
+      b_bar *= std::pow(det_F, -2.0 / dim);
+      return 2.0 * c_1 * b_bar;
+    }
+  };
+  template<int dim>
+  class PointHistory
+  {
+  public:
+    PointHistory()
+    {}
+    virtual ~PointHistory()
+    {}
+    void setup_lqp (const Parameters::AllParameters &parameters)
+    {
+      material.reset(new Material_Compressible_Neo_Hook_Three_Field<dim>(parameters.mu,
+                     parameters.nu));
+    }
+
+    template<typename NumberType>
+    SymmetricTensor<2, dim, NumberType>
+    get_tau(const Tensor<2, dim, NumberType> &F,
+            const NumberType                 &p_tilde) const
+    {
+      return material->get_tau(F, p_tilde);
+    }
+    template<typename NumberType>
+    NumberType
+    get_dPsi_vol_dJ(const NumberType &J_tilde) const
+    {
+      return material->get_dPsi_vol_dJ(J_tilde);
+    }
+  private:
+    std::shared_ptr< Material_Compressible_Neo_Hook_Three_Field<dim> > material;
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  class Solid
+  {
+  public:
+    Solid(const std::string &input_file);
+    virtual
+    ~Solid();
+    void
+    run();
+  private:
+    struct PerTaskData_ASM;
+    struct ScratchData_ASM;
+    struct PerTaskData_SC;
+    struct ScratchData_SC;
+    void
+    make_grid();
+    void
+    system_setup();
+    void
+    determine_component_extractors();
+    void
+    assemble_system(const BlockVector<double> &solution_delta);
+    void
+    assemble_system_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                             ScratchData_ASM &scratch,
+                             PerTaskData_ASM &data) const;
+    void
+    copy_local_to_global_system(const PerTaskData_ASM &data);
+    void
+    assemble_sc();
+    void
+    assemble_sc_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                         ScratchData_SC &scratch,
+                         PerTaskData_SC &data);
+    void
+    copy_local_to_global_sc(const PerTaskData_SC &data);
+    void
+    make_constraints(const int &it_nr);
+    void
+    setup_qph();
+    void
+    solve_nonlinear_timestep(BlockVector<double> &solution_delta);
+    std::pair<unsigned int, double>
+    solve_linear_system(BlockVector<double> &newton_update);
+    BlockVector<double>
+    get_total_solution(const BlockVector<double> &solution_delta) const;
+    void
+    output_results() const;
+    Parameters::AllParameters parameters;
+    double                    vol_reference;
+    Triangulation<dim>        triangulation;
+    Time                      time;
+    mutable TimerOutput       timer;
+    CellDataStorage<typename Triangulation<dim>::cell_iterator,
+                    PointHistory<dim> > quadrature_point_history;
+    const unsigned int               degree;
+    const FESystem<dim>              fe;
+    DoFHandler<dim>                  dof_handler_ref;
+    const unsigned int               dofs_per_cell;
+    const FEValuesExtractors::Vector u_fe;
+    const FEValuesExtractors::Scalar p_fe;
+    const FEValuesExtractors::Scalar J_fe;
+    static const unsigned int n_blocks = 3;
+    static const unsigned int n_components = dim + 2;
+    static const unsigned int first_u_component = 0;
+    static const unsigned int p_component = dim;
+    static const unsigned int J_component = dim + 1;
+    enum
+    {
+      u_dof = 0,
+      p_dof = 1,
+      J_dof = 2
+    };
+    std::vector<types::global_dof_index> dofs_per_block;
+    std::vector<types::global_dof_index> element_indices_u;
+    std::vector<types::global_dof_index> element_indices_p;
+    std::vector<types::global_dof_index> element_indices_J;
+    const QGauss<dim>     qf_cell;
+    const QGauss<dim - 1> qf_face;
+    const unsigned int    n_q_points;
+    const unsigned int    n_q_points_f;
+    ConstraintMatrix          constraints;
+    BlockSparsityPattern      sparsity_pattern;
+    BlockSparseMatrix<double> tangent_matrix;
+    BlockVector<double>       system_rhs;
+    BlockVector<double>       solution_n;
+    struct Errors
+    {
+      Errors()
+        :
+        norm(1.0), u(1.0), p(1.0), J(1.0)
+      {}
+      void reset()
+      {
+        norm = 1.0;
+        u = 1.0;
+        p = 1.0;
+        J = 1.0;
+      }
+      void normalise(const Errors &rhs)
+      {
+        if (rhs.norm != 0.0)
+          norm /= rhs.norm;
+        if (rhs.u != 0.0)
+          u /= rhs.u;
+        if (rhs.p != 0.0)
+          p /= rhs.p;
+        if (rhs.J != 0.0)
+          J /= rhs.J;
+      }
+      double norm, u, p, J;
+    };
+    Errors error_residual, error_residual_0, error_residual_norm, error_update,
+           error_update_0, error_update_norm;
+    void
+    get_error_residual(Errors &error_residual);
+    void
+    get_error_update(const BlockVector<double> &newton_update,
+                     Errors &error_update);
+    std::pair<double, double>
+    get_error_dilation(const BlockVector<double> &solution_total) const;
+    void
+    print_conv_header();
+    void
+    print_conv_footer(const BlockVector<double> &solution_delta);
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  Solid<dim,number_t,ad_type_code>::Solid(const std::string &input_file)
+    :
+    parameters(input_file),
+    triangulation(Triangulation<dim>::maximum_smoothing),
+    time(parameters.end_time, parameters.delta_t),
+    timer(std::cout,
+          TimerOutput::never,
+          TimerOutput::wall_times),
+    degree(parameters.poly_degree),
+    fe(FE_Q<dim>(parameters.poly_degree), dim, // displacement
+       FE_DGPMonomial<dim>(parameters.poly_degree - 1), 1, // pressure
+       FE_DGPMonomial<dim>(parameters.poly_degree - 1), 1), // dilatation
+    dof_handler_ref(triangulation),
+    dofs_per_cell (fe.dofs_per_cell),
+    u_fe(first_u_component),
+    p_fe(p_component),
+    J_fe(J_component),
+    dofs_per_block(n_blocks),
+    qf_cell(parameters.quad_order),
+    qf_face(parameters.quad_order),
+    n_q_points (qf_cell.size()),
+    n_q_points_f (qf_face.size())
+  {
+    Assert(dim==2 || dim==3, ExcMessage("This problem only works in 2 or 3 space dimensions."));
+    determine_component_extractors();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  Solid<dim,number_t,ad_type_code>::~Solid()
+  {
+    dof_handler_ref.clear();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::run()
+  {
+    make_grid();
+    system_setup();
+    {
+      ConstraintMatrix constraints;
+      constraints.close();
+      const ComponentSelectFunction<dim>
+      J_mask (J_component, n_components);
+      VectorTools::project (dof_handler_ref,
+                            constraints,
+                            QGauss<dim>(degree+2),
+                            J_mask,
+                            solution_n);
+    }
+    output_results();
+    time.increment();
+    BlockVector<double> solution_delta(dofs_per_block);
+    while (time.current() < time.end())
+      {
+        solution_delta = 0.0;
+        solve_nonlinear_timestep(solution_delta);
+        solution_n += solution_delta;
+        output_results();
+        // Output displacement at centre of traction surface
+        {
+          const Point<dim> soln_pt (dim==3 ? Point<dim>(0.0, 1.0, 0.0)*parameters.scale : Point<dim>(0.0, 1.0)*parameters.scale);
+          typename DoFHandler<dim>::active_cell_iterator cell =
+            dof_handler_ref.begin_active(), endc = dof_handler_ref.end();
+          for (; cell != endc; ++cell)
+            for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
+              if (cell->vertex(v).distance(soln_pt) < 1e-6*parameters.scale)
+                {
+                  Tensor<1,dim> soln;
+                  for (unsigned int d=0; d<dim; ++d)
+                    soln[d] = solution_n(cell->vertex_dof_index(v,u_dof+d));
+                  deallog
+                      << "Timestep " << time.get_timestep()
+                      << ": " << soln << std::endl;
+                }
+        }
+        time.increment();
+      }
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  struct Solid<dim,number_t,ad_type_code>::PerTaskData_ASM
+  {
+    FullMatrix<double>        cell_matrix;
+    Vector<double>            cell_rhs;
+    std::vector<types::global_dof_index> local_dof_indices;
+    PerTaskData_ASM(const unsigned int dofs_per_cell)
+      :
+      cell_matrix(dofs_per_cell, dofs_per_cell),
+      cell_rhs(dofs_per_cell),
+      local_dof_indices(dofs_per_cell)
+    {}
+    void reset()
+    {
+      cell_matrix = 0.0;
+      cell_rhs = 0.0;
+    }
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  struct Solid<dim,number_t,ad_type_code>::ScratchData_ASM
+  {
+    const BlockVector<double> &solution_total;
+    FEValues<dim>              fe_values_ref;
+    FEFaceValues<dim>          fe_face_values_ref;
+    ScratchData_ASM(const FiniteElement<dim> &fe_cell,
+                    const QGauss<dim> &qf_cell, const UpdateFlags uf_cell,
+                    const QGauss<dim - 1> & qf_face, const UpdateFlags uf_face,
+                    const BlockVector<double> &solution_total)
+      :
+      solution_total (solution_total),
+      fe_values_ref(fe_cell, qf_cell, uf_cell),
+      fe_face_values_ref(fe_cell, qf_face, uf_face)
+    {}
+    ScratchData_ASM(const ScratchData_ASM &rhs)
+      :
+      solution_total (rhs.solution_total),
+      fe_values_ref(rhs.fe_values_ref.get_fe(),
+                    rhs.fe_values_ref.get_quadrature(),
+                    rhs.fe_values_ref.get_update_flags()),
+      fe_face_values_ref(rhs.fe_face_values_ref.get_fe(),
+                         rhs.fe_face_values_ref.get_quadrature(),
+                         rhs.fe_face_values_ref.get_update_flags())
+    {}
+    void reset()
+    {
+
+    }
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  struct Solid<dim,number_t,ad_type_code>::PerTaskData_SC
+  {
+    FullMatrix<double>        cell_matrix;
+    std::vector<types::global_dof_index> local_dof_indices;
+    FullMatrix<double>        k_orig;
+    FullMatrix<double>        k_pu;
+    FullMatrix<double>        k_pJ;
+    FullMatrix<double>        k_JJ;
+    FullMatrix<double>        k_pJ_inv;
+    FullMatrix<double>        k_bbar;
+    FullMatrix<double>        A;
+    FullMatrix<double>        B;
+    FullMatrix<double>        C;
+    PerTaskData_SC(const unsigned int dofs_per_cell,
+                   const unsigned int n_u,
+                   const unsigned int n_p,
+                   const unsigned int n_J)
+      :
+      cell_matrix(dofs_per_cell, dofs_per_cell),
+      local_dof_indices(dofs_per_cell),
+      k_orig(dofs_per_cell, dofs_per_cell),
+      k_pu(n_p, n_u),
+      k_pJ(n_p, n_J),
+      k_JJ(n_J, n_J),
+      k_pJ_inv(n_p, n_J),
+      k_bbar(n_u, n_u),
+      A(n_J,n_u),
+      B(n_J, n_u),
+      C(n_p, n_u)
+    {}
+    void reset()
+    {}
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  struct Solid<dim,number_t,ad_type_code>::ScratchData_SC
+  {
+    void reset()
+    {}
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::make_grid()
+  {
+    GridGenerator::hyper_rectangle(triangulation,
+                                   (dim==3 ? Point<dim>(0.0, 0.0, 0.0) : Point<dim>(0.0, 0.0)),
+                                   (dim==3 ? Point<dim>(1.0, 1.0, 1.0) : Point<dim>(1.0, 1.0)),
+                                   true);
+    GridTools::scale(parameters.scale, triangulation);
+    triangulation.refine_global(std::max (1U, parameters.global_refinement));
+    vol_reference = GridTools::volume(triangulation);
+    std::cout << "Grid:\n\t Reference volume: " << vol_reference << std::endl;
+    typename Triangulation<dim>::active_cell_iterator cell =
+      triangulation.begin_active(), endc = triangulation.end();
+    for (; cell != endc; ++cell)
+      for (unsigned int face = 0;
+           face < GeometryInfo<dim>::faces_per_cell; ++face)
+        {
+          if (cell->face(face)->at_boundary() == true
+              &&
+              cell->face(face)->center()[1] == 1.0 * parameters.scale)
+            {
+              if (dim==3)
+                {
+                  if (cell->face(face)->center()[0] < 0.5 * parameters.scale
+                      &&
+                      cell->face(face)->center()[2] < 0.5 * parameters.scale)
+                    cell->face(face)->set_boundary_id(6);
+                }
+              else
+                {
+                  if (cell->face(face)->center()[0] < 0.5 * parameters.scale)
+                    cell->face(face)->set_boundary_id(6);
+                }
+            }
+        }
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::system_setup()
+  {
+    timer.enter_subsection("Setup system");
+    std::vector<unsigned int> block_component(n_components, u_dof); // Displacement
+    block_component[p_component] = p_dof; // Pressure
+    block_component[J_component] = J_dof; // Dilatation
+    dof_handler_ref.distribute_dofs(fe);
+    DoFRenumbering::Cuthill_McKee(dof_handler_ref);
+    DoFRenumbering::component_wise(dof_handler_ref, block_component);
+    DoFTools::count_dofs_per_block(dof_handler_ref, dofs_per_block,
+                                   block_component);
+    std::cout << "Triangulation:"
+              << "\n\t Number of active cells: " << triangulation.n_active_cells()
+              << "\n\t Number of degrees of freedom: " << dof_handler_ref.n_dofs()
+              << std::endl;
+    tangent_matrix.clear();
+    {
+      const types::global_dof_index n_dofs_u = dofs_per_block[u_dof];
+      const types::global_dof_index n_dofs_p = dofs_per_block[p_dof];
+      const types::global_dof_index n_dofs_J = dofs_per_block[J_dof];
+      BlockDynamicSparsityPattern dsp(n_blocks, n_blocks);
+      dsp.block(u_dof, u_dof).reinit(n_dofs_u, n_dofs_u);
+      dsp.block(u_dof, p_dof).reinit(n_dofs_u, n_dofs_p);
+      dsp.block(u_dof, J_dof).reinit(n_dofs_u, n_dofs_J);
+      dsp.block(p_dof, u_dof).reinit(n_dofs_p, n_dofs_u);
+      dsp.block(p_dof, p_dof).reinit(n_dofs_p, n_dofs_p);
+      dsp.block(p_dof, J_dof).reinit(n_dofs_p, n_dofs_J);
+      dsp.block(J_dof, u_dof).reinit(n_dofs_J, n_dofs_u);
+      dsp.block(J_dof, p_dof).reinit(n_dofs_J, n_dofs_p);
+      dsp.block(J_dof, J_dof).reinit(n_dofs_J, n_dofs_J);
+      dsp.collect_sizes();
+      Table<2, DoFTools::Coupling> coupling(n_components, n_components);
+      for (unsigned int ii = 0; ii < n_components; ++ii)
+        for (unsigned int jj = 0; jj < n_components; ++jj)
+          if (((ii < p_component) && (jj == J_component))
+              || ((ii == J_component) && (jj < p_component))
+              || ((ii == p_component) && (jj == p_component)))
+            coupling[ii][jj] = DoFTools::none;
+          else
+            coupling[ii][jj] = DoFTools::always;
+      DoFTools::make_sparsity_pattern(dof_handler_ref,
+                                      coupling,
+                                      dsp,
+                                      constraints,
+                                      false);
+      sparsity_pattern.copy_from(dsp);
+    }
+    tangent_matrix.reinit(sparsity_pattern);
+    system_rhs.reinit(dofs_per_block);
+    system_rhs.collect_sizes();
+    solution_n.reinit(dofs_per_block);
+    solution_n.collect_sizes();
+    setup_qph();
+    timer.leave_subsection();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void
+  Solid<dim,number_t,ad_type_code>::determine_component_extractors()
+  {
+    element_indices_u.clear();
+    element_indices_p.clear();
+    element_indices_J.clear();
+    for (unsigned int k = 0; k < fe.dofs_per_cell; ++k)
+      {
+        const unsigned int k_group = fe.system_to_base_index(k).first.first;
+        if (k_group == u_dof)
+          element_indices_u.push_back(k);
+        else if (k_group == p_dof)
+          element_indices_p.push_back(k);
+        else if (k_group == J_dof)
+          element_indices_J.push_back(k);
+        else
+          {
+            Assert(k_group <= J_dof, ExcInternalError());
+          }
+      }
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::setup_qph()
+  {
+    std::cout << "    Setting up quadrature point data..." << std::endl;
+    quadrature_point_history.initialize(triangulation.begin_active(),
+                                        triangulation.end(),
+                                        n_q_points);
+    for (typename Triangulation<dim>::active_cell_iterator cell =
+           triangulation.begin_active(); cell != triangulation.end(); ++cell)
+      {
+        const std::vector<std::shared_ptr<PointHistory<dim> > > lqph =
+          quadrature_point_history.get_data(cell);
+        Assert(lqph.size() == n_q_points, ExcInternalError());
+        for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+          lqph[q_point]->setup_lqp(parameters);
+      }
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void
+  Solid<dim,number_t,ad_type_code>::solve_nonlinear_timestep(BlockVector<double> &solution_delta)
+  {
+    std::cout << std::endl << "Timestep " << time.get_timestep() << " @ "
+              << time.current() << "s" << std::endl;
+    BlockVector<double> newton_update(dofs_per_block);
+    error_residual.reset();
+    error_residual_0.reset();
+    error_residual_norm.reset();
+    error_update.reset();
+    error_update_0.reset();
+    error_update_norm.reset();
+    print_conv_header();
+    unsigned int newton_iteration = 0;
+    for (; newton_iteration < parameters.max_iterations_NR;
+         ++newton_iteration)
+      {
+        std::cout << " " << std::setw(2) << newton_iteration << " " << std::flush;
+        make_constraints(newton_iteration);
+        assemble_system(solution_delta);
+        get_error_residual(error_residual);
+        if (newton_iteration == 0)
+          error_residual_0 = error_residual;
+        error_residual_norm = error_residual;
+        error_residual_norm.normalise(error_residual_0);
+        if (newton_iteration > 0 && error_update_norm.u <= parameters.tol_u
+            && error_residual_norm.u <= parameters.tol_f)
+          {
+            std::cout << " CONVERGED! " << std::endl;
+            print_conv_footer(solution_delta);
+            break;
+          }
+        const std::pair<unsigned int, double>
+        lin_solver_output = solve_linear_system(newton_update);
+        get_error_update(newton_update, error_update);
+        if (newton_iteration == 0)
+          error_update_0 = error_update;
+        error_update_norm = error_update;
+        error_update_norm.normalise(error_update_0);
+        solution_delta += newton_update;
+        std::cout << " | " << std::fixed << std::setprecision(3) << std::setw(7)
+                  << std::scientific << lin_solver_output.first << "  "
+                  << lin_solver_output.second << "  " << error_residual_norm.norm
+                  << "  " << error_residual_norm.u << "  "
+                  << error_residual_norm.p << "  " << error_residual_norm.J
+                  << "  " << error_update_norm.norm << "  " << error_update_norm.u
+                  << "  " << error_update_norm.p << "  " << error_update_norm.J
+                  << "  " << std::endl;
+      }
+    AssertThrow (newton_iteration <= parameters.max_iterations_NR,
+                 ExcMessage("No convergence in nonlinear solver!"));
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::print_conv_header()
+  {
+    static const unsigned int l_width = 144;
+    for (unsigned int i = 0; i < l_width; ++i)
+      std::cout << "_";
+    std::cout << std::endl;
+    std::cout << "           SOLVER STEP             "
+              << " |  LIN_IT   LIN_RES    RES_NORM    "
+              << " RES_U     RES_P      RES_J     NU_NORM     "
+              << " NU_U       NU_P       NU_J " << std::endl;
+    for (unsigned int i = 0; i < l_width; ++i)
+      std::cout << "_";
+    std::cout << std::endl;
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::print_conv_footer(const BlockVector<double> &solution_delta)
+  {
+    static const unsigned int l_width = 144;
+    for (unsigned int i = 0; i < l_width; ++i)
+      std::cout << "_";
+    std::cout << std::endl;
+    const std::pair<double,double> error_dil = get_error_dilation(get_total_solution(solution_delta));
+    std::cout << "Relative errors:" << std::endl
+              << "Displacement:\t" << error_update.u / error_update_0.u << std::endl
+              << "Force: \t\t" << error_residual.u / error_residual_0.u << std::endl
+              << "Dilatation:\t" << error_dil.first << std::endl
+              << "v / V_0:\t" << error_dil.second *vol_reference << " / " << vol_reference
+              << " = " << error_dil.second << std::endl;
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  std::pair<double, double>
+  Solid<dim,number_t,ad_type_code>::get_error_dilation(const BlockVector<double> &solution_total) const
+  {
+    double vol_current = 0.0;
+    double dil_L2_error = 0.0;
+    FEValues<dim> fe_values_ref(fe, qf_cell,
+                                update_values | update_gradients | update_JxW_values);
+    std::vector<Tensor<2, dim> > solution_grads_u_total (qf_cell.size());
+    std::vector<double>          solution_values_J_total (qf_cell.size());
+    for (typename DoFHandler<dim>::active_cell_iterator
+         cell = dof_handler_ref.begin_active();
+         cell != dof_handler_ref.end(); ++cell)
+      {
+        fe_values_ref.reinit(cell);
+        fe_values_ref[u_fe].get_function_gradients(solution_total,
+                                                   solution_grads_u_total);
+        fe_values_ref[J_fe].get_function_values(solution_total,
+                                                solution_values_J_total);
+        const std::vector<std::shared_ptr<const PointHistory<dim> > > lqph =
+          quadrature_point_history.get_data(cell);
+        Assert(lqph.size() == n_q_points, ExcInternalError());
+        for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+          {
+            const double det_F_qp = determinant(StandardTensors<dim>::I + solution_grads_u_total[q_point]);
+            const double J_tilde_qp = solution_values_J_total[q_point];
+            const double the_error_qp_squared = std::pow((det_F_qp - J_tilde_qp),
+                                                         2);
+            const double JxW = fe_values_ref.JxW(q_point);
+            dil_L2_error += the_error_qp_squared * JxW;
+            vol_current  += det_F_qp * JxW;
+          }
+      }
+    Assert(vol_current > 0.0, ExcInternalError());
+
+    return std::make_pair(std::sqrt(dil_L2_error),
+                          vol_current / vol_reference);
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::get_error_residual(Errors &error_residual)
+  {
+    BlockVector<double> error_res(dofs_per_block);
+    for (unsigned int i = 0; i < dof_handler_ref.n_dofs(); ++i)
+      if (!constraints.is_constrained(i))
+        error_res(i) = system_rhs(i);
+    error_residual.norm = error_res.l2_norm();
+    error_residual.u = error_res.block(u_dof).l2_norm();
+    error_residual.p = error_res.block(p_dof).l2_norm();
+    error_residual.J = error_res.block(J_dof).l2_norm();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::get_error_update(const BlockVector<double> &newton_update,
+                                                          Errors &error_update)
+  {
+    BlockVector<double> error_ud(dofs_per_block);
+    for (unsigned int i = 0; i < dof_handler_ref.n_dofs(); ++i)
+      if (!constraints.is_constrained(i))
+        error_ud(i) = newton_update(i);
+    error_update.norm = error_ud.l2_norm();
+    error_update.u = error_ud.block(u_dof).l2_norm();
+    error_update.p = error_ud.block(p_dof).l2_norm();
+    error_update.J = error_ud.block(J_dof).l2_norm();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  BlockVector<double>
+  Solid<dim,number_t,ad_type_code>::get_total_solution(const BlockVector<double> &solution_delta) const
+  {
+    BlockVector<double> solution_total(solution_n);
+    solution_total += solution_delta;
+    return solution_total;
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::assemble_system(const BlockVector<double> &solution_delta)
+  {
+    timer.enter_subsection("Assemble system");
+    std::cout << " ASM_SYS " << std::flush;
+    tangent_matrix = 0.0;
+    system_rhs = 0.0;
+    const BlockVector<double> solution_total(get_total_solution(solution_delta));
+    const UpdateFlags uf_cell(update_values |
+                              update_gradients |
+                              update_JxW_values);
+    const UpdateFlags uf_face(update_values |
+                              update_normal_vectors |
+                              update_JxW_values);
+    PerTaskData_ASM per_task_data(dofs_per_cell);
+    ScratchData_ASM scratch_data(fe, qf_cell, uf_cell, qf_face, uf_face, solution_total);
+    // Adol-C is incompatible with TBB
+    // WorkStream::run(dof_handler_ref.begin_active(),
+    //                 dof_handler_ref.end(),
+    //                 std::bind(&Solid<dim,number_t,ad_type_code>::assemble_system_one_cell,
+    //                                 this,
+    //                                 std::placeholders::_1,
+    //                                 std::placeholders::_2,
+    //                                 std::placeholders::_3),
+    //                 std::bind(&Solid<dim,number_t,ad_type_code>::copy_local_to_global_system,
+    //                                 this,
+    //                                 std::placeholders::_1),
+    //                 scratch_data,
+    //                 per_task_data);
+    for (typename DoFHandler<dim>::active_cell_iterator
+         cell = dof_handler_ref.begin_active();
+         cell != dof_handler_ref.end(); ++cell)
+      {
+        assemble_system_one_cell(cell, scratch_data, per_task_data);
+        copy_local_to_global_system(per_task_data);
+      }
+    timer.leave_subsection();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::copy_local_to_global_system(const PerTaskData_ASM &data)
+  {
+    if (data.cell_matrix.frobenius_norm() > 1e-12)
+      constraints.distribute_local_to_global(data.cell_matrix, data.cell_rhs,
+                                             data.local_dof_indices,
+                                             tangent_matrix, system_rhs);
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void
+  Solid<dim,number_t,ad_type_code>::assemble_system_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                                             ScratchData_ASM &scratch,
+                                                             PerTaskData_ASM &data) const
+  {
+    data.reset();
+    scratch.reset();
+    scratch.fe_values_ref.reinit(cell);
+    cell->get_dof_indices(data.local_dof_indices);
+
+    const std::vector<std::shared_ptr<const PointHistory<dim> > > lqph =
+      quadrature_point_history.get_data(cell);
+    Assert(lqph.size() == n_q_points, ExcInternalError());
+
+    const unsigned int n_independent_variables = data.local_dof_indices.size();
+    const unsigned int n_dependent_variables   = dofs_per_cell;
+    Assert(n_dependent_variables == n_independent_variables, ExcMessage("Expect square system."));
+
+    typedef AD::ADHelperResidualLinearisation<dim,ad_type_code,number_t> ADHelper;
+    typedef typename ADHelper::ad_type ADNumberType;
+    ADHelper ad_helper(n_independent_variables, n_dependent_variables);
+
+    const int tape_no = 1;
+    const bool is_recording = ad_helper.enable_record_sensitivities(tape_no, //  material_id
+                              true,    // overwrite_tape
+                              true);   // keep
+
+    if (is_recording == true)
+      {
+        // Set the values for all DoFs
+        ad_helper.register_dof_values(scratch.solution_total,
+                                      data.local_dof_indices);
+        const std::vector<ADNumberType> dof_values_ad = ad_helper.get_sensitive_dof_values();
+
+        // Compute all values, gradients etc. based on sensitive AD DoF values
+        std::vector< Tensor<2,dim,ADNumberType> > Grad_u (n_q_points, Tensor<2,dim,ADNumberType>());
+        std::vector<ADNumberType> p_tilde (n_q_points, ADNumberType(0.0));
+        std::vector<ADNumberType> J_tilde (n_q_points, ADNumberType(0.0));
+        scratch.fe_values_ref[u_fe].get_function_gradients_from_local_dof_values(dof_values_ad, Grad_u);
+        scratch.fe_values_ref[p_fe].get_function_values_from_local_dof_values(dof_values_ad, p_tilde);
+        scratch.fe_values_ref[J_fe].get_function_values_from_local_dof_values(dof_values_ad, J_tilde);
+
+        // Compute the residual
+        // Note: It is critical that this vector be initialised with zero'd values
+        // otherwise the results may be garbage!
+        std::vector<ADNumberType> residual_ad (n_dependent_variables, ADNumberType(0.0));
+        for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+          {
+            const Tensor<2, dim, ADNumberType> F
+              = unit_symmetric_tensor<dim>() + Grad_u[q_point];
+            const Tensor<2, dim, ADNumberType> F_inv = invert(F);
+            const ADNumberType det_F = determinant(F);
+            Assert(det_F > ADNumberType(0.0), ExcMessage("Negative jacobian detected!"));
+
+            const SymmetricTensor<2, dim, ADNumberType> tau
+              = lqph[q_point]->get_tau(F, p_tilde[q_point]);
+            const ADNumberType dPsi_vol_dJ
+              = lqph[q_point]->get_dPsi_vol_dJ(J_tilde[q_point]);
+
+            const double JxW = scratch.fe_values_ref.JxW(q_point);
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              {
+                const unsigned int i_group = fe.system_to_base_index(i).first.first;
+                if (i_group == u_dof)
+                  {
+                    const SymmetricTensor<2, dim, ADNumberType> symm_grad_Nx_i
+                      = symmetrize(scratch.fe_values_ref[u_fe].gradient(i, q_point) * F_inv);
+                    residual_ad[i] += (symm_grad_Nx_i * tau) * JxW;
+                  }
+                else if (i_group == p_dof)
+                  {
+                    const double N_i = scratch.fe_values_ref[p_fe].value(i, q_point);
+                    residual_ad[i] += N_i * (det_F - J_tilde[q_point]) * JxW;
+                  }
+                else if (i_group == J_dof)
+                  {
+                    const double N_i = scratch.fe_values_ref[J_fe].value(i, q_point);
+                    residual_ad[i] += N_i * (dPsi_vol_dJ - p_tilde[q_point]) * JxW;
+                  }
+                else
+                  Assert(i_group <= J_dof, ExcInternalError());
+              }
+          }
+        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
+             ++face)
+          if (cell->face(face)->at_boundary() == true
+              && cell->face(face)->boundary_id() == 6)
+            {
+              scratch.fe_face_values_ref.reinit(cell, face);
+              for (unsigned int f_q_point = 0; f_q_point < n_q_points_f;
+                   ++f_q_point)
+                {
+                  const Tensor<1, dim> &N =
+                    scratch.fe_face_values_ref.normal_vector(f_q_point);
+                  static const double  p0        = -4.0
+                                                   /
+                                                   (parameters.scale * parameters.scale);
+                  const double         time_ramp = (time.current() / time.end());
+                  const double         pressure  = p0 * parameters.p_p0 * time_ramp;
+                  const Tensor<1, dim> traction  = pressure * N;
+                  for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                    {
+                      const unsigned int i_group =
+                        fe.system_to_base_index(i).first.first;
+                      if (i_group == u_dof)
+                        {
+                          const unsigned int component_i =
+                            fe.system_to_component_index(i).first;
+                          const double Ni =
+                            scratch.fe_face_values_ref.shape_value(i,
+                                                                   f_q_point);
+                          const double JxW = scratch.fe_face_values_ref.JxW(
+                                               f_q_point);
+                          residual_ad[i] -= (Ni * traction[component_i])
+                                            * JxW;
+                        }
+                    }
+                }
+            }
+
+        ad_helper.register_residual_vector(residual_ad);
+        ad_helper.disable_record_sensitivities(false /*write_tapes_to_file*/);
+      }
+    else
+      {
+        Assert(is_recording==true, ExcInternalError());
+      }
+
+    // Unnecessary when keep == true
+    // ad_helper.activate_tape(tape_no);
+    // ad_helper.set_dof_values(scratch.solution_total,
+    //                          data.local_dof_indices);
+
+    // Compute the residual values and their jacobian for the new evaluation point
+    data.cell_rhs    = ad_helper.compute_residual();
+    data.cell_rhs   *= -1.0; // RHS = - residual
+    data.cell_matrix = ad_helper.compute_linearization();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::make_constraints(const int &it_nr)
+  {
+    std::cout << " CST " << std::flush;
+    if (it_nr > 1)
+      return;
+    constraints.clear();
+    const bool apply_dirichlet_bc = (it_nr == 0);
+    const FEValuesExtractors::Scalar x_displacement(0);
+    const FEValuesExtractors::Scalar y_displacement(1);
+    {
+      const int boundary_id = 0;
+      if (apply_dirichlet_bc == true)
+        VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                 boundary_id,
+                                                 ZeroFunction<dim>(n_components),
+                                                 constraints,
+                                                 fe.component_mask(x_displacement));
+      else
+        VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                 boundary_id,
+                                                 ZeroFunction<dim>(n_components),
+                                                 constraints,
+                                                 fe.component_mask(x_displacement));
+    }
+    {
+      const int boundary_id = 2;
+      if (apply_dirichlet_bc == true)
+        VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                 boundary_id,
+                                                 ZeroFunction<dim>(n_components),
+                                                 constraints,
+                                                 fe.component_mask(y_displacement));
+      else
+        VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                 boundary_id,
+                                                 ZeroFunction<dim>(n_components),
+                                                 constraints,
+                                                 fe.component_mask(y_displacement));
+    }
+    if (dim==3)
+      {
+        const FEValuesExtractors::Scalar z_displacement(2);
+        {
+          const int boundary_id = 3;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+        }
+        {
+          const int boundary_id = 4;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     fe.component_mask(z_displacement));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     fe.component_mask(z_displacement));
+        }
+        {
+          const int boundary_id = 6;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+        }
+      }
+    else
+      {
+        {
+          const int boundary_id = 3;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+        }
+        {
+          const int boundary_id = 6;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+        }
+      }
+    constraints.close();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::assemble_sc()
+  {
+    timer.enter_subsection("Perform static condensation");
+    std::cout << " ASM_SC " << std::flush;
+    PerTaskData_SC per_task_data(dofs_per_cell, element_indices_u.size(),
+                                 element_indices_p.size(),
+                                 element_indices_J.size());
+    ScratchData_SC scratch_data;
+    WorkStream::run(dof_handler_ref.begin_active(),
+                    dof_handler_ref.end(),
+                    *this,
+                    &Solid::assemble_sc_one_cell,
+                    &Solid::copy_local_to_global_sc,
+                    scratch_data,
+                    per_task_data);
+    timer.leave_subsection();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::copy_local_to_global_sc(const PerTaskData_SC &data)
+  {
+    for (unsigned int i = 0; i < dofs_per_cell; ++i)
+      for (unsigned int j = 0; j < dofs_per_cell; ++j)
+        tangent_matrix.add(data.local_dof_indices[i],
+                           data.local_dof_indices[j],
+                           data.cell_matrix(i, j));
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void
+  Solid<dim,number_t,ad_type_code>::assemble_sc_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                                         ScratchData_SC &scratch,
+                                                         PerTaskData_SC &data)
+  {
+    data.reset();
+    scratch.reset();
+    cell->get_dof_indices(data.local_dof_indices);
+    data.k_orig.extract_submatrix_from(tangent_matrix,
+                                       data.local_dof_indices,
+                                       data.local_dof_indices);
+    data.k_pu.extract_submatrix_from(data.k_orig,
+                                     element_indices_p,
+                                     element_indices_u);
+    data.k_pJ.extract_submatrix_from(data.k_orig,
+                                     element_indices_p,
+                                     element_indices_J);
+    data.k_JJ.extract_submatrix_from(data.k_orig,
+                                     element_indices_J,
+                                     element_indices_J);
+    data.k_pJ_inv.invert(data.k_pJ);
+    data.k_pJ_inv.mmult(data.A, data.k_pu);
+    data.k_JJ.mmult(data.B, data.A);
+    data.k_pJ_inv.Tmmult(data.C, data.B);
+    data.k_pu.Tmmult(data.k_bbar, data.C);
+    data.k_bbar.scatter_matrix_to(element_indices_u,
+                                  element_indices_u,
+                                  data.cell_matrix);
+    data.k_pJ_inv.add(-1.0, data.k_pJ);
+    data.k_pJ_inv.scatter_matrix_to(element_indices_p,
+                                    element_indices_J,
+                                    data.cell_matrix);
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  std::pair<unsigned int, double>
+  Solid<dim,number_t,ad_type_code>::solve_linear_system(BlockVector<double> &newton_update)
+  {
+    unsigned int lin_it = 0;
+    double lin_res = 0.0;
+    if (parameters.use_static_condensation == true)
+      {
+        BlockVector<double> A(dofs_per_block);
+        BlockVector<double> B(dofs_per_block);
+        {
+          assemble_sc();
+          tangent_matrix.block(p_dof, J_dof).vmult(A.block(J_dof),
+                                                   system_rhs.block(p_dof));
+          tangent_matrix.block(J_dof, J_dof).vmult(B.block(J_dof),
+                                                   A.block(J_dof));
+          A.block(J_dof) = system_rhs.block(J_dof);
+          A.block(J_dof) -= B.block(J_dof);
+          tangent_matrix.block(p_dof, J_dof).Tvmult(A.block(p_dof),
+                                                    A.block(J_dof));
+          tangent_matrix.block(u_dof, p_dof).vmult(A.block(u_dof),
+                                                   A.block(p_dof));
+          system_rhs.block(u_dof) -= A.block(u_dof);
+          timer.enter_subsection("Linear solver");
+          std::cout << " SLV " << std::flush;
+          if (parameters.type_lin == "CG")
+            {
+              const int solver_its = tangent_matrix.block(u_dof, u_dof).m()
+                                     * parameters.max_iterations_lin;
+              const double tol_sol = parameters.tol_lin
+                                     * system_rhs.block(u_dof).l2_norm();
+              SolverControl solver_control(solver_its, tol_sol, false, false);
+              GrowingVectorMemory<Vector<double> > GVM;
+              SolverCG<Vector<double> > solver_CG(solver_control, GVM);
+              PreconditionSelector<SparseMatrix<double>, Vector<double> >
+              preconditioner (parameters.preconditioner_type,
+                              parameters.preconditioner_relaxation);
+              preconditioner.use_matrix(tangent_matrix.block(u_dof, u_dof));
+              solver_CG.solve(tangent_matrix.block(u_dof, u_dof),
+                              newton_update.block(u_dof),
+                              system_rhs.block(u_dof),
+                              preconditioner);
+              lin_it = solver_control.last_step();
+              lin_res = solver_control.last_value();
+            }
+          else if (parameters.type_lin == "Direct")
+            {
+              SparseDirectUMFPACK A_direct;
+              A_direct.initialize(tangent_matrix.block(u_dof, u_dof));
+              A_direct.vmult(newton_update.block(u_dof), system_rhs.block(u_dof));
+              lin_it = 1;
+              lin_res = 0.0;
+            }
+          else
+            Assert (false, ExcMessage("Linear solver type not implemented"));
+          timer.leave_subsection();
+        }
+        constraints.distribute(newton_update);
+        timer.enter_subsection("Linear solver postprocessing");
+        std::cout << " PP " << std::flush;
+        {
+          tangent_matrix.block(p_dof, u_dof).vmult(A.block(p_dof),
+                                                   newton_update.block(u_dof));
+          A.block(p_dof) *= -1.0;
+          A.block(p_dof) += system_rhs.block(p_dof);
+          tangent_matrix.block(p_dof, J_dof).vmult(newton_update.block(J_dof),
+                                                   A.block(p_dof));
+        }
+        constraints.distribute(newton_update);
+        {
+          tangent_matrix.block(J_dof, J_dof).vmult(A.block(J_dof),
+                                                   newton_update.block(J_dof));
+          A.block(J_dof) *= -1.0;
+          A.block(J_dof) += system_rhs.block(J_dof);
+          tangent_matrix.block(p_dof, J_dof).Tvmult(newton_update.block(p_dof),
+                                                    A.block(J_dof));
+        }
+        constraints.distribute(newton_update);
+        timer.leave_subsection();
+      }
+    else
+      {
+        std::cout << " ------ " << std::flush;
+        timer.enter_subsection("Linear solver");
+        std::cout << " SLV " << std::flush;
+        if (parameters.type_lin == "CG")
+          {
+            const Vector<double> &f_u = system_rhs.block(u_dof);
+            const Vector<double> &f_p = system_rhs.block(p_dof);
+            const Vector<double> &f_J = system_rhs.block(J_dof);
+            Vector<double> &d_u = newton_update.block(u_dof);
+            Vector<double> &d_p = newton_update.block(p_dof);
+            Vector<double> &d_J = newton_update.block(J_dof);
+            const auto K_uu = linear_operator(tangent_matrix.block(u_dof, u_dof));
+            const auto K_up = linear_operator(tangent_matrix.block(u_dof, p_dof));
+            const auto K_pu = linear_operator(tangent_matrix.block(p_dof, u_dof));
+            const auto K_Jp = linear_operator(tangent_matrix.block(J_dof, p_dof));
+            const auto K_JJ = linear_operator(tangent_matrix.block(J_dof, J_dof));
+            PreconditionSelector< SparseMatrix<double>, Vector<double> >
+            preconditioner_K_Jp_inv ("jacobi");
+            preconditioner_K_Jp_inv.use_matrix(tangent_matrix.block(J_dof, p_dof));
+            ReductionControl solver_control_K_Jp_inv (tangent_matrix.block(J_dof, p_dof).m() * parameters.max_iterations_lin,
+                                                      1.0e-30, parameters.tol_lin);
+            SolverSelector< Vector<double> > solver_K_Jp_inv;
+            solver_K_Jp_inv.select("cg");
+            solver_K_Jp_inv.set_control(solver_control_K_Jp_inv);
+            const auto K_Jp_inv = inverse_operator(K_Jp,
+                                                   solver_K_Jp_inv,
+                                                   preconditioner_K_Jp_inv);
+            const auto K_pJ_inv     = transpose_operator(K_Jp_inv);
+            const auto K_pp_bar     = K_Jp_inv * K_JJ * K_pJ_inv;
+            const auto K_uu_bar_bar = K_up * K_pp_bar * K_pu;
+            const auto K_uu_con     = K_uu + K_uu_bar_bar;
+            PreconditionSelector< SparseMatrix<double>, Vector<double> >
+            preconditioner_K_con_inv (parameters.preconditioner_type,
+                                      parameters.preconditioner_relaxation);
+            preconditioner_K_con_inv.use_matrix(tangent_matrix.block(u_dof, u_dof));
+            ReductionControl solver_control_K_con_inv (tangent_matrix.block(u_dof, u_dof).m() * parameters.max_iterations_lin,
+                                                       1.0e-30, parameters.tol_lin);
+            SolverSelector< Vector<double> > solver_K_con_inv;
+            solver_K_con_inv.select("cg");
+            solver_K_con_inv.set_control(solver_control_K_con_inv);
+            const auto K_uu_con_inv = inverse_operator(K_uu_con,
+                                                       solver_K_con_inv,
+                                                       preconditioner_K_con_inv);
+            d_u = K_uu_con_inv*(f_u - K_up*(K_Jp_inv*f_J - K_pp_bar*f_p));
+            timer.leave_subsection();
+            timer.enter_subsection("Linear solver postprocessing");
+            std::cout << " PP " << std::flush;
+            d_J = K_pJ_inv*(f_p - K_pu*d_u);
+            d_p = K_Jp_inv*(f_J - K_JJ*d_J);
+            lin_it = solver_control_K_con_inv.last_step();
+            lin_res = solver_control_K_con_inv.last_value();
+          }
+        else if (parameters.type_lin == "Direct")
+          {
+            SparseDirectUMFPACK A_direct;
+            A_direct.initialize(tangent_matrix);
+            A_direct.vmult(newton_update, system_rhs);
+            lin_it = 1;
+            lin_res = 0.0;
+            std::cout << " -- " << std::flush;
+          }
+        else
+          Assert (false, ExcMessage("Linear solver type not implemented"));
+        timer.leave_subsection();
+        constraints.distribute(newton_update);
+      }
+    return std::make_pair(lin_it, lin_res);
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::output_results() const
+  {
+    DataOut<dim> data_out;
+    std::vector<DataComponentInterpretation::DataComponentInterpretation>
+    data_component_interpretation(dim,
+                                  DataComponentInterpretation::component_is_part_of_vector);
+    data_component_interpretation.push_back(DataComponentInterpretation::component_is_scalar);
+    data_component_interpretation.push_back(DataComponentInterpretation::component_is_scalar);
+    std::vector<std::string> solution_name(dim, "displacement");
+    solution_name.push_back("pressure");
+    solution_name.push_back("dilatation");
+    data_out.attach_dof_handler(dof_handler_ref);
+    data_out.add_data_vector(solution_n,
+                             solution_name,
+                             DataOut<dim>::type_dof_data,
+                             data_component_interpretation);
+    Vector<double> soln(solution_n.size());
+    for (unsigned int i = 0; i < soln.size(); ++i)
+      soln(i) = solution_n(i);
+    MappingQEulerian<dim> q_mapping(degree, dof_handler_ref, soln);
+    data_out.build_patches(q_mapping, degree);
+    std::ostringstream filename;
+    filename << "solution-" << dim << "d-" << time.get_timestep() << ".vtk";
+    std::ofstream output(filename.str().c_str());
+    data_out.write_vtk(output);
+  }
+}
+int main (int argc,char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  using namespace dealii;
+  namespace AD = dealii::Differentiation::AD;
+  using namespace Step44;
+  try
+    {
+      const unsigned int dim = 3;
+      deallog.push("Taped");
+      {
+        std::cout << "Taped" << std::endl;
+        Solid<dim,double,AD::NumberTypes::adolc_taped> solid(SOURCE_DIR "/prm/parameters-step-44.prm");
+        solid.run();
+
+        deallog << "OK" << std::endl;
+      }
+      deallog.pop();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl << exc.what()
+                << std::endl << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl << "Aborting!"
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  return 0;
+}

--- a/tests/adolc/step-44-helper_res_lin_01.output
+++ b/tests/adolc/step-44-helper_res_lin_01.output
@@ -1,0 +1,12 @@
+
+DEAL:Taped::Timestep 1: 0.00 -0.000129 0.00
+DEAL:Taped::Timestep 2: 0.00 -0.000256 0.00
+DEAL:Taped::Timestep 3: 0.00 -0.000376 0.00
+DEAL:Taped::Timestep 4: 0.00 -0.000485 0.00
+DEAL:Taped::Timestep 5: 0.00 -0.000580 0.00
+DEAL:Taped::Timestep 6: 0.00 -0.000660 0.00
+DEAL:Taped::Timestep 7: 0.00 -0.000727 0.00
+DEAL:Taped::Timestep 8: 0.00 -0.000783 0.00
+DEAL:Taped::Timestep 9: 0.00 -0.000828 0.00
+DEAL:Taped::Timestep 10: 0.00 -0.000866 0.00
+DEAL:Taped::OK

--- a/tests/adolc/step-44-helper_var_form_01.cc
+++ b/tests/adolc/step-44-helper_var_form_01.cc
@@ -1,0 +1,1588 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// This is a modified version of step-44, which tests the implementation of
+// cell-level auto-differentiation (via a variational formulation).
+// The AD number type used is Adol-C (taped).
+
+#include "../tests.h"
+
+#include <deal.II/differentiation/ad.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/timer.h>
+#include <deal.II/base/work_stream.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/base/quadrature_point_data.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/fe/fe_dgp_monomial.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_tools.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q_eulerian.h>
+#include <deal.II/lac/block_sparse_matrix.h>
+#include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/precondition_selector.h>
+#include <deal.II/lac/solver_selector.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/linear_operator.h>
+#include <deal.II/lac/packaged_operation.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <iostream>
+#include <fstream>
+#include <functional>
+namespace Step44
+{
+  using namespace dealii;
+  namespace AD = dealii::Differentiation::AD;
+  namespace Parameters
+  {
+    struct FESystem
+    {
+      unsigned int poly_degree;
+      unsigned int quad_order;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void FESystem::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Finite element system");
+      {
+        prm.declare_entry("Polynomial degree", "2",
+                          Patterns::Integer(0),
+                          "Displacement system polynomial order");
+        prm.declare_entry("Quadrature order", "3",
+                          Patterns::Integer(0),
+                          "Gauss quadrature order");
+      }
+      prm.leave_subsection();
+    }
+    void FESystem::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Finite element system");
+      {
+        poly_degree = prm.get_integer("Polynomial degree");
+        quad_order = prm.get_integer("Quadrature order");
+      }
+      prm.leave_subsection();
+    }
+    struct Geometry
+    {
+      unsigned int global_refinement;
+      double       scale;
+      double       p_p0;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void Geometry::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        prm.declare_entry("Global refinement", "2",
+                          Patterns::Integer(0),
+                          "Global refinement level");
+        prm.declare_entry("Grid scale", "1e-3",
+                          Patterns::Double(0.0),
+                          "Global grid scaling factor");
+        prm.declare_entry("Pressure ratio p/p0", "100",
+                          Patterns::Selection("20|40|60|80|100"),
+                          "Ratio of applied pressure to reference pressure");
+      }
+      prm.leave_subsection();
+    }
+    void Geometry::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        global_refinement = prm.get_integer("Global refinement");
+        scale = prm.get_double("Grid scale");
+        p_p0 = prm.get_double("Pressure ratio p/p0");
+      }
+      prm.leave_subsection();
+    }
+    struct Materials
+    {
+      double nu;
+      double mu;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void Materials::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Material properties");
+      {
+        prm.declare_entry("Poisson's ratio", "0.4999",
+                          Patterns::Double(-1.0,0.5),
+                          "Poisson's ratio");
+        prm.declare_entry("Shear modulus", "80.194e6",
+                          Patterns::Double(),
+                          "Shear modulus");
+      }
+      prm.leave_subsection();
+    }
+    void Materials::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Material properties");
+      {
+        nu = prm.get_double("Poisson's ratio");
+        mu = prm.get_double("Shear modulus");
+      }
+      prm.leave_subsection();
+    }
+    struct LinearSolver
+    {
+      std::string type_lin;
+      double      tol_lin;
+      double      max_iterations_lin;
+      bool        use_static_condensation;
+      std::string preconditioner_type;
+      double      preconditioner_relaxation;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void LinearSolver::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Linear solver");
+      {
+        prm.declare_entry("Solver type", "CG",
+                          Patterns::Selection("CG|Direct"),
+                          "Type of solver used to solve the linear system");
+        prm.declare_entry("Residual", "1e-6",
+                          Patterns::Double(0.0),
+                          "Linear solver residual (scaled by residual norm)");
+        prm.declare_entry("Max iteration multiplier", "1",
+                          Patterns::Double(0.0),
+                          "Linear solver iterations (multiples of the system matrix size)");
+        prm.declare_entry("Use static condensation", "true",
+                          Patterns::Bool(),
+                          "Solve the full block system or a reduced problem");
+        prm.declare_entry("Preconditioner type", "ssor",
+                          Patterns::Selection("jacobi|ssor"),
+                          "Type of preconditioner");
+        prm.declare_entry("Preconditioner relaxation", "0.65",
+                          Patterns::Double(0.0),
+                          "Preconditioner relaxation value");
+      }
+      prm.leave_subsection();
+    }
+    void LinearSolver::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Linear solver");
+      {
+        type_lin = prm.get("Solver type");
+        tol_lin = prm.get_double("Residual");
+        max_iterations_lin = prm.get_double("Max iteration multiplier");
+        use_static_condensation = prm.get_bool("Use static condensation");
+        preconditioner_type = prm.get("Preconditioner type");
+        preconditioner_relaxation = prm.get_double("Preconditioner relaxation");
+      }
+      prm.leave_subsection();
+    }
+    struct NonlinearSolver
+    {
+      unsigned int max_iterations_NR;
+      double       tol_f;
+      double       tol_u;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void NonlinearSolver::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Nonlinear solver");
+      {
+        prm.declare_entry("Max iterations Newton-Raphson", "10",
+                          Patterns::Integer(0),
+                          "Number of Newton-Raphson iterations allowed");
+        prm.declare_entry("Tolerance force", "1.0e-9",
+                          Patterns::Double(0.0),
+                          "Force residual tolerance");
+        prm.declare_entry("Tolerance displacement", "1.0e-6",
+                          Patterns::Double(0.0),
+                          "Displacement error tolerance");
+      }
+      prm.leave_subsection();
+    }
+    void NonlinearSolver::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Nonlinear solver");
+      {
+        max_iterations_NR = prm.get_integer("Max iterations Newton-Raphson");
+        tol_f = prm.get_double("Tolerance force");
+        tol_u = prm.get_double("Tolerance displacement");
+      }
+      prm.leave_subsection();
+    }
+    struct Time
+    {
+      double delta_t;
+      double end_time;
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    void Time::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Time");
+      {
+        prm.declare_entry("End time", "1",
+                          Patterns::Double(),
+                          "End time");
+        prm.declare_entry("Time step size", "0.1",
+                          Patterns::Double(),
+                          "Time step size");
+      }
+      prm.leave_subsection();
+    }
+    void Time::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Time");
+      {
+        end_time = prm.get_double("End time");
+        delta_t = prm.get_double("Time step size");
+      }
+      prm.leave_subsection();
+    }
+    struct AllParameters : public FESystem,
+      public Geometry,
+      public Materials,
+      public LinearSolver,
+      public NonlinearSolver,
+      public Time
+    {
+      AllParameters(const std::string &input_file);
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+    AllParameters::AllParameters(const std::string &input_file)
+    {
+      ParameterHandler prm;
+      declare_parameters(prm);
+      prm.parse_input(input_file);
+      parse_parameters(prm);
+    }
+    void AllParameters::declare_parameters(ParameterHandler &prm)
+    {
+      FESystem::declare_parameters(prm);
+      Geometry::declare_parameters(prm);
+      Materials::declare_parameters(prm);
+      LinearSolver::declare_parameters(prm);
+      NonlinearSolver::declare_parameters(prm);
+      Time::declare_parameters(prm);
+    }
+    void AllParameters::parse_parameters(ParameterHandler &prm)
+    {
+      FESystem::parse_parameters(prm);
+      Geometry::parse_parameters(prm);
+      Materials::parse_parameters(prm);
+      LinearSolver::parse_parameters(prm);
+      NonlinearSolver::parse_parameters(prm);
+      Time::parse_parameters(prm);
+    }
+  }
+  template<int dim>
+  class StandardTensors
+  {
+  public:
+    static const SymmetricTensor<2, dim> I;
+    static const SymmetricTensor<4, dim> IxI;
+    static const SymmetricTensor<4, dim> II;
+    static const SymmetricTensor<4, dim> dev_P;
+  };
+  template<int dim>
+  const SymmetricTensor<2, dim>
+  StandardTensors<dim>::I = unit_symmetric_tensor<dim>();
+  template<int dim>
+  const SymmetricTensor<4, dim>
+  StandardTensors<dim>::IxI = outer_product(I, I);
+  template<int dim>
+  const SymmetricTensor<4, dim>
+  StandardTensors<dim>::II = identity_tensor<dim>();
+  template<int dim>
+  const SymmetricTensor<4, dim>
+  StandardTensors<dim>::dev_P = deviator_tensor<dim>();
+  class Time
+  {
+  public:
+    Time (const double time_end,
+          const double delta_t)
+      :
+      timestep(0),
+      time_current(0.0),
+      time_end(time_end),
+      delta_t(delta_t)
+    {}
+    virtual ~Time()
+    {}
+    double current() const
+    {
+      return time_current;
+    }
+    double end() const
+    {
+      return time_end;
+    }
+    double get_delta_t() const
+    {
+      return delta_t;
+    }
+    unsigned int get_timestep() const
+    {
+      return timestep;
+    }
+    void increment()
+    {
+      time_current += delta_t;
+      ++timestep;
+    }
+  private:
+    unsigned int timestep;
+    double       time_current;
+    const double time_end;
+    const double delta_t;
+  };
+  template<int dim>
+  class Material_Compressible_Neo_Hook_Three_Field
+  {
+  public:
+    Material_Compressible_Neo_Hook_Three_Field(const double mu,
+                                               const double nu)
+      :
+      kappa((2.0 * mu * (1.0 + nu)) / (3.0 * (1.0 - 2.0 * nu))),
+      c_1(mu / 2.0)
+    {
+      Assert(kappa > 0, ExcInternalError());
+    }
+    ~Material_Compressible_Neo_Hook_Three_Field()
+    {}
+
+    template<typename NumberType>
+    NumberType
+    get_Psi_iso(const SymmetricTensor<2,dim,NumberType> &C_bar)
+    {
+      return c_1*(trace(C_bar) - dim);
+    }
+    template<typename NumberType>
+    NumberType
+    get_Psi_vol(const NumberType &J_tilde)
+    {
+      return (kappa / 4.0) * (J_tilde*J_tilde - 1.0 - 2.0*log(J_tilde));
+    }
+
+  protected:
+    const double kappa;
+    const double c_1;
+  };
+  template<int dim>
+  class PointHistory
+  {
+  public:
+    PointHistory()
+    {}
+    virtual ~PointHistory()
+    {}
+    void setup_lqp (const Parameters::AllParameters &parameters)
+    {
+      material.reset(new Material_Compressible_Neo_Hook_Three_Field<dim>(parameters.mu,
+                     parameters.nu));
+    }
+
+    template<typename NumberType>
+    NumberType
+    get_Psi(const Tensor<2, dim, NumberType> &F,
+            const NumberType                 &p_tilde,
+            const NumberType                 &J_tilde) const
+    {
+      const SymmetricTensor<2,dim,NumberType> C = symmetrize(transpose(F)*F);
+      const NumberType det_F = determinant(F);
+      SymmetricTensor<2,dim,NumberType> C_bar (C);
+      C_bar *= std::pow(det_F, -2.0 / dim);
+
+      NumberType psi_CpJ = material->get_Psi_iso(C_bar);
+      psi_CpJ += material->get_Psi_vol(J_tilde);
+      psi_CpJ += p_tilde*(det_F - J_tilde);
+
+      return psi_CpJ;
+    }
+  private:
+    std::shared_ptr< Material_Compressible_Neo_Hook_Three_Field<dim> > material;
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  class Solid
+  {
+  public:
+    Solid(const std::string &input_file);
+    virtual
+    ~Solid();
+    void
+    run();
+  private:
+    struct PerTaskData_ASM;
+    struct ScratchData_ASM;
+    struct PerTaskData_SC;
+    struct ScratchData_SC;
+    void
+    make_grid();
+    void
+    system_setup();
+    void
+    determine_component_extractors();
+    void
+    assemble_system(const BlockVector<double> &solution_delta);
+    void
+    assemble_system_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                             ScratchData_ASM &scratch,
+                             PerTaskData_ASM &data) const;
+    void
+    copy_local_to_global_system(const PerTaskData_ASM &data);
+    void
+    assemble_sc();
+    void
+    assemble_sc_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                         ScratchData_SC &scratch,
+                         PerTaskData_SC &data);
+    void
+    copy_local_to_global_sc(const PerTaskData_SC &data);
+    void
+    make_constraints(const int &it_nr);
+    void
+    setup_qph();
+    void
+    solve_nonlinear_timestep(BlockVector<double> &solution_delta);
+    std::pair<unsigned int, double>
+    solve_linear_system(BlockVector<double> &newton_update);
+    BlockVector<double>
+    get_total_solution(const BlockVector<double> &solution_delta) const;
+    void
+    output_results() const;
+    Parameters::AllParameters parameters;
+    double                    vol_reference;
+    Triangulation<dim>        triangulation;
+    Time                      time;
+    mutable TimerOutput       timer;
+    CellDataStorage<typename Triangulation<dim>::cell_iterator,
+                    PointHistory<dim> > quadrature_point_history;
+    const unsigned int               degree;
+    const FESystem<dim>              fe;
+    DoFHandler<dim>                  dof_handler_ref;
+    const unsigned int               dofs_per_cell;
+    const FEValuesExtractors::Vector u_fe;
+    const FEValuesExtractors::Scalar p_fe;
+    const FEValuesExtractors::Scalar J_fe;
+    static const unsigned int n_blocks = 3;
+    static const unsigned int n_components = dim + 2;
+    static const unsigned int first_u_component = 0;
+    static const unsigned int p_component = dim;
+    static const unsigned int J_component = dim + 1;
+    enum
+    {
+      u_dof = 0,
+      p_dof = 1,
+      J_dof = 2
+    };
+    std::vector<types::global_dof_index> dofs_per_block;
+    std::vector<types::global_dof_index> element_indices_u;
+    std::vector<types::global_dof_index> element_indices_p;
+    std::vector<types::global_dof_index> element_indices_J;
+    const QGauss<dim>     qf_cell;
+    const QGauss<dim - 1> qf_face;
+    const unsigned int    n_q_points;
+    const unsigned int    n_q_points_f;
+    ConstraintMatrix          constraints;
+    BlockSparsityPattern      sparsity_pattern;
+    BlockSparseMatrix<double> tangent_matrix;
+    BlockVector<double>       system_rhs;
+    BlockVector<double>       solution_n;
+    struct Errors
+    {
+      Errors()
+        :
+        norm(1.0), u(1.0), p(1.0), J(1.0)
+      {}
+      void reset()
+      {
+        norm = 1.0;
+        u = 1.0;
+        p = 1.0;
+        J = 1.0;
+      }
+      void normalise(const Errors &rhs)
+      {
+        if (rhs.norm != 0.0)
+          norm /= rhs.norm;
+        if (rhs.u != 0.0)
+          u /= rhs.u;
+        if (rhs.p != 0.0)
+          p /= rhs.p;
+        if (rhs.J != 0.0)
+          J /= rhs.J;
+      }
+      double norm, u, p, J;
+    };
+    Errors error_residual, error_residual_0, error_residual_norm, error_update,
+           error_update_0, error_update_norm;
+    void
+    get_error_residual(Errors &error_residual);
+    void
+    get_error_update(const BlockVector<double> &newton_update,
+                     Errors &error_update);
+    std::pair<double, double>
+    get_error_dilation(const BlockVector<double> &solution_total) const;
+    void
+    print_conv_header();
+    void
+    print_conv_footer(const BlockVector<double> &solution_delta);
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  Solid<dim,number_t,ad_type_code>::Solid(const std::string &input_file)
+    :
+    parameters(input_file),
+    triangulation(Triangulation<dim>::maximum_smoothing),
+    time(parameters.end_time, parameters.delta_t),
+    timer(std::cout,
+          TimerOutput::never,
+          TimerOutput::wall_times),
+    degree(parameters.poly_degree),
+    fe(FE_Q<dim>(parameters.poly_degree), dim, // displacement
+       FE_DGPMonomial<dim>(parameters.poly_degree - 1), 1, // pressure
+       FE_DGPMonomial<dim>(parameters.poly_degree - 1), 1), // dilatation
+    dof_handler_ref(triangulation),
+    dofs_per_cell (fe.dofs_per_cell),
+    u_fe(first_u_component),
+    p_fe(p_component),
+    J_fe(J_component),
+    dofs_per_block(n_blocks),
+    qf_cell(parameters.quad_order),
+    qf_face(parameters.quad_order),
+    n_q_points (qf_cell.size()),
+    n_q_points_f (qf_face.size())
+  {
+    Assert(dim==2 || dim==3, ExcMessage("This problem only works in 2 or 3 space dimensions."));
+    determine_component_extractors();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  Solid<dim,number_t,ad_type_code>::~Solid()
+  {
+    dof_handler_ref.clear();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::run()
+  {
+    make_grid();
+    system_setup();
+    {
+      ConstraintMatrix constraints;
+      constraints.close();
+      const ComponentSelectFunction<dim>
+      J_mask (J_component, n_components);
+      VectorTools::project (dof_handler_ref,
+                            constraints,
+                            QGauss<dim>(degree+2),
+                            J_mask,
+                            solution_n);
+    }
+    output_results();
+    time.increment();
+    BlockVector<double> solution_delta(dofs_per_block);
+    while (time.current() < time.end())
+      {
+        solution_delta = 0.0;
+        solve_nonlinear_timestep(solution_delta);
+        solution_n += solution_delta;
+        output_results();
+        // Output displacement at centre of traction surface
+        {
+          const Point<dim> soln_pt (dim==3 ? Point<dim>(0.0, 1.0, 0.0)*parameters.scale : Point<dim>(0.0, 1.0)*parameters.scale);
+          typename DoFHandler<dim>::active_cell_iterator cell =
+            dof_handler_ref.begin_active(), endc = dof_handler_ref.end();
+          for (; cell != endc; ++cell)
+            for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
+              if (cell->vertex(v).distance(soln_pt) < 1e-6*parameters.scale)
+                {
+                  Tensor<1,dim> soln;
+                  for (unsigned int d=0; d<dim; ++d)
+                    soln[d] = solution_n(cell->vertex_dof_index(v,u_dof+d));
+                  deallog
+                      << "Timestep " << time.get_timestep()
+                      << ": " << soln << std::endl;
+                }
+        }
+        time.increment();
+      }
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  struct Solid<dim,number_t,ad_type_code>::PerTaskData_ASM
+  {
+    FullMatrix<double>        cell_matrix;
+    Vector<double>            cell_rhs;
+    std::vector<types::global_dof_index> local_dof_indices;
+    PerTaskData_ASM(const unsigned int dofs_per_cell)
+      :
+      cell_matrix(dofs_per_cell, dofs_per_cell),
+      cell_rhs(dofs_per_cell),
+      local_dof_indices(dofs_per_cell)
+    {}
+    void reset()
+    {
+      cell_matrix = 0.0;
+      cell_rhs = 0.0;
+    }
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  struct Solid<dim,number_t,ad_type_code>::ScratchData_ASM
+  {
+    const BlockVector<double> &solution_total;
+    FEValues<dim>              fe_values_ref;
+    FEFaceValues<dim>          fe_face_values_ref;
+    ScratchData_ASM(const FiniteElement<dim> &fe_cell,
+                    const QGauss<dim> &qf_cell, const UpdateFlags uf_cell,
+                    const QGauss<dim - 1> & qf_face, const UpdateFlags uf_face,
+                    const BlockVector<double> &solution_total)
+      :
+      solution_total (solution_total),
+      fe_values_ref(fe_cell, qf_cell, uf_cell),
+      fe_face_values_ref(fe_cell, qf_face, uf_face)
+    {}
+    ScratchData_ASM(const ScratchData_ASM &rhs)
+      :
+      solution_total (rhs.solution_total),
+      fe_values_ref(rhs.fe_values_ref.get_fe(),
+                    rhs.fe_values_ref.get_quadrature(),
+                    rhs.fe_values_ref.get_update_flags()),
+      fe_face_values_ref(rhs.fe_face_values_ref.get_fe(),
+                         rhs.fe_face_values_ref.get_quadrature(),
+                         rhs.fe_face_values_ref.get_update_flags())
+    {}
+    void reset()
+    {
+
+    }
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  struct Solid<dim,number_t,ad_type_code>::PerTaskData_SC
+  {
+    FullMatrix<double>        cell_matrix;
+    std::vector<types::global_dof_index> local_dof_indices;
+    FullMatrix<double>        k_orig;
+    FullMatrix<double>        k_pu;
+    FullMatrix<double>        k_pJ;
+    FullMatrix<double>        k_JJ;
+    FullMatrix<double>        k_pJ_inv;
+    FullMatrix<double>        k_bbar;
+    FullMatrix<double>        A;
+    FullMatrix<double>        B;
+    FullMatrix<double>        C;
+    PerTaskData_SC(const unsigned int dofs_per_cell,
+                   const unsigned int n_u,
+                   const unsigned int n_p,
+                   const unsigned int n_J)
+      :
+      cell_matrix(dofs_per_cell, dofs_per_cell),
+      local_dof_indices(dofs_per_cell),
+      k_orig(dofs_per_cell, dofs_per_cell),
+      k_pu(n_p, n_u),
+      k_pJ(n_p, n_J),
+      k_JJ(n_J, n_J),
+      k_pJ_inv(n_p, n_J),
+      k_bbar(n_u, n_u),
+      A(n_J,n_u),
+      B(n_J, n_u),
+      C(n_p, n_u)
+    {}
+    void reset()
+    {}
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  struct Solid<dim,number_t,ad_type_code>::ScratchData_SC
+  {
+    void reset()
+    {}
+  };
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::make_grid()
+  {
+    GridGenerator::hyper_rectangle(triangulation,
+                                   (dim==3 ? Point<dim>(0.0, 0.0, 0.0) : Point<dim>(0.0, 0.0)),
+                                   (dim==3 ? Point<dim>(1.0, 1.0, 1.0) : Point<dim>(1.0, 1.0)),
+                                   true);
+    GridTools::scale(parameters.scale, triangulation);
+    triangulation.refine_global(std::max (1U, parameters.global_refinement));
+    vol_reference = GridTools::volume(triangulation);
+    std::cout << "Grid:\n\t Reference volume: " << vol_reference << std::endl;
+    typename Triangulation<dim>::active_cell_iterator cell =
+      triangulation.begin_active(), endc = triangulation.end();
+    for (; cell != endc; ++cell)
+      for (unsigned int face = 0;
+           face < GeometryInfo<dim>::faces_per_cell; ++face)
+        {
+          if (cell->face(face)->at_boundary() == true
+              &&
+              cell->face(face)->center()[1] == 1.0 * parameters.scale)
+            {
+              if (dim==3)
+                {
+                  if (cell->face(face)->center()[0] < 0.5 * parameters.scale
+                      &&
+                      cell->face(face)->center()[2] < 0.5 * parameters.scale)
+                    cell->face(face)->set_boundary_id(6);
+                }
+              else
+                {
+                  if (cell->face(face)->center()[0] < 0.5 * parameters.scale)
+                    cell->face(face)->set_boundary_id(6);
+                }
+            }
+        }
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::system_setup()
+  {
+    timer.enter_subsection("Setup system");
+    std::vector<unsigned int> block_component(n_components, u_dof); // Displacement
+    block_component[p_component] = p_dof; // Pressure
+    block_component[J_component] = J_dof; // Dilatation
+    dof_handler_ref.distribute_dofs(fe);
+    DoFRenumbering::Cuthill_McKee(dof_handler_ref);
+    DoFRenumbering::component_wise(dof_handler_ref, block_component);
+    DoFTools::count_dofs_per_block(dof_handler_ref, dofs_per_block,
+                                   block_component);
+    std::cout << "Triangulation:"
+              << "\n\t Number of active cells: " << triangulation.n_active_cells()
+              << "\n\t Number of degrees of freedom: " << dof_handler_ref.n_dofs()
+              << std::endl;
+    tangent_matrix.clear();
+    {
+      const types::global_dof_index n_dofs_u = dofs_per_block[u_dof];
+      const types::global_dof_index n_dofs_p = dofs_per_block[p_dof];
+      const types::global_dof_index n_dofs_J = dofs_per_block[J_dof];
+      BlockDynamicSparsityPattern dsp(n_blocks, n_blocks);
+      dsp.block(u_dof, u_dof).reinit(n_dofs_u, n_dofs_u);
+      dsp.block(u_dof, p_dof).reinit(n_dofs_u, n_dofs_p);
+      dsp.block(u_dof, J_dof).reinit(n_dofs_u, n_dofs_J);
+      dsp.block(p_dof, u_dof).reinit(n_dofs_p, n_dofs_u);
+      dsp.block(p_dof, p_dof).reinit(n_dofs_p, n_dofs_p);
+      dsp.block(p_dof, J_dof).reinit(n_dofs_p, n_dofs_J);
+      dsp.block(J_dof, u_dof).reinit(n_dofs_J, n_dofs_u);
+      dsp.block(J_dof, p_dof).reinit(n_dofs_J, n_dofs_p);
+      dsp.block(J_dof, J_dof).reinit(n_dofs_J, n_dofs_J);
+      dsp.collect_sizes();
+      Table<2, DoFTools::Coupling> coupling(n_components, n_components);
+      for (unsigned int ii = 0; ii < n_components; ++ii)
+        for (unsigned int jj = 0; jj < n_components; ++jj)
+          if (((ii < p_component) && (jj == J_component))
+              || ((ii == J_component) && (jj < p_component))
+              || ((ii == p_component) && (jj == p_component)))
+            coupling[ii][jj] = DoFTools::none;
+          else
+            coupling[ii][jj] = DoFTools::always;
+      DoFTools::make_sparsity_pattern(dof_handler_ref,
+                                      coupling,
+                                      dsp,
+                                      constraints,
+                                      false);
+      sparsity_pattern.copy_from(dsp);
+    }
+    tangent_matrix.reinit(sparsity_pattern);
+    system_rhs.reinit(dofs_per_block);
+    system_rhs.collect_sizes();
+    solution_n.reinit(dofs_per_block);
+    solution_n.collect_sizes();
+    setup_qph();
+    timer.leave_subsection();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void
+  Solid<dim,number_t,ad_type_code>::determine_component_extractors()
+  {
+    element_indices_u.clear();
+    element_indices_p.clear();
+    element_indices_J.clear();
+    for (unsigned int k = 0; k < fe.dofs_per_cell; ++k)
+      {
+        const unsigned int k_group = fe.system_to_base_index(k).first.first;
+        if (k_group == u_dof)
+          element_indices_u.push_back(k);
+        else if (k_group == p_dof)
+          element_indices_p.push_back(k);
+        else if (k_group == J_dof)
+          element_indices_J.push_back(k);
+        else
+          {
+            Assert(k_group <= J_dof, ExcInternalError());
+          }
+      }
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::setup_qph()
+  {
+    std::cout << "    Setting up quadrature point data..." << std::endl;
+    quadrature_point_history.initialize(triangulation.begin_active(),
+                                        triangulation.end(),
+                                        n_q_points);
+    for (typename Triangulation<dim>::active_cell_iterator cell =
+           triangulation.begin_active(); cell != triangulation.end(); ++cell)
+      {
+        const std::vector<std::shared_ptr<PointHistory<dim> > > lqph =
+          quadrature_point_history.get_data(cell);
+        Assert(lqph.size() == n_q_points, ExcInternalError());
+        for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+          lqph[q_point]->setup_lqp(parameters);
+      }
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void
+  Solid<dim,number_t,ad_type_code>::solve_nonlinear_timestep(BlockVector<double> &solution_delta)
+  {
+    std::cout << std::endl << "Timestep " << time.get_timestep() << " @ "
+              << time.current() << "s" << std::endl;
+    BlockVector<double> newton_update(dofs_per_block);
+    error_residual.reset();
+    error_residual_0.reset();
+    error_residual_norm.reset();
+    error_update.reset();
+    error_update_0.reset();
+    error_update_norm.reset();
+    print_conv_header();
+    unsigned int newton_iteration = 0;
+    for (; newton_iteration < parameters.max_iterations_NR;
+         ++newton_iteration)
+      {
+        std::cout << " " << std::setw(2) << newton_iteration << " " << std::flush;
+        make_constraints(newton_iteration);
+        assemble_system(solution_delta);
+        get_error_residual(error_residual);
+        if (newton_iteration == 0)
+          error_residual_0 = error_residual;
+        error_residual_norm = error_residual;
+        error_residual_norm.normalise(error_residual_0);
+        if (newton_iteration > 0 && error_update_norm.u <= parameters.tol_u
+            && error_residual_norm.u <= parameters.tol_f)
+          {
+            std::cout << " CONVERGED! " << std::endl;
+            print_conv_footer(solution_delta);
+            break;
+          }
+        const std::pair<unsigned int, double>
+        lin_solver_output = solve_linear_system(newton_update);
+        get_error_update(newton_update, error_update);
+        if (newton_iteration == 0)
+          error_update_0 = error_update;
+        error_update_norm = error_update;
+        error_update_norm.normalise(error_update_0);
+        solution_delta += newton_update;
+        std::cout << " | " << std::fixed << std::setprecision(3) << std::setw(7)
+                  << std::scientific << lin_solver_output.first << "  "
+                  << lin_solver_output.second << "  " << error_residual_norm.norm
+                  << "  " << error_residual_norm.u << "  "
+                  << error_residual_norm.p << "  " << error_residual_norm.J
+                  << "  " << error_update_norm.norm << "  " << error_update_norm.u
+                  << "  " << error_update_norm.p << "  " << error_update_norm.J
+                  << "  " << std::endl;
+      }
+    AssertThrow (newton_iteration <= parameters.max_iterations_NR,
+                 ExcMessage("No convergence in nonlinear solver!"));
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::print_conv_header()
+  {
+    static const unsigned int l_width = 144;
+    for (unsigned int i = 0; i < l_width; ++i)
+      std::cout << "_";
+    std::cout << std::endl;
+    std::cout << "           SOLVER STEP             "
+              << " |  LIN_IT   LIN_RES    RES_NORM    "
+              << " RES_U     RES_P      RES_J     NU_NORM     "
+              << " NU_U       NU_P       NU_J " << std::endl;
+    for (unsigned int i = 0; i < l_width; ++i)
+      std::cout << "_";
+    std::cout << std::endl;
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::print_conv_footer(const BlockVector<double> &solution_delta)
+  {
+    static const unsigned int l_width = 144;
+    for (unsigned int i = 0; i < l_width; ++i)
+      std::cout << "_";
+    std::cout << std::endl;
+    const std::pair<double,double> error_dil = get_error_dilation(get_total_solution(solution_delta));
+    std::cout << "Relative errors:" << std::endl
+              << "Displacement:\t" << error_update.u / error_update_0.u << std::endl
+              << "Force: \t\t" << error_residual.u / error_residual_0.u << std::endl
+              << "Dilatation:\t" << error_dil.first << std::endl
+              << "v / V_0:\t" << error_dil.second *vol_reference << " / " << vol_reference
+              << " = " << error_dil.second << std::endl;
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  std::pair<double, double>
+  Solid<dim,number_t,ad_type_code>::get_error_dilation(const BlockVector<double> &solution_total) const
+  {
+    double vol_current = 0.0;
+    double dil_L2_error = 0.0;
+    FEValues<dim> fe_values_ref(fe, qf_cell,
+                                update_values | update_gradients | update_JxW_values);
+    std::vector<Tensor<2, dim> > solution_grads_u_total (qf_cell.size());
+    std::vector<double>          solution_values_J_total (qf_cell.size());
+    for (typename DoFHandler<dim>::active_cell_iterator
+         cell = dof_handler_ref.begin_active();
+         cell != dof_handler_ref.end(); ++cell)
+      {
+        fe_values_ref.reinit(cell);
+        fe_values_ref[u_fe].get_function_gradients(solution_total,
+                                                   solution_grads_u_total);
+        fe_values_ref[J_fe].get_function_values(solution_total,
+                                                solution_values_J_total);
+        const std::vector<std::shared_ptr<const PointHistory<dim> > > lqph =
+          quadrature_point_history.get_data(cell);
+        Assert(lqph.size() == n_q_points, ExcInternalError());
+        for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+          {
+            const double det_F_qp = determinant(StandardTensors<dim>::I + solution_grads_u_total[q_point]);
+            const double J_tilde_qp = solution_values_J_total[q_point];
+            const double the_error_qp_squared = std::pow((det_F_qp - J_tilde_qp),
+                                                         2);
+            const double JxW = fe_values_ref.JxW(q_point);
+            dil_L2_error += the_error_qp_squared * JxW;
+            vol_current  += det_F_qp * JxW;
+          }
+      }
+    Assert(vol_current > 0.0, ExcInternalError());
+
+    return std::make_pair(std::sqrt(dil_L2_error),
+                          vol_current / vol_reference);
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::get_error_residual(Errors &error_residual)
+  {
+    BlockVector<double> error_res(dofs_per_block);
+    for (unsigned int i = 0; i < dof_handler_ref.n_dofs(); ++i)
+      if (!constraints.is_constrained(i))
+        error_res(i) = system_rhs(i);
+    error_residual.norm = error_res.l2_norm();
+    error_residual.u = error_res.block(u_dof).l2_norm();
+    error_residual.p = error_res.block(p_dof).l2_norm();
+    error_residual.J = error_res.block(J_dof).l2_norm();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::get_error_update(const BlockVector<double> &newton_update,
+                                                          Errors &error_update)
+  {
+    BlockVector<double> error_ud(dofs_per_block);
+    for (unsigned int i = 0; i < dof_handler_ref.n_dofs(); ++i)
+      if (!constraints.is_constrained(i))
+        error_ud(i) = newton_update(i);
+    error_update.norm = error_ud.l2_norm();
+    error_update.u = error_ud.block(u_dof).l2_norm();
+    error_update.p = error_ud.block(p_dof).l2_norm();
+    error_update.J = error_ud.block(J_dof).l2_norm();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  BlockVector<double>
+  Solid<dim,number_t,ad_type_code>::get_total_solution(const BlockVector<double> &solution_delta) const
+  {
+    BlockVector<double> solution_total(solution_n);
+    solution_total += solution_delta;
+    return solution_total;
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::assemble_system(const BlockVector<double> &solution_delta)
+  {
+    timer.enter_subsection("Assemble system");
+    std::cout << " ASM_SYS " << std::flush;
+    tangent_matrix = 0.0;
+    system_rhs = 0.0;
+    const BlockVector<double> solution_total(get_total_solution(solution_delta));
+    const UpdateFlags uf_cell(update_values |
+                              update_gradients |
+                              update_JxW_values);
+    const UpdateFlags uf_face(update_values |
+                              update_normal_vectors |
+                              update_JxW_values);
+    PerTaskData_ASM per_task_data(dofs_per_cell);
+    ScratchData_ASM scratch_data(fe, qf_cell, uf_cell, qf_face, uf_face, solution_total);
+    // Adol-C is incompatible with TBB
+    // WorkStream::run(dof_handler_ref.begin_active(),
+    //                 dof_handler_ref.end(),
+    //                 std::bind(&Solid<dim,number_t,ad_type_code>::assemble_system_one_cell,
+    //                                 this,
+    //                                 std::placeholders::_1,
+    //                                 std::placeholders::_2,
+    //                                 std::placeholders::_3),
+    //                 std::bind(&Solid<dim,number_t,ad_type_code>::copy_local_to_global_system,
+    //                                 this,
+    //                                 std::placeholders::_1),
+    //                 scratch_data,
+    //                 per_task_data);
+    for (typename DoFHandler<dim>::active_cell_iterator
+         cell = dof_handler_ref.begin_active();
+         cell != dof_handler_ref.end(); ++cell)
+      {
+        assemble_system_one_cell(cell, scratch_data, per_task_data);
+        copy_local_to_global_system(per_task_data);
+      }
+    timer.leave_subsection();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::copy_local_to_global_system(const PerTaskData_ASM &data)
+  {
+    if (data.cell_matrix.frobenius_norm() > 1e-12)
+      constraints.distribute_local_to_global(data.cell_matrix, data.cell_rhs,
+                                             data.local_dof_indices,
+                                             tangent_matrix, system_rhs);
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void
+  Solid<dim,number_t,ad_type_code>::assemble_system_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                                             ScratchData_ASM &scratch,
+                                                             PerTaskData_ASM &data) const
+  {
+    data.reset();
+    scratch.reset();
+    scratch.fe_values_ref.reinit(cell);
+    cell->get_dof_indices(data.local_dof_indices);
+
+    const std::vector<std::shared_ptr<const PointHistory<dim> > > lqph =
+      quadrature_point_history.get_data(cell);
+    Assert(lqph.size() == n_q_points, ExcInternalError());
+
+    const unsigned int n_independent_variables = data.local_dof_indices.size();
+
+    typedef AD::ADHelperVariationalFormulation<dim,ad_type_code,number_t> ADHelper;
+    typedef typename ADHelper::ad_type ADNumberType;
+    ADHelper ad_helper(n_independent_variables);
+
+    const int tape_no = 1;
+    const bool is_recording = ad_helper.enable_record_sensitivities(tape_no, //  material_id
+                              true,    // overwrite_tape
+                              true);   // keep
+
+    if (is_recording == true)
+      {
+        // Set the values for all DoFs
+        ad_helper.register_dof_values(scratch.solution_total,
+                                      data.local_dof_indices);
+        const std::vector<ADNumberType> dof_values_ad = ad_helper.get_sensitive_dof_values();
+
+        // Compute all values, gradients etc. based on sensitive AD DoF values
+        std::vector< Tensor<2,dim,ADNumberType> > Grad_u (n_q_points, Tensor<2,dim,ADNumberType>());
+        std::vector<ADNumberType> p_tilde (n_q_points, ADNumberType(0.0));
+        std::vector<ADNumberType> J_tilde (n_q_points, ADNumberType(0.0));
+        scratch.fe_values_ref[u_fe].get_function_gradients_from_local_dof_values(dof_values_ad, Grad_u);
+        scratch.fe_values_ref[p_fe].get_function_values_from_local_dof_values(dof_values_ad, p_tilde);
+        scratch.fe_values_ref[J_fe].get_function_values_from_local_dof_values(dof_values_ad, J_tilde);
+
+        // Compute the total energy = (internal - external) energies
+        ADNumberType energy_ad = ADNumberType(0.0);
+        for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+          {
+            const Tensor<2, dim, ADNumberType> F
+              = unit_symmetric_tensor<dim>() + Grad_u[q_point];
+            const Tensor<2, dim, ADNumberType> F_inv = invert(F);
+            const ADNumberType det_F = determinant(F);
+            Assert(det_F > ADNumberType(0.0), ExcMessage("Negative jacobian detected!"));
+
+            const double JxW = scratch.fe_values_ref.JxW(q_point);
+
+            energy_ad += lqph[q_point]->get_Psi(F, p_tilde[q_point], J_tilde[q_point]) * JxW;
+          }
+        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
+             ++face)
+          if (cell->face(face)->at_boundary() == true
+              && cell->face(face)->boundary_id() == 6)
+            {
+              scratch.fe_face_values_ref.reinit(cell, face);
+
+              std::vector< Tensor<1,dim,ADNumberType> > u_face (n_q_points_f, Tensor<1,dim,ADNumberType>());
+              scratch.fe_face_values_ref[u_fe].get_function_values_from_local_dof_values(dof_values_ad, u_face);
+
+              for (unsigned int f_q_point = 0; f_q_point < n_q_points_f;
+                   ++f_q_point)
+                {
+                  const Tensor<1, dim> &N =
+                    scratch.fe_face_values_ref.normal_vector(f_q_point);
+                  static const double  p0        = -4.0
+                                                   /
+                                                   (parameters.scale * parameters.scale);
+                  const double         time_ramp = (time.current() / time.end());
+                  const double         pressure  = p0 * parameters.p_p0 * time_ramp;
+                  const Tensor<1, dim> traction  = pressure * N;
+
+                  const double JxW = scratch.fe_face_values_ref.JxW(f_q_point);
+
+                  energy_ad -= (u_face[f_q_point] * traction) * JxW;
+                }
+            }
+
+        ad_helper.register_energy_functional(energy_ad);
+        ad_helper.disable_record_sensitivities(false /*write_tapes_to_file*/);
+      }
+    else
+      {
+        Assert(is_recording==true, ExcInternalError());
+      }
+
+    // Unnecessary when keep == true
+    // ad_helper.activate_tape(tape_no);
+    // ad_helper.set_dof_values(scratch.solution_total,
+    //                          data.local_dof_indices);
+
+    // Compute the residual values and their jacobian for the new evaluation point
+    data.cell_rhs    = ad_helper.compute_residual();
+    data.cell_rhs   *= -1.0; // RHS = - residual
+    data.cell_matrix = ad_helper.compute_linearization();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::make_constraints(const int &it_nr)
+  {
+    std::cout << " CST " << std::flush;
+    if (it_nr > 1)
+      return;
+    constraints.clear();
+    const bool apply_dirichlet_bc = (it_nr == 0);
+    const FEValuesExtractors::Scalar x_displacement(0);
+    const FEValuesExtractors::Scalar y_displacement(1);
+    {
+      const int boundary_id = 0;
+      if (apply_dirichlet_bc == true)
+        VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                 boundary_id,
+                                                 ZeroFunction<dim>(n_components),
+                                                 constraints,
+                                                 fe.component_mask(x_displacement));
+      else
+        VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                 boundary_id,
+                                                 ZeroFunction<dim>(n_components),
+                                                 constraints,
+                                                 fe.component_mask(x_displacement));
+    }
+    {
+      const int boundary_id = 2;
+      if (apply_dirichlet_bc == true)
+        VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                 boundary_id,
+                                                 ZeroFunction<dim>(n_components),
+                                                 constraints,
+                                                 fe.component_mask(y_displacement));
+      else
+        VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                 boundary_id,
+                                                 ZeroFunction<dim>(n_components),
+                                                 constraints,
+                                                 fe.component_mask(y_displacement));
+    }
+    if (dim==3)
+      {
+        const FEValuesExtractors::Scalar z_displacement(2);
+        {
+          const int boundary_id = 3;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+        }
+        {
+          const int boundary_id = 4;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     fe.component_mask(z_displacement));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     fe.component_mask(z_displacement));
+        }
+        {
+          const int boundary_id = 6;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+        }
+      }
+    else
+      {
+        {
+          const int boundary_id = 3;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+        }
+        {
+          const int boundary_id = 6;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+        }
+      }
+    constraints.close();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::assemble_sc()
+  {
+    timer.enter_subsection("Perform static condensation");
+    std::cout << " ASM_SC " << std::flush;
+    PerTaskData_SC per_task_data(dofs_per_cell, element_indices_u.size(),
+                                 element_indices_p.size(),
+                                 element_indices_J.size());
+    ScratchData_SC scratch_data;
+    WorkStream::run(dof_handler_ref.begin_active(),
+                    dof_handler_ref.end(),
+                    *this,
+                    &Solid::assemble_sc_one_cell,
+                    &Solid::copy_local_to_global_sc,
+                    scratch_data,
+                    per_task_data);
+    timer.leave_subsection();
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::copy_local_to_global_sc(const PerTaskData_SC &data)
+  {
+    for (unsigned int i = 0; i < dofs_per_cell; ++i)
+      for (unsigned int j = 0; j < dofs_per_cell; ++j)
+        tangent_matrix.add(data.local_dof_indices[i],
+                           data.local_dof_indices[j],
+                           data.cell_matrix(i, j));
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void
+  Solid<dim,number_t,ad_type_code>::assemble_sc_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                                         ScratchData_SC &scratch,
+                                                         PerTaskData_SC &data)
+  {
+    data.reset();
+    scratch.reset();
+    cell->get_dof_indices(data.local_dof_indices);
+    data.k_orig.extract_submatrix_from(tangent_matrix,
+                                       data.local_dof_indices,
+                                       data.local_dof_indices);
+    data.k_pu.extract_submatrix_from(data.k_orig,
+                                     element_indices_p,
+                                     element_indices_u);
+    data.k_pJ.extract_submatrix_from(data.k_orig,
+                                     element_indices_p,
+                                     element_indices_J);
+    data.k_JJ.extract_submatrix_from(data.k_orig,
+                                     element_indices_J,
+                                     element_indices_J);
+    data.k_pJ_inv.invert(data.k_pJ);
+    data.k_pJ_inv.mmult(data.A, data.k_pu);
+    data.k_JJ.mmult(data.B, data.A);
+    data.k_pJ_inv.Tmmult(data.C, data.B);
+    data.k_pu.Tmmult(data.k_bbar, data.C);
+    data.k_bbar.scatter_matrix_to(element_indices_u,
+                                  element_indices_u,
+                                  data.cell_matrix);
+    data.k_pJ_inv.add(-1.0, data.k_pJ);
+    data.k_pJ_inv.scatter_matrix_to(element_indices_p,
+                                    element_indices_J,
+                                    data.cell_matrix);
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  std::pair<unsigned int, double>
+  Solid<dim,number_t,ad_type_code>::solve_linear_system(BlockVector<double> &newton_update)
+  {
+    unsigned int lin_it = 0;
+    double lin_res = 0.0;
+    if (parameters.use_static_condensation == true)
+      {
+        BlockVector<double> A(dofs_per_block);
+        BlockVector<double> B(dofs_per_block);
+        {
+          assemble_sc();
+          tangent_matrix.block(p_dof, J_dof).vmult(A.block(J_dof),
+                                                   system_rhs.block(p_dof));
+          tangent_matrix.block(J_dof, J_dof).vmult(B.block(J_dof),
+                                                   A.block(J_dof));
+          A.block(J_dof) = system_rhs.block(J_dof);
+          A.block(J_dof) -= B.block(J_dof);
+          tangent_matrix.block(p_dof, J_dof).Tvmult(A.block(p_dof),
+                                                    A.block(J_dof));
+          tangent_matrix.block(u_dof, p_dof).vmult(A.block(u_dof),
+                                                   A.block(p_dof));
+          system_rhs.block(u_dof) -= A.block(u_dof);
+          timer.enter_subsection("Linear solver");
+          std::cout << " SLV " << std::flush;
+          if (parameters.type_lin == "CG")
+            {
+              const int solver_its = tangent_matrix.block(u_dof, u_dof).m()
+                                     * parameters.max_iterations_lin;
+              const double tol_sol = parameters.tol_lin
+                                     * system_rhs.block(u_dof).l2_norm();
+              SolverControl solver_control(solver_its, tol_sol, false, false);
+              GrowingVectorMemory<Vector<double> > GVM;
+              SolverCG<Vector<double> > solver_CG(solver_control, GVM);
+              PreconditionSelector<SparseMatrix<double>, Vector<double> >
+              preconditioner (parameters.preconditioner_type,
+                              parameters.preconditioner_relaxation);
+              preconditioner.use_matrix(tangent_matrix.block(u_dof, u_dof));
+              solver_CG.solve(tangent_matrix.block(u_dof, u_dof),
+                              newton_update.block(u_dof),
+                              system_rhs.block(u_dof),
+                              preconditioner);
+              lin_it = solver_control.last_step();
+              lin_res = solver_control.last_value();
+            }
+          else if (parameters.type_lin == "Direct")
+            {
+              SparseDirectUMFPACK A_direct;
+              A_direct.initialize(tangent_matrix.block(u_dof, u_dof));
+              A_direct.vmult(newton_update.block(u_dof), system_rhs.block(u_dof));
+              lin_it = 1;
+              lin_res = 0.0;
+            }
+          else
+            Assert (false, ExcMessage("Linear solver type not implemented"));
+          timer.leave_subsection();
+        }
+        constraints.distribute(newton_update);
+        timer.enter_subsection("Linear solver postprocessing");
+        std::cout << " PP " << std::flush;
+        {
+          tangent_matrix.block(p_dof, u_dof).vmult(A.block(p_dof),
+                                                   newton_update.block(u_dof));
+          A.block(p_dof) *= -1.0;
+          A.block(p_dof) += system_rhs.block(p_dof);
+          tangent_matrix.block(p_dof, J_dof).vmult(newton_update.block(J_dof),
+                                                   A.block(p_dof));
+        }
+        constraints.distribute(newton_update);
+        {
+          tangent_matrix.block(J_dof, J_dof).vmult(A.block(J_dof),
+                                                   newton_update.block(J_dof));
+          A.block(J_dof) *= -1.0;
+          A.block(J_dof) += system_rhs.block(J_dof);
+          tangent_matrix.block(p_dof, J_dof).Tvmult(newton_update.block(p_dof),
+                                                    A.block(J_dof));
+        }
+        constraints.distribute(newton_update);
+        timer.leave_subsection();
+      }
+    else
+      {
+        std::cout << " ------ " << std::flush;
+        timer.enter_subsection("Linear solver");
+        std::cout << " SLV " << std::flush;
+        if (parameters.type_lin == "CG")
+          {
+            const Vector<double> &f_u = system_rhs.block(u_dof);
+            const Vector<double> &f_p = system_rhs.block(p_dof);
+            const Vector<double> &f_J = system_rhs.block(J_dof);
+            Vector<double> &d_u = newton_update.block(u_dof);
+            Vector<double> &d_p = newton_update.block(p_dof);
+            Vector<double> &d_J = newton_update.block(J_dof);
+            const auto K_uu = linear_operator(tangent_matrix.block(u_dof, u_dof));
+            const auto K_up = linear_operator(tangent_matrix.block(u_dof, p_dof));
+            const auto K_pu = linear_operator(tangent_matrix.block(p_dof, u_dof));
+            const auto K_Jp = linear_operator(tangent_matrix.block(J_dof, p_dof));
+            const auto K_JJ = linear_operator(tangent_matrix.block(J_dof, J_dof));
+            PreconditionSelector< SparseMatrix<double>, Vector<double> >
+            preconditioner_K_Jp_inv ("jacobi");
+            preconditioner_K_Jp_inv.use_matrix(tangent_matrix.block(J_dof, p_dof));
+            ReductionControl solver_control_K_Jp_inv (tangent_matrix.block(J_dof, p_dof).m() * parameters.max_iterations_lin,
+                                                      1.0e-30, parameters.tol_lin);
+            SolverSelector< Vector<double> > solver_K_Jp_inv;
+            solver_K_Jp_inv.select("cg");
+            solver_K_Jp_inv.set_control(solver_control_K_Jp_inv);
+            const auto K_Jp_inv = inverse_operator(K_Jp,
+                                                   solver_K_Jp_inv,
+                                                   preconditioner_K_Jp_inv);
+            const auto K_pJ_inv     = transpose_operator(K_Jp_inv);
+            const auto K_pp_bar     = K_Jp_inv * K_JJ * K_pJ_inv;
+            const auto K_uu_bar_bar = K_up * K_pp_bar * K_pu;
+            const auto K_uu_con     = K_uu + K_uu_bar_bar;
+            PreconditionSelector< SparseMatrix<double>, Vector<double> >
+            preconditioner_K_con_inv (parameters.preconditioner_type,
+                                      parameters.preconditioner_relaxation);
+            preconditioner_K_con_inv.use_matrix(tangent_matrix.block(u_dof, u_dof));
+            ReductionControl solver_control_K_con_inv (tangent_matrix.block(u_dof, u_dof).m() * parameters.max_iterations_lin,
+                                                       1.0e-30, parameters.tol_lin);
+            SolverSelector< Vector<double> > solver_K_con_inv;
+            solver_K_con_inv.select("cg");
+            solver_K_con_inv.set_control(solver_control_K_con_inv);
+            const auto K_uu_con_inv = inverse_operator(K_uu_con,
+                                                       solver_K_con_inv,
+                                                       preconditioner_K_con_inv);
+            d_u = K_uu_con_inv*(f_u - K_up*(K_Jp_inv*f_J - K_pp_bar*f_p));
+            timer.leave_subsection();
+            timer.enter_subsection("Linear solver postprocessing");
+            std::cout << " PP " << std::flush;
+            d_J = K_pJ_inv*(f_p - K_pu*d_u);
+            d_p = K_Jp_inv*(f_J - K_JJ*d_J);
+            lin_it = solver_control_K_con_inv.last_step();
+            lin_res = solver_control_K_con_inv.last_value();
+          }
+        else if (parameters.type_lin == "Direct")
+          {
+            SparseDirectUMFPACK A_direct;
+            A_direct.initialize(tangent_matrix);
+            A_direct.vmult(newton_update, system_rhs);
+            lin_it = 1;
+            lin_res = 0.0;
+            std::cout << " -- " << std::flush;
+          }
+        else
+          Assert (false, ExcMessage("Linear solver type not implemented"));
+        timer.leave_subsection();
+        constraints.distribute(newton_update);
+      }
+    return std::make_pair(lin_it, lin_res);
+  }
+  template<int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+  void Solid<dim,number_t,ad_type_code>::output_results() const
+  {
+    DataOut<dim> data_out;
+    std::vector<DataComponentInterpretation::DataComponentInterpretation>
+    data_component_interpretation(dim,
+                                  DataComponentInterpretation::component_is_part_of_vector);
+    data_component_interpretation.push_back(DataComponentInterpretation::component_is_scalar);
+    data_component_interpretation.push_back(DataComponentInterpretation::component_is_scalar);
+    std::vector<std::string> solution_name(dim, "displacement");
+    solution_name.push_back("pressure");
+    solution_name.push_back("dilatation");
+    data_out.attach_dof_handler(dof_handler_ref);
+    data_out.add_data_vector(solution_n,
+                             solution_name,
+                             DataOut<dim>::type_dof_data,
+                             data_component_interpretation);
+    Vector<double> soln(solution_n.size());
+    for (unsigned int i = 0; i < soln.size(); ++i)
+      soln(i) = solution_n(i);
+    MappingQEulerian<dim> q_mapping(degree, dof_handler_ref, soln);
+    data_out.build_patches(q_mapping, degree);
+    std::ostringstream filename;
+    filename << "solution-" << dim << "d-" << time.get_timestep() << ".vtk";
+    std::ofstream output(filename.str().c_str());
+    data_out.write_vtk(output);
+  }
+}
+int main (int argc,char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  using namespace dealii;
+  namespace AD = dealii::Differentiation::AD;
+  using namespace Step44;
+  try
+    {
+      const unsigned int dim = 3;
+      deallog.push("Taped");
+      {
+        std::cout << "Taped" << std::endl;
+        Solid<dim,double,AD::NumberTypes::adolc_taped> solid(SOURCE_DIR "/prm/parameters-step-44.prm");
+        solid.run();
+
+        deallog << "OK" << std::endl;
+      }
+      deallog.pop();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl << exc.what()
+                << std::endl << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl << "Aborting!"
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  return 0;
+}

--- a/tests/adolc/step-44-helper_var_form_01.output
+++ b/tests/adolc/step-44-helper_var_form_01.output
@@ -1,0 +1,12 @@
+
+DEAL:Taped::Timestep 1: 0.00 -0.000129 0.00
+DEAL:Taped::Timestep 2: 0.00 -0.000256 0.00
+DEAL:Taped::Timestep 3: 0.00 -0.000376 0.00
+DEAL:Taped::Timestep 4: 0.00 -0.000485 0.00
+DEAL:Taped::Timestep 5: 0.00 -0.000580 0.00
+DEAL:Taped::Timestep 6: 0.00 -0.000660 0.00
+DEAL:Taped::Timestep 7: 0.00 -0.000727 0.00
+DEAL:Taped::Timestep 8: 0.00 -0.000783 0.00
+DEAL:Taped::Timestep 9: 0.00 -0.000828 0.00
+DEAL:Taped::Timestep 10: 0.00 -0.000866 0.00
+DEAL:Taped::OK


### PR DESCRIPTION
This commit adds the classes that give users a uniform interface to the Adol-C and Sacado automatic differentiation libraries. Also added are a selection of tests that give a indication of how the classes are used. I have many other tests that verify the actual implementation (about 27 other tests for Adol-C and 14 for Sacado), but I reckon that those are best left to another PR.

TODO list:
- [ ]  Doxygen documentation must be finished (include code snippets)
- [ ]  Documentation must be checked for relevance (it was written before I added support for Sacado)
- [ ] Change lazy implementation of assertions (`ExcInternalError`) where applicable
- [ ] Ensure that there is verification of mechanisms put in place to prevent data corruption / initialisation errors work correctly for all number types (maybe for the next PR with other tests).