### PR TITLE
Use more LAPACK and BLAS routines in LAPACKFullMatrix

### DIFF
--- a/doc/news/changes/minor/20180220BenjaminBrands
+++ b/doc/news/changes/minor/20180220BenjaminBrands
@@ -1,0 +1,4 @@
+New: LAPACKFullMatrix: make operators *= and /= use Lapack function,
+LAPACKFullMatrix::add() uses BLAS 1 routine instead of handwritten loops
+<br>
+(Benjamin Brands, 2018/02/20)

--- a/include/deal.II/lac/lapack_templates.h
+++ b/include/deal.II/lac/lapack_templates.h
@@ -315,7 +315,27 @@ extern "C"
               const float *alpha, const float *x,
               const dealii::types::blas_int *incx,
               float *A, const dealii::types::blas_int *lda);
-
+// Multiply rectangular mxn real matrix by real scalar CTO/CFROM
+  void dlascl_(const char *type,
+               const int *kl,
+               const int *ku,
+               const double *cfrom,
+               const double *cto,
+               const int *m,
+               const int *n,
+               double *A,
+               const int *lda,
+               int *info);
+  void slascl_(const char *type,
+               const int *kl,
+               const int *ku,
+               const float *cfrom,
+               const float *cto,
+               const int *m,
+               const int *n,
+               float *A,
+               const int *lda,
+               int *info);
 }
 
 DEAL_II_NAMESPACE_OPEN
@@ -1530,6 +1550,72 @@ inline void
 stev (const char *, const types::blas_int *, float *, float *, float *, const types::blas_int *, float *, types::blas_int *)
 {
   Assert (false, LAPACKSupport::ExcMissing("sstev"));
+}
+#endif
+
+
+/// Template wrapper for LAPACK functions dlascl and slascl
+template <typename number>
+inline void
+lascl(const char *,
+      const types::blas_int *,
+      const types::blas_int *,
+      const number *,
+      const number *,
+      const types::blas_int *,
+      const types::blas_int *,
+      number *,
+      const types::blas_int *,
+      types::blas_int *)
+{
+  Assert (false, ExcNotImplemented());
+}
+
+#ifdef DEAL_II_WITH_LAPACK
+inline void
+lascl(const char *type,
+      const types::blas_int *kl,
+      const types::blas_int *ku,
+      const double *cfrom,
+      const double *cto,
+      const types::blas_int *m,
+      const types::blas_int *n,
+      double *A,
+      const types::blas_int *lda,
+      types::blas_int *info)
+{
+  dlascl_(type,kl,ku,cfrom,cto,m,n,A,lda,info);
+}
+#else
+inline void
+lascl(const char *, const types::blas_int *, const types::blas_int *, const double *, const double *,
+      const types::blas_int *, const types::blas_int *, double *, const types::blas_int *, types::blas_int *)
+{
+  Assert (false, LAPACKSupport::ExcMissing("dlascl"));
+}
+#endif
+
+#ifdef DEAL_II_WITH_LAPACK
+inline void
+lascl(const char *type,
+      const types::blas_int *kl,
+      const types::blas_int *ku,
+      const float *cfrom,
+      const float *cto,
+      const types::blas_int *m,
+      const types::blas_int *n,
+      float *A,
+      const types::blas_int *lda,
+      types::blas_int *info)
+{
+  slascl_(type,kl,ku,cfrom,cto,m,n,A,lda,info);
+}
+#else
+inline void
+lascl(const char *, const types::blas_int *, const types::blas_int *, const float *, const float *,
+      const types::blas_int *, const types::blas_int *, float *, const types::blas_int *, types::blas_int *)
+{
+  Assert (false, LAPACKSupport::ExcMissing("slascl"));
 }
 #endif
 

--- a/include/deal.II/lac/lapack_templates.h
+++ b/include/deal.II/lac/lapack_templates.h
@@ -317,25 +317,25 @@ extern "C"
               float *A, const dealii::types::blas_int *lda);
 // Multiply rectangular mxn real matrix by real scalar CTO/CFROM
   void dlascl_(const char *type,
-               const int *kl,
-               const int *ku,
+               const dealii::types::blas_int *kl,
+               const dealii::types::blas_int *ku,
                const double *cfrom,
                const double *cto,
-               const int *m,
-               const int *n,
+               const dealii::types::blas_int *m,
+               const dealii::types::blas_int *n,
                double *A,
-               const int *lda,
-               int *info);
+               const dealii::types::blas_int *lda,
+               dealii::types::blas_int *info);
   void slascl_(const char *type,
-               const int *kl,
-               const int *ku,
+               const dealii::types::blas_int *kl,
+               const dealii::types::blas_int *ku,
                const float *cfrom,
                const float *cto,
-               const int *m,
-               const int *n,
+               const dealii::types::blas_int *m,
+               const dealii::types::blas_int *n,
                float *A,
-               const int *lda,
-               int *info);
+               const dealii::types::blas_int *lda,
+               dealii::types::blas_int *info);
 }
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -188,9 +188,20 @@ LAPACKFullMatrix<number>::operator*= (const number factor)
          state == LAPACKSupport::inverse_matrix,
          ExcState(state));
 
