### PR TITLE
Fix utilities_pack_unpack_03

### DIFF
--- a/tests/base/utilities_pack_unpack_03.cc
+++ b/tests/base/utilities_pack_unpack_03.cc
@@ -24,8 +24,7 @@
 #include <deal.II/base/point.h>
 #include <boost/serialization/utility.hpp>
 
-#include <tuple>
-#include <cstring>
+#include <array>
 
 struct X
 {
@@ -33,9 +32,9 @@ struct X
   int k;
   double d;
 
-  bool operator == (const X &x) const
+  bool operator != (const X &x) const
   {
-    return i==x.i && k==x.k && d==x.d;
+    return i!=x.i || k!=x.k || d!=x.d;
   }
 
   template <class Archive>
@@ -51,22 +50,34 @@ template <typename T>
 void check (const T &object)
 {
   const std::vector<char> buffer = Utilities::pack (object);
-  if (!(buffer.size() == sizeof(object))
-      ||
-      !(std::memcmp(buffer.data(), &object, buffer.size()) == 0)
-      ||
-      !(Utilities::unpack<T>(buffer) == object))
-    deallog << "Fail!" << std::endl;
+  if (buffer.size() != sizeof(object))
+    deallog << buffer.size() << " should be "
+            << sizeof(object) << "!" << std::endl;
+  else
+    deallog << "same size!" << std::endl;
+
+  if (std::memcmp(buffer.data(), &object, buffer.size()) != 0)
+    deallog << "std::memcmp failed!" << std::endl;
+  else
+    deallog << "std::memcmp passed!" << std::endl;
+
+  if (Utilities::unpack<T>(buffer) != object)
+    deallog << "Comparing the objects failed!" << std::endl;
+  else
+    deallog << "Comparing the objects passed!" << std::endl;
+
+  deallog << std::endl;
 }
 
 
 void test()
 {
-  check (std::make_pair(1, 3.14));
+  deallog << "std::array:" << std::endl;
+  check (std::array<int,3> {{1,2,3}});
+  deallog << "struct X:" << std::endl;
   check (X { 1, 2, 3.1415926 });
-  check (std::tuple<int,double,char> {1,1,1});
-
-  deallog << "OK!" << std::endl;
+  deallog << "double:" << std::endl;
+  check (1.);
 }
 
 int main()

--- a/tests/base/utilities_pack_unpack_03.output
+++ b/tests/base/utilities_pack_unpack_03.output
@@ -1,2 +1,16 @@
 
-DEAL::OK!
+DEAL::std::array:
+DEAL::same size!
+DEAL::std::memcmp passed!
+DEAL::Comparing the objects passed!
+DEAL::
+DEAL::struct X:
+DEAL::same size!
+DEAL::std::memcmp passed!
+DEAL::Comparing the objects passed!
+DEAL::
+DEAL::double:
+DEAL::same size!
+DEAL::std::memcmp passed!
+DEAL::Comparing the objects passed!
+DEAL::


### PR DESCRIPTION
Currently, `utilities_pack_unpack_03` is [failing](https://cdash.kyomu.43-1.org/testSummary.php?project=1&name=base%2Futilities_pack_unpack_03.release&date=2018-01-27) for nearly all configurations. Citing [cppreference](http://en.cppreference.com/w/cpp/types/is_trivially_copyable):
```
The only trivially copyable types are scalar types, trivially copyable classes, and arrays of such types/classes (possibly const-qualified, but not volatile-qualified).
```
In particular, `std::tuple` and `std::pair` are not necessarily trivially copyable. Hence, this PR replaces these two by two other types that are guaranteed to be trivially copyable, i.e. `double` and `std::array<int,3>`. Also increase the verbosity of the test to understand what might go wrong.

