### PR TITLE
Use more std::unique_ptr and std::make_shared/unique

### DIFF
--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -22,6 +22,7 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/work_stream.h>
 #include <deal.II/lac/vector.h>
@@ -54,7 +55,6 @@
 #include <algorithm>
 #include <numeric>
 #include <sstream>
-#include <memory>
 
 // The last step is as in all previous programs:
 namespace Step14
@@ -2894,52 +2894,52 @@ namespace Step14
       {
       case ProblemDescription::dual_weighted_error_estimator:
       {
-        solver.reset
-        (new LaplaceSolver::WeightedResidual<dim> (triangulation,
-                                                   primal_fe,
-                                                   dual_fe,
-                                                   quadrature,
-                                                   face_quadrature,
-                                                   descriptor.data->get_right_hand_side(),
-                                                   descriptor.data->get_boundary_values(),
-                                                   *descriptor.dual_functional));
+        solver = std_cxx14::make_unique<LaplaceSolver::WeightedResidual<dim>>
+                 (triangulation,
+                  primal_fe,
+                  dual_fe,
+                  quadrature,
+                  face_quadrature,
+                  descriptor.data->get_right_hand_side(),
+                  descriptor.data->get_boundary_values(),
+                  *descriptor.dual_functional);
         break;
       }
 
       case ProblemDescription::global_refinement:
       {
-        solver.reset
-        (new LaplaceSolver::RefinementGlobal<dim> (triangulation,
-                                                   primal_fe,
-                                                   quadrature,
-                                                   face_quadrature,
-                                                   descriptor.data->get_right_hand_side(),
-                                                   descriptor.data->get_boundary_values()));
+        solver = std_cxx14::make_unique<LaplaceSolver::RefinementGlobal<dim>>
+                 (triangulation,
+                  primal_fe,
+                  quadrature,
+                  face_quadrature,
+                  descriptor.data->get_right_hand_side(),
+                  descriptor.data->get_boundary_values());
         break;
       }
 
       case ProblemDescription::kelly_indicator:
       {
-        solver.reset
-        (new LaplaceSolver::RefinementKelly<dim> (triangulation,
-                                                  primal_fe,
-                                                  quadrature,
-                                                  face_quadrature,
-                                                  descriptor.data->get_right_hand_side(),
-                                                  descriptor.data->get_boundary_values()));
+        solver = std_cxx14::make_unique<LaplaceSolver::RefinementKelly<dim>>
+                 (triangulation,
+                  primal_fe,
+                  quadrature,
+                  face_quadrature,
+                  descriptor.data->get_right_hand_side(),
+                  descriptor.data->get_boundary_values());
         break;
       }
 
       case ProblemDescription::weighted_kelly_indicator:
       {
-        solver.reset
-        (new LaplaceSolver::RefinementWeightedKelly<dim> (triangulation,
-                                                          primal_fe,
-                                                          quadrature,
-                                                          face_quadrature,
-                                                          descriptor.data->get_right_hand_side(),
-                                                          descriptor.data->get_boundary_values(),
-                                                          *descriptor.kelly_weight));
+        solver = std_cxx14::make_unique<LaplaceSolver::RefinementWeightedKelly<dim>>
+                 (triangulation,
+                  primal_fe,
+                  quadrature,
+                  face_quadrature,
+                  descriptor.data->get_right_hand_side(),
+                  descriptor.data->get_boundary_values(),
+                  *descriptor.kelly_weight);
         break;
       }
 
@@ -3025,7 +3025,7 @@ int main ()
       // values, and right hand side. These are prepackaged in classes. We
       // take here the description of <code>Exercise_2_3</code>, but you can
       // also use <code>CurvedRidges@<dim@></code>:
-      descriptor.data.reset(new Data::SetUp<Data::Exercise_2_3<dim>,dim> ());
+      descriptor.data = std_cxx14::make_unique<Data::SetUp<Data::Exercise_2_3<dim>,dim>>();
 
       // Next set first a dual functional, then a list of evaluation
       // objects. We choose as default the evaluation of the value at an
@@ -3041,8 +3041,8 @@ int main ()
       // each step.  One such additional evaluation is to output the grid in
       // each step.
       const Point<dim> evaluation_point (0.75, 0.75);
-      descriptor.dual_functional.reset
-      (new DualFunctional::PointValueEvaluation<dim> (evaluation_point));
+      descriptor.dual_functional = std_cxx14::make_unique<DualFunctional::PointValueEvaluation<dim>>
+                                   (evaluation_point);
 
       Evaluation::PointValueEvaluation<dim>
       postprocessor1 (evaluation_point);

--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -598,7 +598,7 @@ namespace Step20
     // efficient choice because SolverCG instances allocate memory whenever
     // they are created; this is just a tutorial so such inefficiencies are
     // acceptable for the sake of exposition.
-    SolverControl solver_control (std::max(src.size(), static_cast<std::size_t> (200)),
+    SolverControl solver_control (std::max<unsigned int>(src.size(), 200),
                                   1e-8*src.l2_norm());
     SolverCG<>    cg (solver_control);
 

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -487,7 +487,7 @@ namespace Step21
   void InverseMatrix<MatrixType>::vmult (Vector<double>       &dst,
                                          const Vector<double> &src) const
   {
-    SolverControl solver_control (std::max(src.size(), static_cast<std::size_t> (200)),
+    SolverControl solver_control (std::max<unsigned int>(src.size(), 200),
                                   1e-8*src.l2_norm());
     SolverCG<>    cg (solver_control);
 

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -66,6 +66,7 @@
 // This is C++:
 #include <iostream>
 #include <fstream>
+#include <memory>
 #include <sstream>
 
 // As in all programs, the namespace dealii is included:
@@ -715,7 +716,7 @@ namespace Step22
     std::cout << "   Computing preconditioner..." << std::endl << std::flush;
 
     A_preconditioner
-      = std::shared_ptr<typename InnerPreconditioner<dim>::type>(new typename InnerPreconditioner<dim>::type());
+      = std::make_shared<typename InnerPreconditioner<dim>::type>();
     A_preconditioner->initialize (system_matrix.block(0,0),
                                   typename InnerPreconditioner<dim>::type::AdditionalData());
 

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -69,6 +69,7 @@
 // the aforelisted header files:
 #include <iostream>
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <limits>
 
@@ -1185,8 +1186,8 @@ namespace Step31
 
     assemble_stokes_preconditioner ();
 
-    Amg_preconditioner = std::shared_ptr<TrilinosWrappers::PreconditionAMG>
-                         (new TrilinosWrappers::PreconditionAMG());
+    Amg_preconditioner = std::make_shared<TrilinosWrappers::PreconditionAMG>
+                         ();
 
     std::vector<std::vector<bool> > constant_modes;
     FEValuesExtractors::Vector velocity_components(0);
@@ -1232,8 +1233,8 @@ namespace Step31
     Amg_preconditioner->initialize(stokes_preconditioner_matrix.block(0,0),
                                    amg_data);
 
-    Mp_preconditioner = std::shared_ptr<TrilinosWrappers::PreconditionIC>
-                        (new TrilinosWrappers::PreconditionIC());
+    Mp_preconditioner = std::make_shared<TrilinosWrappers::PreconditionIC>
+                        ();
     Mp_preconditioner->initialize(stokes_preconditioner_matrix.block(1,1));
 
     std::cout << std::endl;

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -2328,8 +2328,8 @@ namespace Step32
                                       stokes_fe.component_mask(velocity_components),
                                       constant_modes);
 
-    Mp_preconditioner.reset  (new TrilinosWrappers::PreconditionJacobi());
-    Amg_preconditioner.reset (new TrilinosWrappers::PreconditionAMG());
+    Mp_preconditioner = std::make_shared<TrilinosWrappers::PreconditionJacobi>();
+    Amg_preconditioner = std::make_shared<TrilinosWrappers::PreconditionAMG>();
 
     TrilinosWrappers::PreconditionAMG::AdditionalData Amg_data;
     Amg_data.constant_modes = constant_modes;
@@ -2854,7 +2854,7 @@ namespace Step32
 
     if (rebuild_temperature_preconditioner == true)
       {
-        T_preconditioner.reset (new TrilinosWrappers::PreconditionJacobi());
+        T_preconditioner = std::make_shared<TrilinosWrappers::PreconditionJacobi>();
         T_preconditioner->initialize (temperature_matrix);
         rebuild_temperature_preconditioner = false;
       }

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -67,6 +67,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <memory>
 
@@ -981,12 +982,10 @@ namespace Step43
   {
     assemble_darcy_preconditioner ();
 
-    Amg_preconditioner = std::shared_ptr<TrilinosWrappers::PreconditionIC>
-                         (new TrilinosWrappers::PreconditionIC());
+    Amg_preconditioner = std::make_shared<TrilinosWrappers::PreconditionIC> ();
     Amg_preconditioner->initialize(darcy_preconditioner_matrix.block(0,0));
 
-    Mp_preconditioner = std::shared_ptr<TrilinosWrappers::PreconditionIC>
-                        (new TrilinosWrappers::PreconditionIC());
+    Mp_preconditioner = std::make_shared<TrilinosWrappers::PreconditionIC> ();
     Mp_preconditioner->initialize(darcy_preconditioner_matrix.block(1,1));
 
   }

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -710,8 +710,8 @@ namespace Step44
     // dilation $\widetilde{J}$ field values.
     void setup_lqp (const Parameters::AllParameters &parameters)
     {
-      material.reset(new Material_Compressible_Neo_Hook_Three_Field<dim>(parameters.mu,
-                     parameters.nu));
+      material = std::make_shared<Material_Compressible_Neo_Hook_Three_Field<dim>>
+                 (parameters.mu, parameters.nu);
       update_values(Tensor<2, dim>(), 0.0, 1.0);
     }
 

--- a/include/deal.II/base/mg_level_object.h
+++ b/include/deal.II/base/mg_level_object.h
@@ -215,7 +215,7 @@ MGLevelObject<Object>::resize (const unsigned int new_minlevel,
 
   minlevel = new_minlevel;
   for (unsigned int i=0; i<new_maxlevel-new_minlevel+1; ++i)
-    objects.push_back(std::shared_ptr<Object> (new Object));
+    objects.push_back(std::make_shared<Object> ());
 }
 
 

--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -706,7 +706,7 @@ namespace parallel
       TBBPartitioner()
 #ifdef DEAL_II_WITH_THREADS
         :
-        my_partitioner(new tbb::affinity_partitioner()),
+        my_partitioner(std::make_shared<tbb::affinity_partitioner>()),
         in_use(false)
 #endif
       {}
@@ -734,7 +734,7 @@ namespace parallel
       {
         dealii::Threads::Mutex::ScopedLock lock(mutex);
         if (in_use)
-          return std::shared_ptr<tbb::affinity_partitioner>(new tbb::affinity_partitioner());
+          return std::make_shared<tbb::affinity_partitioner>();
 
         in_use = true;
         return my_partitioner;

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1468,7 +1468,7 @@ private:
    * object. Every nodes in the property tree corresponding to a parameter
    * stores an index into this array.
    */
-  std::vector<std::shared_ptr<const Patterns::PatternBase> > patterns;
+  std::vector<std::unique_ptr<const Patterns::PatternBase> > patterns;
 
   /**
    * A list of actions that are associated with parameters. These
@@ -1618,7 +1618,7 @@ private:
  *
  *       static void declare_parameters (ParameterHandler &prm);
  *     private:
- *       std::shared_ptr<Problem> p;
+ *       std::unique_ptr<Problem> p;
  *     };
  *
  *
@@ -1627,7 +1627,7 @@ private:
  *
  *     void HelperClass::create_new (const unsigned int run_no)
  *     {
- *       p.reset(new Problem());
+ *       p = std_cxx14::make_unique<Problem>());
  *     }
  *
  *
@@ -1991,7 +1991,7 @@ ParameterHandler::load (Archive &ar, const unsigned int)
 
   patterns.clear ();
   for (unsigned int j=0; j<descriptions.size(); ++j)
-    patterns.push_back (std::shared_ptr<const Patterns::PatternBase>(Patterns::pattern_factory(descriptions[j])));
+    patterns.push_back (Patterns::pattern_factory(descriptions[j]));
 }
 
 

--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -531,10 +531,10 @@ namespace Polynomials
      * polynomial, we keep one pointer to the list of coefficients; we do so
      * rather than keeping a vector of vectors in order to simplify
      * programming multithread-safe. In order to avoid memory leak, we use a
-     * shared_ptr in order to correctly free the memory of the vectors when
+     * unique_ptr in order to correctly free the memory of the vectors when
      * the global destructor is called.
      */
-    static std::vector<std::shared_ptr<const std::vector<double> > > recursive_coefficients;
+    static std::vector<std::unique_ptr<const std::vector<double> > > recursive_coefficients;
   };
 
 

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -863,7 +863,7 @@ namespace Threads
       void start (const std::function<RT ()> &function)
       {
         thread_is_active = true;
-        ret_val.reset(new return_value<RT>());
+        ret_val = std::make_shared<return_value<RT>>();
         thread = std::thread (thread_entry_point, function, ret_val);
       }
 
@@ -943,7 +943,7 @@ namespace Threads
        */
       void start (const std::function<RT ()> &function)
       {
-        ret_val.reset(new return_value<RT>());
+        ret_val = std::make_shared<return_value<RT>>();
         call (function, *ret_val);
       }
 
@@ -1629,7 +1629,7 @@ namespace Threads
     {
       // create a task descriptor and tell it to queue itself up with
       // the scheduling system
-      task_descriptor.reset (new internal::TaskDescriptor<RT>(function_object));
+      task_descriptor = std::make_shared<internal::TaskDescriptor<RT>>(function_object);
       task_descriptor->queue_task ();
     }
 

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -175,8 +175,7 @@ namespace hp
   inline
   QCollection<dim>::QCollection (const Quadrature<dim> &quadrature)
   {
-    quadratures
-    .push_back (std::shared_ptr<const Quadrature<dim> >(new Quadrature<dim>(quadrature)));
+    quadratures.push_back (std::make_shared<const Quadrature<dim> >(quadrature));
   }
 
 
@@ -196,8 +195,7 @@ namespace hp
   void
   QCollection<dim>::push_back (const Quadrature<dim> &new_quadrature)
   {
-    quadratures
-    .push_back (std::shared_ptr<const Quadrature<dim> >(new Quadrature<dim>(new_quadrature)));
+    quadratures.push_back (std::make_shared<const Quadrature<dim> >(new_quadrature));
   }
 
 } // namespace hp

--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -463,7 +463,7 @@ ChunkSparseMatrix<number>::reinit (const ChunkSparsityPattern &sparsity)
                       chunk_size * chunk_size;
   if (N > max_len || max_len == 0)
     {
-      val.reset (new number[N]);
+      val = std_cxx14::make_unique<number[]>(N);
       max_len = N;
     }
 
@@ -1615,7 +1615,7 @@ ChunkSparseMatrix<number>::block_read (std::istream &in)
   AssertThrow (c == '[', ExcIO());
 
   // reallocate space
-  val.reset (new number[max_len]);
+  val = std_cxx14::make_unique<number[]>(max_len);
 
   // then read data
   in.read (reinterpret_cast<char *>(val.get()),

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -18,6 +18,7 @@
 
 
 #include <deal.II/base/config.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/lac/exceptions.h>
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/vector_operations_internal.h>
@@ -76,7 +77,7 @@ namespace LinearAlgebra
           values.reset();
           allocated_size = 0;
         }
-      thread_loop_partitioner.reset(new ::dealii::parallel::internal::TBBPartitioner());
+      thread_loop_partitioner = std::make_shared<::dealii::parallel::internal::TBBPartitioner>();
     }
 
 
@@ -95,7 +96,7 @@ namespace LinearAlgebra
       import_data.reset ();
 
       // set partitioner to serial version
-      partitioner.reset (new Utilities::MPI::Partitioner (size));
+      partitioner = std::make_shared<Utilities::MPI::Partitioner> (size);
 
       // set entries to zero if so requested
       if (omit_zeroing_entries == false)
@@ -540,7 +541,7 @@ namespace LinearAlgebra
 
       // allocate import_data in case it is not set up yet
       if (import_data == nullptr && partitioner->n_import_indices() > 0)
-        import_data.reset (new Number[partitioner->n_import_indices()]);
+        import_data = std_cxx14::make_unique<Number[]>(partitioner->n_import_indices());
 
       partitioner->import_from_ghosted_array_start
       (operation, counter,
@@ -595,7 +596,7 @@ namespace LinearAlgebra
 
       // allocate import_data in case it is not set up yet
       if (import_data == nullptr && partitioner->n_import_indices() > 0)
-        import_data.reset (new Number[partitioner->n_import_indices()]);
+        import_data = std_cxx14::make_unique<Number[]>(partitioner->n_import_indices());
 
       partitioner->export_to_ghosted_array_start
       (counter,
@@ -654,9 +655,8 @@ namespace LinearAlgebra
           ghost_indices.subtract_set(locally_owned_elem);
           IndexSet local_indices(V.get_stored_elements());
           local_indices.subtract_set(ghost_indices);
-          comm_pattern.reset(new Utilities::MPI::Partitioner(local_indices,
-                                                             ghost_indices,
-                                                             get_mpi_communicator()));
+          comm_pattern = std::make_shared<Utilities::MPI::Partitioner>
+                         (local_indices, ghost_indices, get_mpi_communicator());
         }
       else
         {

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -834,13 +834,13 @@ private:
    * The matrix <i>U</i> in the singular value decomposition
    * <i>USV<sup>T</sup></i>.
    */
-  std::shared_ptr<LAPACKFullMatrix<number> > svd_u;
+  std::unique_ptr<LAPACKFullMatrix<number> > svd_u;
 
   /**
    * The matrix <i>V<sup>T</sup></i> in the singular value decomposition
    * <i>USV<sup>T</sup></i>.
    */
-  std::shared_ptr<LAPACKFullMatrix<number> > svd_vt;
+  std::unique_ptr<LAPACKFullMatrix<number> > svd_vt;
 
   /**
    * Thread mutex.

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -240,7 +240,7 @@ namespace PETScWrappers
      * Pointer to an object that stores the solver context. This is recreated
      * in the main solver routine if necessary.
      */
-    std::shared_ptr<SolverData> solver_data;
+    std::unique_ptr<SolverData> solver_data;
 
 #ifdef DEAL_II_WITH_SLEPC
     /**
@@ -984,7 +984,7 @@ namespace PETScWrappers
       PC  pc;
     };
 
-    std::shared_ptr<SolverDataMUMPS> solver_data;
+    std::unique_ptr<SolverDataMUMPS> solver_data;
 
     /**
      * Flag specifies whether matrix being factorized is symmetric or not. It

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -1878,7 +1878,7 @@ namespace internal
           preconditioner->m() != matrix.m())
         {
           if (preconditioner.get() == nullptr)
-            preconditioner.reset(new DiagonalMatrix<VectorType>());
+            preconditioner = std::make_shared<DiagonalMatrix<VectorType>>();
 
           Assert(preconditioner->m() == 0,
                  ExcMessage("Preconditioner appears to be initialized but not sized correctly"));

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -57,7 +57,7 @@ namespace LinearAlgebra
         if (val != nullptr)
           free(val);
         val = nullptr;
-        thread_loop_partitioner.reset(new parallel::internal::TBBPartitioner());
+        thread_loop_partitioner = std::make_shared<parallel::internal::TBBPartitioner>();
       }
     else
       {
@@ -66,7 +66,7 @@ namespace LinearAlgebra
 
         Utilities::System::posix_memalign ((void **)&val, 64, sizeof(Number)*new_alloc_size);
         if (new_alloc_size >= 4*dealii::internal::Vector::minimum_parallel_grain_size)
-          thread_loop_partitioner.reset(new parallel::internal::TBBPartitioner());
+          thread_loop_partitioner = std::make_shared<parallel::internal::TBBPartitioner>();
       }
   }
 
@@ -241,9 +241,10 @@ namespace LinearAlgebra
     std::shared_ptr<const Utilities::MPI::Partitioner> comm_pattern;
     if (communication_pattern.get() == nullptr)
       {
-        comm_pattern.reset(new Utilities::MPI::Partitioner(vec.locally_owned_elements(),
-                                                           get_stored_elements(),
-                                                           vec.get_mpi_communicator()));
+        comm_pattern = std::make_shared<Utilities::MPI::Partitioner>
+                       (vec.locally_owned_elements(),
+                        get_stored_elements(),
+                        vec.get_mpi_communicator());
       }
     else
       {
@@ -524,8 +525,8 @@ namespace LinearAlgebra
     source_stored_elements = source_index_set;
     EpetraWrappers::CommunicationPattern epetra_comm_pattern(
       source_stored_elements, stored_elements, mpi_comm);
-    comm_pattern.reset(new EpetraWrappers::CommunicationPattern(
-                         source_stored_elements, stored_elements, mpi_comm));
+    comm_pattern = std::make_shared<EpetraWrappers::CommunicationPattern>
+                   (source_stored_elements, stored_elements, mpi_comm);
 
     return epetra_comm_pattern;
   }

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -253,7 +253,7 @@ SparseMatrix<number>::reinit (const SparsityPattern &sparsity)
   const std::size_t N = cols->n_nonzero_elements();
   if (N > max_len || max_len == 0)
     {
-      val.reset (new number[N]);
+      val = std_cxx14::make_unique<number[]>(N);
       max_len = N;
     }
 
@@ -1982,7 +1982,7 @@ SparseMatrix<number>::block_read (std::istream &in)
   AssertThrow (c == '[', ExcIO());
 
   // reallocate space
-  val.reset (new number[max_len]);
+  val = std_cxx14::make_unique<number[]> (max_len);
 
   // then read data
   in.read (reinterpret_cast<char *>(val.get()),

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/subscriptor.h>
 
 // boost::serialization::make_array used to be in array.hpp, but was
@@ -31,7 +32,6 @@
 #endif
 #include <boost/serialization/split_member.hpp>
 
-#include <memory>
 #include <vector>
 #include <iostream>
 #include <algorithm>
@@ -1442,8 +1442,8 @@ SparsityPattern::load (Archive &ar, const unsigned int)
 
   ar &max_dim &rows &cols &max_vec_len &max_row_length &compressed &store_diagonal_first_in_row;
 
-  rowstart.reset (new std::size_t[max_dim + 1]);
-  colnums.reset (new size_type[max_vec_len]);
+  rowstart = std_cxx14::make_unique<std::size_t[]>(max_dim + 1);
+  colnums = std_cxx14::make_unique<size_type[]>(max_vec_len);
 
   ar &boost::serialization::make_array(rowstart.get(), max_dim + 1);
   ar &boost::serialization::make_array(colnums.get(), max_vec_len);

--- a/include/deal.II/lac/trilinos_epetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_epetra_communication_pattern.h
@@ -78,7 +78,7 @@ namespace LinearAlgebra
       /**
        * Shared pointer to the Epetra_Import object used.
        */
-      std::shared_ptr<Epetra_Import> import;
+      std::unique_ptr<Epetra_Import> import;
     };
   } // end of namespace EpetraWrappers
 } // end of namespace LinearAlgebra

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -323,7 +323,7 @@ namespace LinearAlgebra
       /**
        * Pointer to the actual Epetra vector object.
        */
