### PR TITLE
Cusparse assert

### DIFF
--- a/doc/news/changes/minor/20180129BrunoTurcksin
+++ b/doc/news/changes/minor/20180129BrunoTurcksin
@@ -1,0 +1,3 @@
+New: Add AssertCusparse macro to assert the error code of cuSPARSE function
+<br>
+(Bruno Turcksin, 2018/01/29)

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -484,6 +484,53 @@ namespace deal_II_exceptions
         }
     }
 
+
+
+#ifdef DEAL_II_WITH_CUDA
+    std::string get_cusparse_error_string(const cusparseStatus_t error_code)
+    {
+      switch (error_code)
+        {
+        case CUSPARSE_STATUS_NOT_INITIALIZED:
+        {
+          return "The cuSPARSE library was not initialized";
+        }
+        case CUSPARSE_STATUS_ALLOC_FAILED:
+        {
+          return "Resource allocation failed inside the cuSPARSE library";
+        }
+        case CUSPARSE_STATUS_INVALID_VALUE:
+        {
+          return "An unsupported value of parameter was passed to the function";
+        }
+        case CUSPARSE_STATUS_ARCH_MISMATCH:
+        {
+          return "The function requires a feature absent from the device architecture";
+        }
+        case CUSPARSE_STATUS_MAPPING_ERROR:
+        {
+          return "An access to GPU memory space failed";
+        }
+        case CUSPARSE_STATUS_EXECUTION_FAILED:
+        {
+          return "The GPU program failed to execute";
+        }
+        case CUSPARSE_STATUS_INTERNAL_ERROR:
+        {
+          return "An internal cuSPARSE operation failed";
+        }
+        case CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
+        {
+          return "The matrix type is not supported by this function";
+        }
+        default:
+        {
+          return "Unknown error";
+        }
+        }
+    }
+#endif
+
   } /*namespace internals*/
 } /*namespace deal_II_exceptions*/
 


### PR DESCRIPTION
Add `AssertCusparse` to check that the call  to a cuSPARSE function was successful. Print the error message instead of the error code.