### PR TITLE
Avoid undefined references in AD::NumberTraits

### DIFF
--- a/include/deal.II/differentiation/ad/ad_number_traits.h
+++ b/include/deal.II/differentiation/ad/ad_number_traits.h
@@ -836,7 +836,7 @@ namespace Differentiation
        * The number of directional derivatives that can be
        * taken with this auto-differentiable number
        */
-      static const unsigned int         n_supported_derivative_levels
+      static constexpr unsigned int     n_supported_derivative_levels
       = internal::ADNumberInfoFromEnum<
         typename internal::RemoveComplexWrapper<ScalarType>::type, ADNumberTypeCode
       >::n_supported_derivative_levels;


### PR DESCRIPTION
For `Intel-18` the test `adolc/ad_number_traits_02a` fails with an `undefined reference` if this variable is not `constexpr`.
Since all the other variables above are `constexpr`, this is consistent anyway.