### PR TITLE
Fix typo in GridOutFlags::Vtu

### DIFF
--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -750,7 +750,7 @@ namespace GridOutFlags
 
   /**
    * Flags for grid output in Vtu format. These flags are the same as those
-   * declared in DataOutBase::VtuFlags.
+   * declared in DataOutBase::VtkFlags.
    *
    * @ingroup output
    */


### PR DESCRIPTION
In fact, there doesn't exist `DataOutBase::VtuFlags` and both `DataOutFlags::Vtu` and `DataOutFlags::Vtk` coincide with `DataOutBase::VtkFlags`.