### PR TITLE
Avoid MPI calls in destructors with exceptions.

### DIFF
--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -1003,16 +1003,7 @@ TimerOutput::Scope::Scope(dealii::TimerOutput &timer_,
   timer.enter_section(section_name);
 }
 
-inline
-TimerOutput::Scope::~Scope()
-{
-  try
-    {
-      stop();
-    }
-  catch (...)
-    {}
-}
+
 
 inline
 void

--- a/tests/base/timer_07.cc
+++ b/tests/base/timer_07.cc
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include "../tests.h"
+#include <deal.II/base/timer.h>
+
+#include <sstream>
+
+DeclException0(Timer07Exception);
+
+int main (int argc, char **argv)
+{
+  initlog();
+
+  // capture cerr for testing purposes
+  std::stringstream captured_cerr;
+  std::streambuf *old_cerr = std::cerr.rdbuf(captured_cerr.rdbuf());
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv);
+  // Test printing from TimerOutput
+  try
+    {
+      std::cerr << "TimerOutput\n";
+      TimerOutput timer_out(MPI_COMM_WORLD,
+                            std::cerr,
+                            TimerOutput::summary,
+                            TimerOutput::cpu_times);
+      timer_out.enter_section("Section1");
+
+      throw Timer07Exception();
+    }
+  catch (const Timer07Exception &exc)
+    {
+    }
+
+  // The Scope should still exit correctly
+  try
+    {
+      std::cerr << "TimerOutput::Scope\n";
+      TimerOutput timer_out(MPI_COMM_WORLD,
+                            std::cerr,
+                            TimerOutput::summary,
+                            TimerOutput::cpu_times);
+      TimerOutput::Scope timer_scope(timer_out, "Section1");
+
+      throw Timer07Exception();
+    }
+  catch (const Timer07Exception &exc)
+    {
+    }
+
+  // Test that no errors are printed for MPI_COMM_SELF since no communication occurs
+  try
+    {
+      std::cerr << "TimerOutput::Scope with MPI_COMM_SELF\n";
+      TimerOutput timer_out(MPI_COMM_SELF,
+                            std::cerr,
+                            TimerOutput::summary,
+                            TimerOutput::cpu_times);
+      TimerOutput::Scope timer_scope(timer_out, "Section1");
+
+      throw Timer07Exception();
+    }
+  catch (const Timer07Exception &exc)
+    {
+    }
+
+  // convert numbers to xs to avoid printing time data
+  auto is_digit = [](const char c) -> bool
+  {
+    return std::isdigit(c);
+  };
+  std::string output = captured_cerr.str();
+  std::string::iterator next_number = std::find_if(output.begin(), output.end(), is_digit);
+  while (next_number != output.end())
+    {
+      // convert everything between the |s to xs so that we have consistent output.
+      const std::string::iterator start_pipe
+        = std::find(std::string::reverse_iterator(next_number),
+                    output.rend(),
+                    '|').base();
+      Assert(start_pipe != output.end(), ExcInternalError());
+      const std::string::iterator end_pipe = std::find(next_number, output.end(), '|');
+      Assert(end_pipe != output.end(), ExcInternalError());
+      Assert(end_pipe - start_pipe > 1, ExcInternalError());
+
+      std::fill(start_pipe + 1, end_pipe - 1, 'x');
+      next_number = std::find_if(next_number, output.end(), is_digit);
+    }
+
+
+  deallog << output << std::endl;
+
+  // restore stream
+  std::cerr.rdbuf(old_cerr);
+}

--- a/tests/base/timer_07.with_mpi=true.output
+++ b/tests/base/timer_07.with_mpi=true.output
@@ -1,0 +1,29 @@
+
+DEAL::TimerOutput
+---------------------------------------------------------
+TimerOutput objects finalize timed values printed to the
+screen by communicating over MPI in their destructors.
+Since an exception is currently uncaught, this
+synchronization (and subsequent output) will be skipped to
+avoid a possible deadlock.
+---------------------------------------------------------
+TimerOutput::Scope
+---------------------------------------------------------
+TimerOutput objects finalize timed values printed to the
+screen by communicating over MPI in their destructors.
+Since an exception is currently uncaught, this
+synchronization (and subsequent output) will be skipped to
+avoid a possible deadlock.
+---------------------------------------------------------
+TimerOutput::Scope with MPI_COMM_SELF
+
+
++---------------------------------------------+------------+------------+
+| Total CPU time elapsed since start          | xxxxxxxxxx |            |
+|                                             |            |            |
+| Section                         | no. calls |  CPU time  | % of total |
++---------------------------------+-----------+------------+------------+
+| xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx | xxxxxxxxx | xxxxxxxxxx | xxxxxxxxxx |
++---------------------------------+-----------+------------+------------+
+
+


### PR DESCRIPTION
The destructors of the `TimerOutput` and `TimerOutput::Scope` classes print timing information after communicating across an MPI communicator. These MPI calls in destructors can lead to deadlocks if some, but not all, proceses throw an exception. Get around this by skipping inter-process MPI calls when there is an uncaught exception.

I am not sure how we can test a deadlock, but the test ensures that we print the error message in the right case.

Fixes #5557.