### PR TITLE
Fix empty lines in subdomain_ids_parallel_08 output

### DIFF
--- a/tests/mpi/subdomain_ids_parallel_08.mpirun=2.output
+++ b/tests/mpi/subdomain_ids_parallel_08.mpirun=2.output
@@ -1,3 +1,5 @@
 
 DEAL:0::OK for 2d
 DEAL:0::OK for 3d
+
+


### PR DESCRIPTION
Somehow these empty lines were removed in the output which makes the test fail.