### PR TITLE
Optimize spherical manifold get_new_point into get_new_points

### DIFF
--- a/doc/news/changes/minor/20171201ReneGassmoeller
+++ b/doc/news/changes/minor/20171201ReneGassmoeller
@@ -1,0 +1,5 @@
+Improved: SphericalManifold::get_new_points now computes a lot
+of information outside of the loop over all points in get_new_point,
+which saves a significant amount of time for spherical geometries.
+<br>
+(Rene Gassmoeller, 2017/12/01)

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -615,6 +615,54 @@ make_array_view (Table<2,ElementType>                           &table,
 
 
 /**
+ * Create a view to an entire Table<2> object. This is equivalent to
+ * initializing an ArrayView object with a pointer to the first element of the
+ * given table, and the number of table entries as the length of the view.
+ *
+ * This function is used for non-@p const references to objects of Table type.
+ * Such objects contain elements that can be written to. Consequently, the
+ * return type of this function is a view to a set of writable objects.
+ *
+ * @param[in] table The Table for which we want to have an array view object.
+ * The array view corresponds to the <em>entire</em> table.
+ *
+ * @relates ArrayView
+ */
+template <typename ElementType>
+inline
+ArrayView<ElementType>
+make_array_view (Table<2,ElementType> &table)
+{
+  return ArrayView<ElementType> (&table[0][0], table.n_elements());
+}
+
+
+
+/**
+ * Create a view to an entire Table<2> object. This is equivalent to
+ * initializing an ArrayView object with a pointer to the first element of the
+ * given table, and the number of table entries as the length of the view.
+ *
+ * This function is used for @p const references to objects of Table type
+ * because they contain immutable elements. Consequently, the return type of
+ * this function is a view to a set of @p const objects.
+ *
+ * @param[in] table The Table for which we want to have an array view object.
+ * The array view corresponds to the <em>entire</em> table.
+ *
+ * @relates ArrayView
+ */
+template <typename ElementType>
+inline
+ArrayView<const ElementType>
+make_array_view (const Table<2,ElementType> &table)
+{
+  return ArrayView<const ElementType> (&table[0][0], table.n_elements());
+}
+
+
+
+/**
  * Create a view to an entire row of a Table<2> object. This is equivalent to
  * initializing an ArrayView object with a pointer to the first element of the
  * given row, and the length of the row as the length of the view.

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -302,6 +302,25 @@ private:
                  const Point<spacedim> &candidate_point) const;
 
   /**
+   * Compute a new set of points that interpolate between the given points @p
+   * surrounding_points. @p weights is an array view with as many entries as @p
+   * surrounding_points.size() times @p new_points.size().
+   *
+   * This function is optimized to perform on a collection
+   * of new points, by collecting operations that are not dependent on the
+   * weights outside of the loop over all new points.
+   *
+   * The implementation does not allow for @p surrounding_points and
+   * @p new_points to point to the same array, so make sure to pass different
+   * objects into the function.
+   */
+  virtual
+  void
+  get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+                  const ArrayView<const double>          &weights,
+                  ArrayView<Point<spacedim>>              new_points) const;
+
+  /**
    * A manifold description to be used for get_new_point in 2D.
    **/
   const PolarManifold<spacedim> polar_manifold;

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -299,7 +299,7 @@ private:
   get_new_point (const ArrayView<const Tensor<1,spacedim>> &directions,
                  const ArrayView<const double> &distances,
                  const ArrayView<const double> &weights,
-                 const Point<spacedim> candidate_point) const;
+                 const Point<spacedim> &candidate_point) const;
 
   /**
    * A manifold description to be used for get_new_point in 2D.

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -253,7 +253,7 @@ public:
   void
   get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                   const Table<2,double>                  &weights,
-                  ArrayView<Point<spacedim>>              new_points) const;
+                  ArrayView<Point<spacedim>>              new_points) const override;
 
   /**
    * Return a point on the spherical manifold which is intermediate
@@ -306,8 +306,6 @@ private:
    **/
   const PolarManifold<spacedim> polar_manifold;
 };
