### PR TITLE
Allow for braced initialization in astyle.rc

### DIFF
--- a/contrib/styles/astyle.rc
+++ b/contrib/styles/astyle.rc
@@ -21,6 +21,7 @@
 --indent-preprocessor
 --indent=spaces=2
 --indent-namespaces
+--keep-one-line-blocks
 --min-conditional-indent=0
 --pad-header
 

--- a/source/dummy.cc
+++ b/source/dummy.cc
@@ -20,7 +20,7 @@
  * the generated Xcode project.
  */
 
-const int global_symbol_42 = 42;
+const int global_symbol_42 {42};
 void use_global_symbol_42()
 {
   (void) global_symbol_42;


### PR DESCRIPTION
Without this change astyle produces the following diff
```
--- a/source/dummy.cc
+++ b/source/dummy.cc
@@ -20,7 +20,10 @@
  * the generated Xcode project.
  */
 
-const int global_symbol_42 {42};
+const int global_symbol_42
+{
+  42
+};
 void use_global_symbol_42()
 {
   (void) global_symbol_42;
```
Of course, this will affect every other one-line block as well, e.g. one-line lambdas.