### PR TITLE
Use std::abs instead of abs.

### DIFF
--- a/tests/base/function_parser_03.cc
+++ b/tests/base/function_parser_03.cc
@@ -39,17 +39,13 @@ int main ()
   fp.initialize("s,t", "s*t+1", constants);
 
   double value = fp.value(Point<2>(2.0,2.5));
-  Assert(abs(1.0+2.0*2.5 - value) < 1e-10, ExcMessage("wrong value"));
+  Assert(std::abs(1.0+2.0*2.5 - value) < 1e-10, ExcMessage("wrong value"));
 
   std::vector<std::string> expressions;
   expressions.push_back("sin(2*mypi*x)+y");
   constants["mypi"] = numbers::PI;
   fp.initialize("x,y", expressions, constants);
   double value1 = fp.value(Point<2>(1.0,2.5), 0);
-  Assert(abs(2.5 - value1) < 1e-10, ExcMessage("wrong value"));
+  Assert(std::abs(2.5 - value1) < 1e-10, ExcMessage("wrong value"));
 
 }
-
-
-
-

--- a/tests/base/function_parser_04.cc
+++ b/tests/base/function_parser_04.cc
@@ -48,10 +48,10 @@ void assemble(const std::vector<int>::iterator &it,
 {
   double s = *it;
   double value = fp.value(Point<2>(s, 2.5));
-  Assert(abs(1.0+s*2.5 - value) < 1e-10, ExcMessage("wrong value"));
+  Assert(std::abs(1.0+s*2.5 - value) < 1e-10, ExcMessage("wrong value"));
   std::cout << data.value  << std::endl;
 
-  data.value = (abs(1.0+s*2.5 - value) < 1e-10)?1:0;
+  data.value = (std::abs(1.0+s*2.5 - value) < 1e-10)?1:0;
 }
 
 void copy(int &value, const copy_data &data)
@@ -90,7 +90,3 @@ int main ()
 
   test2();
 }
-
-
-
-

--- a/tests/bits/find_cell_12.cc
+++ b/tests/bits/find_cell_12.cc
@@ -66,7 +66,7 @@ void test()
   for (; cell!=endc; ++cell)
     {
       Point<2> cell_center = cell->center();
-      if (abs(cell_center(0) - 1500) < 550)
+      if (std::abs(cell_center(0) - 1500) < 550)
         {
           cell->set_refine_flag ();
         }

--- a/tests/codim_one/integrate_log_2.cc
+++ b/tests/codim_one/integrate_log_2.cc
@@ -95,7 +95,7 @@ int main()
                     {
                       double qpow = pow(quad.point(q)[0], (double) power);
                       approx_integral += qpow  * quad.weight(q);
-                      double factor = log(abs( (factored_quad.point(q)-origins[nos])[0] )/alphas[nas] );
+                      double factor = log(std::abs( (factored_quad.point(q)-origins[nos])[0] )/alphas[nas] );
                       // This code cannot work if factor is equal to
                       // zero. In this case, just pass the other
                       // quadrature formula, which should be valid anyway.
@@ -112,9 +112,9 @@ int main()
 
                   deallog << "   Error(n=" << quad.size()
                           << ") = " << (approx_integral - exact_integral);
-                  if ( abs(approx_integral - approx_integral_factored) > eps )
+                  if ( std::abs(approx_integral - approx_integral_factored) > eps )
                     deallog << ", difference between factored and unfactored: "
-                            << abs(approx_integral - approx_integral_factored);
+                            << std::abs(approx_integral - approx_integral_factored);
                   deallog << endl;
                 }
             }

--- a/tests/multigrid/transfer_04.cc
+++ b/tests/multigrid/transfer_04.cc
@@ -153,7 +153,7 @@ void check_fe(FiniteElement<dim> &fe)
     for (unsigned int i=0; i<dofh.locally_owned_dofs().n_elements(); ++i)
       {
         unsigned int index = dofh.locally_owned_dofs().nth_index_in_set(i);
-        if (abs(v[index] - 1.0)>1e-5)
+        if (std::abs(v[index] - 1.0)>1e-5)
           deallog << "ERROR: index=" << index << " is equal to " << v[index] << std::endl;
       }
   }


### PR DESCRIPTION
On some compilers (notably GCC 4.8.4, in some configurations) 'abs' refers to'int abs(int)', and gives the wrong answer for floating point arguments.

This is a followup to #5761.