### PR TITLE
Make the instructions for the p4est installation script more precise

### DIFF
--- a/doc/external-libs/p4est.html
+++ b/doc/external-libs/p4est.html
@@ -35,10 +35,11 @@
       If you want to use the script, copy the tarball to a fresh directory
       together with the <a href="p4est-setup.sh">p4est-setup.sh script</a>
       (the one from this link, not one you may have gotten from the p4est
-      webpage). Then call the script as follows:
+      webpage). Then make the file executable and call the script as follows:
       <pre>
 
-sh ./p4est-setup.sh p4est-x-y-z.tar.gz /path/to/installation
+chmod u+x p4est-setup.sh
+./p4est-setup.sh p4est-x-y-z.tar.gz /path/to/installation
       </pre>
       where <code>p4est-x-y-z.tar.gz</code> is the name of the p4est
       distribution file, and <code>/path/to/installation</code> is a


### PR DESCRIPTION
We in fact require a `bash` and not `sh`. Therefore,
```
sh ./p4est-setup.sh p4est-x-y-z.tar.gz /path/to/installation
```
might not work. Just making the script executable seems to be easier.