-      std::shared_ptr<Epetra_FEVector> vector;
+      std::unique_ptr<Epetra_FEVector> vector;
 
       /**
        * IndexSet of the elements of the last imported vector.

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -321,13 +321,13 @@ namespace TrilinosWrappers
      * side vector and the solution vector, which is passed down to the
      * Trilinos solver.
      */
-    std::shared_ptr<Epetra_LinearProblem> linear_problem;
+    std::unique_ptr<Epetra_LinearProblem> linear_problem;
 
     /**
      * A structure that contains a Trilinos object that can query the linear
      * solver and determine whether the convergence criterion have been met.
      */
-    std::shared_ptr<AztecOO_StatusTest> status_test;
+    std::unique_ptr<AztecOO_StatusTest> status_test;
 
     /**
      * A structure that contains the Trilinos solver and preconditioner
@@ -719,13 +719,13 @@ namespace TrilinosWrappers
      * side vector and the solution vector, which is passed down to the
      * Trilinos solver.
      */
-    std::shared_ptr<Epetra_LinearProblem> linear_problem;
+    std::unique_ptr<Epetra_LinearProblem> linear_problem;
 
     /**
      * A structure that contains the Trilinos solver and preconditioner
      * objects.
      */
-    std::shared_ptr<Amesos_BaseSolver> solver;
+    std::unique_ptr<Amesos_BaseSolver> solver;
 
     /**
      * Store a copy of the flags for this particular solver.

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -36,6 +36,7 @@
 #  include <memory>
 
 #  include <Epetra_FECrsMatrix.h>
+#  include <Epetra_Export.h>
 #  include <Epetra_Map.h>
 #  include <Epetra_CrsGraph.h>
 #  include <Epetra_MultiVector.h>
@@ -47,8 +48,6 @@
 #  else
 #    include <Epetra_SerialComm.h>
 #  endif
-
-class Epetra_Export;
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -2008,26 +2007,26 @@ namespace TrilinosWrappers
      * Pointer to the user-supplied Epetra Trilinos mapping of the matrix
      * columns that assigns parts of the matrix to the individual processes.
      */
-    std::shared_ptr<Epetra_Map> column_space_map;
+    std::unique_ptr<Epetra_Map> column_space_map;
 
     /**
      * A sparse matrix object in Trilinos to be used for finite element based
      * problems which allows for assembling into non-local elements.  The
      * actual type, a sparse matrix, is set in the constructor.
      */
-    std::shared_ptr<Epetra_FECrsMatrix> matrix;
+    std::unique_ptr<Epetra_FECrsMatrix> matrix;
 
     /**
      * A sparse matrix object in Trilinos to be used for collecting the non-
      * local elements if the matrix was constructed from a Trilinos sparsity
      * pattern with the respective option.
      */
-    std::shared_ptr<Epetra_CrsMatrix> nonlocal_matrix;
+    std::unique_ptr<Epetra_CrsMatrix> nonlocal_matrix;
 
     /**
      * An export object used to communicate the nonlocal matrix.
      */
-    std::shared_ptr<Epetra_Export>    nonlocal_matrix_exporter;
+    std::unique_ptr<Epetra_Export>    nonlocal_matrix_exporter;
 
     /**
      * Trilinos doesn't allow to mix additions to matrix entries and

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -1164,14 +1164,14 @@ namespace TrilinosWrappers
      * Pointer to the user-supplied Epetra Trilinos mapping of the matrix
      * columns that assigns parts of the matrix to the individual processes.
      */
-    std::shared_ptr<Epetra_Map> column_space_map;
+    std::unique_ptr<Epetra_Map> column_space_map;
 
     /**
      * A sparsity pattern object in Trilinos to be used for finite element
      * based problems which allows for adding non-local elements to the
      * pattern.
      */
-    std::shared_ptr<Epetra_FECrsGraph> graph;
+    std::unique_ptr<Epetra_FECrsGraph> graph;
 
     /**
      * A sparsity pattern object for the non-local part of the sparsity
@@ -1179,7 +1179,7 @@ namespace TrilinosWrappers
      * when the particular constructor or reinit method with writable_rows
      * argument is set
      */
-    std::shared_ptr<Epetra_CrsGraph> nonlocal_graph;
+    std::unique_ptr<Epetra_CrsGraph> nonlocal_graph;
 
     friend class TrilinosWrappers::SparseMatrix;
     friend class SparsityPatternIterators::Accessor;

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -1242,14 +1242,14 @@ namespace TrilinosWrappers
        * that is in fact distributed among multiple processors. The object
        * requires an existing Epetra_Map for storing data when setting it up.
        */
