### PR TITLE
Fix findings of "modernize-use-emplace"

### DIFF
--- a/cmake/scripts/expand_instantiations.cc
+++ b/cmake/scripts/expand_instantiations.cc
@@ -493,8 +493,7 @@ void process_instantiations ()
 
           for (std::list<std::string>::const_iterator
                x = names.begin(); x != names.end(); ++x)
-            substitutions.push_back (std::make_pair (*x,
-                                                     names_and_type.back()));
+            substitutions.emplace_back (*x, names_and_type.back());
         }
 
       // now read the part in {...}

--- a/examples/step-19/step-19.cc
+++ b/examples/step-19/step-19.cc
@@ -245,7 +245,7 @@ namespace Step19
     // the name of the executable at the zeroth index:
     std::list<std::string> args;
     for (int i=1; i<argc; ++i)
-      args.push_back (argv[i]);
+      args.emplace_back(argv[i]);
 
     // Then process all these parameters. If the parameter is <code>-p</code>,
     // then there must be a parameter file following (which we should then

--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -867,7 +867,7 @@ namespace Step20
   void MixedLaplaceProblem<dim>::output_results () const
   {
     std::vector<std::string> solution_names(dim, "u");
-    solution_names.push_back ("p");
+    solution_names.emplace_back("p");
     std::vector<DataComponentInterpretation::DataComponentInterpretation>
     interpretation (dim,
                     DataComponentInterpretation::component_is_part_of_vector);

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -1103,18 +1103,18 @@ namespace Step21
     switch (dim)
       {
       case 2:
-        solution_names.push_back ("u");
-        solution_names.push_back ("v");
-        solution_names.push_back ("p");
-        solution_names.push_back ("S");
+        solution_names.emplace_back("u");
+        solution_names.emplace_back("v");
+        solution_names.emplace_back("p");
+        solution_names.emplace_back("S");
         break;
 
       case 3:
-        solution_names.push_back ("u");
-        solution_names.push_back ("v");
-        solution_names.push_back ("w");
-        solution_names.push_back ("p");
-        solution_names.push_back ("S");
+        solution_names.emplace_back("u");
+        solution_names.emplace_back("v");
+        solution_names.emplace_back("w");
+        solution_names.emplace_back("p");
+        solution_names.emplace_back("S");
         break;
 
       default:

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -855,7 +855,7 @@ namespace Step22
   StokesProblem<dim>::output_results (const unsigned int refinement_cycle)  const
   {
     std::vector<std::string> solution_names (dim, "velocity");
-    solution_names.push_back ("pressure");
+    solution_names.emplace_back("pressure");
 
     std::vector<DataComponentInterpretation::DataComponentInterpretation>
     data_component_interpretation

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -872,8 +872,8 @@ namespace Step29
     // The solution vectors $v$ and $w$ are added to the DataOut object in the
     // usual way:
     std::vector<std::string> solution_names;
-    solution_names.push_back ("Re_u");
-    solution_names.push_back ("Im_u");
+    solution_names.emplace_back("Re_u");
+    solution_names.emplace_back("Im_u");
 
     data_out.add_data_vector (solution, solution_names);
 

--- a/examples/step-34/step-34.cc
+++ b/examples/step-34/step-34.cc
@@ -880,9 +880,9 @@ namespace Step34
     static std::vector<QGaussOneOverR<2> > quadratures;
     if (quadratures.size() == 0)
       for (unsigned int i=0; i<fe.dofs_per_cell; ++i)
-        quadratures.push_back(QGaussOneOverR<2>(singular_quadrature_order,
-                                                fe.get_unit_support_points()[i],
-                                                true));
+        quadratures.emplace_back(singular_quadrature_order,
+                                 fe.get_unit_support_points()[i],
+                                 true);
     return quadratures[index];
   }
 

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -1337,8 +1337,8 @@ namespace Step35
             }
       }
     std::vector<std::string> joint_solution_names (dim, "v");
-    joint_solution_names.push_back ("p");
-    joint_solution_names.push_back ("rot_u");
+    joint_solution_names.emplace_back("p");
+    joint_solution_names.emplace_back("rot_u");
     DataOut<dim> data_out;
     data_out.attach_dof_handler (joint_dof_handler);
     std::vector< DataComponentInterpretation::DataComponentInterpretation >

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -3361,8 +3361,8 @@ namespace Step44
     data_component_interpretation.push_back(DataComponentInterpretation::component_is_scalar);
 
     std::vector<std::string> solution_name(dim, "displacement");
