### PR TITLE
Change partitioner for mpi/subdomain_ids_parallel_08

### DIFF
--- a/tests/mpi/subdomain_ids_parallel_08.cc
+++ b/tests/mpi/subdomain_ids_parallel_08.cc
@@ -27,7 +27,12 @@
 template<int dim>
 void test()
 {
-  parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD);
+  parallel::shared::Triangulation<dim>
+  tria(MPI_COMM_WORLD,
+       ::Triangulation<dim>::none,
+       false,
+       parallel::shared::Triangulation<dim>::partition_zorder);
+
   GridGenerator::hyper_cube(tria);
   tria.refine_global(3);
 

--- a/tests/mpi/subdomain_ids_parallel_08.mpirun=2.output
+++ b/tests/mpi/subdomain_ids_parallel_08.mpirun=2.output
@@ -1,5 +1,3 @@
 
 DEAL:0::OK for 2d
 DEAL:0::OK for 3d
-
-


### PR DESCRIPTION
We are calling `GridTools::partition_triangulation` which requires `METIS`.