-      std::shared_ptr<Epetra_FEVector> vector;
+      std::unique_ptr<Epetra_FEVector> vector;
 
       /**
        * A vector object in Trilinos to be used for collecting the non-local
        * elements if the vector was constructed with an additional IndexSet
        * describing ghost elements.
        */
-      std::shared_ptr<Epetra_MultiVector> nonlocal_vector;
+      std::unique_ptr<Epetra_MultiVector> nonlocal_vector;
 
       /**
        * An IndexSet storing the indices this vector owns exclusively.

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -883,7 +883,7 @@ public:
   /**
    * Return dimension of the vector.
    */
-  std::size_t size () const;
+  size_type size () const;
 
   /**
    * Return whether the vector contains only elements with value zero. This
@@ -1031,7 +1031,8 @@ Vector<Number>::Vector (const size_type n)
 
 template <typename Number>
 inline
-std::size_t Vector<Number>::size () const
+typename Vector<Number>::size_type
+Vector<Number>::size () const
 {
   return vec_size;
 }

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -264,7 +264,7 @@ void Vector<Number>::reinit (const size_type n,
     {
       values.reset();
       max_vec_size = vec_size = 0;
-      thread_loop_partitioner.reset(new parallel::internal::TBBPartitioner());
+      thread_loop_partitioner = std::make_shared<parallel::internal::TBBPartitioner>();
       return;
     }
 
@@ -281,7 +281,7 @@ void Vector<Number>::reinit (const size_type n,
       // only reset the partitioner if we actually expect a significant vector
       // size
       if (vec_size >= 4*internal::Vector::minimum_parallel_grain_size)
-        thread_loop_partitioner.reset(new parallel::internal::TBBPartitioner());
+        thread_loop_partitioner = std::make_shared<parallel::internal::TBBPartitioner>();
     }
 
   if (omit_zeroing_entries == false)
@@ -298,7 +298,7 @@ void Vector<Number>::grow_or_shrink (const size_type n)
     {
       values.reset();
       max_vec_size = vec_size = 0;
-      thread_loop_partitioner.reset(new parallel::internal::TBBPartitioner());
+      thread_loop_partitioner = std::make_shared<parallel::internal::TBBPartitioner>();
       return;
     }
 
@@ -316,7 +316,7 @@ void Vector<Number>::grow_or_shrink (const size_type n)
       // only reset the partitioner if we actually expect a significant vector
       // size
       if (vec_size >= 4*internal::Vector::minimum_parallel_grain_size)
-        thread_loop_partitioner.reset(new parallel::internal::TBBPartitioner());
+        thread_loop_partitioner = std::make_shared<parallel::internal::TBBPartitioner>();
     }
 
   // pad with zeroes

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -2215,9 +2215,9 @@ FEEvaluationBase<dim,n_components_,Number>
       other->mapped_geometry->get_quadrature() == quadrature)
     mapped_geometry = other->mapped_geometry;
   else
-    mapped_geometry.reset(new internal::MatrixFreeFunctions::
-                          MappingDataOnTheFly<dim,Number>(mapping, quadrature,
-                                                          update_flags));
+    mapped_geometry
+      = std::make_shared<internal::MatrixFreeFunctions::MappingDataOnTheFly<dim,Number> >
+        (mapping, quadrature, update_flags);
   jacobian = mapped_geometry->get_inverse_jacobians().begin();
   J_value = mapped_geometry->get_JxW_values().begin();
   quadrature_points = mapped_geometry->get_quadrature_points().begin();

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -557,7 +557,7 @@ namespace MeshWorker
     :
     fevalv(0),
     multigrid(false),
-    global_data(std::shared_ptr<VectorDataBase<dim, sdim> >(new VectorDataBase<dim, sdim>)),
+    global_data(std::make_shared<VectorDataBase<dim, sdim> >()),
     n_components(numbers::invalid_unsigned_int)
   {}
 
@@ -583,15 +583,15 @@ namespace MeshWorker
         const FESubfaceValues<dim,sdim> *ps = dynamic_cast<const FESubfaceValues<dim,sdim>*>(&p);
 
         if (pc != nullptr)
-          fevalv[i] = std::shared_ptr<FEValuesBase<dim,sdim> > (
-                        new FEValues<dim,sdim> (pc->get_mapping(), pc->get_fe(),
-                                                pc->get_quadrature(), pc->get_update_flags()));
+          fevalv[i] = std::make_shared<FEValues<dim,sdim> >
+                      (pc->get_mapping(), pc->get_fe(),
+                       pc->get_quadrature(), pc->get_update_flags());
         else if (pf != nullptr)
-          fevalv[i] = std::shared_ptr<FEValuesBase<dim,sdim> > (
-                        new FEFaceValues<dim,sdim> (pf->get_mapping(), pf->get_fe(), pf->get_quadrature(), pf->get_update_flags()));
+          fevalv[i] = std::make_shared<FEFaceValues<dim,sdim> >
+                      (pf->get_mapping(), pf->get_fe(), pf->get_quadrature(), pf->get_update_flags());
         else if (ps != nullptr)
-          fevalv[i] = std::shared_ptr<FEValuesBase<dim,sdim> > (
-                        new FESubfaceValues<dim,sdim> (ps->get_mapping(), ps->get_fe(), ps->get_quadrature(), ps->get_update_flags()));
+          fevalv[i] = std::make_shared<FESubfaceValues<dim,sdim> >
+                      (ps->get_mapping(), ps->get_fe(), ps->get_quadrature(), ps->get_update_flags());
         else
           Assert(false, ExcInternalError());
       }
@@ -613,17 +613,13 @@ namespace MeshWorker
     if (block_info == nullptr || block_info->local().size() == 0)
       {
         fevalv.resize(1);
-        fevalv[0] = std::shared_ptr<FEValuesBase<dim,sdim> > (
-                      new FEVALUES (mapping, el, quadrature, flags));
+        fevalv[0] = std::make_shared<FEVALUES>(mapping, el, quadrature, flags);
       }
     else
       {
         fevalv.resize(el.n_base_elements());
         for (unsigned int i=0; i<fevalv.size(); ++i)
-          {
-            fevalv[i] = std::shared_ptr<FEValuesBase<dim,sdim> > (
-                          new FEVALUES (mapping, el.base_element(i), quadrature, flags));
-          }
+          fevalv[i] = std::make_shared<FEVALUES> (mapping, el.base_element(i), quadrature, flags);
       }
     n_components = el.n_components();
   }
@@ -788,7 +784,7 @@ namespace MeshWorker
     std::shared_ptr<VectorData<VectorType, dim, sdim> > p;
     VectorDataBase<dim,sdim> *pp;
 
-    p = std::shared_ptr<VectorData<VectorType, dim, sdim> >(new VectorData<VectorType, dim, sdim> (cell_selector));
+    p = std::make_shared<VectorData<VectorType, dim, sdim> > (cell_selector);
     // Public member function of parent class was not found without
     // explicit cast
     pp = &*p;
@@ -796,13 +792,13 @@ namespace MeshWorker
     cell_data = p;
     cell.initialize_data(p);
 
-    p = std::shared_ptr<VectorData<VectorType, dim, sdim> >(new VectorData<VectorType, dim, sdim> (boundary_selector));
+    p = std::make_shared<VectorData<VectorType, dim, sdim> > (boundary_selector);
     pp = &*p;
     pp->initialize(data);
     boundary_data = p;
     boundary.initialize_data(p);
 
-    p = std::shared_ptr<VectorData<VectorType, dim, sdim> >(new VectorData<VectorType, dim, sdim> (face_selector));
+    p = std::make_shared<VectorData<VectorType, dim, sdim> > (face_selector);
     pp = &*p;
     pp->initialize(data);
     face_data = p;
@@ -825,7 +821,7 @@ namespace MeshWorker
     std::shared_ptr<MGVectorData<VectorType, dim, sdim> > p;
     VectorDataBase<dim,sdim> *pp;
 
-    p = std::shared_ptr<MGVectorData<VectorType, dim, sdim> >(new MGVectorData<VectorType, dim, sdim> (cell_selector));
+    p = std::make_shared<MGVectorData<VectorType, dim, sdim> > (cell_selector);
     // Public member function of parent class was not found without
     // explicit cast
     pp = &*p;
@@ -833,13 +829,13 @@ namespace MeshWorker
     cell_data = p;
     cell.initialize_data(p);
 
-    p = std::shared_ptr<MGVectorData<VectorType, dim, sdim> >(new MGVectorData<VectorType, dim, sdim> (boundary_selector));
+    p = std::make_shared<MGVectorData<VectorType, dim, sdim> > (boundary_selector);
     pp = &*p;
     pp->initialize(data);
     boundary_data = p;
     boundary.initialize_data(p);
 
-    p = std::shared_ptr<MGVectorData<VectorType, dim, sdim> >(new MGVectorData<VectorType, dim, sdim> (face_selector));
+    p = std::make_shared<MGVectorData<VectorType, dim, sdim> > (face_selector);
     pp = &*p;
     pp->initialize(data);
     face_data = p;

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -93,11 +93,11 @@ namespace internal
                     break;
                   }
               if (x_fe_values[i].get() == nullptr)
-                x_fe_values[i].reset(new dealii::hp::FEValues<dim,spacedim>
-                                     (this->mapping_collection,
-                                      *this->finite_elements[i],
-                                      quadrature,
-                                      this->update_flags));
+                x_fe_values[i] = std::make_shared<dealii::hp::FEValues<dim,spacedim>>
+                                 (this->mapping_collection,
+                                  *this->finite_elements[i],
+                                  quadrature,
+                                  this->update_flags);
             }
         }
       else
@@ -118,11 +118,11 @@ namespace internal
                     break;
                   }
               if (x_fe_face_values[i].get() == nullptr)
-                x_fe_face_values[i].reset(new dealii::hp::FEFaceValues<dim,spacedim>
-                                          (this->mapping_collection,
-                                           *this->finite_elements[i],
-                                           quadrature,
-                                           this->update_flags));
+                x_fe_face_values[i] = std::make_shared<dealii::hp::FEFaceValues<dim,spacedim>>
+                                      (this->mapping_collection,
+                                       *this->finite_elements[i],
+                                       quadrature,
+                                       this->update_flags);
             }
         }
 
@@ -177,11 +177,11 @@ namespace internal
                     break;
                   }
               if (x_fe_values[i].get() == nullptr)
-                x_fe_values[i].reset(new dealii::hp::FEValues<dim,spacedim>
-                                     (this->mapping_collection,
-                                      *this->finite_elements[i],
-                                      quadrature,
-                                      this->update_flags));
+                x_fe_values[i] = std::make_shared<dealii::hp::FEValues<dim,spacedim>>
+                                 (this->mapping_collection,
+                                  *this->finite_elements[i],
+                                  quadrature,
+                                  this->update_flags);
             }
         }
       else
@@ -201,11 +201,11 @@ namespace internal
                     break;
                   }
               if (x_fe_face_values[i].get() == nullptr)
-                x_fe_face_values[i].reset(new dealii::hp::FEFaceValues<dim,spacedim>
-                                          (this->mapping_collection,
-                                           *this->finite_elements[i],
-                                           quadrature,
-                                           this->update_flags));
+                x_fe_face_values[i] = std::make_shared<dealii::hp::FEFaceValues<dim,spacedim>>
+                                      (this->mapping_collection,
+                                       *this->finite_elements[i],
+                                       quadrature,
+                                       this->update_flags);
             }
         }
     }
@@ -1327,14 +1327,14 @@ std::vector<std::shared_ptr<dealii::hp::FECollection<DoFHandlerType::dimension,
             duplicate = true;
           }
       if (duplicate == false)
-        finite_elements[i].reset(new dealii::hp::FECollection<dhdim,dhspacedim>
-                                 (this->dof_data[i]->dof_handler->get_fe_collection()));
+        finite_elements[i] = std::make_shared<dealii::hp::FECollection<dhdim,dhspacedim>>
+                             (this->dof_data[i]->dof_handler->get_fe_collection());
     }
   if (this->dof_data.empty())
     {
       finite_elements.resize(1);
-      finite_elements[0].reset(new dealii::hp::FECollection<dhdim,dhspacedim>
-                               (FE_DGQ<dhdim,dhspacedim>(0)));
+      finite_elements[0] = std::make_shared<dealii::hp::FECollection<dhdim,dhspacedim>>
+                           (FE_DGQ<dhdim,dhspacedim>(0));
     }
   return finite_elements;
 }

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -253,7 +253,7 @@ LogStream::get_stream()
   // there can only be one access at a time
   if (outstreams.get().get() == nullptr)
     {
-      outstreams.get().reset (new std::ostringstream);
+      outstreams.get() = std::make_shared<std::ostringstream>();
       outstreams.get()->setf(std::ios::showpoint | std::ios::left);
     }
 

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -458,7 +458,7 @@ namespace
   read_xml_recursively (const boost::property_tree::ptree &source,
                         const std::string                 &current_path,
                         const char                         path_separator,
-                        const std::vector<std::shared_ptr<const Patterns::PatternBase> > &
+                        const std::vector<std::unique_ptr<const Patterns::PatternBase> > &
                         patterns,
                         boost::property_tree::ptree       &destination)
   {
@@ -586,7 +586,7 @@ void ParameterHandler::parse_input_from_xml (std::istream &in)
 
 void ParameterHandler::clear ()
 {
-  entries.reset (new boost::property_tree::ptree());
+  entries = std_cxx14::make_unique<boost::property_tree::ptree> ();
 }
 
 

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -322,17 +322,17 @@ namespace Patterns
             is.ignore(strlen(description_init) + strlen(" range "));
 
             if (!(is >> lower_bound))
-              return std::unique_ptr<Integer>(new Integer());
+              return std_cxx14::make_unique<Integer>();
 
             is.ignore(strlen("..."));
 
             if (!(is >> upper_bound))
-              return std::unique_ptr<Integer>(new Integer());
+              return std_cxx14::make_unique<Integer>();
 
-            return std::unique_ptr<Integer>(new Integer(lower_bound, upper_bound));
+            return std_cxx14::make_unique<Integer>(lower_bound, upper_bound);
           }
         else
-          return std::unique_ptr<Integer>(new Integer());
+          return std_cxx14::make_unique<Integer>();
       }
     else
       return std::unique_ptr<Integer>();
@@ -481,7 +481,7 @@ namespace Patterns
 
     std::string temp = description.substr(description_init_str.size());
     if (temp == "]")
-      return std::unique_ptr<Double>(new Double(1.0, -1.0)); // return an invalid range
+      return std_cxx14::make_unique<Double>(1.0, -1.0); // return an invalid range
 
     if (temp.find("...") != std::string::npos)
       temp.replace(temp.find("..."), 3, " ");
@@ -504,7 +504,7 @@ namespace Patterns
     if (is.fail())
       upper_bound = max_double_value;
 
-    return std::unique_ptr<Double>(new Double(lower_bound, upper_bound));
+    return std_cxx14::make_unique<Double>(lower_bound, upper_bound);
   }
 
 
@@ -613,7 +613,7 @@ namespace Patterns
         sequence.erase(0, std::strlen(description_init) + 1);
         sequence.erase(sequence.length()-2, 2);
 
-        return std::unique_ptr<Selection>(new Selection(sequence));
+        return std_cxx14::make_unique<Selection>(sequence);
       }
     else
       return std::unique_ptr<Selection>();
@@ -753,7 +753,7 @@ namespace Patterns
   {
     if (description.compare(0, std::strlen(description_init), description_init) == 0)
       {
-        int min_elements, max_elements;
+        unsigned int min_elements = 0, max_elements = 0;
 
         std::istringstream is(description);
         is.ignore(strlen(description_init) + strlen(" of <"));
@@ -761,24 +761,24 @@ namespace Patterns
         std::string str;
         std::getline(is, str, '>');
 
-        std::shared_ptr<PatternBase> base_pattern (pattern_factory(str));
+        std::unique_ptr<PatternBase> base_pattern (pattern_factory(str));
 
         is.ignore(strlen(" of length "));
         if (!(is >> min_elements))
-          return std::unique_ptr<List>(new List(*base_pattern));
+          return std_cxx14::make_unique<List>(*base_pattern);
 
         is.ignore(strlen("..."));
         if (!(is >> max_elements))
-          return std::unique_ptr<List>(new List(*base_pattern, min_elements));
+          return std_cxx14::make_unique<List>(*base_pattern, min_elements);
 
         is.ignore(strlen(" (inclusive) separated by <"));
         std::string separator;
-        if (is)
+        if (!is.eof())
           std::getline(is, separator, '>');
         else
           separator = ",";
 
-        return std::unique_ptr<List>(new List(*base_pattern, min_elements, max_elements, separator));
+        return std_cxx14::make_unique<List>(*base_pattern, min_elements, max_elements, separator);
       }
     else
       return std::unique_ptr<List>();
@@ -937,7 +937,7 @@ namespace Patterns
   {
     if (description.compare(0, std::strlen(description_init), description_init) == 0)
       {
-        int min_elements, max_elements;
+        unsigned int min_elements = 0, max_elements = 0;
 
         std::istringstream is(description);
         is.ignore(strlen(description_init) + strlen(" of <"));
@@ -952,27 +952,27 @@ namespace Patterns
         std::string value;
         std::getline(is, value, '>');
 
-        std::shared_ptr<PatternBase> key_pattern (pattern_factory(key));
-        std::shared_ptr<PatternBase> value_pattern (pattern_factory(value));
+        std::unique_ptr<PatternBase> key_pattern (pattern_factory(key));
+        std::unique_ptr<PatternBase> value_pattern (pattern_factory(value));
 
         is.ignore(strlen(" of length "));
         if (!(is >> min_elements))
-          return std::unique_ptr<Map>(new Map(*key_pattern, *value_pattern));
+          return std_cxx14::make_unique<Map>(*key_pattern, *value_pattern);
 
         is.ignore(strlen("..."));
         if (!(is >> max_elements))
-          return std::unique_ptr<Map>(new Map(*key_pattern, *value_pattern, min_elements));
+          return std_cxx14::make_unique<Map>(*key_pattern, *value_pattern, min_elements);
 
         is.ignore(strlen(" (inclusive) separated by <"));
         std::string separator;
-        if (is)
+        if (!is.eof())
           std::getline(is, separator, '>');
         else
           separator = ",";
 
-        return std::unique_ptr<Map>(new Map(*key_pattern, *value_pattern,
-                                            min_elements, max_elements,
-                                            separator, key_value_separator));
+        return std_cxx14::make_unique<Map>(*key_pattern, *value_pattern,
+                                           min_elements, max_elements,
+                                           separator, key_value_separator);
       }
     else
       return std::unique_ptr<Map>();
@@ -1166,12 +1166,12 @@ namespace Patterns
         is.ignore(strlen(" separated by <"));
 
         std::string separator;
-        if (is)
+        if (!is.eof())
           std::getline(is, separator, '>');
         else
           separator = ":";
 
-        return std::unique_ptr<Tuple>(new Tuple(patterns,separator));
+        return std_cxx14::make_unique<Tuple>(patterns,separator);
       }
     else
       return std::unique_ptr<Tuple>();
@@ -1332,7 +1332,7 @@ namespace Patterns
         sequence.erase(0, std::strlen(description_init) + 1);
         sequence.erase(sequence.length()-2, 2);
 
-        return std::unique_ptr<MultipleSelection>(new MultipleSelection(sequence));
+        return std_cxx14::make_unique<MultipleSelection>(sequence);
       }
     else
       return std::unique_ptr<MultipleSelection>();
@@ -1388,7 +1388,7 @@ namespace Patterns
   std::unique_ptr<Bool> Bool::create (const std::string &description)
   {
     if (description.compare(0, std::strlen(description_init), description_init) == 0)
-      return std::unique_ptr<Bool>(new Bool());
+      return std_cxx14::make_unique<Bool>();
     else
       return std::unique_ptr<Bool>();
   }
@@ -1444,7 +1444,7 @@ namespace Patterns
   std::unique_ptr<Anything> Anything::create (const std::string &description)
   {
     if (description.compare(0, std::strlen(description_init), description_init) == 0)
-      return std::unique_ptr<Anything>(new Anything());
+      return std_cxx14::make_unique<Anything>();
     else
       return std::unique_ptr<Anything>();
   }
@@ -1526,7 +1526,7 @@ namespace Patterns
         else
           type = output;
 
-        return std::unique_ptr<FileName>(new FileName(type));
+        return std_cxx14::make_unique<FileName>(type);
       }
     else
       return std::unique_ptr<FileName>();
@@ -1582,7 +1582,7 @@ namespace Patterns
   std::unique_ptr<DirectoryName> DirectoryName::create (const std::string &description)
   {
     if (description.compare(0, std::strlen(description_init), description_init) == 0)
-      return std::unique_ptr<DirectoryName>(new DirectoryName());
+      return std_cxx14::make_unique<DirectoryName>();
     else
       return std::unique_ptr<DirectoryName>();
   }

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -13,14 +13,14 @@
 //
 // ---------------------------------------------------------------------
 
-#include <deal.II/base/polynomial.h>
-#include <deal.II/base/point.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/thread_management.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/polynomial.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/std_cxx14/memory.h>
+#include <deal.II/base/thread_management.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/lapack_full_matrix.h>
-
 
 #include <cmath>
 #include <algorithm>
@@ -373,11 +373,11 @@ namespace Polynomials
     // need to transform p into standard form as
     // well if necessary. copy the polynomial to
     // do this
-    std::shared_ptr<Polynomial<number> > q_data;
+    std::unique_ptr<Polynomial<number> > q_data;
     const Polynomial<number> *q = nullptr;
     if (p.in_lagrange_product_form == true)
       {
-        q_data.reset (new Polynomial<number>(p));
+        q_data = std_cxx14::make_unique<Polynomial<number>>(p);
         q_data->transform_into_standard_form();
         q = q_data.get();
       }
@@ -417,11 +417,11 @@ namespace Polynomials
     // need to transform p into standard form as
     // well if necessary. copy the polynomial to
     // do this
-    std::shared_ptr<Polynomial<number> > q_data;
+    std::unique_ptr<Polynomial<number> > q_data;
     const Polynomial<number> *q = nullptr;
     if (p.in_lagrange_product_form == true)
       {
-        q_data.reset (new Polynomial<number>(p));
+        q_data = std_cxx14::make_unique<Polynomial<number>>(p);
         q_data->transform_into_standard_form();
         q = q_data.get();
       }
@@ -453,11 +453,11 @@ namespace Polynomials
     // need to transform p into standard form as
     // well if necessary. copy the polynomial to
     // do this
-    std::shared_ptr<Polynomial<number> > q_data;
+    std::unique_ptr<Polynomial<number> > q_data;
     const Polynomial<number> *q = nullptr;
     if (p.in_lagrange_product_form == true)
       {
-        q_data.reset (new Polynomial<number>(p));
+        q_data = std_cxx14::make_unique<Polynomial<number>>(p);
         q_data->transform_into_standard_form();
         q = q_data.get();
       }
@@ -600,11 +600,11 @@ namespace Polynomials
     if (degree() == 0)
       return Monomial<number>(0, 0.);
 
-    std::shared_ptr<Polynomial<number> > q_data;
+    std::unique_ptr<Polynomial<number> > q_data;
     const Polynomial<number> *q = nullptr;
     if (in_lagrange_product_form == true)
       {
-        q_data.reset (new Polynomial<number>(*this));
+        q_data = std_cxx14::make_unique<Polynomial<number>>(*this);
         q_data->transform_into_standard_form();
         q = q_data.get();
       }
@@ -626,11 +626,11 @@ namespace Polynomials
   {
     // no simple form possible for Lagrange
     // polynomial on product form
-    std::shared_ptr<Polynomial<number> > q_data;
+    std::unique_ptr<Polynomial<number> > q_data;
     const Polynomial<number> *q = nullptr;
     if (in_lagrange_product_form == true)
       {
-        q_data.reset (new Polynomial<number>(*this));
+        q_data = std_cxx14::make_unique<Polynomial<number>>(*this);
         q_data->transform_into_standard_form();
         q = q_data.get();
       }
@@ -976,7 +976,7 @@ namespace Polynomials
 
 // Reserve space for polynomials up to degree 19. Should be sufficient
 // for the start.
-  std::vector<std::shared_ptr<const std::vector<double> > >
+  std::vector<std::unique_ptr<const std::vector<double> > >
   Hierarchical::recursive_coefficients(20);
 
 
@@ -1053,9 +1053,9 @@ namespace Polynomials
             // now make these arrays
             // const
             recursive_coefficients[0] =
-              std::shared_ptr<const std::vector<double> >(c0);
+              std::unique_ptr<const std::vector<double> >(c0);
             recursive_coefficients[1] =
-              std::shared_ptr<const std::vector<double> >(c1);
+              std::unique_ptr<const std::vector<double> >(c1);
           }
         else if (k==2)
           {
@@ -1072,7 +1072,7 @@ namespace Polynomials
             (*c2)[2] =   4.*a;
 
             recursive_coefficients[2] =
-              std::shared_ptr<const std::vector<double> >(c2);
+              std::unique_ptr<const std::vector<double> >(c2);
           }
         else
           {
@@ -1116,7 +1116,7 @@ namespace Polynomials
             // const pointer in the
             // coefficients array
             recursive_coefficients[k] =
-              std::shared_ptr<const std::vector<double> >(ck);
+              std::unique_ptr<const std::vector<double> >(ck);
           };
       };
   }

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -164,7 +164,7 @@ Quadrature<dim>::Quadrature (const SubQuadrature &q1,
 
   if (is_tensor_product_flag)
     {
-      tensor_basis.reset(new std::array<Quadrature<1>, dim>());
+      tensor_basis = std_cxx14::make_unique<std::array<Quadrature<1>, dim>> ();
       for (unsigned int i=0; i<dim-1; ++i)
         (*tensor_basis)[i] = q1.get_tensor_basis()[i];
       (*tensor_basis)[dim-1] = q2;
@@ -266,7 +266,7 @@ Subscriptor(),
           ++k;
         }
 
-  tensor_basis.reset (new std::array<Quadrature<1>, dim>());
+  tensor_basis = std_cxx14::make_unique<std::array<Quadrature<1>, dim>> ();
   for (unsigned int i=0; i<dim; ++i)
     (*tensor_basis)[i] = q;
 }

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -319,7 +319,7 @@ namespace internal
                      numbers::invalid_dof_index);
           }
 
-        dof_handler.faces.reset (new internal::DoFHandler::DoFFaces<2>);
+        dof_handler.faces = std_cxx14::make_unique<internal::DoFHandler::DoFFaces<2>> ();
         // avoid access to n_raw_lines when there are no cells
         if (dof_handler.tria->n_cells() > 0)
           {
@@ -354,7 +354,7 @@ namespace internal
                      dof_handler.get_fe().dofs_per_cell,
                      numbers::invalid_dof_index);
           }
-        dof_handler.faces.reset (new internal::DoFHandler::DoFFaces<3>);
+        dof_handler.faces = std_cxx14::make_unique<internal::DoFHandler::DoFFaces<3>> ();
 
         // avoid access to n_raw_lines when there are no cells
         if (dof_handler.tria->n_cells() > 0)
@@ -439,11 +439,11 @@ namespace internal
 
         for (unsigned int i = 0; i < n_levels; ++i)
           {
-            dof_handler.mg_levels.emplace_back (new internal::DoFHandler::DoFLevel<2>);
+            dof_handler.mg_levels.emplace_back (std_cxx14::make_unique<internal::DoFHandler::DoFLevel<2>> ());
             dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_quads (i) * fe.dofs_per_quad, numbers::invalid_dof_index);
           }
 
-        dof_handler.mg_faces.reset (new internal::DoFHandler::DoFFaces<2>);
+        dof_handler.mg_faces = std_cxx14::make_unique<internal::DoFHandler::DoFFaces<2>> ();
         dof_handler.mg_faces->lines.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines () * fe.dofs_per_line, numbers::invalid_dof_index);
 
         const unsigned int &n_vertices = tria.n_vertices ();
@@ -498,11 +498,11 @@ namespace internal
 
         for (unsigned int i = 0; i < n_levels; ++i)
           {
-            dof_handler.mg_levels.emplace_back (new internal::DoFHandler::DoFLevel<3>);
+            dof_handler.mg_levels.emplace_back (std_cxx14::make_unique<internal::DoFHandler::DoFLevel<3>> ());
             dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_hexs (i) * fe.dofs_per_hex, numbers::invalid_dof_index);
           }
 
-        dof_handler.mg_faces.reset (new internal::DoFHandler::DoFFaces<3>);
+        dof_handler.mg_faces = std_cxx14::make_unique<internal::DoFHandler::DoFFaces<3>> ();
         dof_handler.mg_faces->lines.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines () * fe.dofs_per_line, numbers::invalid_dof_index);
         dof_handler.mg_faces->quads.dofs = std::vector<types::global_dof_index> (tria.n_raw_quads () * fe.dofs_per_quad, numbers::invalid_dof_index);
 
@@ -661,13 +661,13 @@ DoFHandler<dim,spacedim>::DoFHandler (const Triangulation<dim,spacedim> &tria)
   if (dynamic_cast<const parallel::shared::Triangulation< dim, spacedim>*>
       (&tria)
       != nullptr)
-    policy.reset (new internal::DoFHandler::Policy::ParallelShared<DoFHandler<dim,spacedim> >(*this));
+    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelShared<DoFHandler<dim,spacedim> >> (*this);
   else if (dynamic_cast<const parallel::distributed::Triangulation< dim, spacedim >*>
            (&tria)
            == nullptr)
-    policy.reset (new internal::DoFHandler::Policy::Sequential<DoFHandler<dim,spacedim> >(*this));
+    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::Sequential<DoFHandler<dim,spacedim> >> (*this);
   else
-    policy.reset (new internal::DoFHandler::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >(*this));
+    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >> (*this);
 }
 
 
@@ -707,11 +707,11 @@ initialize(const Triangulation<dim,spacedim> &t,
 
   // decide whether we need a sequential or a parallel distributed policy
   if (dynamic_cast<const parallel::shared::Triangulation< dim, spacedim>*> (&t) != nullptr)
-    policy.reset (new internal::DoFHandler::Policy::ParallelShared<DoFHandler<dim,spacedim> >(*this));
+    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelShared<DoFHandler<dim,spacedim> >> (*this);
   else if (dynamic_cast<const parallel::distributed::Triangulation< dim, spacedim >*> (&t) != nullptr)
-    policy.reset (new internal::DoFHandler::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >(*this));
+    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >> (*this);
   else
-    policy.reset (new internal::DoFHandler::Policy::Sequential<DoFHandler<dim,spacedim> >(*this));
+    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::Sequential<DoFHandler<dim,spacedim> >> (*this);
 
   distribute_dofs(fe);
 }
@@ -1308,7 +1308,7 @@ void DoFHandler<dim, spacedim>::MGVertexDoFs::init (const unsigned int cl,
       const unsigned int n_levels = finest_level - coarsest_level + 1;
       const unsigned int n_indices = n_levels * dofs_per_vertex;
 
-      indices.reset (new types::global_dof_index[n_indices]);
+      indices = std_cxx14::make_unique<types::global_dof_index[]> (n_indices);
       std::fill (indices.get(), indices.get()+n_indices,
                  numbers::invalid_dof_index);
     }

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -40,6 +40,7 @@
 #include <boost/serialization/array.hpp>
 #endif
 
+#include <memory>
 #include <set>
 #include <algorithm>
 #include <numeric>
@@ -160,7 +161,7 @@ namespace internal
         void
         ensure_existence_of_dof_identities (const FiniteElement<dim,spacedim> &fe1,
                                             const FiniteElement<dim,spacedim> &fe2,
-                                            std::shared_ptr<DoFIdentities> &identities)
+                                            std::unique_ptr<DoFIdentities> &identities)
         {
           // see if we need to fill this entry, or whether it already
           // exists
@@ -170,25 +171,22 @@ namespace internal
                 {
                 case 0:
                 {
-                  identities =
-                    std::shared_ptr<DoFIdentities>
-                    (new DoFIdentities(fe1.hp_vertex_dof_identities(fe2)));
+                  identities = std_cxx14::make_unique<DoFIdentities>
+                               (fe1.hp_vertex_dof_identities(fe2));
                   break;
                 }
 
                 case 1:
                 {
-                  identities =
-                    std::shared_ptr<DoFIdentities>
-                    (new DoFIdentities(fe1.hp_line_dof_identities(fe2)));
+                  identities = std_cxx14::make_unique<DoFIdentities>
+                               (fe1.hp_line_dof_identities(fe2));
                   break;
                 }
 
                 case 2:
                 {
-                  identities =
-                    std::shared_ptr<DoFIdentities>
-                    (new DoFIdentities(fe1.hp_quad_dof_identities(fe2)));
+                  identities = std_cxx14::make_unique<DoFIdentities>
+                               (fe1.hp_quad_dof_identities(fe2));
                   break;
                 }
 
@@ -606,7 +604,7 @@ namespace internal
           // it is not clear whether this is actually necessary for
           // vertices at all, I can't think of a finite element that
           // would make that necessary...
-          dealii::Table<2,std::shared_ptr<DoFIdentities> >
+          dealii::Table<2,std::unique_ptr<DoFIdentities> >
           vertex_dof_identities (dof_handler.get_fe_collection().size(),
                                  dof_handler.get_fe_collection().size());
 
@@ -773,7 +771,7 @@ namespace internal
           // is to first treat all pairs of finite elements that have *identical* dofs,
           // and then only deal with those that are not identical of which we can
           // handle at most 2
-          dealii::Table<2,std::shared_ptr<DoFIdentities> >
+          dealii::Table<2,std::unique_ptr<DoFIdentities> >
           line_dof_identities (dof_handler.finite_elements->size(),
                                dof_handler.finite_elements->size());
 
@@ -1005,7 +1003,7 @@ namespace internal
           // trouble. note that this only happens for lines in 3d and
           // higher, and for quads only in 4d and higher, so this
           // isn't a particularly frequent case
-          dealii::Table<2,std::shared_ptr<DoFIdentities> >
+          dealii::Table<2,std::unique_ptr<DoFIdentities> >
           quad_dof_identities (dof_handler.finite_elements->size(),
                                dof_handler.finite_elements->size());
 

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -61,20 +61,20 @@ namespace internal
           {
           case 1:
             if (spacedim==1)
-              q_fine.reset(new QGauss<dim> (degree+1));
+              q_fine = std_cxx14::make_unique<QGauss<dim>>(degree+1);
             else if (spacedim==2)
-              q_fine.reset(new QAnisotropic<dim>(QGauss<1>(degree+1), q_dummy));
+              q_fine = std_cxx14::make_unique<QAnisotropic<dim>>(QGauss<1>(degree+1), q_dummy);
             else
-              q_fine.reset(new QAnisotropic<dim>(QGauss<1>(degree+1), q_dummy, q_dummy));
+              q_fine = std_cxx14::make_unique<QAnisotropic<dim>>(QGauss<1>(degree+1), q_dummy, q_dummy);
             break;
           case 2:
             if (spacedim==2)
-              q_fine.reset(new QGauss<dim> (degree+1));
+              q_fine = std_cxx14::make_unique<QGauss<dim>>(degree+1);
             else
-              q_fine.reset(new QAnisotropic<dim>(QGauss<1>(degree+1), QGauss<1>(degree+1), q_dummy));
+              q_fine = std_cxx14::make_unique<QAnisotropic<dim>>(QGauss<1>(degree+1), QGauss<1>(degree+1), q_dummy);
             break;
           case 3:
-            q_fine.reset(new QGauss<dim> (degree+1));
+            q_fine = std_cxx14::make_unique<QGauss<dim>>(degree+1);
             break;
           default:
             Assert(false, ExcInternalError());

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -19,6 +19,7 @@
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/signaling_nan.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/differentiation/ad.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
@@ -39,7 +40,6 @@
 #include <deal.II/fe/fe.h>
 
 #include <iomanip>
-#include <memory>
 #include <type_traits>
 
 
@@ -3979,7 +3979,7 @@ FEValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   if (flags & update_mapping)
     this->mapping_data.reset (mapping_get_data.return_value());
   else
-    this->mapping_data.reset (new typename Mapping<dim,spacedim>::InternalDataBase());
+    this->mapping_data = std_cxx14::make_unique<typename Mapping<dim,spacedim>::InternalDataBase> ();
 }
 
 
@@ -4010,7 +4010,7 @@ namespace
       }
     else
       // if the types don't match, there is nothing we can do here
-      present_cell.reset (new Type(new_cell));
+      present_cell = std_cxx14::make_unique<Type> (new_cell);
   }
 }
 
@@ -4229,7 +4229,7 @@ FEFaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   if (flags & update_mapping)
     this->mapping_data.reset (mapping_get_data.return_value());
   else
-    this->mapping_data.reset (new typename Mapping<dim,spacedim>::InternalDataBase());
+    this->mapping_data = std_cxx14::make_unique<typename Mapping<dim,spacedim>::InternalDataBase> ();
 }
 
 
@@ -4397,7 +4397,7 @@ FESubfaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   if (flags & update_mapping)
     this->mapping_data.reset (mapping_get_data.return_value());
   else
-    this->mapping_data.reset (new typename Mapping<dim,spacedim>::InternalDataBase());
+    this->mapping_data = std_cxx14::make_unique<typename Mapping<dim,spacedim>::InternalDataBase> ();
 }
 
 

--- a/source/fe/mapping_c1.cc
+++ b/source/fe/mapping_c1.cc
@@ -47,7 +47,7 @@ MappingC1<dim,spacedim>::MappingC1 ()
   //
   // we only need to replace the Qp mapping because that's the one that's
   // used on boundary cells where it matters
-  this->qp_mapping.reset (new MappingC1<dim,spacedim>::MappingC1Generic());
+  this->qp_mapping = std::make_shared<MappingC1<dim,spacedim>::MappingC1Generic>();
 }
 
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -72,13 +72,13 @@ MappingQ<dim,spacedim>::MappingQ (const unsigned int degree,
                               (dim != spacedim)),
   // create a Q1 mapping for use on interior cells (if necessary)
   // or to create a good initial guess in transform_real_to_unit_cell()
-  q1_mapping (new MappingQGeneric<dim,spacedim>(1)),
+  q1_mapping (std::make_shared<MappingQGeneric<dim,spacedim> >(1)),
 
   // create a Q_p mapping; if p=1, simply share the Q_1 mapping already
   // created via the shared_ptr objects
   qp_mapping (this->polynomial_degree>1
               ?
-              std::make_shared<const MappingQGeneric<dim,spacedim>>(degree)
+              std::make_shared<const MappingQGeneric<dim,spacedim> >(degree)
               :
               q1_mapping)
 {}

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -70,11 +70,11 @@ MappingQEulerian (const unsigned int              degree,
   // reset the q1 mapping we use for interior cells (and previously
   // set by the MappingQ constructor) to a MappingQ1Eulerian with the
   // current vector
-  this->q1_mapping.reset (new MappingQ1Eulerian<dim,VectorType,spacedim>(euler_dof_handler,
-                          euler_vector));
+  this->q1_mapping = std::make_shared<MappingQ1Eulerian<dim,VectorType,spacedim>>
+                     (euler_dof_handler, euler_vector);
 
   // also reset the qp mapping pointer with our own class
-  this->qp_mapping.reset (new MappingQEulerianGeneric(degree,*this));
+  this->qp_mapping = std::make_shared<MappingQEulerianGeneric>(degree,*this);
 }
 
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1923,7 +1923,7 @@ namespace internal
 
         // reserve enough space
         triangulation.levels.push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>());
-        triangulation.faces.reset (new internal::Triangulation::TriaFaces<dim>);
+        triangulation.faces = std_cxx14::make_unique<internal::Triangulation::TriaFaces<dim>> ();
         triangulation.levels[0]->reserve_space (cells.size(), dim, spacedim);
         triangulation.faces->lines.reserve_space (0,needed_lines.size());
         triangulation.levels[0]->cells.reserve_space (0,cells.size());
@@ -2291,7 +2291,7 @@ namespace internal
         // for the lines
         // reserve enough space
         triangulation.levels.push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>());
-        triangulation.faces.reset (new internal::Triangulation::TriaFaces<dim>);
+        triangulation.faces = std_cxx14::make_unique<internal::Triangulation::TriaFaces<dim>> ();
         triangulation.levels[0]->reserve_space (cells.size(), dim, spacedim);
         triangulation.faces->lines.reserve_space (0,needed_lines.size());
 
@@ -8814,10 +8814,8 @@ Triangulation (const MeshSmoothing smooth_grid,
 {
   if (dim == 1)
     {
-      vertex_to_boundary_id_map_1d
-      .reset (new std::map<unsigned int, types::boundary_id>());
-      vertex_to_manifold_id_map_1d
-      .reset (new std::map<unsigned int, types::manifold_id>());
+      vertex_to_boundary_id_map_1d = std_cxx14::make_unique<std::map<unsigned int, types::boundary_id>> ();
+      vertex_to_manifold_id_map_1d = std_cxx14::make_unique<std::map<unsigned int, types::manifold_id>> ();
     }
 
   // connect the any_change signal to the other top level signals
@@ -9162,7 +9160,7 @@ copy_triangulation (const Triangulation<dim, spacedim> &other_tria)
   smooth_grid            = other_tria.smooth_grid;
 
   if (dim > 1)
-    faces.reset (new internal::Triangulation::TriaFaces<dim>(*other_tria.faces));
+    faces = std_cxx14::make_unique<internal::Triangulation::TriaFaces<dim>> (*other_tria.faces);
 
   typename std::map<types::manifold_id,
            SmartPointer<const Manifold<dim,spacedim>, Triangulation<dim, spacedim> > >::const_iterator
@@ -9173,19 +9171,18 @@ copy_triangulation (const Triangulation<dim, spacedim> &other_tria)
 
   levels.reserve (other_tria.levels.size());
   for (unsigned int level=0; level<other_tria.levels.size(); ++level)
-    levels.push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>(*other_tria.levels[level]));
+    levels.push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>
+                      (*other_tria.levels[level]));
 
   number_cache = other_tria.number_cache;
 
   if (dim == 1)
     {
-      vertex_to_boundary_id_map_1d
-      .reset(new std::map<unsigned int, types::boundary_id>
-             (*other_tria.vertex_to_boundary_id_map_1d));
+      vertex_to_boundary_id_map_1d = std_cxx14::make_unique<std::map<unsigned int, types::boundary_id>>
+                                     (*other_tria.vertex_to_boundary_id_map_1d);
 
-      vertex_to_manifold_id_map_1d
-      .reset(new std::map<unsigned int, types::manifold_id>
-             (*other_tria.vertex_to_manifold_id_map_1d));
+      vertex_to_manifold_id_map_1d = std_cxx14::make_unique<std::map<unsigned int, types::manifold_id>>
+                                     (*other_tria.vertex_to_manifold_id_map_1d);
     }
 
   // inform those who are listening on other_tria of the copy operation

--- a/source/grid/tria_boundary.cc
+++ b/source/grid/tria_boundary.cc
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/grid/tria_boundary.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_iterator.h>
@@ -166,11 +167,8 @@ get_line_support_points (const unsigned int n_intermediate_points) const
 
       // another thread might have created points in the meantime
       if (points[n_intermediate_points].get() == nullptr)
-        {
-          std::shared_ptr<QGaussLobatto<1> >
-          quadrature (new QGaussLobatto<1>(n_intermediate_points+2));
-          points[n_intermediate_points] = quadrature;
-        }
+        points[n_intermediate_points] = std_cxx14::make_unique<QGaussLobatto<1> >
+                                        (n_intermediate_points+2);
     }
   return points[n_intermediate_points]->get_points();
 }

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -15,6 +15,7 @@
 
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/geometry_info.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/dof_level.h>
@@ -104,7 +105,7 @@ namespace internal
               }
 
             if (dim > 1)
-              dof_handler.faces.reset (new internal::hp::DoFIndicesOnFaces<dim>);
+              dof_handler.faces = std_cxx14::make_unique<internal::hp::DoFIndicesOnFaces<dim>> ();
           }
         }
 
@@ -966,11 +967,11 @@ namespace hp
   {
     // decide whether we need a sequential or a parallel shared/distributed policy
     if (dynamic_cast<const parallel::shared::Triangulation< dim, spacedim>*> (&*this->tria) != nullptr)
-      policy.reset (new internal::DoFHandler::Policy::ParallelShared<DoFHandler<dim,spacedim> >(*this));
+      policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelShared<DoFHandler<dim,spacedim> >> (*this);
     else if (dynamic_cast<const parallel::distributed::Triangulation< dim, spacedim >*> (&*this->tria) != nullptr)
-      policy.reset (new internal::DoFHandler::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >(*this));
+      policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >> (*this);
     else
-      policy.reset (new internal::DoFHandler::Policy::Sequential<DoFHandler<dim,spacedim> >(*this));
+      policy = std_cxx14::make_unique<internal::DoFHandler::Policy::Sequential<DoFHandler<dim,spacedim> >> (*this);
 
     create_active_fe_table ();
 

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -122,8 +122,7 @@ namespace hp
               ExcMessage ("All elements inside a collection need to have the "
                           "same number of vector components!"));
 
-    finite_elements
-    .push_back (std::shared_ptr<const FiniteElement<dim,spacedim> >(new_fe.clone()));
+    finite_elements.push_back (new_fe.clone());
   }
 
 

--- a/source/hp/fe_values.cc
+++ b/source/hp/fe_values.cc
@@ -94,11 +94,11 @@ namespace internal
       if (fe_values_table(present_fe_values_index).get() == nullptr)
         fe_values_table(present_fe_values_index)
           =
-            std::shared_ptr<FEValuesType>
-            (new FEValuesType ((*mapping_collection)[mapping_index],
-                               (*fe_collection)[fe_index],
-                               q_collection[q_index],
-                               update_flags));
+            std::make_shared<FEValuesType>
+            ((*mapping_collection)[mapping_index],
+             (*fe_collection)[fe_index],
+             q_collection[q_index],
+             update_flags);
 
       // now there definitely is one!
       return *fe_values_table(present_fe_values_index);

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -973,8 +973,8 @@ LAPACKFullMatrix<number>::compute_svd()
   std::fill(wr.begin(), wr.end(), 0.);
   ipiv.resize(8*mm);
 
-  svd_u.reset (new LAPACKFullMatrix<number>(mm,mm));
-  svd_vt.reset (new LAPACKFullMatrix<number>(nn,nn));
+  svd_u = std_cxx14::make_unique<LAPACKFullMatrix<number>>(mm,mm);
+  svd_vt = std_cxx14::make_unique<LAPACKFullMatrix<number>>(nn,nn);
   number *const mu  = &svd_u->values[0];
   number *const mvt = &svd_vt->values[0];
   types::blas_int info = 0;

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -62,8 +62,8 @@ namespace PETScWrappers
       // iterator for an empty line (what
       // would it point to?)
       Assert (ncols != 0, ExcInternalError());
-      colnum_cache.reset (new std::vector<size_type> (colnums, colnums+ncols));
-      value_cache.reset (new std::vector<PetscScalar> (values, values+ncols));
+      colnum_cache = std::make_shared<std::vector<size_type>> (colnums, colnums+ncols);
+      value_cache = std::make_shared<std::vector<PetscScalar>> (values, values+ncols);
 
       // and finally restore the matrix
       ierr = MatRestoreRow(*matrix, this->a_row, &ncols, &colnums, &values);

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -15,6 +15,7 @@
 
 
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/lac/petsc_solver.h>
 
 #ifdef DEAL_II_WITH_PETSC
@@ -66,7 +67,7 @@ namespace PETScWrappers
     // is necessary
     if (solver_data.get() == nullptr)
       {
-        solver_data.reset (new SolverData());
+        solver_data = std_cxx14::make_unique<SolverData>();
 
         PetscErrorCode ierr = KSPCreate (mpi_communicator, &solver_data->ksp);
         AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -202,7 +203,7 @@ namespace PETScWrappers
   {
     PetscErrorCode ierr;
 
-    solver_data.reset (new SolverData());
+    solver_data = std_cxx14::make_unique<SolverData>();
 
     ierr = KSPCreate (mpi_communicator, &solver_data->ksp);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -698,7 +699,7 @@ namespace PETScWrappers
      */
     if (solver_data.get() == 0)
       {
-        solver_data.reset (new SolverDataMUMPS ());
+        solver_data = std_cxx14::make_unique<SolverDataMUMPS >();
 
         /**
          * creates the default KSP context and puts it in the location

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -1014,7 +1014,7 @@ void ScaLAPACKMatrix<NumberType>::save_serial(const char *filename,
    * Create a 1x1 column grid which will be used to initialize
    * an effectively serial ScaLAPACK matrix to gather the contents from the current object
    */
-  std::shared_ptr<Utilities::MPI::ProcessGrid> column_grid = std::make_shared<Utilities::MPI::ProcessGrid>(this->grid->mpi_communicator,1,1);
+  const auto column_grid = std::make_shared<Utilities::MPI::ProcessGrid>(this->grid->mpi_communicator,1,1);
 
   const int MB=n_rows, NB=n_columns;
   ScaLAPACKMatrix<NumberType> tmp(n_rows,n_columns,column_grid,MB,NB);
@@ -1096,7 +1096,7 @@ void ScaLAPACKMatrix<NumberType>::save_parallel(const char *filename,
    *
    * Create a 1xn_processes column grid
   */
-  std::shared_ptr<Utilities::MPI::ProcessGrid> column_grid = std::make_shared<Utilities::MPI::ProcessGrid>(this->grid->mpi_communicator,1,n_mpi_processes);
+  const auto column_grid = std::make_shared<Utilities::MPI::ProcessGrid>(this->grid->mpi_communicator,1,n_mpi_processes);
 
   const int MB=n_rows, NB=std::ceil(n_columns/n_mpi_processes);
   ScaLAPACKMatrix<NumberType> tmp(n_rows,n_columns,column_grid,MB,NB);
@@ -1228,7 +1228,7 @@ void ScaLAPACKMatrix<NumberType>::load_serial(const char *filename)
    * Therefore, one process has all the data and can write it to a file
    */
   //create a 1xP column grid with P being the number of MPI processes
-  std::shared_ptr<Utilities::MPI::ProcessGrid> one_grid = std::make_shared<Utilities::MPI::ProcessGrid>(this->grid->mpi_communicator,1,1);
+  const auto one_grid = std::make_shared<Utilities::MPI::ProcessGrid>(this->grid->mpi_communicator,1,1);
 
   const int MB=n_rows, NB=n_columns;
   ScaLAPACKMatrix<NumberType> tmp(n_rows,n_columns,one_grid,MB,NB);
@@ -1313,7 +1313,7 @@ void ScaLAPACKMatrix<NumberType>::load_parallel(const char *filename)
    * Therefore, the processes hold contiguous chunks of the matrix, which they can write to the file
    */
   //create a 1xP column grid with P being the number of MPI processes
-  std::shared_ptr<Utilities::MPI::ProcessGrid> column_grid = std::make_shared<Utilities::MPI::ProcessGrid>(this->grid->mpi_communicator,1,n_mpi_processes);
+  const auto column_grid = std::make_shared<Utilities::MPI::ProcessGrid>(this->grid->mpi_communicator,1,n_mpi_processes);
 
   const int MB=n_rows, NB=std::ceil(n_columns/n_mpi_processes);
   ScaLAPACKMatrix<NumberType> tmp(n_rows,n_columns,column_grid,MB,NB);

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 
 
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/vector_slice.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/lac/sparsity_pattern.h>
@@ -294,7 +295,7 @@ SparsityPattern::reinit (const size_type m,
     {
       vec_len = 1;
       max_vec_len = vec_len;
-      colnums.reset (new size_type[max_vec_len]);
+      colnums = std_cxx14::make_unique<size_type[]> (max_vec_len);
     }
 
   max_row_length = (row_lengths.size() == 0 ?
@@ -315,14 +316,14 @@ SparsityPattern::reinit (const size_type m,
   if (rows > max_dim)
     {
       max_dim = rows;
-      rowstart.reset (new std::size_t[max_dim+1]);
+      rowstart = std_cxx14::make_unique<std::size_t[]> (max_dim+1);
     }
 
   // allocate memory for the column numbers if necessary
   if (vec_len > max_vec_len)
     {
       max_vec_len = vec_len;
-      colnums.reset (new size_type[max_vec_len]);
+      colnums = std_cxx14::make_unique<size_type[]> (max_vec_len);
     }
 
   // set the rowstart array
@@ -974,8 +975,8 @@ SparsityPattern::block_read (std::istream &in)
   AssertThrow (c == '[', ExcIO());
 
   // reallocate space
-  rowstart.reset (new std::size_t[max_dim+1]);
-  colnums.reset (new size_type[max_vec_len]);
+  rowstart = std_cxx14::make_unique<std::size_t[]> (max_dim+1);
+  colnums = std_cxx14::make_unique<size_type[]> (max_vec_len);
 
   // then read data
   in.read (reinterpret_cast<char *>(rowstart.get()),

--- a/source/lac/trilinos_epetra_communication_pattern.cc
+++ b/source/lac/trilinos_epetra_communication_pattern.cc
@@ -13,6 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/lac/trilinos_epetra_communication_pattern.h>
 
 #ifdef DEAL_II_WITH_TRILINOS
@@ -57,7 +58,7 @@ namespace LinearAlgebra
       // Target map is read_write_vector_map
       // Source map is vector_space_vector_map. This map must have uniquely
       // owned GID.
-      import.reset(new Epetra_Import(read_write_vector_map, vector_space_vector_map));
+      import = std_cxx14::make_unique<Epetra_Import>(read_write_vector_map, vector_space_vector_map);
     }
 
 

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -13,6 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/lac/trilinos_epetra_vector.h>
 
 #ifdef DEAL_II_WITH_TRILINOS
@@ -22,6 +23,7 @@
 #include <deal.II/base/index_set.h>
 
 #include <boost/io/ios_state.hpp>
+#include <memory>
 
 #include <deal.II/lac/read_write_vector.h>
 
@@ -65,7 +67,7 @@ namespace LinearAlgebra
     {
       Epetra_Map input_map = parallel_partitioner.make_trilinos_map(communicator,false);
       if (vector->Map().SameAs(input_map)==false)
-        vector.reset(new Epetra_FEVector(input_map));
+        vector = std_cxx14::make_unique<Epetra_FEVector>(input_map);
       else if (omit_zeroing_entries==false)
         {
           const int ierr = vector->PutScalar(0.);
@@ -110,7 +112,7 @@ namespace LinearAlgebra
               (void) ierr;
             }
           else
-            vector.reset(new Epetra_FEVector(V.trilinos_vector()));
+            vector = std_cxx14::make_unique<Epetra_FEVector>(V.trilinos_vector());
         }
 
       return *this;
@@ -594,8 +596,8 @@ namespace LinearAlgebra
                                             const MPI_Comm &mpi_comm)
     {
       source_stored_elements = source_index_set;
-      epetra_comm_pattern.reset(new CommunicationPattern(locally_owned_elements(),
-                                                         source_index_set, mpi_comm));
+      epetra_comm_pattern = std::make_shared<CommunicationPattern>
+                            (locally_owned_elements(), source_index_set, mpi_comm);
     }
   }
 }

--- a/source/lac/trilinos_precondition.cc
+++ b/source/lac/trilinos_precondition.cc
@@ -671,7 +671,7 @@ namespace TrilinosWrappers
                                      const AdditionalData &additional_data)
   {
     preconditioner.reset ();
-    preconditioner.reset (new Ifpack_Chebyshev (&matrix.trilinos_matrix()));
+    preconditioner = std::make_shared<Ifpack_Chebyshev> (&matrix.trilinos_matrix());
 
     Ifpack_Chebyshev *ifpack = static_cast<Ifpack_Chebyshev *>
                                (preconditioner.get());

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -220,8 +220,8 @@ namespace TrilinosWrappers
                                const Teuchos::ParameterList &ml_parameters)
   {
     preconditioner.reset ();
-    preconditioner.reset (new ML_Epetra::MultiLevelPreconditioner
-                          (matrix, ml_parameters));
+    preconditioner = std::make_shared<ML_Epetra::MultiLevelPreconditioner>
+                     (matrix, ml_parameters);
   }
 
 
@@ -241,11 +241,12 @@ namespace TrilinosWrappers
     // equidistributed map; avoid
     // storing the nonzero
     // elements.
-    vector_distributor.reset (new Epetra_Map(static_cast<TrilinosWrappers::types::int_type>(n_rows),
-                                             0, communicator));
+    vector_distributor = std::make_shared<Epetra_Map>
+                         (static_cast<TrilinosWrappers::types::int_type>(n_rows),
+                          0, communicator);
 
     if (trilinos_matrix.get() == nullptr)
-      trilinos_matrix.reset (new SparseMatrix());
+      trilinos_matrix = std::make_shared<SparseMatrix>();
 
     trilinos_matrix->reinit (*vector_distributor, *vector_distributor,
                              deal_ii_sparse_matrix, drop_tolerance, true,

--- a/source/lac/trilinos_precondition_muelu.cc
+++ b/source/lac/trilinos_precondition_muelu.cc
@@ -230,7 +230,7 @@ namespace TrilinosWrappers
 
     // MueLu::EpetraOperator is just a wrapper around a "standard"
     // Epetra_Operator.
-    preconditioner.reset(new MueLu::EpetraOperator(hierarchy));
+    preconditioner = std::make_shared<MueLu::EpetraOperator>(hierarchy);
   }
 
 
@@ -250,11 +250,12 @@ namespace TrilinosWrappers
     // equidistributed map; avoid
     // storing the nonzero
     // elements.
-    vector_distributor.reset (new Epetra_Map(static_cast<TrilinosWrappers::types::int_type>(n_rows),
-                                             0, communicator));
+    vector_distributor = std::make_shared<Epetra_Map>
+                         (static_cast<TrilinosWrappers::types::int_type>(n_rows),
+                          0, communicator);
 
     if (trilinos_matrix.get() == nullptr)
-      trilinos_matrix.reset (new SparseMatrix());
+      trilinos_matrix = std::make_shared<SparseMatrix>();
 
     trilinos_matrix->reinit (*vector_distributor, *vector_distributor,
                              deal_ii_sparse_matrix, drop_tolerance, true,

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -18,6 +18,7 @@
 #ifdef DEAL_II_WITH_TRILINOS
 
 #  include <deal.II/base/conditional_ostream.h>
+#  include <deal.II/base/std_cxx14/memory.h>
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 #  include <deal.II/lac/trilinos_vector.h>
 #  include <deal.II/lac/trilinos_precondition.h>
@@ -80,14 +81,12 @@ namespace TrilinosWrappers
                      const MPI::Vector      &b,
                      const PreconditionBase &preconditioner)
   {
-    linear_problem.reset();
-
     // We need an Epetra_LinearProblem object to let the AztecOO solver know
     // about the matrix and vectors.
-    linear_problem.reset
-    (new Epetra_LinearProblem(const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
-                              &x.trilinos_vector(),
-                              const_cast<Epetra_MultiVector *>(&b.trilinos_vector())));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>
+                     (const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
+                      &x.trilinos_vector(),
+                      const_cast<Epetra_MultiVector *>(&b.trilinos_vector()));
 
     do_solve(preconditioner);
   }
@@ -102,14 +101,12 @@ namespace TrilinosWrappers
                      const MPI::Vector      &b,
                      const PreconditionBase &preconditioner)
   {
-    linear_problem.reset();
-
     // We need an Epetra_LinearProblem object to let the AztecOO solver know
     // about the matrix and vectors.
-    linear_problem.reset
-    (new Epetra_LinearProblem(const_cast<Epetra_Operator *>(&A),
-                              &x.trilinos_vector(),
-                              const_cast<Epetra_MultiVector *>(&b.trilinos_vector())));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>
+                     (const_cast<Epetra_Operator *>(&A),
+                      &x.trilinos_vector(),
+                      const_cast<Epetra_MultiVector *>(&b.trilinos_vector()));
 
     do_solve(preconditioner);
   }
