### PR TITLE
Require a Tensor for an argument that indicates direction.

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -384,7 +384,7 @@ public:
    * scaled, and the given point may be any point on the axis. The tolerance
    * value is used to determine if a point is on the axis.
    */
-  CylindricalManifold (const Point<spacedim> &direction,
+  CylindricalManifold (const Tensor<1, spacedim> &direction,
                        const Point<spacedim> &point_on_axis,
                        const double tolerance = 1e-10);
 

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -931,14 +931,14 @@ CylindricalManifold<dim, spacedim>::CylindricalManifold(const unsigned int axis,
 
 
 template <int dim, int spacedim>
-CylindricalManifold<dim, spacedim>::CylindricalManifold(const Tensor<1, spacedim> &direction_,
-                                                        const Point<spacedim> &point_on_axis_,
+CylindricalManifold<dim, spacedim>::CylindricalManifold(const Tensor<1, spacedim> &direction,
+                                                        const Point<spacedim> &point_on_axis,
                                                         const double tolerance) :
   ChartManifold<dim,spacedim,3>(Tensor<1,3>({0,2.*numbers::PI,0})),
-              normal_direction(internal::compute_normal(direction_, true)),
-              direction (direction_/direction_.norm()),
-              point_on_axis (point_on_axis_),
-              tolerance(tolerance)
+              normal_direction(internal::compute_normal(direction, true)),
+              direction (direction/direction.norm()),
+              point_on_axis (point_on_axis),
+              tolerance (tolerance)
 {
   // do not use static_assert to make dimension-independent programming
   // easier.

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -931,7 +931,7 @@ CylindricalManifold<dim, spacedim>::CylindricalManifold(const unsigned int axis,
 
 
 template <int dim, int spacedim>
-CylindricalManifold<dim, spacedim>::CylindricalManifold(const Point<spacedim> &direction_,
+CylindricalManifold<dim, spacedim>::CylindricalManifold(const Tensor<1, spacedim> &direction_,
                                                         const Point<spacedim> &point_on_axis_,
                                                         const double tolerance) :
   ChartManifold<dim,spacedim,3>(Tensor<1,3>({0,2.*numbers::PI,0})),

--- a/tests/bits/cylinder_04.cc
+++ b/tests/bits/cylinder_04.cc
@@ -52,8 +52,8 @@ void check ()
 
   GridTools::transform ((Point<dim> ( *)(const Point<dim> &))&rotate_by_xy_angle<dim>, triangulation);
 
-  static const CylindricalManifold<dim> boundary (Point<dim>(std::cos(xy_angle), std::sin(xy_angle), 0),
-                                                  Point<dim>());
+  const Tensor<1, dim> direction {{std::cos(xy_angle), std::sin(xy_angle), 0}};
+  static const CylindricalManifold<dim> boundary (direction, /*center=*/Point<dim>());
   triangulation.set_manifold (0, boundary);
   triangulation.refine_global (2);
 
@@ -71,6 +71,3 @@ int main ()
 
   check<3> ();
 }
-
-
-

--- a/tests/mappings/mapping_q_mixed_manifolds_01.cc
+++ b/tests/mappings/mapping_q_mixed_manifolds_01.cc
@@ -36,13 +36,13 @@
 template <int dim>
 struct ManifoldWrapper
 {
-  Manifold<dim> *operator()(const Point<dim> &direction,
+  Manifold<dim> *operator()(const Tensor<1, dim> &direction,
                             const Point<dim> &center ) const;
 };
 
 template <>
 Manifold<2> *
-ManifoldWrapper<2>::operator()(const Point<2> &/*direction*/,
+ManifoldWrapper<2>::operator()(const Tensor<1, 2> &/*direction*/,
                                const Point<2> &center ) const
 {
   return new SphericalManifold<2>(center);
@@ -50,7 +50,7 @@ ManifoldWrapper<2>::operator()(const Point<2> &/*direction*/,
 
 template <>
 Manifold<3> *
-ManifoldWrapper<3>::operator()(const Point<3> &direction,
+ManifoldWrapper<3>::operator()(const Tensor<1, 3> &direction,
                                const Point<3> &center ) const
 {
   return new CylindricalManifold<3>(direction, center);
@@ -59,7 +59,7 @@ ManifoldWrapper<3>::operator()(const Point<3> &direction,
 template <int dim>
 void test()
 {
-  Point<dim> direction;
+  Tensor<1, dim> direction;
   direction[dim-1] = 1.;
 
   std::shared_ptr<Manifold<dim> > cylinder_manifold

--- a/tests/mappings/mapping_q_mixed_manifolds_02.cc
+++ b/tests/mappings/mapping_q_mixed_manifolds_02.cc
@@ -150,13 +150,13 @@ void create_triangulation(Triangulation<3> &tria)
 template <int dim>
 struct ManifoldWrapper
 {
-  Manifold<dim> *operator()(const Point<dim> &direction,
+  Manifold<dim> *operator()(const Tensor<1, dim> &direction,
                             const Point<dim> &center ) const;
 };
 
 template <>
 Manifold<2> *
-ManifoldWrapper<2>::operator()(const Point<2> &/*direction*/,
+ManifoldWrapper<2>::operator()(const Tensor<1, 2> &/*direction*/,
                                const Point<2> &center ) const
 {
   return new SphericalManifold<2>(center);
@@ -164,7 +164,7 @@ ManifoldWrapper<2>::operator()(const Point<2> &/*direction*/,
 
 template <>
 Manifold<3> *
-ManifoldWrapper<3>::operator()(const Point<3> &direction,
+ManifoldWrapper<3>::operator()(const Tensor<1, 3> &direction,
                                const Point<3> &center ) const
 {
   return new CylindricalManifold<3>(direction, center);
@@ -176,7 +176,7 @@ void test()
   Point<dim> center;
   center[0] = X_C;
   center[1] = Y_C;
-  Point<dim> direction;
+  Tensor<1, dim> direction;
   direction[dim-1] = 1.;
 
   std::shared_ptr<Manifold<dim> > cylinder_manifold


### PR DESCRIPTION
This seems like a holdover from when we used `Point<dim>` to represent directions.