### PR TITLE
save/load state and property of ScaLAPACKMatrix

### DIFF
--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -142,6 +142,16 @@ public:
   void set_property(const LAPACKSupport::Property property);
 
   /**
+   * Return current @p property of this matrix
+   */
+  LAPACKSupport::Property get_property() const;
+
+  /**
+   * Return current @p state of this matrix
+   */
+  LAPACKSupport::State get_state() const;
+
+  /**
    * Assignment operator from a regular FullMatrix.
    *
    * @note This function should only be used for relatively small matrix

--- a/tests/scalapack/scalapack_10.cc
+++ b/tests/scalapack/scalapack_10.cc
@@ -16,7 +16,7 @@
 #include "../tests.h"
 #include "../lapack/create_matrix.h"
 
-// test serial saving and loading of distributed ScaLAPACKMatrices
+// test saving and loading of distributed ScaLAPACKMatrices
 
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/utilities.h>
@@ -34,7 +34,7 @@
 template <typename NumberType>
 void test(const unsigned int size, const unsigned int block_size)
 {
-  const std::string filename ("scalapck_10_test.h5");
+  const std::string filename ("scalapack_10_test.h5");
 
   MPI_Comm mpi_communicator(MPI_COMM_WORLD);
   const unsigned int this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator));
@@ -62,6 +62,10 @@ void test(const unsigned int size, const unsigned int block_size)
   copy.add(-1,full);
 
   pcout << size << " " << block_size << std::endl;
+
+  if (copy.frobenius_norm()>1e-12)
+    pcout << "norm of difference: " << copy.frobenius_norm() << std::endl;
+
   AssertThrow(copy.frobenius_norm()<1e-12,ExcInternalError());
   std::remove(filename.c_str());
 }

--- a/tests/scalapack/scalapack_10_b.cc
+++ b/tests/scalapack/scalapack_10_b.cc
@@ -16,7 +16,7 @@
 #include "../tests.h"
 #include "../lapack/create_matrix.h"
 
-// test serial saving and loading of distributed ScaLAPACKMatrices with prescribed chunk sizes
+// test saving and loading of distributed ScaLAPACKMatrices with prescribed chunk sizes
 
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/utilities.h>
@@ -34,7 +34,7 @@
 template <typename NumberType>
 void test(const std::pair<unsigned int,unsigned int> &size, const unsigned int block_size, const std::pair<unsigned int,unsigned int> &chunk_size)
 {
-  const std::string filename ("scalapck_10_b_test.h5");
+  const std::string filename ("scalapack_10_b_test.h5");
 
   MPI_Comm mpi_communicator(MPI_COMM_WORLD);
   const unsigned int this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator));

--- a/tests/scalapack/scalapack_10_c.cc
+++ b/tests/scalapack/scalapack_10_c.cc
@@ -1,0 +1,131 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include "../tests.h"
+#include "../lapack/create_matrix.h"
+
+// test saving and loading of the State and Property of distributed ScaLAPACKMatrices
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/timer.h>
+#include <deal.II/base/multithread_info.h>
+
+#include <deal.II/lac/scalapack.h>
+
+#include <fstream>
+#include <iostream>
+#include <cstdio>
+
+
+template <typename NumberType>
+void test()
+{
+  const std::string filename ("scalapack_10_test.h5");
+
+  MPI_Comm mpi_communicator(MPI_COMM_WORLD);
+  const unsigned int this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator));
+  ConditionalOStream pcout (std::cout, (this_mpi_process ==0));
+
+  pcout << "Saving and restoring the state and property of ScaLAPACKMatrix" << std::endl;
+
+  const unsigned int size=100, block_size=8;
+
+  //create FullMatrix and fill it
+  FullMatrix<NumberType> full(100);
+  create_spd (full);
+
+  //create 2d process grid
+  std::shared_ptr<Utilities::MPI::ProcessGrid> grid = std::make_shared<Utilities::MPI::ProcessGrid>(mpi_communicator,size,size,block_size,block_size);
+
+  ScaLAPACKMatrix<NumberType> scalapack_matrix(size,size,grid,block_size,block_size);
+  ScaLAPACKMatrix<NumberType> scalapack_matrix_copy(size,size,grid,block_size,block_size);
+
+  scalapack_matrix.set_property(LAPACKSupport::Property::diagonal);
+  scalapack_matrix.save(filename.c_str());
+  scalapack_matrix_copy.load(filename.c_str());
+  std::remove(filename.c_str());
+  AssertThrow(scalapack_matrix.get_property()==scalapack_matrix_copy.get_property(),
+              ExcInternalError());
+
+  scalapack_matrix.set_property(LAPACKSupport::Property::general);
+  scalapack_matrix.save(filename.c_str());
+  scalapack_matrix_copy.load(filename.c_str());
+  std::remove(filename.c_str());
+  AssertThrow(scalapack_matrix.get_property()==scalapack_matrix_copy.get_property(),
+              ExcInternalError());
+
+  scalapack_matrix.set_property(LAPACKSupport::Property::hessenberg);
+  scalapack_matrix.save(filename.c_str());
+  scalapack_matrix_copy.load(filename.c_str());
+  std::remove(filename.c_str());
+  AssertThrow(scalapack_matrix.get_property()==scalapack_matrix_copy.get_property(),
+              ExcInternalError());
+
+  scalapack_matrix.set_property(LAPACKSupport::Property::lower_triangular);
+  scalapack_matrix.save(filename.c_str());
+  scalapack_matrix_copy.load(filename.c_str());
+  std::remove(filename.c_str());
+  AssertThrow(scalapack_matrix.get_property()==scalapack_matrix_copy.get_property(),
+              ExcInternalError());
+
+  scalapack_matrix.set_property(LAPACKSupport::Property::symmetric);
+  scalapack_matrix.save(filename.c_str());
+  scalapack_matrix_copy.load(filename.c_str());
+  std::remove(filename.c_str());
+  AssertThrow(scalapack_matrix.get_property()==scalapack_matrix_copy.get_property(),
+              ExcInternalError());
+
+  scalapack_matrix.set_property(LAPACKSupport::Property::upper_triangular);
+  scalapack_matrix.save(filename.c_str());
+  scalapack_matrix_copy.load(filename.c_str());
+  std::remove(filename.c_str());
+  AssertThrow(scalapack_matrix.get_property()==scalapack_matrix_copy.get_property(),
+              ExcInternalError());
+
+  // after construction the matrix state is LAPACKSupport::State::unusable
+  scalapack_matrix.save(filename.c_str());
+  scalapack_matrix_copy.load(filename.c_str());
+  std::remove(filename.c_str());
+  AssertThrow(scalapack_matrix.get_state()==scalapack_matrix_copy.get_state(),
+              ExcInternalError());
+
+  // the assignment operator changes the state to LAPACKSupport::State::matrix
+  scalapack_matrix = full;
+  scalapack_matrix.save(filename.c_str());
+  scalapack_matrix_copy.load(filename.c_str());
+  std::remove(filename.c_str());
+  AssertThrow(scalapack_matrix.get_state()==scalapack_matrix_copy.get_state(),
+              ExcInternalError());
+
+  // calling invert changes the state to LAPACKSupport::inverse_matrix
+  scalapack_matrix.set_property(LAPACKSupport::Property::symmetric);
+  scalapack_matrix.invert();
+  scalapack_matrix.save(filename.c_str());
+  scalapack_matrix_copy.load(filename.c_str());
+  std::remove(filename.c_str());
+  AssertThrow(scalapack_matrix.get_state()==scalapack_matrix_copy.get_state(),
+              ExcInternalError());
+}
+
+
+
+int main (int argc,char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+
+  test<double>();
+}

--- a/tests/scalapack/scalapack_10_c.with_hdf5=on.mpirun=1.output
+++ b/tests/scalapack/scalapack_10_c.with_hdf5=on.mpirun=1.output
@@ -1,0 +1,1 @@
+Saving and restoring the state and property of ScaLAPACKMatrix

--- a/tests/scalapack/scalapack_10_c.with_hdf5=on.mpirun=11.output
+++ b/tests/scalapack/scalapack_10_c.with_hdf5=on.mpirun=11.output
@@ -1,0 +1,1 @@
+Saving and restoring the state and property of ScaLAPACKMatrix

--- a/tests/scalapack/scalapack_10_c.with_hdf5=on.mpirun=4.output
+++ b/tests/scalapack/scalapack_10_c.with_hdf5=on.mpirun=4.output
@@ -1,0 +1,1 @@
+Saving and restoring the state and property of ScaLAPACKMatrix

--- a/tests/scalapack/scalapack_10_c.with_hdf5=on.mpirun=5.output
+++ b/tests/scalapack/scalapack_10_c.with_hdf5=on.mpirun=5.output
@@ -1,0 +1,1 @@
+Saving and restoring the state and property of ScaLAPACKMatrix


### PR DESCRIPTION
Unfortunately, the functions `ScaLAPACKMatrix::save()` and `ScaLAPACKMatrix::load()` did not save or restore the state and property of the object. This PR eliminates that deficiency.