### PR TITLE
Fix ICC-16 ICE in fe_enriched.h

### DIFF
--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -628,7 +628,7 @@ private:
   /**
    * The underlying FESystem object.
    */
-  FESystem<dim,spacedim> fe_system;
+  const std::unique_ptr<const FESystem<dim,spacedim> > fe_system;
 
   /**
    * After calling fill_fe_(face/subface_)values this function


### PR DESCRIPTION
This works around an internal compiler error in ICC-16 (also reported at https://groups.google.com/d/msg/dealii/sKlWdNexZ5A/WFIOFXs9AQAJ).
After throwing out everything else only the `FESystem` member variable was left causing the error. Allocating memory on the heap instead was the only fix I could find.