### PR TITLE
Fix a bug in a CUDA vector constructor

### DIFF
--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -27,7 +27,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 class CommunicationPatternBase;
-class IndexSet;
 template <typename Number> class ReadWriteVector;
 
 namespace LinearAlgebra

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -503,11 +503,10 @@ namespace LinearAlgebra
     template <typename Number>
     Vector<Number>::Vector(const size_type n)
       :
-      n_elements(n)
+      val(nullptr),
+      n_elements(0)
     {
-      // Allocate the memory
-      cudaError_t error_code = cudaMalloc(&val, n_elements*sizeof(Number));
-      AssertCuda(error_code);
+      reinit(n, false);
     }
 
 
@@ -542,7 +541,7 @@ namespace LinearAlgebra
         }
       else
         {
-          if (n_elements != n)
+          if ((n_elements != n) && (val != nullptr))
             {
               cudaError_t error_code = cudaFree(val);
               AssertCuda(error_code);


### PR DESCRIPTION
The constructor did not set the values in the vector to zero unlike what was said in the documentation.