### PR TITLE
fix initializer in tests/manifold/chart_manifold_10

### DIFF
--- a/tests/manifold/chart_manifold_10.cc
+++ b/tests/manifold/chart_manifold_10.cc
@@ -29,8 +29,8 @@ print_intermediate_point (const Manifold<dim> &manifold,
                           const Point<dim> &p2,
                           const double weight)
 {
-  const std::vector<Point<dim> > points({{p1, p2}});
-  const std::vector<double> weights({{1-weight, weight}});
+  const std::vector<Point<dim> > points({p1, p2});
+  const std::vector<double> weights({1-weight, weight});
   deallog.precision(3);
   deallog << manifold_name << " between points [" << p1 << "] and ["
           << p2 << "] with weight " << weight << std::endl;


### PR DESCRIPTION
fixes a nasty crash in clang 5:
```
clang-5.0: error: unable to execute command: Segmentation fault (core dumped)
```
see https://cdash.kyomu.43-1.org/testDetails.php?test=73580853&build=15942