### PR TITLE
Use std::uint8_t as the underlying data type for CellId.

### DIFF
--- a/source/grid/cell_id.cc
+++ b/source/grid/cell_id.cc
@@ -38,7 +38,7 @@ CellId::CellId()
 
 
 CellId::CellId(const unsigned int coarse_cell_id,
-               const std::vector<unsigned char> &id)
+               const std::vector<std::uint8_t> &id)
   :
   coarse_cell_id(coarse_cell_id),
   n_child_indices(id.size())
@@ -50,9 +50,9 @@ CellId::CellId(const unsigned int coarse_cell_id,
 
 
 
-CellId::CellId(const unsigned int coarse_cell_id,
-               const unsigned int n_child_indices,
-               const unsigned char *id)
+CellId::CellId(const unsigned int  coarse_cell_id,
+               const unsigned int  n_child_indices,
+               const std::uint8_t *id)
   :
   coarse_cell_id(coarse_cell_id),
   n_child_indices(n_child_indices)


### PR DESCRIPTION
This is another step towards implementing #5889. Strictly speaking, this is an incompatible change, but I suspect that few people will notice. Furthermore, at least on platforms where `std::uint8_t` is a `typedef` for `unsigned char` (likely all common ones), the change turns out to be backward compatible.

I haven't written a changelog entry since this looks backward compatible to me, but would be happy to if other think that this would be useful.