### PR TITLE
Fix warning in base/bounding_box.cc

### DIFF
--- a/source/base/bounding_box.cc
+++ b/source/base/bounding_box.cc
@@ -88,7 +88,7 @@ NeighborType BoundingBox < spacedim,Number >::get_neighbor_type (const BoundingB
              std::numeric_limits<Number>::epsilon() * (std::abs( intersect_bbox_min[d]) + std::abs(intersect_bbox_max[d] )) )
           --intersect_dim;
 
-      if ( intersect_dim == 0 || intersect_dim == spacedim - 2 )
+      if ( intersect_dim == 0 || intersect_dim + 2 == spacedim )
         return NeighborType::simple_neighbors;
 
       // Checking the two mergeable cases: first if the boxes are aligned so that they can be merged


### PR DESCRIPTION
Fixes the warning in https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&onlydeltap&buildid=13289