### PR TITLE
Change LAPACKFullMatrix::size_type to unsigned int.

### DIFF
--- a/doc/news/changes/incompatibilities/20171220DavidWells
+++ b/doc/news/changes/incompatibilities/20171220DavidWells
@@ -1,0 +1,3 @@
+Changed: The type <code>LAPACKFullMatrix::size_type</code> is now <code>unsigned int</code>, which matches <code>FullMatrix::size_type</code>.
+<br>
+(David Wells, 2017/12/20)

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -57,7 +57,7 @@ public:
   /**
    * Declare type for container size.
    */
-  typedef types::global_dof_index size_type;
+  typedef unsigned int size_type;
 
   /**
    * Constructor. Initialize the matrix as a square matrix with dimension
@@ -217,14 +217,14 @@ public:
    *
    * @note The matrix is of dimension $m \times n$.
    */
-  unsigned int m () const;
+  size_type m () const;
 
   /**
    * Return the dimension of the domain space.
    *
    * @note The matrix is of dimension $m \times n$.
    */
-  unsigned int n () const;
+  size_type n () const;
 
   /**
    * Fill rectangular block.
@@ -859,7 +859,7 @@ private:
 
 template <typename number>
 inline
-unsigned int
+typename LAPACKFullMatrix<number>::size_type
 LAPACKFullMatrix<number>::m () const
 {
   return this->n_rows ();
@@ -867,7 +867,7 @@ LAPACKFullMatrix<number>::m () const
 
 template <typename number>
 inline
-unsigned int
+typename LAPACKFullMatrix<number>::size_type
 LAPACKFullMatrix<number>::n () const
 {
   return this->n_cols ();


### PR DESCRIPTION
This patch fixes compilation with 64 bit indices and also makes things more consistent with base class functions (e.g., `TransposeTable::n_rows()` returns an unsigned int).

Before merging, I think it might be worthwhile to discuss how we can fix the more general problem here: `Table`, `FullMatrix`, and `LAPACKFullMatrix` are inconsistent in their use of integral types for sizes. For example: on `master` (i.e., without this patch) we currently have the following situation:

1. `TableBase::size_type` is `std::size_t`
2. `FullMatrix::size_type` is `unsigned int`
3. `LAPACKFullMatrix::size_type` is `types::global_dof_index`

I believe these should all match, and we should just use `std::size_t` (and then, if LAPACK uses 32 bit integers, we just `static_cast` down).