### PR TITLE
improve consistency of dim=1 objects in the library (p::d::Tria, KellyEstimator,...)

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -878,11 +878,25 @@ namespace parallel
     class Triangulation<1,spacedim> : public dealii::parallel::Triangulation<1,spacedim>
     {
     public:
+
+      /**
+       * dummy settings
+       */
+      enum Settings
+      {
+        default_setting = 0x0,
+        mesh_reconstruction_after_repartitioning = 0x1,
+        construct_multigrid_hierarchy = 0x2
+      };
+
       /**
        * Constructor. The argument denotes the MPI communicator to be used for
        * the triangulation.
        */
-      Triangulation (MPI_Comm mpi_communicator);
+      Triangulation (MPI_Comm mpi_communicator,
+                     const typename dealii::Triangulation<1,spacedim>::MeshSmoothing
+                     smooth_grid = (dealii::Triangulation<1,spacedim>::none),
+                     const Settings settings = default_setting);
 
       /**
        * Destructor.
@@ -958,16 +972,6 @@ namespace parallel
        */
       std::vector<types::global_dof_index> coarse_cell_to_p4est_tree_permutation;
       std::vector<types::global_dof_index> p4est_tree_to_coarse_cell_permutation;
-
-      /**
-       * dummy settings
-       */
-      enum Settings
-      {
-        default_setting = 0x0,
-        mesh_reconstruction_after_repartitioning = 0x1,
-        construct_multigrid_hierarchy = 0x2
-      };
 
 
 //TODO: The following variable should really be private, but it is used in dof_handler_policy.cc ...

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -951,6 +951,17 @@ namespace parallel
       /**
        * This function is not implemented, but needs to be present for the compiler.
        */
+      void load(const char *filename,
+                const bool autopartition = true);
+
+      /**
+       * This function is not implemented, but needs to be present for the compiler.
+       */
+      void save(const char *filename) const;
+
+      /**
+       * This function is not implemented, but needs to be present for the compiler.
+       */
       unsigned int
       register_data_attach (const std::size_t size,
                             const std::function<void (const typename dealii::Triangulation<1,spacedim>::cell_iterator &,

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -550,6 +550,20 @@ class KellyErrorEstimator<1,spacedim>
 {
 public:
   /**
+   * The enum type given to the class functions to decide on the scaling
+   * factors of the facial integrals.
+   */
+  enum Strategy
+  {
+    //! Kelly error estimator with the factor $\frac {h_K}{24}$.
+    cell_diameter_over_24 = 0,
+    //! the boundary residual estimator with the factor $\frac {h_F}{2 max(p^+,p^-)}$.
+    face_diameter_over_twice_max_degree,
+    //! Kelly error estimator with the factor $h_K$.
+    cell_diameter
+  };
+
+  /**
    * Implementation of the error estimator described above. You may give a
    * coefficient, but there is a default value which denotes the constant
    * coefficient with value one. The coefficient function may either be a
@@ -583,7 +597,8 @@ public:
    const Function<spacedim>                   *coefficient    = nullptr,
    const unsigned int                          n_threads      = numbers::invalid_unsigned_int,
    const types::subdomain_id                   subdomain_id   = numbers::invalid_subdomain_id,
-   const types::material_id                    material_id    = numbers::invalid_material_id);
+   const types::material_id                    material_id    = numbers::invalid_material_id,
+   const Strategy                              strategy       = cell_diameter_over_24);
 
   /**
    * Call the @p estimate function, see above, with
@@ -600,7 +615,8 @@ public:
    const Function<spacedim>                   *coefficients   = nullptr,
    const unsigned int                          n_threads      = numbers::invalid_unsigned_int,
    const types::subdomain_id                   subdomain_id   = numbers::invalid_subdomain_id,
-   const types::material_id                    material_id    = numbers::invalid_material_id);
+   const types::material_id                    material_id    = numbers::invalid_material_id,
+   const Strategy                              strategy       = cell_diameter_over_24);
 
   /**
    * Same function as above, but accepts more than one solution vectors and
@@ -627,7 +643,8 @@ public:
    const Function<spacedim>                   *coefficients   = 0,
    const unsigned int                          n_threads      = numbers::invalid_unsigned_int,
    const types::subdomain_id                   subdomain_id   = numbers::invalid_subdomain_id,
-   const types::material_id                    material_id    = numbers::invalid_material_id);
+   const types::material_id                    material_id    = numbers::invalid_material_id,
+   const Strategy                              strategy       = cell_diameter_over_24);
 
   /**
    * Call the @p estimate function, see above, with
@@ -644,7 +661,8 @@ public:
    const Function<spacedim>                   *coefficients   = 0,
    const unsigned int                          n_threads      = numbers::invalid_unsigned_int,
    const types::subdomain_id                   subdomain_id   = numbers::invalid_subdomain_id,
-   const types::material_id                    material_id    = numbers::invalid_material_id);
+   const types::material_id                    material_id    = numbers::invalid_material_id,
+   const Strategy                              strategy       = cell_diameter_over_24);
 
 
   /**
@@ -663,7 +681,8 @@ public:
    const Function<spacedim>                   *coefficients   = 0,
    const unsigned int                          n_threads      = numbers::invalid_unsigned_int,
    const types::subdomain_id                   subdomain_id   = numbers::invalid_subdomain_id,
-   const types::material_id                    material_id    = numbers::invalid_material_id);
+   const types::material_id                    material_id    = numbers::invalid_material_id,
+   const Strategy                              strategy       = cell_diameter_over_24);
 
 
   /**
@@ -681,7 +700,8 @@ public:
    const Function<spacedim>                   *coefficients   = 0,
    const unsigned int                          n_threads      = numbers::invalid_unsigned_int,
    const types::subdomain_id                   subdomain_id   = numbers::invalid_subdomain_id,
-   const types::material_id                    material_id    = numbers::invalid_material_id);
+   const types::material_id                    material_id    = numbers::invalid_material_id,
+   const Strategy                              strategy       = cell_diameter_over_24);
 
 
   /**
@@ -700,7 +720,8 @@ public:
    const Function<spacedim>                   *coefficients   = 0,
    const unsigned int                          n_threads      = numbers::invalid_unsigned_int,
    const types::subdomain_id                   subdomain_id   = numbers::invalid_subdomain_id,
-   const types::material_id                    material_id    = numbers::invalid_material_id);
+   const types::material_id                    material_id    = numbers::invalid_material_id,
+   const Strategy                              strategy       = cell_diameter_over_24);
 
 
   /**
@@ -718,7 +739,8 @@ public:
    const Function<spacedim>                   *coefficients   = 0,
    const unsigned int                          n_threads      = numbers::invalid_unsigned_int,
    const types::subdomain_id                   subdomain_id   = numbers::invalid_subdomain_id,
-   const types::material_id                    material_id    = numbers::invalid_material_id);
+   const types::material_id                    material_id    = numbers::invalid_material_id,
+   const Strategy                              strategy       = cell_diameter_over_24);
 
   /**
    * Exception

--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -102,6 +102,7 @@ SET(_inst
   data_out_base.inst.in
   function.inst.in
   function_time.inst.in
+  geometric_utilities.inst.in
   mpi.inst.in
   partitioner.inst.in
   polynomials_rannacher_turek.inst.in

--- a/source/base/function_spherical.cc
+++ b/source/base/function_spherical.cc
@@ -345,6 +345,8 @@ namespace Functions
 
 
 // explicit instantiations
+  template class Spherical<1>;
+  template class Spherical<2>;
   template class Spherical<3>;
 
 }

--- a/source/base/geometric_utilities.cc
+++ b/source/base/geometric_utilities.cc
@@ -103,11 +103,8 @@ namespace GeometricUtilities
       return ccoord;
     }
 
-
-    template Point<2> from_spherical<2>(const std::array<double,2> &);
-    template Point<3> from_spherical<3>(const std::array<double,3> &);
-    template std::array<double,2> to_spherical<2>(const Point<2> &);
-    template std::array<double,3> to_spherical<3>(const Point<3> &);
+    // explicit instantiations
+#include "geometric_utilities.inst"
 
   }
 }

--- a/source/base/geometric_utilities.inst.in
+++ b/source/base/geometric_utilities.inst.in
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+for (dim : SPACE_DIMENSIONS)
+{
+    template Point<dim> from_spherical<dim>(const std::array<double,dim> &);
+    template std::array<double,dim> to_spherical<dim>(const Point<dim> &);
+}

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -423,6 +423,7 @@ namespace parallel
        const double                                        bottom_fraction_of_cells,
        const unsigned int                                  max_n_cells)
       {
+        Assert (dim > 1, ExcNotImplemented());
         Assert (criteria.size() == tria.n_active_cells(),
                 ExcDimensionMismatch (criteria.size(), tria.n_active_cells()));
         Assert ((top_fraction_of_cells>=0) && (top_fraction_of_cells<=1),
@@ -499,6 +500,7 @@ namespace parallel
        const double                                        top_fraction_of_error,
        const double                                        bottom_fraction_of_error)
       {
+        Assert (dim > 1, ExcNotImplemented());
         Assert (criteria.size() == tria.n_active_cells(),
                 ExcDimensionMismatch (criteria.size(), tria.n_active_cells()));
         Assert ((top_fraction_of_error>=0) && (top_fraction_of_error<=1),

--- a/source/distributed/grid_refinement.inst.in
+++ b/source/distributed/grid_refinement.inst.in
@@ -18,7 +18,6 @@
 
 for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
 {
-#if deal_II_dimension != 1
     namespace parallel
     \{
     namespace distributed
@@ -44,7 +43,6 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
     \}
     \}
     \}
-#endif
 
 
 #if deal_II_dimension == 3

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -49,6 +49,7 @@ namespace parallel
       dof_handler(&dof, typeid(*this).name()),
       offset (numbers::invalid_unsigned_int)
     {
+      Assert (dim > 1, ExcNotImplemented());
       Assert ((dynamic_cast<const parallel::distributed::Triangulation<dim,DoFHandlerType::space_dimension>*>
                (&dof_handler->get_triangulation()) != nullptr),
               ExcMessage("parallel::distributed::SolutionTransfer requires a parallel::distributed::Triangulation object."));

--- a/source/distributed/solution_transfer.inst.in
+++ b/source/distributed/solution_transfer.inst.in
@@ -21,7 +21,6 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
     \{
     namespace distributed
     \{
-#if deal_II_dimension > 1
 #if deal_II_dimension <= deal_II_space_dimension
     template class SolutionTransfer<deal_II_dimension,::dealii::Vector<double>, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
     template class SolutionTransfer<deal_II_dimension,::dealii::LinearAlgebra::distributed::Vector<double>, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
@@ -42,7 +41,6 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
     template class SolutionTransfer<deal_II_dimension, TrilinosWrappers::MPI::BlockVector, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
 #endif
 
-#endif
 #endif
     \}
     \}

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3822,6 +3822,24 @@ namespace parallel
       Assert (false, ExcNotImplemented());
       return std::vector<bool>();
     }
+
+
+
+    template <int spacedim>
+    void
+    Triangulation<1,spacedim>::load(const char *,
+                                    const bool)
+    {
+      Assert (false, ExcNotImplemented());
+    }
+
+    template <int spacedim>
+    void
+    Triangulation<1,spacedim>::save(const char *) const
+    {
+      Assert (false, ExcNotImplemented());
+    }
+
   }
 }
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3733,10 +3733,12 @@ namespace parallel
 
 
     template <int spacedim>
-    Triangulation<1,spacedim>::Triangulation (MPI_Comm)
+    Triangulation<1,spacedim>::Triangulation (MPI_Comm mpi_communicator,
+                                              const typename dealii::Triangulation<1,spacedim>::MeshSmoothing smooth_grid,
+                                              const Settings /*settings*/)
       :
-      dealii::parallel::Triangulation<1,spacedim>(MPI_COMM_WORLD,
-                                                  typename dealii::Triangulation<1,spacedim>::MeshSmoothing(),
+      dealii::parallel::Triangulation<1,spacedim>(mpi_communicator,
+                                                  smooth_grid,
                                                   false)
     {
       Assert (false, ExcNotImplemented());

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -65,13 +65,14 @@ estimate (const Mapping<1,spacedim>                  &mapping,
           const Function<spacedim>                   *coefficients,
           const unsigned int                          n_threads,
           const types::subdomain_id                   subdomain_id,
-          const types::material_id                    material_id)
+          const types::material_id                    material_id,
+          const Strategy                              strategy)
 {
   // just pass on to the other function
   const std::vector<const InputVector *> solutions (1, &solution);
   std::vector<Vector<float>*>              errors (1, &error);
   estimate (mapping, dof_handler, quadrature, neumann_bc, solutions, errors,
-            component_mask, coefficients, n_threads, subdomain_id, material_id);
+            component_mask, coefficients, n_threads, subdomain_id, material_id,strategy);
 }
 
 
@@ -89,10 +90,11 @@ estimate (const DoFHandlerType                       &dof_handler,
           const Function<spacedim>                   *coefficients,
           const unsigned int                          n_threads,
           const types::subdomain_id                   subdomain_id,
-          const types::material_id                    material_id)
+          const types::material_id                    material_id,
+          const Strategy                              strategy)
 {
   estimate(StaticMappingQ1<1,spacedim>::mapping, dof_handler, quadrature, neumann_bc, solution,
-           error, component_mask, coefficients, n_threads, subdomain_id, material_id);
+           error, component_mask, coefficients, n_threads, subdomain_id, material_id,strategy);
 }
 
 
@@ -110,10 +112,11 @@ estimate (const DoFHandlerType                       &dof_handler,
           const Function<spacedim>                   *coefficients,
           const unsigned int                          n_threads,
           const types::subdomain_id                   subdomain_id,
-          const types::material_id                    material_id)
+          const types::material_id                    material_id,
+          const Strategy                              strategy)
 {
   estimate(StaticMappingQ1<1,spacedim>::mapping, dof_handler, quadrature, neumann_bc, solutions,
-           errors, component_mask, coefficients, n_threads, subdomain_id, material_id);
+           errors, component_mask, coefficients, n_threads, subdomain_id, material_id,strategy);
 }
 
 
