### PR TITLE
Make Mapping::clone return a unique_ptr<Mapping>.

### DIFF
--- a/doc/news/changes/incompatibilities/20180208DavidWells
+++ b/doc/news/changes/incompatibilities/20180208DavidWells
@@ -1,0 +1,3 @@
+Changed: The function Mapping::clone (and all inheriting classes' implementations, such as MappingQ1Eulerian::clone) now return a <code>unique_ptr<Mapping<dim,spacedim>></code>.
+<br>
+(David Wells, 2018/02/08)

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -24,6 +24,7 @@
 
 #include <array>
 #include <cmath>
+#include <memory>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -303,7 +304,7 @@ public:
    * This function is mainly used by the hp::MappingCollection class.
    */
   virtual
-  Mapping<dim,spacedim> *clone () const = 0;
+  std::unique_ptr<Mapping<dim,spacedim>> clone () const = 0;
 
   /**
    * Return the mapped vertices of a cell.

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -292,7 +292,8 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~Mapping () = default;
+  virtual
+  ~Mapping () override = default;
 
   /**
    * Return a pointer to a copy of the present object. The caller of this copy
@@ -541,7 +542,8 @@ public:
     /**
      * Virtual destructor for derived classes
      */
-    virtual ~InternalDataBase () = default;
+    virtual
+    ~InternalDataBase () = default;
 
     /**
      * A set of update flags specifying the kind of information that an
@@ -562,7 +564,8 @@ public:
     /**
      * Return an estimate (in bytes) or the memory consumption of this object.
      */
-    virtual std::size_t memory_consumption () const;
+    virtual
+    std::size_t memory_consumption () const;
   };
 
 
@@ -827,7 +830,8 @@ protected:
    * filled; which ones need to be filled is determined by the update flags
    * stored inside the @p internal_data object.
    */
-  virtual void
+  virtual
+  void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator    &cell,
                        const unsigned int                                            face_no,
                        const Quadrature<dim-1>                                      &quadrature,
@@ -860,7 +864,8 @@ protected:
    * filled; which ones need to be filled is determined by the update flags
    * stored inside the @p internal_data object.
    */
-  virtual void
+  virtual
+  void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator     &cell,
                           const unsigned int                                             face_no,
                           const unsigned int                                             subface_no,

--- a/include/deal.II/fe/mapping_c1.h
+++ b/include/deal.II/fe/mapping_c1.h
@@ -77,7 +77,8 @@ protected:
      * interpolating the boundary (as does the base class), but rather such
      * that the resulting cubic mapping is a continuous one.
      */
-    virtual void
+    virtual
+    void
     add_line_support_points (const typename Triangulation<dim>::cell_iterator &cell,
                              std::vector<Point<dim> > &a) const override;
 
@@ -90,7 +91,8 @@ protected:
      * interpolating the boundary (as does the base class), but rather such
      * that the resulting cubic mapping is a continuous one.
      */
-    virtual void
+    virtual
+    void
     add_quad_support_points(const typename Triangulation<dim>::cell_iterator &cell,
                             std::vector<Point<dim> > &a) const override;
   };

--- a/include/deal.II/fe/mapping_c1.h
+++ b/include/deal.II/fe/mapping_c1.h
@@ -50,7 +50,7 @@ public:
    * then assumes ownership of it.
    */
   virtual
-  Mapping<dim,spacedim> *clone () const;
+  std::unique_ptr<Mapping<dim,spacedim>> clone () const override;
 
 protected:
 

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -70,7 +70,8 @@ public:
    * Return @p true because MappingCartesian preserves vertex
    * locations.
    */
