### PR TITLE
Avoid signed integer overflow in Testing::rand

### DIFF
--- a/tests/tests.h
+++ b/tests/tests.h
@@ -146,16 +146,24 @@ namespace Testing
     static int r[32];
     static int k;
     static bool inited=false;
+
     if (!inited || reseed)
       {
         //srand treats a seed 0 as 1 for some reason
         r[0]=(seed==0)?1:seed;
+        long int word = r[0];
 
         for (int i=1; i<31; i++)
           {
-            r[i] = (16807LL * r[i-1]) % 2147483647;
-            if (r[i] < 0)
-              r[i] += 2147483647;
+            // This does:
+            //   r[i] = (16807 * r[i-1]) % 2147483647;
+            // buit avoids overflowing 31 bits.
+            const long int hi = word / 127773;
+            const long int lo = word % 127773;
+            word = 16807 * lo - 2836 * hi;
+            if (word < 0)
+              word += 2147483647;
+            r[i] = word;
           }
         k=31;
         for (int i=31; i<34; i++)
@@ -180,7 +188,7 @@ namespace Testing
     return (unsigned int)ret >> 1;
   }
 
-// reseed our random number generator
+  // reseed our random number generator
   void srand(const int seed)
   {
     rand(true, seed);


### PR DESCRIPTION
This PR avoids undefined behavior cause by signed integer overflow.
The implementation matches the one used in the gcc testsuite (or [glibc-2.15](https://sourceware.org/git/?p=glibc.git;a=blob;f=stdlib/random_r.c;hb=glibc-2.15#l361)).

In itself, the previous implementation probably wasn't really problematic, but it makes running the testsuite with `-fsanitize=undefined` difficult.