### PR TITLE
Allow detecting unused parameters using clang

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -93,8 +93,6 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   #
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unsupported-friend")
 
-  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-parameter")
-
   #
   # Disable a diagnostic that warns about potentially uninstantiated static
   # members. This leads to a ton of false positives.

--- a/include/deal.II/differentiation/ad/ad_number_traits.h
+++ b/include/deal.II/differentiation/ad/ad_number_traits.h
@@ -1022,8 +1022,8 @@ namespace Differentiation
       >::type>
     {
       static ScalarType
-      get_directional_derivative(const ScalarType      &x,
-                                 const unsigned int  direction)
+      get_directional_derivative(const ScalarType   &/*x*/,
+                                 const unsigned int  /*direction*/)
       {
         // If the AD drivers are correctly implemented then we should not get here.
         // This is essentially a dummy for when the ADNumberTypeCode for the original

--- a/include/deal.II/lac/utilities.h
+++ b/include/deal.II/lac/utilities.h
@@ -211,8 +211,8 @@ namespace Utilities
   {
 
     template<typename NumberType>
-    std::array<std::complex<NumberType>,3> hyperbolic_rotation(const std::complex<NumberType> &f,
-                                                               const std::complex<NumberType> &g)
+    std::array<std::complex<NumberType>,3> hyperbolic_rotation(const std::complex<NumberType> &/*f*/,
+                                                               const std::complex<NumberType> &/*g*/)
     {
       AssertThrow(false, ExcNotImplemented());
       std::array<NumberType,3> res;
@@ -244,8 +244,8 @@ namespace Utilities
 
 
     template<typename NumberType>
-    std::array<std::complex<NumberType>,3> givens_rotation(const std::complex<NumberType> &f,
-                                                           const std::complex<NumberType> &g)
+    std::array<std::complex<NumberType>,3> givens_rotation(const std::complex<NumberType> &/*f*/,
+                                                           const std::complex<NumberType> &/*g*/)
     {
       AssertThrow(false, ExcNotImplemented());
       std::array<NumberType,3> res;


### PR DESCRIPTION
I don't see a reason why we should prevent `clang` from reporting unused parameters.
After fixing the below ones, I can compile with `-Werror` enabled.