### PR TITLE
Clean up Python wrrappers

### DIFF
--- a/contrib/python-bindings/include/cell_accessor_wrapper.h
+++ b/contrib/python-bindings/include/cell_accessor_wrapper.h
@@ -115,7 +115,7 @@ namespace python
     DeclException2(ExcVertexDoesNotExist,
                    int, int,
                    << "Requested vertex number " << arg1
-                   << "does not exist. The largest vertex number "
+                   << " does not exist. The largest vertex number "
                    << "acceptable is "<< arg2-1);
 
   private:

--- a/contrib/python-bindings/include/cell_accessor_wrapper.h
+++ b/contrib/python-bindings/include/cell_accessor_wrapper.h
@@ -18,8 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CXX11
-
 #include <deal.II/grid/tria_accessor.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -138,7 +136,5 @@ namespace python
 }
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif
 
 #endif

--- a/contrib/python-bindings/include/point_wrapper.h
+++ b/contrib/python-bindings/include/point_wrapper.h
@@ -17,9 +17,6 @@
 #define dealii_point_wrapper_h
 
 #include <deal.II/base/config.h>
-
-#ifdef DEAL_II_WITH_CXX11
-
 #include <deal.II/base/point.h>
 
 #include <boost/python.hpp>
@@ -238,7 +235,5 @@ namespace python
 }
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif
 
 #endif

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -18,8 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CXX11
-
 #include <point_wrapper.h>
 #include <boost/python.hpp>
 #include <string>
@@ -379,7 +377,5 @@ namespace python
 }
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif
 
 #endif

--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -15,8 +15,6 @@
 
 #include <cell_accessor_wrapper.h>
 
-#ifdef DEAL_II_WITH_CXX11
-
 #include <point_wrapper.h>
 #include <triangulation_wrapper.h>
 #include <boost/python.hpp>
@@ -477,5 +475,3 @@ namespace python
 }
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif

--- a/contrib/python-bindings/source/export_cell_accessor.cc
+++ b/contrib/python-bindings/source/export_cell_accessor.cc
@@ -17,8 +17,6 @@
 #include <triangulation_wrapper.h>
 #include <boost/python.hpp>
 
-#ifdef DEAL_II_WITH_CXX11
-
 DEAL_II_NAMESPACE_OPEN
 
 namespace python
@@ -109,5 +107,3 @@ namespace python
 }
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif

--- a/contrib/python-bindings/source/export_point.cc
+++ b/contrib/python-bindings/source/export_point.cc
@@ -15,8 +15,6 @@
 
 #include <point_wrapper.h>
 
-#ifdef DEAL_II_WITH_CXX11
-
 #include <deal.II/base/point.h>
 #include <deal.II/base/exceptions.h>
 #include <boost/python.hpp>
@@ -93,5 +91,3 @@ namespace python
 }
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -14,9 +14,6 @@
 // ---------------------------------------------------------------------
 
 #include <triangulation_wrapper.h>
-
-#ifdef DEAL_II_WITH_CXX11
-
 #include <cell_accessor_wrapper.h>
 #include <boost/python.hpp>
 
@@ -470,5 +467,3 @@ namespace python
 }
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -246,7 +246,7 @@ namespace python
 
 
   const char shift_docstring [] =
-    "Shift every vertex of the Triangulation by the gien shift vector       \n"
+    "Shift every vertex of the Triangulation by the given shift vector      \n"
     ;
 
 
@@ -274,7 +274,7 @@ namespace python
     "faces of the triangulation to the faces of out_tria. If you need to    \n"
     "specify manifold ids on interior faces, they have to be specified      \n"
     "manually after the triangulation is created. This function will fail   \n"
-    "the input Triangulation contains hanging nodes.                        \n"
+    "if the input Triangulation contains hanging nodes.                     \n"
     ;
 
 

--- a/contrib/python-bindings/source/point_wrapper.cc
+++ b/contrib/python-bindings/source/point_wrapper.cc
@@ -15,9 +15,6 @@
 
 #include <point_wrapper.h>
 
-#ifdef DEAL_II_WITH_CXX11
-
-
 DEAL_II_NAMESPACE_OPEN
 
 namespace python
@@ -521,5 +518,3 @@ namespace python
 }
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -14,9 +14,6 @@
 // ---------------------------------------------------------------------
 
 #include <triangulation_wrapper.h>
-
-#ifdef DEAL_II_WITH_CXX11
-
 #include <cell_accessor_wrapper.h>
 #include <deal.II/base/types.h>
 #include <deal.II/grid/tria.h>
@@ -1112,5 +1109,3 @@ namespace python
 }
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif

--- a/contrib/python-bindings/source/wrappers.cc
+++ b/contrib/python-bindings/source/wrappers.cc
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 
 #include <deal.II/base/config.h>
+#include <deal.II/base/exceptions.h>
 
 #include <boost/python.hpp>
 
@@ -47,6 +48,11 @@ BOOST_PYTHON_MODULE(Debug)
   doc_options.enable_user_defined();
   doc_options.enable_py_signatures();
   doc_options.disable_cpp_signatures();
+
+  // Switch off call to std::abort when an exception is created using Assert.
+  // If the code aborts, the kernel of a Jupyter Notebook is killed and no
+  // message is printed.
+  dealii::deal_II_exceptions::disable_abort_on_exception();
 
   dealii::python::export_cell_accessor();
   dealii::python::export_point();

--- a/contrib/python-bindings/source/wrappers.cc
+++ b/contrib/python-bindings/source/wrappers.cc
@@ -15,8 +15,6 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CXX11
-
 #include <boost/python.hpp>
 
 DEAL_II_NAMESPACE_OPEN
@@ -70,7 +68,5 @@ BOOST_PYTHON_MODULE(Release)
   dealii::python::export_point();
   dealii::python::export_triangulation();
 }
-
-#endif
 
 #endif


### PR DESCRIPTION
This PR does three things:
 - fix a couple of typos
 - remove the c++11 guards that were still in the python code
 - disable abort on exception from `Assert`. Before the notebook kernel was killed when we hit an `Assert` instead of throwing an exception that could be caught by the notebook.