### PR TITLE
FullMatrix size type

### DIFF
--- a/doc/news/changes/incompatibilities/20180201DanielArndt
+++ b/doc/news/changes/incompatibilities/20180201DanielArndt
@@ -1,0 +1,6 @@
+Changed: TableIndices uses std::size_t for index access, 
+LAPACKFullMatrix::size_type is types::blas_int and 
+FullMatrix::size_type is std::size_t.
+<br>
+(Daniel Arndt, 2018/02/02)
+

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1213,6 +1213,17 @@ namespace StandardExceptions
 #define AssertVectorVectorDimension(vec,dim1,dim2) AssertDimension((vec).size(), (dim1)) \
   for (unsigned int i=0;i<dim1;++i) { AssertDimension((vec)[i].size(), (dim2)); }
 
+namespace internal
+{
+  // Workaround to allow for commas in template parameter lists
+  // in preprocessor macros as found in
+  // https://stackoverflow.com/questions/13842468/comma-in-c-c-macro
+  template<typename T> struct argument_type;
+  template<typename T, typename U> struct argument_type<T(U)>
+  {
+    typedef U type;
+  };
+}
 
 /**
  * An assertion that tests that a given index is within the half-open
@@ -1223,8 +1234,12 @@ namespace StandardExceptions
  * @ingroup Exceptions
  * @author Guido Kanschat 2007
  */
-#define AssertIndexRange(index,range) Assert((index) < (range), \
-                                             dealii::ExcIndexRange((index),0,(range)))
+#define AssertIndexRange(index,range) \
+  Assert((index) < (range), \
+         dealii::ExcIndexRangeType< \
+         typename ::dealii::internal::argument_type< \
+         void(typename std::common_type<decltype(index), \
+              decltype(range)>::type)>::type>((index),0,(range)))
 
 /**
  * An assertion that checks whether a number is finite or not. We explicitly

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -114,7 +114,7 @@ namespace internal
      * or not (i.e. write access is only allowed if the value is false).
      *
      * Since with <tt>N</tt> indices, the effect of applying
-     * <tt>operator[]</tt> is getting access to something we <tt>N-1</tt>
+     * <tt>operator[]</tt> is getting access to something with <tt>N-1</tt>
      * indices, we have to implement these accessor classes recursively, with
      * stopping when we have only one index left. For the latter case, a
      * specialization of this class is declared below, where calling
@@ -135,7 +135,7 @@ namespace internal
      * elements, and to know which subset we need to know the dimensions of
      * the table and the present index, which is indicated by <tt>P</tt>.
      *
-     * As stated for the entire namespace, you will not usually have to do
+     * As stated for the entire namespace, you will not usually have to deal
      * with these classes directly, and should not try to use their interface
      * directly as it may change without notice. In fact, since the
      * constructors are made private, you will not even be able to generate
@@ -184,13 +184,13 @@ namespace internal
       /**
        * Index operator. Performs a range check.
        */
-      Accessor<N,T,C,P-1> operator [] (const unsigned int i) const;
+      Accessor<N,T,C,P-1> operator [] (const size_type i) const;
 
       /**
        * Exception for range check. Do not use global exception since this way
        * we can output which index is the wrong one.
        */