@@ -124,14 +121,12 @@ namespace TrilinosWrappers
                      const MPI::Vector      &b,
                      const Epetra_Operator  &preconditioner)
   {
-    linear_problem.reset();
-
     // We need an Epetra_LinearProblem object to let the AztecOO solver know
     // about the matrix and vectors.
-    linear_problem.reset
-    (new Epetra_LinearProblem(const_cast<Epetra_Operator *>(&A),
-                              &x.trilinos_vector(),
-                              const_cast<Epetra_MultiVector *>(&b.trilinos_vector())));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>
+                     (const_cast<Epetra_Operator *>(&A),
+                      &x.trilinos_vector(),
+                      const_cast<Epetra_MultiVector *>(&b.trilinos_vector()));
 
     do_solve(preconditioner);
   }
@@ -146,14 +141,12 @@ namespace TrilinosWrappers
                      const Epetra_MultiVector &b,
                      const PreconditionBase   &preconditioner)
   {
-    linear_problem.reset();
-
     // We need an Epetra_LinearProblem object to let the AztecOO solver know
     // about the matrix and vectors.
-    linear_problem.reset
-    (new Epetra_LinearProblem(const_cast<Epetra_Operator *>(&A),
-                              &x,
-                              const_cast<Epetra_MultiVector *>(&b)));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>
+                     (const_cast<Epetra_Operator *>(&A),
+                      &x,
+                      const_cast<Epetra_MultiVector *>(&b));
 
     do_solve(preconditioner);
   }