-  bool preserves_vertex_locations () const;
+  virtual
+  bool preserves_vertex_locations () const override;
 
   /**
    * @name Mapping points between reference and real cells
@@ -81,13 +82,13 @@ public:
   virtual
   Point<spacedim>
   transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                               const Point<dim>                                          &p) const;
+                               const Point<dim>                                          &p) const override;
 
   // for documentation, see the Mapping base class
   virtual
   Point<dim>
   transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                               const Point<spacedim>                                     &p) const;
+                               const Point<spacedim>                                     &p) const override;
 
   /**
    * @}
@@ -104,7 +105,7 @@ public:
   transform (const ArrayView<const Tensor<1,dim> >                  &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<1,spacedim> >                   &output) const;
+             const ArrayView<Tensor<1,spacedim> >                   &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -112,7 +113,7 @@ public:
   transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
              const MappingType                                         type,
              const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
-             const ArrayView<Tensor<2,spacedim> >                     &output) const;
+             const ArrayView<Tensor<2,spacedim> >                     &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -120,7 +121,7 @@ public:
   transform (const ArrayView<const Tensor<2, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<2,spacedim> >                   &output) const;
+             const ArrayView<Tensor<2,spacedim> >                   &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -128,7 +129,7 @@ public:
   transform (const ArrayView<const DerivativeForm<2, dim, spacedim> > &input,
              const MappingType                                         type,
              const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
-             const ArrayView<Tensor<3,spacedim> >                     &output) const;
+             const ArrayView<Tensor<3,spacedim> >                     &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -136,7 +137,7 @@ public:
   transform (const ArrayView<const Tensor<3, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<3,spacedim> >                   &output) const;
+             const ArrayView<Tensor<3,spacedim> >                   &output) const override;
 
   /**
    * @}
@@ -172,7 +173,8 @@ private:
     /**
      * Return an estimate (in bytes) or the memory consumption of this object.
      */
-    virtual std::size_t memory_consumption () const;
+    virtual
+    std::size_t memory_consumption () const override;
 
     /**
      * Extents of the last cell we have seen in the coordinate directions,
@@ -194,25 +196,25 @@ private:
   // documentation can be found in Mapping::requires_update_flags()
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   // documentation can be found in Mapping::get_data()
   virtual
   typename Mapping<dim, spacedim>::InternalDataBase *
   get_data (const UpdateFlags,
-            const Quadrature<dim> &quadrature) const;
+            const Quadrature<dim> &quadrature) const override;
 
   // documentation can be found in Mapping::get_face_data()
   virtual
   typename Mapping<dim, spacedim>::InternalDataBase *
   get_face_data (const UpdateFlags flags,
-                 const Quadrature<dim-1>& quadrature) const;
+                 const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
   typename Mapping<dim, spacedim>::InternalDataBase *
   get_subface_data (const UpdateFlags flags,
-                    const Quadrature<dim-1>& quadrature) const;
+                    const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::fill_fe_values()
   virtual
@@ -221,24 +223,26 @@ private:
                   const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_face_values()
-  virtual void
+  virtual
+  void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                                         face_no,
                        const Quadrature<dim-1>                                   &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_subface_values()
-  virtual void
+  virtual
+  void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                           const unsigned int                                         face_no,
                           const unsigned int                                         subface_no,
                           const Quadrature<dim-1>                                   &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -64,7 +64,7 @@ public:
 
   // for documentation, see the Mapping base class
   virtual
-  Mapping<dim, spacedim> *clone () const;
+  std::unique_ptr<Mapping<dim, spacedim>> clone () const override;
 
   /**
    * Return @p true because MappingCartesian preserves vertex

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -123,7 +123,7 @@ public:
    * then assumes ownership of it.
    */
   virtual
-  Mapping<dim,spacedim> *clone () const;
+  std::unique_ptr<Mapping<dim,spacedim>> clone () const override;
 
 
 

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -133,7 +133,7 @@ public:
    * class always returns @p false.
    */
   virtual
