### PR TITLE
Make it clear that our CUDA wrappers only support float and double

### DIFF
--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -38,6 +38,8 @@ namespace LinearAlgebra
      * This class implements a vector using CUDA for use on Nvidia GPUs. This
      * class is derived from the LinearAlgebra::VectorSpaceVector class.
      *
+     * @note Only float and double are supported.
+     *
      * @ingroup CUDAWrappers
      * @ingroup Vectors
      * @author Karl Ljungkvist, Bruno Turcksin, 2016
@@ -215,8 +217,8 @@ namespace LinearAlgebra
        * twice. Since most vector operations are memory transfer limited, this
        * reduces the time by 25\% (or 50\% if @p W equals @p this).
        *
-       * For complex-valued vectors, the scalar product in the second step is implemented as
-       * $\left<v,w\right>=\sum_i v_i \bar{w_i}$.
+       * For complex-valued vectors, the scalar product in the second step is
+       * implemented as $\left<v,w\right>=\sum_i v_i \bar{w_i}$.
        */
       virtual Number add_and_dot(const Number                     a,
                                  const VectorSpaceVector<Number> &V,

--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -59,8 +59,8 @@ namespace CUDAWrappers
    * a vector Laplace equation), they can be applied simultaneously with one call
    * (and often more efficiently). Defaults to 1
    *
-   * @tparam Number Number format, usually @p double or @p float. Defaults to @p
-   * double
+   * @tparam Number Number format, @p double or @p float. Defaults to @p
+   * double.
    *
    * @ingroup CUDAWrappers
    *

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -65,6 +65,8 @@ namespace CUDAWrappers
    * This class traverse the cells in a different order than the usual
    * Triangulation class in deal.II.
    *
+   * @note Only float and double are supported.
+   *
    * @ingroup CUDAWrappers
    */
   template <int dim, typename Number=double>


### PR DESCRIPTION
Revert part of #5749 and make it clear in the documentation that our CUDA wrappers only support `float` and `double`.