### PR TITLE
Fix CUDAVector::add_and_dot() for complex-valued vectors.

### DIFF
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -215,6 +215,7 @@ namespace numbers
      * function simply returns the given number.
      */
     static
+    DEAL_II_CUDA_HOST_DEV
     const number &conjugate (const number &x);
 
     /**
@@ -329,6 +330,7 @@ namespace numbers
 
 
   template <typename number>
+  DEAL_II_CUDA_HOST_DEV
   const number &
   NumberTraits<number>::conjugate (const number &x)
   {

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -451,7 +451,7 @@ namespace LinearAlgebra
         if (global_idx < N)
           {
             v1[global_idx] += a*v2[global_idx];
-            res_buf[local_idx] = v1[global_idx]*v3[global_idx];
+            res_buf[local_idx] = v1[global_idx] * Number(numbers::NumberTraits<Number>::conjugate(v3[global_idx]));
           }
         else
           res_buf[local_idx] = 0.;


### PR DESCRIPTION
I have no way of testing that this even compiles, but given the discussion in #5747 and the doc updates in #5749, I think that the current CUDA Vector implementation of `add_and_dot` is in fact wrong. This patch tries to fix this, but I'd appreciate one of our CUDA experts to take a look.

For reference, this is what most of the other vector classes ultimately call:
```
      Number
      operator() (const size_type i) const
      {
        X[i] += a * V[i];
        return X[i] * Number(numbers::NumberTraits<Number>::conjugate(W[i]));
      }
```