-  bool preserves_vertex_locations () const;
+  bool preserves_vertex_locations () const override;
 
 
   /**
@@ -145,13 +145,13 @@ public:
   virtual
   Point<spacedim>
   transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                               const Point<dim>                                 &p) const;
+                               const Point<dim>                                 &p) const override;
 
   // for documentation, see the Mapping base class
   virtual
   Point<dim>
   transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                               const Point<spacedim>                            &p) const;
+                               const Point<spacedim>                            &p) const override;
 
   /**
    * @}
@@ -168,7 +168,7 @@ public:
   transform (const ArrayView<const Tensor<1,dim> >                  &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<1,spacedim> >                   &output) const;
+             const ArrayView<Tensor<1,spacedim> >                   &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -176,7 +176,7 @@ public:
   transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
              const MappingType                                         type,
              const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
-             const ArrayView<Tensor<2,spacedim> >                     &output) const;
+             const ArrayView<Tensor<2,spacedim> >                     &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -184,7 +184,7 @@ public:
   transform (const ArrayView<const Tensor<2, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<2,spacedim> >                   &output) const;
+             const ArrayView<Tensor<2,spacedim> >                   &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -192,7 +192,7 @@ public:
   transform (const ArrayView<const DerivativeForm<2, dim, spacedim> > &input,
              const MappingType                                         type,
              const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
-             const ArrayView<Tensor<3,spacedim> >                     &output) const;
+             const ArrayView<Tensor<3,spacedim> >                     &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -200,7 +200,7 @@ public:
   transform (const ArrayView<const Tensor<3, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<3,spacedim> >                   &output) const;
+             const ArrayView<Tensor<3,spacedim> >                   &output) const override;
 
   /**
    * @}
@@ -234,7 +234,7 @@ private:
   // documentation can be found in Mapping::requires_update_flags()
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
 public:
   /**
@@ -321,7 +321,8 @@ public:
     /**
      * Return an estimate (in bytes) or the memory consumption of this object.
      */
-    virtual std::size_t memory_consumption () const;
+    virtual
+    std::size_t memory_consumption () const override;
 
     /**
      * Values of shape functions. Access by function @p shape.
@@ -446,19 +447,19 @@ private:
   virtual
   InternalData *
   get_data (const UpdateFlags,
-            const Quadrature<dim> &quadrature) const;
+            const Quadrature<dim> &quadrature) const override;
 
   // documentation can be found in Mapping::get_face_data()
   virtual
   typename Mapping<dim,spacedim>::InternalDataBase *
   get_face_data (const UpdateFlags flags,
-                 const Quadrature<dim-1>& quadrature) const;
+                 const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
   typename Mapping<dim,spacedim>::InternalDataBase *
   get_subface_data (const UpdateFlags flags,
-                    const Quadrature<dim-1>& quadrature) const;
+                    const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::fill_fe_values()
   virtual
@@ -467,24 +468,26 @@ private:
                   const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_face_values()
-  virtual void
+  virtual
+  void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                                         face_no,
                        const Quadrature<dim-1>                                   &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_subface_values()
-  virtual void
+  virtual
+  void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                           const unsigned int                                         face_no,
                           const unsigned int                                         subface_no,
                           const Quadrature<dim-1>                                   &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   /**
    * @}
@@ -550,7 +553,8 @@ private:
   /**
    * See the documentation of the base class for detailed information.
    */
-  virtual void
+  virtual
+  void
   compute_shapes_virtual (const std::vector<Point<dim> > &unit_points,
                           typename MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::InternalData &data) const;
 

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -72,7 +72,7 @@ public:
 
   // for documentation, see the Mapping base class
   virtual
-  Mapping<dim,spacedim> *clone () const;
+  std::unique_ptr<Mapping<dim,spacedim>> clone () const override;
 
   /**
    * Always returns @p true because this class assumes that the

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -79,7 +79,7 @@ public:
    * vertices always lies on the underlying Manifold.
    */
   virtual
