### PR TITLE
Fix the location of hats on symbols in the documentation.

### DIFF
--- a/examples/step-51/doc/intro.dox
+++ b/examples/step-51/doc/intro.dox
@@ -132,9 +132,9 @@ We multiply these equations by the weight functions $\mathbf{v}, w$
 and integrate by parts over every element $K$ to obtain:
 @f{eqnarray*}
   (\mathbf{v}, \kappa^{-1} \mathbf{q})_K - (\nabla\cdot\mathbf{v}, u)_K
-    + \left<\mathbf{v}\cdot\mathbf{n}, \hat{u}\right>_{\partial K} &=& 0, \\
+    + \left<\mathbf{v}\cdot\mathbf{n}, {\hat{u}}\right>_{\partial K} &=& 0, \\
   - (\nabla w, \mathbf{c} u + \mathbf{q})_K
-    + \left<w, (\widehat{\mathbf{c} u}+\hat{\mathbf{q}})\cdot\mathbf{n}\right>_{\partial K}
+    + \left<w, (\widehat{\mathbf{c} u}+{\hat{\mathbf{q}}})\cdot\mathbf{n}\right>_{\partial K}
     &=& (w,f)_K.
 @f}
 


### PR DESCRIPTION
In the MathML generated documentation of step-51, there are a number of hats that are misplaced. See for example http://www.dealii.org/8.5.0/doxygen/deal.II/step_51.html#HybridizablediscontinuousGalerkinmethods
This looks correct in latex, but apparently comes out wrong on the website. This patch is a trial with the first two occurrences so we can see if placing another set of braces helps the problem.