### PR TITLE
Tensor iterators

### DIFF
--- a/doc/news/changes/minor/20180125DanielArndt
+++ b/doc/news/changes/minor/20180125DanielArndt
@@ -1,0 +1,5 @@
+New: Tensor::begin_raw, Tensor::end_raw, SymmetricTensor::begin_raw
+and SymmetricTensor::end_raw provide access to the underlying storage for Tensor
+and SymmetricTensor.
+<br>
+(Daniel Arndt, 2018/01/25)

--- a/doc/news/changes/minor/20180125DanielArndt-1
+++ b/doc/news/changes/minor/20180125DanielArndt-1
@@ -1,0 +1,4 @@
+New: There are new overloads of make_array_view for Tensor, SymmetricTensor,
+LAPACKFullMatrix, C-style array and Vector.
+<br>
+(Daniel Arndt, 2018/01/25)

--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -366,20 +366,9 @@ namespace Utilities
     sum (const Tensor<rank,dim,Number> &local,
          const MPI_Comm &mpi_communicator)
     {
-      const unsigned int n_entries = Tensor<rank,dim,Number>::n_independent_components;
-      Number entries[ Tensor<rank,dim,Number>::n_independent_components ];
-
-      for (unsigned int i=0; i< n_entries; ++i)
-        entries[i] = local[ local.unrolled_to_component_indices(i) ];
-
-      Number global_entries[ Tensor<rank,dim,Number>::n_independent_components ];
-      dealii::Utilities::MPI::sum( entries, mpi_communicator, global_entries );
-
-      Tensor<rank,dim,Number> global;
-      for (unsigned int i=0; i< n_entries; ++i)
-        global[ global.unrolled_to_component_indices(i) ] = global_entries[i];
-
-      return global;
+      Tensor<rank, dim, Number> sums;
+      dealii::Utilities::MPI::sum(local, mpi_communicator, sums);
+      return sums;
     }
 
 

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -604,6 +604,31 @@ public:
   SymmetricTensor (const SymmetricTensor<rank_,dim,OtherNumber> &initializer);
 
   /**
+   * Return a pointer to the first element of the underlying storage.
+   */
+  Number *
+  begin_raw();
+
+  /**
+   * Return a const pointer to the first element of the underlying storage.
+   */
+  const Number *
+  begin_raw() const;
+
+  /**
+   * Return a pointer to the element past the end of the underlying storage.
+   */
+  Number *
+  end_raw();
+
+  /**
+   * Return a const pointer to the element past the end of the underlying
+   * storage.
+   */
+  const Number *
+  end_raw() const;
+
+  /**
    * Assignment operator from symmetric tensors with different underlying scalar type.
    * This obviously requires that the @p OtherNumber type is convertible to
    * @p Number.
@@ -707,9 +732,9 @@ public:
   Number &operator() (const TableIndices<rank_> &indices);
 
   /**
-   * Return an element by value.
+   * Return a @p const reference to the value referred to by the argument.
    */
-  Number operator() (const TableIndices<rank_> &indices) const;
+  const Number &operator() (const TableIndices<rank_> &indices) const;
 
   /**
    * Access the elements of a row of this symmetric tensor. This function is
@@ -726,11 +751,11 @@ public:
   operator [] (const unsigned int row);
 
   /**
-   * Return an element by value.
+   * Return a @p const reference to the value referred to by the argument.
    *
    * Exactly the same as operator().
    */
-  Number
+  const Number &
   operator [] (const TableIndices<rank_> &indices) const;
 
   /**
@@ -746,7 +771,7 @@ public:
    * <tt>s.access_raw_entry(unrolled_index)</tt> does the same as
    * <tt>s[s.unrolled_to_component_indices(i)]</tt>, but more efficiently.
    */
