### PR TITLE
Bump required Trilinos version to 12.4.2

### DIFF
--- a/cmake/configure/configure_2_trilinos.cmake
+++ b/cmake/configure/configure_2_trilinos.cmake
@@ -42,7 +42,7 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
       )
 
     FOREACH(_module
-      Amesos Epetra Ifpack AztecOO Sacado Teuchos ML
+      Amesos Epetra Ifpack AztecOO Sacado Teuchos ML MueLu
       )
       ITEM_MATCHES(_module_found ${_module} ${Trilinos_PACKAGE_LIST})
       IF(_module_found)
@@ -66,29 +66,6 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
       ENDIF()
     ENDFOREACH()
 
-    IF(${DEAL_II_TRILINOS_WITH_ROL})
-      IF(TRILINOS_VERSION VERSION_LESS 12.6.1)
-        MESSAGE(STATUS "ROL interface is disabled."
-          "deal.II will not support ROL interface if Trilinos version is less "
-          "than 12.6.1. Trilinos version found: \"${TRILINOS_VERSION}\".")
-          SET(DEAL_II_TRILINOS_WITH_ROL OFF)
-      ENDIF()
-    ENDIF()
-
-    IF((TRILINOS_VERSION_MAJOR EQUAL 11 AND
-        NOT (TRILINOS_VERSION_MINOR LESS 14))
-       OR
-       (NOT (TRILINOS_VERSION_MAJOR LESS 12)))
-        ITEM_MATCHES(_module_found MueLu ${Trilinos_PACKAGE_LIST})
-      IF(_module_found)
-        MESSAGE(STATUS "Found MueLu")
-      ELSE()
-        MESSAGE(STATUS "Module MueLu not found!")
-        SET(_modules_missing "${_modules_missing} MueLu")
-        SET(${var} FALSE)
-      ENDIF()
-    ENDIF()
-
     IF(NOT ${var})
       MESSAGE(STATUS "Could not find a sufficient Trilinos installation: "
         "Missing ${_modules_missing}"
@@ -102,18 +79,18 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
     ENDIF()
 
     #
-    # We require at least Trilinos 11.2
+    # We require at least Trilinos 12.4
     #
-    IF(TRILINOS_VERSION VERSION_LESS 11.2)
+    IF(TRILINOS_VERSION VERSION_LESS 12.4)
 
       MESSAGE(STATUS "Could not find a sufficient Trilinos installation: "
-        "deal.II requires at least version 11.2, but version ${TRILINOS_VERSION} was found."
+        "deal.II requires at least version 12.4, but version ${TRILINOS_VERSION} was found."
         )
       SET(TRILINOS_ADDITIONAL_ERROR_STRING
         ${TRILINOS_ADDITIONAL_ERROR_STRING}
         "The Trilinos installation (found at \"${TRILINOS_DIR}\")\n"
         "with version ${TRILINOS_VERSION} is too old.\n"
-        "deal.II requires at least version 11.2.\n\n"
+        "deal.II requires at least version 12.4.\n\n"
         )
       SET(${var} FALSE)
     ENDIF()

--- a/cmake/modules/FindTRILINOS.cmake
+++ b/cmake/modules/FindTRILINOS.cmake
@@ -29,6 +29,7 @@
 #   TRILINOS_WITH_MPI
 #   TRILINOS_SUPPORTS_CPP11
 #   TRILINOS_HAS_C99_TR1_WORKAROUND
+#   TRILINOS_CXX_SUPPORTS_SACADO_COMPLEX_RAD
 #
 
 SET(TRILINOS_DIR "" CACHE PATH "An optional hint to a Trilinos installation")
@@ -126,7 +127,7 @@ SET(TRILINOS_WITH_MANDATORY_CXX11 FALSE)
 IF(EXISTS ${SACADO_CONFIG_H})
   #
   # Determine whether Trilinos was configured with C++11 support and
-  # enabling C++11 in deal.II is mandatory (Trilinos 12.0.1 and later).
+  # enabling C++11 in deal.II is mandatory.
   #
   FILE(STRINGS "${SACADO_CONFIG_H}" SACADO_CXX11_STRING
     REGEX "#define HAVE_SACADO_CXX11")

--- a/doc/external-libs/trilinos.html
+++ b/doc/external-libs/trilinos.html
@@ -15,18 +15,18 @@
     <p>
       <a href="https://trilinos.org/" target="_top">Trilinos</a> is a
       software package that provides lots of functionality for linear
-      algebra, among other things. For example, it includes implementations of a variety of
-      linear solvers, as well as various different sparse and dense matrix and
-      vector formats. Trilinos also has many subpackages that deal with
-      problems that go far beyond linear algebra, for example nonlinear
+      algebra, among other things. For example, it includes implementations of
+      a variety of linear solvers, as well as various different sparse and dense
+      matrix and vector formats. Trilinos also has many subpackages that deal
+      with problems that go far beyond linear algebra, for example nonlinear
       solvers, automatic differentiation packages, uncertainty propagation
       engines, etc. Of particular interest to deal.II is their ability to
       provide this functionality both on sequential and parallel (using MPI)
-      computers. Compared to <a href="http://www.mcs.anl.gov/petsc/"
-				target="_top">PETSc</a>, which is written in C, Trilinos is written in
-      C++ and can be
-      considered to be a more modern version of PETSc though both packages are
-      under continuing development at their respective national laboratories.
+      computers.
+      Compared to <a href="http://www.mcs.anl.gov/petsc/" target="_top">PETSc</a>,
+      which is written in C, Trilinos is written in C++ and can be considered to
+      be a more modern version of PETSc though both packages are under
+      continuing development at their respective national laboratories.
     </p>
 
     <p>
@@ -49,29 +49,28 @@
     <h5>Installing Trilinos</h5>
 
     <p style="color: red">
-      Note: The current version of deal.II requires at least Trilinos 11.2.
-      Deal.II is known to work with Trilinos up to 11.14 and 12.4. Others versions of
+      Note: The current version of deal.II requires at least Trilinos 12.4.
+      Deal.II is known to work with Trilinos up to 12.12. Other versions of
       Trilinos should work too but we do not do regression tests with them. 
     </p>
 
     <p>
-      deal.II uses the following libraries from Trilinos and will fail to
-      compile with Trilinos if they are not present:
+      deal.II uses the following libraries from Trilinos:
       <ul>
         <li> Amesos,
         <li> AztecOO,
         <li> Epetra,
         <li> Ifpack,
         <li> ML,
-        <li> MueLu (if using Trilinos 11.14 or newer),
-        <li> ROL,
+        <li> MueLu,
+        <li> ROL (optional),
         <li> Sacado, and
         <li> Teuchos.
       </ul>
 
       Trilinos uses <a href="http://cmake.org/">cmake</a> to configure and
       build. The following slightly longish set of commands will set up a
-      reasonable configuration (we require MueLu starting from 12.0):
+      reasonable configuration:
       <pre>
 
     cd trilinos-12.4.2

--- a/doc/news/changes/incompatibilities/20171118DanielArndt
+++ b/doc/news/changes/incompatibilities/20171118DanielArndt
@@ -1,0 +1,3 @@
+Changed: The minimal supported Trilinos version is 12.4.
+<br>
+(Daniel Arndt, 2017/11/18)

--- a/tests/rol/vector_adaptor_02.output.12.4.2
+++ b/tests/rol/vector_adaptor_02.output.12.4.2
@@ -1,0 +1,21 @@
+
+Quasi-Newton Method with Cubic Interpolation Linesearch satisfying Strong Wolfe Conditions
+Secant Type: Limited-Memory BFGS
+  iter  value          gnorm          snorm          #fval     #grad     ls_#fval  ls_#grad  
+  0     1.040000e+02   2.039608e+01   
+  1     0.000000e+00   0.000000e+00   1.019804e+01   3         2         2         0         
+The solution to minimization problem is: 0 0
+
+Quasi-Newton Method with Cubic Interpolation Linesearch satisfying Strong Wolfe Conditions
+Secant Type: Limited-Memory BFGS
+  iter  value          gnorm          snorm          #fval     #grad     ls_#fval  ls_#grad  
+  0     2.000000e-02   2.828427e-01   
+  1     0.000000e+00   0.000000e+00   1.414214e-01   3         2         2         0         
+The solution to minimization problem is: 0 0
+
+Quasi-Newton Method with Cubic Interpolation Linesearch satisfying Strong Wolfe Conditions
+Secant Type: Limited-Memory BFGS
+  iter  value          gnorm          snorm          #fval     #grad     ls_#fval  ls_#grad  
+  0     1.200200e+02   2.191073e+01   
+  1     0.000000e+00   0.000000e+00   1.095536e+01   3         2         2         0         
+The solution to minimization problem is: 0 0


### PR DESCRIPTION
Fixes #5498.
In particular, `ROL` also works with version 12.4.2. It turns out that the output of `tests/rol/vector_adaptor_02` is slightly different but this should still be fine.