### PR TITLE
Do not use pedantic when cuda support is enabled

### DIFF
--- a/cmake/configure/configure_1_cuda.cmake
+++ b/cmake/configure/configure_1_cuda.cmake
@@ -115,6 +115,12 @@ MACRO(FEATURE_CUDA_CONFIGURE_EXTERNAL)
   #
   ADD_FLAGS(DEAL_II_CUDA_FLAGS "${DEAL_II_CXX_VERSION_FLAG}")
 
+  # We cannot use -pedantic as compiler flags. nvcc generates code that
+  # produces a lot of warnings when pedantic is enabled. So filter out the
+  # flag:
+  #
+  STRING(REPLACE "-pedantic" "" DEAL_II_CXX_FLAGS "${DEAL_II_CXX_FLAGS}")
+
   #
   # Export definitions:
   #


### PR DESCRIPTION
nvcc generates code that produces a lot of warnings when pedantic is used. Since the code is generated by nvcc there is nothing we can do about it except not using pedantic. I am not too happy about this but there is nothing else we can do. Right now compiling cuda codes produces hundreds of warnings of the form `style of line directive is a GCC extension` 