### PR TITLE
Fix bundled warnings

### DIFF
--- a/bundled/boost-1.62.0/include/boost/random/binomial_distribution.hpp
+++ b/bundled/boost-1.62.0/include/boost/random/binomial_distribution.hpp
@@ -278,18 +278,18 @@ private:
         m = static_cast<IntType>((t+1)*p);
 
         if(use_inversion()) {
-            q_n = pow((1 - p), static_cast<RealType>(t));
+            _u.q_n = pow((1 - p), static_cast<RealType>(t));
         } else {
-            btrd.r = p/(1-p);
-            btrd.nr = (t+1)*btrd.r;
-            btrd.npq = t*p*(1-p);
-            RealType sqrt_npq = sqrt(btrd.npq);
-            btrd.b = 1.15 + 2.53 * sqrt_npq;
-            btrd.a = -0.0873 + 0.0248*btrd.b + 0.01*p;
-            btrd.c = t*p + 0.5;
-            btrd.alpha = (2.83 + 5.1/btrd.b) * sqrt_npq;
-            btrd.v_r = 0.92 - 4.2/btrd.b;
-            btrd.u_rv_r = 0.86*btrd.v_r;
+            _u.btrd.r = p/(1-p);
+            _u.btrd.nr = (t+1)*_u.btrd.r;
+            _u.btrd.npq = t*p*(1-p);
+            RealType sqrt_npq = sqrt(_u.btrd.npq);
+            _u.btrd.b = 1.15 + 2.53 * sqrt_npq;
+            _u.btrd.a = -0.0873 + 0.0248*_u.btrd.b + 0.01*p;
+            _u.btrd.c = t*p + 0.5;
+            _u.btrd.alpha = (2.83 + 5.1/_u.btrd.b) * sqrt_npq;
+            _u.btrd.v_r = 0.92 - 4.2/_u.btrd.b;
+            _u.btrd.u_rv_r = 0.86*_u.btrd.v_r;
         }
     }
 
@@ -303,24 +303,24 @@ private:
         while(true) {
             RealType u;
             RealType v = uniform_01<RealType>()(urng);
-            if(v <= btrd.u_rv_r) {
-                u = v/btrd.v_r - 0.43;
+            if(v <= _u.btrd.u_rv_r) {
+                u = v/_u.btrd.v_r - 0.43;
                 return static_cast<IntType>(floor(
-                    (2*btrd.a/(0.5 - abs(u)) + btrd.b)*u + btrd.c));
+                    (2*_u.btrd.a/(0.5 - abs(u)) + _u.btrd.b)*u + _u.btrd.c));
             }
 
-            if(v >= btrd.v_r) {
+            if(v >= _u.btrd.v_r) {
                 u = uniform_01<RealType>()(urng) - 0.5;
             } else {
-                u = v/btrd.v_r - 0.93;
+                u = v/_u.btrd.v_r - 0.93;
                 u = ((u < 0)? -0.5 : 0.5) - u;
-                v = uniform_01<RealType>()(urng) * btrd.v_r;
+                v = uniform_01<RealType>()(urng) * _u.btrd.v_r;
             }
 
             RealType us = 0.5 - abs(u);
-            IntType k = static_cast<IntType>(floor((2*btrd.a/us + btrd.b)*u + btrd.c));
+            IntType k = static_cast<IntType>(floor((2*_u.btrd.a/us + _u.btrd.b)*u + _u.btrd.c));
             if(k < 0 || k > _t) continue;
-            v = v*btrd.alpha/(btrd.a/(us*us) + btrd.b);
+            v = v*_u.btrd.alpha/(_u.btrd.a/(us*us) + _u.btrd.b);
             RealType km = abs(k - m);
             if(km <= 15) {
                 RealType f = 1;
@@ -328,13 +328,13 @@ private:
                     IntType i = m;
                     do {
                         ++i;
-                        f = f*(btrd.nr/i - btrd.r);
+                        f = f*(_u.btrd.nr/i - _u.btrd.r);
                     } while(i != k);
                 } else if(m > k) {
                     IntType i = k;
                     do {
                         ++i;
-                        v = v*(btrd.nr/i - btrd.r);
+                        v = v*(_u.btrd.nr/i - _u.btrd.r);
                     } while(i != m);
                 }
                 if(v <= f) return k;
@@ -343,18 +343,18 @@ private:
                 // final acceptance/rejection
                 v = log(v);
                 RealType rho =
-                    (km/btrd.npq)*(((km/3. + 0.625)*km + 1./6)/btrd.npq + 0.5);
-                RealType t = -km*km/(2*btrd.npq);
+                    (km/_u.btrd.npq)*(((km/3. + 0.625)*km + 1./6)/_u.btrd.npq + 0.5);
+                RealType t = -km*km/(2*_u.btrd.npq);
                 if(v < t - rho) return k;
                 if(v > t + rho) continue;
 
                 IntType nm = _t - m + 1;
-                RealType h = (m + 0.5)*log((m + 1)/(btrd.r*nm))
+                RealType h = (m + 0.5)*log((m + 1)/(_u.btrd.r*nm))
                            + fc(m) + fc(_t - m);
 
                 IntType nk = _t - k + 1;
                 if(v <= h + (_t+1)*log(static_cast<RealType>(nm)/nk)
-                          + (k + 0.5)*log(nk*btrd.r/(k+1))
+                          + (k + 0.5)*log(nk*_u.btrd.r/(k+1))
                           - fc(k)
                           - fc(_t - k))
                 {
@@ -372,7 +372,7 @@ private:
         RealType q = 1 - p;
         RealType s = p / q;
         RealType a = (t + 1) * s;
-        RealType r = q_n;
+        RealType r = _u.q_n;
         RealType u = uniform_01<RealType>()(urng);
         IntType x = 0;
         while(u > r) {
@@ -417,7 +417,7 @@ private:
         } btrd;
         // for inversion
         RealType q_n;
-    };
+    } _u;
 
     /// @endcond
 };