@@ -132,13 +135,14 @@ estimate (const Mapping<1,spacedim>                  &mapping,
           const Function<spacedim>                   *coefficients,
           const unsigned int                          n_threads,
           const types::subdomain_id                   subdomain_id,
-          const types::material_id                    material_id)
+          const types::material_id                    material_id,
+          const Strategy                              strategy)
 {
   // just pass on to the other function
   const std::vector<const InputVector *> solutions (1, &solution);
   std::vector<Vector<float>*>              errors (1, &error);
   estimate (mapping, dof_handler, quadrature, neumann_bc, solutions, errors,
-            component_mask, coefficients, n_threads, subdomain_id, material_id);
+            component_mask, coefficients, n_threads, subdomain_id, material_id, strategy);
 }
 
 
@@ -155,10 +159,11 @@ estimate (const DoFHandlerType                       &dof_handler,
           const Function<spacedim>                   *coefficients,
           const unsigned int                          n_threads,
           const types::subdomain_id                   subdomain_id,
-          const types::material_id                    material_id)
+          const types::material_id                    material_id,
+          const Strategy                              strategy)
 {
   estimate(StaticMappingQ1<1,spacedim>::mapping, dof_handler, quadrature, neumann_bc, solution,
-           error, component_mask, coefficients, n_threads, subdomain_id, material_id);
+           error, component_mask, coefficients, n_threads, subdomain_id, material_id,strategy);
 }
 
 