-
-
 
 /**
  * Cylindrical Manifold description.  In three dimensions, points are

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -236,6 +236,26 @@ public:
                       const Point<spacedim> &x2) const override;
 
   /**
+   * Compute a new set of points that interpolate between the given points @p
+   * surrounding_points. @p weights is a table with as many columns as @p
+   * surrounding_points.size(). The number of rows in @p weights must match
+   * the length of @p new_points.
+   *
+   * This function is optimized to perform on a collection
+   * of new points, by collecting operations that are not dependent on the
+   * weights outside of the loop over all new points.
+   *
+   * The implementation does not allow for @p surrounding_points and
+   * @p new_points to point to the same array, so make sure to pass different
+   * objects into the function.
+   */
+  virtual
+  void
+  get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+                  const Table<2,double>                  &weights,
+                  ArrayView<Point<spacedim>>              new_points) const;
+
+  /**
    * Return a point on the spherical manifold which is intermediate
    * with respect to the surrounding points.
    */
@@ -250,6 +270,36 @@ public:
   const Point<spacedim> center;
 
 private:
+  /**
+   * Return a point on the spherical manifold which is intermediate
+   * with respect to the surrounding points. This function uses a linear
+   * average of the directions to find an estimated point. It returns a pair
+   * of radius and direction from the center point to the candidate point.
+   */
+  std::pair<double, Tensor<1,spacedim> >
+  guess_new_point(const ArrayView<const Tensor<1,spacedim>> &directions,
+                  const ArrayView<const double> &distances,
+                  const ArrayView<const double> &weights) const;
+
+  /**
+   * Return a point on the spherical manifold which is intermediate
+   * with respect to the surrounding points. This function uses a candidate point
+   * as guess, and performs a Newton-style iteration to compute the correct point.
+   *
+   * The main part of the implementation uses the ideas in the publication
+   *
+   * Buss, Samuel R., and Jay P. Fillmore.
+   * "Spherical averages and applications to spherical splines and interpolation."
+   * ACM Transactions on Graphics (TOG) 20.2 (2001): 95-126.
+   *
+   * and in particular the implementation provided at
+   * http://math.ucsd.edu/~sbuss/ResearchWeb/spheremean/
+   */
+  Point<spacedim>
+  get_new_point (const ArrayView<const Tensor<1,spacedim>> &directions,
+                 const ArrayView<const double> &distances,
+                 const ArrayView<const double> &weights,
+                 const Point<spacedim> candidate_point) const;
 
   /**
    * A manifold description to be used for get_new_point in 2D.

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -474,13 +474,13 @@ get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
       // If not in 3D, just use the implementation from PolarManifold
       // after we verified that the candidate is not the center.
       if (spacedim<3)
-        {
-          new_points[row] = polar_manifold.get_new_point(surrounding_points, ArrayView<const double>(&weights[row*weight_columns],weight_columns));
-          accurate_point_was_found[row] = true;
-          continue;
-        }
-
+        new_points[row] = polar_manifold.get_new_point(surrounding_points, ArrayView<const double>(&weights[row*weight_columns],weight_columns));
     }
+
+  // In this case, we treated the case that the candidate is the center and obtained
+  // the new locations from the PolarManifold object otherwise.
+  if (spacedim<3)
+    return;
 
   // If all the points are close to each other, we expect the estimate to
   // be good enough. This tolerance was chosen such that the first iteration

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -697,7 +697,8 @@ namespace
             if (std::abs(weights[i])>1.e-15)
               {
                 vPerp = internal::projected_direction(directions[i], candidate);
-                const double sintheta = vPerp.norm();
+                const double sinthetaSq = vPerp.norm_square();
+                const double sintheta = std::sqrt(sinthetaSq);
                 if (sintheta<tolerance)
                   {
                     Hessian[0][0] += weights[i];
@@ -707,24 +708,24 @@ namespace
                   {
                     const double costheta = (directions[i])*candidate;
                     const double theta = atan2(sintheta, costheta);
-                    const double sinthetaInv = 1.0/sintheta;
+                    const double sincthetaInv = theta/sintheta;
 
-                    vPerp *= sinthetaInv;
                     const double cosphi = vPerp*Clocalx;
                     const double sinphi = vPerp*Clocaly;
 
                     gradlocal[0] = cosphi;
                     gradlocal[1] = sinphi;
-                    gradient += (weights[i]*theta)*gradlocal;
+                    gradient += (weights[i]*sincthetaInv)*gradlocal;
 
+                    const double wt = weights[i]/sinthetaSq;
                     const double sinphiSq = sinphi*sinphi;
                     const double cosphiSq = cosphi*cosphi;
-                    const double tt = (theta*sinthetaInv)*costheta;
-                    const double offdiag = cosphi*sinphi*weights[i]*(1.0-tt);
-                    Hessian[0][0] += weights[i]*(cosphiSq+tt*sinphiSq);
+                    const double tt = sincthetaInv*costheta;
+                    const double offdiag = cosphi*sinphi*wt*(1.0-tt);
+                    Hessian[0][0] += wt*(cosphiSq+tt*sinphiSq);
                     Hessian[0][1] += offdiag;
                     Hessian[1][0] += offdiag;
-                    Hessian[1][1] += weights[i]*(sinphiSq+tt*cosphiSq);
+                    Hessian[1][1] += wt*(sinphiSq+tt*cosphiSq);
                   }
               }
 

--- a/tests/grid/project_to_object_01.output
+++ b/tests/grid/project_to_object_01.output
@@ -46,9 +46,9 @@ DEAL::vertex 0 distance from origin: 2.00000
 DEAL::vertex 1 distance from origin: 2.00000
 DEAL::trial point distance from origin: 2.19657
 DEAL::projected point distance from origin: 2.00000
-DEAL::projected point:    -1.12078 -1.12078 -1.21971
-DEAL::true line midpoint: -1.12078 -1.12078 -1.21971
-DEAL::distance: 2.60549e-07
+DEAL::projected point:    -1.12083 -1.12083 -1.21963
+DEAL::true line midpoint: -1.12083 -1.12083 -1.21963
+DEAL::distance: 7.11530e-08
 DEAL::
 DEAL::Check that projecting with spacedim == structdim is the identity map:
 DEAL::
@@ -77,13 +77,13 @@ DEAL::Project a weighed face point onto the same face in 3D:
 DEAL::
 DEAL::trial point distance from origin:     2.00000
 DEAL::projected point distance from origin: 2.00000
-DEAL::Error:                                1.46981e-13
+DEAL::Error:                                1.37322e-11
 DEAL::
 DEAL::Project a point offset from the face onto the face in 3D:
 DEAL::
 DEAL::trial point distance from origin:     2.20000
 DEAL::projected point distance from origin: 2.00000
-DEAL::Error (vs. going along the normal):   1.63528e-06
+DEAL::Error (vs. going along the normal):   4.14146e-07
 DEAL::
 DEAL::Project a weighed line point onto the same line in 3D:
 DEAL::
@@ -102,9 +102,9 @@ DEAL::vertex 0 distance from origin: 2.00000
 DEAL::vertex 1 distance from origin: 2.00000
 DEAL::trial point distance from origin: 2.19917
 DEAL::projected point distance from origin: 2.00000
-DEAL::projected point:    -1.13838 -1.13838 -1.18668
-DEAL::true line midpoint: -1.13837 -1.13837 -1.18668
-DEAL::distance: 3.92713e-06
+DEAL::projected point:    -1.13839 -1.13839 -1.18665
+DEAL::true line midpoint: -1.13839 -1.13839 -1.18666
+DEAL::distance: 2.34143e-06
 DEAL::
 DEAL::Check that projecting with spacedim == structdim is the identity map:
 DEAL::
@@ -133,13 +133,13 @@ DEAL::Project a weighed face point onto the same face in 3D:
 DEAL::
 DEAL::trial point distance from origin:     2.00000
 DEAL::projected point distance from origin: 2.00000
-DEAL::Error:                                3.98330e-06
+DEAL::Error:                                3.98653e-06
 DEAL::
 DEAL::Project a point offset from the face onto the face in 3D:
 DEAL::
 DEAL::trial point distance from origin:     2.20000
 DEAL::projected point distance from origin: 2.00000
-DEAL::Error (vs. going along the normal):   3.61151e-05
+DEAL::Error (vs. going along the normal):   3.61157e-05
 DEAL::
 DEAL::Project a weighed line point onto the same line in 3D:
 DEAL::
@@ -158,9 +158,9 @@ DEAL::vertex 0 distance from origin: 2.00000
 DEAL::vertex 1 distance from origin: 2.00000
 DEAL::trial point distance from origin: 2.19979
 DEAL::projected point distance from origin: 2.00000
-DEAL::projected point:    -1.14669 -1.14669 -1.17055
-DEAL::true line midpoint: -1.14669 -1.14669 -1.17055
-DEAL::distance: 1.12205e-07
+DEAL::projected point:    -1.14670 -1.14670 -1.17054
+DEAL::true line midpoint: -1.14670 -1.14670 -1.17054
+DEAL::distance: 1.06157e-07
 DEAL::
 DEAL::Check that projecting with spacedim == structdim is the identity map:
 DEAL::
@@ -189,13 +189,13 @@ DEAL::Project a weighed face point onto the same face in 3D:
 DEAL::
 DEAL::trial point distance from origin:     2.00000
 DEAL::projected point distance from origin: 2.00000
-DEAL::Error:                                0.000829863
+DEAL::Error:                                0.000830177
 DEAL::
 DEAL::Project a point offset from the face onto the face in 3D:
 DEAL::
 DEAL::trial point distance from origin:     2.20000
 DEAL::projected point distance from origin: 2.00000
-DEAL::Error (vs. going along the normal):   0.00114087
+DEAL::Error (vs. going along the normal):   0.00114118
 DEAL::
 DEAL::Project a weighed line point onto the same line in 3D:
 DEAL::

--- a/tests/grid/project_to_object_01.output
+++ b/tests/grid/project_to_object_01.output
@@ -46,9 +46,9 @@ DEAL::vertex 0 distance from origin: 2.00000
 DEAL::vertex 1 distance from origin: 2.00000
 DEAL::trial point distance from origin: 2.19657
 DEAL::projected point distance from origin: 2.00000
-DEAL::projected point:    -1.12083 -1.12083 -1.21963
-DEAL::true line midpoint: -1.12083 -1.12083 -1.21963
-DEAL::distance: 7.11530e-08
+DEAL::projected point:    -1.12083 -1.12078 -1.21963
+DEAL::true line midpoint: -1.12083 -1.12078 -1.21963
+DEAL::distance: 7.18524e-08
 DEAL::
 DEAL::Check that projecting with spacedim == structdim is the identity map:
 DEAL::
@@ -77,13 +77,13 @@ DEAL::Project a weighed face point onto the same face in 3D:
 DEAL::
 DEAL::trial point distance from origin:     2.00000
 DEAL::projected point distance from origin: 2.00000
-DEAL::Error:                                1.37322e-11
+DEAL::Error:                                9.62537e-12
 DEAL::
 DEAL::Project a point offset from the face onto the face in 3D:
 DEAL::
 DEAL::trial point distance from origin:     2.20000
 DEAL::projected point distance from origin: 2.00000
-DEAL::Error (vs. going along the normal):   4.14146e-07
+DEAL::Error (vs. going along the normal):   1.39793e-05
 DEAL::
 DEAL::Project a weighed line point onto the same line in 3D:
 DEAL::
@@ -104,7 +104,7 @@ DEAL::trial point distance from origin: 2.19917
 DEAL::projected point distance from origin: 2.00000
 DEAL::projected point:    -1.13839 -1.13839 -1.18665
 DEAL::true line midpoint: -1.13839 -1.13839 -1.18666
-DEAL::distance: 2.34143e-06
+DEAL::distance: 3.37530e-06
 DEAL::
 DEAL::Check that projecting with spacedim == structdim is the identity map:
 DEAL::
@@ -139,7 +139,7 @@ DEAL::Project a point offset from the face onto the face in 3D:
 DEAL::
 DEAL::trial point distance from origin:     2.20000
 DEAL::projected point distance from origin: 2.00000
-DEAL::Error (vs. going along the normal):   3.61157e-05
+DEAL::Error (vs. going along the normal):   2.33659e-05
 DEAL::
 DEAL::Project a weighed line point onto the same line in 3D:
 DEAL::

--- a/tests/manifold/transfinite_manifold_03.output
+++ b/tests/manifold/transfinite_manifold_03.output
@@ -2,24 +2,24 @@
 DEAL::Testing with PolarManifold dim=2, spacedim=2
 DEAL::80   cells, degree=1: 3.06146745892 
 DEAL::80   cells, degree=2: 3.14143771670 
-DEAL::80   cells, degree=3: 3.14159250173 
-DEAL::80   cells, degree=4: 3.14159265349 
+DEAL::80   cells, degree=3: 3.14159250174 
+DEAL::80   cells, degree=4: 3.14159265350 
 DEAL::
 DEAL::Testing with SphericalManifold dim=2, spacedim=2
 DEAL::80   cells, degree=1: 3.06146745892 
 DEAL::80   cells, degree=2: 3.14143771670 
-DEAL::80   cells, degree=3: 3.14159250173 
+DEAL::80   cells, degree=3: 3.14159250174 
 DEAL::80   cells, degree=4: 3.14159265350 
 DEAL::
 DEAL::Testing with SphericalManifold dim=3, spacedim=3
 DEAL::56   cells, degree=1: 3.21034343105 
-DEAL::56   cells, degree=2: 4.18001126295 
+DEAL::56   cells, degree=2: 4.18001126296 
 DEAL::56   cells, degree=3: 4.18863487067 
 DEAL::56   cells, degree=4: 4.18878933389 
 DEAL::
 DEAL::Testing with CylindricalManifold in 3d
 DEAL::80   cells, degree=1: 5.65685424949 
 DEAL::80   cells, degree=2: 6.27829514062 
-DEAL::80   cells, degree=3: 6.28316607872 
+DEAL::80   cells, degree=3: 6.28316607871 
 DEAL::80   cells, degree=4: 6.28318526295 
 DEAL::


### PR DESCRIPTION
This PR is on top of #5529 and related to #5506.

First of all sorry for not coming back to this earlier. @masterleinad I checked #5529, and it indeed improves timings for large computations (when less points are computed in the Newton iteration), but it is still significantly slower than before. I suppose that is because now more instructions are done for each point, even for the simple case (e.g. the check for max_distance). I adapted the idea of @kronbichler in #5506 and moved all operations from `get_new_point` that do not depend on the weights into a new `SphericalManifold::get_new_points` functions. Although it is a pain to get all special cases correct, now I am essentially back to the performance before the introduction of the Newton iteration (while still having the increased accuracy of it). I show some timings below.  This new `get_new_points` functions could also allow further optimization as mentioned here https://github.com/dealii/dealii/issues/5506#issuecomment-345641636

Although it is hard to see, the logic in this PR should stay unchanged compared to #5529, except I now use the maximum distance between the surrounding points as upper bound for the maximum distance between candidate point and surrounding points. This seems reasonable as the candidate point lies in between the surrounding points. With this approximation the maximum distance check is independent of the weights.

Some timings below. All were taken from ASPECT, showing all steps of the assembly of an advection-diffusion system, for a 3D spherical shell (Rinner ~ 0.55 Router) with 4 refinements (393,216 cells, 3,195,010 Dofs for a Q2 element), and a MappingQGeneric(4) on 40 MPI processes.

Version | Time
------------ | -------------
8.5 |  6.3s
9.0 pre #5368   | 6.27s
9.0 pre #5529 | 9.27s
9.0 with #5529 | 7.24s
9.0 with this PR | 6.19s

I guess it is hard to generalize to all refinements and special cases, but for the moment I would be happy with this result. @masterleinad: I would appreciate if you could take a look at the code if I broke something (spherical manifold tests seem to work on my machine). Btw: I did not change anything in the Newton iteration itself, so if the discussion in #5506 leads to improvements in the Newton loop that might speed things up further.