### PR TITLE
Check a convergence rate, not errors, in a test.

### DIFF
--- a/tests/grid/project_to_object_01.output
+++ b/tests/grid/project_to_object_01.output
@@ -1,22 +1,10 @@
 
 DEAL::testing cross derivative 0
-DEAL::2.08262e-05
-DEAL::2.61032e-06
-DEAL::3.26714e-07
-DEAL::4.08654e-08
-DEAL::5.10984e-09
+DEAL::slope is nearly 3: 1
 DEAL::testing cross derivative 1
-DEAL::2.10357e-05
-DEAL::2.62342e-06
-DEAL::3.27533e-07
-DEAL::4.09167e-08
-DEAL::5.11266e-09
+DEAL::slope is nearly 3: 1
 DEAL::testing cross derivative 2
-DEAL::5.75514e-06
-DEAL::7.19207e-07
-DEAL::8.98876e-08
-DEAL::1.12350e-08
-DEAL::1.40439e-09
+DEAL::slope is nearly 3: 1
 DEAL::
 DEAL::Project the arithmetic mean of two vertices on a circular
 DEAL::arc. The result should be the geodesic midpoint:

--- a/tests/grid/project_to_object_01.output.with_fma
+++ b/tests/grid/project_to_object_01.output.with_fma
@@ -1,22 +1,10 @@
 
 DEAL::testing cross derivative 0
-DEAL::2.08262e-05
-DEAL::2.61032e-06
-DEAL::3.26714e-07
-DEAL::4.08653e-08
-DEAL::5.10978e-09
+DEAL::slope is nearly 3: 1
 DEAL::testing cross derivative 1
-DEAL::2.10357e-05
-DEAL::2.62342e-06
-DEAL::3.27533e-07
-DEAL::4.09166e-08
-DEAL::5.11283e-09
+DEAL::slope is nearly 3: 1
 DEAL::testing cross derivative 2
-DEAL::5.75514e-06
-DEAL::7.19207e-07
-DEAL::8.98876e-08
-DEAL::1.12351e-08
-DEAL::1.40411e-09
+DEAL::slope is nearly 3: 1
 DEAL::
 DEAL::Project the arithmetic mean of two vertices on a circular
 DEAL::arc. The result should be the geodesic midpoint:


### PR DESCRIPTION
This makes the test a little bit more robust. The testers complain that the last few digits in the errors are usually different, so we can get around this by just checking the convergence rate with a tolerance.