### PR TITLE
Remove argument names when using '= default'.

### DIFF
--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -197,7 +197,7 @@ public:
   /**
    * Move constructor
    */
-  ConstraintMatrix (ConstraintMatrix &&constraint_matrix) = default;
+  ConstraintMatrix (ConstraintMatrix &&) = default;
 
   /**
    * Copy operator. Like for many other large objects, this operator
@@ -213,7 +213,7 @@ public:
   /**
    * Move assignment operator
    */
-  ConstraintMatrix &operator= (ConstraintMatrix &&constraint_matrix) = default;
+  ConstraintMatrix &operator= (ConstraintMatrix &&) = default;
 
   /**
    * Copy the given object to the current one.

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -200,13 +200,13 @@ public:
      * Move constructor: this creates a new Pointer by stealing the internal
      * data owned by @p p.
      */
-    Pointer(Pointer &&p) = default;
+    Pointer(Pointer &&) = default;
 
     /**
      * Move operator: this releases the vector owned by the current Pointer
      * and then steals the internal data owned by @p p.
      */
-    Pointer &operator = (Pointer &&p) = default;
+    Pointer &operator = (Pointer &&) = default;
 
     /**
      * Constructor. This constructor automatically allocates a vector from


### PR DESCRIPTION
GCC 4.9 complains about this.