### PR TITLE
Improve detection of ld.gold

### DIFF
--- a/cmake/checks/check_01_compiler_features.cmake
+++ b/cmake/checks/check_01_compiler_features.cmake
@@ -408,11 +408,21 @@ RESET_CMAKE_REQUIRED()
 # Use the 'gold' linker if possible, given that it's substantially faster.
 #
 # We have to try to link a full executable with -fuse-ld=gold to check
-# whether "ld.gold" is actually available. gcc has the bad habit of
-# accepting the flag without emitting an error.
+# whether "ld.gold" is actually available.
 #
-# Wolfgang Bangerth, Matthias Maier, 2015
+# Clang always reports "argument unused during compilation"
+# if "-fuse-ld=" is used, but fails at link time for an unsupported linker.
 #
+# ICC also emits a warning but passes for unsupported linkers
+# unless we turn diagnostic warnings into errors.
+#
+# Wolfgang Bangerth, Matthias Maier, Daniel Arndt, 2015, 2018
+#
+IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  PUSH_CMAKE_REQUIRED("-Wno-unused-command-line-argument")
+ELSEIF(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+  PUSH_CMAKE_REQUIRED("-diag-error warn")
+ENDIF()
 PUSH_CMAKE_REQUIRED("-Werror")
 PUSH_CMAKE_REQUIRED("-fuse-ld=gold")
 CHECK_CXX_SOURCE_COMPILES(


### PR DESCRIPTION
On the one hand, I noticed that I was not using `ld.gold` in combination with `clang` although this works.
On the other hand, `ICC-15` was using `-fuse-ld=gold` although it wasn't supported.

I could not reproduce "gcc has the bad habit of accepting the flag without emitting an error" on [godbolt.org](https://godbolt.org/g/81XLwJ) for any gcc version and `-fuse-ld=lld`.