### PR TITLE
fix MPI type and remove confusing assert

### DIFF
--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -236,24 +236,20 @@ namespace parallel
             this->number_cache.level_ghost_owners.insert(cell->level_subdomain_id());
 
 #ifdef DEBUG
-        // Check that level_ghost_owners is symmetric by sending a message
-        // to everyone
+        // Check that level_ghost_owners is symmetric by sending a message to everyone
         {
           int ierr = MPI_Barrier(this->mpi_communicator);
           AssertThrowMPI(ierr);
 
           // important: preallocate to avoid (re)allocation:
           std::vector<MPI_Request> requests (this->number_cache.level_ghost_owners.size());
-          int dummy = 0;
+          unsigned int dummy = 0;
           unsigned int req_counter = 0;
 
           for (std::set<types::subdomain_id>::iterator it = this->number_cache.level_ghost_owners.begin();
                it != this->number_cache.level_ghost_owners.end();
                ++it, ++req_counter)
             {
-              Assert (typeid(types::subdomain_id)
-                      == typeid(unsigned int),
-                      ExcNotImplemented());
               ierr = MPI_Isend(&dummy, 1, MPI_UNSIGNED,
                                *it, 9001, this->mpi_communicator,
                                &requests[req_counter]);
@@ -264,9 +260,6 @@ namespace parallel
                it != this->number_cache.level_ghost_owners.end();
                ++it)
             {
-              Assert (typeid(types::subdomain_id)
-                      == typeid(unsigned int),
-                      ExcNotImplemented());
               unsigned int dummy;
               ierr = MPI_Recv(&dummy, 1, MPI_UNSIGNED,
                               *it, 9001, this->mpi_communicator,


### PR DESCRIPTION
clan-tidy correctly complains about an incorrect MPI type (signed vs
unsigned). While here, remove the assert() that doesn't make much sense:
the subdomain id is not the data to be sent, but the destination and
compilation would fail if it wasn't an int (or convertible to it).
Introduced by @bangerth in 2016.

related to #5938