### PR TITLE
Avoid using operator[] in dof_info.h for accessing the end iterator

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -432,7 +432,9 @@ namespace internal
       AssertIndexRange (row, row_starts.size()-1);
       const unsigned int index = row_starts[row][0];
       AssertIndexRange(index, dof_indices.size()+1);
-      return dof_indices.empty() ? nullptr : &dof_indices[index];
+      return dof_indices.empty() ?
+             nullptr :
+             dof_indices.data()+index;
     }
 
 
@@ -444,7 +446,9 @@ namespace internal
       AssertIndexRange (row, row_starts.size()-1);
       const unsigned int index = row_starts[row+1][0];
       AssertIndexRange(index, dof_indices.size()+1);
-      return dof_indices.empty() ? nullptr : &dof_indices[index];
+      return dof_indices.empty() ?
+             nullptr :
+             dof_indices.data()+index;
     }
 
 
@@ -466,7 +470,9 @@ namespace internal
       AssertIndexRange (row, row_starts.size()-1);
       const unsigned int index = row_starts[row][1];
       AssertIndexRange (index, constraint_indicator.size()+1);
-      return constraint_indicator.empty() ? nullptr : &constraint_indicator[index];
+      return constraint_indicator.empty() ?
+             nullptr :
+             constraint_indicator.data()+index;
     }
 
 
@@ -478,7 +484,9 @@ namespace internal
       AssertIndexRange (row, row_starts.size()-1);
       const unsigned int index = row_starts[row+1][1];
       AssertIndexRange (index, constraint_indicator.size()+1);
-      return constraint_indicator.empty() ? nullptr : &constraint_indicator[index];
+      return constraint_indicator.empty() ?
+             nullptr :
+             constraint_indicator.data()+index;
     }
 
 
@@ -509,7 +517,9 @@ namespace internal
           AssertDimension (row_starts.size(), row_starts_plain_indices.size());
           const unsigned int index = row_starts_plain_indices[row];
           AssertIndexRange(index, plain_dof_indices.size()+1);
-          return plain_dof_indices.empty() ? nullptr : &plain_dof_indices[index];
+          return plain_dof_indices.empty() ?
+                 nullptr :
+                 plain_dof_indices.data()+index;
         }
     }
 


### PR DESCRIPTION
In `Debug` mode, `MSVC` checks the accessed not only for `std::vector::at()` but also for `std::vector::operator[]`. Therefore, this PR works around its usage when we need to return `end` iterators. 

With these changes `periodicity_06` runs correctly if we specify the `Mapping` for `VectorTools::project` explicitly (see #5907).