--- a/bundled/boost-1.62.0/include/boost/random/discrete_distribution.hpp
+++ b/bundled/boost-1.62.0/include/boost/random/discrete_distribution.hpp
@@ -92,7 +92,7 @@ struct integer_alias_table {
         return _alias_table == other._alias_table &&
             _average == other._average && _excess == other._excess;
     }
-    static WeightType normalize(WeightType val, WeightType average)
+    static WeightType normalize(WeightType val, WeightType /* average */)
     {
         return val;
     }
@@ -183,7 +183,7 @@ struct real_alias_table {
     {
         return true;
     }
-    static WeightType try_get_sum(const std::vector<WeightType>& weights)
+    static WeightType try_get_sum(const std::vector<WeightType>& /* weights */)
     {
         return static_cast<WeightType>(1);
     }

--- a/bundled/boost-1.62.0/include/boost/random/poisson_distribution.hpp
+++ b/bundled/boost-1.62.0/include/boost/random/poisson_distribution.hpp
@@ -255,13 +255,13 @@ private:
         using std::exp;
 
         if(use_inversion()) {
-            _exp_mean = exp(-_mean);
+            _u._exp_mean = exp(-_mean);
         } else {
-            _ptrd.smu = sqrt(_mean);
-            _ptrd.b = 0.931 + 2.53 * _ptrd.smu;
-            _ptrd.a = -0.059 + 0.02483 * _ptrd.b;
-            _ptrd.inv_alpha = 1.1239 + 1.1328 / (_ptrd.b - 3.4);
-            _ptrd.v_r = 0.9277 - 3.6224 / (_ptrd.b - 2);
+            _u._ptrd.smu = sqrt(_mean);
+            _u._ptrd.b = 0.931 + 2.53 * _u._ptrd.smu;
+            _u._ptrd.a = -0.059 + 0.02483 * _u._ptrd.b;
+            _u._ptrd.inv_alpha = 1.1239 + 1.1328 / (_u._ptrd.b - 3.4);
+            _u._ptrd.v_r = 0.9277 - 3.6224 / (_u._ptrd.b - 2);
         }
     }
     
@@ -275,18 +275,18 @@ private:
         while(true) {
             RealType u;
             RealType v = uniform_01<RealType>()(urng);
-            if(v <= 0.86 * _ptrd.v_r) {
-                u = v / _ptrd.v_r - 0.43;
+            if(v <= 0.86 * _u._ptrd.v_r) {
+                u = v / _u._ptrd.v_r - 0.43;
                 return static_cast<IntType>(floor(
-                    (2*_ptrd.a/(0.5-abs(u)) + _ptrd.b)*u + _mean + 0.445));
+                    (2*_u._ptrd.a/(0.5-abs(u)) + _u._ptrd.b)*u + _mean + 0.445));
             }
 
-            if(v >= _ptrd.v_r) {
+            if(v >= _u._ptrd.v_r) {
                 u = uniform_01<RealType>()(urng) - 0.5;
             } else {
-                u = v/_ptrd.v_r - 0.93;
+                u = v/_u._ptrd.v_r - 0.93;
                 u = ((u < 0)? -0.5 : 0.5) - u;
-                v = uniform_01<RealType>()(urng) * _ptrd.v_r;
+                v = uniform_01<RealType>()(urng) * _u._ptrd.v_r;
             }
 
             RealType us = 0.5 - abs(u);
@@ -294,13 +294,13 @@ private:
                 continue;
             }
 
