### PR TITLE
Utilities::pack and unpack

### DIFF
--- a/doc/news/changes/minor/20171118LucaHeltai
+++ b/doc/news/changes/minor/20171118LucaHeltai
@@ -1,0 +1,4 @@
+New:Added Utilities::pack and Utilities::unpack, to serialize and unserialize arbitrary 
+objects that support boost::serialization/deserialization. 
+<br> 
+(Luca Heltai, 2017/11/18)

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -23,6 +23,7 @@
 #include <utility>
 #include <functional>
 #include <string>
+#include <tuple>
 
 #ifdef DEAL_II_WITH_TRILINOS
 #  include <Epetra_Comm.h>
@@ -832,5 +833,44 @@ namespace Utilities
 
 
 DEAL_II_NAMESPACE_CLOSE
+
+#ifndef DOXYGEN
+namespace boost
+{
+  namespace serialization
+  {
+
+    // Provides boost and c++11 with a way to serialize tuples and pairs automatically
+    template<int N>
+    struct Serialize
+    {
+      template<class Archive, typename... Args>
+      static void serialize(Archive &ar, std::tuple<Args...> &t, const unsigned int version)
+      {
+        ar &std::get<N-1>(t);
+        Serialize<N-1>::serialize(ar, t, version);
+      }
+    };
+
+    template<>
+    struct Serialize<0>
+    {
+      template<class Archive, typename... Args>
+      static void serialize(Archive &ar, std::tuple<Args...> &t, const unsigned int version)
+      {
+        (void) ar;
+        (void) t;
+        (void) version;
+      }
+    };
+
+    template<class Archive, typename... Args>
+    void serialize(Archive &ar, std::tuple<Args...> &t, const unsigned int version)
+    {
+      Serialize<sizeof...(Args)>::serialize(ar, t, version);
+    }
+  }
+}
+#endif
 
 #endif

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -34,6 +34,19 @@
 #  endif
 #endif
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/array.hpp>
+
+#ifdef DEAL_II_WITH_ZLIB
+#  include <boost/iostreams/stream.hpp>
+#  include <boost/iostreams/filtering_stream.hpp>
+#  include <boost/iostreams/device/back_inserter.hpp>
+#  include <boost/iostreams/filter/gzip.hpp>
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
 
@@ -376,6 +389,32 @@ namespace Utilities
    */
   std::vector<unsigned long long int>
   invert_permutation (const std::vector<unsigned long long int> &permutation);
