### PR TITLE
Fix BOOST/ZLIB quicktest

### DIFF
--- a/tests/quick_tests/CMakeLists.txt
+++ b/tests/quick_tests/CMakeLists.txt
@@ -180,7 +180,7 @@ ENDIF()
 
 # Test Zlib and Boost
 IF (DEAL_II_WITH_ZLIB)
-make_quicktest("boost_zlib" ${_mybuild} "")
+  make_quicktest("boost_zlib" ${_mybuild} "")
 ENDIF()
 
 # A custom test target:

--- a/tests/quick_tests/boost_zlib.cc
+++ b/tests/quick_tests/boost_zlib.cc
@@ -20,6 +20,8 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/point.h>
 
+#include <iostream>
+
 using namespace dealii;
 
 template <int dim>


### PR DESCRIPTION
`std::cout` requires `<iostream>`. That seems to be missing.