-            RealType k = floor((2*_ptrd.a/us + _ptrd.b)*u+_mean+0.445);
-            v = v*_ptrd.inv_alpha/(_ptrd.a/(us*us) + _ptrd.b);
+            RealType k = floor((2*_u._ptrd.a/us + _u._ptrd.b)*u+_mean+0.445);
+            v = v*_u._ptrd.inv_alpha/(_u._ptrd.a/(us*us) + _u._ptrd.b);
 
             RealType log_sqrt_2pi = 0.91893853320467267;
 
             if(k >= 10) {
-                if(log(v*_ptrd.smu) <= (k + 0.5)*log(_mean/k)
+                if(log(v*_u._ptrd.smu) <= (k + 0.5)*log(_mean/k)
                                - _mean
                                - log_sqrt_2pi
                                + k
@@ -320,7 +320,7 @@ private:
     template<class URNG>
     IntType invert(URNG& urng) const
     {
-        RealType p = _exp_mean;
+        RealType p = _u._exp_mean;
         IntType x = 0;
         RealType u = uniform_01<RealType>()(urng);
         while(u > p) {
@@ -344,7 +344,7 @@ private:
         } _ptrd;
         // for inversion
         RealType _exp_mean;
-    };
+    } _u;
 
     /// @endcond
 };

--- a/bundled/muparser_v2_2_4/include/muParserBytecode.h
+++ b/bundled/muparser_v2_2_4/include/muParserBytecode.h
@@ -71,7 +71,7 @@ namespace mu
         value_type *ptr;
         int offset;
       } Oprt;
-    };
+    } u;
   };
   
   

--- a/bundled/muparser_v2_2_4/src/muParserBase.cpp
+++ b/bundled/muparser_v2_2_4/src/muParserBase.cpp
@@ -1045,9 +1045,9 @@ namespace mu
           // Bugfix for Bulkmode:
           // for details see:
           //    https://groups.google.com/forum/embed/?place=forum/muparser-dev&showsearch=true&showpopout=true&showtabs=false&parenturl=http://muparser.beltoforion.de/mup_forum.html&afterlogin&pli=1#!topic/muparser-dev/szgatgoHTws
-          --sidx; Stack[sidx] = *(pTok->Oprt.ptr + nOffset) = Stack[sidx + 1]; continue;
+          --sidx; Stack[sidx] = *(pTok->u.Oprt.ptr + nOffset) = Stack[sidx + 1]; continue;
           // original code:
-          //--sidx; Stack[sidx] = *pTok->Oprt.ptr = Stack[sidx+1]; continue;
+          //--sidx; Stack[sidx] = *pTok->u.Oprt.ptr = Stack[sidx+1]; continue;
 
       //case  cmBO:  // unused, listed for compiler optimization purposes
       //case  cmBC:
@@ -1056,11 +1056,11 @@ namespace mu
 
       case  cmIF:
             if (Stack[sidx--]==0)
-              pTok += pTok->Oprt.offset;
+              pTok += pTok->u.Oprt.offset;
             continue;
 
       case  cmELSE:
-            pTok += pTok->Oprt.offset;
+            pTok += pTok->u.Oprt.offset;
             continue;
 
       case  cmENDIF:
@@ -1071,49 +1071,49 @@ namespace mu
       //      continue;
 
       // value and variable tokens
-      case  cmVAR:    Stack[++sidx] = *(pTok->Val.ptr + nOffset);  continue;
-      case  cmVAL:    Stack[++sidx] =  pTok->Val.data2;  continue;
+      case  cmVAR:    Stack[++sidx] = *(pTok->u.Val.ptr + nOffset);  continue;
+      case  cmVAL:    Stack[++sidx] =  pTok->u.Val.data2;  continue;
       
-      case  cmVARPOW2: buf = *(pTok->Val.ptr + nOffset);
+      case  cmVARPOW2: buf = *(pTok->u.Val.ptr + nOffset);
                        Stack[++sidx] = buf*buf;
                        continue;
 
-      case  cmVARPOW3: buf = *(pTok->Val.ptr + nOffset);
+      case  cmVARPOW3: buf = *(pTok->u.Val.ptr + nOffset);
                        Stack[++sidx] = buf*buf*buf;
                        continue;
 
-      case  cmVARPOW4: buf = *(pTok->Val.ptr + nOffset);
+      case  cmVARPOW4: buf = *(pTok->u.Val.ptr + nOffset);
                        Stack[++sidx] = buf*buf*buf*buf;
                        continue;
       