-  for (size_type column = 0; column<this->n(); ++column)
-    for (size_type row = 0; row<this->m(); ++row)
-      (*this)(row,column) *= factor;
+  AssertIsFinite(factor);
+  const char type = 'G';
+  const number cfrom = 1.;
+  const types::blas_int m = this->m();
+  const types::blas_int n = this->n();
+  const types::blas_int lda = this->m();
+  types::blas_int info;
+  // kl and ku will not be referenced for type = G (dense matrices)
+  const types::blas_int kl=0;
+  number *values = &this->values[0];
+
+  lascl(&type,&kl,&kl,&cfrom,&factor,&m,&n,values,&lda,&info);
+
+  Assert(info >= 0, ExcInternalError());
 
   return *this;
 }
@@ -207,9 +218,19 @@ LAPACKFullMatrix<number>::operator/= (const number factor)
   AssertIsFinite(factor);
   Assert (factor != number(0.), ExcZero() );
 
-  for (size_type column = 0; column<this->n(); ++column)
-    for (size_type row = 0; row<this->m(); ++row)
-      (*this)(row,column) /= factor;
+  const char type = 'G';
+  const number cto = 1.;
+  const types::blas_int m = this->m();
+  const types::blas_int n = this->n();
+  const types::blas_int lda = this->m();
+  types::blas_int info;
+  // kl and ku will not be referenced for type = G (dense matrices)
+  const types::blas_int kl=0;
+  number *values = &this->values[0];
+
+  lascl(&type,&kl,&kl,&factor,&cto,&m,&n,values,&lda,&info);
+
+  Assert(info >= 0, ExcInternalError());
 
   return *this;
 }

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -195,12 +195,13 @@ LAPACKFullMatrix<number>::operator*= (const number factor)
   const types::blas_int n = this->n();
   const types::blas_int lda = this->m();
   types::blas_int info;
-  // kl and ku will not be referenced for type = G (dense matrices)
+  // kl and ku will not be referenced for type = G (dense matrices).
   const types::blas_int kl=0;
   number *values = &this->values[0];
 
   lascl(&type,&kl,&kl,&cfrom,&factor,&m,&n,values,&lda,&info);
 
+  // Negative return value implies a wrong argument. This should be internal.
   Assert(info >= 0, ExcInternalError());
 
   return *this;
@@ -224,12 +225,13 @@ LAPACKFullMatrix<number>::operator/= (const number factor)
   const types::blas_int n = this->n();
   const types::blas_int lda = this->m();
   types::blas_int info;
-  // kl and ku will not be referenced for type = G (dense matrices)
+  // kl and ku will not be referenced for type = G (dense matrices).
   const types::blas_int kl=0;
   number *values = &this->values[0];
 
   lascl(&type,&kl,&kl,&factor,&cto,&m,&n,values,&lda,&info);
 
+  // Negative return value implies a wrong argument. This should be internal.
   Assert(info >= 0, ExcInternalError());
 
   return *this;
@@ -239,7 +241,7 @@ LAPACKFullMatrix<number>::operator/= (const number factor)
 
 template <typename number>
 void
-LAPACKFullMatrix<number>::add (const number              a,
+LAPACKFullMatrix<number>::add (const number a,
                                const LAPACKFullMatrix<number> &A)
 {
   Assert(state == LAPACKSupport::matrix ||
@@ -251,9 +253,15 @@ LAPACKFullMatrix<number>::add (const number              a,
 
   AssertIsFinite(a);
 
-  for (size_type i=0; i<m(); ++i)
-    for (size_type j=0; j<n(); ++j)
-      (*this)(i,j) += a * A(i,j);
+  // BLAS does not offer functions to add matrices.
+  // LapackFullMatrix is stored in contiguous array
+  // ==> use BLAS 1 for adding vectors
+  const types::blas_int n = this->m() * this->n();
+  const types::blas_int inc=1;
+  number *values = &this->values[0];
+  const number *values_A = &A.values[0];
+
+  axpy(&n,&a,values_A,&inc,values,&inc);
 }
 
 


### PR DESCRIPTION
This PR is a partial remedy to #5900.
The assignment operator for `FullMatrix` is not changed due to the different memory layouts of `FullMatrix` and `LAPACKFullMatrix`.