+
+  /**
+   * Given an arbitrary object of type T, use boost::serialization utilities
+   * to pack the object into a vector of characters. The object can be unpacked
+   * using the Utilities::unpack function below.
+   *
+   * If the library has been compiled with ZLIB enabled, then the output buffer
+   * is compressed.
+   *
+   * @author Timo Heister, Wolfgang Bangerth, 2017.
+   */
+  template<typename T>
+  std::vector<char> pack(const T &object);
+
+  /**
+   * Given a vector of characters, obtained through a call to the function
+   * Utilities::pack, restore its content in an object of type T.
+   *
+   * This function uses boost::serialization utilities to unpack the object
+   * from a vector of characters, and it is the inverse of the function
+   * Utilities::pack
+   *
+   * @author Timo Heister, Wolfgang Bangerth, 2017.
+   */
+  template<typename T>
+  T unpack(const std::vector<char> &buffer);
 
   /**
    * A namespace for utility functions that probe system properties.
@@ -729,6 +768,65 @@ namespace Utilities
         else
           len = half;
       }
+  }
+
+
+
+  template<typename T>
+  std::vector<char> pack(const T &object)
+  {
+    // set up a buffer and then use it as the target of a compressing
+    // stream into which we serialize the current object
+    std::vector<char> buffer;
+    {
+#ifdef DEAL_II_WITH_ZLIB
+      boost::iostreams::filtering_ostream out;
+      out.push(boost::iostreams::gzip_compressor
+               (boost::iostreams::gzip_params
+                (boost::iostreams::gzip::best_compression)));
+      out.push(boost::iostreams::back_inserter(buffer));
+
+      boost::archive::binary_oarchive archive(out);
+      archive << object;
+      out.flush();
+#else
+      std::ostringstream out;
+      boost::archive::binary_oarchive archive(out);
+      archive << object;
+      const std::string &s = out.str();
+      buffer.reserve(s.size());
+      buffer.assign(s.begin(), s.end());
+#endif
+    }
+    return buffer;
+  }
+
+
+
+  template<typename T>
+  T unpack(const std::vector<char> &buffer)
+  {
+    std::string decompressed_buffer;
+    T object;
+
+    // first decompress the buffer
+    {
+#ifdef DEAL_II_WITH_ZLIB
+      boost::iostreams::filtering_ostream decompressing_stream;
+      decompressing_stream.push(boost::iostreams::gzip_decompressor());
+      decompressing_stream.push(boost::iostreams::back_inserter(decompressed_buffer));
+      decompressing_stream.write (buffer.data(), buffer.size());
+#else
+      decompressed_buffer.assign (buffer.begin(), buffer.end());
+#endif
+    }
+
+    // then restore the object from the buffer
+    std::istringstream in(decompressed_buffer);
+    boost::archive::binary_iarchive archive(in);
+
+    archive >> object;
+    return object;
   }
 }
 

--- a/tests/base/utilities_pack_unpack_01.cc
+++ b/tests/base/utilities_pack_unpack_01.cc
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test Utilities::pack/unpack on some types.
+
+#include "../tests.h"
+
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/point.h>
+
+template <int dim>
+void test(const unsigned int &size)
+{
+  std::vector<Point<dim> > points(size);
+
+  for (auto &p : points)
+    for (unsigned int i=0; i<dim; ++i)
+      p[i] = Testing::rand()/double(RAND_MAX);
+
+  auto buffer = Utilities::pack(points);
+
+  auto unpacked = Utilities::unpack<std::vector<Point<dim> > >(buffer);
+
+  unsigned int i=0;
+  bool ok = true;
+  for (const auto &p : points)
+    if (p.distance(unpacked[i++]) > 1e-12)
+      {
+        deallog << "NOT OK: "
+                << p << " != " << unpacked[i-1] << std::endl;
+        ok = false;
+      }
+
+  if (ok)
+    deallog << "OK!" << std::endl;
+}
+
+int main()
+{
+  initlog();
+
+  test<1>(10);
+  test<2>(10);
+  test<3>(10);
+}

--- a/tests/base/utilities_pack_unpack_01.output
+++ b/tests/base/utilities_pack_unpack_01.output
@@ -1,0 +1,4 @@
+
+DEAL::OK!
+DEAL::OK!
+DEAL::OK!

--- a/tests/base/utilities_pack_unpack_02.cc
+++ b/tests/base/utilities_pack_unpack_02.cc
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test Utilities::pack/unpack on some types.
+
+#include "../tests.h"
+
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/point.h>
+#include <boost/serialization/utility.hpp>
+
+#include <tuple>
+
+template <int dim>
+void test(const unsigned int &size)
+{
+  std::vector<Point<dim> > points(size);
+  auto a_pair = std::make_pair(1, 3.14);
+
+  for (auto &p : points)
+    for (unsigned int i=0; i<dim; ++i)
+      p[i] = Testing::rand()/double(RAND_MAX);
+
+  auto a_tuple = std::make_tuple(a_pair, points);
+
+  auto buffer = Utilities::pack(a_tuple);
+
+  auto tuple_unpacked = Utilities::unpack<decltype(a_tuple)>(buffer);
+
+  auto pair_unpacked = std::get<0>(tuple_unpacked);
+  auto points_unpacked = std::get<1>(tuple_unpacked);
+
+  unsigned int i=0;
+  bool ok = (pair_unpacked == a_pair);
+
+  for (const auto &p : points)
+    if (p.distance(points_unpacked[i++]) > 1e-12)
+      {
+        deallog << "NOT OK: "
+                << p << " != " << points_unpacked[i-1] << std::endl;
+        ok = false;
+      }
+
+  if (ok)
+    deallog << "OK!" << std::endl;
+}
+
+int main()
+{
+  initlog();
+
+  test<1>(10);
+  test<2>(10);
+  test<3>(10);
+}

--- a/tests/base/utilities_pack_unpack_02.output
+++ b/tests/base/utilities_pack_unpack_02.output
@@ -1,0 +1,4 @@
+
+DEAL::OK!
+DEAL::OK!
+DEAL::OK!


### PR DESCRIPTION
Since this is used in many places over the library now, I moved these two to the utilities namespace.

<s>In a followup PR, I'll make sure that whenever this functionality is used in the library, then this is called instead of rewriting the same thing over and over.</s> I already started, by converting some calls inside `grid_tools.h` (see last commit).


