### PR TITLE
cmake: check trilinos optional modules at the very end

### DIFF
--- a/cmake/configure/configure_2_trilinos.cmake
+++ b/cmake/configure/configure_2_trilinos.cmake
@@ -54,18 +54,6 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
       ENDIF()
     ENDFOREACH()
 
-    FOREACH(_optional_module
-   	  ROL
-      )
-      ITEM_MATCHES(_module_found ${_optional_module} ${Trilinos_PACKAGE_LIST})
-      IF(_module_found)
-        MESSAGE(STATUS "Found ${_optional_module}")
-        SET(DEAL_II_TRILINOS_WITH_${_optional_module} ON)
-      ELSE()
-        MESSAGE(STATUS "Module ${_optional_module} not found!")
-      ENDIF()
-    ENDFOREACH()
-
     IF(NOT ${var})
       MESSAGE(STATUS "Could not find a sufficient Trilinos installation: "
         "Missing ${_modules_missing}"
@@ -181,6 +169,25 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
     ENDIF()
 
     CHECK_MPI_INTERFACE(TRILINOS ${var})
+
+    #
+    # Finally when we are sure that Trilinos is good to use, check
+    # optional modules
+    #
+    IF(${var})
+      FOREACH(_optional_module
+        ROL
+        )
+        ITEM_MATCHES(_module_found ${_optional_module} ${Trilinos_PACKAGE_LIST})
+        IF(_module_found)
+          MESSAGE(STATUS "Found ${_optional_module}")
+          SET(DEAL_II_TRILINOS_WITH_${_optional_module} ON)
+        ELSE()
+          MESSAGE(STATUS "Module ${_optional_module} not found!")
+        ENDIF()
+      ENDFOREACH()
+    ENDIF()
+
   ENDIF()
 ENDMACRO()
 


### PR DESCRIPTION
we discovered in https://github.com/dealii/dealii/pull/5514 that those checks should be at the very end.