@@ -168,14 +161,12 @@ namespace TrilinosWrappers
                      const Epetra_MultiVector &b,
                      const Epetra_Operator    &preconditioner)
   {
-    linear_problem.reset();
-
     // We need an Epetra_LinearProblem object to let the AztecOO solver know
     // about the matrix and vectors.
-    linear_problem.reset
-    (new Epetra_LinearProblem(const_cast<Epetra_Operator *>(&A),
-                              &x,
-                              const_cast<Epetra_MultiVector *>(&b)));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>
+                     (const_cast<Epetra_Operator *>(&A),
+                      &x,
+                      const_cast<Epetra_MultiVector *>(&b));
 
     do_solve(preconditioner);
   }
@@ -188,8 +179,6 @@ namespace TrilinosWrappers
                      const dealii::Vector<double> &b,
                      const PreconditionBase       &preconditioner)
   {
-    linear_problem.reset();
-
     // In case we call the solver with deal.II vectors, we create views of the
     // vectors in Epetra format.
     Assert (x.size() == A.n(),
@@ -206,9 +195,9 @@ namespace TrilinosWrappers
 
     // We need an Epetra_LinearProblem object to let the AztecOO solver know
     // about the matrix and vectors.
-    linear_problem.reset (new Epetra_LinearProblem
-                          (const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
-                           &ep_x, &ep_b));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>
+                     (const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
+                      &ep_x, &ep_b);
 
     do_solve(preconditioner);
   }
@@ -221,14 +210,12 @@ namespace TrilinosWrappers
                      const dealii::Vector<double> &b,
                      const PreconditionBase       &preconditioner)
   {
-    linear_problem.reset();
-
     Epetra_Vector ep_x (View, A.OperatorDomainMap(), x.begin());
     Epetra_Vector ep_b (View, A.OperatorRangeMap(), const_cast<double *>(b.begin()));
 
     // We need an Epetra_LinearProblem object to let the AztecOO solver know
     // about the matrix and vectors.
-    linear_problem.reset (new Epetra_LinearProblem(&A,&ep_x, &ep_b));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>(&A,&ep_x, &ep_b);
 
     do_solve(preconditioner);
   }
