### PR TITLE
Add Transfinite Line

### DIFF
--- a/tests/gmsh/create_tria_01.cc
+++ b/tests/gmsh/create_tria_01.cc
@@ -51,10 +51,15 @@ int main ()
       << "Line(2) = {2, 3};" << std::endl
       << "Line(3) = {3, 4};" << std::endl
       << "Line(4) = {4, 1};" << std::endl
+      << "Transfinite Line {1} = 2 Using Progression 1;" << std::endl
+      << "Transfinite Line {2} = 2 Using Progression 1;" << std::endl
+      << "Transfinite Line {3} = 2 Using Progression 1;" << std::endl
+      << "Transfinite Line {4} = 2 Using Progression 1;" << std::endl
       << "Line Loop(5) = {3, 4, 1, 2};" << std::endl
-      << "Plane Surface(0) = {5};" << std::endl
-      << "Transfinite Surface{0} = {5};" << std::endl
-      << "Recombine Surface {0};" << std::endl;
+      << "Plane Surface(6) = {5};" << std::endl
+      << "Transfinite Surface {6};" << std::endl
+      << "Recombine Surface {6};" << std::endl
+      << "Physical Surface(\"dealii_surface\") = {6};" << std::endl;
 
   geo.close();
 

--- a/tests/gmsh/create_tria_01.output
+++ b/tests/gmsh/create_tria_01.output
@@ -1,31 +1,22 @@
 
-DEAL::  2 active cells
-DEAL::  hash=2
+DEAL::  1 active cells
+DEAL::  hash=0
 $MeshFormat
 2.2 0 8
 $EndMeshFormat
+$PhysicalNames
+1
+2 1 "dealii_surface"
+$EndPhysicalNames
 $Nodes
-6
+4
 1 0 0 0
 2 25 0 0
 3 25 1 0
 4 0 1 0
-5 12.49999999995592 0 0
-6 12.50000000006453 1 0
 $EndNodes
 $Elements
-12
-1 15 2 0 1 1
-2 15 2 0 2 2
-3 15 2 0 3 3
-4 15 2 0 4 4
-5 1 2 0 1 1 5
-6 1 2 0 1 5 2
-7 1 2 0 2 2 3
-8 1 2 0 3 3 6
-9 1 2 0 3 6 4
-10 1 2 0 4 4 1
-11 3 2 0 0 3 6 5 2
-12 3 2 0 0 6 4 1 5
+1
+1 3 2 1 6 3 4 1 2
 $EndElements
 

--- a/tests/quick_tests/gmsh.cc
+++ b/tests/quick_tests/gmsh.cc
@@ -31,10 +31,16 @@ int main ()
       << "Line(2) = {2, 3};" << std::endl
       << "Line(3) = {3, 4};" << std::endl
       << "Line(4) = {4, 1};" << std::endl
+      << "Transfinite Line {1} = 2 Using Progression 1;" << std::endl
+      << "Transfinite Line {2} = 2 Using Progression 1;" << std::endl
+      << "Transfinite Line {3} = 2 Using Progression 1;" << std::endl
+      << "Transfinite Line {4} = 2 Using Progression 1;" << std::endl
       << "Line Loop(5) = {3, 4, 1, 2};" << std::endl
-      << "Plane Surface(0) = {5};" << std::endl
-      << "Transfinite Surface{0} = {5};" << std::endl
-      << "Recombine Surface {0};" << std::endl;
+      << "Plane Surface(6) = {5};" << std::endl
+      << "Transfinite Surface {6};" << std::endl
+      << "Recombine Surface {6};" << std::endl
+      << "Physical Surface(\"dealii_surface\") = {6};" << std::endl;
+
   geo.close();
 
   const int ierr = std::system(DEAL_II_GMSH_EXECUTABLE_PATH " -2 file.geo 1>file.log 2>file_warn.log");


### PR DESCRIPTION
Hi,
The gmsh tests fail in my computer (quick test + long test)
- Debian Stretch
- gmsh 2.15

I propose to add Transfinite lines. With this modification the tests do not fail in my computer.

The problem is that maybe the float numbers of the output won't be exactly the same in every computer, ex: 0.3999999999991 vs 0.3999999999992

How do you solve this problem with the tests? outputs with float numbers

Cheers,
Daniel