### PR TITLE
Fix hierarchical renumbering

### DIFF
--- a/doc/news/changes/minor/20171231Bangerth
+++ b/doc/news/changes/minor/20171231Bangerth
@@ -1,0 +1,7 @@
+Fixed: In parallel computations, the DoFRenumbering::hierarchical()
+function created DoF indices that were dependent on the previous DoF
+indices owned by each processor. This was not intended: the new DoF
+indices were supposed to only depend on the order of cells, not any
+previous numbering. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2017/12/31)

--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -752,10 +752,35 @@ namespace DoFRenumbering
    */
 
   /**
-   * Renumber the degrees cell by cell in hierarchical order (also known as
-   * z-order). The main usage is that this guarantees the same ordering
-   * independent of the number of processors involved in a parallel
-   * distributed computation.
+   * Renumber the degrees cell by cell by traversing the cells in
+   * @ref GlossZOrder "Z order".
+   *
+   * There are two reasons to use this function:
+   * - It produces a predictable ordering of degrees of freedom
+   *   that is independent of how exactly you arrived at a mesh.
+   *   In particular, in general the order of cells of a mesh
+   *   depends on the order in which cells were marked for
+   *   refinement and coarsening during the refinement cycles
+   *   the mesh has undergone. On the other hand, the z-order
+   *   of cells is independent of the mesh's history, and so yields a
+   *   predictable DoF numbering.
+   * - For meshes described by parallel::distributed::Triangulation,
+   *   the @ref GlossLocallyOwnedCell "locally owned cells" of
+   *   each MPI process are contiguous in Z order. That means that
+   *   numbering degrees of freedom by visiting cells in Z order yields
+   *   @ref GlossLocallyOwnedDof "locally owned DoF indices" that consist
+   *   of contiguous ranges for each process. This is also true for the
+   *   default ordering of DoFs on such triangulations, but the default
+   *   ordering creates an enumeration that also depends on how many
+   *   processors participate in the mesh, whereas the one generated
+   *   by this function enumerates the degrees of freedom on a particular
+   *   cell with indices that will be the same regardless of how many
+   *   processes the mesh is split up between.
+   *
+   * This function generates an ordering that is independent of the previous
+   * numbering of degrees of freedom. In other words, any information that may
+   * have been produced by a previous call to a renumbering function is
+   * ignored.
    */
   template <int dim>
   void

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1215,6 +1215,14 @@ namespace DoFRenumbering
         }
       else
         {
+          // this is a terminal cell. we need to renumber its DoF indices. there
+          // are now three cases to decide:
+          // - this is a sequential triangulation: we can just go ahead and number
+          //   the DoFs in the order in which we encounter cells. in this case,
+          //   all cells are actually locally owned
+          // - if this is a parallel::distributed::Triangulation, then we only
+          //   need to work on the locally owned cells since they contain
+          //   all locally owned DoFs.
           if (cell->is_locally_owned())
             {
               // first get the existing DoF indices

--- a/tests/mpi/renumber_z_order_04.cc
+++ b/tests/mpi/renumber_z_order_04.cc
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test that DofRenumbering::hierarchical() gives the same DoF numbers
+// independent of their previous ordering. This was broken before where
+// the hierarchical numbering on each processor re-used the indices
+// the processor previously owned. This worked just fine with the
+// original ordering used by default by DoFHandler, but not if there
+// was another reordering step in between
+
+
+#include "../tests.h"
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <boost/concept_check.hpp>
+
+
+void test()
+{
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+
+  parallel::distributed::Triangulation<2> tr (MPI_COMM_WORLD);
+  GridGenerator::subdivided_hyper_rectangle (tr, std::vector<unsigned int> {{2,2}}, Point<2>(), Point<2>(2,2));
+
+  const FE_Q<2> fe (1);
+
+  for (unsigned int test=0; test<2; ++test)
+    {
+      DoFHandler<2> dof_handler (tr);
+      dof_handler.distribute_dofs (fe);
+
+      // in the second test run, revert the global order of DoF
+      // indices. the point is to make sure that processors do not
+      // have strictly increasing, contiguous groups of DoF indices.
+      if (test==1)
+        {
+          IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs ();
+          std::vector<types::global_dof_index> new_numbers (locally_owned_dofs.n_elements());
+          for (auto i : locally_owned_dofs)
+            new_numbers[locally_owned_dofs.index_within_set(i)]
+              = dof_handler.n_dofs() - i - 1;
+          dof_handler.renumber_dofs (new_numbers);
+        }
+
+      // next, let the hierarchical numbering work on it. the
+      // important aspect is that the result of hierarchical
+      // renumbering should not depend on the *previous* numbering. so
+      // we should be getting the same output as in the first run
+      DoFRenumbering::hierarchical (dof_handler);
+
+      // output DoF indices
+      deallog << (test == 0 ? "Without " : "With ") << "prior reordering:" << std::endl;
+      const unsigned int dofs_per_cell = fe.dofs_per_cell;
+      std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
+      DoFHandler<2>::active_cell_iterator
+      cell = dof_handler.begin_active(),
+      endc = dof_handler.end();
+      for (; cell != endc; ++cell)
+        if (cell->subdomain_id() == tr.locally_owned_subdomain())
+          {
+            deallog << "Cell=" << cell << std::endl;
+            cell->get_dof_indices (local_dof_indices);
+            for (auto i : local_dof_indices)
+              deallog << i << ' ';
+            deallog << std::endl;
+          }
+    }
+}
+
+
+int main (int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+  MPILogInitAll log;
+
+  test();
+}

--- a/tests/mpi/renumber_z_order_04.with_p4est=true.mpirun=4.output
+++ b/tests/mpi/renumber_z_order_04.with_p4est=true.mpirun=4.output
@@ -1,0 +1,31 @@
+
+DEAL:0::Without prior reordering:
+DEAL:0::Cell=0.0
+DEAL:0::0 1 2 3 
+DEAL:0::With prior reordering:
+DEAL:0::Cell=0.0
+DEAL:0::0 1 2 3 
+
+DEAL:1::Without prior reordering:
+DEAL:1::Cell=0.1
+DEAL:1::1 4 3 5 
+DEAL:1::With prior reordering:
+DEAL:1::Cell=0.1
+DEAL:1::1 4 3 5 
+
+
+DEAL:2::Without prior reordering:
+DEAL:2::Cell=0.2
+DEAL:2::2 3 6 7 
+DEAL:2::With prior reordering:
+DEAL:2::Cell=0.2
+DEAL:2::2 3 6 7 
+
+
+DEAL:3::Without prior reordering:
+DEAL:3::Cell=0.3
+DEAL:3::3 5 7 8 
+DEAL:3::With prior reordering:
+DEAL:3::Cell=0.3
+DEAL:3::3 5 7 8 
+


### PR DESCRIPTION
This implements what I've been arguing in #5686. It doesn't deal with the shared triangulation part requested in #5622, but only ensures that the `DoFRenumbering::hierarchical()` enumerates DoF indices without regards to any previous numbering.