@@ -241,8 +228,6 @@ namespace TrilinosWrappers
                      const dealii::LinearAlgebra::distributed::Vector<double> &b,
                      const PreconditionBase                              &preconditioner)
   {
-    linear_problem.reset();
-
     // In case we call the solver with deal.II vectors, we create views of the
     // vectors in Epetra format.
     AssertDimension (static_cast<TrilinosWrappers::types::int_type>(x.local_size()),
@@ -255,9 +240,9 @@ namespace TrilinosWrappers
 
     // We need an Epetra_LinearProblem object to let the AztecOO solver know
     // about the matrix and vectors.
-    linear_problem.reset (new Epetra_LinearProblem
-                          (const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
-                           &ep_x, &ep_b));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>
+                     (const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
+                      &ep_x, &ep_b);
 
     do_solve(preconditioner);
   }
@@ -270,8 +255,6 @@ namespace TrilinosWrappers
                      const dealii::LinearAlgebra::distributed::Vector<double> &b,
                      const PreconditionBase                              &preconditioner)
   {
-    linear_problem.reset();
-
     AssertDimension (static_cast<TrilinosWrappers::types::int_type>(x.local_size()),
                      A.OperatorDomainMap().NumMyElements());
     AssertDimension (static_cast<TrilinosWrappers::types::int_type>(b.local_size()),
@@ -282,7 +265,7 @@ namespace TrilinosWrappers
 
     // We need an Epetra_LinearProblem object to let the AztecOO solver know
     // about the matrix and vectors.
-    linear_problem.reset (new Epetra_LinearProblem(&A,&ep_x, &ep_b));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>(&A,&ep_x, &ep_b);
 
     do_solve(preconditioner);
   }
@@ -306,7 +289,7 @@ namespace TrilinosWrappers
       class TrilinosReductionControl : public AztecOO_StatusTest
       {
       public:
-        TrilinosReductionControl (const double               &max_steps,
+        TrilinosReductionControl (const int                  &max_steps,
                                   const double               &tolerance,
                                   const double               &reduction,
                                   const Epetra_LinearProblem &linear_problem);
@@ -368,15 +351,15 @@ namespace TrilinosWrappers
       private:
         double initial_residual;
         double current_residual;
-        std::shared_ptr<AztecOO_StatusTestCombo>    status_test_collection;
-        std::shared_ptr<AztecOO_StatusTestMaxIters> status_test_max_steps;
-        std::shared_ptr<AztecOO_StatusTestResNorm>  status_test_abs_tol;
-        std::shared_ptr<AztecOO_StatusTestResNorm>  status_test_rel_tol;
+        std::unique_ptr<AztecOO_StatusTestCombo>    status_test_collection;
+        std::unique_ptr<AztecOO_StatusTestMaxIters> status_test_max_steps;
+        std::unique_ptr<AztecOO_StatusTestResNorm>  status_test_abs_tol;
+        std::unique_ptr<AztecOO_StatusTestResNorm>  status_test_rel_tol;
       };
 
 
       TrilinosReductionControl::TrilinosReductionControl(
-        const double               &max_steps,
+        const int                  &max_steps,
         const double               &tolerance,
         const double               &reduction,
         const Epetra_LinearProblem &linear_problem )
@@ -386,23 +369,23 @@ namespace TrilinosWrappers
       {
         // Consider linear problem converged if any of the collection
         // of criterion are met
-        status_test_collection.reset(
-          new AztecOO_StatusTestCombo (AztecOO_StatusTestCombo::OR) );
+        status_test_collection = std_cxx14::make_unique<AztecOO_StatusTestCombo>
+                                 (AztecOO_StatusTestCombo::OR);
 
         // Maximum number of iterations
-        status_test_max_steps.reset(
-          new AztecOO_StatusTestMaxIters(max_steps) );
+        Assert (max_steps >=0, ExcInternalError());
+        status_test_max_steps = std_cxx14::make_unique<AztecOO_StatusTestMaxIters>(max_steps);
         status_test_collection->AddStatusTest(*status_test_max_steps);
 
         Assert(linear_problem.GetRHS()->NumVectors() == 1,
                ExcMessage("RHS multivector holds more than one vector"));
 
         // Residual norm is below some absolute value
-        status_test_abs_tol.reset(
-          new AztecOO_StatusTestResNorm(*linear_problem.GetOperator(),
-                                        *(linear_problem.GetLHS()->operator()(0)),
-                                        *(linear_problem.GetRHS()->operator()(0)),
-                                        tolerance) );
+        status_test_abs_tol = std_cxx14::make_unique<AztecOO_StatusTestResNorm>
+                              (*linear_problem.GetOperator(),
+                               *(linear_problem.GetLHS()->operator()(0)),
+                               *(linear_problem.GetRHS()->operator()(0)),
+                               tolerance);
         status_test_abs_tol->DefineResForm(AztecOO_StatusTestResNorm::Explicit,
                                            AztecOO_StatusTestResNorm::TwoNorm);
         status_test_abs_tol->DefineScaleForm(AztecOO_StatusTestResNorm::None,
@@ -410,11 +393,11 @@ namespace TrilinosWrappers
         status_test_collection->AddStatusTest(*status_test_abs_tol);
 
         // Residual norm, scaled by some initial value, is below some threshold
-        status_test_rel_tol.reset(
-          new AztecOO_StatusTestResNorm(*linear_problem.GetOperator(),
-                                        *(linear_problem.GetLHS()->operator()(0)),
-                                        *(linear_problem.GetRHS()->operator()(0)),
-                                        reduction) );
+        status_test_rel_tol = std_cxx14::make_unique<AztecOO_StatusTestResNorm>
+                              (*linear_problem.GetOperator(),
+                               *(linear_problem.GetLHS()->operator()(0)),
+                               *(linear_problem.GetRHS()->operator()(0)),
+                               reduction);
         status_test_rel_tol->DefineResForm(AztecOO_StatusTestResNorm::Explicit,
                                            AztecOO_StatusTestResNorm::TwoNorm);
         status_test_rel_tol->DefineScaleForm(AztecOO_StatusTestResNorm::NormOfInitRes,
@@ -484,11 +467,11 @@ namespace TrilinosWrappers
         if (const ReductionControl* const reduction_control
             = dynamic_cast<const ReductionControl *const>(&solver_control))
           {
-            status_test.reset(new internal::TrilinosReductionControl(
-                                reduction_control->max_steps(),
-                                reduction_control->tolerance(),
-                                reduction_control->reduction(),
-                                *linear_problem) );
+            status_test = std_cxx14::make_unique<internal::TrilinosReductionControl>
+                          (reduction_control->max_steps(),
+                           reduction_control->tolerance(),
+                           reduction_control->reduction(),
+                           *linear_problem);
             solver.SetStatusTest(status_test.get());
           }
       }
@@ -727,7 +710,7 @@ namespace TrilinosWrappers
   {
     // We need an Epetra_LinearProblem object to let the Amesos solver know
     // about the matrix and vectors.
-    linear_problem.reset (new Epetra_LinearProblem ());
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem >();
 
     // Assign the matrix operator to the Epetra_LinearProblem object
     linear_problem->SetOperator(const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()));
@@ -739,8 +722,6 @@ namespace TrilinosWrappers
     // not.
     ConditionalOStream  verbose_cout (std::cout,
                                       additional_data.output_solver_details);
-
-    solver.reset();
 
     // Next allocate the Amesos solver, this is done in two steps, first we
     // create a solver Factory and and generate with that the concrete Amesos
@@ -836,8 +817,6 @@ namespace TrilinosWrappers
     ConditionalOStream verbose_cout (std::cout,
                                      additional_data.output_solver_details);
 
-    solver.reset ();
-
     // Next allocate the Amesos solver, this is done in two steps, first we
     // create a solver Factory and and generate with that the concrete Amesos
     // solver, if possible.
@@ -885,10 +864,10 @@ namespace TrilinosWrappers
   {
     // We need an Epetra_LinearProblem object to let the Amesos solver know
     // about the matrix and vectors.
-    linear_problem.reset
-    (new Epetra_LinearProblem(const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
-                              &x.trilinos_vector(),
-                              const_cast<Epetra_MultiVector *>(&b.trilinos_vector())));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>
+                     (const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
+                      &x.trilinos_vector(),
+                      const_cast<Epetra_MultiVector *>(&b.trilinos_vector()));
 
     do_solve();
   }
@@ -914,9 +893,9 @@ namespace TrilinosWrappers
 
     // We need an Epetra_LinearProblem object to let the Amesos solver know
     // about the matrix and vectors.
-    linear_problem.reset (new Epetra_LinearProblem
-                          (const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
-                           &ep_x, &ep_b));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>
+                     (const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
+                      &ep_x, &ep_b);
 
     do_solve();
   }
@@ -937,9 +916,9 @@ namespace TrilinosWrappers
 
     // We need an Epetra_LinearProblem object to let the Amesos solver know
     // about the matrix and vectors.
-    linear_problem.reset (new Epetra_LinearProblem
-                          (const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
-                           &ep_x, &ep_b));
+    linear_problem = std_cxx14::make_unique<Epetra_LinearProblem>
+                     (const_cast<Epetra_CrsMatrix *>(&A.trilinos_matrix()),
+                      &ep_x, &ep_b);
 
     do_solve();
   }

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -18,6 +18,7 @@
 #ifdef DEAL_II_WITH_TRILINOS
 
 #  include <deal.II/base/mpi.h>
+#  include <deal.II/base/std_cxx14/memory.h>
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 #  include <deal.II/lac/trilinos_parallel_block_vector.h>
 #  include <deal.II/lac/trilinos_index_access.h>
@@ -85,7 +86,7 @@ namespace TrilinosWrappers
       Vector()
     {
       has_ghosts = v.has_ghosts;
-      vector.reset(new Epetra_FEVector(*v.vector));
+      vector = std_cxx14::make_unique<Epetra_FEVector>(*v.vector);
       owned_elements = v.owned_elements;
     }
 
@@ -110,9 +111,8 @@ namespace TrilinosWrappers
                    ExcDimensionMismatch (parallel_partitioner.size(),
                                          TrilinosWrappers::n_global_elements(v.vector->Map())));
 
-      vector.reset (new Epetra_FEVector
-                    (parallel_partitioner.make_trilinos_map(communicator,
-                                                            true)));
+      vector = std_cxx14::make_unique<Epetra_FEVector>
+               (parallel_partitioner.make_trilinos_map(communicator, true));
       reinit (v, false, true);
     }
 
