### PR TITLE
Avoid warning about unused ScopedLock for DEAL_II_WITH_THREADS=OFF

### DIFF
--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -102,9 +102,10 @@ namespace Threads
 
       /**
        * Destructor. Unlock the mutex. Since this is a dummy mutex class, this
-       * of course does nothing.
+       * of course does nothing. We still don't declare it as 'default' to avoid
+       * warnings about objects of this class being unused.
        */
-      ~ScopedLock () = default;
+      ~ScopedLock () {};
     };
 
     /**


### PR DESCRIPTION
`clang` warns that objects of type `Threads::DummyThreadMutex::ScopedLock` are unused.
This is certainly true but not helpful so avoid this warning by making the destructor user-defined.