### PR TITLE
Add json parser for input files

### DIFF
--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -964,6 +964,15 @@ public:
   virtual void parse_input_from_xml (std::istream &input);
 
   /**
+   * Parse input from an JSON stream to populate known parameter fields. This
+   * could be from a file originally written by the print_parameters() function
+   * using the XML output style and then modified by hand as necessary, or from
+   * a file written using this method and then modified by the graphical
+   * parameter GUI (see the general documentation of this class).
+   */
+  virtual void parse_input_from_json (std::istream &input);
+
+  /**
    * Clear all contents.
    */
   void clear ();

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1479,17 +1479,6 @@ private:
   std::vector<std::function<void (const std::string &)> > actions;
 
   /**
-   * Mangle a string so that it doesn't contain any special characters or
-   * spaces.
-   */
-  static std::string mangle (const std::string &s);
-
-  /**
-   * Unmangle a string into its original form.
-   */
-  static std::string demangle (const std::string &s);
-
-  /**
    * Given a list of directories and subdirectories that identify
    * a particular place in the tree, return the string that identifies
    * this place in the way the BOOST property tree libraries likes

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -964,11 +964,11 @@ public:
   virtual void parse_input_from_xml (std::istream &input);
 
   /**
-   * Parse input from an JSON stream to populate known parameter fields. This
+   * Parse input from a JSON stream to populate known parameter fields. This
    * could be from a file originally written by the print_parameters() function
-   * using the XML output style and then modified by hand as necessary, or from
-   * a file written using this method and then modified by the graphical
-   * parameter GUI (see the general documentation of this class).
+   * using the JSON output style and then modified by hand as necessary, or from
+   * a separate program that knows how to write JSON format for ParameterHandler
+   * input.
    */
   virtual void parse_input_from_json (std::istream &input);
 

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -46,181 +46,178 @@ ParameterHandler::ParameterHandler ()
 {}
 
 
