### PR TITLE
Fix another clang-tidy warning

### DIFF
--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -2365,14 +2365,18 @@ void MultipleParameterLoop::Entry::split_different_values ()
 
   while (multiple.find('|') != std::string::npos)
     {
-      different_values.push_back (prefix +
-                                  std::string(multiple, 0, multiple.find('|'))+
-                                  postfix);
+      std::string different_value = prefix;
+      different_value += std::string(multiple, 0, multiple.find('|'));
+      different_value += postfix;
+      different_values.push_back (std::move(different_value));
       multiple.erase (0, multiple.find('|')+1);
     };
   // make up the last selection ("while" broke
   // because there was no '|' any more
-  different_values.push_back (prefix+multiple+postfix);
+  std::string different_value = prefix;
+  different_value += std::string(multiple, 0, multiple.find('|'));
+  different_value += postfix;
+  different_values.push_back (std::move(different_value));
   // finally check whether this was a variant
   // entry ({...}) or an array ({{...}})
   if ((entry_value.find("{{") != std::string::npos) &&

--- a/source/base/path_search.cc
+++ b/source/base/path_search.cc
@@ -130,7 +130,8 @@ PathSearch::find (const std::string &filename,
       // the whole filename specified, including (possibly)
       // the suffix
       {
-        real_name = *path + filename;
+        real_name = *path;
+        real_name += filename;
         if (debug > 1)
           deallog << "PathSearch[" << cls << "] trying "
                   << real_name << std::endl;
@@ -149,7 +150,10 @@ PathSearch::find (const std::string &filename,
       // no suffix
       if (suffix != "")
         {
-          real_name = *path + filename + suffix;
+          real_name = *path;
+          real_name += filename;
+          real_name += suffix;
+
           if (debug > 1)
             deallog << "PathSearch[" << cls << "] trying "
                     << real_name << std::endl;


### PR DESCRIPTION
This one ` clang-tidy` didn't fix automatically (neither correctly nor incorrectly). In combination with the other PRs,  `clang-tidy` should not emit any `performance` warnings anymore (apart from `bundled`).