-      DeclException3 (ExcIndexRange, int, int, int,
+      DeclException3 (ExcIndexRange, size_type, size_type, size_type,
                       << "Index " << N-P+1 << "has a value of "
                       << arg1 << " but needs to be in the range ["
                       << arg2 << "," << arg3 << "[.");
@@ -287,13 +287,13 @@ namespace internal
       /**
        * Index operator. Performs a range check.
        */
-      reference operator [] (const unsigned int) const;
+      reference operator [] (const size_type) const;
 
       /**
        * Return the length of one row, i.e. the number of elements
        * corresponding to the last index of the table object.
        */
-      unsigned int size () const;
+      size_type size () const;
 
       /**
        * Return an iterator to the first element of this row.
@@ -505,7 +505,7 @@ public:
   /**
    * Size of the table in direction <tt>i</tt>.
    */
-  unsigned int size (const unsigned int i) const;
+  size_type size (const unsigned int i) const;
 
   /**
    * Return the sizes of this object in each direction.
@@ -705,7 +705,7 @@ public:
   /**
    * Constructor. Pass down the given dimension to the base class.
    */
-  Table (const unsigned int size);
+  Table (const size_type size);
 
   /**
    * Constructor. Create a table with a given size and initialize it from a
@@ -745,7 +745,7 @@ public:
    * input range. If false, change the first index fastest.
    */
   template <typename InputIterator>
-  Table (const unsigned int size,
+  Table (const size_type size,
          InputIterator entries,
          const bool      C_style_indexing = true);
 
@@ -754,28 +754,28 @@ public:
    * accesses the requested data element. Returns a read-only reference.
    */
   typename AlignedVector<T>::const_reference
-  operator [] (const unsigned int i) const;
+  operator [] (const size_type i) const;
 
   /**
    * Access operator. Since this is a one-dimensional object, this simply
    * accesses the requested data element. Returns a read-write reference.
    */
   typename AlignedVector<T>::reference
-  operator [] (const unsigned int i);
+  operator [] (const size_type i);
 
   /**
    * Access operator. Since this is a one-dimensional object, this simply
    * accesses the requested data element. Returns a read-only reference.
    */
   typename AlignedVector<T>::const_reference
-  operator () (const unsigned int i) const;
+  operator () (const size_type i) const;
 
   /**
    * Access operator. Since this is a one-dimensional object, this simply
    * accesses the requested data element. Returns a read-write reference.
    */
   typename AlignedVector<T>::reference
-  operator () (const unsigned int i);
+  operator () (const size_type i);
 
   /**
    * Make the corresponding operator () from the TableBase base class
@@ -824,8 +824,8 @@ public:
   /**
    * Constructor. Pass down the given dimensions to the base class.
    */
-  Table (const unsigned int size1,
-         const unsigned int size2);
+  Table (const size_type size1,
+         const size_type size2);
 
   /**
    * Constructor. Create a table with a given size and initialize it from a
@@ -866,8 +866,8 @@ public:
    * input range. If false, change the first index fastest.
    */
   template <typename InputIterator>
-  Table (const unsigned int size1,
-         const unsigned int size2,
+  Table (const size_type size1,
+         const size_type size2,
          InputIterator entries,
          const bool      C_style_indexing = true);
 
@@ -876,8 +876,8 @@ public:
    * with the earlier <tt>vector2d</tt> class. Passes down to the base class
    * by converting the arguments to the data type requested by the base class.
    */
-  void reinit (const unsigned int size1,
-               const unsigned int size2,
+  void reinit (const size_type size1,
+               const size_type size2,
                const bool         omit_default_initialization = false);
 
   using TableBase<2,T>::reinit;
@@ -889,7 +889,7 @@ public:
    * This version of the function only allows read access.
    */
   dealii::internal::TableBaseAccessors::Accessor<2,T,true,1>
-  operator [] (const unsigned int i) const;
+  operator [] (const size_type i) const;
 
   /**
    * Access operator. Generate an object that accesses the requested row of
@@ -898,7 +898,7 @@ public:
    * This version of the function allows read-write access.
    */
   dealii::internal::TableBaseAccessors::Accessor<2,T,false,1>
-  operator [] (const unsigned int i);
+  operator [] (const size_type i);
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -907,8 +907,8 @@ public:
    * This version of the function only allows read access.
    */
   typename AlignedVector<T>::const_reference
-  operator () (const unsigned int i,
-               const unsigned int j) const;
+  operator () (const size_type i,
+               const size_type j) const;
 
 
   /**
@@ -918,8 +918,8 @@ public:
    * This version of the function allows read-write access.
    */
   typename AlignedVector<T>::reference
-  operator () (const unsigned int i,
-               const unsigned int j);
+  operator () (const size_type i,
+               const size_type j);
 
   /**
    * Make the corresponding operator () from the TableBase base class
@@ -940,13 +940,13 @@ public:
    * Number of rows. This function really makes only sense since we have a
    * two-dimensional object here.
    */
-  unsigned int n_rows () const;
+  size_type n_rows () const;
 
   /**
    * Number of columns. This function really makes only sense since we have a
    * two-dimensional object here.
    */
-  unsigned int n_cols () const;
+  size_type n_cols () const;
 
 protected:
   /**
@@ -959,8 +959,8 @@ protected:
    * implementation of these table classes for 2d arrays, then called
    * <tt>vector2d</tt>.
    */
-  typename AlignedVector<T>::reference el (const unsigned int i,
-                                           const unsigned int j);
+  typename AlignedVector<T>::reference el (const size_type i,
+                                           const size_type j);
 
   /**
    * Return the value of the element <tt>(i,j)</tt> as a read-only reference.
@@ -976,8 +976,8 @@ protected:
    * implementation of these table classes for 2d arrays, then called
    * <tt>vector2d</tt>.
    */
-  typename AlignedVector<T>::const_reference el (const unsigned int i,
-                                                 const unsigned int j) const;
+  typename AlignedVector<T>::const_reference el (const size_type i,
+                                                 const size_type j) const;
 };
 
 
@@ -1009,9 +1009,9 @@ public:
   /**
    * Constructor. Pass down the given dimensions to the base class.
    */
-  Table (const unsigned int size1,
-         const unsigned int size2,
-         const unsigned int size3);
+  Table (const size_type size1,
+         const size_type size2,
+         const size_type size3);
 
   /**
    * Constructor. Create a table with a given size and initialize it from a
@@ -1054,9 +1054,9 @@ public:
    * input range. If false, change the first index fastest.
    */
   template <typename InputIterator>
-  Table (const unsigned int size1,
-         const unsigned int size2,
-         const unsigned int size3,
+  Table (const size_type size1,
+         const size_type size2,
+         const size_type size3,
          InputIterator entries,
          const bool      C_style_indexing = true);
 
@@ -1068,7 +1068,7 @@ public:
    * This version of the function only allows read access.
    */
   dealii::internal::TableBaseAccessors::Accessor<3,T,true,2>
-  operator [] (const unsigned int i) const;
+  operator [] (const size_type i) const;
 
   /**
    * Access operator. Generate an object that accesses the requested two-
@@ -1078,7 +1078,7 @@ public:
    * This version of the function allows read-write access.
    */
   dealii::internal::TableBaseAccessors::Accessor<3,T,false,2>
-  operator [] (const unsigned int i);
+  operator [] (const size_type i);
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -1086,9 +1086,9 @@ public:
    *
    * This version of the function only allows read access.
    */
-  typename AlignedVector<T>::const_reference operator () (const unsigned int i,
-                                                          const unsigned int j,
-                                                          const unsigned int k) const;
+  typename AlignedVector<T>::const_reference operator () (const size_type i,
+                                                          const size_type j,
+                                                          const size_type k) const;
 
 
   /**
@@ -1097,9 +1097,9 @@ public:
    *
    * This version of the function allows read-write access.
    */
-  typename AlignedVector<T>::reference operator () (const unsigned int i,
-                                                    const unsigned int j,
-                                                    const unsigned int k);
+  typename AlignedVector<T>::reference operator () (const size_type i,
+                                                    const size_type j,
+                                                    const size_type k);
 
   /**
    * Make the corresponding operator () from the TableBase base class
@@ -1143,10 +1143,10 @@ public:
   /**
    * Constructor. Pass down the given dimensions to the base class.
    */
-  Table (const unsigned int size1,
-         const unsigned int size2,
-         const unsigned int size3,
-         const unsigned int size4);
+  Table (const size_type size1,
+         const size_type size2,
+         const size_type size3,
+         const size_type size4);
 
   /**
    * Access operator. Generate an object that accesses the requested three-
@@ -1156,7 +1156,7 @@ public:
    * This version of the function only allows read access.
    */
   dealii::internal::TableBaseAccessors::Accessor<4,T,true,3>
-  operator [] (const unsigned int i) const;
+  operator [] (const size_type i) const;
 
   /**
    * Access operator. Generate an object that accesses the requested three-
@@ -1166,7 +1166,7 @@ public:
    * This version of the function allows read-write access.
    */
   dealii::internal::TableBaseAccessors::Accessor<4,T,false,3>
-  operator [] (const unsigned int i);
+  operator [] (const size_type i);
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -1174,10 +1174,10 @@ public:
    *
    * This version of the function only allows read access.
    */
-  typename AlignedVector<T>::const_reference operator () (const unsigned int i,
-                                                          const unsigned int j,
-                                                          const unsigned int k,
-                                                          const unsigned int l) const;
+  typename AlignedVector<T>::const_reference operator () (const size_type i,
+                                                          const size_type j,
+                                                          const size_type k,
+                                                          const size_type l) const;
 
 
   /**
@@ -1186,10 +1186,10 @@ public:
    *
    * This version of the function allows read-write access.
    */
-  typename AlignedVector<T>::reference operator () (const unsigned int i,
-                                                    const unsigned int j,
-                                                    const unsigned int k,
-                                                    const unsigned int l);
+  typename AlignedVector<T>::reference operator () (const size_type i,
+                                                    const size_type j,
+                                                    const size_type k,
+                                                    const size_type l);
 
   /**
    * Make the corresponding operator () from the TableBase base class
@@ -1236,11 +1236,11 @@ public:
   /**
    * Constructor. Pass down the given dimensions to the base class.
    */
-  Table (const unsigned int size1,
-         const unsigned int size2,
-         const unsigned int size3,
-         const unsigned int size4,
-         const unsigned int size5);
+  Table (const size_type size1,
+         const size_type size2,
+         const size_type size3,
+         const size_type size4,
+         const size_type size5);
 
   /**
    * Access operator. Generate an object that accesses the requested four-
@@ -1250,7 +1250,7 @@ public:
    * This version of the function only allows read access.
    */
   dealii::internal::TableBaseAccessors::Accessor<5,T,true,4>
-  operator [] (const unsigned int i) const;
+  operator [] (const size_type i) const;
 
   /**
    * Access operator. Generate an object that accesses the requested four-
@@ -1260,7 +1260,7 @@ public:
    * This version of the function allows read-write access.
    */
   dealii::internal::TableBaseAccessors::Accessor<5,T,false,4>
-  operator [] (const unsigned int i);
+  operator [] (const size_type i);
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -1268,11 +1268,11 @@ public:
    *
    * This version of the function only allows read access.
    */
-  typename AlignedVector<T>::const_reference operator () (const unsigned int i,
-                                                          const unsigned int j,
-                                                          const unsigned int k,
-                                                          const unsigned int l,
-                                                          const unsigned int m) const;
+  typename AlignedVector<T>::const_reference operator () (const size_type i,
+                                                          const size_type j,
+                                                          const size_type k,
+                                                          const size_type l,
+                                                          const size_type m) const;
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -1280,11 +1280,11 @@ public:
    *
    * This version of the function allows read-write access.
    */
-  typename AlignedVector<T>::reference operator () (const unsigned int i,
-                                                    const unsigned int j,
-                                                    const unsigned int k,
-                                                    const unsigned int l,
-                                                    const unsigned int m);
+  typename AlignedVector<T>::reference operator () (const size_type i,
+                                                    const size_type j,
+                                                    const size_type k,
+                                                    const size_type l,
+                                                    const size_type m);
 
   /**
    * Make the corresponding operator () from the TableBase base class
@@ -1330,12 +1330,12 @@ public:
   /**
    * Constructor. Pass down the given dimensions to the base class.
    */
-  Table (const unsigned int size1,
-         const unsigned int size2,
-         const unsigned int size3,
-         const unsigned int size4,
-         const unsigned int size5,
-         const unsigned int size6);
+  Table (const size_type size1,
+         const size_type size2,
+         const size_type size3,
+         const size_type size4,
+         const size_type size5,
+         const size_type size6);
 
   /**
    * Access operator. Generate an object that accesses the requested five-
@@ -1345,7 +1345,7 @@ public:
    * This version of the function only allows read access.
    */
   dealii::internal::TableBaseAccessors::Accessor<6,T,true,5>
-  operator [] (const unsigned int i) const;
+  operator [] (const size_type i) const;
 
   /**
    * Access operator. Generate an object that accesses the requested five-
@@ -1355,7 +1355,7 @@ public:
    * This version of the function allows read-write access.
    */
   dealii::internal::TableBaseAccessors::Accessor<6,T,false,5>
-  operator [] (const unsigned int i);
+  operator [] (const size_type i);
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -1363,12 +1363,12 @@ public:
    *
    * This version of the function only allows read access.
    */
-  typename AlignedVector<T>::const_reference operator () (const unsigned int i,
-                                                          const unsigned int j,
-                                                          const unsigned int k,
-                                                          const unsigned int l,
-                                                          const unsigned int m,
-                                                          const unsigned int n) const;
+  typename AlignedVector<T>::const_reference operator () (const size_type i,
+                                                          const size_type j,
+                                                          const size_type k,
+                                                          const size_type l,
+                                                          const size_type m,
+                                                          const size_type n) const;
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -1376,12 +1376,12 @@ public:
    *
    * This version of the function allows read-write access.
    */
-  typename AlignedVector<T>::reference operator () (const unsigned int i,
-                                                    const unsigned int j,
-                                                    const unsigned int k,
-                                                    const unsigned int l,
-                                                    const unsigned int m,
-                                                    const unsigned int n);
+  typename AlignedVector<T>::reference operator () (const size_type i,
+                                                    const size_type j,
+                                                    const size_type k,
+                                                    const size_type l,
+                                                    const size_type m,
+                                                    const size_type n);
 
   /**
    * Make the corresponding operator () from the TableBase base class
@@ -1426,13 +1426,13 @@ public:
   /**
    * Constructor. Pass down the given dimensions to the base class.
    */
-  Table (const unsigned int size1,
-         const unsigned int size2,
-         const unsigned int size3,
-         const unsigned int size4,
-         const unsigned int size5,
-         const unsigned int size6,
-         const unsigned int size7);
+  Table (const size_type size1,
+         const size_type size2,
+         const size_type size3,
+         const size_type size4,
+         const size_type size5,
+         const size_type size6,
+         const size_type size7);
 
   /**
    * Access operator. Generate an object that accesses the requested six-
@@ -1442,7 +1442,7 @@ public:
    * This version of the function only allows read access.
    */
   dealii::internal::TableBaseAccessors::Accessor<7,T,true,6>
-  operator [] (const unsigned int i) const;
+  operator [] (const size_type i) const;
 
   /**
    * Access operator. Generate an object that accesses the requested six-
@@ -1452,7 +1452,7 @@ public:
    * This version of the function allows read-write access.
    */
   dealii::internal::TableBaseAccessors::Accessor<7,T,false,6>
-  operator [] (const unsigned int i);
+  operator [] (const size_type i);
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -1460,13 +1460,13 @@ public:
    *
    * This version of the function only allows read access.
    */
-  typename AlignedVector<T>::const_reference operator () (const unsigned int i,
-                                                          const unsigned int j,
-                                                          const unsigned int k,
-                                                          const unsigned int l,
-                                                          const unsigned int m,
-                                                          const unsigned int n,
-                                                          const unsigned int o) const;
+  typename AlignedVector<T>::const_reference operator () (const size_type i,
+                                                          const size_type j,
+                                                          const size_type k,
+                                                          const size_type l,
+                                                          const size_type m,
+                                                          const size_type n,
+                                                          const size_type o) const;
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -1474,13 +1474,13 @@ public:
    *
    * This version of the function allows read-write access.
    */
-  typename AlignedVector<T>::reference operator () (const unsigned int i,
-                                                    const unsigned int j,
-                                                    const unsigned int k,
-                                                    const unsigned int l,
-                                                    const unsigned int m,
-                                                    const unsigned int n,
-                                                    const unsigned int o);
+  typename AlignedVector<T>::reference operator () (const size_type i,
+                                                    const size_type j,
+                                                    const size_type k,
+                                                    const size_type l,
+                                                    const size_type m,
+                                                    const size_type n,
+                                                    const size_type o);
 
   /**
    * Make the corresponding operator () from the TableBase base class
@@ -1529,16 +1529,16 @@ public:
   /**
    * Constructor. Pass down the given dimensions to the base class.
    */
-  TransposeTable (const unsigned int size1,
-                  const unsigned int size2);
+  TransposeTable (const size_type size1,
+                  const size_type size2);
 
   /**
    * Reinitialize the object. This function is mostly here for compatibility
    * with the earlier <tt>vector2d</tt> class. Passes down to the base class
    * by converting the arguments to the data type requested by the base class.
    */
-  void reinit (const unsigned int size1,
-               const unsigned int size2,
+  void reinit (const size_type size1,
+               const size_type size2,
                const bool         omit_default_initialization = false);
 
   /**
@@ -1547,8 +1547,8 @@ public:
    *
    * This version of the function only allows read access.
    */
-  typename AlignedVector<T>::const_reference operator () (const unsigned int i,
-                                                          const unsigned int j) const;
+  typename AlignedVector<T>::const_reference operator () (const size_type i,
+                                                          const size_type j) const;
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -1556,20 +1556,20 @@ public:
    *
    * This version of the function allows read-write access.
    */
-  typename AlignedVector<T>::reference operator () (const unsigned int i,
-                                                    const unsigned int j);
+  typename AlignedVector<T>::reference operator () (const size_type i,
+                                                    const size_type j);
 
   /**
    * Number of rows. This function really makes only sense since we have a
    * two-dimensional object here.
    */
-  unsigned int n_rows () const;
+  size_type n_rows () const;
 
   /**
    * Number of columns. This function really makes only sense since we have a
    * two-dimensional object here.
    */
-  unsigned int n_cols () const;
+  size_type n_cols () const;
 
 protected:
   /**
@@ -1582,8 +1582,8 @@ protected:
    * implementation of these table classes for 2d arrays, then called
    * <tt>vector2d</tt>.
    */
-  typename AlignedVector<T>::reference el (const unsigned int i,
-                                           const unsigned int j);
+  typename AlignedVector<T>::reference el (const size_type i,
+                                           const size_type j);
 
   /**
    * Return the value of the element <tt>(i,j)</tt> as a read-only reference.
@@ -1599,8 +1599,8 @@ protected:
    * implementation of these table classes for 2d arrays, then called
    * <tt>vector2d</tt>.
    */
-  typename AlignedVector<T>::const_reference el (const unsigned int i,
-                                                 const unsigned int j) const;
+  typename AlignedVector<T>::const_reference el (const size_type i,
+                                                 const size_type j) const;
 };
 
 
@@ -1707,7 +1707,7 @@ namespace internal
     template <int N, typename T, bool C, unsigned int P>
     inline
     Accessor<N,T,C,P-1>
-    Accessor<N,T,C,P>::operator [] (const unsigned int i) const
+    Accessor<N,T,C,P>::operator [] (const size_type i) const
     {
       Assert (i < table.size()[N-P],
               ExcIndexRange (i, 0, table.size()[N-P]));
@@ -1756,10 +1756,9 @@ namespace internal
     template <int N, typename T, bool C>
     inline
     typename Accessor<N,T,C,1>::reference
-    Accessor<N,T,C,1>::operator [] (const unsigned int i) const
+    Accessor<N,T,C,1>::operator [] (const size_type i) const
     {
-      Assert (i < table.size()[N-1],
-              ExcIndexRange (i, 0, table.size()[N-1]));
+      AssertIndexRange (i, table.size()[N-1]);
       return *(data+i);
     }
 
@@ -1767,7 +1766,7 @@ namespace internal
 
     template <int N, typename T, bool C>
     inline
-    unsigned int
+    typename Accessor<N,T,C,1>::size_type
     Accessor<N,T,C,1>::size () const
     {
       return table.size()[N-1];
@@ -1933,7 +1932,7 @@ TableBase<N,T>::size () const
 
 template <int N, typename T>
 inline
-unsigned int
+typename TableBase<N,T>::size_type
 TableBase<N,T>::size (const unsigned int i) const
 {
   Assert (i<N, ExcIndexRange(i,0,N));
@@ -1973,7 +1972,8 @@ namespace internal
     void fill_Fortran_style (InputIterator  entries,
                              TableBase<1,T>  &table)
     {
-      for (unsigned int i=0; i<table.size()[0]; ++i)
+      using size_type = typename TableBase<1,T>::size_type;
+      for (size_type i=0; i<table.size()[0]; ++i)
         table(TableIndices<1>(i)) = *entries++;
     }
 
@@ -1982,8 +1982,9 @@ namespace internal
     void fill_Fortran_style (InputIterator  entries,
                              TableBase<2,T>  &table)
     {
-      for (unsigned int j=0; j<table.size()[1]; ++j)
-        for (unsigned int i=0; i<table.size()[0]; ++i)
+      using size_type = typename TableBase<2,T>::size_type;
+      for (size_type j=0; j<table.size()[1]; ++j)
+        for (size_type i=0; i<table.size()[0]; ++i)
           table(TableIndices<2>(i,j)) = *entries++;
     }
 
@@ -1992,9 +1993,10 @@ namespace internal
     void fill_Fortran_style (InputIterator  entries,
                              TableBase<3,T>  &table)
     {
-      for (unsigned int k=0; k<table.size()[2]; ++k)
-        for (unsigned int j=0; j<table.size()[1]; ++j)
-          for (unsigned int i=0; i<table.size()[0]; ++i)
+      using size_type = typename TableBase<3,T>::size_type;
+      for (size_type k=0; k<table.size()[2]; ++k)
+        for (size_type j=0; j<table.size()[1]; ++j)
+          for (size_type i=0; i<table.size()[0]; ++i)
             table(TableIndices<3>(i,j,k)) = *entries++;
     }
 
@@ -2071,7 +2073,7 @@ TableBase<N,T>::position (const TableIndices<N> &indices) const
               + indices[2]);
     default:
     {
-      size_type s = indices[0];
+      unsigned int s = indices[0];
       for (unsigned int n=1; n<N; ++n)
         s = s*table_size[n] + indices[n];
       return s;
@@ -2087,8 +2089,7 @@ typename AlignedVector<T>::const_reference
 TableBase<N,T>::operator () (const TableIndices<N> &indices) const
 {
   for (unsigned int n=0; n<N; ++n)
-    Assert (indices[n] < table_size[n],
-            ExcIndexRange (indices[n], 0, table_size[n]));
+    AssertIndexRange (indices[n], table_size[n]);
   return el(indices);
 }
 
@@ -2100,8 +2101,7 @@ typename AlignedVector<T>::reference
 TableBase<N,T>::operator () (const TableIndices<N> &indices)
 {
   for (unsigned int n=0; n<N; ++n)
-    Assert (indices[n] < table_size[n],
-            ExcIndexRange (indices[n], 0, table_size[n]));
+    AssertIndexRange (indices[n], table_size[n]);
   return el(indices);
 }
 
@@ -2122,8 +2122,7 @@ inline
 typename AlignedVector<T>::reference
 TableBase<N,T>::el (const TableIndices<N> &indices)
 {
-  Assert (position(indices) < values.size(),
-          ExcIndexRange (position(indices), 0, values.size()));
+  AssertIndexRange (position(indices), values.size());
   return values[position(indices)];
 }
 
@@ -2131,7 +2130,7 @@ TableBase<N,T>::el (const TableIndices<N> &indices)
 
 template <typename T>
 inline
-Table<1,T>::Table (const unsigned int size)
+Table<1,T>::Table (const size_type size)
   :
   TableBase<1,T> (TableIndices<1> (size))
 {}
@@ -2141,7 +2140,7 @@ Table<1,T>::Table (const unsigned int size)
 template <typename T>
 template <typename InputIterator>
 inline
-Table<1,T>::Table (const unsigned int size,
+Table<1,T>::Table (const size_type size,
                    InputIterator entries,
                    const bool C_style_indexing)
   :
@@ -2155,10 +2154,9 @@ Table<1,T>::Table (const unsigned int size,
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-Table<1,T>::operator [] (const unsigned int i) const
+Table<1,T>::operator [] (const size_type i) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   return this->values[i];
 }
 
@@ -2167,10 +2165,9 @@ Table<1,T>::operator [] (const unsigned int i) const
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-Table<1,T>::operator [] (const unsigned int i)
+Table<1,T>::operator [] (const size_type i)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   return this->values[i];
 }
 
@@ -2179,10 +2176,9 @@ Table<1,T>::operator [] (const unsigned int i)
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-Table<1,T>::operator () (const unsigned int i) const
+Table<1,T>::operator () (const size_type i) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   return this->values[i];
 }
 
@@ -2191,10 +2187,9 @@ Table<1,T>::operator () (const unsigned int i) const
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-Table<1,T>::operator () (const unsigned int i)
+Table<1,T>::operator () (const size_type i)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   return this->values[i];
 }
 
@@ -2225,8 +2220,8 @@ Table<1,T>::operator () (const TableIndices<1> &indices)
 
 template <typename T>
 inline
-Table<2,T>::Table (const unsigned int size1,
-                   const unsigned int size2)
+Table<2,T>::Table (const size_type size1,
+                   const size_type size2)
   :
   TableBase<2,T> (TableIndices<2> (size1, size2))
 {}
@@ -2236,8 +2231,8 @@ Table<2,T>::Table (const unsigned int size1,
 template <typename T>
 template <typename InputIterator>
 inline
-Table<2,T>::Table (const unsigned int size1,
-                   const unsigned int size2,
+Table<2,T>::Table (const size_type size1,
+                   const size_type size2,
                    InputIterator entries,
                    const bool C_style_indexing)
   :
@@ -2251,8 +2246,8 @@ Table<2,T>::Table (const unsigned int size1,
 template <typename T>
 inline
 void
-Table<2,T>::reinit (const unsigned int size1,
-                    const unsigned int size2,
+Table<2,T>::reinit (const size_type size1,
+                    const size_type size2,
                     const bool         omit_default_initialization)
 {
   this->TableBase<2,T>::reinit (TableIndices<2> (size1, size2),omit_default_initialization);
@@ -2263,10 +2258,9 @@ Table<2,T>::reinit (const unsigned int size1,
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<2,T,true,1>
-Table<2,T>::operator [] (const unsigned int i) const
+Table<2,T>::operator [] (const size_type i) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   return dealii::internal::TableBaseAccessors::Accessor<2,T,true,1>(*this,
          this->values.begin()+size_type(i)*n_cols());
 }
@@ -2276,10 +2270,9 @@ Table<2,T>::operator [] (const unsigned int i) const
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<2,T,false,1>
-Table<2,T>::operator [] (const unsigned int i)
+Table<2,T>::operator [] (const size_type i)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   return dealii::internal::TableBaseAccessors::Accessor<2,T,false,1>(*this,
          this->values.begin()+size_type(i)*n_cols());
 }
@@ -2289,13 +2282,11 @@ Table<2,T>::operator [] (const unsigned int i)
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-Table<2,T>::operator () (const unsigned int i,
-                         const unsigned int j) const
+Table<2,T>::operator () (const size_type i,
+                         const size_type j) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
   return this->values[size_type(i)*this->table_size[1]+j];
 }
 
@@ -2304,13 +2295,11 @@ Table<2,T>::operator () (const unsigned int i,
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-Table<2,T>::operator () (const unsigned int i,
-                         const unsigned int j)
+Table<2,T>::operator () (const size_type i,
+                         const size_type j)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
   return this->values[size_type(i)*this->table_size[1]+j];
 }
 
@@ -2339,8 +2328,8 @@ Table<2,T>::operator () (const TableIndices<2> &indices)
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-Table<2,T>::el (const unsigned int i,
-                const unsigned int j) const
+Table<2,T>::el (const size_type i,
+                const size_type j) const
 {
   return this->values[size_type(i)*this->table_size[1]+j];
 }
@@ -2350,8 +2339,8 @@ Table<2,T>::el (const unsigned int i,
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-Table<2,T>::el (const unsigned int i,
-                const unsigned int j)
+Table<2,T>::el (const size_type i,
+                const size_type j)
 {
   return this->values[size_type(i)*this->table_size[1]+j];
 }
@@ -2360,7 +2349,7 @@ Table<2,T>::el (const unsigned int i,
 
 template <typename T>
 inline
-unsigned int
+typename Table<2,T>::size_type
 Table<2,T>::n_rows () const
 {
   return this->table_size[0];
@@ -2370,7 +2359,7 @@ Table<2,T>::n_rows () const
 
 template <typename T>
 inline
-unsigned int
+typename Table<2,T>::size_type
 Table<2,T>::n_cols () const
 {
   return this->table_size[1];
@@ -2381,8 +2370,8 @@ Table<2,T>::n_cols () const
 //---------------------------------------------------------------------------
 template <typename T>
 inline
-TransposeTable<T>::TransposeTable (const unsigned int size1,
-                                   const unsigned int size2)
+TransposeTable<T>::TransposeTable (const size_type size1,
+                                   const size_type size2)
   :
   TableBase<2,T> (TableIndices<2> (size2, size1))
 {}
@@ -2392,9 +2381,9 @@ TransposeTable<T>::TransposeTable (const unsigned int size1,
 template <typename T>
 inline
 void
-TransposeTable<T>::reinit (const unsigned int size1,
-                           const unsigned int size2,
-                           const bool         omit_default_initialization)
+TransposeTable<T>::reinit (const size_type size1,
+                           const size_type size2,
+                           const bool      omit_default_initialization)
 {
   this->TableBase<2,T>::reinit (TableIndices<2> (size2, size1), omit_default_initialization);
 }
@@ -2404,13 +2393,11 @@ TransposeTable<T>::reinit (const unsigned int size1,
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-TransposeTable<T>::operator () (const unsigned int i,
-                                const unsigned int j) const
+TransposeTable<T>::operator () (const size_type i,
+                                const size_type j) const
 {
-  Assert (i < this->table_size[1],
-          ExcIndexRange (i, 0, this->table_size[1]));
-  Assert (j < this->table_size[0],
-          ExcIndexRange (j, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[1]);
+  AssertIndexRange (j, this->table_size[0]);
   return this->values[size_type(j)*this->table_size[1]+i];
 }
 
@@ -2419,13 +2406,11 @@ TransposeTable<T>::operator () (const unsigned int i,
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-TransposeTable<T>::operator () (const unsigned int i,
-                                const unsigned int j)
+TransposeTable<T>::operator () (const size_type i,
+                                const size_type j)
 {
-  Assert (i < this->table_size[1],
-          ExcIndexRange (i, 0, this->table_size[1]));
-  Assert (j < this->table_size[0],
-          ExcIndexRange (j, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[1]);
+  AssertIndexRange (j, this->table_size[0]);
   return this->values[size_type(j)*this->table_size[1]+i];
 }
 
@@ -2434,8 +2419,8 @@ TransposeTable<T>::operator () (const unsigned int i,
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-TransposeTable<T>::el (const unsigned int i,
-                       const unsigned int j) const
+TransposeTable<T>::el (const size_type i,
+                       const size_type j) const
 {
   return this->values[size_type(j)*this->table_size[1]+i];
 }
@@ -2445,8 +2430,8 @@ TransposeTable<T>::el (const unsigned int i,
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-TransposeTable<T>::el (const unsigned int i,
-                       const unsigned int j)
+TransposeTable<T>::el (const size_type i,
+                       const size_type j)
 {
   return this->values[size_type(j)*this->table_size[1]+i];
 }
@@ -2455,7 +2440,7 @@ TransposeTable<T>::el (const unsigned int i,
 
 template <typename T>
 inline
-unsigned int
+typename TransposeTable<T>::size_type
 TransposeTable<T>::n_rows () const
 {
   return this->table_size[1];
@@ -2465,7 +2450,7 @@ TransposeTable<T>::n_rows () const
 
 template <typename T>
 inline
-unsigned int
+typename TransposeTable<T>::size_type
 TransposeTable<T>::n_cols () const
 {
   return this->table_size[0];
@@ -2479,9 +2464,9 @@ TransposeTable<T>::n_cols () const
 
 template <typename T>
 inline
-Table<3,T>::Table (const unsigned int size1,
-                   const unsigned int size2,
-                   const unsigned int size3)
+Table<3,T>::Table (const size_type size1,
+                   const size_type size2,
+                   const size_type size3)
   :
   TableBase<3,T> (TableIndices<3> (size1, size2, size3))
 {}
@@ -2491,9 +2476,9 @@ Table<3,T>::Table (const unsigned int size1,
 template <typename T>
 template <typename InputIterator>
 inline
-Table<3,T>::Table (const unsigned int size1,
-                   const unsigned int size2,
-                   const unsigned int size3,
+Table<3,T>::Table (const size_type size1,
+                   const size_type size2,
+                   const size_type size3,
                    InputIterator entries,
                    const bool C_style_indexing)
   :
@@ -2507,10 +2492,9 @@ Table<3,T>::Table (const unsigned int size1,
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<3,T,true,2>
-Table<3,T>::operator [] (const unsigned int i) const
+Table<3,T>::operator [] (const size_type i) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
                                    this->table_size[2];
   return (dealii::internal::TableBaseAccessors::Accessor<3,T,true,2>
@@ -2523,10 +2507,9 @@ Table<3,T>::operator [] (const unsigned int i) const
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<3,T,false,2>
-Table<3,T>::operator [] (const unsigned int i)
+Table<3,T>::operator [] (const size_type i)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
                                    this->table_size[2];
   return (dealii::internal::TableBaseAccessors::Accessor<3,T,false,2>
@@ -2539,16 +2522,13 @@ Table<3,T>::operator [] (const unsigned int i)
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-Table<3,T>::operator () (const unsigned int i,
-                         const unsigned int j,
-                         const unsigned int k) const
+Table<3,T>::operator () (const size_type i,
+                         const size_type j,
+                         const size_type k) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
-  Assert (k < this->table_size[2],
-          ExcIndexRange (k, 0, this->table_size[2]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
+  AssertIndexRange (k, this->table_size[2]);
   return this->values[(size_type(i)*this->table_size[1]+j)
                       *this->table_size[2] + k];
 }
@@ -2558,16 +2538,13 @@ Table<3,T>::operator () (const unsigned int i,
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-Table<3,T>::operator () (const unsigned int i,
-                         const unsigned int j,
-                         const unsigned int k)
+Table<3,T>::operator () (const size_type i,
+                         const size_type j,
+                         const size_type k)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
-  Assert (k < this->table_size[2],
-          ExcIndexRange (k, 0, this->table_size[2]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
+  AssertIndexRange (k, this->table_size[2]);
   return this->values[(size_type(i)*this->table_size[1]+j)
                       *this->table_size[2] + k];
 }
@@ -2596,10 +2573,10 @@ Table<3,T>::operator () (const TableIndices<3> &indices)
 
 template <typename T>
 inline
-Table<4,T>::Table (const unsigned int size1,
-                   const unsigned int size2,
-                   const unsigned int size3,
-                   const unsigned int size4)
+Table<4,T>::Table (const size_type size1,
+                   const size_type size2,
+                   const size_type size3,
+                   const size_type size4)
   :
   TableBase<4,T> (TableIndices<4> (size1, size2, size3, size4))
 {}
@@ -2609,10 +2586,9 @@ Table<4,T>::Table (const unsigned int size1,
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<4,T,true,3>
-Table<4,T>::operator [] (const unsigned int i) const
+Table<4,T>::operator [] (const size_type i) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
                                    this->table_size[2] *
                                    this->table_size[3];
@@ -2626,10 +2602,9 @@ Table<4,T>::operator [] (const unsigned int i) const
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<4,T,false,3>
-Table<4,T>::operator [] (const unsigned int i)
+Table<4,T>::operator [] (const size_type i)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
                                    this->table_size[2] *
                                    this->table_size[3];
@@ -2643,19 +2618,15 @@ Table<4,T>::operator [] (const unsigned int i)
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-Table<4,T>::operator () (const unsigned int i,
-                         const unsigned int j,
-                         const unsigned int k,
-                         const unsigned int l) const
+Table<4,T>::operator () (const size_type i,
+                         const size_type j,
+                         const size_type k,
+                         const size_type l) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
-  Assert (k < this->table_size[2],
-          ExcIndexRange (k, 0, this->table_size[2]));
-  Assert (l < this->table_size[3],
-          ExcIndexRange (l, 0, this->table_size[3]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
+  AssertIndexRange (k, this->table_size[2]);
+  AssertIndexRange (l, this->table_size[3]);
   return this->values[((size_type(i)*this->table_size[1]+j)
                        *this->table_size[2] + k)
                       *this->table_size[3] + l];
@@ -2666,19 +2637,15 @@ Table<4,T>::operator () (const unsigned int i,
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-Table<4,T>::operator () (const unsigned int i,
-                         const unsigned int j,
-                         const unsigned int k,
-                         const unsigned int l)
+Table<4,T>::operator () (const size_type i,
+                         const size_type j,
+                         const size_type k,
+                         const size_type l)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
-  Assert (k < this->table_size[2],
-          ExcIndexRange (k, 0, this->table_size[2]));
-  Assert (l < this->table_size[3],
-          ExcIndexRange (l, 0, this->table_size[3]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
+  AssertIndexRange (k, this->table_size[2]);
+  AssertIndexRange (l, this->table_size[3]);
   return this->values[((size_type(i)*this->table_size[1]+j)
                        *this->table_size[2] + k)
                       *this->table_size[3] + l];
@@ -2708,11 +2675,11 @@ Table<4,T>::operator () (const TableIndices<4> &indices)
 
 template <typename T>
 inline
-Table<5,T>::Table (const unsigned int size1,
-                   const unsigned int size2,
-                   const unsigned int size3,
-                   const unsigned int size4,
-                   const unsigned int size5)
+Table<5,T>::Table (const size_type size1,
+                   const size_type size2,
+                   const size_type size3,
+                   const size_type size4,
+                   const size_type size5)
   :
   TableBase<5,T> (TableIndices<5> (size1, size2, size3, size4, size5))
 {}
@@ -2722,10 +2689,9 @@ Table<5,T>::Table (const unsigned int size1,
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<5,T,true,4>
-Table<5,T>::operator [] (const unsigned int i) const
+Table<5,T>::operator [] (const size_type i) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
                                    this->table_size[2] *
                                    this->table_size[3] *
@@ -2740,10 +2706,9 @@ Table<5,T>::operator [] (const unsigned int i) const
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<5,T,false,4>
-Table<5,T>::operator [] (const unsigned int i)
+Table<5,T>::operator [] (const size_type i)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
                                    this->table_size[2] *
                                    this->table_size[3] *
@@ -2758,22 +2723,17 @@ Table<5,T>::operator [] (const unsigned int i)
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-Table<5,T>::operator () (const unsigned int i,
-                         const unsigned int j,
-                         const unsigned int k,
-                         const unsigned int l,
-                         const unsigned int m) const
+Table<5,T>::operator () (const size_type i,
+                         const size_type j,
+                         const size_type k,
+                         const size_type l,
+                         const size_type m) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
-  Assert (k < this->table_size[2],
-          ExcIndexRange (k, 0, this->table_size[2]));
-  Assert (l < this->table_size[3],
-          ExcIndexRange (l, 0, this->table_size[3]));
-  Assert (m < this->table_size[4],
-          ExcIndexRange (m, 0, this->table_size[4]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
+  AssertIndexRange (k, this->table_size[2]);
+  AssertIndexRange (l, this->table_size[3]);
+  AssertIndexRange (m, this->table_size[4]);
   return this->values[(((size_type(i)*this->table_size[1]+j)
                         *this->table_size[2] + k)
                        *this->table_size[3] + l)
@@ -2785,22 +2745,17 @@ Table<5,T>::operator () (const unsigned int i,
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-Table<5,T>::operator () (const unsigned int i,
-                         const unsigned int j,
-                         const unsigned int k,
-                         const unsigned int l,
-                         const unsigned int m)
+Table<5,T>::operator () (const size_type i,
+                         const size_type j,
+                         const size_type k,
+                         const size_type l,
+                         const size_type m)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
-  Assert (k < this->table_size[2],
-          ExcIndexRange (k, 0, this->table_size[2]));
-  Assert (l < this->table_size[3],
-          ExcIndexRange (l, 0, this->table_size[3]));
-  Assert (m < this->table_size[4],
-          ExcIndexRange (m, 0, this->table_size[4]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
+  AssertIndexRange (k, this->table_size[2]);
+  AssertIndexRange (l, this->table_size[3]);
+  AssertIndexRange (m, this->table_size[4]);
   return this->values[(((size_type(i)*this->table_size[1]+j)
                         *this->table_size[2] + k)
                        *this->table_size[3] + l)
@@ -2831,12 +2786,12 @@ Table<5,T>::operator () (const TableIndices<5> &indices)
 
 template <typename T>
 inline
-Table<6,T>::Table (const unsigned int size1,
-                   const unsigned int size2,
-                   const unsigned int size3,
-                   const unsigned int size4,
-                   const unsigned int size5,
-                   const unsigned int size6)
+Table<6,T>::Table (const size_type size1,
+                   const size_type size2,
+                   const size_type size3,
+                   const size_type size4,
+                   const size_type size5,
+                   const size_type size6)
   :
   TableBase<6,T> ()
 {
@@ -2856,10 +2811,9 @@ Table<6,T>::Table (const unsigned int size1,
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<6,T,true,5>
-Table<6,T>::operator [] (const unsigned int i) const
+Table<6,T>::operator [] (const size_type i) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
                                    this->table_size[2] *
                                    this->table_size[3] *
@@ -2875,10 +2829,9 @@ Table<6,T>::operator [] (const unsigned int i) const
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<6,T,false,5>
-Table<6,T>::operator [] (const unsigned int i)
+Table<6,T>::operator [] (const size_type i)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
                                    this->table_size[2] *
                                    this->table_size[3] *
@@ -2894,25 +2847,19 @@ Table<6,T>::operator [] (const unsigned int i)
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-Table<6,T>::operator () (const unsigned int i,
-                         const unsigned int j,
-                         const unsigned int k,
-                         const unsigned int l,
-                         const unsigned int m,
-                         const unsigned int n) const
+Table<6,T>::operator () (const size_type i,
+                         const size_type j,
+                         const size_type k,
+                         const size_type l,
+                         const size_type m,
+                         const size_type n) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
-  Assert (k < this->table_size[2],
-          ExcIndexRange (k, 0, this->table_size[2]));
-  Assert (l < this->table_size[3],
-          ExcIndexRange (l, 0, this->table_size[3]));
-  Assert (m < this->table_size[4],
-          ExcIndexRange (m, 0, this->table_size[4]));
-  Assert (n < this->table_size[5],
-          ExcIndexRange (n, 0, this->table_size[5]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
+  AssertIndexRange (k, this->table_size[2]);
+  AssertIndexRange (l, this->table_size[3]);
+  AssertIndexRange (m, this->table_size[4]);
+  AssertIndexRange (n, this->table_size[5]);
   return this->values[((((size_type(i)*this->table_size[1]+j)
                          *this->table_size[2] + k)
                         *this->table_size[3] + l)
@@ -2925,25 +2872,19 @@ Table<6,T>::operator () (const unsigned int i,
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-Table<6,T>::operator () (const unsigned int i,
-                         const unsigned int j,
-                         const unsigned int k,
-                         const unsigned int l,
-                         const unsigned int m,
-                         const unsigned int n)
+Table<6,T>::operator () (const size_type i,
+                         const size_type j,
+                         const size_type k,
+                         const size_type l,
+                         const size_type m,
+                         const size_type n)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
-  Assert (k < this->table_size[2],
-          ExcIndexRange (k, 0, this->table_size[2]));
-  Assert (l < this->table_size[3],
-          ExcIndexRange (l, 0, this->table_size[3]));
-  Assert (m < this->table_size[4],
-          ExcIndexRange (m, 0, this->table_size[4]));
-  Assert (n < this->table_size[5],
-          ExcIndexRange (n, 0, this->table_size[5]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
+  AssertIndexRange (k, this->table_size[2]);
+  AssertIndexRange (l, this->table_size[3]);
+  AssertIndexRange (m, this->table_size[4]);
+  AssertIndexRange (n, this->table_size[5]);
   return this->values[((((size_type(i)*this->table_size[1]+j)
                          *this->table_size[2] + k)
                         *this->table_size[3] + l)
@@ -2975,13 +2916,13 @@ Table<6,T>::operator () (const TableIndices<6> &indices)
 
 template <typename T>
 inline
-Table<7,T>::Table (const unsigned int size1,
-                   const unsigned int size2,
-                   const unsigned int size3,
-                   const unsigned int size4,
-                   const unsigned int size5,
-                   const unsigned int size6,
-                   const unsigned int size7)
+Table<7,T>::Table (const size_type size1,
+                   const size_type size2,
+                   const size_type size3,
+                   const size_type size4,
+                   const size_type size5,
+                   const size_type size6,
+                   const size_type size7)
   :
   TableBase<7,T> ()
 {
@@ -3002,10 +2943,9 @@ Table<7,T>::Table (const unsigned int size1,
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<7,T,true,6>
-Table<7,T>::operator [] (const unsigned int i) const
+Table<7,T>::operator [] (const size_type i) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
                                    this->table_size[2] *
                                    this->table_size[3] *
@@ -3022,10 +2962,9 @@ Table<7,T>::operator [] (const unsigned int i) const
 template <typename T>
 inline
 dealii::internal::TableBaseAccessors::Accessor<7,T,false,6>
-Table<7,T>::operator [] (const unsigned int i)
+Table<7,T>::operator [] (const size_type i)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
+  AssertIndexRange (i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
                                    this->table_size[2] *
                                    this->table_size[3] *
@@ -3042,28 +2981,21 @@ Table<7,T>::operator [] (const unsigned int i)
 template <typename T>
 inline
 typename AlignedVector<T>::const_reference
-Table<7,T>::operator () (const unsigned int i,
-                         const unsigned int j,
-                         const unsigned int k,
-                         const unsigned int l,
-                         const unsigned int m,
-                         const unsigned int n,
-                         const unsigned int o) const
+Table<7,T>::operator () (const size_type i,
+                         const size_type j,
+                         const size_type k,
+                         const size_type l,
+                         const size_type m,
+                         const size_type n,
+                         const size_type o) const
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
-  Assert (k < this->table_size[2],
-          ExcIndexRange (k, 0, this->table_size[2]));
-  Assert (l < this->table_size[3],
-          ExcIndexRange (l, 0, this->table_size[3]));
-  Assert (m < this->table_size[4],
-          ExcIndexRange (m, 0, this->table_size[4]));
-  Assert (n < this->table_size[5],
-          ExcIndexRange (n, 0, this->table_size[5]));
-  Assert (o < this->table_size[6],
-          ExcIndexRange (o, 0, this->table_size[6]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
+  AssertIndexRange (k, this->table_size[2]);
+  AssertIndexRange (l, this->table_size[3]);
+  AssertIndexRange (m, this->table_size[4]);
+  AssertIndexRange (n, this->table_size[5]);
+  AssertIndexRange (o, this->table_size[6]);
   return this->values[(((((size_type(i)*this->table_size[1]+j)
                           *this->table_size[2] + k)
                          *this->table_size[3] + l)
@@ -3077,28 +3009,21 @@ Table<7,T>::operator () (const unsigned int i,
 template <typename T>
 inline
 typename AlignedVector<T>::reference
-Table<7,T>::operator () (const unsigned int i,
-                         const unsigned int j,
-                         const unsigned int k,
-                         const unsigned int l,
-                         const unsigned int m,
-                         const unsigned int n,
-                         const unsigned int o)
+Table<7,T>::operator () (const size_type i,
+                         const size_type j,
+                         const size_type k,
+                         const size_type l,
+                         const size_type m,
+                         const size_type n,
+                         const size_type o)
 {
-  Assert (i < this->table_size[0],
-          ExcIndexRange (i, 0, this->table_size[0]));
-  Assert (j < this->table_size[1],
-          ExcIndexRange (j, 0, this->table_size[1]));
-  Assert (k < this->table_size[2],
-          ExcIndexRange (k, 0, this->table_size[2]));
-  Assert (l < this->table_size[3],
-          ExcIndexRange (l, 0, this->table_size[3]));
-  Assert (m < this->table_size[4],
-          ExcIndexRange (m, 0, this->table_size[4]));
-  Assert (n < this->table_size[5],
-          ExcIndexRange (n, 0, this->table_size[5]));
-  Assert (o < this->table_size[5],
-          ExcIndexRange (o, 0, this->table_size[6]));
+  AssertIndexRange (i, this->table_size[0]);
+  AssertIndexRange (j, this->table_size[1]);
+  AssertIndexRange (k, this->table_size[2]);
+  AssertIndexRange (l, this->table_size[3]);
+  AssertIndexRange (m, this->table_size[4]);
+  AssertIndexRange (n, this->table_size[5]);
+  AssertIndexRange (o, this->table_size[6]);
   return this->values[(((((size_type(i)*this->table_size[1]+j)
                           *this->table_size[2] + k)
                          *this->table_size[3] + l)

--- a/include/deal.II/base/table_indices.h
+++ b/include/deal.II/base/table_indices.h
@@ -57,7 +57,7 @@ public:
    * This constructor will result in a compiler error if
    * the template argument @p N is different from one.
    */
-  explicit TableIndices (const unsigned int index0);
+  explicit TableIndices (const std::size_t index0);
 
   /**
    * Constructor. This is the appropriate constructor for an
@@ -67,8 +67,8 @@ public:
    * This constructor will result in a compiler error if
    * the template argument @p N is different from two.
    */
-  TableIndices (const unsigned int index0,
-                const unsigned int index1);
+  TableIndices (const std::size_t index0,
+                const std::size_t index1);
 
   /**
    * Constructor. This is the appropriate constructor for an
@@ -78,9 +78,9 @@ public:
    * This constructor will result in a compiler error if
    * the template argument @p N is different from three.
    */
-  TableIndices (const unsigned int index0,
-                const unsigned int index1,
-                const unsigned int index2);
+  TableIndices (const std::size_t index0,
+                const std::size_t index1,
+                const std::size_t index2);
 
   /**
    * Constructor. This is the appropriate constructor for an
@@ -90,10 +90,10 @@ public:
    * This constructor will result in a compiler error if
    * the template argument @p N is different from four.
    */
-  TableIndices (const unsigned int index0,
-                const unsigned int index1,
-                const unsigned int index2,
-                const unsigned int index3);
+  TableIndices (const std::size_t index0,
+                const std::size_t index1,
+                const std::size_t index2,
+                const std::size_t index3);
 
   /**
    * Constructor. This is the appropriate constructor for an
@@ -103,11 +103,11 @@ public:
    * This constructor will result in a compiler error if
    * the template argument @p N is different from five.
    */
-  TableIndices (const unsigned int index0,
-                const unsigned int index1,
-                const unsigned int index2,
-                const unsigned int index3,
-                const unsigned int index4);
+  TableIndices (const std::size_t index0,
+                const std::size_t index1,
+                const std::size_t index2,
+                const std::size_t index3,
+                const std::size_t index4);
 
   /**
    * Convenience constructor that takes up to 9 arguments. It can be used to
@@ -124,25 +124,25 @@ public:
    *   to initialize the @p N indices instead.
    */
   DEAL_II_DEPRECATED
-  TableIndices (const unsigned int index0,
-                const unsigned int index1,
-                const unsigned int index2,
-                const unsigned int index3,
-                const unsigned int index4,
-                const unsigned int index5,
-                const unsigned int index6 = numbers::invalid_unsigned_int,
-                const unsigned int index7 = numbers::invalid_unsigned_int,
-                const unsigned int index8 = numbers::invalid_unsigned_int);
+  TableIndices (const std::size_t index0,
+                const std::size_t index1,
+                const std::size_t index2,
+                const std::size_t index3,
+                const std::size_t index4,
+                const std::size_t index5,
+                const std::size_t index6 = numbers::invalid_unsigned_int,
+                const std::size_t index7 = numbers::invalid_unsigned_int,
+                const std::size_t index8 = numbers::invalid_unsigned_int);
 
   /**
    * Read-only access the value of the <tt>i</tt>th index.
    */
-  unsigned int operator[] (const unsigned int i) const;
+  std::size_t operator[] (const unsigned int i) const;
 
   /**
    * Write access the value of the <tt>i</tt>th index.
    */
-  unsigned int &operator[] (const unsigned int i);
+  std::size_t &operator[] (const unsigned int i);
 
   /**
    * Compare two index fields for equality.
@@ -171,7 +171,7 @@ protected:
   /**
    * Store the indices in an array.
    */
-  unsigned int indices[N];
+  std::size_t indices[N];
 };
 
 
@@ -191,7 +191,7 @@ TableIndices<N>::TableIndices()
 
 
 template <int N>
-TableIndices<N>::TableIndices(const unsigned int index0)
+TableIndices<N>::TableIndices(const std::size_t index0)
 {
   static_assert (N==1,
                  "This constructor is only available for TableIndices<1> objects.");
@@ -201,8 +201,8 @@ TableIndices<N>::TableIndices(const unsigned int index0)
 
 
 template <int N>
-TableIndices<N>::TableIndices(const unsigned int index0,
-                              const unsigned int index1)
+TableIndices<N>::TableIndices(const std::size_t index0,
+                              const std::size_t index1)
 {
   static_assert (N==2,
                  "This constructor is only available for TableIndices<2> objects.");
@@ -213,9 +213,9 @@ TableIndices<N>::TableIndices(const unsigned int index0,
 
 
 template <int N>
-TableIndices<N>::TableIndices(const unsigned int index0,
-                              const unsigned int index1,
-                              const unsigned int index2)
+TableIndices<N>::TableIndices(const std::size_t index0,
+                              const std::size_t index1,
+                              const std::size_t index2)
 {
   static_assert (N==3,
                  "This constructor is only available for TableIndices<3> objects.");
@@ -227,10 +227,10 @@ TableIndices<N>::TableIndices(const unsigned int index0,
 
 
 template <int N>
-TableIndices<N>::TableIndices(const unsigned int index0,
-                              const unsigned int index1,
-                              const unsigned int index2,
-                              const unsigned int index3)
+TableIndices<N>::TableIndices(const std::size_t index0,
+                              const std::size_t index1,
+                              const std::size_t index2,
+                              const std::size_t index3)
 {
   static_assert (N==4,
                  "This constructor is only available for TableIndices<4> objects.");
@@ -243,11 +243,11 @@ TableIndices<N>::TableIndices(const unsigned int index0,
 
 
 template <int N>
-TableIndices<N>::TableIndices(const unsigned int index0,
-                              const unsigned int index1,
-                              const unsigned int index2,
-                              const unsigned int index3,
-                              const unsigned int index4)
+TableIndices<N>::TableIndices(const std::size_t index0,
+                              const std::size_t index1,
+                              const std::size_t index2,
+                              const std::size_t index3,
+                              const std::size_t index4)
 {
   static_assert (N==5,
                  "This constructor is only available for TableIndices<5> objects.");
@@ -261,15 +261,15 @@ TableIndices<N>::TableIndices(const unsigned int index0,
 
 
 template <int N>
-TableIndices<N>::TableIndices(const unsigned int index0,
-                              const unsigned int index1,
-                              const unsigned int index2,
-                              const unsigned int index3,
-                              const unsigned int index4,
-                              const unsigned int index5,
-                              const unsigned int index6,
-                              const unsigned int index7,
-                              const unsigned int index8)
+TableIndices<N>::TableIndices(const std::size_t index0,
+                              const std::size_t index1,
+                              const std::size_t index2,
+                              const std::size_t index3,
+                              const std::size_t index4,
+                              const std::size_t index5,
+                              const std::size_t index6,
+                              const std::size_t index7,
+                              const std::size_t index8)
 {
   Assert (N > 0, ExcMessage("Cannot create a TableIndices object of size 0"));
 
@@ -346,20 +346,20 @@ TableIndices<N>::TableIndices(const unsigned int index0,
 
 template <int N>
 inline
-unsigned int
+std::size_t
 TableIndices<N>::operator [] (const unsigned int i) const
 {
-  Assert (i < N, ExcIndexRange (i, 0, N));
+  AssertIndexRange (i, N);
   return indices[i];
 }
 
 
 template <int N>
 inline
-unsigned int &
+std::size_t &
 TableIndices<N>::operator [] (const unsigned int i)
 {
-  Assert (i < N, ExcIndexRange (i, 0, N));
+  AssertIndexRange (i, N);
   return indices[i];
 }
 

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -65,12 +65,9 @@ class FullMatrix : public Table<2,number>
 {
 public:
   /**
-   * A type of used to index into this container. Because we can not expect to
-   * store matrices bigger than what can be indexed by a regular unsigned
-   * integer, <code>unsigned int</code> is completely sufficient as an index
-   * type.
+   * A type of used to index into this container.
    */
-  typedef unsigned int size_type;
+  typedef std::size_t size_type;
 
   /**
    * Type of matrix entries. This typedef is analogous to <tt>value_type</tt>
@@ -317,10 +314,10 @@ public:
   template <int dim>
   void
   copy_from (const Tensor<2,dim> &T,
-             const size_type src_r_i=0,
-             const size_type src_r_j=dim-1,
-             const size_type src_c_i=0,
-             const size_type src_c_j=dim-1,
+             const unsigned int src_r_i=0,
+             const unsigned int src_r_j=dim-1,
+             const unsigned int src_c_i=0,
+             const unsigned int src_c_j=dim-1,
              const size_type dst_r=0,
              const size_type dst_c=0);
 
@@ -338,8 +335,8 @@ public:
           const size_type src_r_j=dim-1,
           const size_type src_c_i=0,
           const size_type src_c_j=dim-1,
-          const size_type dst_r=0,
-          const size_type dst_c=0) const;
+          const unsigned int dst_r=0,
+          const unsigned int dst_c=0) const;
 
   /**
    * Copy a subset of the rows and columns of another matrix into the current
@@ -731,7 +728,7 @@ public:
    */
   template <typename number2, typename index_type>
   void add (const size_type     row,
-            const unsigned int  n_cols,
+            const size_type     n_cols,
             const index_type   *col_indices,
             const number2      *values,
             const bool          elide_zero_values = true,
@@ -1475,7 +1472,7 @@ inline
 typename FullMatrix<number>::const_iterator
 FullMatrix<number>::begin (const size_type r) const
 {
-  Assert (r<m(), ExcIndexRange(r,0,m()));
+  AssertIndexRange(r,m());
   return const_iterator(this, r, 0);
 }
 
@@ -1486,7 +1483,7 @@ inline
 typename FullMatrix<number>::const_iterator
 FullMatrix<number>::end (const size_type r) const
 {
-  Assert (r<m(), ExcIndexRange(r,0,m()));
+  AssertIndexRange(r,m());
   return const_iterator(this, r+1, 0);
 }
 
@@ -1509,10 +1506,10 @@ template <typename number>
 template <typename number2, typename index_type>
 inline
 void
-FullMatrix<number>::add (const size_type    row,
-                         const unsigned int n_cols,
-                         const index_type  *col_indices,
-                         const number2     *values,
+FullMatrix<number>::add (const size_type   row,
+                         const size_type   n_cols,
+                         const index_type *col_indices,
+                         const number2    *values,
                          const bool,
                          const bool)
 {
@@ -1536,8 +1533,8 @@ FullMatrix<number>::print (StreamType         &s,
   Assert (!this->empty(), ExcEmptyMatrix());
 
   // save the state of out stream
-  const unsigned int old_precision = s.precision (p);
-  const unsigned int old_width = s.width (w);
+  const std::streamsize old_precision = s.precision (p);
+  const std::streamsize old_width = s.width (w);
 
   for (size_type i=0; i<this->m(); ++i)
     {

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -528,7 +528,10 @@ void FullMatrix<number>::mmult (FullMatrix<number2>       &dst,
        std::is_same<number,float>::value)
       &&
       std::is_same<number,number2>::value)
-    if (this->n()*this->m()*src.n() > 300)
+    if (this->n()*this->m()*src.n() > 300 &&
+        src.n() <= std::numeric_limits<types::blas_int>::max() &&
+        this->m() <= std::numeric_limits<types::blas_int>::max() &&
+        this->n() <= std::numeric_limits<types::blas_int>::max())
       {
         // In case we have the BLAS function gemm detected by CMake, we
         // use that algorithm for matrix-matrix multiplication since it
@@ -542,9 +545,9 @@ void FullMatrix<number>::mmult (FullMatrix<number2>       &dst,
         // transpose matrices, and read the result as if it were row-wise
         // again. In other words, we calculate (B^T A^T)^T, which is AB.
 
-        const types::blas_int m = src.n();
-        const types::blas_int n = this->m();
-        const types::blas_int k = this->n();
+        const types::blas_int m = static_cast<types::blas_int>(src.n());
+        const types::blas_int n = static_cast<types::blas_int>(this->m());
+        const types::blas_int k = static_cast<types::blas_int>(this->n());
         const char *notrans = "n";
 
         const number alpha = 1.;
@@ -598,7 +601,10 @@ void FullMatrix<number>::Tmmult (FullMatrix<number2>       &dst,
        std::is_same<number,float>::value)
       &&
       std::is_same<number,number2>::value)
-    if (this->n()*this->m()*src.n() > 300)
+    if (this->n()*this->m()*src.n() > 300 &&
+        src.n() <= std::numeric_limits<types::blas_int>::max() &&
+        this->n() <= std::numeric_limits<types::blas_int>::max() &&
+        this->m() <= std::numeric_limits<types::blas_int>::max())
       {
         // In case we have the BLAS function gemm detected by CMake, we
         // use that algorithm for matrix-matrix multiplication since it
@@ -612,9 +618,9 @@ void FullMatrix<number>::Tmmult (FullMatrix<number2>       &dst,
         // transpose matrices, and read the result as if it were row-wise
         // again. In other words, we calculate (B^T A)^T, which is A^T B.
 
-        const types::blas_int m = src.n();
-        const types::blas_int n = this->n();
-        const types::blas_int k = this->m();
+        const types::blas_int m = static_cast<types::blas_int>(src.n());
+        const types::blas_int n = static_cast<types::blas_int>(this->n());
+        const types::blas_int k = static_cast<types::blas_int>(this->m());
         const char *trans = "t";
         const char *notrans = "n";
 
@@ -688,7 +694,10 @@ void FullMatrix<number>::mTmult (FullMatrix<number2>       &dst,
        std::is_same<number,float>::value)
       &&
       std::is_same<number,number2>::value)
-    if (this->n()*this->m()*src.m() > 300)
+    if (this->n()*this->m()*src.m() > 300 &&
+        src.m() <= std::numeric_limits<types::blas_int>::max() &&
+        this->n() <= std::numeric_limits<types::blas_int>::max() &&
+        this->m() <= std::numeric_limits<types::blas_int>::max())
       {
         // In case we have the BLAS function gemm detected by CMake, we
         // use that algorithm for matrix-matrix multiplication since it
@@ -702,9 +711,9 @@ void FullMatrix<number>::mTmult (FullMatrix<number2>       &dst,
         // transpose matrices, and read the result as if it were row-wise
         // again. In other words, we calculate (B A^T)^T, which is AB^T.
 
-        const types::blas_int m = src.m();
-        const types::blas_int n = this->m();
-        const types::blas_int k = this->n();
+        const types::blas_int m = static_cast<types::blas_int>(src.m());
+        const types::blas_int n = static_cast<types::blas_int>(this->m());
+        const types::blas_int k = static_cast<types::blas_int>(this->n());
         const char *notrans = "n";
         const char *trans = "t";
 
@@ -776,7 +785,10 @@ void FullMatrix<number>::TmTmult (FullMatrix<number2>       &dst,
        std::is_same<number,float>::value)
       &&
       std::is_same<number,number2>::value)
-    if (this->n()*this->m()*src.m() > 300)
+    if (this->n()*this->m()*src.m() > 300 &&
+        src.m() <= std::numeric_limits<types::blas_int>::max() &&
+        this->n() <= std::numeric_limits<types::blas_int>::max() &&
+        this->m() <= std::numeric_limits<types::blas_int>::max())
       {
         // In case we have the BLAS function gemm detected by CMake, we
         // use that algorithm for matrix-matrix multiplication since it
@@ -790,9 +802,9 @@ void FullMatrix<number>::TmTmult (FullMatrix<number2>       &dst,
         // transpose matrices, and read the result as if it were row-wise
         // again. In other words, we calculate (B A)^T, which is A^T B^T.
 
-        const types::blas_int m = src.m();
-        const types::blas_int n = this->n();
-        const types::blas_int k = this->m();
+        const types::blas_int m = static_cast<types::blas_int>(src.m());
+        const types::blas_int n = static_cast<types::blas_int>(this->n());
+        const types::blas_int k = static_cast<types::blas_int>(this->m());
         const char *trans = "t";
 
         const number alpha = 1.;
@@ -1182,8 +1194,8 @@ namespace internal
       static number value (const FullMatrix<number> &A)
       {
         using s_type = typename LAPACKFullMatrix<number>::size_type;
-        AssertIndexRange (A.m(), std::numeric_limits<s_type>::max()+1);
-        AssertIndexRange (A.n(), std::numeric_limits<s_type>::max()+1);
+        AssertIndexRange (A.m()-1, std::numeric_limits<s_type>::max());
+        AssertIndexRange (A.n()-1, std::numeric_limits<s_type>::max());
         LAPACKFullMatrix<number> lp_A (static_cast<s_type>(A.m()),
                                        static_cast<s_type>(A.n()));
         lp_A = A;
@@ -1759,7 +1771,8 @@ FullMatrix<number>::gauss_jordan ()
   if (std::is_same<number,double>::value
       ||
       std::is_same<number,float>::value)
-    if (this->n_cols() > 15)
+    if (this->n_cols() > 15 &&
+        this->n_cols() <= std::numeric_limits<types::blas_int>::max())
       {
         // In case we have the LAPACK functions
         // getrf and getri detected by CMake,
@@ -1780,7 +1793,7 @@ FullMatrix<number>::gauss_jordan ()
         // we just got ((A^T)^{-1})^T, which is
         // A^{-1}.
 
-        const types::blas_int nn = this->n();
+        const types::blas_int nn = static_cast<types::blas_int>(this->n());
 
         // workspace for permutations
         std::vector<types::blas_int> ipiv(nn);

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -883,7 +883,7 @@ inline
 typename LAPACKFullMatrix<number>::size_type
 LAPACKFullMatrix<number>::m () const
 {
-  return this->n_rows ();
+  return static_cast<size_type>(this->n_rows ());
 }
 
 template <typename number>
@@ -891,7 +891,7 @@ inline
 typename LAPACKFullMatrix<number>::size_type
 LAPACKFullMatrix<number>::n () const
 {
-  return this->n_cols ();
+  return static_cast<size_type>(this->n_cols ());
 }
 
 template <typename number>

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -57,7 +57,7 @@ public:
   /**
    * Declare type for container size.
    */
-  typedef unsigned int size_type;
+  typedef std::make_unsigned<types::blas_int>::type size_type;
 
   /**
    * Constructor. Initialize the matrix as a square matrix with dimension
@@ -1007,7 +1007,7 @@ LAPACKFullMatrix<number>::eigenvalue (const size_type i) const
   Assert (state & LAPACKSupport::eigenvalues, ExcInvalidState());
   Assert (wr.size() == this->n_rows(), ExcInternalError());
   Assert (wi.size() == this->n_rows(), ExcInternalError());
-  Assert (i<this->n_rows(), ExcIndexRange(i,0,this->n_rows()));
+  AssertIndexRange (i,this->n_rows());
 
   return std::complex<number>(wr[i], wi[i]);
 }

--- a/source/lac/full_matrix.inst.in
+++ b/source/lac/full_matrix.inst.in
@@ -25,26 +25,26 @@ for (S : REAL_AND_COMPLEX_SCALARS)
         std::ostream&, const unsigned int, const unsigned int) const;
 
     template void FullMatrix<S>::copy_from<1>(
-        const Tensor<2,1>&, const size_type, const size_type, const size_type, const size_type, const size_type, const size_type);
+        const Tensor<2,1>&, const unsigned int, const unsigned int, unsigned int, const unsigned int, const size_type, const size_type);
 
     template void FullMatrix<S>::copy_from<2>(
-        const Tensor<2,2>&, const size_type, const size_type, const size_type, const size_type, const size_type, const size_type);
+        const Tensor<2,2>&, const unsigned int, const unsigned int, unsigned int, const unsigned int, const size_type, const size_type);
 
     template void FullMatrix<S>::copy_from<3>(
-        const Tensor<2,3>&, const size_type, const size_type, const size_type, const size_type, const size_type, const size_type);
+        const Tensor<2,3>&, const unsigned int, const unsigned int, unsigned int, const unsigned int, const size_type, const size_type);
 }
 
 
 for (S : REAL_SCALARS)
 {
     template void FullMatrix<S>::copy_to<1>(
-        Tensor<2,1>&, const size_type, const size_type, const size_type, const size_type, const size_type, const size_type) const;
+        Tensor<2,1>&, const size_type, const size_type, const size_type, const size_type, const unsigned int, const unsigned int) const;
 
     template void FullMatrix<S>::copy_to<2>(
-        Tensor<2,2>&, const size_type, const size_type, const size_type, const size_type, const size_type, const size_type) const;
+        Tensor<2,2>&, const size_type, const size_type, const size_type, const size_type, const unsigned int, const unsigned int) const;
 
     template void FullMatrix<S>::copy_to<3>(
-        Tensor<2,3>&, const size_type, const size_type, const size_type, const size_type, const size_type, const size_type) const;
+        Tensor<2,3>&, const size_type, const size_type, const size_type, const size_type, const unsigned int, const unsigned int) const;
 }
 
 

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -99,8 +99,8 @@ template <typename number>
 void
 LAPACKFullMatrix<number>::remove_row_and_column (const size_type row, const size_type col)
 {
-  Assert (row<this->n_rows(), ExcIndexRange(row,0,this->n_rows()));
-  Assert (col<this->n_cols(), ExcIndexRange(col,0,this->n_cols()));
+  AssertIndexRange (row,this->n_rows());
+  AssertIndexRange (col,this->n_cols());
 
   const size_type nrows = this->n_rows()-1;
   const size_type ncols = this->n_cols()-1;
@@ -1551,7 +1551,7 @@ LAPACKFullMatrix<number>::print_formatted (
   // set output format, but store old
   // state
   std::ios::fmtflags old_flags = out.flags();
-  unsigned int old_precision = out.precision (precision);
+  std::streamsize old_precision = out.precision (precision);
 
   if (scientific)
     {

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -770,7 +770,7 @@ LAPACKFullMatrix<number>::compute_lu_factorization()
 
   const types::blas_int mm = this->n_rows();
   const types::blas_int nn = this->n_cols();
-  number *values = const_cast<number *> (&this->values[0]);
+  number *const values = &this->values[0];
   ipiv.resize(mm);
   types::blas_int info = 0;
   getrf(&mm, &nn, values, &mm, ipiv.data(), &info);
@@ -832,7 +832,7 @@ number LAPACKFullMatrix<number>::norm(const char type) const
 
   const types::blas_int N = this->n_cols();
   const types::blas_int M = this->n_rows();
-  const number *values = &this->values[0];
+  const number *const values = &this->values[0];
   if (property == symmetric)
     {
       const types::blas_int lda = std::max<types::blas_int>(1,N);
@@ -886,7 +886,7 @@ LAPACKFullMatrix<number>::compute_cholesky_factorization()
   (void) mm;
   Assert (mm == nn, ExcDimensionMismatch(mm,nn));
 
-  number *values = &this->values[0];
+  number *const values = &this->values[0];
   types::blas_int info = 0;
   const types::blas_int lda = std::max<types::blas_int>(1,nn);
   potrf (&LAPACKSupport::L, &nn, values, &lda, &info);
@@ -938,7 +938,7 @@ LAPACKFullMatrix<number>::reciprocal_condition_number() const
   number rcond = 0.;
 
   const types::blas_int N = this->n_rows();
-  const number *values = &this->values[0];
+  const number *const values = &this->values[0];
   types::blas_int info = 0;
   const types::blas_int lda = std::max<types::blas_int>(1,N);
   work.resize(3*N);
@@ -968,15 +968,15 @@ LAPACKFullMatrix<number>::compute_svd()
 
   const types::blas_int mm = this->n_rows();
   const types::blas_int nn = this->n_cols();
-  number *values = const_cast<number *> (&this->values[0]);
+  number *const values = &this->values[0];
   wr.resize(std::max(mm,nn));
   std::fill(wr.begin(), wr.end(), 0.);
   ipiv.resize(8*mm);
 
   svd_u.reset (new LAPACKFullMatrix<number>(mm,mm));
   svd_vt.reset (new LAPACKFullMatrix<number>(nn,nn));
-  number *mu  = const_cast<number *> (&svd_u->values[0]);
-  number *mvt = const_cast<number *> (&svd_vt->values[0]);
+  number *const mu  = &svd_u->values[0];
+  number *const mvt = &svd_vt->values[0];
   types::blas_int info = 0;
 
   // First determine optimal workspace size
@@ -1035,7 +1035,7 @@ LAPACKFullMatrix<number>::invert()
   const types::blas_int nn = this->n_cols();
   Assert (nn == mm, ExcNotQuadratic());
 
-  number *values = const_cast<number *> (&this->values[0]);
+  number *const values = &this->values[0];
   types::blas_int info = 0;
 
   if (property != symmetric)
@@ -1078,7 +1078,7 @@ LAPACKFullMatrix<number>::solve(Vector<number> &v,
   AssertDimension(this->n_rows(), v.size());
   const char *trans = transposed ? &T : &N;
   const types::blas_int nn = this->n_cols();
-  const number *values = &this->values[0];
+  const number *const values = &this->values[0];
   const types::blas_int n_rhs = 1;
   types::blas_int info = 0;
 
@@ -1127,7 +1127,7 @@ LAPACKFullMatrix<number>::solve(LAPACKFullMatrix<number> &B,
   AssertDimension(this->n_rows(), B.n_rows());
   const char *trans = transposed ? &T : &N;
   const types::blas_int nn = this->n_cols();
-  const number *values = &this->values[0];
+  const number *const values = &this->values[0];
   const types::blas_int n_rhs = B.n_cols();
   types::blas_int info = 0;
 
@@ -1226,7 +1226,7 @@ LAPACKFullMatrix<number>::compute_eigenvalues(const bool right,
   if (right) vr.resize(nn*nn);
   if (left)  vl.resize(nn*nn);
 
-  number *values = const_cast<number *> (&this->values[0]);
+  number *const values = &this->values[0];
 
   types::blas_int info  = 0;
   types::blas_int lwork = 1;
@@ -1290,8 +1290,8 @@ LAPACKFullMatrix<number>::compute_eigenvalues_symmetric(const number        lowe
   wr.resize(nn);
   LAPACKFullMatrix<number> matrix_eigenvectors(nn, nn);
 
-  number *values_A = const_cast<number *> (&this->values[0]);
-  number *values_eigenvectors = const_cast<number *> (&matrix_eigenvectors.values[0]);
+  number *const values_A = &this->values[0];
+  number *const values_eigenvectors = &matrix_eigenvectors.values[0];
 
   types::blas_int info(0),
         lwork(-1),
@@ -1382,9 +1382,9 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric(
   wr.resize(nn);
   LAPACKFullMatrix<number> matrix_eigenvectors(nn, nn);
 
-  number *values_A = const_cast<number *> (&this->values[0]);
-  number *values_B = const_cast<number *> (&B.values[0]);
-  number *values_eigenvectors = const_cast<number *> (&matrix_eigenvectors.values[0]);
+  number *const values_A = &this->values[0];
+  number *const values_B = &B.values[0];
+  number *const values_eigenvectors = &matrix_eigenvectors.values[0];
 
   types::blas_int info(0),
         lwork(-1),
@@ -1473,8 +1473,8 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric (
   wi.resize(nn); //This is set purely for consistency reasons with the
   //eigenvalues() function.
 
-  number *values_A = const_cast<number *> (&this->values[0]);
-  number *values_B = const_cast<number *> (&B.values[0]);
+  number *const values_A = &this->values[0];
+  number *const values_B = &B.values[0];
 
   types::blas_int info  = 0;
   types::blas_int lwork = -1;

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -99,11 +99,11 @@ template <typename number>
 void
 LAPACKFullMatrix<number>::remove_row_and_column (const size_type row, const size_type col)
 {
-  AssertIndexRange (row,this->n_rows());
-  AssertIndexRange (col,this->n_cols());
+  AssertIndexRange (row,this->m());
+  AssertIndexRange (col,this->n());
 
-  const size_type nrows = this->n_rows()-1;
-  const size_type ncols = this->n_cols()-1;
+  const size_type nrows = this->m()-1;
+  const size_type ncols = this->n()-1;
 
   TransposeTable<number> copy(std::move(*this));
   this->TransposeTable<number>::reinit (nrows, ncols);
@@ -136,10 +136,10 @@ template <typename number2>
 LAPACKFullMatrix<number> &
 LAPACKFullMatrix<number>::operator = (const FullMatrix<number2> &M)
 {
-  Assert (this->n_rows() == M.n_rows(), ExcDimensionMismatch(this->n_rows(), M.n_rows()));
-  Assert (this->n_cols() == M.n(), ExcDimensionMismatch(this->n_cols(), M.n()));
-  for (size_type i=0; i<this->n_rows(); ++i)
-    for (size_type j=0; j<this->n_cols(); ++j)
+  Assert (this->m() == M.m(), ExcDimensionMismatch(this->m(), M.m()));
+  Assert (this->n() == M.n(), ExcDimensionMismatch(this->n(), M.n()));
+  for (size_type i=0; i<this->m(); ++i)
+    for (size_type j=0; j<this->n(); ++j)
       (*this)(i,j) = M(i,j);
 
   state = LAPACKSupport::matrix;
@@ -153,10 +153,10 @@ template <typename number2>
 LAPACKFullMatrix<number> &
 LAPACKFullMatrix<number>::operator = (const SparseMatrix<number2> &M)
 {
-  Assert (this->n_rows() == M.n(), ExcDimensionMismatch(this->n_rows(), M.n()));
-  Assert (this->n_cols() == M.m(), ExcDimensionMismatch(this->n_cols(), M.m()));
-  for (size_type i=0; i<this->n_rows(); ++i)
-    for (size_type j=0; j<this->n_cols(); ++j)
+  Assert (this->m() == M.n(), ExcDimensionMismatch(this->m(), M.n()));
+  Assert (this->n() == M.m(), ExcDimensionMismatch(this->n(), M.m()));
+  for (size_type i=0; i<this->m(); ++i)
+    for (size_type j=0; j<this->n(); ++j)
       (*this)(i,j) = M.el(i,j);
 
   state = LAPACKSupport::matrix;
@@ -346,7 +346,7 @@ LAPACKFullMatrix<number>::rank1_update(const number a,
   if (state == LAPACKSupport::matrix)
     {
       {
-        const types::blas_int N = this->n_rows();
+        const types::blas_int N = this->m();
         const char uplo = LAPACKSupport::U;
         const types::blas_int lda = N;
         const types::blas_int incx=1;
@@ -354,7 +354,7 @@ LAPACKFullMatrix<number>::rank1_update(const number a,
         syr(&uplo, &N, &a, v.begin(), &incx, this->values.begin(), &lda);
       }
 
-      const size_type N = this->n_rows();
+      const size_type N = this->m();
       // FIXME: we should really only update upper or lower triangular parts
       // of symmetric matrices and make sure the interface is consistent,
       // for example operator(i,j) gives correct results regardless of storage.
@@ -379,8 +379,8 @@ LAPACKFullMatrix<number>::vmult (
   const Vector<number> &v,
   const bool            adding) const
 {
-  const types::blas_int mm = this->n_rows();
-  const types::blas_int nn = this->n_cols();
+  const types::blas_int mm = this->m();
+  const types::blas_int nn = this->n();
   const number alpha = 1.;
   const number beta = (adding ? 1. : 0.);
   const number null = 0.;
@@ -394,8 +394,8 @@ LAPACKFullMatrix<number>::vmult (
       Assert (adding == false,
               ExcNotImplemented());
 
-      AssertDimension(v.size(), this->n_cols());
-      AssertDimension(w.size(), this->n_rows());
+      AssertDimension(v.size(), this->n());
+      AssertDimension(w.size(), this->m());
 
       const char diag = 'N';
       const char trans = 'N';
@@ -419,8 +419,8 @@ LAPACKFullMatrix<number>::vmult (
     case matrix:
     case inverse_matrix:
     {
-      AssertDimension(v.size(), this->n_cols());
-      AssertDimension(w.size(), this->n_rows());
+      AssertDimension(v.size(), this->n());
+      AssertDimension(w.size(), this->m());
 
       gemv("N", &mm, &nn, &alpha, &this->values[0], &mm, v.values.get(), &one, &beta, w.values.get(), &one);
       break;
@@ -428,8 +428,8 @@ LAPACKFullMatrix<number>::vmult (
     case svd:
     {
       Threads::Mutex::ScopedLock lock (mutex);
-      AssertDimension(v.size(), this->n_cols());
-      AssertDimension(w.size(), this->n_rows());
+      AssertDimension(v.size(), this->n());
+      AssertDimension(w.size(), this->m());
       // Compute V^T v
       work.resize(std::max(mm,nn));
       gemv("N", &nn, &nn, &alpha, &svd_vt->values[0], &nn, v.values.get(), &one, &null, work.data(), &one);
@@ -443,8 +443,8 @@ LAPACKFullMatrix<number>::vmult (
     case inverse_svd:
     {
       Threads::Mutex::ScopedLock lock (mutex);
-      AssertDimension(w.size(), this->n_cols());
-      AssertDimension(v.size(), this->n_rows());
+      AssertDimension(w.size(), this->n());
+      AssertDimension(v.size(), this->m());
       // Compute U^T v
       work.resize(std::max(mm,nn));
       gemv("T", &mm, &mm, &alpha, &svd_u->values[0], &mm, v.values.get(), &one, &null, work.data(), &one);
@@ -468,8 +468,8 @@ LAPACKFullMatrix<number>::Tvmult (
   const Vector<number> &v,
   const bool            adding) const
 {
-  const types::blas_int mm = this->n_rows();
-  const types::blas_int nn = this->n_cols();
+  const types::blas_int mm = this->m();
+  const types::blas_int nn = this->n();
   const number alpha = 1.;
   const number beta = (adding ? 1. : 0.);
   const number null = 0.;
@@ -483,8 +483,8 @@ LAPACKFullMatrix<number>::Tvmult (
       Assert (adding == false,
               ExcNotImplemented());
 
-      AssertDimension(v.size(), this->n_cols());
-      AssertDimension(w.size(), this->n_rows());
+      AssertDimension(v.size(), this->n());
+      AssertDimension(w.size(), this->m());
 
       const char diag = 'N';
       const char trans = 'T';
@@ -509,8 +509,8 @@ LAPACKFullMatrix<number>::Tvmult (
     case matrix:
     case inverse_matrix:
     {
-      AssertDimension(w.size(), this->n_cols());
-      AssertDimension(v.size(), this->n_rows());
+      AssertDimension(w.size(), this->n());
+      AssertDimension(v.size(), this->m());
 
       gemv("T", &mm, &nn, &alpha, &this->values[0], &mm, v.values.get(), &one, &beta, w.values.get(), &one);
       break;
@@ -518,8 +518,8 @@ LAPACKFullMatrix<number>::Tvmult (
     case svd:
     {
       Threads::Mutex::ScopedLock lock (mutex);
-      AssertDimension(w.size(), this->n_cols());
-      AssertDimension(v.size(), this->n_rows());
+      AssertDimension(w.size(), this->n());
+      AssertDimension(v.size(), this->m());
 
       // Compute U^T v
       work.resize(std::max(mm,nn));
@@ -534,8 +534,8 @@ LAPACKFullMatrix<number>::Tvmult (
     case inverse_svd:
     {
       Threads::Mutex::ScopedLock lock (mutex);
-      AssertDimension(v.size(), this->n_cols());
-      AssertDimension(w.size(), this->n_rows());
+      AssertDimension(v.size(), this->n());
+      AssertDimension(w.size(), this->m());
 
       // Compute V^T v
       work.resize(std::max(mm,nn));
@@ -580,12 +580,12 @@ LAPACKFullMatrix<number>::mmult(LAPACKFullMatrix<number>       &C,
   Assert(state == matrix || state == inverse_matrix, ExcState(state));
   Assert(B.state == matrix || B.state == inverse_matrix, ExcState(state));
   Assert(C.state == matrix || C.state == inverse_matrix, ExcState(state));
-  Assert (this->n_cols() == B.n_rows(), ExcDimensionMismatch(this->n_cols(), B.n_rows()));
-  Assert (C.n_cols() == B.n_cols(), ExcDimensionMismatch(C.n_cols(), B.n_cols()));
-  Assert (C.n_rows() == this->n_rows(), ExcDimensionMismatch(this->n_rows(), C.n_rows()));
-  const types::blas_int mm = this->n_rows();
-  const types::blas_int nn = B.n_cols();
-  const types::blas_int kk = this->n_cols();
+  Assert (this->n() == B.m(), ExcDimensionMismatch(this->n(), B.m()));
+  Assert (C.n() == B.n(), ExcDimensionMismatch(C.n(), B.n()));
+  Assert (C.m() == this->m(), ExcDimensionMismatch(this->m(), C.m()));
+  const types::blas_int mm = this->m();
+  const types::blas_int nn = B.n();
+  const types::blas_int kk = this->n();
   const number alpha = 1.;
   const number beta = (adding ? 1. : 0.);
 
@@ -602,12 +602,12 @@ LAPACKFullMatrix<number>::mmult(FullMatrix<number>             &C,
 {
   Assert(state == matrix || state == inverse_matrix, ExcState(state));
   Assert(B.state == matrix || B.state == inverse_matrix, ExcState(state));
-  Assert (this->n_cols() == B.n_rows(), ExcDimensionMismatch(this->n_cols(), B.n_rows()));
-  Assert (C.n_cols() == B.n_cols(), ExcDimensionMismatch(C.n_cols(), B.n_cols()));
-  Assert (C.n_rows() == this->n_rows(), ExcDimensionMismatch(this->n_rows(), C.n_rows()));
-  const types::blas_int mm = this->n_rows();
-  const types::blas_int nn = B.n_cols();
-  const types::blas_int kk = this->n_cols();
+  Assert (this->n() == B.m(), ExcDimensionMismatch(this->n(), B.m()));
+  Assert (C.n() == B.n(), ExcDimensionMismatch(C.n(), B.n()));
+  Assert (C.m() == this->m(), ExcDimensionMismatch(this->m(), C.m()));
+  const types::blas_int mm = this->m();
+  const types::blas_int nn = B.n();
+  const types::blas_int kk = this->n();
   const number alpha = 1.;
   const number beta = (adding ? 1. : 0.);
 
@@ -628,12 +628,12 @@ LAPACKFullMatrix<number>::Tmmult(LAPACKFullMatrix<number>       &C,
   Assert(state == matrix || state == inverse_matrix, ExcState(state));
   Assert(B.state == matrix || B.state == inverse_matrix, ExcState(state));
   Assert(C.state == matrix || C.state == inverse_matrix, ExcState(state));
-  Assert (this->n_rows() == B.n_rows(), ExcDimensionMismatch(this->n_rows(), B.n_rows()));
-  Assert (C.n_cols() == B.n_cols(), ExcDimensionMismatch(C.n_cols(), B.n_cols()));
-  Assert (C.n_rows() == this->n_cols(), ExcDimensionMismatch(this->n_cols(), C.n_rows()));
-  const types::blas_int mm = this->n_cols();
-  const types::blas_int nn = B.n_cols();
-  const types::blas_int kk = B.n_rows();
+  Assert (this->m() == B.m(), ExcDimensionMismatch(this->m(), B.m()));
+  Assert (C.n() == B.n(), ExcDimensionMismatch(C.n(), B.n()));
+  Assert (C.m() == this->n(), ExcDimensionMismatch(this->n(), C.m()));
+  const types::blas_int mm = this->n();
+  const types::blas_int nn = B.n();
+  const types::blas_int kk = B.m();
   const number alpha = 1.;
   const number beta = (adding ? 1. : 0.);
 
@@ -650,12 +650,12 @@ LAPACKFullMatrix<number>::Tmmult(FullMatrix<number>             &C,
 {
   Assert(state == matrix || state == inverse_matrix, ExcState(state));
   Assert(B.state == matrix || B.state == inverse_matrix, ExcState(state));
-  Assert (this->n_rows() == B.n_rows(), ExcDimensionMismatch(this->n_rows(), B.n_rows()));
-  Assert (C.n_cols() == B.n_cols(), ExcDimensionMismatch(C.n_cols(), B.n_cols()));
-  Assert (C.n_rows() == this->n_cols(), ExcDimensionMismatch(this->n_cols(), C.n_rows()));
-  const types::blas_int mm = this->n_cols();
-  const types::blas_int nn = B.n_cols();
-  const types::blas_int kk = B.n_rows();
+  Assert (this->m() == B.m(), ExcDimensionMismatch(this->m(), B.m()));
+  Assert (C.n() == B.n(), ExcDimensionMismatch(C.n(), B.n()));
+  Assert (C.m() == this->n(), ExcDimensionMismatch(this->n(), C.m()));
+  const types::blas_int mm = this->n();
+  const types::blas_int nn = B.n();
+  const types::blas_int kk = B.m();
   const number alpha = 1.;
   const number beta = (adding ? 1. : 0.);
 
@@ -675,12 +675,12 @@ LAPACKFullMatrix<number>::mTmult(LAPACKFullMatrix<number>       &C,
   Assert(state == matrix || state == inverse_matrix, ExcState(state));
   Assert(B.state == matrix || B.state == inverse_matrix, ExcState(state));
   Assert(C.state == matrix || C.state == inverse_matrix, ExcState(state));
-  Assert (this->n_cols() == B.n_cols(), ExcDimensionMismatch(this->n_cols(), B.n_cols()));
-  Assert (C.n_cols() == B.n_rows(), ExcDimensionMismatch(C.n_cols(), B.n_rows()));
-  Assert (C.n_rows() == this->n_rows(), ExcDimensionMismatch(this->n_rows(), C.n_rows()));
-  const types::blas_int mm = this->n_rows();
-  const types::blas_int nn = B.n_rows();
-  const types::blas_int kk = B.n_cols();
+  Assert (this->n() == B.n(), ExcDimensionMismatch(this->n(), B.n()));
+  Assert (C.n() == B.m(), ExcDimensionMismatch(C.n(), B.m()));
+  Assert (C.m() == this->m(), ExcDimensionMismatch(this->m(), C.m()));
+  const types::blas_int mm = this->m();
+  const types::blas_int nn = B.m();
+  const types::blas_int kk = B.n();
   const number alpha = 1.;
   const number beta = (adding ? 1. : 0.);
 
@@ -698,12 +698,12 @@ LAPACKFullMatrix<number>::mTmult(FullMatrix<number>             &C,
 {
   Assert(state == matrix || state == inverse_matrix, ExcState(state));
   Assert(B.state == matrix || B.state == inverse_matrix, ExcState(state));
-  Assert (this->n_cols() == B.n_cols(), ExcDimensionMismatch(this->n_cols(), B.n_cols()));
-  Assert (C.n_cols() == B.n_rows(), ExcDimensionMismatch(C.n_cols(), B.n_rows()));
-  Assert (C.n_rows() == this->n_rows(), ExcDimensionMismatch(this->n_rows(), C.n_rows()));
-  const types::blas_int mm = this->n_rows();
-  const types::blas_int nn = B.n_rows();
-  const types::blas_int kk = B.n_cols();
+  Assert (this->n() == B.n(), ExcDimensionMismatch(this->n(), B.n()));
+  Assert (C.n() == B.m(), ExcDimensionMismatch(C.n(), B.m()));
+  Assert (C.m() == this->m(), ExcDimensionMismatch(this->m(), C.m()));
+  const types::blas_int mm = this->m();
+  const types::blas_int nn = B.m();
+  const types::blas_int kk = B.n();
   const number alpha = 1.;
   const number beta = (adding ? 1. : 0.);
 
@@ -723,12 +723,12 @@ LAPACKFullMatrix<number>::TmTmult(LAPACKFullMatrix<number>       &C,
   Assert(state == matrix || state == inverse_matrix, ExcState(state));
   Assert(B.state == matrix || B.state == inverse_matrix, ExcState(state));
   Assert(C.state == matrix || C.state == inverse_matrix, ExcState(state));
-  Assert (this->n_rows() == B.n_cols(), ExcDimensionMismatch(this->n_rows(), B.n_cols()));
-  Assert (C.n_cols() == B.n_rows(), ExcDimensionMismatch(C.n_cols(), B.n_rows()));
-  Assert (C.n_rows() == this->n_cols(), ExcDimensionMismatch(this->n_cols(), C.n_rows()));
-  const types::blas_int mm = this->n_cols();
-  const types::blas_int nn = B.n_rows();
-  const types::blas_int kk = B.n_cols();
+  Assert (this->m() == B.n(), ExcDimensionMismatch(this->m(), B.n()));
+  Assert (C.n() == B.m(), ExcDimensionMismatch(C.n(), B.m()));
+  Assert (C.m() == this->n(), ExcDimensionMismatch(this->n(), C.m()));
+  const types::blas_int mm = this->n();
+  const types::blas_int nn = B.m();
+  const types::blas_int kk = B.n();
   const number alpha = 1.;
   const number beta = (adding ? 1. : 0.);
 
@@ -745,12 +745,12 @@ LAPACKFullMatrix<number>::TmTmult(FullMatrix<number>             &C,
 {
   Assert(state == matrix || state == inverse_matrix, ExcState(state));
   Assert(B.state == matrix || B.state == inverse_matrix, ExcState(state));
-  Assert (this->n_rows() == B.n_cols(), ExcDimensionMismatch(this->n_rows(), B.n_cols()));
-  Assert (C.n_cols() == B.n_rows(), ExcDimensionMismatch(C.n_cols(), B.n_rows()));
-  Assert (C.n_rows() == this->n_cols(), ExcDimensionMismatch(this->n_cols(), C.n_rows()));
-  const types::blas_int mm = this->n_cols();
-  const types::blas_int nn = B.n_rows();
-  const types::blas_int kk = B.n_cols();
+  Assert (this->m() == B.n(), ExcDimensionMismatch(this->m(), B.n()));
+  Assert (C.n() == B.m(), ExcDimensionMismatch(C.n(), B.m()));
+  Assert (C.m() == this->n(), ExcDimensionMismatch(this->n(), C.m()));
+  const types::blas_int mm = this->n();
+  const types::blas_int nn = B.m();
+  const types::blas_int kk = B.n();
   const number alpha = 1.;
   const number beta = (adding ? 1. : 0.);
 
@@ -768,8 +768,8 @@ LAPACKFullMatrix<number>::compute_lu_factorization()
   Assert(state == matrix, ExcState(state));
   state = LAPACKSupport::unusable;
 
-  const types::blas_int mm = this->n_rows();
-  const types::blas_int nn = this->n_cols();
+  const types::blas_int mm = this->m();
+  const types::blas_int nn = this->n();
   number *const values = &this->values[0];
   ipiv.resize(mm);
   types::blas_int info = 0;
@@ -830,8 +830,8 @@ number LAPACKFullMatrix<number>::norm(const char type) const
           state == LAPACKSupport::inverse_matrix,
           ExcMessage("norms can be called in matrix state only."));
 
-  const types::blas_int N = this->n_cols();
-  const types::blas_int M = this->n_rows();
+  const types::blas_int N = this->n();
+  const types::blas_int M = this->m();
   const number *const values = &this->values[0];
   if (property == symmetric)
     {
@@ -861,11 +861,11 @@ number LAPACKFullMatrix<number>::trace() const
   Assert (state == LAPACKSupport::matrix ||
           state == LAPACKSupport::inverse_matrix,
           ExcMessage("Trace can be called in matrix state only."));
-  Assert (this->n_cols() == this->n_rows(),
-          ExcDimensionMismatch(this->n_cols(), this->n_rows()));
+  Assert (this->n() == this->m(),
+          ExcDimensionMismatch(this->n(), this->m()));
 
   number tr = 0;
-  for (size_type i=0; i<this->n_rows(); ++i)
+  for (size_type i=0; i<this->m(); ++i)
     tr += (*this)(i,i);
 
   return tr;
@@ -881,8 +881,8 @@ LAPACKFullMatrix<number>::compute_cholesky_factorization()
   Assert(property == symmetric, ExcProperty(property));
   state = LAPACKSupport::unusable;
 
-  const types::blas_int mm = this->n_rows();
-  const types::blas_int nn = this->n_cols();
+  const types::blas_int mm = this->m();
+  const types::blas_int nn = this->n();
   (void) mm;
   Assert (mm == nn, ExcDimensionMismatch(mm,nn));
 
@@ -908,7 +908,7 @@ LAPACKFullMatrix<number>::reciprocal_condition_number(const number a_norm) const
   Assert(state == cholesky, ExcState(state));
   number rcond = 0.;
 
-  const types::blas_int N = this->n_rows();
+  const types::blas_int N = this->m();
   const number *values = &this->values[0];
   types::blas_int info = 0;
   const types::blas_int lda = std::max<types::blas_int>(1,N);
@@ -937,7 +937,7 @@ LAPACKFullMatrix<number>::reciprocal_condition_number() const
          ExcProperty(property));
   number rcond = 0.;
 
-  const types::blas_int N = this->n_rows();
+  const types::blas_int N = this->m();
   const number *const values = &this->values[0];
   types::blas_int info = 0;
   const types::blas_int lda = std::max<types::blas_int>(1,N);
@@ -966,8 +966,8 @@ LAPACKFullMatrix<number>::compute_svd()
   Assert(state == matrix, ExcState(state));
   state = LAPACKSupport::unusable;
 
-  const types::blas_int mm = this->n_rows();
-  const types::blas_int nn = this->n_cols();
+  const types::blas_int mm = this->m();
+  const types::blas_int nn = this->n();
   number *const values = &this->values[0];
   wr.resize(std::max(mm,nn));
   std::fill(wr.begin(), wr.end(), 0.);
@@ -1031,8 +1031,8 @@ LAPACKFullMatrix<number>::invert()
 {
   Assert(state == matrix || state == lu || state == cholesky,
          ExcState(state));
-  const types::blas_int mm = this->n_rows();
-  const types::blas_int nn = this->n_cols();
+  const types::blas_int mm = this->m();
+  const types::blas_int nn = this->n();
   Assert (nn == mm, ExcNotQuadratic());
 
   number *const values = &this->values[0];
@@ -1073,11 +1073,11 @@ void
 LAPACKFullMatrix<number>::solve(Vector<number> &v,
                                 const bool transposed) const
 {
-  Assert(this->n_rows() == this->n_cols(),
+  Assert(this->m() == this->n(),
          LACExceptions::ExcNotQuadratic());
-  AssertDimension(this->n_rows(), v.size());
+  AssertDimension(this->m(), v.size());
   const char *trans = transposed ? &T : &N;
-  const types::blas_int nn = this->n_cols();
+  const types::blas_int nn = this->n();
   const number *const values = &this->values[0];
   const types::blas_int n_rhs = 1;
   types::blas_int info = 0;
@@ -1122,13 +1122,13 @@ LAPACKFullMatrix<number>::solve(LAPACKFullMatrix<number> &B,
 {
   Assert(B.state == matrix, ExcState(B.state));
 
-  Assert(this->n_rows() == this->n_cols(),
+  Assert(this->m() == this->n(),
          LACExceptions::ExcNotQuadratic());
-  AssertDimension(this->n_rows(), B.n_rows());
+  AssertDimension(this->m(), B.m());
   const char *trans = transposed ? &T : &N;
-  const types::blas_int nn = this->n_cols();
+  const types::blas_int nn = this->n();
   const number *const values = &this->values[0];
-  const types::blas_int n_rhs = B.n_cols();
+  const types::blas_int n_rhs = B.n();
   types::blas_int info = 0;
 
   if (state == lu)
@@ -1188,7 +1188,7 @@ template <typename number>
 number
 LAPACKFullMatrix<number>::determinant() const
 {
-  Assert(this->n_rows() == this->n_cols(), LACExceptions::ExcNotQuadratic());
+  Assert(this->m() == this->n(), LACExceptions::ExcNotQuadratic());
 
   // LAPACK doesn't offer a function to compute a matrix determinant.
   // This is due to the difficulty in maintaining numerical accuracy, as the
@@ -1206,9 +1206,9 @@ LAPACKFullMatrix<number>::determinant() const
   // http://icl.cs.utk.edu/lapack-forum/viewtopic.php?p=341&#p336
   // for further information.
   Assert(state == lu, ExcState(state));
-  Assert(ipiv.size() == this->n_rows(), ExcInternalError());
+  Assert(ipiv.size() == this->m(), ExcInternalError());
   number det = 1.0;
-  for (size_type i=0; i<this->n_rows(); ++i)
+  for (size_type i=0; i<this->m(); ++i)
     det *= ( ipiv[i] == types::blas_int(i+1) ? this->el(i,i) : -this->el(i,i) );
   return det;
 }
@@ -1220,7 +1220,7 @@ LAPACKFullMatrix<number>::compute_eigenvalues(const bool right,
                                               const bool left)
 {
   Assert(state == matrix, ExcState(state));
-  const types::blas_int nn = this->n_cols();
+  const types::blas_int nn = this->n();
   wr.resize(nn);
   wi.resize(nn);
   if (right) vr.resize(nn*nn);
@@ -1284,8 +1284,8 @@ LAPACKFullMatrix<number>::compute_eigenvalues_symmetric(const number        lowe
                                                         FullMatrix<number> &eigenvectors)
 {
   Assert(state == matrix, ExcState(state));
-  const types::blas_int nn = (this->n_cols() > 0 ? this->n_cols() : 1);
-  Assert(static_cast<size_type>(nn) == this->n_rows(), ExcNotQuadratic());
+  const types::blas_int nn = (this->n() > 0 ? this->n() : 1);
+  Assert(static_cast<size_type>(nn) == this->m(), ExcNotQuadratic());
 
   wr.resize(nn);
   LAPACKFullMatrix<number> matrix_eigenvectors(nn, nn);
@@ -1373,11 +1373,11 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric(
   const types::blas_int itype)
 {
   Assert(state == matrix, ExcState(state));
-  const types::blas_int nn = (this->n_cols() > 0 ? this->n_cols() : 1);
-  Assert(static_cast<size_type>(nn) == this->n_rows(), ExcNotQuadratic());
-  Assert(B.n_rows() == B.n_cols(), ExcNotQuadratic());
-  Assert(static_cast<size_type>(nn) == B.n_cols(),
-         ExcDimensionMismatch (nn, B.n_cols()));
+  const types::blas_int nn = (this->n() > 0 ? this->n() : 1);
+  Assert(static_cast<size_type>(nn) == this->m(), ExcNotQuadratic());
+  Assert(B.m() == B.n(), ExcNotQuadratic());
+  Assert(static_cast<size_type>(nn) == B.n(),
+         ExcDimensionMismatch (nn, B.n()));
 
   wr.resize(nn);
   LAPACKFullMatrix<number> matrix_eigenvectors(nn, nn);
@@ -1461,13 +1461,13 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric (
   const types::blas_int itype)
 {
   Assert(state == matrix, ExcState(state));
-  const types::blas_int nn = this->n_cols();
-  Assert(static_cast<size_type>(nn) == this->n_rows(), ExcNotQuadratic());
-  Assert(B.n_rows() == B.n_cols(), ExcNotQuadratic());
-  Assert(static_cast<size_type>(nn) == B.n_cols(),
-         ExcDimensionMismatch (nn, B.n_cols()));
+  const types::blas_int nn = this->n();
+  Assert(static_cast<size_type>(nn) == this->m(), ExcNotQuadratic());
+  Assert(B.m() == B.n(), ExcNotQuadratic());
+  Assert(static_cast<size_type>(nn) == B.n(),
+         ExcDimensionMismatch (nn, B.n()));
   Assert(eigenvectors.size() <= static_cast<size_type>(nn),
-         ExcMessage ("eigenvectors.size() > matrix.n_cols()"));
+         ExcMessage ("eigenvectors.size() > matrix.n()"));
 
   wr.resize(nn);
   wi.resize(nn); //This is set purely for consistency reasons with the
@@ -1541,7 +1541,7 @@ LAPACKFullMatrix<number>::print_formatted (
 {
   unsigned int width = width_;
 
-  Assert ((!this->empty()) || (this->n_cols()+this->n_rows()==0),
+  Assert ((!this->empty()) || (this->n()+this->m()==0),
           ExcInternalError());
   Assert (state == LAPACKSupport::matrix ||
           state == LAPACKSupport::inverse_matrix ||
@@ -1566,10 +1566,10 @@ LAPACKFullMatrix<number>::print_formatted (
         width = precision+2;
     }
 
-  for (size_type i=0; i<this->n_rows(); ++i)
+  for (size_type i=0; i<this->m(); ++i)
     {
       // Cholesky is stored in lower triangular, so just output this part:
-      const size_type nc = state == LAPACKSupport::cholesky ? i+1 : this->n_cols();
+      const size_type nc = state == LAPACKSupport::cholesky ? i+1 : this->n();
       for (size_type j=0; j<nc; ++j)
         // we might have complex numbers, so use abs also to check for nan
         // since there is no isnan on complex numbers

--- a/tests/fe/component_mask_02.debug.output
+++ b/tests/fe/component_mask_02.debug.output
@@ -1,3 +1,3 @@
 
-DEAL::dealii::ExcIndexRange((component_index),0,(component_mask.size()))
+DEAL::dealii::ExcIndexRangeType< typename ::dealii::internal::argument_type< void(typename std::common_type<decltype(component_index), decltype(component_mask.size())>::type)>::type>((component_index),0,(component_mask.size()))
 DEAL::OK

--- a/tests/fe/fe_move_01.output
+++ b/tests/fe/fe_move_01.output
@@ -4,61 +4,61 @@ DEAL::components: 1
 DEAL::blocks: 1
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 1
-DEAL::memory consumption: 1368
+DEAL::memory consumption: 1408
 DEAL::
 DEAL::dim: 1
 DEAL::components: 1
 DEAL::blocks: 1
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 0
-DEAL::memory consumption: 736
+DEAL::memory consumption: 744
 DEAL::
 DEAL::dim: 1
 DEAL::components: 1
 DEAL::blocks: 1
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 1
-DEAL::memory consumption: 1368
+DEAL::memory consumption: 1408
 DEAL::
 DEAL::dim: 2
 DEAL::components: 1
 DEAL::blocks: 1
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 1
-DEAL::memory consumption: 3260
+DEAL::memory consumption: 3396
 DEAL::
 DEAL::dim: 2
 DEAL::components: 1
 DEAL::blocks: 1
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 0
-DEAL::memory consumption: 920
+DEAL::memory consumption: 928
 DEAL::
 DEAL::dim: 2
 DEAL::components: 1
 DEAL::blocks: 1
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 1
-DEAL::memory consumption: 3260
+DEAL::memory consumption: 3396
 DEAL::
 DEAL::dim: 3
 DEAL::components: 1
 DEAL::blocks: 1
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 1
-DEAL::memory consumption: 8692
+DEAL::memory consumption: 9116
 DEAL::
 DEAL::dim: 3
 DEAL::components: 1
 DEAL::blocks: 1
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 0
-DEAL::memory consumption: 1288
+DEAL::memory consumption: 1296
 DEAL::
 DEAL::dim: 3
 DEAL::components: 1
 DEAL::blocks: 1
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 1
-DEAL::memory consumption: 8692
+DEAL::memory consumption: 9116
 DEAL::

--- a/tests/fe/fe_move_02.output
+++ b/tests/fe/fe_move_02.output
@@ -4,61 +4,61 @@ DEAL::components: 2
 DEAL::blocks: 2
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 2
-DEAL::memory consumption: 4608
+DEAL::memory consumption: 4728
 DEAL::
 DEAL::FESystem<1>[]
 DEAL::components: 2
 DEAL::blocks: 2
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 0
-DEAL::memory consumption: 1036
+DEAL::memory consumption: 1044
 DEAL::
 DEAL::FESystem<1>[FE_Q<1>(2)-FE_Q<1>(1)]
 DEAL::components: 2
 DEAL::blocks: 2
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 2
-DEAL::memory consumption: 4608
+DEAL::memory consumption: 4728
 DEAL::
 DEAL::FESystem<2>[FE_Q<2>(2)^2-FE_Q<2>(1)]
 DEAL::components: 3
 DEAL::blocks: 3
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 2
-DEAL::memory consumption: 13032
+DEAL::memory consumption: 13440
 DEAL::
 DEAL::FESystem<2>[]
 DEAL::components: 3
 DEAL::blocks: 3
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 0
-DEAL::memory consumption: 2600
+DEAL::memory consumption: 2608
 DEAL::
 DEAL::FESystem<2>[FE_Q<2>(2)^2-FE_Q<2>(1)]
 DEAL::components: 3
 DEAL::blocks: 3
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 2
-DEAL::memory consumption: 13032
+DEAL::memory consumption: 13440
 DEAL::
 DEAL::FESystem<3>[FE_Q<3>(2)^3-FE_Q<3>(1)]
 DEAL::components: 4
 DEAL::blocks: 4
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 2
-DEAL::memory consumption: 56040
+DEAL::memory consumption: 57312
 DEAL::
 DEAL::FESystem<3>[]
 DEAL::components: 4
 DEAL::blocks: 4
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 0
-DEAL::memory consumption: 8772
+DEAL::memory consumption: 8780
 DEAL::
 DEAL::FESystem<3>[FE_Q<3>(2)^3-FE_Q<3>(1)]
 DEAL::components: 4
 DEAL::blocks: 4
 DEAL::conforms H1: 1
 DEAL::n_base_elements: 2
-DEAL::memory consumption: 56040
+DEAL::memory consumption: 57312
 DEAL::


### PR DESCRIPTION
Fixes #5662 by changing `LAPACKFullMatrix::size_type` to `types::blas_int` and `FullMatrix::size_type` to `std::size_t`.
Also get rid off the unnecessary `const_cast`s in `lapack_full_matrix.cc`.