-      case  cmVARMUL:  Stack[++sidx] = *(pTok->Val.ptr + nOffset) * pTok->Val.data + pTok->Val.data2;
+      case  cmVARMUL:  Stack[++sidx] = *(pTok->u.Val.ptr + nOffset) * pTok->u.Val.data + pTok->u.Val.data2;
                        continue;
 
       // Next is treatment of numeric functions
       case  cmFUNC:
             {
-              int iArgCount = pTok->Fun.argc;
+              int iArgCount = pTok->u.Fun.argc;
 
               // switch according to argument count
               switch(iArgCount)  
               {
-              case 0: sidx += 1; Stack[sidx] = (*(fun_type0)pTok->Fun.ptr)(); continue;
-              case 1:            Stack[sidx] = (*(fun_type1)pTok->Fun.ptr)(Stack[sidx]);   continue;
-              case 2: sidx -= 1; Stack[sidx] = (*(fun_type2)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1]); continue;
-              case 3: sidx -= 2; Stack[sidx] = (*(fun_type3)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2]); continue;
-              case 4: sidx -= 3; Stack[sidx] = (*(fun_type4)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3]); continue;
-              case 5: sidx -= 4; Stack[sidx] = (*(fun_type5)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4]); continue;
-              case 6: sidx -= 5; Stack[sidx] = (*(fun_type6)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5]); continue;
-              case 7: sidx -= 6; Stack[sidx] = (*(fun_type7)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6]); continue;
-              case 8: sidx -= 7; Stack[sidx] = (*(fun_type8)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7]); continue;
-              case 9: sidx -= 8; Stack[sidx] = (*(fun_type9)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8]); continue;
-              case 10:sidx -= 9; Stack[sidx] = (*(fun_type10)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8], Stack[sidx+9]); continue;
+              case 0: sidx += 1; Stack[sidx] = (*(fun_type0)pTok->u.Fun.ptr)(); continue;
+              case 1:            Stack[sidx] = (*(fun_type1)pTok->u.Fun.ptr)(Stack[sidx]);   continue;
+              case 2: sidx -= 1; Stack[sidx] = (*(fun_type2)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1]); continue;
+              case 3: sidx -= 2; Stack[sidx] = (*(fun_type3)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2]); continue;
+              case 4: sidx -= 3; Stack[sidx] = (*(fun_type4)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3]); continue;
+              case 5: sidx -= 4; Stack[sidx] = (*(fun_type5)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4]); continue;
+              case 6: sidx -= 5; Stack[sidx] = (*(fun_type6)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5]); continue;
+              case 7: sidx -= 6; Stack[sidx] = (*(fun_type7)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6]); continue;
+              case 8: sidx -= 7; Stack[sidx] = (*(fun_type8)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7]); continue;
+              case 9: sidx -= 8; Stack[sidx] = (*(fun_type9)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8]); continue;
+              case 10:sidx -= 9; Stack[sidx] = (*(fun_type10)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8], Stack[sidx+9]); continue;
               default:
                 if (iArgCount>0) // function with variable arguments store the number as a negative value
                   Error(ecINTERNAL_ERROR, 1);
 
                 sidx -= -iArgCount - 1;
-                Stack[sidx] =(*(multfun_type)pTok->Fun.ptr)(&Stack[sidx], -iArgCount);
+                Stack[sidx] =(*(multfun_type)pTok->u.Fun.ptr)(&Stack[sidx], -iArgCount);
                 continue;
               }
             }
@@ -1121,17 +1121,17 @@ namespace mu
       // Next is treatment of string functions
       case  cmFUNC_STR:
             {
-              sidx -= pTok->Fun.argc -1;
+              sidx -= pTok->u.Fun.argc -1;
 
               // The index of the string argument in the string table
-              int iIdxStack = pTok->Fun.idx;  
+              int iIdxStack = pTok->u.Fun.idx;  
               MUP_ASSERT( iIdxStack>=0 && iIdxStack<(int)m_vStringBuf.size() );
 
-              switch(pTok->Fun.argc)  // switch according to argument count
+              switch(pTok->u.Fun.argc)  // switch according to argument count
               {
-              case 0: Stack[sidx] = (*(strfun_type1)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str()); continue;
-              case 1: Stack[sidx] = (*(strfun_type2)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx]); continue;
-              case 2: Stack[sidx] = (*(strfun_type3)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx], Stack[sidx+1]); continue;
+              case 0: Stack[sidx] = (*(strfun_type1)pTok->u.Fun.ptr)(m_vStringBuf[iIdxStack].c_str()); continue;
+              case 1: Stack[sidx] = (*(strfun_type2)pTok->u.Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx]); continue;
+              case 2: Stack[sidx] = (*(strfun_type3)pTok->u.Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx], Stack[sidx+1]); continue;
               }
 
               continue;
