### PR TITLE
Fix some failing tests

### DIFF
--- a/tests/mpi/blockwise_parallel_01.cc
+++ b/tests/mpi/blockwise_parallel_01.cc
@@ -56,9 +56,9 @@ void test()
     locally_owned_dofs_per_block[1] =
       locally_owned_dofs_per_subdomain[this_mpi_process].get_view(dofs_per_block, dh.n_dofs());
 
-    if (locally_owned_dofs_per_block[0] != locally_owned_dofs_per_block[1]))
-      ExcMessage("Locally owned dofs differ across blocks."));
-    }
+    if (locally_owned_dofs_per_block[0] != locally_owned_dofs_per_block[1])
+      AssertThrow(false, ExcMessage("Locally owned dofs differ across blocks."));
+  }
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     deallog << "OK for " << dim << "d" << std::endl;

--- a/tests/mpi/blockwise_parallel_01.mpirun=2.output
+++ b/tests/mpi/blockwise_parallel_01.mpirun=2.output
@@ -1,3 +1,5 @@
+
 DEAL:0::OK for 2d
 DEAL:0::OK for 3d
+
 

--- a/tests/mpi/locally_owned_dofs_per_subdomain.cc
+++ b/tests/mpi/locally_owned_dofs_per_subdomain.cc
@@ -31,7 +31,7 @@ void test ()
   triangulation (MPI_COMM_WORLD,
                  ::Triangulation<dim>::none,
                  false,
-                 parallel::shared::Triangulation<dim>::partition_metis);
+                 parallel::shared::Triangulation<dim>::partition_zorder);
   GridGenerator::hyper_cube(triangulation, -1.0, 1.0);
 
   FE_Q<dim> fe(1);

--- a/tests/mpi/locally_owned_dofs_per_subdomain.mpirun=2.output
+++ b/tests/mpi/locally_owned_dofs_per_subdomain.mpirun=2.output
@@ -2,18 +2,18 @@
 DEAL:0::dim=2
 DEAL:0::rank=0
 DEAL:0::  n_dofs=4
-DEAL:0::  n_locally_owned_dofs=4
+DEAL:0::  n_locally_owned_dofs=0
 DEAL:0::dim=3
 DEAL:0::rank=0
 DEAL:0::  n_dofs=8
-DEAL:0::  n_locally_owned_dofs=8
+DEAL:0::  n_locally_owned_dofs=0
 
 DEAL:1::dim=2
 DEAL:1::rank=1
 DEAL:1::  n_dofs=4
-DEAL:1::  n_locally_owned_dofs=0
+DEAL:1::  n_locally_owned_dofs=4
 DEAL:1::dim=3
 DEAL:1::rank=1
 DEAL:1::  n_dofs=8
-DEAL:1::  n_locally_owned_dofs=0
+DEAL:1::  n_locally_owned_dofs=8
 

--- a/tests/mpi/locally_owned_dofs_per_subdomain_hp.cc
+++ b/tests/mpi/locally_owned_dofs_per_subdomain_hp.cc
@@ -30,7 +30,11 @@
 template <int dim>
 void test ()
 {
-  parallel::shared::Triangulation<dim> triangulation(MPI_COMM_WORLD);
+  parallel::shared::Triangulation<dim>
+  triangulation (MPI_COMM_WORLD,
+                 ::Triangulation<dim>::none,
+                 false,
+                 parallel::shared::Triangulation<dim>::partition_zorder);
   GridGenerator::hyper_cube(triangulation, -1.0, 1.0);
 
   hp::FECollection<dim> fe;

--- a/tests/mpi/locally_owned_dofs_per_subdomain_hp.mpirun=2.output
+++ b/tests/mpi/locally_owned_dofs_per_subdomain_hp.mpirun=2.output
@@ -2,18 +2,18 @@
 DEAL:0::dim=2
 DEAL:0::rank=0
 DEAL:0::  n_dofs=4
-DEAL:0::  n_locally_owned_dofs=4
+DEAL:0::  n_locally_owned_dofs=0
 DEAL:0::dim=3
 DEAL:0::rank=0
 DEAL:0::  n_dofs=8
-DEAL:0::  n_locally_owned_dofs=8
+DEAL:0::  n_locally_owned_dofs=0
 
 DEAL:1::dim=2
 DEAL:1::rank=1
 DEAL:1::  n_dofs=4
-DEAL:1::  n_locally_owned_dofs=0
+DEAL:1::  n_locally_owned_dofs=4
 DEAL:1::dim=3
 DEAL:1::rank=1
 DEAL:1::  n_dofs=8
-DEAL:1::  n_locally_owned_dofs=0
+DEAL:1::  n_locally_owned_dofs=8
 

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -284,7 +284,7 @@ namespace Step18
     triangulation(MPI_COMM_WORLD,
                   ::Triangulation<dim>::none,
                   false,
-                  parallel::shared::Triangulation<dim>::partition_metis),
+                  parallel::shared::Triangulation<dim>::partition_zorder),
     fe (FE_Q<dim>(1), dim),
     dof_handler (triangulation),
     quadrature_formula (2),

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -311,7 +311,7 @@ namespace Step18
     triangulation(MPI_COMM_WORLD,
                   ::Triangulation<dim>::none,
                   false,
-                  parallel::shared::Triangulation<dim>::partition_metis),
+                  parallel::shared::Triangulation<dim>::partition_zorder),
     fe (FE_Q<dim>(1), dim),
     dof_handler (triangulation),
     quadrature_formula (2),


### PR DESCRIPTION
- mpi/locally_owned_dofs_per_subdomain
- mpi/locally_owned_dofs_per_subdomain_hp
- physics/step-18-rotation_matrix
- physics/step-18

were using METIS without restricting the test to it. Changing to `zorder`-partitioning should also make the tests more robust.

- mpi/blockwise_parallel_01

wasn't compiling.