### PR TITLE
Use uniform grammar in function documentation.

### DIFF
--- a/include/deal.II/base/polynomials_integrated_legendre_sz.h
+++ b/include/deal.II/base/polynomials_integrated_legendre_sz.h
@@ -54,7 +54,7 @@ public:
   IntegratedLegendreSZ (const unsigned int p);
 
   /**
-   * Returns the complete set of Integrated Legendre polynomials up to the
+   * Return the complete set of Integrated Legendre polynomials up to the
    * given degree.
    */
   static std::vector<Polynomials::Polynomial<double>> generate_complete_basis (const unsigned int degree);

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -227,7 +227,7 @@ public:
    * synchronized over all processors in the communicator (i.e., the lap times
    * are set to the maximum lap time).
    *
-   * Returns the accumulated CPU time in seconds.
+   * Return the accumulated CPU time in seconds.
    */
   double stop ();
 
@@ -280,7 +280,7 @@ public:
   double last_cpu_time() const;
 
   /**
-   * Returns the wall time taken between the last start()/stop() call.
+   * Return the wall time taken between the last start()/stop() call.
    *
    * @deprecated Use last_wall_time() instead.
    */

--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -535,7 +535,7 @@ namespace internal
 
 
     /**
-     * Returns whether q1 and q2 are equal
+     * Return whether q1 and q2 are equal
      */
     template <int dim>
     bool
@@ -545,7 +545,7 @@ namespace internal
 
 
     /**
-     * Returns whether q1 is an ancestor of q2
+     * Return whether q1 is an ancestor of q2
      */
     template <int dim>
     bool