-
-std::string
-ParameterHandler::mangle (const std::string &s)
+namespace
 {
-  std::string u;
+  std::string
+  mangle (const std::string &s)
+  {
+    std::string u;
 
-  // reserve the minimum number of characters we will need. it may
-  // be more but this is the least we can do
-  u.reserve (s.size());
+    // reserve the minimum number of characters we will need. it may
+    // be more but this is the least we can do
+    u.reserve (s.size());
 
-  // see if the name is special and if so mangle the whole thing
-  const bool mangle_whole_string = (s == "value");
+    // see if the name is special and if so mangle the whole thing
+    const bool mangle_whole_string = (s == "value");
 
-  // for all parts of the string, see
-  // if it is an allowed character or
-  // not
-  for (unsigned int i=0; i<s.size(); ++i)
-    {
-      static const std::string allowed_characters
-      ("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+    // for all parts of the string, see
+    // if it is an allowed character or
+    // not
+    for (unsigned int i=0; i<s.size(); ++i)
+      {
+        static const std::string allowed_characters
+        ("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
 
-      if ((! mangle_whole_string)
-          &&
-          (allowed_characters.find (s[i]) != std::string::npos))
+        if ((! mangle_whole_string)
+            &&
+            (allowed_characters.find (s[i]) != std::string::npos))
+          u.push_back (s[i]);
+        else
+          {
+            u.push_back ('_');
+            static const char hex[16]
+              = { '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
+            u.push_back (hex[static_cast<unsigned char>(s[i])/16]);
+            u.push_back (hex[static_cast<unsigned char>(s[i])%16]);
+          }
+      }
+
+    return u;
+  }
+
+
+
+  std::string
+  demangle (const std::string &s)
+  {
+    std::string u;
+    u.reserve (s.size());
+
+    for (unsigned int i=0; i<s.size(); ++i)
+      if (s[i] != '_')
         u.push_back (s[i]);
       else
         {
-          u.push_back ('_');
-          static const char hex[16]
-            = { '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
-          u.push_back (hex[static_cast<unsigned char>(s[i])/16]);
-          u.push_back (hex[static_cast<unsigned char>(s[i])%16]);
+          Assert (i+2 < s.size(),
+                  ExcMessage ("Trying to demangle an invalid string."));
+
+          unsigned char c = 0;
+          switch (s[i+1])
+            {
+            case '0':
+              c = 0 * 16;
+              break;
+            case '1':
+              c = 1 * 16;
+              break;
+            case '2':
+              c = 2 * 16;
+              break;
+            case '3':
+              c = 3 * 16;
+              break;
+            case '4':
+              c = 4 * 16;
+              break;
+            case '5':
+              c = 5 * 16;
+              break;
+            case '6':
+              c = 6 * 16;
+              break;
+            case '7':
+              c = 7 * 16;
+              break;
+            case '8':
+              c = 8 * 16;
+              break;
+            case '9':
+              c = 9 * 16;
+              break;
+            case 'a':
+              c = 10 * 16;
+              break;
+            case 'b':
+              c = 11 * 16;
+              break;
+            case 'c':
+              c = 12 * 16;
+              break;
+            case 'd':
+              c = 13 * 16;
+              break;
+            case 'e':
+              c = 14 * 16;
+              break;
+            case 'f':
+              c = 15 * 16;
+              break;
+            default:
+              Assert (false, ExcInternalError());
+            }
+          switch (s[i+2])
+            {
+            case '0':
+              c += 0;
+              break;
+            case '1':
+              c += 1;
+              break;
+            case '2':
+              c += 2;
+              break;
+            case '3':
+              c += 3;
+              break;
+            case '4':
+              c += 4;
+              break;
+            case '5':
+              c += 5;
+              break;
+            case '6':
+              c += 6;
+              break;
+            case '7':
+              c += 7;
+              break;
+            case '8':
+              c += 8;
+              break;
+            case '9':
+              c += 9;
+              break;
+            case 'a':
+              c += 10;
+              break;
+            case 'b':
+              c += 11;
+              break;
+            case 'c':
+              c += 12;
+              break;
+            case 'd':
+              c += 13;
+              break;
+            case 'e':
+              c += 14;
+              break;
+            case 'f':
+              c += 15;
+              break;
+            default:
+              Assert (false, ExcInternalError());
+            }
+
+          u.push_back (static_cast<char>(c));
+
+          // skip the two characters
+          i += 2;
         }
-    }
 
-  return u;
-}
+    return u;
+  }
 
-
-
-std::string
-ParameterHandler::demangle (const std::string &s)
-{
-  std::string u;
-  u.reserve (s.size());
-
-  for (unsigned int i=0; i<s.size(); ++i)
-    if (s[i] != '_')
-      u.push_back (s[i]);
-    else
-      {
-        Assert (i+2 < s.size(),
-                ExcMessage ("Trying to demangle an invalid string."));
-
-        unsigned char c = 0;
-        switch (s[i+1])
-          {
-          case '0':
-            c = 0 * 16;
-            break;
-          case '1':
-            c = 1 * 16;
-            break;
-          case '2':
-            c = 2 * 16;
-            break;
-          case '3':
-            c = 3 * 16;
-            break;
-          case '4':
-            c = 4 * 16;
-            break;
-          case '5':
-            c = 5 * 16;
-            break;
-          case '6':
-            c = 6 * 16;
-            break;
-          case '7':
-            c = 7 * 16;
-            break;
-          case '8':
-            c = 8 * 16;
-            break;
-          case '9':
-            c = 9 * 16;
-            break;
-          case 'a':
-            c = 10 * 16;
-            break;
-          case 'b':
-            c = 11 * 16;
-            break;
-          case 'c':
-            c = 12 * 16;
-            break;
-          case 'd':
-            c = 13 * 16;
-            break;
-          case 'e':
-            c = 14 * 16;
-            break;
-          case 'f':
-            c = 15 * 16;
-            break;
-          default:
-            Assert (false, ExcInternalError());
-          }
-        switch (s[i+2])
-          {
-          case '0':
-            c += 0;
-            break;
-          case '1':
-            c += 1;
-            break;
-          case '2':
-            c += 2;
-            break;
-          case '3':
-            c += 3;
-            break;
-          case '4':
-            c += 4;
-            break;
-          case '5':
-            c += 5;
-            break;
-          case '6':
-            c += 6;
-            break;
-          case '7':
-            c += 7;
-            break;
-          case '8':
-            c += 8;
-            break;
-          case '9':
-            c += 9;
-            break;
-          case 'a':
-            c += 10;
-            break;
-          case 'b':
-            c += 11;
-            break;
-          case 'c':
-            c += 12;
-            break;
-          case 'd':
-            c += 13;
-            break;
-          case 'e':
-            c += 14;
-            break;
-          case 'f':
-            c += 15;
-            break;
-          default:
-            Assert (false, ExcInternalError());
-          }
-
-        u.push_back (static_cast<char>(c));
-
-        // skip the two characters
-        i += 2;
-      }
-
-  return u;
-}
-
-
-
-namespace
-{
   /**
    * Return whether a given node is a parameter node (as opposed
    * to being a subsection or alias node)

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -580,6 +580,21 @@ void ParameterHandler::parse_input_from_xml (std::istream &in)
 }
 
 
+void ParameterHandler::parse_input_from_json (std::istream &in)
+{
+  AssertThrow(in, ExcIO());
+
+  boost::property_tree::ptree node_tree;
+  // This boost function will raise an exception if this is not a valid JSON
+  // file.
+  read_json (in, node_tree);
+
+  // The xml function is reused to read in the xml into the paramter file.
+  // This means that only mangled files can be read.
+  read_xml_recursively (node_tree, "", path_separator, patterns, *entries);
+}
+
+
 
 void ParameterHandler::clear ()
 {

--- a/tests/parameter_handler/parameter_handler_read_json.cc
+++ b/tests/parameter_handler/parameter_handler_read_json.cc
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2002 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check ParameterHandler::parse_input_from_xml
+
+#include "../tests.h"
+#include <deal.II/base/parameter_handler.h>
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+
+  ParameterHandler prm;
+  prm.declare_entry ("int1",
+                     "1",
+                     Patterns::Integer(),
+                     "doc 1");
+  prm.declare_entry ("int2",
+                     "2",
+                     Patterns::Integer(),
+                     "doc 2");
+  prm.enter_subsection ("ss1");
+  {
+    prm.declare_entry ("double 1",
+                       "1.234",
+                       Patterns::Double(),
+                       "doc 3");
+
+    prm.enter_subsection ("ss2");
+    {
+      prm.declare_entry ("double 2",
+                         "4.321",
+                         Patterns::Double(),
+                         "doc 4");
+    }
+    prm.leave_subsection ();
+  }
+  prm.leave_subsection ();
+
+  // things with strange characters
+  prm.enter_subsection ("Testing%testing");
+  {
+    prm.declare_entry ("string&list",
+                       "< & > ; /",
+                       Patterns::Anything(),
+                       "docs 1");
+    prm.declare_entry ("int*int",
+                       "2",
+                       Patterns::Integer());
+    prm.declare_entry ("double+double",
+                       "6.1415926",
+                       Patterns::Double(),
+                       "docs 3");
+  }
+  prm.leave_subsection ();
+
+  // read from json
+  std::ifstream in (SOURCE_DIR "/prm/parameter_handler_read_json.prm");
+  prm.parse_input_from_json (in);
+
+  // write it out again
+  prm.print_parameters (deallog.get_file_stream(), ParameterHandler::JSON);
+  logfile << std::endl;
+
+  return 0;
+}

--- a/tests/parameter_handler/parameter_handler_read_json.output
+++ b/tests/parameter_handler/parameter_handler_read_json.output
@@ -1,0 +1,69 @@
+
+{
+    "int1":
+    {
+        "value": "2",
+        "default_value": "1",
+        "documentation": "doc 1",
+        "pattern": "0",
+        "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
+    },
+    "int2":
+    {
+        "value": "3",
+        "default_value": "2",
+        "documentation": "doc 2",
+        "pattern": "1",
+        "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
+    },
+    "ss1":
+    {
+        "double_201":
+        {
+            "value": "2.234",
+            "default_value": "1.234",
+            "documentation": "doc 3",
+            "pattern": "2",
+            "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+        },
+        "ss2":
+        {
+            "double_202":
+            {
+                "value": "5.321",
+                "default_value": "4.321",
+                "documentation": "doc 4",
+                "pattern": "3",
+                "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+            }
+        }
+    },
+    "Testing_25testing":
+    {
+        "string_26list":
+        {
+            "value": "< & > ; \/",
+            "default_value": "< & > ; \/",
+            "documentation": "docs 1",
+            "pattern": "4",
+            "pattern_description": "[Anything]"
+        },
+        "int_2aint":
+        {
+            "value": "2",
+            "default_value": "2",
+            "documentation": "",
+            "pattern": "5",
+            "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
+        },
+        "double_2bdouble":
+        {
+            "value": "7.1415926",
+            "default_value": "6.1415926",
+            "documentation": "docs 3",
+            "pattern": "6",
+            "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+        }
+    }
+}
+

--- a/tests/parameter_handler/prm/parameter_handler_read_json.prm
+++ b/tests/parameter_handler/prm/parameter_handler_read_json.prm
@@ -1,0 +1,69 @@
+
+{
+    "int1":
+    {
+        "value": "2",
+        "default_value": "1",
+        "documentation": "doc 1",
+        "pattern": "0",
+        "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
+    },
+    "int2":
+    {
+        "value": "3",
+        "default_value": "2",
+        "documentation": "doc 2",
+        "pattern": "1",
+        "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
+    },
+    "ss1":
+    {
+        "double_201":
+        {
+            "value": "2.234",
+            "default_value": "1.234",
+            "documentation": "doc 3",
+            "pattern": "2",
+            "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+        },
+        "ss2":
+        {
+            "double_202":
+            {
+                "value": "5.321",
+                "default_value": "4.321",
+                "documentation": "doc 4",
+                "pattern": "3",
+                "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+            }
+        }
+    },
+    "Testing_25testing":
+    {
+        "string_26list":
+        {
+            "value": "< & > ; \/",
+            "default_value": "< & > ; \/",
+            "documentation": "docs 1",
+            "pattern": "4",
+            "pattern_description": "[Anything]"
+        },
+        "int_2aint":
+        {
+            "value": "2",
+            "default_value": "2",
+            "documentation": "",
+            "pattern": "5",
+            "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
+        },
+        "double_2bdouble":
+        {
+            "value": "7.1415926",
+            "default_value": "6.1415926",
+            "documentation": "docs 3",
+            "pattern": "6",
+            "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+        }
+    }
+}
+


### PR DESCRIPTION
This adds the possibility of parsing json files to the parameter handler. I tried to follow the xml implementation as closely as possible, but I think the xml implementation contains a bug, which doesn't to use spaces in the names of variables. That is solved here by making the mangler public and using it to escape/mangle the text. 

If it is agreed that this is a correct implementation, I can add some tests. We also might want to make demangle public.