### PR TITLE
Avoid link errors in GeometryInfo<0>

### DIFF
--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -1121,7 +1121,7 @@ struct GeometryInfo<0>
    * with the UCD numbering, this field can also be used like a
    * old_to_lexicographic mapping.
    */
-  static constexpr std::array<unsigned int, vertices_per_cell> ucd_to_deal {{0}};
+  static const std::array<unsigned int, vertices_per_cell> ucd_to_deal;
 
   /**
    * Rearrange vertices for OpenDX output.  For a cell being written in OpenDX
@@ -1136,7 +1136,7 @@ struct GeometryInfo<0>
    *   out << cell->vertex(dx_to_deal[i]);
    * @endcode
    */
-  static constexpr std::array<unsigned int, vertices_per_cell> dx_to_deal {{0}};
+  static const std::array<unsigned int, vertices_per_cell> dx_to_deal;
 };
 
 

--- a/source/base/geometry_info.cc
+++ b/source/base/geometry_info.cc
@@ -54,12 +54,11 @@ template <int dim>
 constexpr std::array<unsigned int, GeometryInfo<dim>::vertices_per_cell>
 GeometryInfo<dim>::ucd_to_deal;
 
-constexpr std::array<unsigned int, GeometryInfo<0>::vertices_per_cell>
-GeometryInfo<0>::ucd_to_deal;
+const std::array<unsigned int, GeometryInfo<0>::vertices_per_cell>
+GeometryInfo<0>::ucd_to_deal = {{0}};
 
-constexpr std::array<unsigned int, GeometryInfo<0>::vertices_per_cell>
-GeometryInfo<0>::dx_to_deal;
-
+const std::array<unsigned int, GeometryInfo<0>::vertices_per_cell>
+GeometryInfo<0>::dx_to_deal = {{0}};
 
 template struct GeometryInfo<1>;
 template struct GeometryInfo<2>;


### PR DESCRIPTION
Fixes #5770.
I had the linker problem with `clang-5.0.0` as well. Going back to `const [...] GeometryInfo<0>::ucd_to_deal` and `const [...] GeometryInfo<0>::dx_to_deal` instead of `constexpr [...] GeometryInfo::ucd_to_deal` and `constexpr [...] GeometryInfo<0>::dx_to_deal`as a workaround fixes the issue for me.

@davydden Please try if this helps for mac as well.