### PR TITLE
Fix EXC_BAD_ACCESS occurring when marking all elements for refinement or coarsening

### DIFF
--- a/doc/news/changes/minor/20171117OliverSutton
+++ b/doc/news/changes/minor/20171117OliverSutton
@@ -1,0 +1,5 @@
+Fixed: The function GridRefinement::refine_and_coarsen_fixed_number 
+no longer produces an EXC_BAD_ACCESS exception when either of the 
+arguments top_fraction or bottom_fraction are set to 1.0.
+<br>
+(Oliver Sutton, 2017/11/17)

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -306,19 +306,29 @@ GridRefinement::refine_and_coarsen_fixed_number (Triangulation<dim,spacedim> &tr
       Vector<typename VectorType::value_type> tmp (criteria);
       if (refine_cells)
         {
-          std::nth_element (tmp.begin(), tmp.begin()+refine_cells,
-                            tmp.end(),
-                            std::greater<double>());
-          refine (tria, criteria, *(tmp.begin() + refine_cells));
+          if (static_cast<size_t>(refine_cells) == criteria.size())
+              refine (tria, criteria, -std::numeric_limits<double>::max());
+          else
+            {
+              std::nth_element (tmp.begin(), tmp.begin()+refine_cells,
+                                tmp.end(),
+                                std::greater<double>());
+              refine (tria, criteria, *(tmp.begin() + refine_cells));
+            }
         }
 
       if (coarsen_cells)
         {
-          std::nth_element (tmp.begin(), tmp.begin()+tmp.size()-coarsen_cells,
-                            tmp.end(),
-                            std::greater<double>());
-          coarsen (tria, criteria,
-                   *(tmp.begin() + tmp.size() - coarsen_cells));
+          if (static_cast<size_t>(coarsen_cells) == criteria.size())
+            coarsen (tria, criteria, std::numeric_limits<double>::max());
+          else
+            {
+              std::nth_element (tmp.begin(), tmp.begin()+tmp.size()-coarsen_cells,
+                                tmp.end(),
+                                std::greater<double>());
+              coarsen (tria, criteria,
+                       *(tmp.begin() + tmp.size() - coarsen_cells));
+            }
         }
     }
 }

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -307,7 +307,7 @@ GridRefinement::refine_and_coarsen_fixed_number (Triangulation<dim,spacedim> &tr
       if (refine_cells)
         {
           if (static_cast<size_t>(refine_cells) == criteria.size())
-              refine (tria, criteria, -std::numeric_limits<double>::max());
+            refine (tria, criteria, -std::numeric_limits<double>::max());
           else
             {
               std::nth_element (tmp.begin(), tmp.begin()+refine_cells,

--- a/tests/grid/refine_and_coarsen_fixed_number.cc
+++ b/tests/grid/refine_and_coarsen_fixed_number.cc
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2017 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// This test ensures that all cells get refined (resp. coarsened) when
+// the value 1.0 is passed as top_fraction (resp. bottom_fraction) to
+// the function GridRefinement::refine_and_coarsen_fixed_number.
+
+#include "../tests.h"
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/lac/vector.h>
+
+using namespace dealii;
+
+int main(int argc, const char *argv[])
+{
+  initlog();
+
+  Triangulation<2> tria;
+  GridGenerator::hyper_cube (tria);
+  tria.refine_global(4);
+
+  Vector<float> indicator(tria.n_active_cells());
+  for (int i = 0; i != indicator.size(); ++i)
+    {
+      indicator[i] = i;
+    }
+
+  deallog << "n_active_cells: " << tria.n_active_cells() << std::endl;
+
+  GridRefinement::refine_and_coarsen_fixed_number(tria, indicator, 1.0, 0.0);
+  tria.execute_coarsening_and_refinement();
+
+  deallog << "n_active_cells: " << tria.n_active_cells() << std::endl;
+
+  indicator.reinit(tria.n_active_cells());
+  for (int i = 0; i != indicator.size(); ++i)
+    {
+      indicator[i] = i;
+    }
+
+  GridRefinement::refine_and_coarsen_fixed_number(tria, indicator, 0.0, 1.0);
+  tria.execute_coarsening_and_refinement();
+
+  deallog << "n_active_cells: " << tria.n_active_cells() << std::endl;
+
+  return 0;
+}

--- a/tests/grid/refine_and_coarsen_fixed_number.output
+++ b/tests/grid/refine_and_coarsen_fixed_number.output
@@ -1,0 +1,4 @@
+
+DEAL::n_active_cells: 256
+DEAL::n_active_cells: 1024
+DEAL::n_active_cells: 256


### PR DESCRIPTION
A fix for the `EXC_BAD_ACCESS` occurring when using `refine_and_coarsen_fixed_number`, as described in https://github.com/dealii/dealii/issues/5487, using Wolfgang's suggestion.