### PR TITLE
Restrict instantiations in GridRefinement to Vector

### DIFF
--- a/doc/news/changes/incompatibilities/20180204DanielArndt
+++ b/doc/news/changes/incompatibilities/20180204DanielArndt
@@ -1,0 +1,4 @@
+Changed: The GridRefinement functions only allow Vector objects
+to be passed in as criteria.
+<br>
+(Daniel Arndt, 2018/02/04)

--- a/include/deal.II/distributed/grid_refinement.h
+++ b/include/deal.II/distributed/grid_refinement.h
@@ -69,11 +69,11 @@ namespace parallel
        *
        * The same is true for the fraction of cells that is coarsened.
        */
-      template <int dim, class VectorType, int spacedim>
+      template <int dim, typename Number, int spacedim>
       void
       refine_and_coarsen_fixed_number
       (parallel::distributed::Triangulation<dim,spacedim> &tria,
-       const VectorType                                   &criteria,
+       const dealii::Vector<Number>                       &criteria,
        const double                                       top_fraction_of_cells,
        const double                                       bottom_fraction_of_cells,
        const unsigned int                                 max_n_cells = std::numeric_limits<unsigned int>::max());
@@ -100,11 +100,11 @@ namespace parallel
        *
        * The same is true for the fraction of cells that is coarsened.
        */
-      template <int dim, class VectorType, int spacedim>
+      template <int dim, typename Number, int spacedim>
       void
       refine_and_coarsen_fixed_fraction
       (parallel::distributed::Triangulation<dim,spacedim> &tria,
-       const VectorType                                   &criteria,
+       const dealii::Vector<Number>                       &criteria,
        const double                                       top_fraction_of_error,
        const double                                       bottom_fraction_of_error);
     }

--- a/include/deal.II/grid/grid_refinement.h
+++ b/include/deal.II/grid/grid_refinement.h
@@ -26,7 +26,7 @@ DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
 template <int dim, int spacedim> class Triangulation;