@@ -1139,22 +1139,22 @@ namespace mu
 
         case  cmFUNC_BULK:
               {
-                int iArgCount = pTok->Fun.argc;
+                int iArgCount = pTok->u.Fun.argc;
 
                 // switch according to argument count
                 switch(iArgCount)  
                 {
-                case 0: sidx += 1; Stack[sidx] = (*(bulkfun_type0 )pTok->Fun.ptr)(nOffset, nThreadID); continue;
-                case 1:            Stack[sidx] = (*(bulkfun_type1 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx]); continue;
-                case 2: sidx -= 1; Stack[sidx] = (*(bulkfun_type2 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1]); continue;
-                case 3: sidx -= 2; Stack[sidx] = (*(bulkfun_type3 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2]); continue;
-                case 4: sidx -= 3; Stack[sidx] = (*(bulkfun_type4 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3]); continue;
-                case 5: sidx -= 4; Stack[sidx] = (*(bulkfun_type5 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4]); continue;
-                case 6: sidx -= 5; Stack[sidx] = (*(bulkfun_type6 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5]); continue;
-                case 7: sidx -= 6; Stack[sidx] = (*(bulkfun_type7 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6]); continue;
-                case 8: sidx -= 7; Stack[sidx] = (*(bulkfun_type8 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7]); continue;
-                case 9: sidx -= 8; Stack[sidx] = (*(bulkfun_type9 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8]); continue;
-                case 10:sidx -= 9; Stack[sidx] = (*(bulkfun_type10)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8], Stack[sidx+9]); continue;
+                case 0: sidx += 1; Stack[sidx] = (*(bulkfun_type0 )pTok->u.Fun.ptr)(nOffset, nThreadID); continue;
+                case 1:            Stack[sidx] = (*(bulkfun_type1 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx]); continue;
+                case 2: sidx -= 1; Stack[sidx] = (*(bulkfun_type2 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1]); continue;
+                case 3: sidx -= 2; Stack[sidx] = (*(bulkfun_type3 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2]); continue;
+                case 4: sidx -= 3; Stack[sidx] = (*(bulkfun_type4 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3]); continue;
+                case 5: sidx -= 4; Stack[sidx] = (*(bulkfun_type5 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4]); continue;
+                case 6: sidx -= 5; Stack[sidx] = (*(bulkfun_type6 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5]); continue;
+                case 7: sidx -= 6; Stack[sidx] = (*(bulkfun_type7 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6]); continue;
+                case 8: sidx -= 7; Stack[sidx] = (*(bulkfun_type8 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7]); continue;
+                case 9: sidx -= 8; Stack[sidx] = (*(bulkfun_type9 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8]); continue;
+                case 10:sidx -= 9; Stack[sidx] = (*(bulkfun_type10)pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8], Stack[sidx+9]); continue;
                 default:
                   Error(ecINTERNAL_ERROR, 2);
                   continue;

--- a/bundled/muparser_v2_2_4/src/muParserBytecode.cpp
+++ b/bundled/muparser_v2_2_4/src/muParserBytecode.cpp
@@ -108,9 +108,9 @@ namespace mu
     // optimization does not apply
     SToken tok;
     tok.Cmd       = cmVAR;
-    tok.Val.ptr   = a_pVar;
-    tok.Val.data  = 1;
-    tok.Val.data2 = 0;
+    tok.u.Val.ptr   = a_pVar;
+    tok.u.Val.data  = 1;
+    tok.u.Val.data2 = 0;
     m_vRPN.push_back(tok);
   }
 
@@ -135,9 +135,9 @@ namespace mu
     // If optimization does not apply
     SToken tok;
     tok.Cmd = cmVAL;
-    tok.Val.ptr   = NULL;
-    tok.Val.data  = 0;
-    tok.Val.data2 = a_fVal;
+    tok.u.Val.ptr   = NULL;
+    tok.u.Val.data  = 0;
+    tok.u.Val.data2 = a_fVal;
     m_vRPN.push_back(tok);
   }
 
