### PR TITLE
Minor change in FE Enriched element

### DIFF
--- a/doc/news/changes/minor/20180115NiveshD
+++ b/doc/news/changes/minor/20180115NiveshD
@@ -1,0 +1,5 @@
+Fixed: In FE_Enriched element, avoid evaluating quadrature points if no dofs are
+assigned. This happens when FE_Nothing is used together with other FE
+(i.e. FE_Q) as enrichments in FE_Enriched constructor.
+<br>
+(Nivesh Dommaraju, 2018/01/15)

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -663,6 +663,11 @@ FE_Enriched<dim,spacedim>::multiply_by_enrichment
                                    fe_data.enrichment[base_no].size()));
       for (unsigned int m=0; m < base_no_mult_local_enriched_dofs[base_no].size(); m++)
         {
+          //Avoid evaluating quadrature points if no dofs are assigned. This
+          //happens when FE_Nothing is used together with other FE (i.e. FE_Q) as enrichments.
+          if (base_no_mult_local_enriched_dofs[base_no][m].size()==0)
+            continue;
+
           Assert (enrichments[base_no-1][m](cell) != nullptr,
                   ExcMessage("The pointer to the enrichment function is NULL"));
 

--- a/tests/fe/fe_enriched_compare_to_fe_system_2.cc
+++ b/tests/fe/fe_enriched_compare_to_fe_system_2.cc
@@ -215,10 +215,12 @@ void test(const FiniteElement<dim> &fe_base,
   p2[0] = 10.0;
   p3[0] = 5.0;
   EnrichmentFunction<dim> fun1(p1), fun2(p2),fun3(p3);
-  std::vector<const FiniteElement<dim> *> fe_enrichements(2);
+  std::vector<const FiniteElement<dim> *> fe_enrichements(3);
   fe_enrichements[0] = &fe_en1;
   fe_enrichements[1] = &fe_en2;
-  std::vector<std::vector<std::function<const Function<dim> *(const typename Triangulation<dim, dim>::cell_iterator &) > > > functions(2);
+  FE_Nothing<dim> fe_nothing(1,true);
+  fe_enrichements[2] = &fe_nothing; //should be ignored
+  std::vector<std::vector<std::function<const Function<dim> *(const typename Triangulation<dim, dim>::cell_iterator &) > > > functions(3);
   functions[0].resize(1);
   functions[0][0] = [&](const typename Triangulation<dim, dim>::cell_iterator &)
   {
@@ -232,6 +234,12 @@ void test(const FiniteElement<dim> &fe_base,
   functions[1][1] = [&](const typename Triangulation<dim, dim>::cell_iterator &)
   {
     return &fun3;
+  };
+  functions[2].resize(1);
+  functions[2][0] = [&](const typename Triangulation<dim, dim>::cell_iterator &)
+  {
+    AssertThrow(false, ExcMessage("Called enrichment function for FE_Nothing"));
+    return nullptr;
   };
 
   FE_Enriched<dim> fe_enriched(&fe_base,


### PR DESCRIPTION
Allow for dummy FE elements (FE_Nothing) in the construction of FE_Enriched element. In this case, since no Dofs are actually assigned to these, evaluation at quadrature points is skipped for the dummy FE elements.

The constructor in consideration is:
https://www.dealii.org/developer/doxygen/deal.II/classFE__Enriched.html#ad31122d9fe2f4be2ba7f084b87635127