### PR TITLE
More unused parameters without METIS

### DIFF
--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -63,7 +63,9 @@ namespace SparsityTools
       // Make sure that METIS is actually
       // installed and detected
 #ifndef DEAL_II_WITH_METIS
-      (void)sparsity_pattern;
+      (void) sparsity_pattern;
+      (void) n_partitions;
+      (void) partition_indices;
       AssertThrow (false, ExcMETISNotInstalled());
 #else
 


### PR DESCRIPTION
Reported by [CDash](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=14942).