### PR TITLE
Fix unused variables in SUNDIALS wrappers' destructors

### DIFF
--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -239,6 +239,7 @@ namespace SUNDIALS
     if (is_serial_vector<VectorType>::value == false)
       {
         const int ierr = MPI_Comm_free(&communicator);
+        (void)ierr;
         AssertNothrow(ierr == MPI_SUCCESS, ExcMPI(ierr));
       }
 #endif

--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -167,6 +167,7 @@ namespace SUNDIALS
     if (is_serial_vector<VectorType>::value == false)
       {
         const int ierr = MPI_Comm_free(&communicator);
+        (void)ierr;
         AssertNothrow(ierr == MPI_SUCCESS, ExcMPI(ierr));
       }
 #endif

--- a/source/sundials/kinsol.cc
+++ b/source/sundials/kinsol.cc
@@ -169,6 +169,7 @@ namespace SUNDIALS
     if (is_serial_vector<VectorType>::value == false)
       {
         const int ierr = MPI_Comm_free(&communicator);
+        (void)ierr;
         AssertNothrow(ierr == MPI_SUCCESS, ExcMPI(ierr));
       }
 #endif


### PR DESCRIPTION
As reported in [CDash](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&onlydeltap&buildid=15336). Since `AssertNothrow` expands to an empty statement in `Release` mode, we need to mark `ierr` as "maybe unused".