### PR TITLE
 Print out more info when TFI encounters errors.

### DIFF
--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1859,7 +1859,7 @@ TransfiniteInterpolationManifold<dim, spacedim>
           // generate additional information to help debugging why we did not
           // get a point
           std::ostringstream message;
-          for (unsigned int b=0; b<c; ++b)
+          for (unsigned int b=0; b<=c; ++b)
             {
               typename Triangulation<dim,spacedim>::cell_iterator cell(triangulation,
                                                                        level_coarse,


### PR DESCRIPTION
the upper loop bound, `c`, cannot be larger than the maximum valid index into the relevant array: therefore we should use `<=` instead of `<` in a loop bounded above by `c`.

I noticed this while investigating the issue at https://groups.google.com/forum/#!topic/dealii/7rhZad4KWOw .