### PR TITLE
Fix scalapack_10

### DIFF
--- a/tests/scalapack/scalapack_10.cc
+++ b/tests/scalapack/scalapack_10.cc
@@ -34,7 +34,7 @@
 template <typename NumberType>
 void test(const unsigned int size, const unsigned int block_size)
 {
-  const std::string filename = std::string(SOURCE_DIR) + "/test.h5";
+  const std::string filename ("scalapck_10_test.h5");
 
   MPI_Comm mpi_communicator(MPI_COMM_WORLD);
   const unsigned int this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator));


### PR DESCRIPTION
Tests should not modify files in the source directory. Most of the testers (rightfully) forbid this and that is the reason for the current failure of `scalapack_10`.