### PR TITLE
Avoid warning about "braces around scalar initializer"

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -1403,7 +1403,7 @@ namespace VectorTools
 
       typedef MatrixFreeOperators::MassOperator<dim, fe_degree, n_q_points_1d, 1, LinearAlgebra::distributed::Vector<Number> > MatrixType;
       MatrixType mass_matrix;
-      mass_matrix.initialize(matrix_free, {{fe_component}});
+      mass_matrix.initialize(matrix_free, {fe_component});
       mass_matrix.compute_diagonal();
 
       typedef LinearAlgebra::distributed::Vector<Number> LocalVectorType;


### PR DESCRIPTION
The clang tester complains about the extra pair of curly brackets as can for example be seen in http://www.math.clemson.edu/~heister/cib/dealii-tjhei-alpha/a34b1d34f81d1f1add017641cd3dfcf6d28cd0df/log-clang.