### PR TITLE
Adding mpi_send_and_receive functions object comunication

### DIFF
--- a/doc/news/changes/minor/20171117GiovanniAlzetta-LucaHeltai
+++ b/doc/news/changes/minor/20171117GiovanniAlzetta-LucaHeltai
@@ -1,0 +1,3 @@
+New: added two internal functions Utilities::MPI::internal::send_and_receive which allow to easily do a many-to-many or allgatherv communication of objects.
+<br>
+(GiovanniAlzetta, LucaHeltai, 2017/11/17)

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/array_view.h>
 
 #include <vector>
+#include <map>
 
 #if !defined(DEAL_II_WITH_MPI) && !defined(DEAL_II_WITH_PETSC)
 // without MPI, we would still like to use
@@ -500,6 +501,51 @@ namespace Utilities
                        const ArrayView<const T> &values,
                        const MPI_Comm           &mpi_communicator,
                        const ArrayView<T>       &output);
+      /**
+       * This function is intented for internal use in the library and
+       * aims at simplifying a many to many communication.
+       *
+       * @param[in] comm MPI communicator.
+       * @param[in] objects_to_send A map from the rank (unsigned int)
+       *  of the process meant to receive the data and the vector of
+       *  objects to send.
+       *
+       * @param[out] A map from the rank (unsigned int) of the process
+       *  which sent the data and the vector of objects received.
+       *
+       * Notice this is not just a point to point communication as the
+       * function uses an all-to-all communication to understand how
+       * many objects each process shall send, which is much slower.
+       *
+       * @author Giovanni Alzetta, Luca Heltai, 2017
+       */
+      template<typename T>
+      std::map<unsigned int, std::vector<T> >
+      send_and_receive(const MPI_Comm                       &comm,
+                       const std::map
+                       <unsigned int, typename std::vector<T> >
+                       &objects_to_send);
+
+      /**
+       * This function is intented for internal use in the library and
+       * aims at simplifying a collective gather operation with an arbitrary
+       * number of objects.
+       *
+       * @param[in] comm MPI communicator.
+       * @param[in] objects_to_send A vector of objects to sent to all
+       *  processes
+       *
+       * @param[out] A vector of vectors of objects of size number of processes
+       *  in the MPI communicator. Each entry contains
+       *  the vector of objects received from the processor with the corresponding
+       *  rank.
+       *
+       * @author Giovanni Alzetta, Luca Heltai, 2017
+       */
+      template<typename T>
+      std::vector<std::vector<T> >
+      send_and_receive(const MPI_Comm              &comm,
+                       const std::vector<T>        &objects_to_send);
     }
 
     // Since these depend on N they must live in the header file

--- a/tests/base/mpi_send_and_receive_01.cc
+++ b/tests/base/mpi_send_and_receive_01.cc
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Test for the internal::send_and_receive function in the case of
+// collective communication
+
+#include "../tests.h"
+#include "../../include/deal.II/base/mpi.templates.h"
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+
+#include <mpi.h>
+#include <vector>
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  initlog();
+
+  auto n_procs = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  auto my_proc = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  // Creating the local array of points
+  std::vector<Point<3> > local_points(my_proc + 1);
+  for (unsigned int i=0; i<my_proc+1; ++i)
+    local_points[i] = Point<3>(my_proc, -my_proc, i);
+
+  auto gathered_points = dealii::Utilities::MPI::internal::send_and_receive(MPI_COMM_WORLD, local_points);
+  bool test_passed = true;
+  for (unsigned int i=0; i< n_procs; ++i)
+    {
+      if (gathered_points[i].size() != i+1)
+        {
+          test_passed = false;
+          deallog << "Error: Points received from rank " << i << " have wrong size. " << std::endl;
+        }
+      for (unsigned int p=0; p< gathered_points[i].size(); ++p)
+        if ( gathered_points[i][p][0] != (double) i  ||
+             gathered_points[i][p][1] != (double) -i ||
+             gathered_points[i][p][2] != (double) p)
+          {
+            test_passed = false;
+            deallog << "Error with point " << p << " from rank " << i << std::endl;
+          }
+    }
+
+  if (test_passed)
+    deallog << "Test: ok" << std::endl;
+  else
+    deallog << "Test: FAILED" << std::endl;
+}

--- a/tests/base/mpi_send_and_receive_01.mpirun=2.output
+++ b/tests/base/mpi_send_and_receive_01.mpirun=2.output
@@ -1,0 +1,2 @@
+
+DEAL::Test: ok

--- a/tests/base/mpi_send_and_receive_01.mpirun=6.output
+++ b/tests/base/mpi_send_and_receive_01.mpirun=6.output
@@ -1,0 +1,2 @@
+
+DEAL::Test: ok

--- a/tests/base/mpi_send_and_receive_02.cc
+++ b/tests/base/mpi_send_and_receive_02.cc
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Test for the internal::send_and_receive function in the case of
+// collective communication
+
+#include "../tests.h"
+#include "../../include/deal.II/base/mpi.templates.h"
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+
+#include <mpi.h>
+#include <vector>
+
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  initlog();
+
+  auto n_procs = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  auto my_proc = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  // Creating the map array of points to be sent
+  std::map<unsigned int, std::vector< Point<2> > > m;
+  for (unsigned int i=0; i<n_procs; ++i)
+    if (i != my_proc)
+      m[i].push_back(Point<2>(my_proc, -2.0*my_proc));
+
+  auto received_pts = dealii::Utilities::MPI::internal::send_and_receive< Point<2> >(MPI_COMM_WORLD, m);
+
+  bool test_passed = true;
+  for (auto const &pt: received_pts)
+    if ( std::abs(pt.first - pt.second[0][0]) > 1e-12 ||
+         std::abs(2.0*pt.first + pt.second[0][1]) > 1e-12 )
+      {
+        test_passed = false;
+        deallog << "Error with point " << pt.second[0] << " received from rank " << pt.first << std::endl;
+      }
+  if (test_passed)
+    deallog << "Test: ok" << std::endl;
+  else
+    deallog << "Test: FAILED" << std::endl;
+}

--- a/tests/base/mpi_send_and_receive_02.mpirun=2.output
+++ b/tests/base/mpi_send_and_receive_02.mpirun=2.output
@@ -1,0 +1,2 @@
+
+DEAL::Test: ok

--- a/tests/base/mpi_send_and_receive_02.mpirun=6.output
+++ b/tests/base/mpi_send_and_receive_02.mpirun=6.output
@@ -1,0 +1,2 @@
+
+DEAL::Test: ok


### PR DESCRIPTION
Hi everyone,
   together with @luca-heltai we wrote these two functions: we believe they might be helpful for internal use (for instance GridTools::exchange_local_bounding_boxes might be using one of these two functions). This is also the last pice before we shall be able to completely implement https://github.com/dealii/dealii/pull/5414

We implemented an allgatherv version, which generalizes  GridTools::exchange_local_bounding_boxes , and a many to many communication pattern.

The functions work, but if there are suggestions these are more than welcome :)

Best,
Giovanni