### PR TITLE
check Trilinos compress() argument

### DIFF
--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -547,6 +547,15 @@ namespace TrilinosWrappers
           else if (given_last_action==::dealii::VectorOperation::insert)
             mode = Insert;
         }
+      else
+        {
+          Assert(
+            ((last_action == Add) && (given_last_action==::dealii::VectorOperation::add))
+            ||
+            ((last_action == Insert) && (given_last_action==::dealii::VectorOperation::insert)),
+            ExcMessage("The last operation on the Vector and the given last action in the compress() call do not agree!"));
+        }
+
 
 #ifdef DEBUG
 #  ifdef DEAL_II_WITH_MPI


### PR DESCRIPTION
We do not check the given action in the call to ``compress()`` if an action was executed. This can lead to subtle bugs.

I have not run any tests on this yet...

Does this make sense? Can last_action be anything else than Add/Insert?