### PR TITLE
Fix some things that the clang static analyzer found.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -552,7 +552,8 @@ public:
    *
    * @ingroup Exceptions
    */
-  DeclException0 (ExcInvalidObject);
+  DeclExceptionMsg (ExcInvalidObject, "This accessor object has not been "
+                    "associated with any DoFHandler object.");
   /**
    * Exception
    *
@@ -1018,7 +1019,8 @@ public:
    *
    * @ingroup Exceptions
    */
-  DeclException0 (ExcInvalidObject);
+  DeclExceptionMsg (ExcInvalidObject, "This accessor object has not been "
+                    "associated with any DoFHandler object.");
   /**
    * Exception
    *

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2011,9 +2011,7 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::get_dof_indices
 (std::vector<types::global_dof_index> &dof_indices,
  const unsigned int                    fe_index) const
 {
-  Assert (this->dof_handler != nullptr,
-          ExcMessage("This accessor object has not been associated "
-                     "with any DoFHandler object."));
+  Assert (this->dof_handler != nullptr, ExcInvalidObject());
   Assert (static_cast<unsigned int>(this->level()) < this->dof_handler->levels.size(),
           ExcMessage ("The DoFHandler to which this accessor points has not "
                       "been initialized, i.e., it doesn't appear that DoF indices "

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -124,6 +124,7 @@ inline
 const DoFHandlerType &
 DoFAccessor<structdim,DoFHandlerType,level_dof_access>::get_dof_handler () const
 {
+  Assert (this->dof_handler != nullptr, ExcInvalidObject());
   return *this->dof_handler;
 }
 
@@ -3527,6 +3528,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::get_dof_values
           ExcMessage ("Can't ask for DoF indices on artificial cells."));
   Assert (!this->has_children(),
           ExcMessage ("Cell must be active."));
+  Assert (this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
 
   Assert (static_cast<unsigned int>(local_values_end-local_values_begin)
           == this->get_fe().dofs_per_cell,
@@ -3595,6 +3597,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::set_dof_values
           typename DoFCellAccessor::ExcVectorDoesNotMatch());
 
 
+  Assert (this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
   const types::global_dof_index *cache
     = this->dof_handler->levels[this->present_level]
       ->get_cell_cache_start (this->present_index, this->get_fe().dofs_per_cell);
@@ -3618,6 +3621,8 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::get_fe () const
           ExcMessage ("In hp::DoFHandler objects, finite elements are only associated "
                       "with active cells. Consequently, you can not ask for the "
                       "active finite element on cells with children."));
+  Assert (this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
+
   return this->dof_handler->get_fe(active_fe_index());
 }
 

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1410,7 +1410,7 @@ namespace internal
         Assert ( (fe_index != dealii::hp::DoFHandler<dim,spacedim>::default_fe_index),
                  ExcMessage ("You need to specify a FE index when working "
                              "with hp DoFHandlers"));
-        Assert (dof_handler.finite_elements != 0,
+        Assert (dof_handler.finite_elements != nullptr,
                 ExcMessage ("No finite element collection is associated with "
                             "this DoFHandler"));
         Assert (fe_index < dof_handler.finite_elements->size(),
@@ -2543,7 +2543,7 @@ void
 DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::copy_from
 (const TriaAccessorBase<0,1,spacedim> &da)
 {
-  Assert (this->dof_handler != 0, ExcInvalidObject());
+  Assert (this->dof_handler != nullptr, ExcInvalidObject());
   BaseClass::copy_from(da);
 }
 
@@ -3061,7 +3061,7 @@ namespace internal
                                   ForwardIterator local_source_end,
                                   OutputVector   &global_destination)
       {
-        Assert (accessor.dof_handler != 0,
+        Assert (accessor.dof_handler != nullptr,
                 (typename std::decay<decltype(accessor)>::type::ExcInvalidObject()));
         Assert (local_source_end-local_source_begin == accessor.get_fe().dofs_per_cell,
                 (typename std::decay<decltype(accessor)>::type::ExcVectorDoesNotMatch()));
@@ -3091,7 +3091,7 @@ namespace internal
                                   ForwardIterator         local_source_end,
                                   OutputVector           &global_destination)
       {
-        Assert (accessor.dof_handler != 0,
+        Assert (accessor.dof_handler != nullptr,
                 (typename std::decay<decltype(accessor)>::type::ExcInvalidObject()));
         Assert (local_source_end-local_source_begin == accessor.get_fe().dofs_per_cell,
                 (typename std::decay<decltype(accessor)>::type::ExcVectorDoesNotMatch()));
@@ -3122,7 +3122,7 @@ namespace internal
                                   ForwardIterator         local_source_end,
                                   OutputVector           &global_destination)
       {
-        Assert (accessor.dof_handler != 0,
+        Assert (accessor.dof_handler != nullptr,
                 (typename std::decay<decltype(accessor)>::type::ExcInvalidObject()));
         Assert (local_source_end-local_source_begin == accessor.get_fe().dofs_per_cell,
                 (typename std::decay<decltype(accessor)>::type::ExcVectorDoesNotMatch()));
@@ -3185,7 +3185,7 @@ namespace internal
                                   const dealii::FullMatrix<number> &local_source,
                                   OutputMatrix                     &global_destination)
       {
-        Assert (accessor.dof_handler != 0,
+        Assert (accessor.dof_handler != nullptr,
                 (typename std::decay<decltype(accessor)>::type::ExcInvalidObject()));
         Assert (local_source.m() == accessor.get_fe().dofs_per_cell,
                 (typename std::decay<decltype(accessor)>::type::ExcMatrixDoesNotMatch()));
@@ -3220,7 +3220,7 @@ namespace internal
                                   OutputMatrix                     &global_matrix,
                                   OutputVector                     &global_vector)
       {
-        Assert (accessor.dof_handler != 0,
+        Assert (accessor.dof_handler != nullptr,
                 (typename std::decay<decltype(accessor)>::type::ExcInvalidObject()));
         Assert (local_matrix.m() == accessor.get_fe().dofs_per_cell,
                 (typename std::decay<decltype(accessor)>::type::ExcMatrixDoesNotMatch()));
@@ -3262,7 +3262,7 @@ namespace internal
                                   OutputMatrix                     &global_matrix,
                                   OutputVector                     &global_vector)
       {
-        Assert (accessor.dof_handler != 0,
+        Assert (accessor.dof_handler != nullptr,
                 (typename std::decay<decltype(accessor)>::type::ExcInvalidObject()));
         Assert (local_matrix.m() == accessor.get_fe().dofs_per_cell,
                 (typename std::decay<decltype(accessor)>::type::ExcMatrixDoesNotMatch()));

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -1347,7 +1347,6 @@ not_connect:
         task_info.partition_color_blocks_row_index.resize(partition+1,0);
         task_info.partition_color_blocks_data.resize(1,0);
 
-        start_up = 0;
         counter = 0;
         unsigned int missing_macros;
         for (unsigned int part=0; part<partition; ++part)

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -650,11 +650,10 @@ IndexSet::is_ascending_and_one_to_one (const MPI_Comm &communicator) const
   if (my_rank == 0)
     {
       // find out if the received std::vector is ascending
-      types::global_dof_index old_dof = global_dofs[0];
       types::global_dof_index index = 0;
       while (global_dofs[index] == numbers::invalid_dof_index)
         ++index;
-      old_dof = global_dofs[index++];
+      types::global_dof_index old_dof = global_dofs[index++];
       for (; index<global_dofs.size(); ++index)
         {
           const types::global_dof_index new_dof = global_dofs[index];

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -265,19 +265,20 @@ namespace SparsityTools
       int *export_to_part=nullptr;
 
       //call partitioner
-      int rc = zz->LB_Partition (changes,
-                                 num_gid_entries,
-                                 num_lid_entries,
-                                 num_import,
-                                 import_global_ids,
-                                 import_local_ids,
-                                 import_procs,
-                                 import_to_part,
-                                 num_export,
-                                 export_global_ids,
-                                 export_local_ids,
-                                 export_procs,
-                                 export_to_part);
+      const int rc = zz->LB_Partition (changes,
+                                       num_gid_entries,
+                                       num_lid_entries,
+                                       num_import,
+                                       import_global_ids,
+                                       import_local_ids,
+                                       import_procs,
+                                       import_to_part,
+                                       num_export,
+                                       export_global_ids,
+                                       export_local_ids,
+                                       export_procs,
+                                       export_to_part);
+      (void)rc;
 
       //check for error code in partitioner
       Assert( rc == ZOLTAN_OK , ExcInternalError() );

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1624,6 +1624,7 @@ namespace TrilinosWrappers
         ierr = matrix->Epetra_CrsMatrix::SumIntoGlobalValues(row, n_columns,
                                                              col_value_ptr,
                                                              col_index_ptr);
+        AssertThrow (ierr == 0, ExcTrilinosError(ierr));
       }
     else if (nonlocal_matrix.get() != nullptr)
       {
@@ -1638,6 +1639,7 @@ namespace TrilinosWrappers
         ierr = nonlocal_matrix->SumIntoGlobalValues(row, n_columns,
                                                     col_value_ptr,
                                                     col_index_ptr);
+        AssertThrow (ierr == 0, ExcTrilinosError(ierr));
       }
     else
       {
@@ -1654,6 +1656,7 @@ namespace TrilinosWrappers
                                             col_index_ptr,
                                             &col_value_ptr,
                                             Epetra_FECrsMatrix::ROW_MAJOR);
+        AssertThrow (ierr == 0, ExcTrilinosError(ierr));
       }
 
 #ifdef DEBUG

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -311,7 +311,6 @@ namespace TrilinosWrappers
         }
 
       TrilinosScalar *entries = (*actual_vec)[0];
-      block_offset = 0;
       for (size_type block=0; block<v.n_blocks(); ++block)
         {
           v.block(block).trilinos_vector().ExtractCopy (entries, 0);


### PR DESCRIPTION
I ran `clang-check` on the source files and it found a few minor things. I took the opportunity to clean up `ExcInvalidObject` so that it always prints a message.

Part of #610. 