### PR TITLE
Fix structure of Assert in scalapack.cc

### DIFF
--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -627,9 +627,14 @@ void ScaLAPACKMatrix<NumberType>::least_squares(ScaLAPACKMatrix<NumberType> &B,
   Assert (B.state == LAPACKSupport::matrix,
           ExcMessage("Matrix B has to be in Matrix state before calling this function."));
 
-  transpose ?
-  (Assert(n_columns==B.n_rows,ExcDimensionMismatch(n_columns,B.n_rows))) :
-  (Assert(n_rows==B.n_rows,ExcDimensionMismatch(n_rows,B.n_rows)));
+  if (transpose)
+    {
+      Assert(n_columns==B.n_rows,ExcDimensionMismatch(n_columns,B.n_rows));
+    }
+  else
+    {
+      Assert(n_rows==B.n_rows,ExcDimensionMismatch(n_rows,B.n_rows));
+    }
 
   //see https://www.ibm.com/support/knowledgecenter/en/SSNR5K_4.2.0/com.ibm.cluster.pessl.v4r2.pssl100.doc/am6gr_lgels.htm
   Assert(row_block_size==column_block_size,ExcMessage("Use identical block sizes for rows and columns of matrix A"));


### PR DESCRIPTION
The previous version would result in
```
source/lac/scalapack.cc:631:3: warning: ISO C++ forbids braced-groups within expressions [-Wpedantic]
```
as also detected in [CDash](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=14875).