### PR TITLE
Update sparse matrix mmult with DynamicSparsityPattern::compute_mmult_pattern(..)

### DIFF
--- a/doc/news/changes/minor/20171222ChristophGoering
+++ b/doc/news/changes/minor/20171222ChristophGoering
@@ -1,0 +1,4 @@
+Improved: SparseMatrix::mmult(..) is now using the
+DynamicSparsityPattern::compute_mmult_pattern(..) function to create
+the sparsity pattern of the final matrix C.
+<br> (Christoph Goering, 2017/12/22)

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -1008,37 +1008,10 @@ SparseMatrix<number>::mmult (SparseMatrix<numberC>       &C,
       C.clear();
       sp_C.reinit (0,0,0);
 
-      // create a sparsity pattern for the matrix. we will go through all the
-      // rows in the matrix A, and for each column in a row we add the whole
-      // row of matrix B with that row number. This means that we will insert
-      // a lot of entries to each row, which is best handled by the
-      // DynamicSparsityPattern class.
+      // create a sparsity pattern for the matrix C.
       {
-        DynamicSparsityPattern dsp (m(), B.n());
-        for (size_type i = 0; i < dsp.n_rows(); ++i)
-          {
-            const size_type *rows = &sp_A.colnums[sp_A.rowstart[i]];
-            const size_type *const end_rows =
-              &sp_A.colnums[sp_A.rowstart[i+1]];
-            for (; rows != end_rows; ++rows)
-              {
-                const size_type col = *rows;
-                size_type *new_cols = const_cast<size_type *>
-                                      (&sp_B.colnums[sp_B.rowstart[col]]);
-                size_type *end_new_cols = const_cast<size_type *>
-                                          (&sp_B.colnums[sp_B.rowstart[col+1]]);
-
-                // if B has a diagonal, need to add that manually. this way,
-                // we maintain sortedness.
-                if (sp_B.n_rows() == sp_B.n_cols())
-                  {
-                    ++new_cols;
-                    dsp.add(i, col);
-                  }
-
-                dsp.add_entries (i, new_cols, end_new_cols, true);
-              }
-          }
+        DynamicSparsityPattern dsp ;
+        dsp.compute_mmult_pattern(sp_A,sp_B);
         sp_C.copy_from (dsp);
       }
 


### PR DESCRIPTION
This PullRequest originates in #5598 and #5632. 
To sum it up, inside the [SparseMatrix::mmult(..)](https://github.com/dealii/dealii/blob/84a6d39800d3e0f1cdf426e64c97d707484c7df8/include/deal.II/lac/sparse_matrix.templates.h#L1011-L1041) function the computation of the resulting sparsity pattern of is outsourced to the newly added [DynamicSparsityPattern::compute_mmult_pattern(..)](https://github.com/dealii/dealii/blob/84a6d39800d3e0f1cdf426e64c97d707484c7df8/include/deal.II/lac/dynamic_sparsity_pattern.h#L423-L429).

After building the latest fetched deal.II, I ran `make setup_tests` and after that `ctest -R "lac/sparse_matri*"` --> all 24 tests passed.