@@ -555,7 +555,7 @@ namespace internal
 
 
     /**
-     * Returns whether the children of a coarse cell are stored locally
+     * Return whether the children of a coarse cell are stored locally
      */
     template <int dim>
     bool

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1330,7 +1330,7 @@ namespace GridTools
   vertex_to_cell_map(const Triangulation<dim,spacedim> &triangulation);
 
   /**
-   * Returns a vector of normalized tensors for each vertex-cell combination of
+   * Return a vector of normalized tensors for each vertex-cell combination of
    * the output of GridTools::vertex_to_cell_map() (which is expected as input
    * parameter for this function). Each tensor represents a geometric vector
    * from the vertex to the respective cell center.
@@ -1350,7 +1350,7 @@ namespace GridTools
 
 
   /**
-   * Returns the local vertex index of cell @p cell that is closest to
+   * Return the local vertex index of cell @p cell that is closest to
    * the given location @p position.
    *
    * @author Rene Gassmoeller, Luca Heltai, 2017.

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -759,7 +759,7 @@ private:
    * chart_points with the pullbacks of the surrounding points. This method
    * internally calls @p get_possible_cells_around_points().
    *
-   * Returns an iterator to the cell on which the chart is defined.
+   * Return an iterator to the cell on which the chart is defined.
    */
   typename Triangulation<dim,spacedim>::cell_iterator
   compute_chart_points(const ArrayView<const Point<spacedim>> &surrounding_points,

--- a/include/deal.II/lac/diagonal_matrix.h
+++ b/include/deal.II/lac/diagonal_matrix.h
@@ -69,7 +69,7 @@ public:
   void compress (VectorOperation::values operation);
 
   /**
-   * Returns a reference to the underlying vector for manipulation of the
+   * Return a reference to the underlying vector for manipulation of the
    * entries on the matrix diagonal.
    */
   VectorType &get_vector();
@@ -80,7 +80,7 @@ public:
   void clear();
 
   /**
-   * Returns a read-only reference to the underlying vector.
+   * Return a read-only reference to the underlying vector.
    */
   const VectorType &get_vector() const;
 

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -937,7 +937,7 @@ namespace internal
 
 
       /**
-       * Returns a payload configured for identity operations
+       * Return a payload configured for identity operations
        */
       EmptyPayload
       identity_payload () const
@@ -947,7 +947,7 @@ namespace internal
 
 
       /**
-       * Returns a payload configured for null operations
+       * Return a payload configured for null operations
        */
       EmptyPayload
       null_payload () const
@@ -957,7 +957,7 @@ namespace internal
 
 
       /**
-       * Returns a payload configured for transpose operations
+       * Return a payload configured for transpose operations
        */
       EmptyPayload
       transpose_payload () const
@@ -967,7 +967,7 @@ namespace internal
 
 
       /**
-       * Returns a payload configured for inverse operations
+       * Return a payload configured for inverse operations
        */
       template <typename Solver, typename Preconditioner>
       EmptyPayload

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -68,14 +68,14 @@ class TensorProductMatrixSymmetricSumBase
 {
 public:
   /**
-   * Returns the number of rows of the tensor product matrix
+   * Return the number of rows of the tensor product matrix
    * resulting from the Kronecker product of 1D matrices, which is described
    * in the main documentation of TensorProductMatrixSymmetricSum.
    */
   unsigned int m () const;
 
   /**
-   * Returns the number of columns of the tensor product matrix
+   * Return the number of columns of the tensor product matrix
    * resulting from the Kronecker product of 1D matrices, which is described
    * in the main documentation of TensorProductMatrixSymmetricSum.
    */

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2205,22 +2205,22 @@ namespace TrilinosWrappers
         virtual ~TrilinosPayload() = default;
 
         /**
-         * Returns a payload configured for identity operations
+         * Return a payload configured for identity operations
          */
         TrilinosPayload identity_payload () const;
 
         /**
-         * Returns a payload configured for null operations
+         * Return a payload configured for null operations
          */
         TrilinosPayload null_payload () const;
 
         /**
-         * Returns a payload configured for transpose operations
+         * Return a payload configured for transpose operations
          */
         TrilinosPayload transpose_payload () const;
 
         /**
-         * Returns a payload configured for inverse operations
+         * Return a payload configured for inverse operations
          *
          * Invoking this factory function will configure two additional functions,
          * namely <tt>inv_vmult</tt> and <tt>inv_Tvmult</tt>, both of which wrap
@@ -2243,7 +2243,7 @@ namespace TrilinosWrappers
             inverse_payload (Solver &, const Preconditioner &) const;
 
         /**
-         * Returns a payload configured for inverse operations
+         * Return a payload configured for inverse operations
          *
          * Invoking this factory function will configure two additional functions,
          * namely <tt>inv_vmult</tt> and <tt>inv_Tvmult</tt>, both of which
@@ -2273,7 +2273,7 @@ namespace TrilinosWrappers
 //@{
 
         /**
-         * Returns an IndexSet that defines the partitioning of the domain space
+         * Return an IndexSet that defines the partitioning of the domain space
          * of this matrix, i.e., the partitioning of the vectors this matrix has
          * to be multiplied with / operate on.
          */
@@ -2281,7 +2281,7 @@ namespace TrilinosWrappers
         locally_owned_domain_indices () const;
 
         /**
-         * Returns an IndexSet that defines the partitioning of the range space
+         * Return an IndexSet that defines the partitioning of the range space
          * of this matrix, i.e., the partitioning of the vectors that result
          * from matrix-vector products.
          */
@@ -2416,7 +2416,7 @@ namespace TrilinosWrappers
 //@{
 
         /**
-         * Returns a label to describe this class.
+         * Return a label to describe this class.
          *
          * This overloads the same function from the Trilinos class
          * Epetra_Operator.
@@ -2425,7 +2425,7 @@ namespace TrilinosWrappers
         Label () const;
 
         /**
-         * Returns a reference to the underlying MPI communicator for
+         * Return a reference to the underlying MPI communicator for
          * this object.
          *
          * This overloads the same function from the Trilinos class
@@ -2487,7 +2487,7 @@ namespace TrilinosWrappers
         Epetra_Map range_map;
 
         /**
-         * Returns a flag that describes whether this operator can return the
+         * Return a flag that describes whether this operator can return the
          * computation of the infinity norm. Since in general this is not the
          * case, this always returns a negetive result.
          *
@@ -2498,7 +2498,7 @@ namespace TrilinosWrappers
         HasNormInf () const;
 
         /**
-         * Returns the infinity norm of this operator.
+         * Return the infinity norm of this operator.
          * Throws an error since, in general, we cannot compute this value.
          *
          * This overloads the same function from the Trilinos class
@@ -2509,14 +2509,14 @@ namespace TrilinosWrappers
       };
 
       /**
-       * Returns an operator that returns a payload configured to support the
+       * Return an operator that returns a payload configured to support the
        * addition of two LinearOperators
        */
       TrilinosPayload operator+(const TrilinosPayload &first_op,
                                 const TrilinosPayload &second_op);
 
       /**
-       * Returns an operator that returns a payload configured to support the
+       * Return an operator that returns a payload configured to support the
        * multiplication of two LinearOperators
        */
       TrilinosPayload operator*(const TrilinosPayload &first_op,

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -594,7 +594,7 @@ public:
   get_internal_dof_numbering() const;
 
   /**
-   * Returns an ArrayView to internal memory for temporary use. Note that some
+   * Return an ArrayView to internal memory for temporary use. Note that some
    * of this memory is overwritten during evaluate() and integrate() calls so
    * do not assume it to be stable over those calls. The maximum size you can
    * write into is 3*dofs_per_cell+2*n_q_points.

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -619,7 +619,7 @@ public:
    */
   //@{
   /**
-   * Returns whether a given FiniteElement @p fe is supported by this class.
+   * Return whether a given FiniteElement @p fe is supported by this class.
    */
   template <int spacedim>
   static

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -316,7 +316,7 @@ namespace MatrixFreeOperators
                      const VectorType &src) const;
 
     /**
-     * Returns the value of the matrix entry (row,col). In matrix-free context
+     * Return the value of the matrix entry (row,col). In matrix-free context
      * this function is valid only for row==col when diagonal is initialized.
      */
     value_type el (const unsigned int row,

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -560,14 +560,14 @@ private:
   std::vector <std::vector <double> > independent_values;
 
   /**
-   * Saves a vector listing component names associated with a
+   * Save a vector listing component names associated with a
    * independent_values. This will be an empty vector if the user does not
    * supplies names.
    */
   std::vector<std::string> indep_names;
 
   /**
-   * Saves data for each mnemonic entry. data_store: mnemonic ->
+   * Save data for each mnemonic entry. data_store: mnemonic ->
    * [point_0_components point_1_components ... point_n-1_components][key]
    * This format facilitates scalar mnemonics in a vector space, because
    * scalar mnemonics will only have one component per point. Vector
@@ -576,19 +576,19 @@ private:
   std::map <std::string, std::vector <std::vector <double> > > data_store;
 
   /**
-   * Saves a component mask for each mnemonic.
+   * Save a component mask for each mnemonic.
    */
   std::map <std::string, ComponentMask> component_mask;
 
 
   /**
-   * Saves a vector listing component names associated with a mnemonic. This
+   * Save a vector listing component names associated with a mnemonic. This
    * will be an empty vector if the user does not supplies names.
    */
   std::map <std::string, std::vector<std::string> > component_names_map;
 
   /**
-   * Saves the location and other mesh info about support points.
+   * Save the location and other mesh info about support points.
    */
   std::vector <internal::PointValueHistory::PointGeometryData <dim> >
   point_geometry_data;

--- a/include/deal.II/optimization/rol/vector_adaptor.h
+++ b/include/deal.II/optimization/rol/vector_adaptor.h
@@ -150,13 +150,13 @@ namespace Rol
     VectorAdaptor (const Teuchos::RCP<VectorType> &vector_ptr);
 
     /**
-     * Returns the Teuchos smart reference counting pointer to
+     * Return the Teuchos smart reference counting pointer to
      * the wrapper vector, #vector_ptr.
      */
     Teuchos::RCP<VectorType> getVector ();
 
     /**
-     * Returns the Teuchos smart reference counting pointer to const vector.
+     * Return the Teuchos smart reference counting pointer to const vector.
      */
     Teuchos::RCP<const VectorType> getVector () const;
 

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -239,7 +239,7 @@ namespace Particles
     set_property_pool(PropertyPool &property_pool);
 
     /**
-      * Returns whether this particle has a valid property pool and a valid
+      * Return whether this particle has a valid property pool and a valid
       * handle to properties.
       */
     bool
@@ -271,7 +271,7 @@ namespace Particles
     get_properties () const;
 
     /**
-     * Returns the size in bytes this particle occupies if all of its data is
+     * Return the size in bytes this particle occupies if all of its data is
      * serialized (i.e. the number of bytes that is written by the write_data
      * function of this class).
      */

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -96,7 +96,7 @@ namespace Particles
     set_property_pool(PropertyPool &property_pool);
 
     /**
-      * Returns whether this particle has a valid property pool and a valid
+      * Return whether this particle has a valid property pool and a valid
       * handle to properties.
       */
     bool
@@ -128,7 +128,7 @@ namespace Particles
     get_properties () const;
 
     /**
-     * Returns the size in bytes this particle occupies if all of its data is
+     * Return the size in bytes this particle occupies if all of its data is
      * serialized (i.e. the number of bytes that is written by the write_data
      * function of this class).
      */

--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -59,7 +59,7 @@ namespace Particles
     PropertyPool (const unsigned int n_properties_per_slot=1);
 
     /**
-     * Returns a new handle that allows accessing the reserved block
+     * Return a new handle that allows accessing the reserved block
      * of memory.
      */
     Handle allocate_properties_array ();
@@ -84,7 +84,7 @@ namespace Particles
     void reserve(const std::size_t size);
 
     /**
-     * Returns how many properties are stored per slot in the pool.
+     * Return how many properties are stored per slot in the pool.
      */
     unsigned int n_properties_per_slot() const;
 

--- a/include/deal.II/physics/elasticity/kinematics.h
+++ b/include/deal.II/physics/elasticity/kinematics.h
@@ -52,7 +52,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the deformation gradient tensor,
+       * Return the deformation gradient tensor,
        * as constructed from the material displacement gradient
        * tensor @p Grad_u.
        * The result is expressed as
@@ -74,7 +74,7 @@ namespace Physics
       F (const Tensor<2, dim, Number> &Grad_u);
 
       /**
-       * Returns the isochoric counterpart of the deformation gradient
+       * Return the isochoric counterpart of the deformation gradient
        * tensor @p F .
        * The result is expressed as
        * @f[
@@ -90,7 +90,7 @@ namespace Physics
       F_iso (const Tensor<2, dim, Number> &F);
 
       /**
-       * Returns the volumetric counterpart of the deformation gradient
+       * Return the volumetric counterpart of the deformation gradient
        * tensor @p F .
        * The result is expressed as
        * @f[
@@ -106,7 +106,7 @@ namespace Physics
       F_vol (const Tensor<2, dim, Number> &F);
 
       /**
-       * Returns the symmetric right Cauchy-Green deformation tensor,
+       * Return the symmetric right Cauchy-Green deformation tensor,
        * as constructed from the deformation gradient tensor @p F.
        * The result is expressed as
        * @f[
@@ -121,7 +121,7 @@ namespace Physics
       C (const Tensor<2, dim, Number> &F);
 
       /**
-       * Returns the symmetric left Cauchy-Green deformation tensor,
+       * Return the symmetric left Cauchy-Green deformation tensor,
        * as constructed from the deformation gradient tensor @p F.
        * The result is expressed as
        * @f[
@@ -143,7 +143,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the symmetric Green-Lagrange strain tensor,
+       * Return the symmetric Green-Lagrange strain tensor,
        * as constructed from the deformation gradient tensor @p F.
        * The result is expressed as
        * @f[
@@ -158,7 +158,7 @@ namespace Physics
       E (const Tensor<2, dim, Number> &F);
 
       /**
-       * Returns the symmetric small strain tensor,
+       * Return the symmetric small strain tensor,
        * as constructed from the displacement gradient tensor @p Grad_u.
        * The result is expressed as
        * @f[
@@ -177,7 +177,7 @@ namespace Physics
       epsilon (const Tensor<2, dim, Number> &Grad_u);
 
       /**
-       * Returns the symmetric Almansi strain tensor,
+       * Return the symmetric Almansi strain tensor,
        * as constructed from the deformation gradient tensor @p F.
        * The result is expressed as
        * @f[
@@ -200,7 +200,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the spatial velocity gradient tensor,
+       * Return the spatial velocity gradient tensor,
        * as constructed from the deformation gradient tensor @p F
        * and its material time derivative @p dF_dt (the material velocity
        * gradient).
@@ -218,7 +218,7 @@ namespace Physics
          const Tensor<2, dim, Number> &dF_dt);
 
       /**
-       * Returns the rate of deformation tensor (also known as the rate of strain
+       * Return the rate of deformation tensor (also known as the rate of strain
        * tensor), as constructed from the deformation gradient tensor @p F
        * and its material time derivative @p dF_dt (the material velocity
        * gradient).
@@ -241,7 +241,7 @@ namespace Physics
          const Tensor<2, dim, Number> &dF_dt);
 
       /**
-       * Returns the rate of rotation tensor (also known as the vorticity
+       * Return the rate of rotation tensor (also known as the vorticity
        * tensor), as constructed from the deformation gradient tensor @p F
        * and its material time derivative @p dF_dt (the material velocity
        * gradient).

--- a/include/deal.II/physics/elasticity/standard_tensors.h
+++ b/include/deal.II/physics/elasticity/standard_tensors.h
@@ -149,7 +149,7 @@ namespace Physics
       static const SymmetricTensor<4, dim> dev_P;
 
       /**
-       * Returns the fourth-order referential deviatoric tensor, as constructed from
+       * Return the fourth-order referential deviatoric tensor, as constructed from
        * the deformation gradient tensor @p F.
        * Also known as the deviatoric operator, this tensor projects a second-order
        * symmetric tensor onto a deviatoric space (for which the hydrostatic
@@ -208,7 +208,7 @@ namespace Physics
       Dev_P (const Tensor<2, dim, Number> &F);
 
       /**
-       * Returns the transpose of the fourth-order referential deviatoric tensor,
+       * Return the transpose of the fourth-order referential deviatoric tensor,
        * as constructed from the deformation gradient tensor @p F.
        * The result performs the following operation:
        * @f[
@@ -228,7 +228,7 @@ namespace Physics
        */
 //@{
       /**
-       * Returns the derivative of the volumetric Jacobian
+       * Return the derivative of the volumetric Jacobian
        * $J = \text{det} \mathbf{F}$ with respect to the right Cauchy-Green
        * tensor, as constructed from the deformation gradient tensor @p F.
        * The computed result is
@@ -256,7 +256,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the derivative of the inverse of the right Cauchy-Green
+       * Return the derivative of the inverse of the right Cauchy-Green
        * tensor with respect to the right Cauchy-Green tensor itself,
        * as constructed from the deformation gradient tensor @p F.
        * The result, accounting for symmetry, is defined in index notation as

--- a/include/deal.II/physics/transformations.h
+++ b/include/deal.II/physics/transformations.h
@@ -43,7 +43,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the rotation matrix for 2-d Euclidean space, namely
+       * Return the rotation matrix for 2-d Euclidean space, namely
        * @f[
        *  \mathbf{R} := \left[ \begin{array}{cc}
        *  cos(\theta) & sin(\theta) \\
@@ -63,7 +63,7 @@ namespace Physics
 
 
       /**
-       * Returns the rotation matrix for 3-d Euclidean space. Most concisely
+       * Return the rotation matrix for 3-d Euclidean space. Most concisely
        * stated using the Rodrigues' rotation formula, this function returns
        * the equivalent of
        * @f[
@@ -126,7 +126,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the result of the push forward transformation on a
+       * Return the result of the push forward transformation on a
        * contravariant vector, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\sharp}
@@ -144,7 +144,7 @@ namespace Physics
                     const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-2
+       * Return the result of the push forward transformation on a rank-2
        * contravariant tensor, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\sharp}
@@ -162,7 +162,7 @@ namespace Physics
                     const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-2
+       * Return the result of the push forward transformation on a rank-2
        * contravariant symmetric tensor, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\sharp}
@@ -181,7 +181,7 @@ namespace Physics
                     const Tensor<2,dim,Number>          &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-4
+       * Return the result of the push forward transformation on a rank-4
        * contravariant tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi\left(\bullet\right)^{\sharp} \right]_{ijkl}
@@ -199,7 +199,7 @@ namespace Physics
                     const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-4
+       * Return the result of the push forward transformation on a rank-4
        * contravariant symmetric tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi\left(\bullet\right)^{\sharp} \right]_{ijkl}
@@ -225,7 +225,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the result of the pull back transformation on a contravariant
+       * Return the result of the pull back transformation on a contravariant
        * vector, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\sharp}
@@ -243,7 +243,7 @@ namespace Physics
                  const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-2
+       * Return the result of the pull back transformation on a rank-2
        * contravariant tensor, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\sharp}
@@ -261,7 +261,7 @@ namespace Physics
                  const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-2
+       * Return the result of the pull back transformation on a rank-2
        * contravariant symmetric tensor, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\sharp}
@@ -279,7 +279,7 @@ namespace Physics
                  const Tensor<2,dim,Number>          &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-4
+       * Return the result of the pull back transformation on a rank-4
        * contravariant tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi^{-1}\left(\bullet\right)^{\sharp} \right]_{IJKL}
@@ -297,7 +297,7 @@ namespace Physics
                  const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-4
+       * Return the result of the pull back transformation on a rank-4
        * contravariant symmetric tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi^{-1}\left(\bullet\right)^{\sharp} \right]_{IJKL}
@@ -345,7 +345,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the result of the push forward transformation on a covariant
+       * Return the result of the push forward transformation on a covariant
        * vector, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\flat}
@@ -363,7 +363,7 @@ namespace Physics
                     const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-2
+       * Return the result of the push forward transformation on a rank-2
        * covariant tensor, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\flat}
@@ -381,7 +381,7 @@ namespace Physics
                     const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-2
+       * Return the result of the push forward transformation on a rank-2
        * covariant symmetric tensor, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\flat}
@@ -400,7 +400,7 @@ namespace Physics
                     const Tensor<2,dim,Number>          &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-4
+       * Return the result of the push forward transformation on a rank-4
        * covariant tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi\left(\bullet\right)^{\flat} \right]_{ijkl}
@@ -418,7 +418,7 @@ namespace Physics
                     const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-4
+       * Return the result of the push forward transformation on a rank-4
        * covariant symmetric tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi\left(\bullet\right)^{\flat} \right]_{ijkl}
@@ -444,7 +444,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the result of the pull back transformation on a covariant
+       * Return the result of the pull back transformation on a covariant
        * vector, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\flat}
@@ -462,7 +462,7 @@ namespace Physics
                  const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-2
+       * Return the result of the pull back transformation on a rank-2
        * covariant tensor, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\flat}
@@ -480,7 +480,7 @@ namespace Physics
                  const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-2
+       * Return the result of the pull back transformation on a rank-2
        * covariant symmetric tensor, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\flat}
@@ -498,7 +498,7 @@ namespace Physics
                  const Tensor<2,dim,Number>          &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-4
+       * Return the result of the pull back transformation on a rank-4
        * contravariant tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi^{-1}\left(\bullet\right)^{\flat} \right]_{IJKL}
@@ -516,7 +516,7 @@ namespace Physics
                  const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-4
+       * Return the result of the pull back transformation on a rank-4
        * contravariant symmetric tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi^{-1}\left(\bullet\right)^{\flat} \right]_{IJKL}
@@ -552,7 +552,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the result of the push forward transformation on a
+       * Return the result of the push forward transformation on a
        * contravariant vector, i.e.
        * @f[
        *  \textrm{det} \mathbf{F}^{-1} \; \chi\left(\bullet\right)^{\sharp}
@@ -571,7 +571,7 @@ namespace Physics
                     const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-2
+       * Return the result of the push forward transformation on a rank-2
        * contravariant tensor, i.e.
        * @f[
        *  \textrm{det} \mathbf{F}^{-1} \; \chi\left(\bullet\right)^{\sharp}
@@ -590,7 +590,7 @@ namespace Physics
                     const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-2
+       * Return the result of the push forward transformation on a rank-2
        * contravariant symmetric tensor, i.e.
        * @f[
        *  \textrm{det} \mathbf{F}^{-1} \; \chi\left(\bullet\right)^{\sharp}
@@ -610,7 +610,7 @@ namespace Physics
                     const Tensor<2,dim,Number>          &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-4
+       * Return the result of the push forward transformation on a rank-4
        * contravariant tensor, i.e. (in index notation)
        * @f[
        *  \textrm{det} \mathbf{F}^{-1} \; \left[ \chi\left(\bullet\right)^{\sharp} \right]_{ijkl}
@@ -629,7 +629,7 @@ namespace Physics
                     const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the push forward transformation on a rank-4
+       * Return the result of the push forward transformation on a rank-4
        * contravariant symmetric tensor, i.e. (in index notation)
        * @f[
        *  \textrm{det} \mathbf{F}^{-1} \; \left[ \chi\left(\bullet\right)^{\sharp} \right]_{ijkl}
@@ -656,7 +656,7 @@ namespace Physics
 //@{
 
       /**
-       * Returns the result of the pull back transformation on a contravariant
+       * Return the result of the pull back transformation on a contravariant
        * vector, i.e.
        * @f[
        *  \textrm{det} \mathbf{F} \; \chi^{-1}\left(\bullet\right)^{\sharp}
@@ -675,7 +675,7 @@ namespace Physics
                  const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-2
+       * Return the result of the pull back transformation on a rank-2
        * contravariant tensor, i.e.
        * @f[
        *  \textrm{det} \mathbf{F} \; \chi^{-1}\left(\bullet\right)^{\sharp}
@@ -694,7 +694,7 @@ namespace Physics
                  const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-2
+       * Return the result of the pull back transformation on a rank-2
        * contravariant symmetric tensor, i.e.
        * @f[
        *  \textrm{det} \mathbf{F} \; \chi^{-1}\left(\bullet\right)^{\sharp}
@@ -713,7 +713,7 @@ namespace Physics
                  const Tensor<2,dim,Number>          &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-4
+       * Return the result of the pull back transformation on a rank-4
        * contravariant tensor, i.e. (in index notation)
        * @f[
        *  \textrm{det} \mathbf{F} \; \left[ \chi^{-1}\left(\bullet\right)^{\sharp} \right]_{IJKL}
@@ -732,7 +732,7 @@ namespace Physics
                  const Tensor<2,dim,Number> &F);
 
       /**
-       * Returns the result of the pull back transformation on a rank-4
+       * Return the result of the pull back transformation on a rank-4
        * contravariant symmetric tensor, i.e. (in index notation)
        * @f[
        *  \textrm{det} \mathbf{F} \; \left[ \chi^{-1}\left(\bullet\right)^{\sharp} \right]_{IJKL}
@@ -759,7 +759,7 @@ namespace Physics
 //@{
 
     /**
-     * Returns the result of applying Nanson's formula for the transformation
+     * Return the result of applying Nanson's formula for the transformation
      * of the material surface area element $d\mathbf{A}$ to the current
      * surfaces area element $d\mathbf{a}$ under the nonlinear transformation
      * map $\mathbf{x} = \boldsymbol{\varphi} \left( \mathbf{X} \right)$.


### PR DESCRIPTION
This may be a slightly controversial patch, but it was easy enough to whip up so
we can have a discussion. The point being that in most places we use the
infinitive form of verbs in the starting sentence of a function documentation,
as in 'Compute the number of ...', rather than [This function] 'Computes the
number of ...'. This patch converts some instances of the second to the
first form. There are many others one could address if that's what the
consensus should turn out to be -- or we could just ignore things.