### PR TITLE
added white margin to grey frame for last row or column

### DIFF
--- a/doc/news/changes/minor/20171205ChristophGoering
+++ b/doc/news/changes/minor/20171205ChristophGoering
@@ -1,0 +1,5 @@
+Fixed: SparsityPattern::print_svg(...) has the right size for the
+white rectangle so there is a small margin between the first and last
+row/column of the printed matrix.
+<br> 
+(Christoph Goering, 2017/12/05)

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -884,7 +884,7 @@ SparsityPattern::print_svg (std::ostream &out) const
       "    ]]>\n"
       "  </style>\n\n"
       "   <rect width=\"" << n+2 << "\" height=\"" << m+2 << "\" fill=\"rgb(128, 128, 128)\"/>\n"
-      "   <rect x=\"1\" y=\"1\" width=\"" << n << "\" height=\"" << m
+      "   <rect x=\"1\" y=\"1\" width=\"" << n+0.1 << "\" height=\"" << m+0.1
       << "\" fill=\"rgb(255, 255, 255)\"/>\n\n";
 
   SparsityPattern::iterator

--- a/tests/sparsity/sparsity_pattern_write_svg_01.output
+++ b/tests/sparsity/sparsity_pattern_write_svg_01.output
@@ -9,7 +9,7 @@
   </style>
 
    <rect width="5" height="4" fill="rgb(128, 128, 128)"/>
-   <rect x="1" y="1" width="3" height="2" fill="rgb(255, 255, 255)"/>
+   <rect x="1" y="1" width="3.10000" height="2.10000" fill="rgb(255, 255, 255)"/>
 
   <rect class="pixel" x="2" y="1" width=".9" height=".9"/>
   <rect class="pixel" x="3" y="1" width=".9" height=".9"/>


### PR DESCRIPTION
Hi deal.ii-team,

I discussed this issue with Martin Kronbichler and he suggested that I propose the little fix myself.

I encountered an aesthetic problem when I used the print_svg(...) function of [SparsityPattern](https://www.dealii.org/8.4.0/doxygen/deal.II/sparsity__pattern_8cc_source.html) The function creates two rectangles, a grey one (as frame for the svg) and a white one (as background for the visualization), before the entries of the matrices are plotted with little reds rectangles.

If an input is visualized in the last row or colum the red rectangle "touches" directly the grey frame; this does not happen for the first row or column because there is a little gap of 0.1 pixels.

Therefore my propose for resolving this minor issue is to change line 875 of [SparsityPattern](https://www.dealii.org/8.4.0/doxygen/deal.II/sparsity__pattern_8cc_source.html) 
from
`" <rect x=\"1\" y=\"1\" width=\"" << n << "\" height=\"" << m`
to
`" <rect x=\"1\" y=\"1\" width=\"" << n+0.1 << "\" height=\"" << m+0.1`
in order to have a litte white gap around all red rectangles which are at the boundaries of the matrix.

If there are any question, do not hesitate to ask me.

Christoph