-  bool preserves_vertex_locations () const;
+  bool preserves_vertex_locations () const override;
 
   /**
    * @name Mapping points between reference and real cells
@@ -90,13 +90,13 @@ public:
   virtual
   Point<spacedim>
   transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                               const Point<dim>                                 &p) const;
+                               const Point<dim>                                 &p) const override;
 
   // for documentation, see the Mapping base class
   virtual
   Point<dim>
   transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                               const Point<spacedim>                            &p) const;
+                               const Point<spacedim>                            &p) const override;
 
   /**
    * @}
@@ -113,7 +113,7 @@ public:
   transform (const ArrayView<const Tensor<1,dim> >                  &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<1,spacedim> >                   &output) const;
+             const ArrayView<Tensor<1,spacedim> >                   &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -121,7 +121,7 @@ public:
   transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
              const MappingType                                         type,
              const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
-             const ArrayView<Tensor<2,spacedim> >                     &output) const;
+             const ArrayView<Tensor<2,spacedim> >                     &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -129,7 +129,7 @@ public:
   transform (const ArrayView<const Tensor<2, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<2,spacedim> >                   &output) const;
+             const ArrayView<Tensor<2,spacedim> >                   &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -137,7 +137,7 @@ public:
   transform (const ArrayView<const DerivativeForm<2, dim, spacedim> > &input,
              const MappingType                                         type,
              const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
-             const ArrayView<Tensor<3,spacedim> >                     &output) const;
+             const ArrayView<Tensor<3,spacedim> >                     &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -145,7 +145,7 @@ public:
   transform (const ArrayView<const Tensor<3, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<3,spacedim> >                   &output) const;
+             const ArrayView<Tensor<3,spacedim> >                   &output) const override;
 
   /**
    * @}
@@ -217,7 +217,8 @@ public:
     /**
      * Return an estimate (in bytes) or the memory consumption of this object.
      */
-    virtual std::size_t memory_consumption () const;
+    virtual
+    std::size_t memory_consumption () const override;
 
     /**
      * The current cell vertices.
@@ -336,25 +337,25 @@ public:
   // documentation can be found in Mapping::requires_update_flags()
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   // documentation can be found in Mapping::get_data()
   virtual
   InternalData *
   get_data (const UpdateFlags,
-            const Quadrature<dim> &quadrature) const;
+            const Quadrature<dim> &quadrature) const override;
 
   // documentation can be found in Mapping::get_face_data()
   virtual
   InternalData *
   get_face_data (const UpdateFlags flags,
-                 const Quadrature<dim-1>& quadrature) const;
+                 const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
   InternalData *
   get_subface_data (const UpdateFlags flags,
-                    const Quadrature<dim-1>& quadrature) const;
+                    const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::fill_fe_values()
   virtual
@@ -363,24 +364,26 @@ public:
                   const CellSimilarity::Similarity                               cell_similarity,
                   const Quadrature<dim>                                         &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                  dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_face_values()
-  virtual void
+  virtual
+  void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator     &cell,
                        const unsigned int                                             face_no,
                        const Quadrature<dim-1>                                       &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                       dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_subface_values()
-  virtual void
+  virtual
+  void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator     &cell,
                           const unsigned int                                             face_no,
                           const unsigned int                                             subface_no,
                           const Quadrature<dim-1>                                       &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                          dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -118,7 +118,7 @@ public:
    * this class preserves vertex locations.
    */
   virtual
-  bool preserves_vertex_locations () const;
+  bool preserves_vertex_locations () const override;
 
   /**
    * Transform the point @p p on the unit cell to the point @p p_real on the
@@ -128,7 +128,7 @@ public:
   Point<spacedim>
   transform_unit_to_real_cell (
     const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-    const Point<dim>                                 &p) const;
+    const Point<dim>                                 &p) const override;
 
   /**
    * Transform the point @p p on the real cell to the point @p p_unit on the
@@ -154,7 +154,7 @@ public:
   virtual
   Point<dim>
   transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                               const Point<spacedim>                                     &p) const;
+                               const Point<spacedim>                                     &p) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -162,7 +162,7 @@ public:
   transform (const ArrayView<const Tensor<1,dim> >                  &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<1,spacedim> >                   &output) const;
+             const ArrayView<Tensor<1,spacedim> >                   &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -170,7 +170,7 @@ public:
   transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
              const MappingType                                         type,
              const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
-             const ArrayView<Tensor<2,spacedim> >                     &output) const;
+             const ArrayView<Tensor<2,spacedim> >                     &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -178,7 +178,7 @@ public:
   transform (const ArrayView<const Tensor<2, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<2,spacedim> >                   &output) const;
+             const ArrayView<Tensor<2,spacedim> >                   &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -186,7 +186,7 @@ public:
   transform (const ArrayView<const DerivativeForm<2, dim, spacedim> > &input,
              const MappingType                                         type,
              const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
-             const ArrayView<Tensor<3,spacedim> >                     &output) const;
+             const ArrayView<Tensor<3,spacedim> >                     &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -194,12 +194,13 @@ public:
   transform (const ArrayView<const Tensor<3, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<3,spacedim> >                   &output) const;
+             const ArrayView<Tensor<3,spacedim> >                   &output) const override;
 
   /**
    * Return a pointer to a copy of the present object. The caller of this copy
    * then assumes ownership of it.
    */
