### PR TITLE
Fix some things cppcheck found.

### DIFF
--- a/include/deal.II/base/synchronous_iterator.h
+++ b/include/deal.II/base/synchronous_iterator.h
@@ -56,11 +56,6 @@ struct SynchronousIterators
   SynchronousIterators (const Iterators &i);
 
   /**
-   * Copy constructor.
-   */
-  SynchronousIterators (const SynchronousIterators &i);
-
-  /**
    * Dereference const operator. Returns a const reference to the iterators
    * represented by the current class.
    */
@@ -87,15 +82,6 @@ SynchronousIterators<Iterators>::
 SynchronousIterators (const Iterators &i)
   :
   iterators (i)
-{}
-
-
-template <typename Iterators>
-inline
-SynchronousIterators<Iterators>::
-SynchronousIterators (const SynchronousIterators &i)
-  :
-  iterators (i.iterators)
 {}
 
 

--- a/include/deal.II/base/time_stepping.templates.h
+++ b/include/deal.II/base/time_stepping.templates.h
@@ -421,7 +421,8 @@ namespace TimeStepping
     refine_tol(refine_tol),
     coarsen_tol(coarsen_tol),
     last_same_as_first(false),
-    last_stage(nullptr)
+    last_stage(nullptr),
+    status {}
   {
     // virtual functions called in constructors and destructors never use the
     // override in a derived class

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -945,7 +945,7 @@ inline
 void
 Timer::print_last_lap_wall_time_data(StreamType &stream) const
 {
-  const Utilities::MPI::MinMaxAvg statistic = get_last_lap_wall_time_data();
+  const Utilities::MPI::MinMaxAvg &statistic = get_last_lap_wall_time_data();
   stream << statistic.max << " wall,"
          << " max @" << statistic.max_index << ", min=" << statistic.min << " @"
          << statistic.min_index << ", avg=" << statistic.avg << std::endl;

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -61,11 +61,6 @@ namespace hp
     explicit QCollection (const Quadrature<dim> &quadrature);
 
     /**
-     * Copy constructor.
-     */
-    QCollection (const QCollection<dim> &q_collection);
-
-    /**
      * Adds a new quadrature rule to the QCollection. In most cases, you will
      * want to add quadrature rules in the same order as the elements were
      * added to the hp::FECollection for which this quadrature rule collection is
@@ -183,28 +178,6 @@ namespace hp
     quadratures
     .push_back (std::shared_ptr<const Quadrature<dim> >(new Quadrature<dim>(quadrature)));
   }
-
-
-
-  template <int dim>
-  inline
-  QCollection<dim>::
-  QCollection (const QCollection<dim> &q_collection)
-    :
-    Subscriptor (),
-    // copy the array
-    // of shared
-    // pointers. nothing
-    // bad should
-    // happen -- they
-    // simply all point
-    // to the same
-    // objects, and the
-    // last one to die
-    // will delete the
-    // mappings
-    quadratures (q_collection.quadratures)
-  {}
 
 
 

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -30,6 +30,54 @@ DEAL_II_NAMESPACE_OPEN
 /*!@addtogroup Solvers */
 /*@{*/
 
+namespace internal
+{
+  /**
+   * Class containing the non-parameter non-template values used by the
+   * SolverBicgstab class.
+   */
+  class SolverBicgstabData
+  {
+  protected:
+    /**
+     * Auxiliary value.
+     */
+    double alpha;
+    /**
+     * Auxiliary value.
+     */
+    double beta;
+    /**
+     * Auxiliary value.
+     */
+    double omega;
+    /**
+     * Auxiliary value.
+     */
+    double rho;
+    /**
+     * Auxiliary value.
+     */
+    double rhobar;
+
+    /**
+     * Current iteration step.
+     */
+    unsigned int step;
+
+    /**
+     * Residual.
+     */
+    double res;
+
+    /**
+     * Default constructor. This is protected so that only SolverBicgstab can
+     * create instances.
+     */
+    SolverBicgstabData();
+  };
+}
+
 /**
  * Bicgstab algorithm by van der Vorst.
  *
@@ -70,7 +118,8 @@ DEAL_II_NAMESPACE_OPEN
  *
  */
 template <typename VectorType = Vector<double> >
-class SolverBicgstab : public Solver<VectorType>
+class SolverBicgstab : public Solver<VectorType>,
+  protected internal::SolverBicgstabData
 {
 public:
   /**
@@ -138,6 +187,51 @@ public:
 
 protected:
   /**
+   * Auxiliary vector.
+   */
+  VectorType *Vx;
+
+  /**
+   * Auxiliary vector.
+   */
+  typename VectorMemory<VectorType>::Pointer Vr;
+
+  /**
+   * Auxiliary vector.
+   */
+  typename VectorMemory<VectorType>::Pointer Vrbar;
+
+  /**
+   * Auxiliary vector.
+   */
+  typename VectorMemory<VectorType>::Pointer Vp;
+
+  /**
+   * Auxiliary vector.
+   */
+  typename VectorMemory<VectorType>::Pointer Vy;
+
+  /**
+   * Auxiliary vector.
+   */
+  typename VectorMemory<VectorType>::Pointer Vz;
+
+  /**
+   * Auxiliary vector.
+   */
+  typename VectorMemory<VectorType>::Pointer Vt;
+
+  /**
+   * Auxiliary vector.
+   */
+  typename VectorMemory<VectorType>::Pointer Vv;
+
+  /**
+   * Right hand side vector.
+   */
+  const VectorType *Vb;
+
+  /**
    * Computation of the stopping criterion.
    */
   template <typename MatrixType>
@@ -152,74 +246,6 @@ protected:
                              const VectorType   &x,
                              const VectorType   &r,
                              const VectorType   &d) const;
-
-  /**
-   * Auxiliary vector.
-   */
-  VectorType *Vx;
-  /**
-   * Auxiliary vector.
-   */
-  typename VectorMemory<VectorType>::Pointer Vr;
-  /**
-   * Auxiliary vector.
-   */
-  typename VectorMemory<VectorType>::Pointer Vrbar;
-  /**
-   * Auxiliary vector.
-   */
-  typename VectorMemory<VectorType>::Pointer Vp;
-  /**
-   * Auxiliary vector.
-   */
-  typename VectorMemory<VectorType>::Pointer Vy;
-  /**
-   * Auxiliary vector.
-   */
-  typename VectorMemory<VectorType>::Pointer Vz;
-  /**
-   * Auxiliary vector.
-   */
-  typename VectorMemory<VectorType>::Pointer Vt;
-  /**
-   * Auxiliary vector.
-   */
-  typename VectorMemory<VectorType>::Pointer Vv;
-  /**
-   * Right hand side vector.
-   */
-  const VectorType *Vb;
-
-  /**
-   * Auxiliary value.
-   */
-  double alpha;
-  /**
-   * Auxiliary value.
-   */
-  double beta;
-  /**
-   * Auxiliary value.
-   */
-  double omega;
-  /**
-   * Auxiliary value.
-   */
-  double rho;
-  /**
-   * Auxiliary value.
-   */
-  double rhobar;
-
-  /**
-   * Current iteration step.
-   */
-  unsigned int step;
-
-  /**
-   * Residual.
-   */
-  double res;
 
   /**
    * Additional parameters.
@@ -280,12 +306,28 @@ SolverBicgstab<VectorType>::IterationResult::IterationResult
 {}
 
 
+
+internal::SolverBicgstabData::SolverBicgstabData ()
+  :
+  alpha(0.),
+  beta(0.),
+  omega(0.),
+  rho(0.),
+  rhobar(0.),
+  step(numbers::invalid_unsigned_int),
+  res(numbers::signaling_nan<double>())
+{}
+
+
+
 template <typename VectorType>
 SolverBicgstab<VectorType>::SolverBicgstab (SolverControl            &cn,
                                             VectorMemory<VectorType> &mem,
                                             const AdditionalData     &data)
   :
   Solver<VectorType>(cn,mem),
+  Vx (nullptr),
+  Vb (nullptr),
   additional_data(data)
 {}
 
@@ -296,13 +338,8 @@ SolverBicgstab<VectorType>::SolverBicgstab (SolverControl        &cn,
                                             const AdditionalData &data)
   :
   Solver<VectorType>(cn),
-  alpha(0.),
-  beta(0.),
-  omega(0.),
-  rho(0.),
-  rhobar(0.),
-  step(numbers::invalid_unsigned_int),
-  res(numbers::signaling_nan<double>()),
+  Vx (nullptr),
+  Vb (nullptr),
   additional_data(data)
 {}
 

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -152,7 +152,8 @@ SolverMinRes<VectorType>::SolverMinRes (SolverControl            &cn,
                                         VectorMemory<VectorType> &mem,
                                         const AdditionalData &)
   :
-  Solver<VectorType>(cn,mem)
+  Solver<VectorType>(cn,mem),
+  res2(numbers::signaling_nan<double>())
 {}
 
 

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -197,7 +197,6 @@ protected:
   AdditionalData additional_data;
 
 private:
-
   /**
    * A structure returned by the iterate() function representing what it found
    * is happening during the iteration.
@@ -238,31 +237,35 @@ private:
 
 #ifndef DOXYGEN
 
+
 template <class VectorType>
 SolverQMRS<VectorType>::IterationResult::IterationResult (const SolverControl::State state,
                                                           const double last_residual)
   :
   state (state),
   last_residual (last_residual)
-{
-}
+{}
+
+
 
 template <class VectorType>
-SolverQMRS<VectorType>::SolverQMRS (SolverControl &cn,
+SolverQMRS<VectorType>::SolverQMRS (SolverControl            &cn,
                                     VectorMemory<VectorType> &mem,
-                                    const AdditionalData &data)
+                                    const AdditionalData     &data)
   :
   Solver<VectorType> (cn, mem),
-  additional_data (data)
+  additional_data (data),
+  step (0)
 {
 }
 
 template <class VectorType>
-SolverQMRS<VectorType>::SolverQMRS (SolverControl &cn,
+SolverQMRS<VectorType>::SolverQMRS (SolverControl        &cn,
                                     const AdditionalData &data)
   :
   Solver<VectorType> (cn),
-  additional_data (data)
+  additional_data (data),
+  step (0)
 {
 }
 

--- a/include/deal.II/lac/utilities.h
+++ b/include/deal.II/lac/utilities.h
@@ -328,12 +328,9 @@ namespace Utilities
       std::vector<double> diagonal;
       std::vector<double> subdiagonal;
 
-      // scalars to store norms and inner products
-      double a = 0, b = 0;
-
       // 1. Normalize input vector
       (*v) = v0_;
-      a = v->l2_norm();
+      double a = v->l2_norm();
       Assert (a!=0, ExcDivideByZero());
       (*v) *= 1./a;
 
@@ -347,7 +344,7 @@ namespace Utilities
       for (unsigned int i = 1; i < k; ++i)
         {
           // 4. L2 norm of f
-          b = f->l2_norm();
+          const double b = f->l2_norm();
           Assert (b!=0, ExcDivideByZero());
           // 5. v0 <- v; v <- f/b
           *v0 = *v;

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -77,9 +77,9 @@ namespace internal
      */
     EvaluatorTensorProduct ()
       :
-      shape_values (0),
-      shape_gradients (0),
-      shape_hessians (0)
+      shape_values (nullptr),
+      shape_gradients (nullptr),
+      shape_hessians (nullptr)
     {}
 
     /**
@@ -316,9 +316,9 @@ namespace internal
      */
     EvaluatorTensorProduct ()
       :
-      shape_values (0),
-      shape_gradients (0),
-      shape_hessians (0),
+      shape_values (nullptr),
+      shape_gradients (nullptr),
+      shape_hessians (nullptr),
       fe_degree (numbers::invalid_unsigned_int),
       n_q_points_1d (numbers::invalid_unsigned_int)
     {}

--- a/include/deal.II/meshworker/output.h
+++ b/include/deal.II/meshworker/output.h
@@ -159,6 +159,8 @@ namespace MeshWorker
     inline
     GnuplotPatch::GnuplotPatch()
       :
+      n_vectors(numbers::invalid_unsigned_int),
+      n_points(numbers::invalid_unsigned_int),
       os(nullptr)
     {}
 

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -1016,7 +1016,7 @@ DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::
 merge_patches (const DataOut_DoFData<DoFHandlerType2,patch_dim,patch_space_dim> &source,
                const Point<patch_space_dim> &shift)
 {
-  const std::vector<Patch> source_patches = source.get_patches ();
+  const std::vector<Patch> &source_patches = source.get_patches ();
   Assert ((patches.size () != 0) &&
           (source_patches.size () != 0),
           ExcMessage ("When calling this function, both the current "

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -347,7 +347,7 @@ namespace Particles
   void Particle<dim,spacedim>::save (Archive &ar, const unsigned int) const
   {
     unsigned int n_properties = 0;
-    if ((property_pool != NULL) && (properties != PropertyPool::invalid_handle))
+    if ((property_pool != nullptr) && (properties != PropertyPool::invalid_handle))
       n_properties = get_properties().size();
 
     ar &location

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -6974,7 +6974,7 @@ void DataOutBase::write_hdf5_parallel (const std::vector<Patch<dim,spacedim> > &
               ExcMessage("DataOutBase was asked to write HDF5 output for a space dimension of 1. "
                          "HDF5 only supports datasets that live in 2 or 3 dimensions."));
 
-  int ierr;
+  int ierr = 0;
   (void)ierr;
 #ifndef DEAL_II_WITH_HDF5
   // throw an exception, but first make sure the compiler does not warn about

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -268,7 +268,6 @@ compute_quadrature_weights(const std::vector<long double> &x,
 {
   const unsigned int q = x.size();
   std::vector<long double> w(q);
-  long double s = 0.L;
 
   const long double factor = std::pow(2., alpha+beta+1) *
                              gamma(alpha+q) *
@@ -276,7 +275,7 @@ compute_quadrature_weights(const std::vector<long double> &x,
                              ((q-1)*gamma(q)*gamma(alpha+beta+q+1));
   for (unsigned int i=0; i<q; ++i)
     {
-      s = JacobiP(x[i], alpha, beta, q-1);
+      const long double s = JacobiP(x[i], alpha, beta, q-1);
       w[i] = factor/(s*s);
     }
   w[0]   *= (beta + 1);

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -253,8 +253,8 @@ ScaLAPACKMatrix<NumberType>::copy_to (ScaLAPACKMatrix<NumberType> &dest) const
       int union_n_process_columns = 1;
       Cblacs_gridinit(&union_blacs_context, order, union_n_process_rows, union_n_process_columns);
 
-      const NumberType *loc_vals_source = NULL;
-      NumberType *loc_vals_dest = NULL;
+      const NumberType *loc_vals_source = nullptr;
+      NumberType *loc_vals_dest = nullptr;
 
       if (this->grid->mpi_process_is_active && (this->values.size()>0))
         {


### PR DESCRIPTION
We haven't run cppcheck in awhile; here are some new things.

I also found a few cases where we used `0` or `NULL` instead of `nullptr`; those have also been fixed.