### PR TITLE
Fix Intel 18 warnings in OpenCASCADE wrapper

### DIFF
--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -177,6 +177,8 @@ namespace OpenCASCADE
       case 3:
         return gp_Pnt(p[0], p[1], p[2]);
       }
+    AssertThrow (false, ExcNotImplemented());
+    return {};
   }
 
   template <int spacedim>
@@ -198,6 +200,8 @@ namespace OpenCASCADE
       case 3:
         return Point<spacedim>(p.X(), p.Y(), p.Z());
       }
+    AssertThrow (false, ExcNotImplemented());
+    return {};
   }
 
   template<int dim>

--- a/source/opencascade/utilities.inst.in
+++ b/source/opencascade/utilities.inst.in
@@ -33,7 +33,7 @@ for (deal_II_dimension : DIMENSIONS)
 
     template
     TopoDS_Edge interpolation_curve(std::vector<Point<deal_II_dimension> >& curve_points,
-                                    const Tensor<1, deal_II_dimension>& direction=Tensor<1,deal_II_dimension>(),
+                                    const Tensor<1, deal_II_dimension>& direction,
                                     const bool closed,
                                     const double tolerance);
 


### PR DESCRIPTION
`Intel 18` reported some missing return values and a default argument in explicit instantiations as warnings.