+
   virtual
   std::unique_ptr<Mapping<dim,spacedim>> clone () const override;
 
@@ -243,7 +244,8 @@ protected:
     /**
      * Return an estimate (in bytes) or the memory consumption of this object.
      */
-    virtual std::size_t memory_consumption () const;
+    virtual
+    std::size_t memory_consumption () const override;
 
     /**
      * Flag that is set by the <tt>fill_fe_[[sub]face]_values</tt> function.
@@ -271,25 +273,25 @@ protected:
   // documentation can be found in Mapping::requires_update_flags()
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   // documentation can be found in Mapping::get_data()
   virtual
   InternalData *
   get_data (const UpdateFlags,
-            const Quadrature<dim> &quadrature) const;
+            const Quadrature<dim> &quadrature) const override;
 
   // documentation can be found in Mapping::get_face_data()
   virtual
   InternalData *
   get_face_data (const UpdateFlags flags,
-                 const Quadrature<dim-1>& quadrature) const;
+                 const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
   InternalData *
   get_subface_data (const UpdateFlags flags,
-                    const Quadrature<dim-1>& quadrature) const;
+                    const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::fill_fe_values()
   virtual
@@ -298,24 +300,26 @@ protected:
                   const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_face_values()
-  virtual void
+  virtual
+  void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                                         face_no,
                        const Quadrature<dim-1>                                   &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_subface_values()
-  virtual void
+  virtual
+  void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                           const unsigned int                                         face_no,
                           const unsigned int                                         subface_no,
                           const Quadrature<dim-1>                                   &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -201,7 +201,7 @@ public:
    * then assumes ownership of it.
    */
   virtual
-  Mapping<dim,spacedim> *clone () const;
+  std::unique_ptr<Mapping<dim,spacedim>> clone () const override;
 
 
   /**

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -63,7 +63,7 @@ public:
 
   // for documentation, see the Mapping base class
   virtual
-  MappingQ1<dim,spacedim> *clone () const;
+  std::unique_ptr<Mapping<dim,spacedim>> clone () const override;
 };
 
 

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -116,7 +116,7 @@ public:
    */
   virtual
   std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell>
-  get_vertices (const typename Triangulation<dim,spacedim>::cell_iterator &cell) const;
+  get_vertices (const typename Triangulation<dim,spacedim>::cell_iterator &cell) const override;
 
   /**
    * Return a pointer to a copy of the present object. The caller of this copy
@@ -130,7 +130,8 @@ public:
    * preserve vertex locations (unless the translation vector happens to
    * provide for zero displacements at vertex locations).
    */
-  bool preserves_vertex_locations () const;
+  virtual
+  bool preserves_vertex_locations () const override;
 
   /**
    * Exception.
@@ -154,7 +155,7 @@ protected:
                   const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   /**
    * Compute the support points of the mapping. For the current class, these
@@ -164,7 +165,7 @@ protected:
    */
   virtual
   std::vector<Point<spacedim> >
-  compute_mapping_support_points(const typename Triangulation<dim,spacedim>::cell_iterator &cell) const;
+  compute_mapping_support_points(const typename Triangulation<dim,spacedim>::cell_iterator &cell) const override;
 
   /**
    * Reference to the vector of shifts.

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -123,7 +123,7 @@ public:
    * then assumes ownership of it.
    */
   virtual
