### PR TITLE
Fix some warnings and errors reported by MSVC

### DIFF
--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -474,7 +474,7 @@ public:
   void add_parameter(const std::string &entry,
                      ParameterType &parameter,
                      const std::string &documentation = std::string(),
-                     ParameterHandler &prm = ParameterAcceptor::prm,
+                     ParameterHandler &prm_ = prm,
                      const Patterns::PatternBase &pattern =
                        *Patterns::Tools::Convert<ParameterType>::to_pattern());
 

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -93,7 +93,9 @@ public:
    * The DoFHandler is actually not needed.
    */
   template <int dim>
+#ifndef _MSC_VER
   DEAL_II_DEPRECATED
+#endif
   Multigrid(const DoFHandler<dim>              &mg_dof_handler,
             const MGMatrixBase<VectorType>     &matrix,
             const MGCoarseGridBase<VectorType> &coarse,

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -1579,8 +1579,14 @@ namespace VectorTools
                 const Quadrature<dim-1>        &q_boundary,
                 const bool                      project_to_boundary_first)
   {
+#ifdef _MSC_VER
+    Assert(false,
+           ExcMessage("Please specify the mapping explicitly "
+                      "when building with MSVC!"));
+#else
     project(StaticMappingQ1<dim,spacedim>::mapping, dof, constraints, quadrature, function, vec,
             enforce_zero_boundary, q_boundary, project_to_boundary_first);
+#endif
   }
 
 

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -297,6 +297,13 @@ namespace parallel
     Assert (false, ExcNotImplemented());
   }
 
+  template <int dim, int spacedim>
+  void
+  Triangulation<dim, spacedim>::fill_level_ghost_owners()
+  {
+    Assert(false, ExcNotImplemented());
+  }
+
 #endif
 
   template <int dim, int spacedim>

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -119,7 +119,7 @@ namespace FEValuesViews
 // variables from FEValuesBase, but they aren't initialized yet
 // at the time we get here, so re-create it all
     const std::vector<unsigned int> shape_function_to_row_table
-      = internal::make_shape_function_to_row_table (fe);
+      = dealii::internal::make_shape_function_to_row_table (fe);
 
     for (unsigned int i=0; i<fe.dofs_per_cell; ++i)
       {
@@ -180,7 +180,7 @@ namespace FEValuesViews
 // variables from FEValuesBase, but they aren't initialized yet
 // at the time we get here, so re-create it all
     const std::vector<unsigned int> shape_function_to_row_table
-      = internal::make_shape_function_to_row_table (fe);
+      = dealii::internal::make_shape_function_to_row_table (fe);
 
     for (unsigned int d=0; d<spacedim; ++d)
       {
@@ -278,7 +278,7 @@ namespace FEValuesViews
 // variables from FEValuesBase, but they aren't initialized yet
 // at the time we get here, so re-create it all
     const std::vector<unsigned int> shape_function_to_row_table
-      = internal::make_shape_function_to_row_table (fe);
+      = dealii::internal::make_shape_function_to_row_table (fe);
 
     for (unsigned int d = 0; d < dealii::SymmetricTensor<2,dim>::n_independent_components; ++d)
       {
@@ -377,7 +377,7 @@ namespace FEValuesViews
 // variables from FEValuesBase, but they aren't initialized yet
 // at the time we get here, so re-create it all
     const std::vector<unsigned int> shape_function_to_row_table
-      = internal::make_shape_function_to_row_table (fe);
+      = dealii::internal::make_shape_function_to_row_table (fe);
 
     for (unsigned int d = 0; d < dim*dim; ++d)
       {
@@ -2609,7 +2609,7 @@ namespace internal
       // the rows in the tables storing the data by shape function and
       // nonzero component
       this->shape_function_to_row_table
-        = internal::make_shape_function_to_row_table (fe);
+        = dealii::internal::make_shape_function_to_row_table (fe);
 
       // count the total number of non-zero components accumulated
       // over all shape functions

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -934,8 +934,8 @@ get_intermediate_point (const Point<spacedim> &p1,
                         const Point<spacedim> &p2,
                         const double w) const
 {
-  const std::array<Point<spacedim>, 2> points({{p1, p2}});
-  const std::array<double, 2> weights({{1.-w, w}});
+  const std::array<Point<spacedim>, 2> points {{p1, p2}};
+  const std::array<double, 2> weights {{1.-w, w}};
   return get_new_point(make_array_view(points.begin(), points.end()),
                        make_array_view(weights.begin(), weights.end()));
 }


### PR DESCRIPTION
These changes allow to compile using Visual Studio 2017 again. 

- `parameter_acceptor.h`: `ParameterAcceptor::prm` was not found specifying the class name
- `grid_tools.h`: missing `Cache::active_cell_iterator` were reported
- `grid_tools.h`: Using `GeometryInfo<structdim>::vertices_per_cell` in a lambda wasn't possible.
- `tria_base.cc`: `fill_level_ghost_owners` was only declared but not defined for `DEAL_II_WITH_MPI=OFF`
- `fe_values.cc`: `internal::make_shape_function_to_row_table` wasn't found in namespace `FEValuesView` without the additional `dealii::` prefix
- `manifold.cc`: using round brackets for initialization of ` std::array` objects were not allowed
- `multigrid.h`: MSVC didn't compile the class with the "deprecated" attribute. At other places this didn't pose any problem.
- `vector_tools.templates.h`: we hit an ICE in the version of `VectorTools::project` without `Mapping` parameter