### PR TITLE
Restrict the template arguments of GridGenerator::hyper_sphere.

### DIFF
--- a/doc/news/changes/minor/20180258Bangerth
+++ b/doc/news/changes/minor/20180258Bangerth
@@ -1,0 +1,6 @@
+Changed: The GridRefinement::hyper_sphere() function used to have two
+template arguments (`dim` and `spacedim`), but it really only existed
+if <code>dim == spacedim-1</code>. Consequently, it now has lost its
+`dim` template argument and has only retained `spacedim`.
+<br>
+(Wolfgang Bangerth, 2018/01/25)

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -461,7 +461,7 @@ namespace GridGenerator
   /**
    * Creates a hyper sphere, i.e., a surface of a ball in @p spacedim
    * dimensions. This function only exists for dim+1=spacedim in 2 and 3 space
-   * dimensions.
+   * dimensions. (To create a mesh of a ball, use GridGenerator::hyper_ball().)
    *
    * You should attach a SphericalManifold to the cells and faces for correct
    * placement of vertices upon refinement and to be able to use higher order
@@ -490,10 +490,10 @@ namespace GridGenerator
    * @note The triangulation needs to be void upon calling this function.
    */
 
-  template <int dim, int spacedim>
-  void hyper_sphere (Triangulation<dim,spacedim> &tria,
-                     const Point<spacedim>   &center = Point<spacedim>(),
-                     const double        radius = 1.);
+  template <int spacedim>
+  void hyper_sphere (Triangulation<spacedim-1,spacedim> &tria,
+                     const Point<spacedim>              &center = Point<spacedim>(),
+                     const double                        radius = 1.);
 
   /**
    * This class produces a hyper-ball intersected with the positive orthant

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3060,11 +3060,13 @@ namespace GridGenerator
       SubCellData());       // no boundary information
   }
 
-  template <int dim, int spacedim>
+
+
+  template <int spacedim>
   void
-  hyper_sphere (Triangulation<dim,spacedim> &tria,
-                const Point<spacedim>   &p,
-                const double      radius)
+  hyper_sphere (Triangulation<spacedim-1,spacedim> &tria,
+                const Point<spacedim>              &p,
+                const double                        radius)
   {
     Triangulation<spacedim> volume_mesh;
     GridGenerator::hyper_ball(volume_mesh,p,radius);
@@ -4646,18 +4648,6 @@ namespace GridGenerator
 }
 
 // explicit instantiations
-namespace GridGenerator
-{
-
-  template void
-  hyper_sphere< 1,  2 > (Triangulation< 1,   2> &,
-                         const Point<2>   &center,
-                         const double        radius);
-  template void
-  hyper_sphere< 2,  3 > (Triangulation< 2,   3> &,
-                         const Point<3>   &center,
-                         const double        radius);
-}
 #include "grid_generator.inst"
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -167,6 +167,20 @@ for (deal_II_dimension : DIMENSIONS)
 }
 
 
+
+for (deal_II_space_dimension : DIMENSIONS)
+{
+    namespace GridGenerator \{
+
+#if deal_II_space_dimension >= 2
+    template void
+    hyper_sphere<deal_II_space_dimension> (
+        Triangulation<deal_II_space_dimension-1, deal_II_space_dimension> &, const Point<deal_II_space_dimension> &, double);
+#endif
+
+    \}
+}
+
 for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS; deal_II_space_dimension_2 : SPACE_DIMENSIONS)
 {
     namespace GridGenerator \{


### PR DESCRIPTION
This function can only work for dim==spacedim-1, and this is also documented.
Consequently, get rid of the dim template argument.

This PR resulted from one of my students being greatly surprised (and
myself too) that his call to this function with a Triangulation<2>
passed the compiler but then led to a linker error. It took me a
few minutes to figure out that what he really meant to do is
call 'hyper_ball()' instead of 'hyper_sphere()', but we really
need not make it so difficult for people to figure this out --
when we get to a linker error, we've made it too hard.