-  MappingQ1Eulerian<dim,VectorType,spacedim> *clone () const;
+  std::unique_ptr<Mapping<dim,spacedim>> clone () const override;
 
   /**
    * Always returns @p false because MappingQ1Eulerian does not in general

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -119,7 +119,7 @@ public:
    */
   virtual
   std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell>
-  get_vertices (const typename Triangulation<dim,spacedim>::cell_iterator &cell) const;
+  get_vertices (const typename Triangulation<dim,spacedim>::cell_iterator &cell) const override;
 
   /**
    * Return a pointer to a copy of the present object. The caller of this copy
@@ -134,7 +134,7 @@ public:
    * provide zero displacements at vertex locations).
    */
   virtual
-  bool preserves_vertex_locations () const;
+  bool preserves_vertex_locations () const override;
 
   /**
    * Exception which is thrown when the mapping is being evaluated at
@@ -157,7 +157,7 @@ protected:
                   const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   /**
    * Reference to the vector of shifts.
@@ -200,7 +200,7 @@ private:
      */
     virtual
     std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell>
-    get_vertices (const typename Triangulation<dim,spacedim>::cell_iterator &cell) const;
+    get_vertices (const typename Triangulation<dim,spacedim>::cell_iterator &cell) const override;
 
     /**
      * Compute the positions of the support points in the current
@@ -209,7 +209,7 @@ private:
      */
     virtual
     std::vector<Point<spacedim> >
-    compute_mapping_support_points(const typename Triangulation<dim,spacedim>::cell_iterator &cell) const;
+    compute_mapping_support_points(const typename Triangulation<dim,spacedim>::cell_iterator &cell) const override;
 
     /**
      * Always return @p false because MappingQEulerianGeneric does not in general
@@ -217,7 +217,7 @@ private:
      * provide for zero displacements at vertex locations).
      */
     virtual
-    bool preserves_vertex_locations () const;
+    bool preserves_vertex_locations () const override;
 
   private:
     /**

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -126,7 +126,7 @@ public:
    * then assumes ownership of it.
    */
   virtual
-  Mapping<dim,spacedim> *clone () const;
+  std::unique_ptr<Mapping<dim,spacedim>> clone () const override;
 
   /**
    * Always return @p false because MappingQEulerian does not in general

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -142,7 +142,7 @@ public:
 
   // for documentation, see the Mapping base class
   virtual
-  Mapping<dim,spacedim> *clone () const;
+  std::unique_ptr<Mapping<dim,spacedim>> clone () const override;
 
   /**
    * Return the degree of the mapping, i.e. the value which was passed to the

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -155,7 +155,7 @@ public:
    * this class preserves vertex locations.
    */
   virtual
-  bool preserves_vertex_locations () const;
+  bool preserves_vertex_locations () const override;
 
   /**
    * @name Mapping points between reference and real cells
@@ -166,13 +166,13 @@ public:
   virtual
   Point<spacedim>
   transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                               const Point<dim>                                 &p) const;
+                               const Point<dim>                                 &p) const override;
 
   // for documentation, see the Mapping base class
   virtual
   Point<dim>
   transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                               const Point<spacedim>                            &p) const;
+                               const Point<spacedim>                            &p) const override;
 
   /**
    * @}
@@ -189,7 +189,7 @@ public:
   transform (const ArrayView<const Tensor<1,dim> >                  &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<1,spacedim> >                   &output) const;
+             const ArrayView<Tensor<1,spacedim> >                   &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -197,7 +197,7 @@ public:
   transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
              const MappingType                                         type,
              const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
-             const ArrayView<Tensor<2,spacedim> >                     &output) const;
+             const ArrayView<Tensor<2,spacedim> >                     &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -205,7 +205,7 @@ public:
   transform (const ArrayView<const Tensor<2, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<2,spacedim> >                   &output) const;
+             const ArrayView<Tensor<2,spacedim> >                   &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -213,7 +213,7 @@ public:
   transform (const ArrayView<const DerivativeForm<2, dim, spacedim> > &input,
              const MappingType                                         type,
              const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
-             const ArrayView<Tensor<3,spacedim> >                     &output) const;
+             const ArrayView<Tensor<3,spacedim> >                     &output) const override;
 
   // for documentation, see the Mapping base class
   virtual
@@ -221,7 +221,7 @@ public:
   transform (const ArrayView<const Tensor<3, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const ArrayView<Tensor<3,spacedim> >                   &output) const;
+             const ArrayView<Tensor<3,spacedim> >                   &output) const override;
 
   /**
    * @}
@@ -358,7 +358,8 @@ public:
     /**
      * Return an estimate (in bytes) or the memory consumption of this object.
      */
