### PR TITLE
Use the correct size type for a column number.

### DIFF
--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -133,7 +133,7 @@ public:
     /**
      * Current column number.
      */
-    unsigned short a_col;
+    size_type a_col;
 
     /*
      * Make enclosing class a friend.


### PR DESCRIPTION
I noticed this strange bit of code when working on #5956.