### PR TITLE
Amend comment related to making a local copy of Trilinos MPI vector.

### DIFF
--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -196,8 +196,8 @@ public:
    * the same time. This means that unless you use a split MPI communicator
    * then it is not normally possible for only one or a subset of processes
    * to obtain a copy of a parallel vector while the other jobs do something
-   * else. This call will therefore result in a copy of the vector on all
-   * processors that share @p v.
+   * else. In other words, calling this function is a 'collective operation'
+   * that needs to be executed by all MPI processes that jointly share @p v.
    */
   explicit Vector (const TrilinosWrappers::MPI::Vector &v);
 #endif
@@ -386,8 +386,8 @@ public:
    * the same time. This means that unless you use a split MPI communicator
    * then it is not normally possible for only one or a subset of processes
    * to obtain a copy of a parallel vector while the other jobs do something
-   * else. This call will therefore result in a copy of the vector on all
-   * processors that share @p v.
+   * else. In other words, calling this function is a 'collective operation'
+   * that needs to be executed by all MPI processes that jointly share @p v.
    */
   Vector<Number> &
   operator= (const TrilinosWrappers::MPI::Vector &v);


### PR DESCRIPTION
Addresses (*cough*) latecomer (*cough*) suggestion in #5794.