@@ -140,7 +140,7 @@ namespace TrilinosWrappers
 #endif
 
       has_ghosts = false;
-      vector.reset (new Epetra_FEVector(map));
+      vector = std_cxx14::make_unique<Epetra_FEVector>(map);
       last_action = Zero;
     }
 
@@ -156,7 +156,7 @@ namespace TrilinosWrappers
       Epetra_Map map = parallel_partitioner.make_trilinos_map (communicator,
                                                                true);
 
-      vector.reset (new Epetra_FEVector(map));
+      vector = std_cxx14::make_unique<Epetra_FEVector>(map);
 
       has_ghosts = vector->Map().UniqueGIDs()==false;
 
@@ -210,7 +210,7 @@ namespace TrilinosWrappers
 #endif
           if (!same_communicators || vector->Map().SameAs(v.vector->Map()) == false)
             {
-              vector.reset (new Epetra_FEVector(v.vector->Map()));
+              vector = std_cxx14::make_unique<Epetra_FEVector>(v.vector->Map());
               has_ghosts = v.has_ghosts;
               last_action = Zero;
               owned_elements = v.owned_elements;
@@ -299,14 +299,7 @@ namespace TrilinosWrappers
       Epetra_Map new_map (v.size(), n_elements, global_ids.data(), 0,
                           v.block(0).vector_partitioner().Comm());
 
-      std::shared_ptr<Epetra_FEVector> actual_vec;
-      if ( import_data == true )
-        actual_vec.reset (new Epetra_FEVector (new_map));
-      else
-        {
-          vector.reset (new Epetra_FEVector (new_map));
-          actual_vec = vector;
-        }
+      auto actual_vec = std_cxx14::make_unique<Epetra_FEVector>(new_map);
 
       TrilinosScalar *entries = (*actual_vec)[0];
       for (size_type block=0; block<v.n_blocks(); ++block)
@@ -329,6 +322,8 @@ namespace TrilinosWrappers
 
           last_action = Insert;
         }
