### PR TITLE
expand_all_instantiations cmake target

### DIFF
--- a/cmake/macros/macro_expand_instantiations.cmake
+++ b/cmake/macros/macro_expand_instantiations.cmake
@@ -73,6 +73,11 @@ MACRO(EXPAND_INSTANTIATIONS _target _inst_in_files)
   ADD_CUSTOM_TARGET(${_target}_inst ALL DEPENDS ${_inst_targets})
 
   #
+  # Provide a way to generate all .inst files with a custom target.
+  #
+  ADD_DEPENDENCIES(expand_all_instantiations ${_target}_inst)
+
+  #
   # Add a dependency to all target.${build_type} so that target.inst is
   # fully generated before target will be processed.
   #

--- a/cmake/setup_custom_targets.cmake
+++ b/cmake/setup_custom_targets.cmake
@@ -174,3 +174,9 @@ FILE(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/print_info.cmake
 ADD_CUSTOM_TARGET(info
   COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/print_info.cmake
   )
+
+
+#
+# Provide a target to build all .inst files
+#
+ADD_CUSTOM_TARGET(expand_all_instantiations)

--- a/doc/news/changes/minor/20180220Heister
+++ b/doc/news/changes/minor/20180220Heister
@@ -1,0 +1,3 @@
+New: A top level target 'expand_all_instantiations' generates all .inst files.
+<br>
+(Timo Heister, Daniel Arndt, 2018/02/20)


### PR DESCRIPTION
This target is useful to be able to run clang-tidy as it needs all .inst
files but doesn't require a built project.