-  Number
+  const Number &
   access_raw_entry (const unsigned int unrolled_index) const;
 
   /**
@@ -1684,7 +1709,7 @@ namespace internal
 
   template <int dim, typename Number>
   inline
-  Number
+  const Number &
   symmetric_tensor_access (const TableIndices<2> &indices,
                            const typename SymmetricTensorAccessors::StorageType<2,dim,Number>::base_tensor_type &data)
   {
@@ -1833,7 +1858,7 @@ namespace internal
 
   template <int dim, typename Number>
   inline
-  Number
+  const Number &
   symmetric_tensor_access (const TableIndices<4> &indices,
                            const typename SymmetricTensorAccessors::StorageType<4,dim,Number>::base_tensor_type &data)
   {
@@ -1952,7 +1977,7 @@ SymmetricTensor<rank_,dim,Number>::operator () (const TableIndices<rank_> &indic
 
 template <int rank_, int dim, typename Number>
 inline
-Number
+const Number &
 SymmetricTensor<rank_,dim,Number>::operator ()
 (const TableIndices<rank_> &indices) const
 {
@@ -2021,7 +2046,7 @@ SymmetricTensor<rank_,dim,Number>::operator [] (const unsigned int row)
 
 template <int rank_, int dim, typename Number>
 inline
-Number
+const Number &
 SymmetricTensor<rank_,dim,Number>::operator [] (const TableIndices<rank_> &indices) const
 {
   return operator()(indices);
@@ -2037,6 +2062,45 @@ SymmetricTensor<rank_,dim,Number>::operator [] (const TableIndices<rank_> &indic
   return operator()(indices);
 }
 
+
+
+template <int rank_, int dim, typename Number>
+inline
+Number *
+SymmetricTensor<rank_,dim,Number>::begin_raw()
+{
+  return std::addressof(this->access_raw_entry(0));
+}
+
+
+
+template <int rank_, int dim, typename Number>
+inline
+const Number *
+SymmetricTensor<rank_,dim,Number>::begin_raw() const
+{
+  return std::addressof(this->access_raw_entry(0));
+}
+
+
+
+template <int rank_, int dim, typename Number>
+inline
+Number *
+SymmetricTensor<rank_,dim,Number>::end_raw()
+{
+  return begin_raw()+n_independent_components;
+}
+
+
+
+template <int rank_, int dim, typename Number>
+inline
+const Number *
+SymmetricTensor<rank_,dim,Number>::end_raw() const
+{
+  return begin_raw()+n_independent_components;
+}
 
 
 
@@ -2070,7 +2134,7 @@ namespace internal
 
 template <int rank_, int dim, typename Number>
 inline
-Number
+const Number &
 SymmetricTensor<rank_,dim,Number>::access_raw_entry (const unsigned int index) const
 {
   AssertIndexRange (index, n_independent_components);

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -152,6 +152,31 @@ public:
   Tensor (const OtherNumber &initializer);
 
   /**
+   * Return a pointer to the first element of the underlying storage.
+   */
+  Number *
+  begin_raw();
+
+  /**
+   * Return a const pointer to the first element of the underlying storage.
+   */
+  const Number *
+  begin_raw() const;
+
+  /**
+   * Return a pointer to the element past the end of the underlying storage.
+   */
+  Number *
+  end_raw();
+
+  /**
+   * Return a const pointer to the element past the end of the underlying
+   * storage.
+   */
+  const Number *
+  end_raw() const;
+
+  /**
    * Return a reference to the encapsulated Number object. Since rank-0
    * tensors are scalars, this is a natural operation.
    *
@@ -426,6 +451,30 @@ public:
   Number &operator [] (const TableIndices<rank_> &indices);
 
   /**
+   * Return a pointer to the first element of the underlying storage.
+   */
+  Number *
+  begin_raw();
+
+  /**
+   * Return a const pointer to the first element of the underlying storage.
+   */
+  const Number *
+  begin_raw() const;
+
+  /**
+   * Return a pointer to the element past the end of the underlying storage.
+   */
+  Number *
+  end_raw();
+
+  /**
+   * Return a pointer to the element past the end of the underlying storage.
+   */
+  const Number *
+  end_raw() const;
+
+  /**
    * Assignment operator from tensors with different underlying scalar type.
    * This obviously requires that the @p OtherNumber type is convertible to @p
    * Number.
@@ -653,6 +702,7 @@ DEAL_II_CUDA_HOST_DEV Tensor<0,dim,Number>::Tensor ()
 }
 
 
+
 template <int dim, typename Number>
 template <typename OtherNumber>
 inline
@@ -662,6 +712,7 @@ Tensor<0,dim,Number>::Tensor (const OtherNumber &initializer)
 }
 
 
+
 template <int dim, typename Number>
 template <typename OtherNumber>
 inline
@@ -669,6 +720,47 @@ Tensor<0,dim,Number>::Tensor (const Tensor<0,dim,OtherNumber> &p)
 {
   value = p.value;
 }
+
+
+
+template <int dim, typename Number>
+inline
+Number *
+Tensor<0,dim,Number>::begin_raw()
+{
+  return std::addressof(value);
+}
+
+
+
+template <int dim, typename Number>
+inline
+const Number *
+Tensor<0,dim,Number>::begin_raw() const
+{
+  return std::addressof(value);
+}
+
+
+
+template <int dim, typename Number>
+inline
+Number *
+Tensor<0,dim,Number>::end_raw()
+{
+  return begin_raw()+n_independent_components;
+}
+
+
+
+template <int dim, typename Number>
+inline
+const Number *
+Tensor<0,dim,Number>::end_raw() const
+{
+  return begin_raw()+n_independent_components;
+}
+
 
 
 template <int dim, typename Number>
@@ -945,6 +1037,7 @@ Tensor<rank_,dim,Number>::operator[] (const TableIndices<rank_> &indices) const
 }
 
 
+
 template <int rank_, int dim, typename Number>
 inline
 Number &
@@ -954,6 +1047,47 @@ Tensor<rank_,dim,Number>::operator[] (const TableIndices<rank_> &indices)
 
   return TensorAccessors::extract<rank_>(*this, indices);
 }
+
+
+
+template <int rank_, int dim, typename Number>
+inline
+Number *
+Tensor<rank_,dim,Number>::begin_raw()
+{
+  return std::addressof(this->operator[](this->unrolled_to_component_indices(0)));
+}
+
+
+
+template <int rank_, int dim, typename Number>
+inline
+const Number *
+Tensor<rank_,dim,Number>::begin_raw() const
+{
+  return std::addressof(this->operator[](this->unrolled_to_component_indices(0)));
+}
+
+
+
+template <int rank_, int dim, typename Number>
+inline
+Number *
+Tensor<rank_,dim,Number>::end_raw()
+{
+  return begin_raw()+n_independent_components;
+}
+
+
+
+template <int rank_, int dim, typename Number>
+inline
+const Number *
+Tensor<rank_,dim,Number>::end_raw() const
+{
+  return begin_raw()+n_independent_components;
+}
+
 
 
 template <int rank_, int dim, typename Number>


### PR DESCRIPTION
Fixes #5787. In particular, `Tensor::raw_begin`, `Tensor::raw_end`, `SymmetricTensor::raw_begin` 
and `SymmetricTensor::raw_end` are introduced that allow access to the underlying storage.
For this to work, the element access provided by `SymmetricTensor::access_raw_entry` had to change from `Number` to `const Number&`. For conformity with the class `Tensor`, I also changed the return type for the `const` version of  `operator[]` (which implied the return type of `symmetric_tensor_access` to also change).

Using these iterators, we can now create an `ArrayView` object for `Tensor` and `SymmetricTensor`. This also allows simplifying the implementation of `Utilities::MPI::sum`.