@@ -176,10 +181,11 @@ estimate (const DoFHandlerType                       &dof_handler,
           const Function<spacedim>                   *coefficients,
           const unsigned int                          n_threads,
           const types::subdomain_id                   subdomain_id,
-          const types::material_id                    material_id)
+          const types::material_id                    material_id,
+          const Strategy                              strategy)
 {
   estimate(StaticMappingQ1<1,spacedim>::mapping, dof_handler, quadrature, neumann_bc, solutions,
-           errors, component_mask, coefficients, n_threads, subdomain_id, material_id);
+           errors, component_mask, coefficients, n_threads, subdomain_id, material_id,strategy);
 }
 
 
@@ -198,7 +204,8 @@ estimate (const Mapping<1,spacedim>                  & /*mapping*/,
           const Function<spacedim>                   * /*coefficient*/,
           const unsigned int,
           const types::subdomain_id                    /*subdomain_id*/,
-          const types::material_id                     /*material_id*/)
+          const types::material_id                     /*material_id*/,
+          const Strategy                              /*strategy*/)
 {
   Assert (false, ExcInternalError());
 }
@@ -218,8 +225,10 @@ estimate (const Mapping<1,spacedim>                  &mapping,
           const Function<spacedim>                   *coefficient,
           const unsigned int,
           const types::subdomain_id                   subdomain_id_,
-          const types::material_id                    material_id)
+          const types::material_id                    material_id,
+          const Strategy                              strategy)
 {
+  AssertThrow(strategy==cell_diameter_over_24, ExcNotImplemented());
   typedef typename InputVector::value_type number;
 #ifdef DEAL_II_WITH_P4EST
   if (dynamic_cast<const parallel::distributed::Triangulation<1,spacedim>*>

--- a/source/numerics/error_estimator_1d.inst.in
+++ b/source/numerics/error_estimator_1d.inst.in
@@ -31,7 +31,8 @@ for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimensio
             const Function<deal_II_space_dimension>     *,
             const unsigned int,
             const types::subdomain_id,
-            const types::material_id);
+            const types::material_id,
+            const Strategy);
 
     template
     void