-    solution_name.push_back("pressure");
-    solution_name.push_back("dilatation");
+    solution_name.emplace_back("pressure");
+    solution_name.emplace_back("dilatation");
 
     data_out.attach_dof_handler(dof_handler_ref);
     data_out.add_data_vector(solution_n,

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -888,9 +888,9 @@ namespace Step46
   output_results (const unsigned int refinement_cycle)  const
   {
     std::vector<std::string> solution_names (dim, "velocity");
-    solution_names.push_back ("pressure");
+    solution_names.emplace_back("pressure");
     for (unsigned int d=0; d<dim; ++d)
-      solution_names.push_back ("displacement");
+      solution_names.emplace_back("displacement");
 
     std::vector<DataComponentInterpretation::DataComponentInterpretation>
     data_component_interpretation

--- a/examples/step-47/step-47.cc
+++ b/examples/step-47/step-47.cc
@@ -924,7 +924,7 @@ namespace Step47
   Postprocessor<dim>::get_names() const
   {
     std::vector<std::string> solution_names (1, "total_solution");
-    solution_names.push_back ("error");
+    solution_names.emplace_back("error");
     return solution_names;
   }
 

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -1212,7 +1212,7 @@ namespace Step51
     // We first define the names and types of the local solution,
     // and add the data to @p data_out.
     std::vector<std::string> names (dim, "gradient");
-    names.push_back ("solution");
+    names.emplace_back("solution");
     std::vector<DataComponentInterpretation::DataComponentInterpretation>
     component_interpretation
     (dim+1, DataComponentInterpretation::component_is_part_of_vector);

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -1032,7 +1032,7 @@ namespace Step56
   StokesProblem<dim>::output_results (const unsigned int refinement_cycle)  const
   {
     std::vector<std::string> solution_names (dim, "velocity");
-    solution_names.push_back ("pressure");
+    solution_names.emplace_back("pressure");
 
     std::vector<DataComponentInterpretation::DataComponentInterpretation>
     data_component_interpretation

--- a/examples/step-57/step-57.cc
+++ b/examples/step-57/step-57.cc
@@ -760,7 +760,7 @@ namespace Step57
   void StationaryNavierStokes<dim>::output_results (const unsigned int output_index)  const
   {
     std::vector<std::string> solution_names (dim, "velocity");
-    solution_names.push_back ("pressure");
+    solution_names.emplace_back("pressure");
 
     std::vector<DataComponentInterpretation::DataComponentInterpretation>
     data_component_interpretation

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -1228,9 +1228,9 @@ namespace Step7
         // Selecting and re-ordering the columns works as follows (note that
         // this includes super columns):
         std::vector<std::string> new_order;
-        new_order.push_back("n cells");
-        new_order.push_back("H1");
-        new_order.push_back("L2");
+        new_order.emplace_back("n cells");
+        new_order.emplace_back("H1");
+        new_order.emplace_back("L2");
         convergence_table.set_column_order (new_order);
 
         // For everything that happened to the ConvergenceTable until this

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -553,16 +553,16 @@ namespace Step8
     switch (dim)
       {
       case 1:
-        solution_names.push_back ("displacement");
+        solution_names.emplace_back("displacement");
         break;
       case 2:
-        solution_names.push_back ("x_displacement");
-        solution_names.push_back ("y_displacement");
+        solution_names.emplace_back("x_displacement");
+        solution_names.emplace_back("y_displacement");
         break;
       case 3:
-        solution_names.push_back ("x_displacement");
-        solution_names.push_back ("y_displacement");
-        solution_names.push_back ("z_displacement");
+        solution_names.emplace_back("x_displacement");
+        solution_names.emplace_back("y_displacement");
+        solution_names.emplace_back("z_displacement");
         break;
       default:
         Assert (false, ExcNotImplemented());

--- a/tests/quick_tests/nanoflann.cc
+++ b/tests/quick_tests/nanoflann.cc
@@ -29,17 +29,17 @@ int main ()
   std::vector<Point<2> > points;
 
   // Add four points
-  points.push_back(Point<2>(0,0));
-  points.push_back(Point<2>(0,1));
-  points.push_back(Point<2>(1,0));
-  points.push_back(Point<2>(1,1));
+  points.emplace_back(0,0);
+  points.emplace_back(0,1);
+  points.emplace_back(1,0);
+  points.emplace_back(1,1);
 
   deallog << "Distance from unit square:" << std::endl;
 
   std::vector<Point<2> > test_points;
-  test_points.push_back(Point<2>(.5, .5));
-  test_points.push_back(Point<2>(2, 0));
-  test_points.push_back(Point<2>(2, 2));
+  test_points.emplace_back(.5, .5);
+  test_points.emplace_back(2, 0);
+  test_points.emplace_back(2, 2);
 
   kdtree.set_points(points);
 


### PR DESCRIPTION
While confirming that `clang-tidy` would indeed not prefer `push_back(std::move(...))` over `emplace_back(std::move(...))` in #5943, some more improvements for `modernize-use-emplace` were found.