+      else
+        vector = std::move(actual_vec);
 #if defined(DEBUG) && defined(DEAL_II_WITH_MPI)
       const Epetra_MpiComm *comm_ptr
         = dynamic_cast<const Epetra_MpiComm *>(&(vector->Comm()));
@@ -355,7 +350,7 @@ namespace TrilinosWrappers
           parallel_partitioner.add_indices(ghost_entries);
           Epetra_Map map = parallel_partitioner.make_trilinos_map (communicator,
                                                                    true);
-          vector.reset (new Epetra_FEVector(map));
+          vector = std_cxx14::make_unique<Epetra_FEVector>(map);
         }
       else
         {
@@ -366,7 +361,7 @@ namespace TrilinosWrappers
                              "its parallel partitioning"));
 
           if (vector->Map().SameAs(map)==false)
-            vector.reset (new Epetra_FEVector(map));
+            vector = std_cxx14::make_unique<Epetra_FEVector>(map);
           else
             {
               const int ierr = vector->PutScalar(0.);
@@ -380,7 +375,7 @@ namespace TrilinosWrappers
             {
               Epetra_Map nonlocal_map =
                 nonlocal_entries.make_trilinos_map(communicator, true);
-              nonlocal_vector.reset(new Epetra_MultiVector(nonlocal_map, 1));
+              nonlocal_vector = std_cxx14::make_unique<Epetra_MultiVector>(nonlocal_map, 1);
             }
         }
 
@@ -442,7 +437,7 @@ namespace TrilinosWrappers
         {
           *vector = *v.vector;
           if (v.nonlocal_vector.get() != nullptr)
-            nonlocal_vector.reset(new Epetra_MultiVector(v.nonlocal_vector->Map(), 1));
+            nonlocal_vector = std_cxx14::make_unique<Epetra_MultiVector>(v.nonlocal_vector->Map(), 1);
           last_action = Zero;
         }
       // Second case: vectors have the same global
@@ -458,14 +453,14 @@ namespace TrilinosWrappers
       // size.
       else
         {
-          vector.reset (new Epetra_FEVector(*v.vector));
+          vector = std_cxx14::make_unique<Epetra_FEVector>(*v.vector);
           last_action = Zero;
           has_ghosts = v.has_ghosts;
           owned_elements = v.owned_elements;
         }
 
       if (v.nonlocal_vector.get() != nullptr)
-        nonlocal_vector.reset(new Epetra_MultiVector(v.nonlocal_vector->Map(), 1));
+        nonlocal_vector = std_cxx14::make_unique<Epetra_MultiVector>(v.nonlocal_vector->Map(), 1);
 
       return *this;
     }
@@ -513,11 +508,7 @@ namespace TrilinosWrappers
                           "which is not allowed."));
 
       if (vector->Map().SameAs(m.trilinos_matrix().ColMap()) == false)
-        {
-          vector.reset (new Epetra_FEVector(
-                          m.trilinos_matrix().ColMap()
-                        ));
-        }
+        vector = std_cxx14::make_unique<Epetra_FEVector>(m.trilinos_matrix().ColMap());
 
       Epetra_Import data_exchange (vector->Map(), v.vector->Map());
       const int ierr = vector->Import(*v.vector, data_exchange, Insert);

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -305,8 +305,7 @@ namespace internal
         {
           // shift the local number of the copy indices according to the new
           // partitioner that we are going to use for the vector
-          const std::shared_ptr<const Utilities::MPI::Partitioner> &part
-            = ghosted_level_vector.get_partitioner();
+          const auto &part = ghosted_level_vector.get_partitioner();
           ghosted_dofs.add_indices(part->ghost_indices());
           for (unsigned int i=0; i<copy_indices_global_mine.size(); ++i)
             copy_indices_global_mine[i].second =
@@ -505,11 +504,9 @@ namespace internal
                 ExcInternalError());
         fe_name[template_starts+1] = '1';
       }
-      std::shared_ptr<FiniteElement<1> > fe_1d
-      (FETools::get_fe_by_name<1,1>(fe_name));
-      const FiniteElement<1> &fe = *fe_1d;
+      const std::unique_ptr<FiniteElement<1> > fe (FETools::get_fe_by_name<1,1>(fe_name));
 
-      setup_element_info(elem_info,fe,mg_dof);
+      setup_element_info(elem_info,*fe,mg_dof);
 
 
       // -------------- 2. Extract and match dof indices between child and parent
@@ -595,8 +592,8 @@ namespace internal
                     if (!owned_level_dofs.is_element(local_dof_indices[i]))
                       ghosted_level_dofs.push_back(local_dof_indices[i]);
 
-                  add_child_indices<dim>(c, fe.dofs_per_cell - fe.dofs_per_vertex,
-                                         fe.degree, elem_info.lexicographic_numbering,
+                  add_child_indices<dim>(c, fe->dofs_per_cell - fe->dofs_per_vertex,
+                                         fe->degree, elem_info.lexicographic_numbering,
                                          local_dof_indices,
                                          &next_indices[start_index]);
 
@@ -656,8 +653,8 @@ namespace internal
                   const std::size_t start_index = global_level_dof_indices_l0.size();
                   global_level_dof_indices_l0.resize(start_index+elem_info.n_child_cell_dofs,
                                                      numbers::invalid_dof_index);
-                  add_child_indices<dim>(0, fe.dofs_per_cell - fe.dofs_per_vertex,
-                                         fe.degree, elem_info.lexicographic_numbering,
+                  add_child_indices<dim>(0, fe->dofs_per_cell - fe->dofs_per_vertex,
+                                         fe->degree, elem_info.lexicographic_numbering,
                                          local_dof_indices,
                                          &global_level_dof_indices_l0[start_index]);
 
@@ -726,7 +723,7 @@ namespace internal
 
       // ---------------------- 3. compute weights to make restriction additive
 
-      const unsigned int n_child_dofs_1d = fe.degree + 1 + fe.dofs_per_cell - fe.dofs_per_vertex;
+      const unsigned int n_child_dofs_1d = fe->degree + 1 + fe->dofs_per_cell - fe->dofs_per_vertex;
 
       // get the valence of the individual components and compute the weights as
       // the inverse of the valence

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -15,6 +15,7 @@
 
 #include <deal.II/particles/particle_handler.h>
 
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/grid_tools_cache.h>
 
@@ -81,7 +82,7 @@ namespace Particles
     mapping = &mapp;
 
     // Create the memory pool that will store all particle properties
-    property_pool.reset(new PropertyPool(n_properties));
+    property_pool = std_cxx14::make_unique<PropertyPool>(n_properties);
   }
 
 


### PR DESCRIPTION
The purpose of this PR is twofold

1. In accordance with https://github.com/dealii/dealii/projects/6#card-2223180 try to replace `std::shared_ptr` by `std::unique_ptr` where possible. Especially, in the `TrilinosWrappers` classes, we have a lot of `private` members that can be converted.
2. Replace the `[...]reset(new ...` idiom by `std::make_unique` resp. `std::make_shared`. This is in line with avoiding to call `new` explicitly. This change should also have some minor performance improvements with respect to `std::make_shared`.

To be able to use `std::make_unique` where possible I also had to implement `std_cxx14::make_unique` for unbounded C-style arrays.
This PR does not require any changes in the tests and seems therefore to be mostly backwards compatible. Of course, having `std::unique_ptr` member variables prevents classes from having (default) copy constructors but this PR doesn't remove any.