@@ -46,7 +47,8 @@ for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimensio
         const Function<deal_II_space_dimension>     *,
         const unsigned int,
         const types::subdomain_id,
-        const types::material_id);
+        const types::material_id,
+        const Strategy);
 
     template
     void
@@ -61,7 +63,8 @@ for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimensio
             const Function<deal_II_space_dimension>     *,
             const unsigned int,
             const types::subdomain_id,
-            const types::material_id);
+            const types::material_id,
+            const Strategy);
 
     template
     void
@@ -76,7 +79,8 @@ for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimensio
         const Function<deal_II_space_dimension>     *,
         const unsigned int,
         const types::subdomain_id,
-        const types::material_id);
+        const types::material_id,
+        const Strategy);
 
     template
     void
@@ -91,7 +95,8 @@ for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimensio
             const Function<deal_II_space_dimension>     *,
             const unsigned int,
             const types::subdomain_id,
-            const types::material_id);
+            const types::material_id,
+            const Strategy);
 
     template
     void
@@ -106,7 +111,8 @@ for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimensio
         const Function<deal_II_space_dimension>     *,
         const unsigned int,
         const types::subdomain_id,
-        const types::material_id);
+        const types::material_id,
+        const Strategy);
 
     template
     void
@@ -121,7 +127,8 @@ for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimensio
             const Function<deal_II_space_dimension>     *,
             const unsigned int,
             const types::subdomain_id,
