### PR TITLE
Fix multiple definitions for internal::SolverBicgstabData

### DIFF
--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -307,19 +307,6 @@ SolverBicgstab<VectorType>::IterationResult::IterationResult
 
 
 
-internal::SolverBicgstabData::SolverBicgstabData ()
-  :
-  alpha(0.),
-  beta(0.),
-  omega(0.),
-  rho(0.),
-  rhobar(0.),
-  step(numbers::invalid_unsigned_int),
-  res(numbers::signaling_nan<double>())
-{}
-
-
-
 template <typename VectorType>
 SolverBicgstab<VectorType>::SolverBicgstab (SolverControl            &cn,
                                             VectorMemory<VectorType> &mem,

--- a/include/deal.II/physics/notation.h
+++ b/include/deal.II/physics/notation.h
@@ -608,7 +608,7 @@ namespace Physics
       to_tensor (const FullMatrix<Number> &vec);
 //@}
 
-    };
+    }
 
   }
 }

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(_unity_include_src
   relaxation_block.cc
   read_write_vector.cc
   solver.cc
+  solver_bicgstab.cc
   solver_control.cc
   sparse_decomposition.cc
   sparse_direct.cc

--- a/source/lac/solver_bicgstab.cc
+++ b/source/lac/solver_bicgstab.cc
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 1998 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/lac/solver_bicgstab.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+
+internal::SolverBicgstabData::SolverBicgstabData ()
+  :
+  alpha(0.),
+  beta(0.),
+  omega(0.),
+  rho(0.),
+  rhobar(0.),
+  step(numbers::invalid_unsigned_int),
+  res(numbers::signaling_nan<double>())
+{}
+
+
+DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Also fix a warning message while we're at it