-    virtual std::size_t memory_consumption () const;
+    virtual
+    std::size_t memory_consumption () const override;
 
     /**
      * Values of shape functions. Access by function @p shape.
@@ -529,25 +530,25 @@ public:
   // documentation can be found in Mapping::requires_update_flags()
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   // documentation can be found in Mapping::get_data()
   virtual
   InternalData *
   get_data (const UpdateFlags,
-            const Quadrature<dim> &quadrature) const;
+            const Quadrature<dim> &quadrature) const override;
 
   // documentation can be found in Mapping::get_face_data()
   virtual
   InternalData *
   get_face_data (const UpdateFlags flags,
-                 const Quadrature<dim-1>& quadrature) const;
+                 const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
   InternalData *
   get_subface_data (const UpdateFlags flags,
-                    const Quadrature<dim-1>& quadrature) const;
+                    const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::fill_fe_values()
   virtual
@@ -556,24 +557,26 @@ public:
                   const CellSimilarity::Similarity                               cell_similarity,
                   const Quadrature<dim>                                         &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                  dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_face_values()
-  virtual void
+  virtual
+  void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator     &cell,
                        const unsigned int                                             face_no,
                        const Quadrature<dim-1>                                       &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                       dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_subface_values()
-  virtual void
+  virtual
+  void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator     &cell,
                           const unsigned int                                             face_no,
                           const unsigned int                                             subface_no,
                           const Quadrature<dim-1>                                       &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                          dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   /**
    * @}

--- a/source/fe/mapping_c1.cc
+++ b/source/fe/mapping_c1.cc
@@ -13,10 +13,14 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/std_cxx14/memory.h>
+
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_boundary.h>
+
 #include <deal.II/fe/mapping_c1.h>
+
 #include <cmath>
 
 DEAL_II_NAMESPACE_OPEN
@@ -208,10 +212,10 @@ MappingC1<dim,spacedim>::MappingC1Generic::add_quad_support_points (const typena
 
 
 template <int dim, int spacedim>
-Mapping<dim, spacedim> *
+std::unique_ptr<Mapping<dim,spacedim> >
 MappingC1<dim,spacedim>::clone () const
 {
-  return new MappingC1<dim,spacedim>();
+  return std_cxx14::make_unique<MappingC1<dim,spacedim>>();
 }
 
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -13,7 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
-
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/quadrature.h>
@@ -1064,10 +1064,10 @@ MappingCartesian<dim, spacedim>::transform_real_to_unit_cell (
 
 
 template <int dim, int spacedim>
-Mapping<dim, spacedim> *
+std::unique_ptr<Mapping<dim, spacedim> >
 MappingCartesian<dim, spacedim>::clone () const
 {
-  return new MappingCartesian<dim, spacedim>(*this);
+  return std_cxx14::make_unique<MappingCartesian<dim,spacedim>>(*this);
 }
 
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -20,6 +20,7 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/vector.h>
@@ -1974,10 +1975,10 @@ MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::get_component_mask() con
 
 
 template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
-Mapping<dim,spacedim> *
+std::unique_ptr<Mapping<dim,spacedim> >
 MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::clone () const
 {
-  return new MappingFEField<dim,spacedim,VectorType,DoFHandlerType>(*this);
+  return std_cxx14::make_unique<MappingFEField<dim,spacedim,VectorType,DoFHandlerType>>(*this);
 }
 
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -19,6 +19,7 @@
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/lac/full_matrix.h>
@@ -176,10 +177,10 @@ MappingManifold<dim,spacedim>::MappingManifold (const MappingManifold<dim,spaced
 
 
 template <int dim, int spacedim>
-Mapping<dim,spacedim> *
+std::unique_ptr<Mapping<dim,spacedim> >
 MappingManifold<dim,spacedim>::clone () const
 {
-  return new MappingManifold<dim,spacedim>(*this);
+  return std_cxx14::make_unique<MappingManifold<dim,spacedim>>(*this);
 }
 
 

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -20,6 +20,7 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_iterator.h>
@@ -49,10 +50,10 @@ MappingQ1<dim,spacedim>::MappingQ1 ()
 
 
 template <int dim, int spacedim>
-MappingQ1<dim,spacedim> *
+std::unique_ptr<Mapping<dim,spacedim> >
 MappingQ1<dim,spacedim>::clone () const
 {
-  return new MappingQ1<dim,spacedim>(*this);
+  return std_cxx14::make_unique<MappingQ1<dim,spacedim>>(*this);
 }
 
 //---------------------------------------------------------------------------

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -13,6 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/std_cxx14/memory.h>
+
 #include <deal.II/fe/mapping_q1_eulerian.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
@@ -116,10 +118,10 @@ compute_mapping_support_points(const typename Triangulation<dim,spacedim>::cell_
 
 
 template <int dim, class VectorType, int spacedim>
-MappingQ1Eulerian<dim,VectorType,spacedim> *
+std::unique_ptr<Mapping<dim,spacedim> >
 MappingQ1Eulerian<dim, VectorType, spacedim>::clone () const
 {
-  return new MappingQ1Eulerian<dim,VectorType,spacedim>(*this);
+  return std_cxx14::make_unique<MappingQ1Eulerian<dim,VectorType,spacedim>>(*this);
 }
 
 

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -15,6 +15,7 @@
 
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/la_vector.h>
@@ -79,12 +80,11 @@ MappingQEulerian (const unsigned int              degree,
 
 
 template <int dim, class VectorType, int spacedim>
-Mapping<dim,spacedim> *
+std::unique_ptr<Mapping<dim,spacedim> >
 MappingQEulerian<dim, VectorType, spacedim>::clone () const
 {
-  return new MappingQEulerian<dim,VectorType,spacedim>(this->get_degree(),
-                                                       *euler_dof_handler,
-                                                       *euler_vector);
+  return std_cxx14::make_unique<MappingQEulerian<dim,VectorType,spacedim>>
+         (this->get_degree(), *euler_dof_handler, *euler_vector);
 }
 
 

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -22,6 +22,7 @@
 #include <deal.II/base/table.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/grid/tria.h>
@@ -2154,10 +2155,10 @@ MappingQGeneric<dim,spacedim>::MappingQGeneric (const MappingQGeneric<dim,spaced
 
 
 template <int dim, int spacedim>
-Mapping<dim,spacedim> *
+std::unique_ptr<Mapping<dim,spacedim> >
 MappingQGeneric<dim,spacedim>::clone () const
 {
-  return new MappingQGeneric<dim,spacedim>(*this);
+  return std_cxx14::make_unique<MappingQGeneric<dim,spacedim>>(*this);
 }
 
 

--- a/tests/hp/mapping_collection_03.cc
+++ b/tests/hp/mapping_collection_03.cc
@@ -31,9 +31,9 @@ void test ()
 {
   MappingQ<dim> mapping(2);
   deallog << "Cloning..." << std::endl;
-  Mapping<dim> *copy = mapping.clone();
+  std::unique_ptr<Mapping<dim>> copy = mapping.clone();
   deallog << "Deleting clone..." << std::endl;
-  delete copy;
+  copy.reset();
   deallog << "Destroying original..." << std::endl;
 }
 


### PR DESCRIPTION
This commit converts the current interface into one based on smart pointers. It also gets rid of the use of a covariant return type in MappingQ1::clone and MappingQ1Eulerian::clone.

Part of #5880.