@@ -145,8 +145,8 @@ namespace mu
   void ParserByteCode::ConstantFolding(ECmdCode a_Oprt)
   {
     std::size_t sz = m_vRPN.size();
-    value_type &x = m_vRPN[sz-2].Val.data2,
-               &y = m_vRPN[sz-1].Val.data2;
+    value_type &x = m_vRPN[sz-2].u.Val.data2,
+               &y = m_vRPN[sz-1].u.Val.data2;
     switch (a_Oprt)
     {
     case cmLAND: x = (int)x && (int)y; m_vRPN.pop_back(); break;
@@ -216,11 +216,11 @@ namespace mu
               // Optimization for ploynomials of low order
               if (m_vRPN[sz-2].Cmd == cmVAR && m_vRPN[sz-1].Cmd == cmVAL)
               {
-                if (m_vRPN[sz-1].Val.data2==2)
+                if (m_vRPN[sz-1].u.Val.data2==2)
                   m_vRPN[sz-2].Cmd = cmVARPOW2;
-                else if (m_vRPN[sz-1].Val.data2==3)
+                else if (m_vRPN[sz-1].u.Val.data2==3)
                   m_vRPN[sz-2].Cmd = cmVARPOW3;
-                else if (m_vRPN[sz-1].Val.data2==4)
+                else if (m_vRPN[sz-1].u.Val.data2==4)
                   m_vRPN[sz-2].Cmd = cmVARPOW4;
                 else
                   break;
@@ -238,19 +238,19 @@ namespace mu
                    (m_vRPN[sz-1].Cmd == cmVAL    && m_vRPN[sz-2].Cmd == cmVAR)    || 
                    (m_vRPN[sz-1].Cmd == cmVAL    && m_vRPN[sz-2].Cmd == cmVARMUL) ||
                    (m_vRPN[sz-1].Cmd == cmVARMUL && m_vRPN[sz-2].Cmd == cmVAL)    ||
-                   (m_vRPN[sz-1].Cmd == cmVAR    && m_vRPN[sz-2].Cmd == cmVAR    && m_vRPN[sz-2].Val.ptr == m_vRPN[sz-1].Val.ptr) ||
-                   (m_vRPN[sz-1].Cmd == cmVAR    && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-2].Val.ptr == m_vRPN[sz-1].Val.ptr) ||
-                   (m_vRPN[sz-1].Cmd == cmVARMUL && m_vRPN[sz-2].Cmd == cmVAR    && m_vRPN[sz-2].Val.ptr == m_vRPN[sz-1].Val.ptr) ||
-                   (m_vRPN[sz-1].Cmd == cmVARMUL && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-2].Val.ptr == m_vRPN[sz-1].Val.ptr) )
+                   (m_vRPN[sz-1].Cmd == cmVAR    && m_vRPN[sz-2].Cmd == cmVAR    && m_vRPN[sz-2].u.Val.ptr == m_vRPN[sz-1].u.Val.ptr) ||
+                   (m_vRPN[sz-1].Cmd == cmVAR    && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-2].u.Val.ptr == m_vRPN[sz-1].u.Val.ptr) ||
+                   (m_vRPN[sz-1].Cmd == cmVARMUL && m_vRPN[sz-2].Cmd == cmVAR    && m_vRPN[sz-2].u.Val.ptr == m_vRPN[sz-1].u.Val.ptr) ||
+                   (m_vRPN[sz-1].Cmd == cmVARMUL && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-2].u.Val.ptr == m_vRPN[sz-1].u.Val.ptr) )
               {
-                assert( (m_vRPN[sz-2].Val.ptr==NULL && m_vRPN[sz-1].Val.ptr!=NULL) ||
-                        (m_vRPN[sz-2].Val.ptr!=NULL && m_vRPN[sz-1].Val.ptr==NULL) || 
-                        (m_vRPN[sz-2].Val.ptr == m_vRPN[sz-1].Val.ptr) );
+                assert( (m_vRPN[sz-2].u.Val.ptr==NULL && m_vRPN[sz-1].u.Val.ptr!=NULL) ||
+                        (m_vRPN[sz-2].u.Val.ptr!=NULL && m_vRPN[sz-1].u.Val.ptr==NULL) || 
+                        (m_vRPN[sz-2].u.Val.ptr == m_vRPN[sz-1].u.Val.ptr) );
 
                 m_vRPN[sz-2].Cmd = cmVARMUL;
-                m_vRPN[sz-2].Val.ptr    = (value_type*)((long long)(m_vRPN[sz-2].Val.ptr) | (long long)(m_vRPN[sz-1].Val.ptr));    // variable
-                m_vRPN[sz-2].Val.data2 += ((a_Oprt==cmSUB) ? -1 : 1) * m_vRPN[sz-1].Val.data2;  // offset
-                m_vRPN[sz-2].Val.data  += ((a_Oprt==cmSUB) ? -1 : 1) * m_vRPN[sz-1].Val.data;   // multiplikatior
+                m_vRPN[sz-2].u.Val.ptr    = (value_type*)((long long)(m_vRPN[sz-2].u.Val.ptr) | (long long)(m_vRPN[sz-1].u.Val.ptr));    // variable
+                m_vRPN[sz-2].u.Val.data2 += ((a_Oprt==cmSUB) ? -1 : 1) * m_vRPN[sz-1].u.Val.data2;  // offset
+                m_vRPN[sz-2].u.Val.data  += ((a_Oprt==cmSUB) ? -1 : 1) * m_vRPN[sz-1].u.Val.data;   // multiplikatior
                 m_vRPN.pop_back();
                 bOptimized = true;
               } 
@@ -261,9 +261,9 @@ namespace mu
                    (m_vRPN[sz-1].Cmd == cmVAL && m_vRPN[sz-2].Cmd == cmVAR) ) 
               {
                 m_vRPN[sz-2].Cmd        = cmVARMUL;
-                m_vRPN[sz-2].Val.ptr    = (value_type*)((long long)(m_vRPN[sz-2].Val.ptr) | (long long)(m_vRPN[sz-1].Val.ptr));
-                m_vRPN[sz-2].Val.data   = m_vRPN[sz-2].Val.data2 + m_vRPN[sz-1].Val.data2;
-                m_vRPN[sz-2].Val.data2  = 0;
+                m_vRPN[sz-2].u.Val.ptr    = (value_type*)((long long)(m_vRPN[sz-2].u.Val.ptr) | (long long)(m_vRPN[sz-1].u.Val.ptr));
+                m_vRPN[sz-2].u.Val.data   = m_vRPN[sz-2].u.Val.data2 + m_vRPN[sz-1].u.Val.data2;
+                m_vRPN[sz-2].u.Val.data2  = 0;
                 m_vRPN.pop_back();
                 bOptimized = true;
               } 
