### PR TITLE
scalapack: split _06 test into four

### DIFF
--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -621,8 +621,8 @@ ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric(const bool compute_eigenvector
           plamch( &(this->grid->blacs_context), &cmach, abstol);
           abstol *= 2;
           ifail.resize(n_rows);
-          iclustr.resize(n_local_rows * n_local_columns);
-          gap.resize(n_local_rows * n_local_columns);
+          iclustr.resize(2 * grid->n_process_rows * grid->n_process_columns);
+          gap.resize(grid->n_process_rows * grid->n_process_columns);
 
           psyevx(&jobz, &range, &uplo, &n_rows, A_loc, &submatrix_row, &submatrix_column, descriptor,
                  &vl, &vu, &il, &iu, &abstol, &m, &nz, &ev[0], &orfac,

--- a/tests/scalapack/scalapack_06.mpirun=1.output
+++ b/tests/scalapack/scalapack_06.mpirun=1.output
@@ -3,58 +3,28 @@ comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pds
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
-
 200 64 1 1
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
-
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
 
 400 32 1 1
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
-
 400 64 1 1
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
-
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
 
 600 32 1 1
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
-
 600 64 1 1
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
-
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
 

--- a/tests/scalapack/scalapack_06.mpirun=11.output
+++ b/tests/scalapack/scalapack_06.mpirun=11.output
@@ -3,58 +3,28 @@ comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pds
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
-
 200 64 3 3
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
-
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
 
 400 32 3 3
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
-
 400 64 3 3
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
-
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
 
 600 32 3 3
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
-
 600 64 3 3
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
-
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
 

--- a/tests/scalapack/scalapack_06.mpirun=9.output
+++ b/tests/scalapack/scalapack_06.mpirun=9.output
@@ -3,58 +3,28 @@ comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pds
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
-
 200 64 3 3
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
-
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
 
 400 32 3 3
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
-
 400 64 3 3
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
-
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
 
 600 32 3 3
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
-
 600 64 3 3
 comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
-
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
-   with respect to the given tolerance the eigenvalues coincide
-   with respect to the given tolerance also the eigenvectors coincide
-
 

--- a/tests/scalapack/scalapack_06a.mpirun=1.output
+++ b/tests/scalapack/scalapack_06a.mpirun=1.output
@@ -1,0 +1,18 @@
+200 32 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_06a.mpirun=11.output
+++ b/tests/scalapack/scalapack_06a.mpirun=11.output
@@ -1,0 +1,18 @@
+200 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_06a.mpirun=4.output
+++ b/tests/scalapack/scalapack_06a.mpirun=4.output
@@ -1,0 +1,18 @@
+200 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_06a.mpirun=9.output
+++ b/tests/scalapack/scalapack_06a.mpirun=9.output
@@ -1,0 +1,18 @@
+200 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyev:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_06b.mpirun=1.output
+++ b/tests/scalapack/scalapack_06b.mpirun=1.output
@@ -1,30 +1,30 @@
-200 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+200 32 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-200 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+200 64 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-400 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+400 32 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-400 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+400 64 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-600 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+600 32 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-600 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+600 64 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 

--- a/tests/scalapack/scalapack_06b.mpirun=11.output
+++ b/tests/scalapack/scalapack_06b.mpirun=11.output
@@ -1,30 +1,30 @@
-200 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+200 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-200 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+200 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-400 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+400 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-400 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+400 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-600 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+600 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-600 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+600 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 

--- a/tests/scalapack/scalapack_06b.mpirun=4.output
+++ b/tests/scalapack/scalapack_06b.mpirun=4.output
@@ -1,30 +1,30 @@
 200 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
 200 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
 400 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
 400 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
 600 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
 600 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 

--- a/tests/scalapack/scalapack_06b.mpirun=9.output
+++ b/tests/scalapack/scalapack_06b.mpirun=9.output
@@ -1,30 +1,30 @@
-200 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+200 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-200 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+200 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-400 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+400 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-400 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+400 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-600 32 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+600 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 
-600 64 2 2
-comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:
+600 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyevx:
    with respect to the given tolerance the eigenvalues coincide
    with respect to the given tolerance also the eigenvectors coincide
 

--- a/tests/scalapack/scalapack_06c.cc
+++ b/tests/scalapack/scalapack_06c.cc
@@ -17,7 +17,8 @@
 #include "../lapack/create_matrix.h"
 
 // test eigenpairs_symmetric_by_index(const std::pair<unsigned int,unsigned int> &, const bool)
-// for all eigenvalues with eigenvectors
+// for some eigenvalues without eigenvectors
+
 
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/utilities.h>
@@ -56,15 +57,12 @@ void test(const unsigned int size, const unsigned int block_size, const NumberTy
   // Create SPD matrices of requested size:
   FullMatrix<NumberType> full_A(size);
   std::vector<NumberType> eigenvalues_Lapack(size);
-  std::vector<Vector<NumberType>> s_eigenvectors_ (max_n_eigenvalues,Vector<NumberType>(size));
-  std::vector<Vector<NumberType>> p_eigenvectors_ (max_n_eigenvalues,Vector<NumberType>(size));
-  FullMatrix<NumberType> p_eigenvectors (size,size);
 
-  ScaLAPACKMatrix<NumberType> scalapack_syev (size, grid, block_size);
-  scalapack_syev.set_property(LAPACKSupport::Property::symmetric);
+  ScaLAPACKMatrix<NumberType> scalapack_syevx (size, grid, block_size);
+  scalapack_syevx.set_property(LAPACKSupport::Property::symmetric);
 
   create_spd (full_A);
-  scalapack_syev = full_A;
+  scalapack_syevx = full_A;
 
   //Lapack as reference
   {
@@ -87,38 +85,27 @@ void test(const unsigned int size, const unsigned int block_size, const NumberTy
     lwork=work[0];
     work.resize (lwork);
     syev(&jobz, &uplo, &LDA, & *lapack_A.begin(), &LDA, & *eigenvalues_Lapack.begin(), & *work.begin(), &lwork, &info);
-
     AssertThrow (info==0, LAPACKSupport::ExcErrorCode("syev", info));
-    for (int i=0; i<max_n_eigenvalues; ++i)
-      for (int j=0; j<size; ++j)
-        s_eigenvectors_[i][j] = lapack_A[(size-1-i)*size+j];
-
   }
 
   // the actual test:
 
-  pcout << "comparing " << max_n_eigenvalues << " eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK pdsyev:" << std::endl;
-  const std::vector<NumberType> eigenvalues_psyev = scalapack_syev.eigenpairs_symmetric_by_index(std::make_pair(0,size-1),true);
-  scalapack_syev.copy_to(p_eigenvectors);
-  for (unsigned int i=0; i<max_n_eigenvalues; ++i)
-    AssertThrow ( std::abs(eigenvalues_psyev[n_eigenvalues-i-1]-eigenvalues_Lapack[n_eigenvalues-i-1]) / std::abs(eigenvalues_Lapack[n_eigenvalues-i-1]) < tol,
-                  ExcInternalError());
-
-  pcout << "   with respect to the given tolerance the eigenvalues coincide" << std::endl;
-
-  for (unsigned int i=0; i<max_n_eigenvalues; ++i)
-    for (unsigned int j=0; j<size; ++j)
-      p_eigenvectors_[i][j] = p_eigenvectors(j,size-1-i);
-
-  //product of eigenvectors computed using Lapack and ScaLapack has to be either 1 or -1
-  for (unsigned int i=0; i<max_n_eigenvalues; ++i)
+  pcout << "comparing " << max_n_eigenvalues << " eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:" << std::endl;
+  const std::vector<NumberType> eigenvalues_psyevx = scalapack_syevx.eigenpairs_symmetric_by_index(std::make_pair(size-max_n_eigenvalues,size-1),false);
+  for (unsigned int i=eigenvalues_psyevx.size()-1; i>0; --i)
     {
-      const NumberType product = p_eigenvectors_[i] * s_eigenvectors_[i];
-      //the requirement for alignment of the eigenvectors has to be released (primarily for floats)
-      AssertThrow (std::abs(std::abs(product)-1) < tol*10,
-                   ExcInternalError());
+      if ( !(std::abs(eigenvalues_psyevx[i]-eigenvalues_Lapack[size-eigenvalues_psyevx.size()+i]) /
+             std::abs(eigenvalues_Lapack[size-eigenvalues_psyevx.size()+i]) < tol))
+        {
+          std::cout << "process #" << this_mpi_process << ": eigenvalues do not fit: "
+                    << eigenvalues_psyevx[i] << " <--> " << eigenvalues_Lapack[size-eigenvalues_psyevx.size()+i] << std::endl;
+        }
+
+      AssertThrow ( std::abs(eigenvalues_psyevx[i]-eigenvalues_Lapack[size-eigenvalues_psyevx.size()+i]) /
+                    std::abs(eigenvalues_Lapack[size-eigenvalues_psyevx.size()+i]) < tol,
+                    ExcInternalError());
     }
-  pcout << "   with respect to the given tolerance also the eigenvectors coincide" << std::endl << std::endl;
+  pcout << "   with respect to the given tolerance the eigenvalues coincide" << std::endl;
 }
 
 

--- a/tests/scalapack/scalapack_06c.mpirun=1.output
+++ b/tests/scalapack/scalapack_06c.mpirun=1.output
@@ -1,0 +1,18 @@
+200 32 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_06c.mpirun=11.output
+++ b/tests/scalapack/scalapack_06c.mpirun=11.output
@@ -1,0 +1,18 @@
+200 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_06c.mpirun=4.output
+++ b/tests/scalapack/scalapack_06c.mpirun=4.output
@@ -1,0 +1,18 @@
+200 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_06c.mpirun=9.output
+++ b/tests/scalapack/scalapack_06c.mpirun=9.output
@@ -1,0 +1,18 @@
+200 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
+   with respect to the given tolerance the eigenvalues coincide


### PR DESCRIPTION
also clean up a bit.


~~WIP until I check it on Linux as~~ the last two parts `06b/06_c` fail on macOS, that's the reason why I split the test into four parts to see where exactly it fails.

```
200 32 1 1
comparing 5 eigenvalues computed using LAPACK and ScaLAPACK pdsyevx:
   with respect to the given tolerance the eigenvalues coincide
[MBP-Denis:60680] *** Process received signal ***
[MBP-Denis:60680] Signal: Segmentation fault: 11 (11)
[MBP-Denis:60680] Signal code: Address not mapped (1)
[MBP-Denis:60680] Failing at address: 0x30
[MBP-Denis:60680] [ 0] 0   libsystem_platform.dylib            0x00007fff64212f5a _sigtramp + 26
[MBP-Denis:60680] [ 1] 0   libsystem_c.dylib                   0x00007fff9cc970f0 __c_locale + 0
[MBP-Denis:60680] [ 2] 0   libmpi.40.dylib                     0x0000000108fbb9c3 ompi_comm_destruct + 67
[MBP-Denis:60680] [ 3] 0   libmpi.40.dylib                     0x0000000108fbd255 ompi_comm_free + 357
[MBP-Denis:60680] [ 4] 0   libmpi.40.dylib                     0x0000000108ff1162 MPI_Comm_free + 178
[MBP-Denis:60680] [ 5] 0   libscalapack.dylib                  0x000000010894e4d9 Cblacs_gridexit + 153
[MBP-Denis:60680] [ 6] 0   libdeal_II.g.9.0.0-pre.dylib        0x000000011259f0c7 _ZN6dealii9Utilities3MPI11ProcessGridD2Ev + 23
[MBP-Denis:60680] [ 7] 0   libc++.1.dylib                      0x00007fff61ffc8fd _ZNSt3__119__shared_weak_count16__release_sharedEv + 43
[MBP-Denis:60680] [ 8] 0   scalapack_06c.debug                 0x00000001071a424f _Z4testIdEvjjT_ + 1727
[MBP-Denis:60680] [ 9] 0   scalapack_06c.debug                 0x00000001071a3b16 main + 230
[MBP-Denis:60680] [10] 0   libdyld.dylib                       0x00007fff63f91115 start + 1
[MBP-Denis:60680] *** End of error message ***
-------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
-------------------------------------------------------
--------------------------------------------------------------------------
mpiexec noticed that process rank 0 with PID 0 on node MBP-Denis exited on signal 11 (Segmentation fault: 11).
```