### PR TITLE
Provide more instantiations for std::complex data types.

### DIFF
--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -1464,13 +1464,13 @@ private:
   /**
    * Internal helper function for distribute_local_to_global function.
    */
-  template <typename LocalType>
-  LocalType
+  template <typename MatrixScalar, typename VectorScalar>
+  typename ProductType<VectorScalar,MatrixScalar>::type
   resolve_vector_entry (const size_type                       i,
                         const internals::GlobalRowsFromLocal &global_rows,
-                        const Vector<LocalType>              &local_vector,
+                        const Vector<VectorScalar>           &local_vector,
                         const std::vector<size_type>         &local_dof_indices,
-                        const FullMatrix<LocalType>          &local_matrix) const;
+                        const FullMatrix<MatrixScalar>       &local_matrix) const;
 };
 
 

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -277,10 +277,10 @@ namespace MatrixCreator
   void create_mass_matrix (const Mapping<dim, spacedim>   &mapping,
                            const DoFHandler<dim,spacedim> &dof,
                            const Quadrature<dim>    &q,
-                           SparseMatrix<number>     &matrix,
+                           SparseMatrix<typename numbers::NumberTraits<number>::real_type>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const a = nullptr,
+                           const Function<spacedim,typename numbers::NumberTraits<number>::real_type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -290,10 +290,10 @@ namespace MatrixCreator
   template <int dim, int spacedim, typename number>
   void create_mass_matrix (const DoFHandler<dim,spacedim> &dof,
                            const Quadrature<dim>    &q,
-                           SparseMatrix<number>     &matrix,
+                           SparseMatrix<typename numbers::NumberTraits<number>::real_type>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const a = nullptr,
+                           const Function<spacedim,typename numbers::NumberTraits<number>::real_type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -324,10 +324,10 @@ namespace MatrixCreator
   void create_mass_matrix (const hp::MappingCollection<dim,spacedim> &mapping,
                            const hp::DoFHandler<dim,spacedim> &dof,
                            const hp::QCollection<dim> &q,
-                           SparseMatrix<number>     &matrix,
+                           SparseMatrix<typename numbers::NumberTraits<number>::real_type>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const a = nullptr,
+                           const Function<spacedim,typename numbers::NumberTraits<number>::real_type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -336,10 +336,10 @@ namespace MatrixCreator
   template <int dim, int spacedim, typename number>
   void create_mass_matrix (const hp::DoFHandler<dim,spacedim> &dof,
                            const hp::QCollection<dim> &q,
-                           SparseMatrix<number>     &matrix,
+                           SparseMatrix<typename numbers::NumberTraits<number>::real_type>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const a = nullptr,
+                           const Function<spacedim,typename numbers::NumberTraits<number>::real_type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
 
@@ -372,11 +372,11 @@ namespace MatrixCreator
   void create_boundary_mass_matrix (const Mapping<dim, spacedim>       &mapping,
                                     const DoFHandler<dim,spacedim>    &dof,
                                     const Quadrature<dim-1>  &q,
-                                    SparseMatrix<number>     &matrix,
+                                    SparseMatrix<typename numbers::NumberTraits<number>::real_type>     &matrix,
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const weight = 0,
+                                    const Function<spacedim,typename numbers::NumberTraits<number>::real_type> *const weight = 0,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
 
@@ -387,11 +387,11 @@ namespace MatrixCreator
   template <int dim, int spacedim, typename number>
   void create_boundary_mass_matrix (const DoFHandler<dim,spacedim>    &dof,
                                     const Quadrature<dim-1>  &q,
-                                    SparseMatrix<number>     &matrix,
+                                    SparseMatrix<typename numbers::NumberTraits<number>::real_type>     &matrix,
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a = nullptr,
+                                    const Function<spacedim,typename numbers::NumberTraits<number>::real_type> *const a = nullptr,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
@@ -401,11 +401,11 @@ namespace MatrixCreator
   void create_boundary_mass_matrix (const hp::MappingCollection<dim,spacedim>       &mapping,
                                     const hp::DoFHandler<dim,spacedim>    &dof,
                                     const hp::QCollection<dim-1>  &q,
-                                    SparseMatrix<number>     &matrix,
+                                    SparseMatrix<typename numbers::NumberTraits<number>::real_type>     &matrix,
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a = nullptr,
+                                    const Function<spacedim,typename numbers::NumberTraits<number>::real_type> *const a = nullptr,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
@@ -414,11 +414,11 @@ namespace MatrixCreator
   template <int dim, int spacedim, typename number>
   void create_boundary_mass_matrix (const hp::DoFHandler<dim,spacedim>    &dof,
                                     const hp::QCollection<dim-1>  &q,
-                                    SparseMatrix<number>     &matrix,
+                                    SparseMatrix<typename numbers::NumberTraits<number>::real_type>     &matrix,
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a = nullptr,
+                                    const Function<spacedim,typename numbers::NumberTraits<number>::real_type> *const a = nullptr,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**

--- a/source/lac/constraint_matrix.cc
+++ b/source/lac/constraint_matrix.cc
@@ -1324,13 +1324,13 @@ PARALLEL_VECTOR_FUNCTIONS(TrilinosWrappers::MPI::BlockVector);
                                                       VectorType                      &, \
                                                       bool                             , \
                                                       std::integral_constant<bool, false>) const
-#define MATRIX_FUNCTIONS(MatrixType) \
+#define MATRIX_FUNCTIONS(MatrixType,VectorScalar) \
   template void ConstraintMatrix:: \
-  distribute_local_to_global<MatrixType,Vector<MatrixType::value_type> > (const FullMatrix<MatrixType::value_type>        &, \
-      const Vector<MatrixType::value_type>            &, \
+  distribute_local_to_global<MatrixType,Vector<VectorScalar> > (const FullMatrix<MatrixType::value_type>        &, \
+      const Vector<VectorScalar>            &, \
       const std::vector<ConstraintMatrix::size_type> &, \
       MatrixType                      &, \
-      Vector<MatrixType::value_type>                  &, \
+      Vector<VectorScalar>                  &, \
       bool                             , \
       std::integral_constant<bool, false>) const
 #define BLOCK_MATRIX_VECTOR_FUNCTIONS(MatrixType, VectorType)   \
@@ -1352,37 +1352,42 @@ PARALLEL_VECTOR_FUNCTIONS(TrilinosWrappers::MPI::BlockVector);
       bool                             , \
       std::integral_constant<bool, true>) const
 
-MATRIX_FUNCTIONS(SparseMatrix<double>);
-MATRIX_FUNCTIONS(SparseMatrix<float>);
-MATRIX_FUNCTIONS(FullMatrix<double>);
-MATRIX_FUNCTIONS(FullMatrix<float>);
-MATRIX_FUNCTIONS(FullMatrix<std::complex<double> >);
-MATRIX_FUNCTIONS(SparseMatrix<std::complex<double> >);
-MATRIX_FUNCTIONS(SparseMatrix<std::complex<float> >);
+MATRIX_FUNCTIONS(FullMatrix<double>,double);
+MATRIX_FUNCTIONS(FullMatrix<float>,float);
+MATRIX_FUNCTIONS(FullMatrix<double>,std::complex<double>);
+MATRIX_FUNCTIONS(FullMatrix<std::complex<double> >,std::complex<double>);
+
+MATRIX_FUNCTIONS(SparseMatrix<double>,double);
+MATRIX_FUNCTIONS(SparseMatrix<float>,float);
+MATRIX_FUNCTIONS(SparseMatrix<double>,std::complex<double>);
+MATRIX_FUNCTIONS(SparseMatrix<float>,std::complex<float>);
+MATRIX_FUNCTIONS(SparseMatrix<std::complex<double> >,std::complex<double>);
+MATRIX_FUNCTIONS(SparseMatrix<std::complex<float> >,std::complex<float>);
+
+MATRIX_FUNCTIONS(SparseMatrixEZ<double>,double);
+MATRIX_FUNCTIONS(SparseMatrixEZ<float>,float);
+MATRIX_FUNCTIONS(ChunkSparseMatrix<double>,double);
+MATRIX_FUNCTIONS(ChunkSparseMatrix<float>,float);
+
 
 BLOCK_MATRIX_FUNCTIONS(BlockSparseMatrix<double>);
 BLOCK_MATRIX_FUNCTIONS(BlockSparseMatrix<float>);
 BLOCK_MATRIX_VECTOR_FUNCTIONS(BlockSparseMatrix<double>, BlockVector<double>);
 BLOCK_MATRIX_VECTOR_FUNCTIONS(BlockSparseMatrix<float>,  BlockVector<float>);
 
-MATRIX_FUNCTIONS(SparseMatrixEZ<double>);
-MATRIX_FUNCTIONS(SparseMatrixEZ<float>);
-MATRIX_FUNCTIONS(ChunkSparseMatrix<double>);
-MATRIX_FUNCTIONS(ChunkSparseMatrix<float>);
-
 // BLOCK_MATRIX_FUNCTIONS(BlockSparseMatrixEZ<double>);
 // BLOCK_MATRIX_VECTOR_FUNCTIONS(BlockSparseMatrixEZ<float>,  Vector<float>);
 
 #ifdef DEAL_II_WITH_PETSC
-MATRIX_FUNCTIONS(PETScWrappers::SparseMatrix);
-MATRIX_FUNCTIONS(PETScWrappers::MPI::SparseMatrix);
+MATRIX_FUNCTIONS(PETScWrappers::SparseMatrix,PetscScalar);
+MATRIX_FUNCTIONS(PETScWrappers::MPI::SparseMatrix,PetscScalar);
 BLOCK_MATRIX_FUNCTIONS(PETScWrappers::MPI::BlockSparseMatrix);
 MATRIX_VECTOR_FUNCTIONS(PETScWrappers::MPI::SparseMatrix, PETScWrappers::MPI::Vector);
 BLOCK_MATRIX_VECTOR_FUNCTIONS(PETScWrappers::MPI::BlockSparseMatrix,PETScWrappers::MPI::BlockVector);
 #endif
 
 #ifdef DEAL_II_WITH_TRILINOS
-MATRIX_FUNCTIONS(TrilinosWrappers::SparseMatrix);
+MATRIX_FUNCTIONS(TrilinosWrappers::SparseMatrix,double);
 BLOCK_MATRIX_FUNCTIONS(TrilinosWrappers::BlockSparseMatrix);
 MATRIX_VECTOR_FUNCTIONS(TrilinosWrappers::SparseMatrix, TrilinosWrappers::MPI::Vector);
 BLOCK_MATRIX_VECTOR_FUNCTIONS(TrilinosWrappers::BlockSparseMatrix, TrilinosWrappers::MPI::BlockVector);
@@ -1468,15 +1473,17 @@ ONLY_MATRIX_FUNCTIONS(PETScWrappers::MPI::BlockSparseMatrix);
 // constructor of scratch_data (it won't allow one to be constructed in place).
 namespace internals
 {
-#define SCRATCH_INITIALIZER(Number,Name)                                \
-  ConstraintMatrixData<Number>::ScratchData scratch_data_initializer_##Name; \
-  template <> Threads::ThreadLocalStorage<ConstraintMatrixData<Number>::ScratchData> \
-  ConstraintMatrixData<Number>::scratch_data(scratch_data_initializer_##Name)
+#define SCRATCH_INITIALIZER(MatrixScalar,VectorScalar,Name)                  \
+  ConstraintMatrixData<MatrixScalar,VectorScalar>::ScratchData scratch_data_initializer_##Name; \
+  template <> Threads::ThreadLocalStorage<ConstraintMatrixData<MatrixScalar,VectorScalar>::ScratchData> \
+  ConstraintMatrixData<MatrixScalar,VectorScalar>::scratch_data(scratch_data_initializer_##Name)
 
-  SCRATCH_INITIALIZER(double,double);
-  SCRATCH_INITIALIZER(float,float);
-  SCRATCH_INITIALIZER(std::complex<double>,cdouble);
-  SCRATCH_INITIALIZER(std::complex<float>,cfloat);
+  SCRATCH_INITIALIZER(double,double,dd);
+  SCRATCH_INITIALIZER(float,float,ff);
+  SCRATCH_INITIALIZER(std::complex<double>,std::complex<double>,zz);
+  SCRATCH_INITIALIZER(std::complex<float>,std::complex<float>,cc);
+  SCRATCH_INITIALIZER(double,std::complex<double>,dz);
+  SCRATCH_INITIALIZER(float,std::complex<float>,fc);
 #undef SCRATCH_INITIALIZER
 }
 

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -29,21 +29,57 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
 {
     template void ConstraintMatrix::condense<LinearAlgebra::distributed::T<S> >(const LinearAlgebra::distributed::T<S> &, LinearAlgebra::distributed::T<S> &) const;
     template void ConstraintMatrix::condense<LinearAlgebra::distributed::T<S> >(LinearAlgebra::distributed::T<S> &vec) const;
-    template void ConstraintMatrix::distribute_local_to_global<LinearAlgebra::distributed::T<S> > (
-        const Vector<S>&, const std::vector<types::global_dof_index> &, LinearAlgebra::distributed::T<S> &, const FullMatrix<S>&) const;
-    template void ConstraintMatrix::distribute_local_to_global<LinearAlgebra::distributed::T<S> > (
-        const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, LinearAlgebra::distributed::T<S> &, const FullMatrix<S>&, bool) const;
-    template void ConstraintMatrix::set_zero<LinearAlgebra::distributed::T<S> >(LinearAlgebra::distributed::T<S> &) const;
-    template void ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> > > (
-        const FullMatrix<S> &, const std::vector< size_type > &, DiagonalMatrix<LinearAlgebra::distributed::T<S> > &) const;
-    template void ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> >, LinearAlgebra::distributed::T<S> > (
-        const FullMatrix<S> &, const Vector<S>&, const std::vector< size_type > &,
-        DiagonalMatrix<LinearAlgebra::distributed::T<S> > &, LinearAlgebra::distributed::T<S>&,
-        bool, std::integral_constant<bool, false>) const;
-    template void ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> >, T<S> > (
-        const FullMatrix<S> &, const Vector<S>&, const std::vector< size_type > &,
-        DiagonalMatrix<LinearAlgebra::distributed::T<S> > &, T<S>&,
-        bool, std::integral_constant<bool, false>) const;
+
+    template
+    void
+    ConstraintMatrix::distribute_local_to_global<LinearAlgebra::distributed::T<S> >
+    (const Vector<S>&,
+     const std::vector<types::global_dof_index> &,
+     LinearAlgebra::distributed::T<S> &,
+     const FullMatrix<S>&) const;
+
+    template
+    void
+    ConstraintMatrix::distribute_local_to_global<LinearAlgebra::distributed::T<S> >
+    (const Vector<S>&,
+     const std::vector<types::global_dof_index> &,
+     const std::vector<types::global_dof_index> &,
+     LinearAlgebra::distributed::T<S> &,
+     const FullMatrix<S>&,
+     bool) const;
+
+    template
+    void
+    ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> > >
+    (const FullMatrix<S> &,
+     const std::vector< size_type > &,
+     DiagonalMatrix<LinearAlgebra::distributed::T<S> > &) const;
+
+    template
+    void
+    ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> >, LinearAlgebra::distributed::T<S> >
+    (const FullMatrix<S> &,
+     const Vector<S>&,
+     const std::vector< size_type > &,
+     DiagonalMatrix<LinearAlgebra::distributed::T<S> > &,
+     LinearAlgebra::distributed::T<S>&,
+     bool,
+     std::integral_constant<bool, false>) const;
+
+    template
+    void
+    ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> >, T<S> >
+    (const FullMatrix<S> &,
+     const Vector<S>&,
+     const std::vector< size_type > &,
+     DiagonalMatrix<LinearAlgebra::distributed::T<S> > &,
+     T<S>&,
+     bool,
+     std::integral_constant<bool, false>) const;
+
+    template
+    void
+    ConstraintMatrix::set_zero<LinearAlgebra::distributed::T<S> >(LinearAlgebra::distributed::T<S> &) const;
 }
 
 

--- a/source/lac/sparse_matrix.inst.in
+++ b/source/lac/sparse_matrix.inst.in
@@ -137,6 +137,19 @@ for (S1, S2, S3 : REAL_SCALARS;
     Tvmult_add (V1<S2> &, const V2<S3> &) const;
 }
 
+for (S1 : REAL_SCALARS; S2, S3 : COMPLEX_SCALARS;
+        V1, V2     : DEAL_II_VEC_TEMPLATES)
+{
+    template void SparseMatrix<S1>::
+    vmult (V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::
+    Tvmult (V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::
+    vmult_add (V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::
+    Tvmult_add (V1<S2> &, const V2<S3> &) const;
+}
+
 for (S1 : REAL_SCALARS)
 {
     template void SparseMatrix<S1>::

--- a/source/numerics/matrix_creator.inst.in
+++ b/source/numerics/matrix_creator.inst.in
@@ -14,6 +14,8 @@
 // ---------------------------------------------------------------------
 
 
+
+// MatrixCreator::create_mass_matrix for the matrix only --> only real-valued scalars
 for (scalar: REAL_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
@@ -33,29 +35,30 @@ for (scalar: REAL_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimensi
      SparseMatrix<scalar>     &matrix,
      const Function<deal_II_space_dimension,scalar> * const coefficient,
      const ConstraintMatrix   &constraints);
+
+    // hp versions of functions
     template
     void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
+    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>       &mapping,
+     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
+     const hp::QCollection<deal_II_dimension>    &q,
      SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar>      &rhs,
-     Vector<scalar>           &rhs_vector,
      const Function<deal_II_space_dimension,scalar> * const coefficient,
      const ConstraintMatrix   &constraints);
+
     template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
+    void MatrixCreator::create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>
+    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
+     const hp::QCollection<deal_II_dimension>    &q,
      SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar>      &rhs,
-     Vector<scalar>           &rhs_vector,
      const Function<deal_II_space_dimension,scalar> * const coefficient,
      const ConstraintMatrix   &constraints);
 #endif
 }
 
-for (scalar: COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+
+// MatrixCreator::create_mass_matrix for matrix + rhs --> real- and complex-valued scalars
+for (scalar: REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     // non-hp version of create_mass_matrix
@@ -64,51 +67,58 @@ for (scalar: COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dime
     (const Mapping<deal_II_dimension,deal_II_space_dimension>       &mapping,
      const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
      const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
+     SparseMatrix<numbers::NumberTraits<scalar>::real_type>     &matrix,
+     const Function<deal_II_space_dimension,scalar>      &rhs,
+     Vector<scalar>           &rhs_vector,
+     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const coefficient,
      const ConstraintMatrix   &constraints);
     template
     void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
     (const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
      const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
+     SparseMatrix<numbers::NumberTraits<scalar>::real_type>     &matrix,
      const Function<deal_II_space_dimension,scalar>      &rhs,
      Vector<scalar>           &rhs_vector,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
+     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const coefficient,
      const ConstraintMatrix   &constraints);
+
+    // hp version
     template
     void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
+    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>       &mapping,
+     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
+     const hp::QCollection<deal_II_dimension>    &q,
+     SparseMatrix<numbers::NumberTraits<scalar>::real_type>     &matrix,
      const Function<deal_II_space_dimension,scalar>      &rhs,
      Vector<scalar>           &rhs_vector,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
+     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const coefficient,
+     const ConstraintMatrix   &constraints);
+
+    template
+    void MatrixCreator::create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>
+    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
+     const hp::QCollection<deal_II_dimension>    &q,
+     SparseMatrix<numbers::NumberTraits<scalar>::real_type>     &matrix,
+     const Function<deal_II_space_dimension,scalar>      &rhs,
+     Vector<scalar>           &rhs_vector,
+     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const coefficient,
      const ConstraintMatrix   &constraints);
 #endif
 }
 
 
-for (scalar: REAL_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+for (scalar: REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
     template
     void MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
     (const DoFHandler<deal_II_dimension,deal_II_space_dimension>     &dof,
      const Quadrature<deal_II_dimension-1>   &q,
-     SparseMatrix<scalar>      &matrix,
+     SparseMatrix<numbers::NumberTraits<scalar>::real_type>      &matrix,
      const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*> &rhs,
      Vector<scalar>            &rhs_vector,
      std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-     const Function<deal_II_space_dimension,scalar> * const a,
+     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const a,
      std::vector<unsigned int>);
 
     template
@@ -116,11 +126,11 @@ for (scalar: REAL_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimensi
     (const Mapping<deal_II_dimension,deal_II_space_dimension> &,
      const DoFHandler<deal_II_dimension,deal_II_space_dimension>     &dof,
      const Quadrature<deal_II_dimension-1>   &q,
-     SparseMatrix<scalar>      &matrix,
+     SparseMatrix<numbers::NumberTraits<scalar>::real_type>      &matrix,
      const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*> &rhs,
      Vector<scalar>            &rhs_vector,
      std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-     const Function<deal_II_space_dimension,scalar> * const a,
+     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const a,
      std::vector<unsigned int>);
 
     template
@@ -129,179 +139,27 @@ for (scalar: REAL_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimensi
     (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>&,
      const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
      const hp::QCollection<deal_II_dimension-1>&,
-     SparseMatrix<scalar>&,
+     SparseMatrix<numbers::NumberTraits<scalar>::real_type>&,
      const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*>&,
      Vector<scalar>&,
      std::vector<types::global_dof_index>&,
-     const Function<deal_II_space_dimension,scalar> * const,
+     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const,
      std::vector<unsigned int>);
 
     template
     void MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
     (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
      const hp::QCollection<deal_II_dimension-1>&,
-     SparseMatrix<scalar>&,
+     SparseMatrix<numbers::NumberTraits<scalar>::real_type>&,
      const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*>&,
      Vector<scalar>&,
      std::vector<types::global_dof_index>&,
-     const Function<deal_II_space_dimension,scalar> * const,
+     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const,
      std::vector<unsigned int>);
 #endif
 }
 
-for (scalar: COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
-#if deal_II_dimension <= deal_II_space_dimension
-    template
-    void MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>     &dof,
-     const Quadrature<deal_II_dimension-1>   &q,
-     SparseMatrix<scalar>      &matrix,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*> &rhs,
-     Vector<scalar>            &rhs_vector,
-     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-     const Function<deal_II_space_dimension,scalar> * const a,
-     std::vector<unsigned int>);
 
-    template
-    void MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,deal_II_space_dimension, scalar>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension> &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>     &dof,
-     const Quadrature<deal_II_dimension-1>   &q,
-     SparseMatrix<scalar>      &matrix,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*> &rhs,
-     Vector<scalar>            &rhs_vector,
-     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-     const Function<deal_II_space_dimension,scalar> * const a,
-     std::vector<unsigned int>);
-
-    template
-    void
-    MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>&,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const hp::QCollection<deal_II_dimension-1>&,
-     SparseMatrix<scalar>&,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*>&,
-     Vector<scalar>&,
-     std::vector<types::global_dof_index>&,
-     const Function<deal_II_space_dimension,scalar> * const,
-     std::vector<unsigned int>);
-
-    template
-    void MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const hp::QCollection<deal_II_dimension-1>&,
-     SparseMatrix<scalar>&,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*>&,
-     Vector<scalar>&,
-     std::vector<types::global_dof_index>&,
-     const Function<deal_II_space_dimension,scalar> * const,
-     std::vector<unsigned int>);
-#endif
-}
-
-//TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension, deal_II_space_dimension>
-// where applicable and move to codimension cases above also when applicable
-for (scalar : REAL_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
-// hp versions of functions
-#if deal_II_dimension <= deal_II_space_dimension
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
-
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar>      &rhs,
-     Vector<scalar>           &rhs_vector,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
-
-#endif
-
-#if deal_II_dimension == deal_II_space_dimension
-
-
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
-
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar>      &rhs,
-     Vector<scalar>           &rhs_vector,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
-
-#endif
-}
-
-for (scalar : COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
-// hp versions of functions
-#if deal_II_dimension <= deal_II_space_dimension
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
-
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar>      &rhs,
-     Vector<scalar>           &rhs_vector,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
-
-#endif
-
-#if deal_II_dimension == deal_II_space_dimension
-
-
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
-
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar>      &rhs,
-     Vector<scalar>           &rhs_vector,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
-
-#endif
-}
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {

--- a/source/numerics/vector_tools_boundary.inst.in
+++ b/source/numerics/vector_tools_boundary.inst.in
@@ -109,26 +109,45 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 #endif
 }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; number : REAL_AND_COMPLEX_SCALARS)
 {
-    namespace VectorTools \{
 #if deal_II_dimension == deal_II_space_dimension
+    namespace VectorTools \{
 
     template
     void project_boundary_values<deal_II_dimension>
     (const Mapping<deal_II_dimension>     &,
      const DoFHandler<deal_II_dimension>  &,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,double>*> &,
+     const std::map<types::boundary_id, const Function<deal_II_dimension,number>*> &,
      const Quadrature<deal_II_dimension-1>&,
-     std::map<types::global_dof_index,double>&, std::vector<unsigned int>);
+     std::map<types::global_dof_index,number>&,
+     std::vector<unsigned int>);
 
     template
     void project_boundary_values<deal_II_dimension>
     (const DoFHandler<deal_II_dimension>  &,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,double>*> &,
+     const std::map<types::boundary_id, const Function<deal_II_dimension,number>*> &,
      const Quadrature<deal_II_dimension-1>&,
-     std::map<types::global_dof_index,double>&,
+     std::map<types::global_dof_index,number>&,
      std::vector<unsigned int>);
+
+    template
+    void project_boundary_values<deal_II_dimension,deal_II_space_dimension>
+    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension> &,
+     const std::map<types::boundary_id, const Function<deal_II_dimension,number>*> &,
+     const hp::QCollection<deal_II_dimension-1> &,
+     std::map<types::global_dof_index,number> &,
+     std::vector<unsigned int>);
+
+    \}
+#endif
+}
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+{
+    namespace VectorTools \{
+#if deal_II_dimension == deal_II_space_dimension
+
 
     template
     void project_boundary_values<deal_II_dimension>
@@ -145,16 +164,6 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
      const Quadrature<deal_II_dimension-1>&,
      ConstraintMatrix&,
      std::vector<unsigned int>);
-
-    template
-    void project_boundary_values<deal_II_dimension,deal_II_space_dimension>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension> &,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,double>*> &,
-     const hp::QCollection<deal_II_dimension-1> &,
-     std::map<types::global_dof_index,double> &,
-     std::vector<unsigned int>);
-
-
 
 #if deal_II_dimension != 1
     template


### PR DESCRIPTION
This is necessary to run some more functions like `VectorTools::project` for complex-valued right hand sides. The changes herein are mostly uncontroversial and so I package them up into a patch of their own -- their just mechanically adding instantiations and then ensuring that things actually compile (and when they don't, to add the necessary template arguments and change data types). 

The functions I'm instantiating here are mostly for mixed complex-real arithmetic. I need this in `VectorTools::project` and similar places because the mass matrix should remain real, but it's applied to a complex-valued right hand side.

Part of #2033.