### PR TITLE
Fix bug in JobIdentifier::base_name.

### DIFF
--- a/source/base/job_identifier.cc
+++ b/source/base/job_identifier.cc
@@ -54,11 +54,13 @@ std::string
 JobIdentifier::base_name(const char *filename)
 {
   std::string name(filename);
-  std::string::size_type pos = name.find('.');
-  name.erase(pos, name.size());
+  std::string::size_type pos;
   pos = name.rfind('/');
-  if (pos < name.size())
-    name.erase(0,pos);
+  if (pos != std::string::npos)
+    name.erase(0, pos + 1);
+  pos = name.rfind('.');
+  if (pos != std::string::npos)
+    name.erase(pos, name.size());
   return name;
 }
 

--- a/tests/base/base_name.cc
+++ b/tests/base/base_name.cc
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 1998 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// test the functions of JobIdentifier::base_name
+
+#include "../tests.h"
+
+int main()
+{
+  initlog();
+
+  deallog << dealjobid.base_name("mypath/test.cc") << std::endl;;
+  deallog << dealjobid.base_name("/foo.bar/mypath/test.cc") << std::endl;
+
+  return 0;
+}

--- a/tests/base/base_name.output
+++ b/tests/base/base_name.output
@@ -1,0 +1,3 @@
+
+DEAL::test
+DEAL::test


### PR DESCRIPTION
This PR mainly fixes three problems in JobIdentifier::base_name:

- We should use `std::string::rfind` to locate the last dot in the file name
- `std::string::npos` should be used to test whether the character is found or not
- characters in range `[0, pos + 1)` should be erased to remove the file path