-            const types::material_id);
+            const types::material_id,
+            const Strategy);
 
     template
     void
@@ -136,7 +143,8 @@ for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimensio
         const Function<deal_II_space_dimension>     *,
         const unsigned int,
         const types::subdomain_id,
-        const types::material_id);
+        const types::material_id,
+        const Strategy);
 
 #endif
 }

--- a/tests/distributed_grids/1d_grid.cc
+++ b/tests/distributed_grids/1d_grid.cc
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2008 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test that we can compile p::d::Tria<1>
+
+#include "../tests.h"
+#include <deal.II/distributed/tria.h>
+
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+
+  parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD);
+
+  deallog << "Ok" << std::endl;
+
+}

--- a/tests/distributed_grids/1d_grid.expect=build.output
+++ b/tests/distributed_grids/1d_grid.expect=build.output
@@ -1,0 +1,106 @@
+
+DEAL:2d::hyper_cube
+DEAL:2d::Checksum: 786433
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <PPointData>
+    </PPointData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="4" NumberOfCells="1">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            2.50000004e-02   2.50000004e-02   0.00000000e+00
+            9.75000024e-01   2.50000004e-02   0.00000000e+00
+            2.50000004e-02   9.75000024e-01   0.00000000e+00
+            9.75000024e-01   9.75000024e-01   0.00000000e+00
+        </DataArray>
+      </Points>
+      <Cells>
+        <DataArray type="Int32" Name="connectivity" format="ascii">
+          0 1 2 3
+        </DataArray>
+        <DataArray type="Int32" Name="offsets" format="ascii">
+          4
+        </DataArray>
+DEAL:2d::hyper_ball
+DEAL:2d::Checksum: 3932161
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <PPointData>
+    </PPointData>
+    <Piece Source="2_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="20" NumberOfCells="5">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+           -1.98574162e+00  -2.09025431e+00   0.00000000e+00
+            1.98574162e+00  -2.09025431e+00   0.00000000e+00
+           -8.64258409e-01  -9.09745693e-01   0.00000000e+00
+            8.64258409e-01  -9.09745693e-01   0.00000000e+00
+           -2.09025431e+00  -1.98574162e+00   0.00000000e+00
+           -9.09745693e-01  -8.64258409e-01   0.00000000e+00
+           -2.09025431e+00   1.98574162e+00   0.00000000e+00
+           -9.09745693e-01   8.64258409e-01   0.00000000e+00
+           -8.34745646e-01  -8.34745646e-01   0.00000000e+00
+            8.34745646e-01  -8.34745646e-01   0.00000000e+00
+           -8.34745646e-01   8.34745646e-01   0.00000000e+00
+            8.34745646e-01   8.34745646e-01   0.00000000e+00
+            2.09025431e+00  -1.98574162e+00   0.00000000e+00
+DEAL:2d::half_hyper_ball
+DEAL:2d::Checksum: 3145729
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <PPointData>
+    </PPointData>
+    <Piece Source="3_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="16" NumberOfCells="4">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            5.22563569e-02  -2.92554927e+00   0.00000000e+00
+            2.03799796e+00  -2.11167216e+00   0.00000000e+00
+            2.27436423e-02  -9.31163490e-01   0.00000000e+00
+            8.87002051e-01  -9.10294831e-01   0.00000000e+00
+            2.19669919e-02  -8.34745646e-01   0.00000000e+00
+            8.56712639e-01  -8.34745646e-01   0.00000000e+00
+            2.19669919e-02   8.34745646e-01   0.00000000e+00
+            8.56712639e-01   8.34745646e-01   0.00000000e+00
+            2.09025431e+00  -1.98574162e+00   0.00000000e+00
+            2.09025431e+00   1.98574162e+00   0.00000000e+00
+            9.09745693e-01  -8.64258409e-01   0.00000000e+00
+            9.09745693e-01   8.64258409e-01   0.00000000e+00
+            5.22563569e-02   2.92554927e+00   0.00000000e+00


### PR DESCRIPTION
The second commit is related to https://github.com/dealii/dealii/issues/5972