### PR TITLE
Be explicit about virtual functions called in con-/destructors

### DIFF
--- a/include/deal.II/base/time_stepping.templates.h
+++ b/include/deal.II/base/time_stepping.templates.h
@@ -55,7 +55,7 @@ namespace TimeStepping
   template <typename VectorType>
   ExplicitRungeKutta<VectorType>::ExplicitRungeKutta(const runge_kutta_method method)
   {
-    initialize(method);
+    ExplicitRungeKutta<VectorType>::initialize(method);
   }
 
 
@@ -211,7 +211,7 @@ namespace TimeStepping
     max_it(max_it),
     tolerance(tolerance)
   {
-    initialize(method);
+    ImplicitRungeKutta<VectorType>::initialize(method);
   }
 
 
@@ -417,7 +417,7 @@ namespace TimeStepping
     last_same_as_first(false),
     last_stage(nullptr)
   {
-    initialize(method);
+    EmbeddedExplicitRungeKutta<VectorType>::initialize(method);
   }
 
 

--- a/include/deal.II/lac/block_sparse_matrix.templates.h
+++ b/include/deal.II/lac/block_sparse_matrix.templates.h
@@ -27,7 +27,7 @@ template <typename number>
 BlockSparseMatrix<number>::
 BlockSparseMatrix (const BlockSparsityPattern &sparsity)
 {
-  reinit (sparsity);
+  BlockSparseMatrix<number>::reinit (sparsity);
 }
 
 

--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -332,7 +332,7 @@ ChunkSparseMatrix<number>::ChunkSparseMatrix (const ChunkSparsityPattern &c)
   val(nullptr),
   max_len(0)
 {
-  reinit (c);
+  ChunkSparseMatrix<number>::reinit (c);
 }
 
 
@@ -349,7 +349,7 @@ ChunkSparseMatrix<number>::ChunkSparseMatrix (const ChunkSparsityPattern &c,
   Assert (c.n_rows() == id.m(), ExcDimensionMismatch (c.n_rows(), id.m()));
   Assert (c.n_cols() == id.n(), ExcDimensionMismatch (c.n_cols(), id.n()));
 
-  reinit (c);
+  ChunkSparseMatrix<number>::reinit (c);
   for (size_type i=0; i<n(); ++i)
     this->set(i,i,1.);
 }

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -673,7 +673,7 @@ namespace LinearAlgebra
     :
     val(nullptr)
   {
-    reinit(0, true);
+    ReadWriteVector<Number>::reinit(0, true);
   }
 
 
@@ -696,7 +696,7 @@ namespace LinearAlgebra
     :
     val(nullptr)
   {
-    reinit (size, false);
+    ReadWriteVector<Number>::reinit (size, false);
   }
 
 
@@ -707,7 +707,7 @@ namespace LinearAlgebra
     :
     val(nullptr)
   {
-    reinit (locally_stored_indices);
+    ReadWriteVector<Number>::reinit (locally_stored_indices);
   }
 
 

--- a/include/deal.II/lac/sparse_decomposition.templates.h
+++ b/include/deal.II/lac/sparse_decomposition.templates.h
@@ -40,7 +40,7 @@ SparseLUDecomposition<number>::SparseLUDecomposition()
 template <typename number>
 SparseLUDecomposition<number>::~SparseLUDecomposition()
 {
-  clear();
+  SparseLUDecomposition<number>::clear();
 }
 
 

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -126,7 +126,7 @@ SparseMatrix<number>::SparseMatrix (const SparsityPattern &c)
   val(nullptr),
   max_len(0)
 {
-  reinit (c);
+  SparseMatrix<number>::reinit (c);
 }
 
 
@@ -143,7 +143,7 @@ SparseMatrix<number>::SparseMatrix (const SparsityPattern &c,
   Assert (c.n_rows() == id.m(), ExcDimensionMismatch (c.n_rows(), id.m()));
   Assert (c.n_cols() == id.n(), ExcDimensionMismatch (c.n_cols(), id.n()));
 
-  reinit (c);
+  SparseMatrix<number>::reinit (c);
   for (size_type i=0; i<n(); ++i)
     this->set(i,i,1.);
 }

--- a/include/deal.II/lac/sparse_mic.templates.h
+++ b/include/deal.II/lac/sparse_mic.templates.h
@@ -36,7 +36,7 @@ SparseMIC<number>::SparseMIC ()
 template <typename number>
 SparseMIC<number>::~SparseMIC()
 {
-  clear();
+  SparseMIC<number>::clear();
 }
 
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -978,7 +978,7 @@ Vector<Number>::Vector ()
   max_vec_size(0),
   values(nullptr, &free)
 {
-  reinit(0);
+  Vector<Number>::reinit(0);
 }
 
 
@@ -1007,7 +1007,7 @@ Vector<Number>::Vector (const size_type n)
   max_vec_size(0),
   values(nullptr, &free)
 {
-  reinit (n, false);
+  Vector<Number>::reinit (n, false);
 }
 
 

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -897,7 +897,7 @@ DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::DataOut_DoFData ()
 template <typename DoFHandlerType, int patch_dim, int patch_space_dim>
 DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::~DataOut_DoFData ()
 {
-  clear ();
+  DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::clear ();
 }
 
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1304,7 +1304,7 @@ namespace parallel
     template <int dim, int spacedim>
     Triangulation<dim,spacedim>::~Triangulation ()
     {
-      clear ();
+      Triangulation<dim, spacedim>::clear ();
 
       Assert (triangulation_has_content == false,
               ExcInternalError());

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -683,7 +683,7 @@ template <int dim, int spacedim>
 DoFHandler<dim,spacedim>::~DoFHandler ()
 {
   // release allocated memory
-  clear ();
+  DoFHandler<dim, spacedim>::clear ();
 
   // also release the policy. this needs to happen before the
   // current object disappears because the policy objects

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -1009,7 +1009,7 @@ namespace hp
     tria_listeners.clear ();
 
     // ...and release allocated memory
-    clear ();
+    DoFHandler<dim, spacedim>::clear ();
   }
 
 

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -31,7 +31,7 @@ namespace PETScWrappers
     Vector::Vector ()
       : communicator (MPI_COMM_SELF)
     {
-      create_vector(0, 0);
+      Vector::create_vector(0, 0);
     }
 
 

--- a/source/lac/trilinos_epetra_communication_pattern.cc
+++ b/source/lac/trilinos_epetra_communication_pattern.cc
@@ -37,7 +37,7 @@ namespace LinearAlgebra
                                                const IndexSet &read_write_vector_index_set,
                                                const MPI_Comm &communicator)
     {
-      reinit(vector_space_vector_index_set, read_write_vector_index_set, communicator);
+      CommunicationPattern::reinit(vector_space_vector_index_set, read_write_vector_index_set, communicator);
     }
 
 


### PR DESCRIPTION
Virtual functions in constructors and destructors don't behave like call in other contexts.
This PR makes clear which function is called. Noticed by `clang-analyze`.