-
+template <typename Number> class Vector;
 
 /**
  * This namespace provides a collection of functions that aid in refinement
@@ -150,11 +150,11 @@ namespace GridRefinement
    * this number is only an indicator. The default value of this argument is
    * to impose no limit on the number of cells.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename Number, int spacedim>
   void
   refine_and_coarsen_fixed_number
   (Triangulation<dim,spacedim> &triangulation,
-   const VectorType            &criteria,
+   const Vector<Number>        &criteria,
    const double                top_fraction_of_cells,
    const double                bottom_fraction_of_cells,
    const unsigned int          max_n_cells = std::numeric_limits<unsigned int>::max());
@@ -215,11 +215,11 @@ namespace GridRefinement
    * this number is only an indicator. The default value of this argument is
    * to impose no limit on the number of cells.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename Number, int spacedim>
   void
   refine_and_coarsen_fixed_fraction
   (Triangulation<dim,spacedim> &tria,
-   const VectorType            &criteria,
+   const Vector<Number>        &criteria,
    const double                top_fraction,
    const double                bottom_fraction,
    const unsigned int          max_n_cells = std::numeric_limits<unsigned int>::max());
@@ -299,10 +299,10 @@ namespace GridRefinement
    * thesis, University of Heidelberg, 2005. See in particular Section 4.3,
    * pp. 42-43.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename Number, int spacedim>
   void
   refine_and_coarsen_optimize (Triangulation<dim,spacedim> &tria,
-                               const VectorType            &criteria,
+                               const Vector<Number>        &criteria,
                                const unsigned int          order=2);
 
   /**
@@ -319,9 +319,9 @@ namespace GridRefinement
    * This function does not implement a refinement strategy, it is more a
    * helper function for the actual strategies.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename Number, int spacedim>
   void refine (Triangulation<dim,spacedim> &tria,
-               const VectorType            &criteria,
+               const Vector<Number>        &criteria,
                const double                threshold,
                const unsigned int          max_to_mark = numbers::invalid_unsigned_int);
 
@@ -339,9 +339,9 @@ namespace GridRefinement
    * This function does not implement a refinement strategy, it is more a
    * helper function for the actual strategies.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename Number, int spacedim>
   void coarsen (Triangulation<dim,spacedim> &tria,
-                const VectorType            &criteria,
+                const Vector<Number>        &criteria,
                 const double                threshold);
 
   /**

--- a/source/distributed/grid_refinement.inst.in
+++ b/source/distributed/grid_refinement.inst.in
@@ -27,7 +27,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     \{
     template
     void
-    refine_and_coarsen_fixed_number<deal_II_dimension,dealii::Vector<S>,deal_II_dimension>
+    refine_and_coarsen_fixed_number<deal_II_dimension,S,deal_II_dimension>
     (parallel::distributed::Triangulation<deal_II_dimension> &,
      const dealii::Vector<S> &,
      const double,
@@ -36,7 +36,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
 
     template
     void
-    refine_and_coarsen_fixed_fraction<deal_II_dimension,dealii::Vector<S>,deal_II_dimension>
+    refine_and_coarsen_fixed_fraction<deal_II_dimension,S,deal_II_dimension>
     (parallel::distributed::Triangulation<deal_II_dimension> &,
      const dealii::Vector<S> &,
      const double,
@@ -57,7 +57,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     \{
     template
     void
-    refine_and_coarsen_fixed_number<deal_II_dimension-1,dealii::Vector<S>,deal_II_dimension>
+    refine_and_coarsen_fixed_number<deal_II_dimension-1,S,deal_II_dimension>
     (parallel::distributed::Triangulation<deal_II_dimension-1,deal_II_dimension> &,
      const dealii::Vector<S> &,
      const double,
@@ -66,7 +66,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
 
     template
     void
-    refine_and_coarsen_fixed_fraction<deal_II_dimension-1,dealii::Vector<S>,deal_II_dimension>
+    refine_and_coarsen_fixed_fraction<deal_II_dimension-1,S,deal_II_dimension>
     (parallel::distributed::Triangulation<deal_II_dimension-1,deal_II_dimension> &,
      const dealii::Vector<S> &,
      const double,

--- a/source/grid/grid_refinement.inst.in
+++ b/source/grid/grid_refinement.inst.in
@@ -21,7 +21,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     template
     void
     GridRefinement::
-    refine<deal_II_dimension,dealii::Vector<S>,deal_II_dimension>
+    refine<deal_II_dimension,S,deal_II_dimension>
     (Triangulation<deal_II_dimension> &,
      const dealii::Vector<S> &,
      const double,
@@ -30,7 +30,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     template
     void
     GridRefinement::
-    coarsen<deal_II_dimension,dealii::Vector<S>,deal_II_dimension>
+    coarsen<deal_II_dimension,S,deal_II_dimension>
     (Triangulation<deal_II_dimension> &,
      const dealii::Vector<S> &,
      const double);
@@ -38,7 +38,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     template
     void
     GridRefinement::
-    refine_and_coarsen_fixed_number<deal_II_dimension,dealii::Vector<S>,deal_II_dimension>
+    refine_and_coarsen_fixed_number<deal_II_dimension,S,deal_II_dimension>
     (Triangulation<deal_II_dimension> &,
      const dealii::Vector<S> &,
      const double,
@@ -48,7 +48,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     template
     void
     GridRefinement::
-    refine_and_coarsen_fixed_fraction<deal_II_dimension,dealii::Vector<S>,deal_II_dimension>
+    refine_and_coarsen_fixed_fraction<deal_II_dimension,S,deal_II_dimension>
     (Triangulation<deal_II_dimension> &,
      const dealii::Vector<S> &,
      const double,
@@ -58,7 +58,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     template
     void
     GridRefinement::
-    refine_and_coarsen_optimize<deal_II_dimension,dealii::Vector<S>,deal_II_dimension>
+    refine_and_coarsen_optimize<deal_II_dimension,S,deal_II_dimension>
     (Triangulation<deal_II_dimension> &,
      const dealii::Vector<S> &,
      const unsigned int);
@@ -67,7 +67,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     template
     void
     GridRefinement::
-    refine<deal_II_dimension,dealii::Vector<S>,deal_II_dimension+1>
+    refine<deal_II_dimension,S,deal_II_dimension+1>
     (Triangulation<deal_II_dimension,deal_II_dimension+1> &,
      const dealii::Vector<S> &,
      const double,
@@ -76,7 +76,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     template
     void
     GridRefinement::
-    coarsen<deal_II_dimension,dealii::Vector<S>,deal_II_dimension+1>
+    coarsen<deal_II_dimension,S,deal_II_dimension+1>
     (Triangulation<deal_II_dimension,deal_II_dimension+1> &,
      const dealii::Vector<S> &,
      const double);
@@ -84,7 +84,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     template
     void
     GridRefinement::
-    refine_and_coarsen_fixed_number<deal_II_dimension,dealii::Vector<S>,deal_II_dimension+1>
+    refine_and_coarsen_fixed_number<deal_II_dimension,S,deal_II_dimension+1>
     (Triangulation<deal_II_dimension,deal_II_dimension+1> &,
      const dealii::Vector<S> &,
      const double,
@@ -94,7 +94,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     template
     void
     GridRefinement::
-    refine_and_coarsen_fixed_fraction<deal_II_dimension,dealii::Vector<S>,deal_II_dimension+1>
+    refine_and_coarsen_fixed_fraction<deal_II_dimension,S,deal_II_dimension+1>
     (Triangulation<deal_II_dimension,deal_II_dimension+1> &,
      const dealii::Vector<S> &,
      const double,
@@ -104,7 +104,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     template
     void
     GridRefinement::
-    refine_and_coarsen_optimize<deal_II_dimension,dealii::Vector<S>,deal_II_dimension+1>
+    refine_and_coarsen_optimize<deal_II_dimension,S,deal_II_dimension+1>
     (Triangulation<deal_II_dimension,deal_II_dimension+1> &,
      const dealii::Vector<S> &,
      const unsigned int);


### PR DESCRIPTION
Fixes #5858. As `Vector<Number>` are the only types that are used (and needed) in the `GridRefinement` functions, restrict the signatures to these.