### PR TITLE
Ensure parallel::Tria can't be used with DoFRenumbering::subdomain_wise

### DIFF
--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -1138,9 +1138,13 @@ namespace DoFRenumbering
    * Renumber the degrees of freedom such that they are associated with the
    * subdomain id of the cells they are living on, i.e. first all degrees of
    * freedom that belong to cells with subdomain zero, then all with subdomain
-   * one, etc. This is useful when doing parallel computations after assigning
-   * subdomain ids using a partitioner (see the
-   * GridTools::partition_triangulation function for this).
+   * one, etc. This is useful when doing parallel computations with a standard
+   * Triangulation after assigning subdomain ids using a partitioner (see the
+   * GridTools::partition_triangulation function for this). Calling this
+   * function is unnecessary when using a parallel::shared::Triangulation or
+   * parallel::distributed::Triangulation, as the degrees of freedom are
+   * already enumerated according to the MPI process id. Therefore, if the
+   * underlying triangulation is of this type then an error will be thrown.
    *
    * Note that degrees of freedom associated with faces, edges, and vertices
    * may be associated with multiple subdomains if they are sitting on

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -2031,6 +2031,9 @@ namespace DoFRenumbering
   void
   subdomain_wise (DoFHandlerType &dof_handler)
   {
+    Assert((!dynamic_cast<const parallel::Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*> (&dof_handler.get_triangulation())),
+           ExcMessage("Parallel triangulations are already enumerated according to their MPI process id."));
+
     std::vector<types::global_dof_index> renumbering(dof_handler.n_dofs(),
                                                      numbers::invalid_dof_index);
     compute_subdomain_wise(renumbering, dof_handler);


### PR DESCRIPTION
The documentation is also updated to reflect this point. Fixes #5763.

edit (masterleinad): Fix reference to the issue.