@@ -272,22 +272,22 @@ namespace mu
               {
                 // Optimization: 2*(3*b+1) or (3*b+1)*2 -> 6*b+2
                 m_vRPN[sz-2].Cmd     = cmVARMUL;
-                m_vRPN[sz-2].Val.ptr = (value_type*)((long long)(m_vRPN[sz-2].Val.ptr) | (long long)(m_vRPN[sz-1].Val.ptr));
+                m_vRPN[sz-2].u.Val.ptr = (value_type*)((long long)(m_vRPN[sz-2].u.Val.ptr) | (long long)(m_vRPN[sz-1].u.Val.ptr));
                 if (m_vRPN[sz-1].Cmd == cmVAL)
                 {
-                  m_vRPN[sz-2].Val.data  *= m_vRPN[sz-1].Val.data2;
-                  m_vRPN[sz-2].Val.data2 *= m_vRPN[sz-1].Val.data2;
+                  m_vRPN[sz-2].u.Val.data  *= m_vRPN[sz-1].u.Val.data2;
+                  m_vRPN[sz-2].u.Val.data2 *= m_vRPN[sz-1].u.Val.data2;
                 }
                 else
                 {
-                  m_vRPN[sz-2].Val.data  = m_vRPN[sz-1].Val.data  * m_vRPN[sz-2].Val.data2;
-                  m_vRPN[sz-2].Val.data2 = m_vRPN[sz-1].Val.data2 * m_vRPN[sz-2].Val.data2;
+                  m_vRPN[sz-2].u.Val.data  = m_vRPN[sz-1].u.Val.data  * m_vRPN[sz-2].u.Val.data2;
+                  m_vRPN[sz-2].u.Val.data2 = m_vRPN[sz-1].u.Val.data2 * m_vRPN[sz-2].u.Val.data2;
                 }
                 m_vRPN.pop_back();
                 bOptimized = true;
               }
               else if (m_vRPN[sz-1].Cmd == cmVAR && m_vRPN[sz-2].Cmd == cmVAR &&
-                       m_vRPN[sz-1].Val.ptr == m_vRPN[sz-2].Val.ptr)
+                       m_vRPN[sz-1].u.Val.ptr == m_vRPN[sz-2].u.Val.ptr)
               {
                 // Optimization: a*a -> a^2
                 m_vRPN[sz-2].Cmd = cmVARPOW2;
@@ -297,11 +297,11 @@ namespace mu
               break;
 
         case cmDIV:
-              if (m_vRPN[sz-1].Cmd == cmVAL && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-1].Val.data2!=0)
+              if (m_vRPN[sz-1].Cmd == cmVAL && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-1].u.Val.data2!=0)
               {
                 // Optimization: 4*a/2 -> 2*a
-                m_vRPN[sz-2].Val.data  /= m_vRPN[sz-1].Val.data2;
-                m_vRPN[sz-2].Val.data2 /= m_vRPN[sz-1].Val.data2;
+                m_vRPN[sz-2].u.Val.data  /= m_vRPN[sz-1].u.Val.data2;
+                m_vRPN[sz-2].u.Val.data2 /= m_vRPN[sz-1].u.Val.data2;
                 m_vRPN.pop_back();
                 bOptimized = true;
               }
@@ -346,7 +346,7 @@ namespace mu
 
     SToken tok;
     tok.Cmd = cmASSIGN;
-    tok.Oprt.ptr = a_pVar;
+    tok.u.Oprt.ptr = a_pVar;
     m_vRPN.push_back(tok);
   }
 
@@ -371,8 +371,8 @@ namespace mu
 
     SToken tok;
     tok.Cmd = cmFUNC;
-    tok.Fun.argc = a_iArgc;
-    tok.Fun.ptr = a_pFun;
+    tok.u.Fun.argc = a_iArgc;
+    tok.u.Fun.ptr = a_pFun;
     m_vRPN.push_back(tok);
   }
 
@@ -389,8 +389,8 @@ namespace mu
 
     SToken tok;
     tok.Cmd = cmFUNC_BULK;
-    tok.Fun.argc = a_iArgc;
-    tok.Fun.ptr = a_pFun;
+    tok.u.Fun.argc = a_iArgc;
+    tok.u.Fun.ptr = a_pFun;
     m_vRPN.push_back(tok);
   }
 
@@ -408,9 +408,9 @@ namespace mu
 
     SToken tok;
     tok.Cmd = cmFUNC_STR;
-    tok.Fun.argc = a_iArgc;
-    tok.Fun.idx = a_iIdx;
-    tok.Fun.ptr = a_pFun;
+    tok.u.Fun.argc = a_iArgc;
+    tok.u.Fun.idx = a_iIdx;
+    tok.u.Fun.ptr = a_pFun;
     m_vRPN.push_back(tok);
 
     m_iMaxStackSize = std::max(m_iMaxStackSize, (size_t)m_iStackPos);
@@ -442,12 +442,12 @@ namespace mu
       case  cmELSE:
             stElse.push(i);
             idx = stIf.pop();
-            m_vRPN[idx].Oprt.offset = i - idx;
+            m_vRPN[idx].u.Oprt.offset = i - idx;
             break;
       
       case cmENDIF:
             idx = stElse.pop();
-            m_vRPN[idx].Oprt.offset = i - idx;
+            m_vRPN[idx].u.Oprt.offset = i - idx;
             break;
 
       default:
@@ -511,42 +511,42 @@ namespace mu
       switch (m_vRPN[i].Cmd)
       {
       case cmVAL:   mu::console() << _T("VAL \t");
-                    mu::console() << _T("[") << m_vRPN[i].Val.data2 << _T("]\n");
+                    mu::console() << _T("[") << m_vRPN[i].u.Val.data2 << _T("]\n");
                     break;
 
       case cmVAR:   mu::console() << _T("VAR \t");
-	                  mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Val.ptr << _T("]\n"); 
+	                  mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Val.ptr << _T("]\n"); 
                     break;
 
       case cmVARPOW2: mu::console() << _T("VARPOW2 \t");
-	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Val.ptr << _T("]\n"); 
+	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Val.ptr << _T("]\n"); 
                       break;
 
       case cmVARPOW3: mu::console() << _T("VARPOW3 \t");
-	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Val.ptr << _T("]\n"); 
+	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Val.ptr << _T("]\n"); 
                       break;
 
       case cmVARPOW4: mu::console() << _T("VARPOW4 \t");
-	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Val.ptr << _T("]\n"); 
+	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Val.ptr << _T("]\n"); 
                       break;
 
       case cmVARMUL:  mu::console() << _T("VARMUL \t");
-	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Val.ptr << _T("]"); 
-                      mu::console() << _T(" * [") << m_vRPN[i].Val.data << _T("]");
-                      mu::console() << _T(" + [") << m_vRPN[i].Val.data2 << _T("]\n");
+	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Val.ptr << _T("]"); 
+                      mu::console() << _T(" * [") << m_vRPN[i].u.Val.data << _T("]");
+                      mu::console() << _T(" + [") << m_vRPN[i].u.Val.data2 << _T("]\n");
                       break;
 
       case cmFUNC:  mu::console() << _T("CALL\t");
-                    mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].Fun.argc << _T("]"); 
-                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Fun.ptr << _T("]"); 
+                    mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].u.Fun.argc << _T("]"); 
+                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Fun.ptr << _T("]"); 
                     mu::console() << _T("\n");
                     break;
 
       case cmFUNC_STR:
                     mu::console() << _T("CALL STRFUNC\t");
-                    mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].Fun.argc << _T("]");
-                    mu::console() << _T("[IDX:") << std::dec << m_vRPN[i].Fun.idx << _T("]");
-                    mu::console() << _T("[ADDR: 0x") << m_vRPN[i].Fun.ptr << _T("]\n"); 
+                    mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].u.Fun.argc << _T("]");
+                    mu::console() << _T("[IDX:") << std::dec << m_vRPN[i].u.Fun.idx << _T("]");
+                    mu::console() << _T("[ADDR: 0x") << m_vRPN[i].u.Fun.ptr << _T("]\n"); 
                     break;
 
       case cmLT:    mu::console() << _T("LT\n");  break;
@@ -564,18 +564,18 @@ namespace mu
       case cmPOW:   mu::console() << _T("POW\n"); break;
 
       case cmIF:    mu::console() << _T("IF\t");
-                    mu::console() << _T("[OFFSET:") << std::dec << m_vRPN[i].Oprt.offset << _T("]\n");
+                    mu::console() << _T("[OFFSET:") << std::dec << m_vRPN[i].u.Oprt.offset << _T("]\n");
                     break;
 
       case cmELSE:  mu::console() << _T("ELSE\t");
-                    mu::console() << _T("[OFFSET:") << std::dec << m_vRPN[i].Oprt.offset << _T("]\n");
+                    mu::console() << _T("[OFFSET:") << std::dec << m_vRPN[i].u.Oprt.offset << _T("]\n");
                     break;
 
       case cmENDIF: mu::console() << _T("ENDIF\n"); break;
 
       case cmASSIGN: 
                     mu::console() << _T("ASSIGN\t");
-                    mu::console() << _T("[ADDR: 0x") << m_vRPN[i].Oprt.ptr << _T("]\n"); 
+                    mu::console() << _T("[ADDR: 0x") << m_vRPN[i].u.Oprt.ptr << _T("]\n"); 
                     break; 
 
       default:      mu::console() << _T("(unknown code: ") << m_vRPN[i].Cmd << _T(")\n"); 


### PR DESCRIPTION
After #3897, `clang` gives the warning
```
 anonymous types declared in an anonymous union are an extension [-Wnested-anon-types]
```
in the bundled `boost` and `muParser`. The changes to `boost` coincide with the (relevant part of) https://github.com/boostorg/random/pull/32.