### PR TITLE
Avoid clashes of class names and namespace names

### DIFF
--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -753,7 +753,7 @@ namespace parallel
 
 namespace internal
 {
-  namespace Vector
+  namespace VectorImplementation
   {
     /**
      * If we do computations on vectors in parallel (say, we add two vectors
@@ -773,10 +773,10 @@ namespace internal
   }
 
 
-  namespace SparseMatrix
+  namespace SparseMatrixImplementation
   {
     /**
-     * Like internal::Vector::minimum_parallel_grain_size, but now denoting
+     * Like internal::VectorImplementation::minimum_parallel_grain_size, but now denoting
      * the number of rows of a matrix that should be worked on as a minimum.
      */
     extern unsigned int minimum_parallel_grain_size;

--- a/include/deal.II/base/polynomials_rannacher_turek.h
+++ b/include/deal.II/base/polynomials_rannacher_turek.h
@@ -94,7 +94,7 @@ public:
 
 namespace internal
 {
-  namespace PolynomialsRannacherTurek
+  namespace PolynomialsRannacherTurekImplementation
   {
     template <int order, int dim>
     inline
@@ -199,7 +199,7 @@ Tensor<order,dim>
 PolynomialsRannacherTurek<dim>::compute_derivative (const unsigned int i,
                                                     const Point<dim> &p) const
 {
-  return internal::PolynomialsRannacherTurek::compute_derivative<order> (i, p);
+  return internal::PolynomialsRannacherTurekImplementation::compute_derivative<order> (i, p);
 }
 
 

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -62,7 +62,7 @@ namespace internal
    * A namespace for functions and classes that are internal to how the
    * SymmetricTensor class (and its associate functions) works.
    */
-  namespace SymmetricTensor
+  namespace SymmetricTensorImplementation
   {
     /**
      * Compute the inverse of a symmetric tensor of a
@@ -896,9 +896,9 @@ private:
   /**
    * Make a few helper classes friends as well.
    */
-  friend struct internal::SymmetricTensor::Inverse<2,dim,Number>;
+  friend struct internal::SymmetricTensorImplementation::Inverse<2,dim,Number>;
 
-  friend struct internal::SymmetricTensor::Inverse<4,dim,Number>;
+  friend struct internal::SymmetricTensorImplementation::Inverse<4,dim,Number>;
 };
 
 
@@ -1084,7 +1084,7 @@ SymmetricTensor<rank_,dim,Number>::operator = (const Number &d)
 
 namespace internal
 {
-  namespace SymmetricTensor
+  namespace SymmetricTensorImplementation
   {
     template <int dim, typename Number>
     dealii::Tensor<2,dim,Number>
@@ -1403,7 +1403,7 @@ inline
 SymmetricTensor<rank_,dim,Number>::
 operator Tensor<rank_,dim,Number> () const
 {
-  return internal::SymmetricTensor::convert_to_tensor (*this);
+  return internal::SymmetricTensorImplementation::convert_to_tensor (*this);
 }
 
 
@@ -1996,7 +1996,7 @@ SymmetricTensor<rank_,dim,Number>::operator ()
 
 namespace internal
 {
-  namespace SymmetricTensor
+  namespace SymmetricTensorImplementation
   {
     template <int rank_>
     TableIndices<rank_>
@@ -2031,7 +2031,7 @@ SymmetricTensor<rank_,dim,Number>::operator [] (const unsigned int row) const
   return
     internal::SymmetricTensorAccessors::
     Accessor<rank_,dim,true,rank_-1,Number> (*this,
-                                             internal::SymmetricTensor::get_partially_filled_indices<rank_> (row,
+                                             internal::SymmetricTensorImplementation::get_partially_filled_indices<rank_> (row,
                                                  std::integral_constant<int, rank_>()));
 }
 
@@ -2044,7 +2044,7 @@ SymmetricTensor<rank_,dim,Number>::operator [] (const unsigned int row)
   return
     internal::SymmetricTensorAccessors::
     Accessor<rank_,dim,false,rank_-1,Number> (*this,
-                                              internal::SymmetricTensor::get_partially_filled_indices<rank_> (row,
+                                              internal::SymmetricTensorImplementation::get_partially_filled_indices<rank_> (row,
                                                   std::integral_constant<int, rank_>()));
 }
 
@@ -2112,7 +2112,7 @@ SymmetricTensor<rank_,dim,Number>::end_raw() const
 
 namespace internal
 {
-  namespace SymmetricTensor
+  namespace SymmetricTensorImplementation
   {
     template <int dim, typename Number>
     unsigned int
@@ -2144,7 +2144,7 @@ const Number &
 SymmetricTensor<rank_,dim,Number>::access_raw_entry (const unsigned int index) const
 {
   AssertIndexRange (index, n_independent_components);
-  return data[internal::SymmetricTensor::entry_to_indices(*this, index)];
+  return data[internal::SymmetricTensorImplementation::entry_to_indices(*this, index)];
 }
 
 
@@ -2155,7 +2155,7 @@ Number &
 SymmetricTensor<rank_,dim,Number>::access_raw_entry (const unsigned int index)
 {
   AssertIndexRange (index, n_independent_components);
-  return data[internal::SymmetricTensor::entry_to_indices(*this, index)];
+  return data[internal::SymmetricTensorImplementation::entry_to_indices(*this, index)];
 }
 
 
@@ -2253,7 +2253,7 @@ SymmetricTensor<rank_,dim,Number>::norm () const
 
 namespace internal
 {
-  namespace SymmetricTensor
+  namespace SymmetricTensorImplementation
   {
     namespace
     {
@@ -2353,14 +2353,14 @@ unsigned int
 SymmetricTensor<rank_,dim,Number>::component_to_unrolled_index
 (const TableIndices<rank_> &indices)
 {
-  return internal::SymmetricTensor::component_to_unrolled_index<dim> (indices);
+  return internal::SymmetricTensorImplementation::component_to_unrolled_index<dim> (indices);
 }
 
 
 
 namespace internal
 {
-  namespace SymmetricTensor
+  namespace SymmetricTensorImplementation
   {
     namespace
     {
@@ -2460,7 +2460,7 @@ SymmetricTensor<rank_,dim,Number>::unrolled_to_component_indices
 (const unsigned int i)
 {
   return
-    internal::SymmetricTensor::unrolled_to_component_indices<dim> (i,
+    internal::SymmetricTensorImplementation::unrolled_to_component_indices<dim> (i,
         std::integral_constant<int, rank_>());
 }
 
@@ -2830,7 +2830,7 @@ eigenvalues (const SymmetricTensor<2,3,Number> &T);
 
 namespace internal
 {
-  namespace SymmetricTensor
+  namespace SymmetricTensorImplementation
   {
     /**
      * Tridiagonalize a rank-2 symmetric tensor using the Householder method.
@@ -3164,13 +3164,13 @@ eigenvectors (const SymmetricTensor<2,dim,Number>         &T,
   switch (method)
     {
     case SymmetricTensorEigenvectorMethod::hybrid:
-      eig_vals_vecs = internal::SymmetricTensor::hybrid(T);
+      eig_vals_vecs = internal::SymmetricTensorImplementation::hybrid(T);
       break;
     case SymmetricTensorEigenvectorMethod::ql_implicit_shifts:
-      eig_vals_vecs = internal::SymmetricTensor::ql_implicit_shifts(T);
+      eig_vals_vecs = internal::SymmetricTensorImplementation::ql_implicit_shifts(T);
       break;
     case SymmetricTensorEigenvectorMethod::jacobi:
-      eig_vals_vecs = internal::SymmetricTensor::jacobi(T);
+      eig_vals_vecs = internal::SymmetricTensorImplementation::jacobi(T);
       break;
     default:
       AssertThrow(false, ExcNotImplemented());
@@ -3178,7 +3178,7 @@ eigenvectors (const SymmetricTensor<2,dim,Number>         &T,
 
   // Sort in descending order before output.
   std::sort(eig_vals_vecs.begin(), eig_vals_vecs.end(),
-            internal::SymmetricTensor::SortEigenValuesVectors<dim,Number>());
+            internal::SymmetricTensorImplementation::SortEigenValuesVectors<dim,Number>());
   return eig_vals_vecs;
 }
 
@@ -3441,7 +3441,7 @@ inline
 SymmetricTensor<2,dim,Number>
 invert (const SymmetricTensor<2,dim,Number> &t)
 {
-  return internal::SymmetricTensor::Inverse<2,dim,Number>::value(t);
+  return internal::SymmetricTensorImplementation::Inverse<2,dim,Number>::value(t);
 }
 
 
@@ -3462,7 +3462,7 @@ inline
 SymmetricTensor<4,dim,Number>
 invert (const SymmetricTensor<4,dim,Number> &t)
 {
-  return internal::SymmetricTensor::Inverse<4,dim,Number>::value(t);
+  return internal::SymmetricTensorImplementation::Inverse<4,dim,Number>::value(t);
 }
 
 

--- a/include/deal.II/base/symmetric_tensor.templates.h
+++ b/include/deal.II/base/symmetric_tensor.templates.h
@@ -141,7 +141,7 @@ eigenvalues (const SymmetricTensor<2,3,Number> &T)
 
 namespace internal
 {
-  namespace SymmetricTensor
+  namespace SymmetricTensorImplementation
   {
     template <int dim, typename Number>
     void

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -1966,7 +1966,7 @@ TableBase<N,T>::empty () const
 
 namespace internal
 {
-  namespace Table
+  namespace TableImplementation
   {
     template <typename InputIterator, typename T>
     void fill_Fortran_style (InputIterator  entries,
@@ -2026,7 +2026,7 @@ TableBase<N,T>::fill (InputIterator entries,
          p != values.end(); ++p)
       *p = *entries++;
   else
-    internal::Table::fill_Fortran_style (entries, *this);
+    internal::TableImplementation::fill_Fortran_style (entries, *this);
 }
 
 

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -54,7 +54,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     namespace Policy
     {
@@ -863,7 +863,7 @@ namespace parallel
       std::vector<bool>
       mark_locally_active_vertices_on_level(const int level) const;
 
-      template <typename> friend class dealii::internal::DoFHandler::Policy::ParallelDistributed;
+      template <typename> friend class dealii::internal::DoFHandlerImplementation::Policy::ParallelDistributed;
 
       template <int,int,class> friend class dealii::FETools::internal::ExtrapolateImplementation;
     };

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -37,12 +37,12 @@ template <int, int> class FiniteElement;
 
 namespace internal
 {
-  namespace DoFCellAccessor
+  namespace DoFCellAccessorImplementation
   {
     struct Implementation;
   }
 
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     struct Implementation;
     namespace Policy
@@ -53,7 +53,7 @@ namespace internal
 
   namespace hp
   {
-    namespace DoFHandler
+    namespace DoFHandlerImplementation
     {
       struct Implementation;
     }
@@ -68,7 +68,7 @@ namespace internal
 
 namespace internal
 {
-  namespace DoFAccessor
+  namespace DoFAccessorImplementation
   {
     /**
      * This is a switch class which only declares a @p typedef. It is meant to
@@ -198,7 +198,7 @@ namespace internal
  * 2012, 2013
  */
 template <int structdim, typename DoFHandlerType, bool level_dof_access>
-class DoFAccessor : public dealii::internal::DoFAccessor::Inheritance<structdim, DoFHandlerType::dimension, DoFHandlerType::space_dimension>::BaseClass
+class DoFAccessor : public dealii::internal::DoFAccessorImplementation::Inheritance<structdim, DoFHandlerType::dimension, DoFHandlerType::space_dimension>::BaseClass
 {
 public:
 
@@ -219,7 +219,7 @@ public:
    * exception classes simpler.
    */
   typedef
-  typename dealii::internal::DoFAccessor::Inheritance<structdim, dimension, space_dimension>::BaseClass
+  typename dealii::internal::DoFAccessorImplementation::Inheritance<structdim, dimension, space_dimension>::BaseClass
   BaseClass;
 
   /**
@@ -345,7 +345,7 @@ public:
    * a line itself, then the only valid index is @p i equals to zero, and the
    * function returns an iterator to itself.
    */
-  typename dealii::internal::DoFHandler::Iterators<DoFHandlerType, level_dof_access>::line_iterator
+  typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType, level_dof_access>::line_iterator
   line (const unsigned int i) const;
 
   /**
@@ -353,7 +353,7 @@ public:
    * a quad itself, then the only valid index is @p i equals to zero, and the
    * function returns an iterator to itself.
    */
-  typename dealii::internal::DoFHandler::Iterators<DoFHandlerType, level_dof_access>::quad_iterator
+  typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType, level_dof_access>::quad_iterator
   quad (const unsigned int i) const;
 
   /**
@@ -690,11 +690,11 @@ private:
   template <int dim, int spacedim> friend class DoFHandler;
   template <int dim, int spacedim> friend class hp::DoFHandler;
 
-  friend struct dealii::internal::DoFHandler::Policy::Implementation;
-  friend struct dealii::internal::DoFHandler::Implementation;
-  friend struct dealii::internal::hp::DoFHandler::Implementation;
-  friend struct dealii::internal::DoFCellAccessor::Implementation;
-  friend struct dealii::internal::DoFAccessor::Implementation;
+  friend struct dealii::internal::DoFHandlerImplementation::Policy::Implementation;
+  friend struct dealii::internal::DoFHandlerImplementation::Implementation;
+  friend struct dealii::internal::hp::DoFHandlerImplementation::Implementation;
+  friend struct dealii::internal::DoFCellAccessorImplementation::Implementation;
+  friend struct dealii::internal::DoFAccessorImplementation::Implementation;
 };
 
 
@@ -855,7 +855,7 @@ public:
    * Since meshes with dimension 1 do not have quads this method just throws
    * an exception.
    */
-  typename dealii::internal::DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::line_iterator
+  typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::line_iterator
   line (const unsigned int i) const;
 
   /**
@@ -864,7 +864,7 @@ public:
    * Since meshes with dimension 1 do not have quads this method just throws
    * an exception.
    */
-  typename dealii::internal::DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::quad_iterator
+  typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::quad_iterator
   quad (const unsigned int i) const;
 
   /**
@@ -1135,10 +1135,10 @@ protected:
   template <int, int> friend class DoFHandler;
   template <int, int> friend class hp::DoFHandler;
 
-  friend struct dealii::internal::DoFHandler::Policy::Implementation;
-  friend struct dealii::internal::DoFHandler::Implementation;
-  friend struct dealii::internal::hp::DoFHandler::Implementation;
-  friend struct dealii::internal::DoFCellAccessor::Implementation;
+  friend struct dealii::internal::DoFHandlerImplementation::Policy::Implementation;
+  friend struct dealii::internal::DoFHandlerImplementation::Implementation;
+  friend struct dealii::internal::hp::DoFHandlerImplementation::Implementation;
+  friend struct dealii::internal::DoFCellAccessorImplementation::Implementation;
 };
 
 
@@ -1835,7 +1835,7 @@ private:
    * update_cell_dof_indices_cache() function
    */
   template <int dim, int spacedim> friend class DoFHandler;
-  friend struct dealii::internal::DoFCellAccessor::Implementation;
+  friend struct dealii::internal::DoFCellAccessorImplementation::Implementation;
 };
 
 

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -55,7 +55,7 @@ DoFAccessor (const Triangulation<DoFHandlerType::dimension,DoFHandlerType::space
              const int             index,
              const DoFHandlerType *dof_handler)
   :
-  dealii::internal::DoFAccessor::Inheritance<structdim,DoFHandlerType::dimension,
+  dealii::internal::DoFAccessorImplementation::Inheritance<structdim,DoFHandlerType::dimension,
   DoFHandlerType::space_dimension>::BaseClass (tria,
                                                level,
                                                index),
@@ -201,7 +201,7 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::child (const unsigned in
 
 namespace internal
 {
-  namespace DoFAccessor
+  namespace DoFAccessorImplementation
   {
     /**
      * A class like the one with same name in tria.cc. See there for more
@@ -791,7 +791,7 @@ namespace internal
                  (structdim==1
                   ?
                   typename
-                  internal::Triangulation::Iterators<dim,spacedim>::
+                  internal::TriangulationImplementation::Iterators<dim,spacedim>::
                   raw_line_iterator (&dof_handler.get_triangulation(),
                                      obj_level,
                                      obj_index)->used()
@@ -841,7 +841,7 @@ namespace internal
                  (structdim==1
                   ?
                   typename
-                  internal::Triangulation::Iterators<dim,spacedim>::
+                  internal::TriangulationImplementation::Iterators<dim,spacedim>::
                   raw_line_iterator (&dof_handler.get_triangulation(),
                                      obj_level,
                                      obj_index)->used()
@@ -1599,7 +1599,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::dof_index (const unsigned int 
     const unsigned int fe_index) const
 {
   // access the respective DoF
-  return dealii::internal::DoFAccessor::Implementation::get_dof_index (*this->dof_handler,
+  return dealii::internal::DoFAccessorImplementation::Implementation::get_dof_index (*this->dof_handler,
          this->level(),
          this->present_index,
          fe_index,
@@ -1626,7 +1626,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::set_dof_index (const unsigned 
     const unsigned int fe_index) const
 {
   // access the respective DoF
-  dealii::internal::DoFAccessor::Implementation::set_dof_index (*this->dof_handler,
+  dealii::internal::DoFAccessorImplementation::Implementation::set_dof_index (*this->dof_handler,
       this->level(),
       this->present_index,
       fe_index,
@@ -1644,7 +1644,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::n_active_fe_indices () const
 {
   // access the respective DoF
   return
-    dealii::internal::DoFAccessor::Implementation::
+    dealii::internal::DoFAccessorImplementation::Implementation::
     n_active_fe_indices (*this->dof_handler,
                          this->level(),
                          this->present_index,
@@ -1660,7 +1660,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::nth_active_fe_index (const uns
 {
   // access the respective DoF
   return
-    dealii::internal::DoFAccessor::Implementation::
+    dealii::internal::DoFAccessorImplementation::Implementation::
     nth_active_fe_index (*this->dof_handler,
                          this->level(),
                          this->present_index,
@@ -1677,7 +1677,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::fe_index_is_active (const unsi
 {
   // access the respective DoF
   return
-    dealii::internal::DoFAccessor::Implementation::
+    dealii::internal::DoFAccessorImplementation::Implementation::
     fe_index_is_active (*this->dof_handler,
                         this->level(),
                         this->present_index,
@@ -1696,7 +1696,7 @@ DoFAccessor<structdim, DoFHandlerType,level_dof_access>::vertex_dof_index
  const unsigned int fe_index) const
 {
   return
-    dealii::internal::DoFAccessor::Implementation::get_vertex_dof_index
+    dealii::internal::DoFAccessorImplementation::Implementation::get_vertex_dof_index
     (*this->dof_handler,
      this->vertex_index(vertex),
      fe_index,
@@ -1720,7 +1720,7 @@ DoFAccessor<structdim, DoFHandlerType,level_dof_access>::mg_vertex_dof_index (co
           ExcIndexRange (i, 0, this->dof_handler->get_fe (fe_index).dofs_per_vertex));
 
   return
-    dealii::internal::DoFAccessor::Implementation::mg_vertex_dof_index
+    dealii::internal::DoFAccessorImplementation::Implementation::mg_vertex_dof_index
     (*this->dof_handler,
      level,
      this->vertex_index(vertex),
@@ -1736,7 +1736,7 @@ DoFAccessor<structdim, DoFHandlerType,level_dof_access>::set_vertex_dof_index (c
     const types::global_dof_index index,
     const unsigned int fe_index) const
 {
-  dealii::internal::DoFAccessor::Implementation::set_vertex_dof_index
+  dealii::internal::DoFAccessorImplementation::Implementation::set_vertex_dof_index
   (*this->dof_handler,
    this->vertex_index(vertex),
    fe_index,
@@ -1763,7 +1763,7 @@ DoFAccessor<structdim, DoFHandlerType,level_dof_access>::set_mg_vertex_dof_index
           ExcIndexRange (i, 0, this->dof_handler->get_fe (fe_index).dofs_per_vertex));
 
   return
-    dealii::internal::DoFAccessor::Implementation::set_mg_vertex_dof_index
+    dealii::internal::DoFAccessorImplementation::Implementation::set_mg_vertex_dof_index
     (*this->dof_handler,
      level,
      this->vertex_index(vertex),
@@ -1800,7 +1800,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::get_fe (const unsigned int fe_
 
 namespace internal
 {
-  namespace DoFAccessor
+  namespace DoFAccessorImplementation
   {
     template <typename DoFHandlerType, bool level_dof_access>
     void get_dof_indices (const dealii::DoFAccessor<1,DoFHandlerType,level_dof_access> &accessor,
@@ -2065,7 +2065,7 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::get_dof_indices
           ExcInternalError());
 
   // now do the actual work
-  dealii::internal::DoFAccessor::get_dof_indices (*this, dof_indices, fe_index);
+  dealii::internal::DoFAccessorImplementation::get_dof_indices (*this, dof_indices, fe_index);
 }
 
 
@@ -2115,10 +2115,10 @@ void DoFAccessor<structdim, DoFHandlerType,level_dof_access>::get_mg_dof_indices
       Assert (false, ExcNotImplemented ());
     }
 
-  internal::DoFAccessor::get_mg_dof_indices (*this,
-                                             level,
-                                             dof_indices,
-                                             fe_index);
+  internal::DoFAccessorImplementation::get_mg_dof_indices (*this,
+                                                           level,
+                                                           dof_indices,
+                                                           fe_index);
 }
 
 
@@ -2167,20 +2167,20 @@ void DoFAccessor<structdim, DoFHandlerType,level_dof_access>::set_mg_dof_indices
       Assert (false, ExcNotImplemented ());
     }
 
-  internal::DoFAccessor::Implementation::set_mg_dof_indices (*this,
-                                                             level,
-                                                             dof_indices,
-                                                             fe_index);
+  internal::DoFAccessorImplementation::Implementation::set_mg_dof_indices (*this,
+      level,
+      dof_indices,
+      fe_index);
 }
 
 
 namespace internal
 {
-  namespace DoFAccessor
+  namespace DoFAccessorImplementation
   {
     template <bool level_dof_access, typename DoFHandlerType>
     inline
-    typename dealii::internal::DoFHandler::Iterators<DoFHandlerType, level_dof_access>::quad_iterator
+    typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType, level_dof_access>::quad_iterator
     get_quad(const dealii::Triangulation<DoFHandlerType::dimension, DoFHandlerType::space_dimension> *,
              unsigned int /*index*/,
              DoFHandlerType *)
@@ -2190,46 +2190,46 @@ namespace internal
 
     template <bool level_dof_access>
     inline
-    typename dealii::internal::DoFHandler::Iterators<dealii::DoFHandler<2,2>, level_dof_access>::quad_iterator
+    typename dealii::internal::DoFHandlerImplementation::Iterators<dealii::DoFHandler<2,2>, level_dof_access>::quad_iterator
     get_quad(const dealii::Triangulation<2,2> *,
              unsigned int,
              dealii::DoFHandler<2,2> *)
     {
       Assert(false, ExcNotImplemented());
-      return typename dealii::internal::DoFHandler::Iterators<dealii::DoFHandler<2,2>, level_dof_access>::line_iterator();
+      return typename dealii::internal::DoFHandlerImplementation::Iterators<dealii::DoFHandler<2,2>, level_dof_access>::line_iterator();
     }
 
     template <bool level_dof_access>
     inline
-    typename dealii::internal::DoFHandler::Iterators<dealii::DoFHandler<2,3>, level_dof_access>::quad_iterator
+    typename dealii::internal::DoFHandlerImplementation::Iterators<dealii::DoFHandler<2,3>, level_dof_access>::quad_iterator
     get_quad(const dealii::Triangulation<2,3> *,
              unsigned int,
              dealii::DoFHandler<2,3> *)
     {
       Assert(false, ExcNotImplemented());
-      return typename dealii::internal::DoFHandler::Iterators<dealii::DoFHandler<2,3>, level_dof_access>::line_iterator();
+      return typename dealii::internal::DoFHandlerImplementation::Iterators<dealii::DoFHandler<2,3>, level_dof_access>::line_iterator();
     }
 
     template <bool level_dof_access>
     inline
-    typename dealii::internal::DoFHandler::Iterators<dealii::hp::DoFHandler<2,2>, level_dof_access>::quad_iterator
+    typename dealii::internal::DoFHandlerImplementation::Iterators<dealii::hp::DoFHandler<2,2>, level_dof_access>::quad_iterator
     get_quad(const dealii::Triangulation<2,2> *,
              unsigned int,
              dealii::hp::DoFHandler<2,2> *)
     {
       Assert(false, ExcNotImplemented());
-      return typename dealii::internal::DoFHandler::Iterators<dealii::hp::DoFHandler<2,2>, level_dof_access>::line_iterator();
+      return typename dealii::internal::DoFHandlerImplementation::Iterators<dealii::hp::DoFHandler<2,2>, level_dof_access>::line_iterator();
     }
 
     template <bool level_dof_access>
     inline
-    typename dealii::internal::DoFHandler::Iterators<dealii::hp::DoFHandler<2,3>, level_dof_access>::quad_iterator
+    typename dealii::internal::DoFHandlerImplementation::Iterators<dealii::hp::DoFHandler<2,3>, level_dof_access>::quad_iterator
     get_quad(const dealii::Triangulation<2,3> *,
              unsigned int,
              dealii::hp::DoFHandler<2,3> *)
     {
       Assert(false, ExcNotImplemented());
-      return typename dealii::internal::DoFHandler::Iterators<dealii::hp::DoFHandler<2,3>, level_dof_access>::line_iterator();
+      return typename dealii::internal::DoFHandlerImplementation::Iterators<dealii::hp::DoFHandler<2,3>, level_dof_access>::line_iterator();
     }
   }
 }
@@ -2237,7 +2237,7 @@ namespace internal
 
 template <int structdim, typename DoFHandlerType, bool level_dof_access>
 inline
-typename dealii::internal::DoFHandler::Iterators<DoFHandlerType,level_dof_access>::line_iterator
+typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType,level_dof_access>::line_iterator
 DoFAccessor<structdim,DoFHandlerType,level_dof_access>::line (const unsigned int i) const
 {
   // if we are asking for a particular line and this object refers to
@@ -2248,7 +2248,7 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::line (const unsigned int
       Assert (i==0, ExcMessage ("You can only ask for line zero if the "
                                 "current object is a line itself."));
       return
-        typename dealii::internal::DoFHandler::Iterators<DoFHandlerType,level_dof_access>::cell_iterator
+        typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType,level_dof_access>::cell_iterator
         (&this->get_triangulation(),
          this->level(),
          this->index(),
@@ -2260,7 +2260,7 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::line (const unsigned int
   Assert (DoFHandlerType::dimension > 1, ExcImpossibleInDim(DoFHandlerType::dimension));
 
   // checking of 'i' happens in line_index(i)
-  return typename dealii::internal::DoFHandler::Iterators<DoFHandlerType,level_dof_access>::line_iterator
+  return typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType,level_dof_access>::line_iterator
          (this->tria,
           0,  // only sub-objects are allowed, which have no level
           this->line_index(i),
@@ -2270,7 +2270,7 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::line (const unsigned int
 
 template <int structdim, typename DoFHandlerType, bool level_dof_access>
 inline
-typename dealii::internal::DoFHandler::Iterators<DoFHandlerType,level_dof_access>::quad_iterator
+typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType,level_dof_access>::quad_iterator
 DoFAccessor<structdim,DoFHandlerType,level_dof_access>::quad (const unsigned int i) const
 {
   // if we are asking for a
@@ -2283,7 +2283,7 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::quad (const unsigned int
       Assert (i==0, ExcMessage ("You can only ask for quad zero if the "
                                 "current object is a quad itself."));
       return
-        typename dealii::internal::DoFHandler::Iterators<DoFHandlerType>::cell_iterator
+        typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType>::cell_iterator
         (&this->get_triangulation(),
          this->level(),
          this->index(),
@@ -2295,7 +2295,7 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::quad (const unsigned int
   Assert (DoFHandlerType::dimension > 2, ExcImpossibleInDim(DoFHandlerType::dimension));
 
   // checking of 'i' happens in quad_index(i)
-  return typename dealii::internal::DoFHandler::Iterators<DoFHandlerType,level_dof_access>::quad_iterator
+  return typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType,level_dof_access>::quad_iterator
          (this->tria,
           0,  // only sub-objects are allowed, which have no level
           this->quad_index(i),
@@ -2425,7 +2425,7 @@ DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::get_dof_indices
 {
   for (unsigned int i=0; i<dof_indices.size(); ++i)
     dof_indices[i]
-      = dealii::internal::DoFAccessor::Implementation::get_vertex_dof_index (
+      = dealii::internal::DoFAccessorImplementation::Implementation::get_vertex_dof_index (
           *dof_handler,
           this->global_vertex_index,
           fe_index,
@@ -2464,7 +2464,7 @@ vertex_dof_index (const unsigned int vertex,
 {
   (void)vertex;
   Assert (vertex == 0, ExcIndexRange (vertex, 0, 1));
-  return dealii::internal::DoFAccessor::Implementation::get_vertex_dof_index (
+  return dealii::internal::DoFAccessorImplementation::Implementation::get_vertex_dof_index (
            *dof_handler,
            this->global_vertex_index,
            fe_index,
@@ -2480,7 +2480,7 @@ DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
 dof_index (const unsigned int i,
            const unsigned int fe_index) const
 {
-  return dealii::internal::DoFAccessor::Implementation::get_vertex_dof_index
+  return dealii::internal::DoFAccessorImplementation::Implementation::get_vertex_dof_index
          (*this->dof_handler,
           this->vertex_index(0),
           fe_index,
@@ -2574,26 +2574,26 @@ DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::child (const unsign
 
 template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
 inline
-typename dealii::internal::DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::line_iterator
+typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::line_iterator
 DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::line
 (const unsigned int /*c*/) const
 {
   Assert(false, ExcNotImplemented());
   return typename dealii::internal::
-         DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::line_iterator();
+         DoFHandlerImplementation::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::line_iterator();
 }
 
 
 
 template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
 inline
-typename dealii::internal::DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::quad_iterator
+typename dealii::internal::DoFHandlerImplementation::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::quad_iterator
 DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::quad
 (const unsigned int /*c*/) const
 {
   Assert(false, ExcNotImplemented());
   return typename dealii::internal::
-         DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::quad_iterator();
+         DoFHandlerImplementation::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::quad_iterator();
 }
 
 
@@ -2631,7 +2631,7 @@ DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::operator !=
 
 namespace internal
 {
-  namespace DoFCellAccessor
+  namespace DoFCellAccessorImplementation
   {
     // make sure we refer to class
     // dealii::DoFCellAccessor, not
@@ -3385,7 +3385,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::parent () const
 
 namespace internal
 {
-  namespace DoFCellAccessor
+  namespace DoFCellAccessorImplementation
   {
     template <typename DoFHandlerType, bool level_dof_access>
     inline
@@ -3443,7 +3443,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::face (const unsigned int i) co
   Assert (i<GeometryInfo<dim>::faces_per_cell, ExcIndexRange (i, 0, GeometryInfo<dim>::faces_per_cell));
 
   const unsigned int dim = DoFHandlerType::dimension;
-  return dealii::internal::DoFCellAccessor::get_face (*this, i, std::integral_constant<int, dim>());
+  return dealii::internal::DoFCellAccessorImplementation::get_face (*this, i, std::integral_constant<int, dim>());
 }
 
 
@@ -3539,7 +3539,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::get_dof_values
   const types::global_dof_index *cache
     = this->dof_handler->levels[this->present_level]
       ->get_cell_cache_start (this->present_index, this->get_fe().dofs_per_cell);
-  dealii::internal::DoFAccessor::Implementation::extract_subvector_to(
+  dealii::internal::DoFAccessorImplementation::Implementation::extract_subvector_to(
     values, cache, cache + this->get_fe().dofs_per_cell, local_values_begin);
 }
 
@@ -3649,7 +3649,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::active_fe_index () const
                       "that are either locally owned or (after distributing "
                       "degrees of freedom) are ghost cells."));
 
-  return dealii::internal::DoFCellAccessor::Implementation::active_fe_index (*this);
+  return dealii::internal::DoFCellAccessorImplementation::Implementation::active_fe_index (*this);
 }
 
 
@@ -3676,7 +3676,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::set_active_fe_index (const uns
                       "will automatically be propagated from the owning process "
                       "of that cell, and there is no information at all on "
                       "artificial cells."));
-  dealii::internal::DoFCellAccessor::Implementation::set_active_fe_index (*this, i);
+  dealii::internal::DoFCellAccessorImplementation::Implementation::set_active_fe_index (*this, i);
 }
 
 
@@ -3690,7 +3690,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::distribute_local_to_global
 (const Vector<number> &local_source,
  OutputVector         &global_destination) const
 {
-  dealii::internal::DoFCellAccessor::Implementation::
+  dealii::internal::DoFCellAccessorImplementation::Implementation::
   distribute_local_to_global (*this, local_source.begin(),
                               local_source.end(), global_destination);
 }
@@ -3706,7 +3706,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::distribute_local_to_global
  ForwardIterator  local_source_end,
  OutputVector    &global_destination) const
 {
-  dealii::internal::DoFCellAccessor::Implementation::
+  dealii::internal::DoFCellAccessorImplementation::Implementation::
   distribute_local_to_global (*this, local_source_begin,
                               local_source_end, global_destination);
 }
@@ -3723,7 +3723,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::distribute_local_to_global
  ForwardIterator         local_source_end,
  OutputVector           &global_destination) const
 {
-  dealii::internal::DoFCellAccessor::Implementation::
+  dealii::internal::DoFCellAccessorImplementation::Implementation::
   distribute_local_to_global (*this, constraints, local_source_begin,
                               local_source_end, global_destination);
 }
@@ -3738,7 +3738,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::distribute_local_to_global
 (const FullMatrix<number> &local_source,
  OutputMatrix             &global_destination) const
 {
-  dealii::internal::DoFCellAccessor::Implementation::
+  dealii::internal::DoFCellAccessorImplementation::Implementation::
   distribute_local_to_global (*this,local_source,global_destination);
 }
 
@@ -3754,7 +3754,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::distribute_local_to_global
  OutputMatrix             &global_matrix,
  OutputVector             &global_vector) const
 {
-  dealii::internal::DoFCellAccessor::Implementation::
+  dealii::internal::DoFCellAccessorImplementation::Implementation::
   distribute_local_to_global (*this,local_matrix,local_vector,
                               global_matrix,global_vector);
 }

--- a/include/deal.II/dofs/dof_faces.h
+++ b/include/deal.II/dofs/dof_faces.h
@@ -32,7 +32,7 @@ namespace internal
    *
    * @ingroup dofs
    */
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
 
     /**
@@ -113,7 +113,7 @@ namespace internal
       /**
        * The object containing the data of DoFs on lines.
        */
-      internal::DoFHandler::DoFObjects<1> lines;
+      internal::DoFHandlerImplementation::DoFObjects<1> lines;
 
       /**
        * Determine an estimate for the memory consumption (in bytes) of this
@@ -143,12 +143,12 @@ namespace internal
       /**
        * The object containing the data of DoFs on lines.
        */
-      internal::DoFHandler::DoFObjects<1> lines;
+      internal::DoFHandlerImplementation::DoFObjects<1> lines;
 
       /**
        * The object containing the data of DoFs on quads.
        */
-      internal::DoFHandler::DoFObjects<2> quads;
+      internal::DoFHandlerImplementation::DoFObjects<2> quads;
 
       /**
        * Determine an estimate for the memory consumption (in bytes) of this

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -45,7 +45,7 @@ template <int dim, int spacedim> class Triangulation;
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     struct Implementation;
 
@@ -56,12 +56,12 @@ namespace internal
     }
   }
 
-  namespace DoFAccessor
+  namespace DoFAccessorImplementation
   {
     struct Implementation;
   }
 
-  namespace DoFCellAccessor
+  namespace DoFCellAccessorImplementation
   {
     struct Implementation;
   }
@@ -88,7 +88,7 @@ namespace internal
  * matrices also refer to all degrees of freedom and some kind of condensation
  * is needed to restrict the systems of equations to the unconstrained degrees
  * of freedom only. The actual layout of storage of the indices is described
- * in the dealii::internal::DoFHandler::DoFLevel class documentation.
+ * in the dealii::internal::DoFHandlerImplementation::DoFLevel class documentation.
  *
  * The class offers iterators to traverse all cells, in much the same way as
  * the Triangulation class does. Using the begin() and end() functions (and
@@ -191,8 +191,8 @@ namespace internal
 template <int dim, int spacedim=dim>
 class DoFHandler  :  public Subscriptor
 {
-  typedef dealii::internal::DoFHandler::Iterators<DoFHandler<dim,spacedim>, false> ActiveSelector;
-  typedef dealii::internal::DoFHandler::Iterators<DoFHandler<dim,spacedim>, true> LevelSelector;
+  typedef dealii::internal::DoFHandlerImplementation::Iterators<DoFHandler<dim,spacedim>, false> ActiveSelector;
+  typedef dealii::internal::DoFHandlerImplementation::Iterators<DoFHandler<dim,spacedim>, true> LevelSelector;
 public:
   typedef typename ActiveSelector::CellAccessor         cell_accessor;
   typedef typename ActiveSelector::FaceAccessor         face_accessor;
@@ -1043,7 +1043,7 @@ private:
    * An object that describes how degrees of freedom should be distributed and
    * renumbered.
    */
-  std::unique_ptr<dealii::internal::DoFHandler::Policy::PolicyBase<dim,spacedim> > policy;
+  std::unique_ptr<dealii::internal::DoFHandlerImplementation::Policy::PolicyBase<dim,spacedim> > policy;
 
   /**
    * A structure that contains all sorts of numbers that characterize the
@@ -1052,12 +1052,12 @@ private:
    * For most members of this structure, there is an accessor function in this
    * class that returns its value.
    */
-  dealii::internal::DoFHandler::NumberCache number_cache;
+  dealii::internal::DoFHandlerImplementation::NumberCache number_cache;
 
   /**
    * Data structure like number_cache, but for each multigrid level.
    */
-  std::vector<dealii::internal::DoFHandler::NumberCache> mg_number_cache;
+  std::vector<dealii::internal::DoFHandlerImplementation::NumberCache> mg_number_cache;
 
   /**
    * A data structure that is used to store the DoF indices associated with a
@@ -1171,29 +1171,29 @@ private:
    * Space to store the DoF numbers for the different levels. Analogous to the
    * <tt>levels[]</tt> tree of the Triangulation objects.
    */
-  std::vector<std::unique_ptr<dealii::internal::DoFHandler::DoFLevel<dim> > > levels;
+  std::vector<std::unique_ptr<dealii::internal::DoFHandlerImplementation::DoFLevel<dim> > > levels;
 
-  std::vector<std::unique_ptr<dealii::internal::DoFHandler::DoFLevel<dim> > > mg_levels;
+  std::vector<std::unique_ptr<dealii::internal::DoFHandlerImplementation::DoFLevel<dim> > > mg_levels;
 
   /**
    * Space to store DoF numbers of faces. They are not stored in
    * <tt>levels</tt> since faces are not organized hierarchically, but in a
    * flat array.
    */
-  std::unique_ptr<dealii::internal::DoFHandler::DoFFaces<dim> > faces;
+  std::unique_ptr<dealii::internal::DoFHandlerImplementation::DoFFaces<dim> > faces;
 
-  std::unique_ptr<dealii::internal::DoFHandler::DoFFaces<dim> > mg_faces;
+  std::unique_ptr<dealii::internal::DoFHandlerImplementation::DoFFaces<dim> > mg_faces;
 
   /**
    * Make accessor objects friends.
    */
   template <int, class, bool> friend class DoFAccessor;
   template <class, bool> friend class DoFCellAccessor;
-  friend struct dealii::internal::DoFAccessor::Implementation;
-  friend struct dealii::internal::DoFCellAccessor::Implementation;
+  friend struct dealii::internal::DoFAccessorImplementation::Implementation;
+  friend struct dealii::internal::DoFCellAccessorImplementation::Implementation;
 
-  friend struct dealii::internal::DoFHandler::Implementation;
-  friend struct dealii::internal::DoFHandler::Policy::Implementation;
+  friend struct dealii::internal::DoFHandlerImplementation::Implementation;
+  friend struct dealii::internal::DoFHandlerImplementation::Policy::Implementation;
 
   // explicitly check for sensible template arguments, but not on windows
   // because MSVC creates bogus warnings during normal compilation
@@ -1386,7 +1386,7 @@ namespace internal
    * Defined in dof_handler.cc.
    */
   template <int dim, int spacedim>
-  std::string policy_to_string(const dealii::internal::DoFHandler::Policy::PolicyBase<dim,spacedim> &policy);
+  std::string policy_to_string(const dealii::internal::DoFHandlerImplementation::Policy::PolicyBase<dim,spacedim> &policy);
 }
 
 
@@ -1452,7 +1452,7 @@ void DoFHandler<dim,spacedim>::load (Archive &ar,
   levels.resize(size);
   for (unsigned int i = 0; i < levels.size(); ++i)
     {
-      std::unique_ptr<internal::DoFHandler::DoFLevel<dim>> level;
+      std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<dim>> level;
       ar &level;
       levels[i] = std::move(level);
     }

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -35,7 +35,7 @@ template <int, int> class DoFHandler;
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     struct NumberCache;
 

--- a/include/deal.II/dofs/dof_iterator_selector.h
+++ b/include/deal.II/dofs/dof_iterator_selector.h
@@ -32,7 +32,7 @@ template <typename Accessor> class TriaActiveIterator;
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     template <typename DoFHandlerType, bool lda=false>
     struct Iterators;
@@ -42,7 +42,7 @@ namespace internal
      * Define some types for DoF handling in one dimension.
      *
      * The types have the same meaning as those declared in
-     * internal::Triangulation::Iterators<1,spacedim>, only the treatment of
+     * internal::TriangulationImplementation::Iterators<1,spacedim>, only the treatment of
      * templates is a little more complicated. See the
      * @ref Iterators
      * module for more information.
@@ -85,7 +85,7 @@ namespace internal
      * Define some types for DoF handling in two dimensions.
      *
      * The types have the same meaning as those declared in
-     * internal::Triangulation::Iterators<2,spacedim>, only the treatment of
+     * internal::TriangulationImplementation::Iterators<2,spacedim>, only the treatment of
      * templates is a little more complicated. See the
      * @ref Iterators
      * module for more information.
@@ -128,7 +128,7 @@ namespace internal
      * Define some types for DoF handling in three dimensions.
      *
      * The types have the same meaning as those declared in
-     * internal::Triangulation::Iterators<3,spacedim>, only the treatment of
+     * internal::TriangulationImplementation::Iterators<3,spacedim>, only the treatment of
      * templates is a little more complicated. See the
      * @ref Iterators
      * module for more information.

--- a/include/deal.II/dofs/dof_levels.h
+++ b/include/deal.II/dofs/dof_levels.h
@@ -29,7 +29,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
 
 

--- a/include/deal.II/dofs/dof_objects.h
+++ b/include/deal.II/dofs/dof_objects.h
@@ -27,7 +27,7 @@ template <int, int> class DoFHandler;
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     template <int> class DoFLevel;
     template <int> class DoFFaces;

--- a/include/deal.II/dofs/number_cache.h
+++ b/include/deal.II/dofs/number_cache.h
@@ -26,7 +26,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     /**
      * A structure used by the DoFHandler classes to store information about

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -2599,10 +2599,10 @@ protected:
    * FEValues object for a given mapping and finite element object. The
    * returned object will later be passed to FiniteElement::fill_fe_values()
    * for a concrete cell, which will itself place its output into an object of
-   * type internal::FEValues::FiniteElementRelatedData. Since there may be
+   * type internal::FEValuesImplementation::FiniteElementRelatedData. Since there may be
    * data that can already be computed in its <i>final</i> form on the
    * reference cell, this function also receives a reference to the
-   * internal::FEValues::FiniteElementRelatedData object as its last argument.
+   * internal::FEValuesImplementation::FiniteElementRelatedData object as its last argument.
    * This output argument is guaranteed to always be the same one when used
    * with the InternalDataBase object returned by this function. In other
    * words, the subdivision of scratch data and final data in the returned
@@ -2664,7 +2664,7 @@ protected:
   get_data (const UpdateFlags                                                    update_flags,
             const Mapping<dim,spacedim>                                         &mapping,
             const Quadrature<dim>                                               &quadrature,
-            dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
 
   /**
    * Like get_data(), but return an object that will later be used for
@@ -2712,7 +2712,7 @@ protected:
   get_face_data (const UpdateFlags                                                    update_flags,
                  const Mapping<dim,spacedim>                                         &mapping,
                  const Quadrature<dim-1>                                             &quadrature,
-                 dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Like get_data(), but return an object that will later be used for
@@ -2760,7 +2760,7 @@ protected:
   get_subface_data (const UpdateFlags                                                    update_flags,
                     const Mapping<dim,spacedim>                                         &mapping,
                     const Quadrature<dim-1>                                             &quadrature,
-                    dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Compute information about the shape functions on the cell denoted by the
@@ -2849,9 +2849,9 @@ protected:
                   const Quadrature<dim>                                               &quadrature,
                   const Mapping<dim,spacedim>                                         &mapping,
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const InternalDataBase                                              &fe_internal,
-                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
 
   /**
    * This function is the equivalent to FiniteElement::fill_fe_values(), but
@@ -2902,9 +2902,9 @@ protected:
                        const Quadrature<dim-1>                                             &quadrature,
                        const Mapping<dim,spacedim>                                         &mapping,
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const InternalDataBase                                              &fe_internal,
-                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
 
   /**
    * This function is the equivalent to FiniteElement::fill_fe_values(), but
@@ -2959,9 +2959,9 @@ protected:
                           const Quadrature<dim-1>                                             &quadrature,
                           const Mapping<dim,spacedim>                                         &mapping,
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const InternalDataBase                                              &fe_internal,
-                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
 
   friend class InternalDataBase;
   friend class FEValuesBase<dim,spacedim>;

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -512,7 +512,7 @@ protected:
   get_data (const UpdateFlags                                                    update_flags,
             const Mapping<dim,spacedim>                                         &mapping,
             const Quadrature<dim>                                               &quadrature,
-            dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -521,9 +521,9 @@ protected:
                   const Quadrature<dim>                                               &quadrature,
                   const Mapping<dim,spacedim>                                         &mapping,
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -532,9 +532,9 @@ protected:
                        const Quadrature<dim-1>                                             &quadrature,
                        const Mapping<dim,spacedim>                                         &mapping,
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -544,9 +544,9 @@ protected:
                           const Quadrature<dim-1>                                             &quadrature,
                           const Mapping<dim,spacedim>                                         &mapping,
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
 private:
 

--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -490,7 +490,7 @@ protected:
      * <code>base_no</code>th base element will write its output when calling
      * FiniteElement::fill_fe_values() and similar functions.
      */
-    internal::FEValues::FiniteElementRelatedData<dim,spacedim> &
+    internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &
     get_fe_output_object (const unsigned int base_no) const;
 
     /**
@@ -567,19 +567,19 @@ protected:
   get_data (const UpdateFlags      flags,
             const Mapping<dim,spacedim>    &mapping,
             const Quadrature<dim> &quadrature,
-            dealii::internal::FEValues::FiniteElementRelatedData< dim, spacedim > &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim > &output_data) const;
 
   virtual typename FiniteElement<dim,spacedim>::InternalDataBase *
   get_face_data (const UpdateFlags      update_flags,
                  const Mapping<dim,spacedim>    &mapping,
                  const Quadrature<dim-1> &quadrature,
-                 dealii::internal::FEValues::FiniteElementRelatedData< dim, spacedim >        &output_data) const;
+                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim >        &output_data) const;
 
   virtual typename FiniteElement<dim,spacedim>::InternalDataBase *
   get_subface_data (const UpdateFlags      update_flags,
                     const Mapping<dim,spacedim>    &mapping,
                     const Quadrature<dim-1> &quadrature,
-                    dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void fill_fe_values (const typename Triangulation<dim, spacedim>::cell_iterator &cell,
@@ -587,9 +587,9 @@ protected:
                        const Quadrature<dim> &quadrature,
                        const Mapping<dim, spacedim> &mapping,
                        const typename Mapping<dim, spacedim>::InternalDataBase &mapping_internal,
-                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
-                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data
                       ) const;
 
   virtual
@@ -599,9 +599,9 @@ protected:
                         const Quadrature<dim-1> &quadrature,
                         const Mapping<dim, spacedim> &mapping,
                         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_internal,
-                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                         const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
-                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data
+                        dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data
                       ) const;
 
   virtual
@@ -612,9 +612,9 @@ protected:
                           const Quadrature<dim-1> &quadrature,
                           const Mapping<dim, spacedim> &mapping,
                           const typename Mapping< dim, spacedim >::InternalDataBase &mapping_internal,
-                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
-                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data
                          ) const;
 
 private:
@@ -639,9 +639,9 @@ private:
   void
   multiply_by_enrichment (const Quadrature<dim_1>                                       &quadrature,
                           const InternalData                                            &fe_data,
-                          const internal::FEValues::MappingRelatedData<dim,spacedim>    &mapping_data,
+                          const internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>    &mapping_data,
                           const typename Triangulation< dim, spacedim >::cell_iterator  &cell,
-                          internal::FEValues::FiniteElementRelatedData<dim,spacedim>    &output_data) const;
+                          internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim>    &output_data) const;
 };
 
 //}

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -343,7 +343,7 @@ protected:
   get_data (const UpdateFlags                                                  /*update_flags*/,
             const Mapping<1,spacedim>                                         &/*mapping*/,
             const Quadrature<1>                                               &/*quadrature*/,
-            dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &/*output_data*/) const
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &/*output_data*/) const
   {
     return new typename FiniteElement<1, spacedim>::InternalDataBase;
   }
@@ -352,7 +352,7 @@ protected:
   get_face_data(const UpdateFlags update_flags,
                 const Mapping<1,spacedim> &/*mapping*/,
                 const Quadrature<0> &quadrature,
-                dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &/*output_data*/) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &/*output_data*/) const
   {
     // generate a new data object and initialize some fields
     typename FiniteElement<1,spacedim>::InternalDataBase *data =
@@ -376,7 +376,7 @@ protected:
   get_subface_data(const UpdateFlags                                                  update_flags,
                    const Mapping<1,spacedim>                                         &mapping,
                    const Quadrature<0>                                               &quadrature,
-                   dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &output_data) const
+                   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const
   {
     return get_face_data(update_flags, mapping, quadrature, output_data);
   }
@@ -388,9 +388,9 @@ protected:
                   const Quadrature<1>                                               &quadrature,
                   const Mapping<1,spacedim>                                         &mapping,
                   const typename Mapping<1,spacedim>::InternalDataBase              &mapping_internal,
-                  const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &mapping_data,
+                  const dealii::internal::FEValuesImplementation::MappingRelatedData<1, spacedim> &mapping_data,
                   const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const;
 
   virtual
   void
@@ -399,9 +399,9 @@ protected:
                        const Quadrature<0>                                               &quadrature,
                        const Mapping<1,spacedim>                                         &mapping,
                        const typename Mapping<1,spacedim>::InternalDataBase              &mapping_internal,
-                       const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &mapping_data,
+                       const dealii::internal::FEValuesImplementation::MappingRelatedData<1, spacedim> &mapping_data,
                        const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const;
 
   virtual
   void
@@ -411,9 +411,9 @@ protected:
                           const Quadrature<0>                                               &quadrature,
                           const Mapping<1,spacedim>                                         &mapping,
                           const typename Mapping<1,spacedim>::InternalDataBase              &mapping_internal,
-                          const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &mapping_data,
+                          const dealii::internal::FEValuesImplementation::MappingRelatedData<1, spacedim> &mapping_data,
                           const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const;
 
 private:
   /**

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -130,9 +130,9 @@ public:
                   const Quadrature<dim>                                               &quadrature,
                   const Mapping<dim,spacedim>                                         &mapping,
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -141,9 +141,9 @@ public:
                        const Quadrature<dim-1>                                             &quadrature,
                        const Mapping<dim,spacedim>                                         &mapping,
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -153,9 +153,9 @@ public:
                           const Quadrature<dim-1>                                             &quadrature,
                           const Mapping<dim,spacedim>                                         &mapping,
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Prepare internal data structures and fill in values independent of the
@@ -171,7 +171,7 @@ public:
   get_data (const UpdateFlags                                                    update_flags,
             const Mapping<dim,spacedim>                                         &mapping,
             const Quadrature<dim>                                               &quadrature,
-            dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Return whether this element dominates the one given as argument when they

--- a/include/deal.II/fe/fe_p1nc.h
+++ b/include/deal.II/fe/fe_p1nc.h
@@ -301,19 +301,19 @@ private:
   get_data (const UpdateFlags update_flags,
             const Mapping<2,2> &,
             const Quadrature<2> &quadrature,
-            dealii::internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
 
   virtual FiniteElement<2,2>::InternalDataBase *
   get_face_data (const UpdateFlags update_flags,
                  const Mapping<2,2> &,
                  const Quadrature<1> &quadrature,
-                 dealii::internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const;
+                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
 
   virtual FiniteElement<2,2>::InternalDataBase *
   get_subface_data (const UpdateFlags update_flags,
                     const Mapping<2,2> &,
                     const Quadrature<1> &quadrature,
-                    dealii::internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const;
+                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
 
   /**
    * Compute the data on the current cell.
@@ -324,9 +324,9 @@ private:
                   const Quadrature<2>                               &quadrature,
                   const Mapping<2,2>                                &mapping,
                   const Mapping<2,2>::InternalDataBase              &mapping_internal,
-                  const internal::FEValues::MappingRelatedData<2,2> &mapping_data,
+                  const internal::FEValuesImplementation::MappingRelatedData<2,2> &mapping_data,
                   const FiniteElement<2,2>::InternalDataBase        &fe_internal,
-                  internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const;
+                  internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
 
   /**
    * Compute the data on the face of the current cell.
@@ -337,9 +337,9 @@ private:
                        const Quadrature<1>                                       &quadrature,
                        const Mapping<2,2>                                        &mapping,
                        const Mapping<2,2>::InternalDataBase                      &mapping_internal,
-                       const dealii::internal::FEValues::MappingRelatedData<2,2> &mapping_data,
+                       const dealii::internal::FEValuesImplementation::MappingRelatedData<2,2> &mapping_data,
                        const InternalDataBase                                    &fe_internal,
-                       dealii::internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
 
   /**
    * Compute the data on the subface of the current cell.
@@ -351,9 +351,9 @@ private:
                           const Quadrature<1>                                       &quadrature,
                           const Mapping<2,2>                                        &mapping,
                           const Mapping<2,2>::InternalDataBase                      &mapping_internal,
-                          const dealii::internal::FEValues::MappingRelatedData<2,2> &mapping_data,
+                          const dealii::internal::FEValuesImplementation::MappingRelatedData<2,2> &mapping_data,
                           const InternalDataBase                                    &fe_internal,
-                          dealii::internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
 
   /**
    * Create the constraints matrix for hanging edges.

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -222,7 +222,7 @@ protected:
   get_data(const UpdateFlags                                                    update_flags,
            const Mapping<dim,spacedim>                                         &/*mapping*/,
            const Quadrature<dim>                                               &quadrature,
-           dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+           dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
   {
     // generate a new data object and
     // initialize some fields
@@ -331,9 +331,9 @@ protected:
                   const Quadrature<dim>                                               &quadrature,
                   const Mapping<dim,spacedim>                                         &mapping,
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -342,9 +342,9 @@ protected:
                        const Quadrature<dim-1>                                             &quadrature,
                        const Mapping<dim,spacedim>                                         &mapping,
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -354,9 +354,9 @@ protected:
                           const Quadrature<dim-1>                                             &quadrature,
                           const Mapping<dim,spacedim>                                         &mapping,
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Fields of cell-independent data.
@@ -432,8 +432,8 @@ protected:
    * is the Jacobian pushed-forward second derivative.
    */
   void
-  correct_third_derivatives (internal::FEValues::FiniteElementRelatedData<dim,spacedim>       &output_data,
-                             const internal::FEValues::MappingRelatedData<dim,spacedim>       &mapping_data,
+  correct_third_derivatives (internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim>       &output_data,
+                             const internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>       &mapping_data,
                              const unsigned int                                                n_q_points,
                              const unsigned int                                                dof) const;
 

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -223,9 +223,9 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
                 const Quadrature<dim>                                               &quadrature,
                 const Mapping<dim,spacedim>                                         &mapping,
                 const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                 const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -285,9 +285,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator  
                      const Quadrature<dim-1>                                             &quadrature,
                      const Mapping<dim,spacedim>                                         &mapping,
                      const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                     const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                      const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                     dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -364,9 +364,9 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const Quadrature<dim-1>                                             &quadrature,
                         const Mapping<dim,spacedim>                                         &mapping,
                         const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                         const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                        dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -438,8 +438,8 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 template <class PolynomialType, int dim, int spacedim>
 inline void
 FE_Poly<PolynomialType,dim,spacedim>::
-correct_third_derivatives (internal::FEValues::FiniteElementRelatedData<dim,spacedim>       &output_data,
-                           const internal::FEValues::MappingRelatedData<dim,spacedim>       &mapping_data,
+correct_third_derivatives (internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim>       &output_data,
+                           const internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>       &mapping_data,
                            const unsigned int                                                n_q_points,
                            const unsigned int                                                dof) const
 {

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -85,7 +85,7 @@ protected:
   get_data (const UpdateFlags                                                    /*update_flags*/,
             const Mapping<dim,spacedim>                                         &/*mapping*/,
             const Quadrature<dim>                                               &/*quadrature*/,
-            dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
   {
     InternalData *data = new InternalData;
     return data;
@@ -95,7 +95,7 @@ protected:
   get_face_data(const UpdateFlags                                                    update_flags,
                 const Mapping<dim,spacedim>                                         &/*mapping*/,
                 const Quadrature<dim-1>                                             &quadrature,
-                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
   {
     // generate a new data object and
     // initialize some fields
@@ -144,7 +144,7 @@ protected:
   get_subface_data(const UpdateFlags                                                    update_flags,
                    const Mapping<dim,spacedim>                                         &mapping,
                    const Quadrature<dim-1>                                             &quadrature,
-                   dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
   {
     return get_face_data(update_flags, mapping,
                          QProjector<dim - 1>::project_to_all_children(quadrature),
@@ -158,9 +158,9 @@ protected:
                   const Quadrature<dim>                                               &quadrature,
                   const Mapping<dim,spacedim>                                         &mapping,
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -169,9 +169,9 @@ protected:
                        const Quadrature<dim-1>                                             &quadrature,
                        const Mapping<dim,spacedim>                                         &mapping,
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -181,9 +181,9 @@ protected:
                           const Quadrature<dim-1>                                             &quadrature,
                           const Mapping<dim,spacedim>                                         &mapping,
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Fields of cell-independent data.

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -79,9 +79,9 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
                 const Quadrature<dim> &,
                 const Mapping<dim,spacedim> &,
                 const typename Mapping<dim,spacedim>::InternalDataBase &,
-                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &,
                 const typename FiniteElement<dim,spacedim>::InternalDataBase &,
-                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &) const
 {
   // Do nothing, since we do not have
   // values in the interior
@@ -97,9 +97,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                      const Quadrature<dim-1>                                             &quadrature,
                      const Mapping<dim,spacedim> &,
                      const typename Mapping<dim,spacedim>::InternalDataBase &,
-                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                     const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &,
                      const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                     dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -166,9 +166,9 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const Quadrature<dim-1>                                             &quadrature,
                         const Mapping<dim,spacedim> &,
                         const typename Mapping<dim,spacedim>::InternalDataBase &,
-                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &,
                         const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                        dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -212,7 +212,7 @@ protected:
   get_data(const UpdateFlags                                                    update_flags,
            const Mapping<dim,spacedim>                                         &/*mapping*/,
            const Quadrature<dim>                                               &quadrature,
-           dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+           dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
   {
     // generate a new data object and
     // initialize some fields
@@ -338,9 +338,9 @@ protected:
                   const Quadrature<dim>                                               &quadrature,
                   const Mapping<dim,spacedim>                                         &mapping,
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -349,9 +349,9 @@ protected:
                        const Quadrature<dim-1>                                             &quadrature,
                        const Mapping<dim,spacedim>                                         &mapping,
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -361,9 +361,9 @@ protected:
                           const Quadrature<dim-1>                                             &quadrature,
                           const Mapping<dim,spacedim>                                         &mapping,
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Fields of cell-independent data for FE_PolyTensor. Stores the values of

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -963,21 +963,21 @@ protected:
   get_data (const UpdateFlags                                                    update_flags,
             const Mapping<dim,spacedim>                                         &mapping,
             const Quadrature<dim>                                               &quadrature,
-            dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   typename FiniteElement<dim,spacedim>::InternalDataBase *
   get_face_data (const UpdateFlags                                                    update_flags,
                  const Mapping<dim,spacedim>                                         &mapping,
                  const Quadrature<dim-1>                                             &quadrature,
-                 dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   typename FiniteElement<dim,spacedim>::InternalDataBase *
   get_subface_data (const UpdateFlags                                                    update_flags,
                     const Mapping<dim,spacedim>                                         &mapping,
                     const Quadrature<dim-1>                                             &quadrature,
-                    dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -986,9 +986,9 @@ protected:
                   const Quadrature<dim>                                               &quadrature,
                   const Mapping<dim,spacedim>                                         &mapping,
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -997,9 +997,9 @@ protected:
                        const Quadrature<dim-1>                                             &quadrature,
                        const Mapping<dim,spacedim>                                         &mapping,
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
@@ -1009,9 +1009,9 @@ protected:
                           const Quadrature<dim-1>                                             &quadrature,
                           const Mapping<dim,spacedim>                                         &mapping,
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Do the work for the three <tt>fill_fe*_values</tt> functions.
@@ -1032,8 +1032,8 @@ protected:
                      const CellSimilarity::Similarity                   cell_similarity,
                      const typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
                      const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_data,
-                     const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                     internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+                     const internal::FEValuesImplementation::MappingRelatedData<dim,spacedim> &mapping_data,
+                     internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &output_data) const;
 
 private:
 
@@ -1129,7 +1129,7 @@ private:
      * <code>base_no</code>th base element will write its output when calling
      * FiniteElement::fill_fe_values() and similar functions.
      */
-    internal::FEValues::FiniteElementRelatedData<dim,spacedim> &
+    internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &
     get_fe_output_object (const unsigned int base_no) const;
 
   private:
@@ -1154,7 +1154,7 @@ private:
      * The size of this vector is set to @p n_base_elements by the
      * InternalData constructor.
      */
-    mutable std::vector<internal::FEValues::FiniteElementRelatedData<dim,spacedim> > base_fe_output_objects;
+    mutable std::vector<internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> > base_fe_output_objects;
   };
 
   /*

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -394,7 +394,7 @@ namespace CellSimilarity
 
 namespace internal
 {
-  namespace FEValues
+  namespace FEValuesImplementation
   {
     /**
      * A class that stores all of the mapping related data used in

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2985,7 +2985,7 @@ protected:
    * An object into which the Mapping::fill_fe_values() and similar functions
    * place their output.
    */
-  dealii::internal::FEValues::MappingRelatedData<dim, spacedim> mapping_output;
+  dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> mapping_output;
 
 
   /**
@@ -3005,7 +3005,7 @@ protected:
    * An object into which the FiniteElement::fill_fe_values() and similar
    * functions place their output.
    */
-  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> finite_element_output;
+  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> finite_element_output;
 
 
   /**

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -804,7 +804,7 @@ protected:
                   const CellSimilarity::Similarity                              cell_similarity,
                   const Quadrature<dim>                                        &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase       &internal_data,
-                  dealii::internal::FEValues::MappingRelatedData<dim,spacedim> &output_data) const = 0;
+                  dealii::internal::FEValuesImplementation::MappingRelatedData<dim,spacedim> &output_data) const = 0;
 
   /**
    * This function is the equivalent to Mapping::fill_fe_values(), but for
@@ -836,7 +836,7 @@ protected:
                        const unsigned int                                            face_no,
                        const Quadrature<dim-1>                                      &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase       &internal_data,
-                       dealii::internal::FEValues::MappingRelatedData<dim,spacedim> &output_data) const = 0;
+                       dealii::internal::FEValuesImplementation::MappingRelatedData<dim,spacedim> &output_data) const = 0;
 
   /**
    * This function is the equivalent to Mapping::fill_fe_values(), but for
@@ -871,7 +871,7 @@ protected:
                           const unsigned int                                             subface_no,
                           const Quadrature<dim-1>                                       &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                          dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const = 0;
+                          dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &output_data) const = 0;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -223,7 +223,7 @@ private:
                   const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                  internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_face_values()
   virtual
@@ -232,7 +232,7 @@ private:
                        const unsigned int                                         face_no,
                        const Quadrature<dim-1>                                   &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                       internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_subface_values()
   virtual
@@ -242,7 +242,7 @@ private:
                           const unsigned int                                         subface_no,
                           const Quadrature<dim-1>                                   &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                          internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -468,7 +468,7 @@ private:
                   const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                  internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_face_values()
   virtual
@@ -477,7 +477,7 @@ private:
                        const unsigned int                                         face_no,
                        const Quadrature<dim-1>                                   &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                       internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_subface_values()
   virtual
@@ -487,7 +487,7 @@ private:
                           const unsigned int                                         subface_no,
                           const Quadrature<dim-1>                                   &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                          internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -364,7 +364,7 @@ public:
                   const CellSimilarity::Similarity                               cell_similarity,
                   const Quadrature<dim>                                         &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                  dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
+                  dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_face_values()
   virtual
@@ -373,7 +373,7 @@ public:
                        const unsigned int                                             face_no,
                        const Quadrature<dim-1>                                       &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                       dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
+                       dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_subface_values()
   virtual
@@ -383,7 +383,7 @@ public:
                           const unsigned int                                             subface_no,
                           const Quadrature<dim-1>                                       &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                          dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
+                          dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -300,7 +300,7 @@ protected:
                   const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                  internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_face_values()
   virtual
@@ -309,7 +309,7 @@ protected:
                        const unsigned int                                         face_no,
                        const Quadrature<dim-1>                                   &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                       internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_subface_values()
   virtual
@@ -319,7 +319,7 @@ protected:
                           const unsigned int                                         subface_no,
                           const Quadrature<dim-1>                                   &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                          internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -155,7 +155,7 @@ protected:
                   const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                  internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   /**
    * Compute the support points of the mapping. For the current class, these

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -157,7 +157,7 @@ protected:
                   const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const override;
+                  internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const override;
 
   /**
    * Reference to the vector of shifts.

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -557,7 +557,7 @@ public:
                   const CellSimilarity::Similarity                               cell_similarity,
                   const Quadrature<dim>                                         &quadrature,
                   const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                  dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
+                  dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_face_values()
   virtual
@@ -566,7 +566,7 @@ public:
                        const unsigned int                                             face_no,
                        const Quadrature<dim-1>                                       &quadrature,
                        const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                       dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
+                       dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   // documentation can be found in Mapping::fill_fe_subface_values()
   virtual
@@ -576,7 +576,7 @@ public:
                           const unsigned int                                             subface_no,
                           const Quadrature<dim-1>                                       &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase        &internal_data,
-                          dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &output_data) const override;
+                          dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &output_data) const override;
 
   /**
    * @}

--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -775,7 +775,7 @@ make_filtered_iterator (const BaseIterator &i,
 
 namespace internal
 {
-  namespace FilteredIterator
+  namespace FilteredIteratorImplementation
   {
     // The following classes create a nested sequence of
     // FilteredIterator<FilteredIterator<...<BaseIterator>...>> with as many
@@ -881,7 +881,7 @@ filter_iterators (IteratorRange<BaseIterator> i,
  * @ingroup CPP11
  */
 template <typename BaseIterator, typename Predicate, typename... Targs>
-IteratorRange<typename internal::FilteredIterator::
+IteratorRange<typename internal::FilteredIteratorImplementation::
 NestFilteredIterators<BaseIterator,std::tuple<Predicate, Targs...> >::type>
 filter_iterators (IteratorRange<BaseIterator> i,
                   const Predicate &p,

--- a/include/deal.II/grid/tensor_product_manifold.h
+++ b/include/deal.II/grid/tensor_product_manifold.h
@@ -119,7 +119,7 @@ private:
 
 namespace internal
 {
-  namespace TensorProductManifold
+  namespace TensorProductManifoldImplementation
   {
     template <int dim1, int dim2>
     Tensor<1,dim1+dim2> concat(const Tensor<1,dim1> &p1, const Tensor<1,dim2> &p2)
@@ -163,7 +163,7 @@ TensorProductManifold<dim, dim_A, spacedim_A, chartdim_A, dim_B, spacedim_B, cha
   const ChartManifold<dim_A, spacedim_A, chartdim_A> &manifold_A,
   const ChartManifold<dim_B, spacedim_B, chartdim_B> &manifold_B)
   : ChartManifold<dim,spacedim_A+spacedim_B,chartdim_A+chartdim_B> (
-    internal::TensorProductManifold::concat(
+    internal::TensorProductManifoldImplementation::concat(
       manifold_A.get_periodicity(),
       manifold_B.get_periodicity())),
   manifold_A (&manifold_A),
@@ -179,12 +179,12 @@ TensorProductManifold<dim, dim_A, spacedim_A, chartdim_A, dim_B, spacedim_B, cha
 {
   Point<spacedim_A> space_point_A;
   Point<spacedim_B> space_point_B;
-  internal::TensorProductManifold::split_point(space_point, space_point_A, space_point_B);
+  internal::TensorProductManifoldImplementation::split_point(space_point, space_point_A, space_point_B);
 
   Point<chartdim_A> result_A = manifold_A->pull_back(space_point_A);
   Point<chartdim_B> result_B = manifold_B->pull_back(space_point_B);
 
-  return internal::TensorProductManifold::concat(result_A, result_B);
+  return internal::TensorProductManifoldImplementation::concat(result_A, result_B);
 }
 
 template <int dim,
@@ -196,12 +196,12 @@ TensorProductManifold<dim, dim_A, spacedim_A, chartdim_A, dim_B, spacedim_B, cha
 {
   Point<chartdim_A> chart_point_A;
   Point<chartdim_B> chart_point_B;
-  internal::TensorProductManifold::split_point(chart_point, chart_point_A, chart_point_B);
+  internal::TensorProductManifoldImplementation::split_point(chart_point, chart_point_A, chart_point_B);
 
   Point<spacedim_A> result_A = manifold_A->push_forward(chart_point_A);
   Point<spacedim_B> result_B = manifold_B->push_forward(chart_point_B);
 
-  return internal::TensorProductManifold::concat(result_A, result_B);
+  return internal::TensorProductManifoldImplementation::concat(result_A, result_B);
 }
 
 template <int dim,
@@ -216,7 +216,7 @@ DerivativeForm<1,
 {
   Point<chartdim_A> chart_point_A;
   Point<chartdim_B> chart_point_B;
-  internal::TensorProductManifold::split_point(chart_point, chart_point_A, chart_point_B);
+  internal::TensorProductManifoldImplementation::split_point(chart_point, chart_point_A, chart_point_B);
 
   DerivativeForm<1,chartdim_A,spacedim_A> result_A
     = manifold_A->push_forward_gradient(chart_point_A);

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -58,7 +58,7 @@ template <int, int, int> class TriaAccessorBase;
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
     template <int dim> class TriaLevel;
     template <int dim> class TriaFaces;
@@ -73,7 +73,7 @@ namespace internal
     struct Implementation;
   }
 
-  namespace TriaAccessor
+  namespace TriaAccessorImplementation
   {
     struct Implementation;
   }
@@ -277,7 +277,7 @@ namespace internal
    * A namespace for classes internal to the triangulation classes and
    * helpers.
    */
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
 
     /**
@@ -497,7 +497,7 @@ namespace internal
  *
  * This class is written to be as independent of the dimension as possible
  * (thus the complex construction of the
- * dealii::internal::Triangulation::TriaLevel classes) to allow code-sharing,
+ * dealii::internal::TriangulationImplementation::TriaLevel classes) to allow code-sharing,
  * to allow reducing the need to mirror changes in the code for one dimension
  * to the code for other dimensions. Nonetheless, some of the functions are
  * dependent of the dimension and there only exist specialized versions for
@@ -1247,7 +1247,7 @@ private:
    * An internal typedef to make the definition of the iterator classes
    * simpler.
    */
-  typedef dealii::internal::Triangulation::Iterators<dim, spacedim> IteratorSelector;
+  typedef dealii::internal::TriangulationImplementation::Iterators<dim, spacedim> IteratorSelector;
 
 public:
   /**
@@ -3514,14 +3514,14 @@ private:
    * Array of pointers pointing to the objects storing the cell data on the
    * different levels.
    */
-  std::vector<std::unique_ptr<dealii::internal::Triangulation::TriaLevel<dim> > > levels;
+  std::vector<std::unique_ptr<dealii::internal::TriangulationImplementation::TriaLevel<dim> > > levels;
 
   /**
    * Pointer to the faces of the triangulation. In 1d this contains nothing,
    * in 2D it contains data concerning lines and in 3D quads and lines.  All
    * of these have no level and are therefore treated separately.
    */
-  std::unique_ptr<dealii::internal::Triangulation::TriaFaces<dim> > faces;
+  std::unique_ptr<dealii::internal::TriangulationImplementation::TriaFaces<dim> > faces;
 
 
   /**
@@ -3562,7 +3562,7 @@ private:
    * and since access to the number of lines etc is a rather frequent
    * operation, this was not an optimal solution.
    */
-  dealii::internal::Triangulation::NumberCache<dim> number_cache;
+  dealii::internal::TriangulationImplementation::NumberCache<dim> number_cache;
 
   /**
    * A map that relates the number of a boundary vertex to the boundary
@@ -3609,14 +3609,14 @@ private:
 
   friend class CellAccessor<dim, spacedim>;
 
-  friend struct dealii::internal::TriaAccessor::Implementation;
+  friend struct dealii::internal::TriaAccessorImplementation::Implementation;
 
   friend class hp::DoFHandler<dim,spacedim>;
 
-  friend struct dealii::internal::Triangulation::Implementation;
+  friend struct dealii::internal::TriangulationImplementation::Implementation;
 
   template <typename>
-  friend class dealii::internal::Triangulation::TriaObjects;
+  friend class dealii::internal::TriangulationImplementation::TriaObjects;
 
   // explicitly check for sensible template arguments, but not on windows
   // because MSVC creates bogus warnings during normal compilation
@@ -3649,7 +3649,7 @@ CellData<structdim>::CellData ()
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
     template <class Archive>
     void NumberCache<1>::serialize (Archive &ar,
@@ -3790,7 +3790,7 @@ Triangulation<dim,spacedim>::load (Archive &ar,
   levels.resize(size);
   for (unsigned int i = 0; i < levels.size(); ++i)
     {
-      std::unique_ptr<internal::Triangulation::TriaLevel<dim>> level;
+      std::unique_ptr<internal::TriangulationImplementation::TriaLevel<dim>> level;
       ar &level;
       levels[i] = std::move(level);
     }

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -42,14 +42,14 @@ template <int dim, int spacedim> class Manifold;
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
     template <int dim> class TriaObject;
     template <typename G> class TriaObjects;
     struct Implementation;
   }
 
-  namespace TriaAccessor
+  namespace TriaAccessorImplementation
   {
     struct Implementation;
 
@@ -387,7 +387,7 @@ protected:
   /**
    * Access to the other objects of a Triangulation with same dimension.
    */
-  dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<structdim> > &
+  dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<structdim> > &
   objects () const;
 
 public:
@@ -471,7 +471,7 @@ protected:
    * The level if this is a cell (<tt>structdim==dim</tt>). Else, contains
    * zero.
    */
-  typename dealii::internal::TriaAccessor::PresentLevelType<structdim,dim>::type present_level;
+  typename dealii::internal::TriaAccessorImplementation::PresentLevelType<structdim,dim>::type present_level;
 
   /**
    * Used to store the index of the element presently pointed to on the level
@@ -593,13 +593,13 @@ public:
   /**
    * Dummy function to extract lines. Returns a default-constructed line iterator.
    */
-  typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator
+  typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::line_iterator
   line (const unsigned int i) const;
 
   /**
    * Dummy function to extract quads. Returns a default-constructed quad iterator.
    */
-  typename dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator
+  typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::quad_iterator
   quad (const unsigned int i) const;
 };
 
@@ -755,7 +755,7 @@ public:
   /**
    * Pointer to the @p ith line bounding this object.
    */
-  typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator
+  typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::line_iterator
   line (const unsigned int i) const;
 
   /**
@@ -769,7 +769,7 @@ public:
   /**
    * Pointer to the @p ith quad bounding this object.
    */
-  typename dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator
+  typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::quad_iterator
   quad (const unsigned int i) const;
 
   /**
@@ -1496,7 +1496,7 @@ private:
    * Copy the data of the given object into the internal data structures of a
    * triangulation.
    */
-  void set (const dealii::internal::Triangulation::TriaObject<structdim> &o) const;
+  void set (const dealii::internal::TriangulationImplementation::TriaObject<structdim> &o) const;
 
   /**
    * Set the flag indicating, what <code>line_orientation()</code> will
@@ -1586,8 +1586,8 @@ private:
 
   template <int, int> friend class Triangulation;
 
-  friend struct dealii::internal::Triangulation::Implementation;
-  friend struct dealii::internal::TriaAccessor::Implementation;
+  friend struct dealii::internal::TriangulationImplementation::Implementation;
+  friend struct dealii::internal::TriaAccessorImplementation::Implementation;
 };
 
 
@@ -1754,7 +1754,7 @@ public:
    * Pointer to the @p ith line bounding this object. Will point to an invalid
    * object.
    */
-  typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator
+  typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::line_iterator
   static line (const unsigned int);
 
   /**
@@ -1766,7 +1766,7 @@ public:
    * Pointer to the @p ith quad bounding this object.
    */
   static
-  typename dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator
+  typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::quad_iterator
   quad (const unsigned int i);
 
   /**
@@ -2152,7 +2152,7 @@ public:
    * Pointer to the @p ith line bounding this object. Will point to an invalid
    * object.
    */
-  typename dealii::internal::Triangulation::Iterators<1,spacedim>::line_iterator
+  typename dealii::internal::TriangulationImplementation::Iterators<1,spacedim>::line_iterator
   static line (const unsigned int);
 
   /**
@@ -2167,7 +2167,7 @@ public:
    * Pointer to the @p ith quad bounding this object.
    */
   static
-  typename dealii::internal::Triangulation::Iterators<1,spacedim>::quad_iterator
+  typename dealii::internal::TriangulationImplementation::Iterators<1,spacedim>::quad_iterator
   quad (const unsigned int i);
 
   /**
@@ -3316,7 +3316,7 @@ private:
 
   template <int, int> friend class Triangulation;
 
-  friend struct dealii::internal::Triangulation::Implementation;
+  friend struct dealii::internal::TriangulationImplementation::Implementation;
 };
 
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -282,7 +282,7 @@ TriaAccessorBase<structdim,dim,spacedim>::operator -- ()
 
 namespace internal
 {
-  namespace TriaAccessorBase
+  namespace TriaAccessorBaseImplementation
   {
     /**
      * Out of a face object, get the sub-objects of dimensionality given by
@@ -290,8 +290,8 @@ namespace internal
      */
     template <int dim>
     inline
-    dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<1> > *
-    get_objects (dealii::internal::Triangulation::TriaFaces<dim> *faces,
+    dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<1> > *
+    get_objects (dealii::internal::TriangulationImplementation::TriaFaces<dim> *faces,
                  const std::integral_constant<int, 1>)
     {
       return &faces->lines;
@@ -300,16 +300,16 @@ namespace internal
 
     template <int dim>
     inline
-    dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<2> > *
-    get_objects (dealii::internal::Triangulation::TriaFaces<dim> *faces,
+    dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<2> > *
+    get_objects (dealii::internal::TriangulationImplementation::TriaFaces<dim> *faces,
                  const std::integral_constant<int, 2>)
     {
       return &faces->quads;
     }
 
     inline
-    dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<1> > *
-    get_objects (dealii::internal::Triangulation::TriaFaces<1> *,
+    dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<1> > *
+    get_objects (dealii::internal::TriangulationImplementation::TriaFaces<1> *,
                  const std::integral_constant<int, 1>)
     {
       Assert (false, ExcInternalError());
@@ -317,8 +317,8 @@ namespace internal
     }
 
     inline
-    dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<2> > *
-    get_objects (dealii::internal::Triangulation::TriaFaces<2> *,
+    dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<2> > *
+    get_objects (dealii::internal::TriangulationImplementation::TriaFaces<2> *,
                  const std::integral_constant<int, 2>)
     {
       Assert (false, ExcInternalError());
@@ -326,8 +326,8 @@ namespace internal
     }
 
     inline
-    dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<3> > *
-    get_objects (dealii::internal::Triangulation::TriaFaces<3> *,
+    dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<3> > *
+    get_objects (dealii::internal::TriangulationImplementation::TriaFaces<3> *,
                  const std::integral_constant<int, 3>)
     {
       Assert (false, ExcInternalError());
@@ -340,8 +340,8 @@ namespace internal
      */
     template <int dim>
     inline
-    dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<3> > *
-    get_objects (dealii::internal::Triangulation::TriaFaces<dim> *,
+    dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<3> > *
+    get_objects (dealii::internal::TriangulationImplementation::TriaFaces<dim> *,
                  const std::integral_constant<int, 3>)
     {
       Assert (false, ExcInternalError());
@@ -353,8 +353,8 @@ namespace internal
      */
     template <int structdim, int dim>
     inline
-    dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<structdim> > *
-    get_objects (dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<dim> > *,
+    dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<structdim> > *
+    get_objects (dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<dim> > *,
                  const std::integral_constant<int, structdim>)
     {
       Assert (false, ExcInternalError());
@@ -363,8 +363,8 @@ namespace internal
 
     template <int dim>
     inline
-    dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<dim> > *
-    get_objects (dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<dim> > *cells,
+    dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<dim> > *
+    get_objects (dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<dim> > *cells,
                  const std::integral_constant<int, dim>)
     {
       return cells;
@@ -376,18 +376,18 @@ namespace internal
 
 template <int structdim, int dim, int spacedim>
 inline
-dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<structdim> > &
+dealii::internal::TriangulationImplementation::TriaObjects<dealii::internal::TriangulationImplementation::TriaObject<structdim> > &
 TriaAccessorBase<structdim,dim,spacedim>::objects() const
 {
   if (structdim != dim)
     // get sub-objects. note that the
     // current class is only used for
     // objects that are *not* cells
-    return *dealii::internal::TriaAccessorBase::get_objects (this->tria->faces.get(),
-                                                             std::integral_constant<int, structdim> ());
+    return *dealii::internal::TriaAccessorBaseImplementation::get_objects (this->tria->faces.get(),
+           std::integral_constant<int, structdim> ());
   else
-    return *dealii::internal::TriaAccessorBase::get_objects (&this->tria->levels[this->present_level]->cells,
-                                                             std::integral_constant<int, structdim> ());
+    return *dealii::internal::TriaAccessorBaseImplementation::get_objects (&this->tria->levels[this->present_level]->cells,
+           std::integral_constant<int, structdim> ());
 }
 
 
@@ -535,24 +535,24 @@ InvalidAccessor<structdim, dim, spacedim>::vertex (const unsigned int) const
 
 template <int structdim, int dim, int spacedim>
 inline
-typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator
+typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::line_iterator
 InvalidAccessor<structdim, dim, spacedim>::line (const unsigned int) const
 {
   // nothing to do here. we could throw an exception but we can't get here
   // without first creating an object which would have already thrown
-  return typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator();
+  return typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::line_iterator();
 }
 
 
 
 template <int structdim, int dim, int spacedim>
 inline
-typename dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator
+typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::quad_iterator
 InvalidAccessor<structdim, dim, spacedim>::quad (const unsigned int) const
 {
   // nothing to do here. we could throw an exception but we can't get here
   // without first creating an object which would have already thrown
-  return dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator();
+  return dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::quad_iterator();
 }
 
 
@@ -561,7 +561,7 @@ InvalidAccessor<structdim, dim, spacedim>::quad (const unsigned int) const
 
 namespace internal
 {
-  namespace TriaAccessor
+  namespace TriaAccessorImplementation
   {
     // make sure that if in the following we
     // write TriaAccessor
@@ -1242,7 +1242,7 @@ vertex_index (const unsigned int corner) const
   Assert (corner<GeometryInfo<structdim>::vertices_per_cell,
           ExcIndexRange(corner,0,GeometryInfo<structdim>::vertices_per_cell));
 
-  return dealii::internal::TriaAccessor::Implementation::vertex_index (*this, corner);
+  return dealii::internal::TriaAccessorImplementation::Implementation::vertex_index (*this, corner);
 }
 
 
@@ -1259,11 +1259,11 @@ TriaAccessor<structdim, dim, spacedim>::vertex (const unsigned int i) const
 
 template <int structdim, int dim, int spacedim>
 inline
-typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator
+typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::line_iterator
 TriaAccessor<structdim,dim,spacedim>::line (const unsigned int i) const
 {
   // checks happen in line_index
-  return typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator
+  return typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::line_iterator
          (this->tria, 0, line_index (i));
 }
 
@@ -1277,7 +1277,7 @@ TriaAccessor<structdim,dim,spacedim>::line_index (const unsigned int i) const
   Assert (i < GeometryInfo<structdim>::lines_per_cell,
           ExcIndexRange (i, 0, GeometryInfo<structdim>::lines_per_cell));
 
-  return dealii::internal::TriaAccessor::Implementation::line_index (*this, i);
+  return dealii::internal::TriaAccessorImplementation::Implementation::line_index (*this, i);
 }
 
 
@@ -1285,11 +1285,11 @@ TriaAccessor<structdim,dim,spacedim>::line_index (const unsigned int i) const
 
 template <int structdim, int dim, int spacedim>
 inline
-typename dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator
+typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::quad_iterator
 TriaAccessor<structdim,dim,spacedim>::quad (const unsigned int i) const
 {
   // checks happen in quad_index
-  return typename dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator
+  return typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::quad_iterator
          (this->tria, 0, quad_index (i));
 }
 
@@ -1300,7 +1300,7 @@ inline
 unsigned int
 TriaAccessor<structdim,dim,spacedim>::quad_index (const unsigned int i) const
 {
-  return dealii::internal::TriaAccessor::Implementation::quad_index (*this, i);
+  return dealii::internal::TriaAccessorImplementation::Implementation::quad_index (*this, i);
 }
 
 
@@ -1312,7 +1312,7 @@ TriaAccessor<structdim,dim,spacedim>::face_orientation (const unsigned int face)
 {
   Assert (used(), TriaAccessorExceptions::ExcCellNotUsed());
 
-  return dealii::internal::TriaAccessor::Implementation::face_orientation (*this, face);
+  return dealii::internal::TriaAccessorImplementation::Implementation::face_orientation (*this, face);
 }
 
 
@@ -1324,7 +1324,7 @@ TriaAccessor<structdim,dim,spacedim>::face_flip (const unsigned int face) const
 {
   Assert (used(), TriaAccessorExceptions::ExcCellNotUsed());
 
-  return dealii::internal::TriaAccessor::Implementation::face_flip (*this, face);
+  return dealii::internal::TriaAccessorImplementation::Implementation::face_flip (*this, face);
 }
 
 
@@ -1335,7 +1335,7 @@ TriaAccessor<structdim,dim,spacedim>::face_rotation (const unsigned int face) co
 {
   Assert (used(), TriaAccessorExceptions::ExcCellNotUsed());
 
-  return dealii::internal::TriaAccessor::Implementation::face_rotation (*this, face);
+  return dealii::internal::TriaAccessorImplementation::Implementation::face_rotation (*this, face);
 }
 
 
@@ -1349,7 +1349,7 @@ TriaAccessor<structdim,dim,spacedim>::line_orientation (const unsigned int line)
   Assert (line<GeometryInfo<structdim>::lines_per_cell,
           ExcIndexRange (line, 0, GeometryInfo<structdim>::lines_per_cell));
 
-  return dealii::internal::TriaAccessor::Implementation::line_orientation (*this, line);
+  return dealii::internal::TriaAccessorImplementation::Implementation::line_orientation (*this, line);
 }
 
 
@@ -1362,7 +1362,7 @@ TriaAccessor<structdim,dim,spacedim>::set_face_orientation (const unsigned int f
 {
   Assert (used(), TriaAccessorExceptions::ExcCellNotUsed());
 
-  dealii::internal::TriaAccessor::Implementation::set_face_orientation (*this, face, value);
+  dealii::internal::TriaAccessorImplementation::Implementation::set_face_orientation (*this, face, value);
 }
 
 
@@ -1375,7 +1375,7 @@ TriaAccessor<structdim,dim,spacedim>::set_face_flip (const unsigned int face,
 {
   Assert (used(), TriaAccessorExceptions::ExcCellNotUsed());
 
-  dealii::internal::TriaAccessor::Implementation::set_face_flip (*this, face, value);
+  dealii::internal::TriaAccessorImplementation::Implementation::set_face_flip (*this, face, value);
 }
 
 
@@ -1387,7 +1387,7 @@ TriaAccessor<structdim,dim,spacedim>::set_face_rotation (const unsigned int face
 {
   Assert (used(), TriaAccessorExceptions::ExcCellNotUsed());
 
-  dealii::internal::TriaAccessor::Implementation::set_face_rotation (*this, face, value);
+  dealii::internal::TriaAccessorImplementation::Implementation::set_face_rotation (*this, face, value);
 }
 
 
@@ -1402,7 +1402,7 @@ TriaAccessor<structdim,dim,spacedim>::set_line_orientation (const unsigned int l
   Assert (line<GeometryInfo<structdim>::lines_per_cell,
           ExcIndexRange (line, 0, GeometryInfo<structdim>::lines_per_cell));
 
-  dealii::internal::TriaAccessor::Implementation::set_line_orientation (*this, line, value);
+  dealii::internal::TriaAccessorImplementation::Implementation::set_line_orientation (*this, line, value);
 }
 
 
@@ -2493,10 +2493,10 @@ TriaAccessor<0, dim, spacedim>::vertex (const unsigned int) const
 
 template <int dim, int spacedim>
 inline
-typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator
+typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::line_iterator
 TriaAccessor<0, dim, spacedim>::line (const unsigned int)
 {
-  return typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator();
+  return typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::line_iterator();
 }
 
 
@@ -2514,10 +2514,10 @@ TriaAccessor<0, dim, spacedim>::line_index (const unsigned int)
 
 template <int dim, int spacedim>
 inline
-typename dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator
+typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::quad_iterator
 TriaAccessor<0, dim, spacedim>::quad (const unsigned int)
 {
-  return typename dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator();
+  return typename dealii::internal::TriangulationImplementation::Iterators<dim,spacedim>::quad_iterator();
 }
 
 
@@ -2898,10 +2898,10 @@ TriaAccessor<0, 1, spacedim>::center () const
 
 template <int spacedim>
 inline
-typename dealii::internal::Triangulation::Iterators<1,spacedim>::line_iterator
+typename dealii::internal::TriangulationImplementation::Iterators<1,spacedim>::line_iterator
 TriaAccessor<0, 1, spacedim>::line (const unsigned int)
 {
-  return typename dealii::internal::Triangulation::Iterators<1,spacedim>::line_iterator();
+  return typename dealii::internal::TriangulationImplementation::Iterators<1,spacedim>::line_iterator();
 }
 
 
@@ -2917,10 +2917,10 @@ TriaAccessor<0, 1, spacedim>::line_index (const unsigned int)
 
 template <int spacedim>
 inline
-typename dealii::internal::Triangulation::Iterators<1,spacedim>::quad_iterator
+typename dealii::internal::TriangulationImplementation::Iterators<1,spacedim>::quad_iterator
 TriaAccessor<0, 1, spacedim>::quad (const unsigned int)
 {
-  return typename dealii::internal::Triangulation::Iterators<1,spacedim>::quad_iterator();
+  return typename dealii::internal::TriangulationImplementation::Iterators<1,spacedim>::quad_iterator();
 }
 
 
@@ -3180,7 +3180,7 @@ CellAccessor<dim,spacedim>::CellAccessor (const TriaAccessor<dim,dim,spacedim> &
 
 namespace internal
 {
-  namespace CellAccessor
+  namespace CellAccessorImplementation
   {
     template <int spacedim>
     inline
@@ -3232,7 +3232,7 @@ inline
 TriaIterator<TriaAccessor<dim-1, dim, spacedim> >
 CellAccessor<dim,spacedim>::face (const unsigned int i) const
 {
-  return dealii::internal::CellAccessor::get_face (*this, i);
+  return dealii::internal::CellAccessorImplementation::get_face (*this, i);
 }
 
 

--- a/include/deal.II/grid/tria_faces.h
+++ b/include/deal.II/grid/tria_faces.h
@@ -25,7 +25,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
     /**
      * General template for information belonging to the faces of a

--- a/include/deal.II/grid/tria_iterator_selector.h
+++ b/include/deal.II/grid/tria_iterator_selector.h
@@ -31,7 +31,7 @@ template <typename Accessor> class TriaActiveIterator;
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
     template <int dim, int spacedim>
     struct Iterators;

--- a/include/deal.II/grid/tria_levels.h
+++ b/include/deal.II/grid/tria_levels.h
@@ -31,7 +31,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
     /**
      * Store all information which belongs to one level of the multilevel

--- a/include/deal.II/grid/tria_object.h
+++ b/include/deal.II/grid/tria_object.h
@@ -25,7 +25,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
 
     /**

--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -43,7 +43,7 @@ template <int, int, int> class TriaAccessor;
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
 
     /**

--- a/include/deal.II/hp/dof_faces.h
+++ b/include/deal.II/hp/dof_faces.h
@@ -42,7 +42,7 @@ namespace internal
      * the DoF indices on cells.
      *
      * The things we store here is very similar to what is stored in the
-     * internal::DoFHandler::DoFObjects classes (see there for more
+     * internal::DoFHandlerImplementation::DoFObjects classes (see there for more
      * information, in particular on the layout of the class hierarchy, and
      * the use of file names).
      *
@@ -51,7 +51,7 @@ namespace internal
      * For hp methods, not all cells may use the same finite element, and it
      * is consequently more complicated to determine where the DoF indices for
      * a given line, quad, or hex are stored. As described in the
-     * documentation of the internal::DoFHandler::DoFLevel class, we can
+     * documentation of the internal::DoFHandlerImplementation::DoFLevel class, we can
      * compute the location of the first line DoF, for example, by calculating
      * the offset as <code>line_index *
      * dof_handler.get_fe().dofs_per_line</code>. This of course doesn't work

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -41,7 +41,7 @@ template <int dim, int spacedim> class Triangulation;
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     struct Implementation;
 
@@ -56,7 +56,7 @@ namespace internal
   {
     class DoFLevel;
 
-    namespace DoFHandler
+    namespace DoFHandlerImplementation
     {
       struct Implementation;
     }
@@ -65,12 +65,12 @@ namespace internal
 
 namespace internal
 {
-  namespace DoFAccessor
+  namespace DoFAccessorImplementation
   {
     struct Implementation;
   }
 
-  namespace DoFCellAccessor
+  namespace DoFCellAccessorImplementation
   {
     struct Implementation;
   }
@@ -162,8 +162,8 @@ namespace hp
   template <int dim, int spacedim=dim>
   class DoFHandler : public Subscriptor
   {
-    typedef dealii::internal::DoFHandler::Iterators<DoFHandler<dim,spacedim>, false> ActiveSelector;
-    typedef dealii::internal::DoFHandler::Iterators<DoFHandler<dim,spacedim>, true> LevelSelector;
+    typedef dealii::internal::DoFHandlerImplementation::Iterators<DoFHandler<dim,spacedim>, false> ActiveSelector;
+    typedef dealii::internal::DoFHandlerImplementation::Iterators<DoFHandler<dim,spacedim>, true> LevelSelector;
   public:
     typedef typename ActiveSelector::CellAccessor         cell_accessor;
     typedef typename ActiveSelector::FaceAccessor         face_accessor;
@@ -833,7 +833,7 @@ namespace hp
      * An object that describes how degrees of freedom should be distributed and
      * renumbered.
      */
-    std::unique_ptr<dealii::internal::DoFHandler::Policy::PolicyBase<dim,spacedim> > policy;
+    std::unique_ptr<dealii::internal::DoFHandlerImplementation::Policy::PolicyBase<dim,spacedim> > policy;
 
 
     /**
@@ -892,14 +892,14 @@ namespace hp
      * For most members of this structure, there is an accessor function in
      * this class that returns its value.
      */
-    dealii::internal::DoFHandler::NumberCache number_cache;
+    dealii::internal::DoFHandlerImplementation::NumberCache number_cache;
 
     /**
      * A structure that contains all sorts of numbers that characterize the
      * degrees of freedom on multigrid levels. Since multigrid is not currently
      * supported, this table is not filled with valid entries.
      */
-    std::vector<dealii::internal::DoFHandler::NumberCache> mg_number_cache;
+    std::vector<dealii::internal::DoFHandlerImplementation::NumberCache> mg_number_cache;
 
     /**
      * Array to store the indices for degrees of freedom located at vertices.
@@ -948,16 +948,16 @@ namespace hp
      */
     template <int, class, bool> friend class dealii::DoFAccessor;
     template <class, bool> friend class dealii::DoFCellAccessor;
-    friend struct dealii::internal::DoFAccessor::Implementation;
-    friend struct dealii::internal::DoFCellAccessor::Implementation;
+    friend struct dealii::internal::DoFAccessorImplementation::Implementation;
+    friend struct dealii::internal::DoFCellAccessorImplementation::Implementation;
 
     /**
      * Likewise for DoFLevel objects since they need to access the vertex dofs
      * in the functions that set and retrieve vertex dof indices.
      */
     template <int> friend class dealii::internal::hp::DoFIndicesOnFacesOrEdges;
-    friend struct dealii::internal::hp::DoFHandler::Implementation;
-    friend struct dealii::internal::DoFHandler::Policy::Implementation;
+    friend struct dealii::internal::hp::DoFHandlerImplementation::Implementation;
+    friend struct dealii::internal::DoFHandlerImplementation::Policy::Implementation;
   };
 
 
@@ -996,7 +996,7 @@ namespace internal
    * Defined in source/dofs/dof_handler.cc.
    */
   template <int dim, int spacedim>
-  std::string policy_to_string(const dealii::internal::DoFHandler::Policy::PolicyBase<dim,spacedim> &policy);
+  std::string policy_to_string(const dealii::internal::DoFHandlerImplementation::Policy::PolicyBase<dim,spacedim> &policy);
 }
 
 

--- a/include/deal.II/hp/dof_level.h
+++ b/include/deal.II/hp/dof_level.h
@@ -36,12 +36,12 @@ namespace internal
 {
   namespace hp
   {
-    namespace DoFHandler
+    namespace DoFHandlerImplementation
     {
       struct Implementation;
     }
   }
-  namespace DoFCellAccessor
+  namespace DoFCellAccessorImplementation
   {
     struct Implementation;
   }
@@ -318,8 +318,8 @@ namespace internal
        * class that needs to create these data structures.
        */
       template <int, int> friend class dealii::hp::DoFHandler;
-      friend struct dealii::internal::hp::DoFHandler::Implementation;
-      friend struct dealii::internal::DoFCellAccessor::Implementation;
+      friend struct dealii::internal::hp::DoFHandlerImplementation::Implementation;
+      friend struct dealii::internal::DoFCellAccessorImplementation::Implementation;
     };
 
 

--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -28,9 +28,9 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace BlockLinearOperator
+  namespace BlockLinearOperatorImplementation
   {
-    template <typename PayloadBlockType = internal::LinearOperator::EmptyPayload>
+    template <typename PayloadBlockType = internal::LinearOperatorImplementation::EmptyPayload>
     class EmptyBlockPayload;
   }
 }
@@ -39,12 +39,12 @@ template <typename Number> class BlockVector;
 
 template <typename Range = BlockVector<double>,
           typename Domain = Range,
-          typename BlockPayload = internal::BlockLinearOperator::EmptyBlockPayload<> >
+          typename BlockPayload = internal::BlockLinearOperatorImplementation::EmptyBlockPayload<> >
 class BlockLinearOperator;
 
 template <typename Range = BlockVector<double>,
           typename Domain = Range,
-          typename BlockPayload = internal::BlockLinearOperator::EmptyBlockPayload<>,
+          typename BlockPayload = internal::BlockLinearOperatorImplementation::EmptyBlockPayload<>,
           typename BlockMatrixType>
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_operator(const BlockMatrixType &matrix);
@@ -52,21 +52,21 @@ block_operator(const BlockMatrixType &matrix);
 template <size_t m, size_t n,
           typename Range = BlockVector<double>,
           typename Domain = Range,
-          typename BlockPayload = internal::BlockLinearOperator::EmptyBlockPayload<> >
+          typename BlockPayload = internal::BlockLinearOperatorImplementation::EmptyBlockPayload<> >
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_operator(const std::array<std::array<LinearOperator<typename Range::BlockType, typename Domain::BlockType, typename BlockPayload::BlockType>, n>, m> &);
 
 template <size_t m,
           typename Range = BlockVector<double>,
           typename Domain = Range,
-          typename BlockPayload = internal::BlockLinearOperator::EmptyBlockPayload<> >
+          typename BlockPayload = internal::BlockLinearOperatorImplementation::EmptyBlockPayload<> >
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_diagonal_operator(const std::array<LinearOperator<typename Range::BlockType, typename Domain::BlockType, typename BlockPayload::BlockType>, m> &);
 
 template <size_t m,
           typename Range = BlockVector<double>,
           typename Domain = Range,
-          typename BlockPayload = internal::BlockLinearOperator::EmptyBlockPayload<> >
+          typename BlockPayload = internal::BlockLinearOperatorImplementation::EmptyBlockPayload<> >
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_diagonal_operator(const LinearOperator<typename Range::BlockType, typename Domain::BlockType, typename BlockPayload::BlockType> &op);
 
@@ -79,21 +79,21 @@ block_diagonal_operator(const LinearOperator<typename Range::BlockType, typename
 
 template <typename Range = BlockVector<double>,
           typename Domain = Range,
-          typename BlockPayload = internal::BlockLinearOperator::EmptyBlockPayload<>,
+          typename BlockPayload = internal::BlockLinearOperatorImplementation::EmptyBlockPayload<>,
           typename BlockMatrixType>
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_diagonal_operator(const BlockMatrixType &block_matrix);
 
 template <typename Range = BlockVector<double>,
           typename Domain = Range,
-          typename BlockPayload = internal::BlockLinearOperator::EmptyBlockPayload<> >
+          typename BlockPayload = internal::BlockLinearOperatorImplementation::EmptyBlockPayload<> >
 LinearOperator<Domain, Range, typename BlockPayload::BlockType>
 block_forward_substitution(const BlockLinearOperator<Range, Domain, BlockPayload> &,
                            const BlockLinearOperator<Domain, Range, BlockPayload> &);
 
 template <typename Range = BlockVector<double>,
           typename Domain = Range,
-          typename BlockPayload = internal::BlockLinearOperator::EmptyBlockPayload<> >
+          typename BlockPayload = internal::BlockLinearOperatorImplementation::EmptyBlockPayload<> >
 LinearOperator<Domain, Range, typename BlockPayload::BlockType>
 block_back_substitution(const BlockLinearOperator<Range, Domain, BlockPayload> &,
                         const BlockLinearOperator<Domain, Range, BlockPayload> &);
@@ -312,7 +312,7 @@ public:
 
 namespace internal
 {
-  namespace BlockLinearOperator
+  namespace BlockLinearOperatorImplementation
   {
     // Populate the LinearOperator interfaces with the help of the
     // BlockLinearOperator functions
@@ -494,7 +494,7 @@ block_operator(const BlockMatrixType &block_matrix)
     return BlockType(block_matrix.block(i, j));
   };
 
-  internal::BlockLinearOperator::populate_linear_operator_functions(return_op);
+  internal::BlockLinearOperatorImplementation::populate_linear_operator_functions(return_op);
   return return_op;
 }
 
@@ -556,7 +556,7 @@ block_operator(const std::array<std::array<LinearOperator<typename Range::BlockT
     return ops[i][j];
   };
 
-  internal::BlockLinearOperator::populate_linear_operator_functions(return_op);
+  internal::BlockLinearOperatorImplementation::populate_linear_operator_functions(return_op);
   return return_op;
 }
 
@@ -613,7 +613,7 @@ block_diagonal_operator(const BlockMatrixType &block_matrix)
       return null_operator(BlockType(block_matrix.block(i, j)));
   };
 
-  internal::BlockLinearOperator::populate_linear_operator_functions(return_op);
+  internal::BlockLinearOperatorImplementation::populate_linear_operator_functions(return_op);
   return return_op;
 }
 

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -467,7 +467,7 @@ void swap (BlockVector<Number> &u,
 
 namespace internal
 {
-  namespace LinearOperator
+  namespace LinearOperatorImplementation
   {
     template <typename> class ReinitHelper;
 

--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -44,7 +44,7 @@ namespace internal
 // the vectorization features of modern processors. to make this happen,
 // we will have to vectorize the functions in the following namespace, either
 // by hand or by using, for example, optimized BLAS versions for them.
-  namespace ChunkSparseMatrix
+  namespace ChunkSparseMatrixImplementation
   {
     /**
      * Declare type for container size.
@@ -372,7 +372,7 @@ ChunkSparseMatrix<number>::~ChunkSparseMatrix ()
 
 namespace internal
 {
-  namespace ChunkSparseMatrix
+  namespace ChunkSparseMatrixImplementation
   {
     template <typename T>
     void zero_subrange (const unsigned int begin,
@@ -407,11 +407,11 @@ ChunkSparseMatrix<number>::operator = (const double d)
   const unsigned int matrix_size = cols->sparsity_pattern.n_nonzero_elements()
                                    * cols->chunk_size * cols->chunk_size;
   const unsigned int grain_size =
-    internal::SparseMatrix::minimum_parallel_grain_size *
+    internal::SparseMatrixImplementation::minimum_parallel_grain_size *
     (matrix_size+m()) / m();
   if (matrix_size>grain_size)
     parallel::apply_to_subranges (0U, matrix_size,
-                                  std::bind(&internal::ChunkSparseMatrix::template
+                                  std::bind(&internal::ChunkSparseMatrixImplementation::template
                                             zero_subrange<number>,
                                             std::placeholders::_1, std::placeholders::_2,
                                             val.get()),
@@ -715,7 +715,7 @@ ChunkSparseMatrix<number>::vmult_add (OutVector &dst,
 
   Assert (!PointerComparison::equal(&src, &dst), ExcSourceEqualsDestination());
   parallel::apply_to_subranges (0U, cols->sparsity_pattern.n_rows(),
-                                std::bind (&internal::ChunkSparseMatrix::vmult_add_on_subrange
+                                std::bind (&internal::ChunkSparseMatrixImplementation::vmult_add_on_subrange
                                            <number,InVector,OutVector>,
                                            std::cref(*cols),
                                            std::placeholders::_1, std::placeholders::_2,
@@ -724,7 +724,7 @@ ChunkSparseMatrix<number>::vmult_add (OutVector &dst,
                                            cols->sparsity_pattern.colnums.get(),
                                            std::cref(src),
                                            std::ref(dst)),
-                                internal::SparseMatrix::minimum_parallel_grain_size/cols->chunk_size+1);
+                                internal::SparseMatrixImplementation::minimum_parallel_grain_size/cols->chunk_size+1);
 
 }
 
@@ -769,7 +769,7 @@ ChunkSparseMatrix<number>::Tvmult_add (OutVector &dst,
           if ((cols_have_padding == false)
               ||
               (*colnum_ptr != cols->sparsity_pattern.n_cols()-1))
-            internal::ChunkSparseMatrix::chunk_Tvmult_add
+            internal::ChunkSparseMatrixImplementation::chunk_Tvmult_add
             (cols->chunk_size,
              val_ptr,
              src.begin() + chunk_row * cols->chunk_size,
@@ -865,7 +865,7 @@ ChunkSparseMatrix<number>::matrix_norm_square (const Vector<somenumber> &v) cons
               ||
               (*colnum_ptr != cols->sparsity_pattern.n_cols()-1))
             result +=
-              internal::ChunkSparseMatrix::
+              internal::ChunkSparseMatrixImplementation::
               chunk_matrix_scalar_product<somenumber>
               (cols->chunk_size,
                val_ptr,
@@ -973,7 +973,7 @@ ChunkSparseMatrix<number>::matrix_scalar_product (const Vector<somenumber> &u,
               ||
               (*colnum_ptr != cols->sparsity_pattern.n_cols()-1))
             result +=
-              internal::ChunkSparseMatrix::
+              internal::ChunkSparseMatrixImplementation::
               chunk_matrix_scalar_product<somenumber>
               (cols->chunk_size,
                val_ptr,
@@ -1174,7 +1174,7 @@ ChunkSparseMatrix<number>::residual (Vector<somenumber>       &dst,
           if ((cols_have_padding == false)
               ||
               (*colnum_ptr != cols->sparsity_pattern.n_cols()-1))
-            internal::ChunkSparseMatrix::chunk_vmult_subtract
+            internal::ChunkSparseMatrixImplementation::chunk_vmult_subtract
             (cols->chunk_size,
              val_ptr,
              u.begin() + *colnum_ptr * cols->chunk_size,

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -507,7 +507,7 @@ ConstraintMatrix::condense (BlockSparseMatrix<number> &uncondensed,
 // number of functions to select the right implementation for set_zero().
 namespace internal
 {
-  namespace ConstraintMatrix
+  namespace ConstraintMatrixImplementation
   {
     namespace
     {
@@ -623,7 +623,7 @@ ConstraintMatrix::set_zero (VectorType &vec) const
   std::vector<size_type> constrained_lines(lines.size());
   for (unsigned int i=0; i<lines.size(); ++i)
     constrained_lines[i] = lines[i].index;
-  internal::ConstraintMatrix::set_zero_all(constrained_lines, vec);
+  internal::ConstraintMatrixImplementation::set_zero_all(constrained_lines, vec);
 }
 
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1548,7 +1548,7 @@ struct is_serial_vector< LinearAlgebra::distributed::Vector< Number > > : std::f
 
 namespace internal
 {
-  namespace LinearOperator
+  namespace LinearOperatorImplementation
   {
     template <typename> class ReinitHelper;
 

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -30,7 +30,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace LinearOperator
+  namespace LinearOperatorImplementation
   {
     class EmptyPayload;
   }
@@ -40,12 +40,12 @@ template <typename Number> class Vector;
 
 template <typename Range = Vector<double>,
           typename Domain = Range,
-          typename Payload = internal::LinearOperator::EmptyPayload>
+          typename Payload = internal::LinearOperatorImplementation::EmptyPayload>
 class LinearOperator;
 
 template <typename Range = Vector<double>,
           typename Domain = Range,
-          typename Payload = internal::LinearOperator::EmptyPayload,
+          typename Payload = internal::LinearOperatorImplementation::EmptyPayload,
           typename OperatorExemplar,
           typename Matrix>
 LinearOperator<Range, Domain, Payload> linear_operator (const OperatorExemplar &,
@@ -53,13 +53,13 @@ LinearOperator<Range, Domain, Payload> linear_operator (const OperatorExemplar &
 
 template <typename Range = Vector<double>,
           typename Domain = Range,
-          typename Payload = internal::LinearOperator::EmptyPayload,
+          typename Payload = internal::LinearOperatorImplementation::EmptyPayload,
           typename Matrix>
 LinearOperator<Range, Domain, Payload> linear_operator (const Matrix &);
 
 template <typename Range = Vector<double>,
           typename Domain = Range,
-          typename Payload = internal::LinearOperator::EmptyPayload>
+          typename Payload = internal::LinearOperatorImplementation::EmptyPayload>
 LinearOperator<Range, Domain, Payload>
 null_operator(const LinearOperator<Range, Domain, Payload> &);
 
@@ -122,7 +122,7 @@ null_operator(const LinearOperator<Range, Domain, Payload> &);
  * For example: LinearOperator instances representing matrix inverses usually
  * require calling some linear solver. These solvers may not have interfaces
  * to the LinearOperator (which, for example, may represent a composite
- * operation). The TrilinosWrappers::internal::LinearOperator::TrilinosPayload
+ * operation). The TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload
  * therefore provides an interface extension to the LinearOperator so that it
  * can be passed to the solver and used by the solver as if it were a Trilinos
  * operator. This implies that all of the necessary functionality of the
@@ -743,7 +743,7 @@ inverse_operator(const LinearOperator<Range, Domain, Payload> &op,
  * @ingroup LAOperators
  */
 template <typename Range,
-          typename Payload = internal::LinearOperator::EmptyPayload>
+          typename Payload = internal::LinearOperatorImplementation::EmptyPayload>
 LinearOperator<Range, Range, Payload>
 identity_operator(const std::function<void(Range &, bool)> &reinit_vector)
 {
@@ -853,7 +853,7 @@ null_operator(const LinearOperator<Range, Domain, Payload> &op)
 
 namespace internal
 {
-  namespace LinearOperator
+  namespace LinearOperatorImplementation
   {
     /**
      * A helper class that is responsible for the initialization of a vector
@@ -1265,12 +1265,12 @@ linear_operator(const OperatorExemplar &operator_exemplar, const Matrix &matrix)
 
   return_op.reinit_range_vector = [&operator_exemplar](Range &v, bool omit_zeroing_entries)
   {
-    internal::LinearOperator::ReinitHelper<Range>::reinit_range_vector(operator_exemplar, v, omit_zeroing_entries);
+    internal::LinearOperatorImplementation::ReinitHelper<Range>::reinit_range_vector(operator_exemplar, v, omit_zeroing_entries);
   };
 
   return_op.reinit_domain_vector = [&operator_exemplar](Domain &v, bool omit_zeroing_entries)
   {
-    internal::LinearOperator::ReinitHelper<Domain>::reinit_domain_vector(operator_exemplar, v, omit_zeroing_entries);
+    internal::LinearOperatorImplementation::ReinitHelper<Domain>::reinit_domain_vector(operator_exemplar, v, omit_zeroing_entries);
   };
 
   typename std::conditional<

--- a/include/deal.II/lac/matrix_out.h
+++ b/include/deal.II/lac/matrix_out.h
@@ -191,7 +191,7 @@ private:
 
 namespace internal
 {
-  namespace MatrixOut
+  namespace MatrixOutImplementation
   {
     namespace
     {
@@ -287,9 +287,9 @@ MatrixOut::get_gridpoint_value (const Matrix   &matrix,
   if (options.block_size == 1)
     {
       if (options.show_absolute_values == true)
-        return std::fabs(internal::MatrixOut::get_element (matrix, i, j));
+        return std::fabs(internal::MatrixOutImplementation::get_element (matrix, i, j));
       else
-        return internal::MatrixOut::get_element (matrix, i, j);
+        return internal::MatrixOutImplementation::get_element (matrix, i, j);
     }
 
   // if blocksize greater than one,
@@ -303,9 +303,9 @@ MatrixOut::get_gridpoint_value (const Matrix   &matrix,
          col < std::min(size_type(matrix.m()),
                         size_type((j+1)*options.block_size)); ++col, ++n_elements)
       if (options.show_absolute_values == true)
-        average += std::fabs(internal::MatrixOut::get_element (matrix, row, col));
+        average += std::fabs(internal::MatrixOutImplementation::get_element (matrix, row, col));
       else
-        average += internal::MatrixOut::get_element (matrix, row, col);
+        average += internal::MatrixOutImplementation::get_element (matrix, row, col);
   average /= n_elements;
   return average;
 }

--- a/include/deal.II/lac/petsc_parallel_block_vector.h
+++ b/include/deal.II/lac/petsc_parallel_block_vector.h
@@ -512,7 +512,7 @@ namespace PETScWrappers
 
 namespace internal
 {
-  namespace LinearOperator
+  namespace LinearOperatorImplementation
   {
     template <typename> class ReinitHelper;
 

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -511,7 +511,7 @@ namespace PETScWrappers
 
 namespace internal
 {
-  namespace LinearOperator
+  namespace LinearOperatorImplementation
   {
     template <typename> class ReinitHelper;
 

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -1671,7 +1671,7 @@ AdditionalData (const double relaxation)
 
 namespace internal
 {
-  namespace PreconditionChebyshev
+  namespace PreconditionChebyshevImplementation
   {
     // for deal.II vectors, perform updates for Chebyshev preconditioner all
     // at once to reduce memory transfer. Here, we select between general
@@ -1796,11 +1796,11 @@ namespace internal
         :
         updater (updater)
       {
-        if (size < internal::Vector::minimum_parallel_grain_size)
+        if (size < internal::VectorImplementation::minimum_parallel_grain_size)
           apply_to_subrange (0, size);
         else
           apply_parallel (0, size,
-                          internal::Vector::minimum_parallel_grain_size);
+                          internal::VectorImplementation::minimum_parallel_grain_size);
       }
 
       ~VectorUpdatesRange() = default;
@@ -2004,9 +2004,9 @@ PreconditionChebyshev<MatrixType,VectorType,PreconditionerType>::initialize
 {
   matrix_ptr = &matrix;
   data = additional_data;
-  internal::PreconditionChebyshev::initialize_preconditioner(matrix,
-                                                             data.preconditioner,
-                                                             data.matrix_diagonal_inverse);
+  internal::PreconditionChebyshevImplementation::initialize_preconditioner(matrix,
+      data.preconditioner,
+      data.matrix_diagonal_inverse);
   eigenvalues_are_initialized = false;
 }
 
@@ -2059,15 +2059,15 @@ PreconditionChebyshev<MatrixType,VectorType,PreconditionerType>::estimate_eigenv
                                 std::sqrt(std::numeric_limits<typename VectorType::value_type>::epsilon()),
                                 1e-10, false, false);
 
-      internal::PreconditionChebyshev::EigenvalueTracker eigenvalue_tracker;
+      internal::PreconditionChebyshevImplementation::EigenvalueTracker eigenvalue_tracker;
       SolverCG<VectorType> solver (control);
-      solver.connect_eigenvalues_slot(std::bind(&internal::PreconditionChebyshev::EigenvalueTracker::slot,
+      solver.connect_eigenvalues_slot(std::bind(&internal::PreconditionChebyshevImplementation::EigenvalueTracker::slot,
                                                 &eigenvalue_tracker,
                                                 std::placeholders::_1));
 
       // set an initial guess which is close to the constant vector but where
       // one entry is different to trigger high frequencies
-      internal::PreconditionChebyshev::set_initial_guess(update2);
+      internal::PreconditionChebyshevImplementation::set_initial_guess(update2);
 
       try
         {
@@ -2149,7 +2149,7 @@ PreconditionChebyshev<MatrixType,VectorType,PreconditionerType>
       const double rhokp = 1./(2.*sigma-rhok);
       const double factor1 = rhokp * rhok, factor2 = 2.*rhokp/delta;
       rhok = rhokp;
-      internal::PreconditionChebyshev::vector_updates
+      internal::PreconditionChebyshevImplementation::vector_updates
       (src, *data.preconditioner, false, factor1, factor2, update1, update2, update3, dst);
     }
 }
@@ -2170,7 +2170,7 @@ PreconditionChebyshev<MatrixType,VectorType,PreconditionerType>
       const double rhokp = 1./(2.*sigma-rhok);
       const double factor1 = rhokp * rhok, factor2 = 2.*rhokp/delta;
       rhok = rhokp;
-      internal::PreconditionChebyshev::vector_updates
+      internal::PreconditionChebyshevImplementation::vector_updates
       (src, *data.preconditioner, false, factor1, factor2, update1, update2, update3, dst);
     }
 }
@@ -2188,7 +2188,7 @@ PreconditionChebyshev<MatrixType,VectorType,PreconditionerType>
   if (eigenvalues_are_initialized == false)
     estimate_eigenvalues(src);
 
-  internal::PreconditionChebyshev::vector_updates
+  internal::PreconditionChebyshevImplementation::vector_updates
   (src, *data.preconditioner, true, 0., 1./theta, update1, update2, update3, dst);
 
   do_chebyshev_loop(dst, src);
@@ -2207,7 +2207,7 @@ PreconditionChebyshev<MatrixType,VectorType,PreconditionerType>
   if (eigenvalues_are_initialized == false)
     estimate_eigenvalues(src);
 
-  internal::PreconditionChebyshev::vector_updates
+  internal::PreconditionChebyshevImplementation::vector_updates
   (src, *data.preconditioner, true, 0., 1./theta, update1, update2, update3, dst);
 
   do_transpose_chebyshev_loop(dst, src);
@@ -2227,7 +2227,7 @@ PreconditionChebyshev<MatrixType,VectorType,PreconditionerType>
     estimate_eigenvalues(src);
 
   matrix_ptr->vmult (update2, dst);
-  internal::PreconditionChebyshev::vector_updates
+  internal::PreconditionChebyshevImplementation::vector_updates
   (src, *data.preconditioner, false, 0., 1./theta, update1, update2, update3, dst);
 
   do_chebyshev_loop(dst, src);
@@ -2247,7 +2247,7 @@ PreconditionChebyshev<MatrixType,VectorType,PreconditionerType>
     estimate_eigenvalues(src);
 
   matrix_ptr->Tvmult (update2, dst);
-  internal::PreconditionChebyshev::vector_updates
+  internal::PreconditionChebyshevImplementation::vector_updates
   (src, *data.preconditioner, false, 0., 1./theta, update1, update2, update3, dst);
 
   do_transpose_chebyshev_loop(dst, src);

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -65,7 +65,7 @@ namespace LinearAlgebra
           free(val);
 
         Utilities::System::posix_memalign ((void **)&val, 64, sizeof(Number)*new_alloc_size);
-        if (new_alloc_size >= 4*dealii::internal::Vector::minimum_parallel_grain_size)
+        if (new_alloc_size >= 4*dealii::internal::VectorImplementation::minimum_parallel_grain_size)
           thread_loop_partitioner = std::make_shared<parallel::internal::TBBPartitioner>();
       }
   }

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -44,7 +44,7 @@ namespace internal
   /**
    * A namespace for a helper class to the GMRES solver.
    */
-  namespace SolverGMRES
+  namespace SolverGMRESImplementation
   {
     /**
      * Class to hold temporary vectors.  This class automatically allocates a
@@ -289,7 +289,7 @@ public:
    */
   boost::signals2::connection
   connect_krylov_space_slot(
-    const std::function<void (const internal::SolverGMRES::TmpVectors<VectorType> &)> &slot);
+    const std::function<void (const internal::SolverGMRESImplementation::TmpVectors<VectorType> &)> &slot);
 
 
   /**
@@ -353,7 +353,7 @@ protected:
    * Signal used to retrieve the Krylov space basis vectors. Called once
    * when all iterations are ended.
    */
-  boost::signals2::signal<void (const internal::SolverGMRES::TmpVectors<VectorType> &)> krylov_space_signal;
+  boost::signals2::signal<void (const internal::SolverGMRESImplementation::TmpVectors<VectorType> &)> krylov_space_signal;
 
   /**
    * Signal used to retrieve a notification
@@ -386,7 +386,7 @@ protected:
    */
   static double
   modified_gram_schmidt
-  (const internal::SolverGMRES::TmpVectors<VectorType> &orthogonal_vectors,
+  (const internal::SolverGMRESImplementation::TmpVectors<VectorType> &orthogonal_vectors,
    const unsigned int                                  dim,
    const unsigned int                                  accumulated_iterations,
    VectorType                                          &vv,
@@ -521,7 +521,7 @@ private:
 #ifndef DOXYGEN
 namespace internal
 {
-  namespace SolverGMRES
+  namespace SolverGMRESImplementation
   {
     template <class VectorType>
     inline
@@ -654,7 +654,7 @@ template <class VectorType>
 inline
 double
 SolverGMRES<VectorType>::modified_gram_schmidt
-(const internal::SolverGMRES::TmpVectors<VectorType> &orthogonal_vectors,
+(const internal::SolverGMRESImplementation::TmpVectors<VectorType> &orthogonal_vectors,
  const unsigned int                                  dim,
  const unsigned int                                  accumulated_iterations,
  VectorType                                          &vv,
@@ -746,7 +746,7 @@ SolverGMRES<VectorType>::compute_eigs_and_cond
             eigenvalues[i] = mat_eig.eigenvalue(i);
           //Sort eigenvalues for nicer output.
           std::sort(eigenvalues.begin(), eigenvalues.end(),
-                    internal::SolverGMRES::complex_less_pred);
+                    internal::SolverGMRESImplementation::complex_less_pred);
           eigenvalues_signal(eigenvalues);
         }
       //Calculate condition number, avoid calculating the svd if a slot
@@ -781,7 +781,7 @@ SolverGMRES<VectorType>::solve (const MatrixType         &A,
   const unsigned int n_tmp_vectors = additional_data.max_n_tmp_vectors;
 
   // Generate an object where basis vectors are stored.
-  internal::SolverGMRES::TmpVectors<VectorType> tmp_vectors (n_tmp_vectors, this->memory);
+  internal::SolverGMRESImplementation::TmpVectors<VectorType> tmp_vectors (n_tmp_vectors, this->memory);
 
   // number of the present iteration; this
   // number is not reset to zero upon a
@@ -1111,7 +1111,7 @@ SolverGMRES<VectorType>::connect_hessenberg_slot
 template <class VectorType>
 boost::signals2::connection
 SolverGMRES<VectorType>::connect_krylov_space_slot
-(const std::function<void (const internal::SolverGMRES::TmpVectors<VectorType> &)> &slot)
+(const std::function<void (const internal::SolverGMRESImplementation::TmpVectors<VectorType> &)> &slot)
 {
   return krylov_space_signal.connect(slot);
 }
@@ -1177,8 +1177,8 @@ SolverFGMRES<VectorType>::solve (const MatrixType         &A,
   const unsigned int basis_size = additional_data.max_basis_size;
 
   // Generate an object where basis vectors are stored.
-  typename internal::SolverGMRES::TmpVectors<VectorType> v (basis_size, this->memory);
-  typename internal::SolverGMRES::TmpVectors<VectorType> z (basis_size, this->memory);
+  typename internal::SolverGMRESImplementation::TmpVectors<VectorType> v (basis_size, this->memory);
+  typename internal::SolverGMRESImplementation::TmpVectors<VectorType> z (basis_size, this->memory);
 
   // number of the present iteration; this number is not reset to zero upon a
   // restart

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -166,7 +166,7 @@ SparseMatrix<number>::~SparseMatrix ()
 
 namespace internal
 {
-  namespace SparseMatrix
+  namespace SparseMatrixImplementation
   {
     typedef types::global_dof_index size_type;
 
@@ -201,11 +201,11 @@ SparseMatrix<number>::operator = (const double d)
   // per row on average.
   const std::size_t matrix_size = cols->n_nonzero_elements();
   const size_type grain_size =
-    internal::SparseMatrix::minimum_parallel_grain_size *
+    internal::SparseMatrixImplementation::minimum_parallel_grain_size *
     (cols->n_nonzero_elements()+m()) / m();
   if (matrix_size>grain_size)
     parallel::apply_to_subranges (0U, matrix_size,
-                                  std::bind(&internal::SparseMatrix::template
+                                  std::bind(&internal::SparseMatrixImplementation::template
                                             zero_subrange<number>,
                                             std::placeholders::_1, std::placeholders::_2,
                                             val.get()),
@@ -463,7 +463,7 @@ SparseMatrix<number>::add (const number factor,
 
 namespace internal
 {
-  namespace SparseMatrix
+  namespace SparseMatrixImplementation
   {
     /**
      * Perform a vmult using the SparseMatrix data structures, but only using
@@ -759,7 +759,7 @@ SparseMatrix<number>::vmult (OutVector &dst,
   Assert (!PointerComparison::equal(&src, &dst), ExcSourceEqualsDestination());
 
   parallel::apply_to_subranges (0U, m(),
-                                std::bind (&internal::SparseMatrix::vmult_on_subrange
+                                std::bind (&internal::SparseMatrixImplementation::vmult_on_subrange
                                            <number,InVector,OutVector>,
                                            std::placeholders::_1, std::placeholders::_2,
                                            val.get(),
@@ -768,7 +768,7 @@ SparseMatrix<number>::vmult (OutVector &dst,
                                            std::cref(src),
                                            std::ref(dst),
                                            false),
-                                internal::SparseMatrix::minimum_parallel_grain_size);
+                                internal::SparseMatrixImplementation::minimum_parallel_grain_size);
 }
 
 
@@ -814,7 +814,7 @@ SparseMatrix<number>::vmult_add (OutVector &dst,
   Assert (!PointerComparison::equal(&src, &dst), ExcSourceEqualsDestination());
 
   parallel::apply_to_subranges (0U, m(),
-                                std::bind (&internal::SparseMatrix::vmult_on_subrange
+                                std::bind (&internal::SparseMatrixImplementation::vmult_on_subrange
                                            <number,InVector,OutVector>,
                                            std::placeholders::_1, std::placeholders::_2,
                                            val.get(),
@@ -823,7 +823,7 @@ SparseMatrix<number>::vmult_add (OutVector &dst,
                                            std::cref(src),
                                            std::ref(dst),
                                            true),
-                                internal::SparseMatrix::minimum_parallel_grain_size);
+                                internal::SparseMatrixImplementation::minimum_parallel_grain_size);
 }
 
 
@@ -852,7 +852,7 @@ SparseMatrix<number>::Tvmult_add (OutVector &dst,
 
 namespace internal
 {
-  namespace SparseMatrix
+  namespace SparseMatrixImplementation
   {
     /**
      * Perform a vmult using the SparseMatrix data structures, but only using
@@ -900,7 +900,7 @@ SparseMatrix<number>::matrix_norm_square (const Vector<somenumber> &v) const
 
   return
     parallel::accumulate_from_subranges<somenumber>
-    (std::bind (&internal::SparseMatrix::matrix_norm_sqr_on_subrange
+    (std::bind (&internal::SparseMatrixImplementation::matrix_norm_sqr_on_subrange
                 <number,Vector<somenumber> >,
                 std::placeholders::_1, std::placeholders::_2,
                 val.get(),
@@ -908,14 +908,14 @@ SparseMatrix<number>::matrix_norm_square (const Vector<somenumber> &v) const
                 cols->colnums.get(),
                 std::cref(v)),
      0, m(),
-     internal::SparseMatrix::minimum_parallel_grain_size);
+     internal::SparseMatrixImplementation::minimum_parallel_grain_size);
 }
 
 
 
 namespace internal
 {
-  namespace SparseMatrix
+  namespace SparseMatrixImplementation
   {
     /**
      * Perform a vmult using the SparseMatrix data structures, but only using
@@ -965,7 +965,7 @@ SparseMatrix<number>::matrix_scalar_product (const Vector<somenumber> &u,
 
   return
     parallel::accumulate_from_subranges<somenumber>
-    (std::bind (&internal::SparseMatrix::matrix_scalar_product_on_subrange
+    (std::bind (&internal::SparseMatrixImplementation::matrix_scalar_product_on_subrange
                 <number,Vector<somenumber> >,
                 std::placeholders::_1, std::placeholders::_2,
                 val.get(),
@@ -974,7 +974,7 @@ SparseMatrix<number>::matrix_scalar_product (const Vector<somenumber> &u,
                 std::cref(u),
                 std::cref(v)),
      0, m(),
-     internal::SparseMatrix::minimum_parallel_grain_size);
+     internal::SparseMatrixImplementation::minimum_parallel_grain_size);
 }
 
 
@@ -1271,7 +1271,7 @@ SparseMatrix<number>::frobenius_norm () const
 
 namespace internal
 {
-  namespace SparseMatrix
+  namespace SparseMatrixImplementation
   {
     /**
      * Perform a vmult using the SparseMatrix data structures, but only using
@@ -1327,7 +1327,7 @@ SparseMatrix<number>::residual (Vector<somenumber>       &dst,
 
   return
     std::sqrt (parallel::accumulate_from_subranges<somenumber>
-               (std::bind (&internal::SparseMatrix::residual_sqr_on_subrange
+               (std::bind (&internal::SparseMatrixImplementation::residual_sqr_on_subrange
                            <number,Vector<somenumber>,Vector<somenumber> >,
                            std::placeholders::_1, std::placeholders::_2,
                            val.get(),
@@ -1337,7 +1337,7 @@ SparseMatrix<number>::residual (Vector<somenumber>       &dst,
                            std::cref(b),
                            std::ref(dst)),
                 0, m(),
-                internal::SparseMatrix::minimum_parallel_grain_size));
+                internal::SparseMatrixImplementation::minimum_parallel_grain_size));
 }
 
 

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -580,7 +580,7 @@ namespace TrilinosWrappers
 
   namespace internal
   {
-    namespace BlockLinearOperator
+    namespace BlockLinearOperatorImplementation
     {
 
       /**
@@ -619,7 +619,7 @@ namespace TrilinosWrappers
         template <typename... Args>
         TrilinosBlockPayload (const Args &...)
         {
-          static_assert(typeid(PayloadBlockType)==typeid(internal::LinearOperator::TrilinosPayload),
+          static_assert(typeid(PayloadBlockType)==typeid(internal::LinearOperatorImplementation::TrilinosPayload),
                         "TrilinosBlockPayload can only accept a payload of type TrilinosPayload.");
         }
       };

--- a/include/deal.II/lac/trilinos_linear_operator.h
+++ b/include/deal.II/lac/trilinos_linear_operator.h
@@ -35,12 +35,12 @@ namespace TrilinosWrappers
 
   namespace internal
   {
-    namespace LinearOperator
+    namespace LinearOperatorImplementation
     {
       class TrilinosPayload;
     }
 
-    namespace BlockLinearOperator
+    namespace BlockLinearOperatorImplementation
     {
       template <typename PayloadBlockType>
       class TrilinosBlockPayload;
@@ -71,11 +71,11 @@ namespace TrilinosWrappers
    */
   template <typename Range, typename Domain = Range,
             typename Matrix>
-  inline LinearOperator<Range, Domain, TrilinosWrappers::internal::LinearOperator::TrilinosPayload>
+  inline LinearOperator<Range, Domain, TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload>
   linear_operator(const TrilinosWrappers::SparseMatrix &operator_exemplar, const Matrix &matrix)
   {
     typedef TrilinosWrappers::SparseMatrix OperatorExemplar;
-    typedef TrilinosWrappers::internal::LinearOperator::TrilinosPayload Payload;
+    typedef TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload Payload;
     return dealii::linear_operator<Range, Domain, Payload, OperatorExemplar, Matrix>(operator_exemplar, matrix);
   }
 
@@ -95,11 +95,11 @@ namespace TrilinosWrappers
    * @ingroup TrilinosWrappers
    */
   template <typename Range, typename Domain = Range>
-  inline LinearOperator<Range, Domain, TrilinosWrappers::internal::LinearOperator::TrilinosPayload>
+  inline LinearOperator<Range, Domain, TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload>
   linear_operator(const TrilinosWrappers::SparseMatrix &matrix)
   {
     typedef TrilinosWrappers::SparseMatrix Matrix;
-    typedef TrilinosWrappers::internal::LinearOperator::TrilinosPayload Payload;
+    typedef TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload Payload;
     return dealii::linear_operator<Range, Domain, Payload, Matrix, Matrix>(matrix, matrix);
   }
 
@@ -126,12 +126,12 @@ namespace TrilinosWrappers
    */
   template <typename Range,
             typename Domain = Range>
-  inline BlockLinearOperator<Range, Domain, TrilinosWrappers::internal::BlockLinearOperator::TrilinosBlockPayload<TrilinosWrappers::internal::LinearOperator::TrilinosPayload> >
+  inline BlockLinearOperator<Range, Domain, TrilinosWrappers::internal::BlockLinearOperatorImplementation::TrilinosBlockPayload<TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload> >
   block_operator(const TrilinosWrappers::BlockSparseMatrix &block_matrix)
   {
     typedef TrilinosWrappers::BlockSparseMatrix BlockMatrix;
-    typedef TrilinosWrappers::internal::LinearOperator::TrilinosPayload PayloadBlockType;
-    typedef TrilinosWrappers::internal::BlockLinearOperator::TrilinosBlockPayload<PayloadBlockType> BlockPayload;
+    typedef TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PayloadBlockType;
+    typedef TrilinosWrappers::internal::BlockLinearOperatorImplementation::TrilinosBlockPayload<PayloadBlockType> BlockPayload;
     return dealii::block_operator<Range,Domain,BlockPayload,BlockMatrix>(block_matrix);
   }
 
@@ -154,11 +154,11 @@ namespace TrilinosWrappers
   template <size_t m, size_t n,
             typename Range,
             typename Domain = Range>
-  inline BlockLinearOperator<Range, Domain, TrilinosWrappers::internal::BlockLinearOperator::TrilinosBlockPayload<TrilinosWrappers::internal::LinearOperator::TrilinosPayload> >
-  block_operator(const std::array<std::array<LinearOperator<typename Range::BlockType, typename Domain::BlockType, TrilinosWrappers::internal::LinearOperator::TrilinosPayload>, n>, m> &ops)
+  inline BlockLinearOperator<Range, Domain, TrilinosWrappers::internal::BlockLinearOperatorImplementation::TrilinosBlockPayload<TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload> >
+  block_operator(const std::array<std::array<LinearOperator<typename Range::BlockType, typename Domain::BlockType, TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload>, n>, m> &ops)
   {
-    typedef TrilinosWrappers::internal::LinearOperator::TrilinosPayload PayloadBlockType;
-    typedef TrilinosWrappers::internal::BlockLinearOperator::TrilinosBlockPayload<PayloadBlockType> BlockPayload;
+    typedef TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PayloadBlockType;
+    typedef TrilinosWrappers::internal::BlockLinearOperatorImplementation::TrilinosBlockPayload<PayloadBlockType> BlockPayload;
     return dealii::block_operator<m,n,Range,Domain,BlockPayload>(ops);
   }
 
@@ -182,12 +182,12 @@ namespace TrilinosWrappers
    */
   template <typename Range,
             typename Domain = Range>
-  inline BlockLinearOperator<Range, Domain, TrilinosWrappers::internal::BlockLinearOperator::TrilinosBlockPayload<TrilinosWrappers::internal::LinearOperator::TrilinosPayload> >
+  inline BlockLinearOperator<Range, Domain, TrilinosWrappers::internal::BlockLinearOperatorImplementation::TrilinosBlockPayload<TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload> >
   block_diagonal_operator(const TrilinosWrappers::BlockSparseMatrix &block_matrix)
   {
     typedef TrilinosWrappers::BlockSparseMatrix BlockMatrix;
-    typedef TrilinosWrappers::internal::LinearOperator::TrilinosPayload PayloadBlockType;
-    typedef TrilinosWrappers::internal::BlockLinearOperator::TrilinosBlockPayload<PayloadBlockType> BlockPayload;
+    typedef TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PayloadBlockType;
+    typedef TrilinosWrappers::internal::BlockLinearOperatorImplementation::TrilinosBlockPayload<PayloadBlockType> BlockPayload;
     return dealii::block_diagonal_operator<Range, Domain, BlockPayload, BlockMatrix>(block_matrix);
   }
 
@@ -208,11 +208,11 @@ namespace TrilinosWrappers
    * @ingroup TrilinosWrappers
    */
   template <size_t m, typename Range, typename Domain = Range>
-  inline BlockLinearOperator<Range, Domain, TrilinosWrappers::internal::BlockLinearOperator::TrilinosBlockPayload<TrilinosWrappers::internal::LinearOperator::TrilinosPayload> >
-  block_diagonal_operator(const std::array<LinearOperator<typename Range::BlockType, typename Domain::BlockType, TrilinosWrappers::internal::LinearOperator::TrilinosPayload>, m> &ops)
+  inline BlockLinearOperator<Range, Domain, TrilinosWrappers::internal::BlockLinearOperatorImplementation::TrilinosBlockPayload<TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload> >
+  block_diagonal_operator(const std::array<LinearOperator<typename Range::BlockType, typename Domain::BlockType, TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload>, m> &ops)
   {
-    typedef TrilinosWrappers::internal::LinearOperator::TrilinosPayload PayloadBlockType;
-    typedef TrilinosWrappers::internal::BlockLinearOperator::TrilinosBlockPayload<PayloadBlockType> BlockPayload;
+    typedef TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PayloadBlockType;
+    typedef TrilinosWrappers::internal::BlockLinearOperatorImplementation::TrilinosBlockPayload<PayloadBlockType> BlockPayload;
     return dealii::block_diagonal_operator<m,Range,Domain,BlockPayload>(ops);
   }
 

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -423,7 +423,7 @@ namespace TrilinosWrappers
 
 namespace internal
 {
-  namespace LinearOperator
+  namespace LinearOperatorImplementation
   {
     template <typename> class ReinitHelper;
 

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2114,7 +2114,7 @@ namespace TrilinosWrappers
       }
     }
 
-    namespace LinearOperator
+    namespace LinearOperatorImplementation
     {
 
       /**
@@ -2129,7 +2129,7 @@ namespace TrilinosWrappers
        * reference to the <tt>vmult</tt> and <tt>Tvmult</tt> functions. This
        * object is not thread-safe when the transpose flag is set on it or the
        * Trilinos object to which it refers. See the docuemtation for the
-       * TrilinosWrappers::internal::LinearOperator::TrilinosPayload::SetUseTranspose()
+       * TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload::SetUseTranspose()
        * function for further details.
        *
        * @author Jean-Paul Pelteret, 2016
@@ -3179,7 +3179,7 @@ namespace TrilinosWrappers
 
   namespace internal
   {
-    namespace LinearOperator
+    namespace LinearOperatorImplementation
     {
       template <typename Solver, typename Preconditioner>
       typename std::enable_if<

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -2188,7 +2188,7 @@ namespace TrilinosWrappers
 
 namespace internal
 {
-  namespace LinearOperator
+  namespace LinearOperatorImplementation
   {
     template <typename> class ReinitHelper;
 

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -280,7 +280,7 @@ void Vector<Number>::reinit (const size_type n,
 
       // only reset the partitioner if we actually expect a significant vector
       // size
-      if (vec_size >= 4*internal::Vector::minimum_parallel_grain_size)
+      if (vec_size >= 4*internal::VectorImplementation::minimum_parallel_grain_size)
         thread_loop_partitioner = std::make_shared<parallel::internal::TBBPartitioner>();
     }
 
@@ -315,7 +315,7 @@ void Vector<Number>::grow_or_shrink (const size_type n)
 
       // only reset the partitioner if we actually expect a significant vector
       // size
-      if (vec_size >= 4*internal::Vector::minimum_parallel_grain_size)
+      if (vec_size >= 4*internal::VectorImplementation::minimum_parallel_grain_size)
         thread_loop_partitioner = std::make_shared<parallel::internal::TBBPartitioner>();
     }
 

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -454,7 +454,7 @@ private:
 
 namespace internal
 {
-  namespace GrowingVectorMemory
+  namespace GrowingVectorMemoryImplementation
   {
     void release_all_unused_memory();
   }

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -126,7 +126,7 @@ namespace internal
       {
         const size_type vec_size = end-start;
         // set chunk size for sub-tasks
-        const unsigned int gs = internal::Vector::minimum_parallel_grain_size;
+        const unsigned int gs = internal::VectorImplementation::minimum_parallel_grain_size;
         n_chunks = std::min(static_cast<size_type>(4*MultithreadInfo::n_threads()),
                             vec_size / gs);
         chunk_size = vec_size / n_chunks;
@@ -167,7 +167,7 @@ namespace internal
       size_type vec_size = end-start;
       // only go to the parallel function in case there are at least 4 parallel
       // items, otherwise the overhead is too large
-      if (vec_size >= 4*internal::Vector::minimum_parallel_grain_size &&
+      if (vec_size >= 4*internal::VectorImplementation::minimum_parallel_grain_size &&
           MultithreadInfo::n_threads() > 1)
         {
           Assert(partitioner.get() != nullptr,
@@ -1211,7 +1211,7 @@ namespace internal
       {
         const size_type vec_size = end-start;
         // set chunk size for sub-tasks
-        const unsigned int gs = internal::Vector::minimum_parallel_grain_size;
+        const unsigned int gs = internal::VectorImplementation::minimum_parallel_grain_size;
         n_chunks = std::min(static_cast<size_type>(4*MultithreadInfo::n_threads()),
                             vec_size / gs);
         chunk_size = vec_size / n_chunks;
@@ -1292,7 +1292,7 @@ namespace internal
       size_type vec_size = end-start;
       // only go to the parallel function in case there are at least 4 parallel
       // items, otherwise the overhead is too large
-      if (vec_size >= 4*internal::Vector::minimum_parallel_grain_size &&
+      if (vec_size >= 4*internal::VectorImplementation::minimum_parallel_grain_size &&
           MultithreadInfo::n_threads() > 1)
         {
           Assert(partitioner.get() != nullptr,

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1555,7 +1555,7 @@ MatrixFree<dim,Number>::release_scratch_data(const AlignedVector<VectorizedArray
 
 namespace internal
 {
-  namespace MatrixFree
+  namespace MatrixFreeImplementation
   {
     template <typename DoFHandlerType>
     inline
@@ -1610,7 +1610,7 @@ reinit(const DoFHandlerType                                  &dof_handler,
   quads.push_back (quad);
 
   std::vector<IndexSet> locally_owned_sets =
-    internal::MatrixFree::extract_locally_owned_index_sets
+    internal::MatrixFreeImplementation::extract_locally_owned_index_sets
     (dof_handlers, additional_data.level_mg_handler);
 
   std::vector<hp::QCollection<1> > quad_hp;
@@ -1638,7 +1638,7 @@ reinit(const Mapping<dim>                                    &mapping,
   constraints.push_back (&constraints_in);
 
   std::vector<IndexSet> locally_owned_sets =
-    internal::MatrixFree::extract_locally_owned_index_sets
+    internal::MatrixFreeImplementation::extract_locally_owned_index_sets
     (dof_handlers, additional_data.level_mg_handler);
 
   std::vector<hp::QCollection<1> > quad_hp;
@@ -1659,7 +1659,7 @@ reinit(const std::vector<const DoFHandlerType *>   &dof_handler,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
   std::vector<IndexSet> locally_owned_set =
-    internal::MatrixFree::extract_locally_owned_index_sets
+    internal::MatrixFreeImplementation::extract_locally_owned_index_sets
     (dof_handler, additional_data.level_mg_handler);
   std::vector<hp::QCollection<1> > quad_hp;
   for (unsigned int q=0; q<quad.size(); ++q)
@@ -1679,7 +1679,7 @@ reinit(const std::vector<const DoFHandlerType *>             &dof_handler,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
   std::vector<IndexSet> locally_owned_set =
-    internal::MatrixFree::extract_locally_owned_index_sets
+    internal::MatrixFreeImplementation::extract_locally_owned_index_sets
     (dof_handler, additional_data.level_mg_handler);
   std::vector<hp::QCollection<1> > quad_hp;
   quad_hp.emplace_back (quad);
@@ -1699,7 +1699,7 @@ reinit(const Mapping<dim>                                    &mapping,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
   std::vector<IndexSet> locally_owned_set =
-    internal::MatrixFree::extract_locally_owned_index_sets
+    internal::MatrixFreeImplementation::extract_locally_owned_index_sets
     (dof_handler, additional_data.level_mg_handler);
   std::vector<hp::QCollection<1> > quad_hp;
   quad_hp.emplace_back (quad);
@@ -1719,7 +1719,7 @@ reinit(const Mapping<dim>                                   &mapping,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
   std::vector<IndexSet> locally_owned_set =
-    internal::MatrixFree::extract_locally_owned_index_sets
+    internal::MatrixFreeImplementation::extract_locally_owned_index_sets
     (dof_handler, additional_data.level_mg_handler);
   std::vector<hp::QCollection<1> > quad_hp;
   for (unsigned int q=0; q<quad.size(); ++q)

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -568,7 +568,7 @@ Multigrid<VectorType>::get_minlevel () const
 
 namespace internal
 {
-  namespace PreconditionMG
+  namespace PreconditionMGImplementation
   {
     template <int dim, typename VectorType, class TRANSFER, typename OtherVectorType>
     typename std::enable_if<TRANSFER::supports_dof_handler_vector>::type
@@ -716,8 +716,8 @@ PreconditionMG<dim, VectorType, TRANSFER>::vmult
 (OtherVectorType       &dst,
  const OtherVectorType &src) const
 {
-  internal::PreconditionMG::vmult(dof_handler_vector_raw,*multigrid,*transfer,
-                                  dst,src,uses_dof_handler_vector,0);
+  internal::PreconditionMGImplementation::vmult(dof_handler_vector_raw,*multigrid,*transfer,
+                                                dst,src,uses_dof_handler_vector,0);
 }
 
 
@@ -759,8 +759,8 @@ PreconditionMG<dim, VectorType, TRANSFER>::vmult_add
 (OtherVectorType       &dst,
  const OtherVectorType &src) const
 {
-  internal::PreconditionMG::vmult_add(dof_handler_vector_raw,*multigrid,*transfer,
-                                      dst,src,uses_dof_handler_vector,0);
+  internal::PreconditionMGImplementation::vmult_add(dof_handler_vector_raw,*multigrid,*transfer,
+                                                    dst,src,uses_dof_handler_vector,0);
 }
 
 

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -27,7 +27,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DataOut
+  namespace DataOutImplementation
   {
     /**
      * A derived class for use in the DataOut class. This is a class for the
@@ -333,7 +333,7 @@ private:
    */
   void build_one_patch
   (const std::pair<cell_iterator, unsigned int>                 *cell_and_index,
-   internal::DataOut::ParallelData<DoFHandlerType::dimension, DoFHandlerType::space_dimension>  &scratch_data,
+   internal::DataOutImplementation::ParallelData<DoFHandlerType::dimension, DoFHandlerType::space_dimension>  &scratch_data,
    const unsigned int                                            n_subdivisions,
    const CurvedCellRegion                                        curved_cell_region);
 };

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -41,7 +41,7 @@ namespace Exceptions
    * A namespace for exceptions that are used throughout the DataOut*
    * collection of classes.
    */
-  namespace DataOut
+  namespace DataOutImplementation
   {
     /**
      * Exception
@@ -143,7 +143,7 @@ namespace Exceptions
 
 namespace internal
 {
-  namespace DataOut
+  namespace DataOutImplementation
   {
     /**
      * The DataEntry classes abstract away the concrete data type of vectors
@@ -865,12 +865,12 @@ protected:
   /**
    * List of data elements with vectors of values for each degree of freedom.
    */
-  std::vector<std::shared_ptr<internal::DataOut::DataEntryBase<DoFHandlerType> > >  dof_data;
+  std::vector<std::shared_ptr<internal::DataOutImplementation::DataEntryBase<DoFHandlerType> > >  dof_data;
 
   /**
    * List of data elements with vectors of values for each cell.
    */
-  std::vector<std::shared_ptr<internal::DataOut::DataEntryBase<DoFHandlerType> > >  cell_data;
+  std::vector<std::shared_ptr<internal::DataOutImplementation::DataEntryBase<DoFHandlerType> > >  cell_data;
 
   /**
    * This is a list of patches that is created each time build_patches() is
@@ -942,7 +942,7 @@ add_data_vector
  const DataVectorType                      type,
  const std::vector<DataComponentInterpretation::DataComponentInterpretation> &data_component_interpretation)
 {
-  Assert (triangulation != nullptr, Exceptions::DataOut::ExcNoTriangulationSelected ());
+  Assert (triangulation != nullptr, Exceptions::DataOutImplementation::ExcNoTriangulationSelected ());
   std::vector<std::string> names(1, name);
   add_data_vector_internal (dofs, vec, names, type, data_component_interpretation, true);
 }
@@ -959,7 +959,7 @@ add_data_vector
  const DataVectorType                      type,
  const std::vector<DataComponentInterpretation::DataComponentInterpretation> &data_component_interpretation)
 {
-  Assert (triangulation != nullptr, Exceptions::DataOut::ExcNoTriangulationSelected ());
+  Assert (triangulation != nullptr, Exceptions::DataOutImplementation::ExcNoTriangulationSelected ());
   add_data_vector_internal(dofs, vec, names, type, data_component_interpretation, false);
 }
 
@@ -1003,7 +1003,7 @@ DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::
 add_data_vector (const VectorType                       &vec,
                  const DataPostprocessor<DoFHandlerType::space_dimension> &data_postprocessor)
 {
-  Assert (dofs != nullptr, Exceptions::DataOut::ExcNoDoFHandlerSelected ());
+  Assert (dofs != nullptr, Exceptions::DataOutImplementation::ExcNoDoFHandlerSelected ());
   add_data_vector(*dofs, vec, data_postprocessor);
 }
 
@@ -1028,17 +1028,17 @@ merge_patches (const DataOut_DoFData<DoFHandlerType2,patch_dim,patch_space_dim> 
   // check equality of component
   // names
   Assert (get_dataset_names() == source.get_dataset_names(),
-          Exceptions::DataOut::ExcIncompatibleDatasetNames());
+          Exceptions::DataOutImplementation::ExcIncompatibleDatasetNames());
   // make sure patches are compatible. we'll
   // assume that if the first respective
   // patches are ok that all the other ones
   // are ok as well
   Assert (patches[0].n_subdivisions == source_patches[0].n_subdivisions,
-          Exceptions::DataOut::ExcIncompatiblePatchLists());
+          Exceptions::DataOutImplementation::ExcIncompatiblePatchLists());
   Assert (patches[0].data.n_rows() == source_patches[0].data.n_rows(),
-          Exceptions::DataOut::ExcIncompatiblePatchLists());
+          Exceptions::DataOutImplementation::ExcIncompatiblePatchLists());
   Assert (patches[0].data.n_cols() == source_patches[0].data.n_cols(),
-          Exceptions::DataOut::ExcIncompatiblePatchLists());
+          Exceptions::DataOutImplementation::ExcIncompatiblePatchLists());
 
   // check equality of the vector data
   // specifications

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -55,7 +55,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DataOut
+  namespace DataOutImplementation
   {
     template <int dim, int spacedim>
     ParallelDataBase<dim,spacedim>::
@@ -311,7 +311,7 @@ namespace internal
 
 namespace internal
 {
-  namespace DataOut
+  namespace DataOutImplementation
   {
     /**
      * Extract the specified component of a number. This template is used
@@ -395,10 +395,10 @@ namespace internal
         Assert (names[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
                                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                            "0123456789_<>()") == std::string::npos,
-                Exceptions::DataOut::ExcInvalidCharacter (names[i],
-                                                          names[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
-                                                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                              "0123456789_<>()")));
+                Exceptions::DataOutImplementation::ExcInvalidCharacter (names[i],
+                    names[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
+                                               "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                               "0123456789_<>()")));
     }
 
 
@@ -425,10 +425,10 @@ namespace internal
         Assert (names[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
                                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                            "0123456789_<>()") == std::string::npos,
-                Exceptions::DataOut::ExcInvalidCharacter (names[i],
-                                                          names[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
-                                                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                              "0123456789_<>()")));
+                Exceptions::DataOutImplementation::ExcInvalidCharacter (names[i],
+                    names[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
+                                               "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                               "0123456789_<>()")));
     }
 
 
@@ -911,9 +911,9 @@ DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::
 attach_dof_handler (const DoFHandlerType &d)
 {
   Assert (dof_data.size() == 0,
-          Exceptions::DataOut::ExcOldDataStillPresent());
+          Exceptions::DataOutImplementation::ExcOldDataStillPresent());
   Assert (cell_data.size() == 0,
-          Exceptions::DataOut::ExcOldDataStillPresent());
+          Exceptions::DataOutImplementation::ExcOldDataStillPresent());
 
   triangulation = SmartPointer<const Triangulation<DoFHandlerType::dimension,
   DoFHandlerType::space_dimension> >
@@ -929,9 +929,9 @@ DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::
 attach_triangulation (const Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &tria)
 {
   Assert (dof_data.size() == 0,
-          Exceptions::DataOut::ExcOldDataStillPresent());
+          Exceptions::DataOutImplementation::ExcOldDataStillPresent());
   Assert (cell_data.size() == 0,
-          Exceptions::DataOut::ExcOldDataStillPresent());
+          Exceptions::DataOutImplementation::ExcOldDataStillPresent());
 
   triangulation = SmartPointer<const Triangulation<DoFHandlerType::dimension,
   DoFHandlerType::space_dimension> >
@@ -965,12 +965,12 @@ add_data_vector (const DoFHandlerType                   &dof_handler,
     }
 
   Assert (vec.size() == dof_handler.n_dofs(),
-          Exceptions::DataOut::ExcInvalidVectorSize (vec.size(),
-                                                     dof_handler.n_dofs(),
-                                                     dof_handler.get_triangulation().n_active_cells()));
+          Exceptions::DataOutImplementation::ExcInvalidVectorSize (vec.size(),
+              dof_handler.n_dofs(),
+              dof_handler.get_triangulation().n_active_cells()));
 
 
-  auto new_entry = std_cxx14::make_unique<internal::DataOut::DataEntry<DoFHandlerType,VectorType>>
+  auto new_entry = std_cxx14::make_unique<internal::DataOutImplementation::DataEntry<DoFHandlerType,VectorType>>
                    (&dof_handler, &vec, &data_postprocessor);
   dof_data.emplace_back (std::move(new_entry));
 }
@@ -1058,18 +1058,18 @@ add_data_vector_internal
               ExcDimensionMismatch (data_vector.size(),
                                     triangulation->n_active_cells()));
       Assert (deduced_names.size() == 1,
-              Exceptions::DataOut::ExcInvalidNumberOfNames (deduced_names.size(), 1));
+              Exceptions::DataOutImplementation::ExcInvalidNumberOfNames (deduced_names.size(), 1));
       break;
     case type_dof_data:
       Assert (dof_handler != nullptr,
-              Exceptions::DataOut::ExcNoDoFHandlerSelected ());
+              Exceptions::DataOutImplementation::ExcNoDoFHandlerSelected ());
       Assert (data_vector.size() == dof_handler->n_dofs(),
-              Exceptions::DataOut::ExcInvalidVectorSize (data_vector.size(),
-                                                         dof_handler->n_dofs(),
-                                                         triangulation->n_active_cells()));
+              Exceptions::DataOutImplementation::ExcInvalidVectorSize (data_vector.size(),
+                  dof_handler->n_dofs(),
+                  triangulation->n_active_cells()));
       Assert (deduced_names.size() == dof_handler->get_fe(0).n_components(),
-              Exceptions::DataOut::ExcInvalidNumberOfNames (deduced_names.size(),
-                                                            dof_handler->get_fe(0).n_components()));
+              Exceptions::DataOutImplementation::ExcInvalidNumberOfNames (deduced_names.size(),
+                  dof_handler->get_fe(0).n_components()));
       break;
     default:
       Assert (false, ExcInternalError());
@@ -1084,7 +1084,7 @@ add_data_vector_internal
        (deduced_names.size(), DataComponentInterpretation::component_is_scalar));
 
   // finally, add the data vector:
-  auto new_entry = std_cxx14::make_unique<internal::DataOut::DataEntry<DoFHandlerType,VectorType>>
+  auto new_entry = std_cxx14::make_unique<internal::DataOutImplementation::DataEntry<DoFHandlerType,VectorType>>
                    (dof_handler, &data_vector, deduced_names, data_component_interpretation);
 
   if (actual_type == type_dof_data)
@@ -1173,7 +1173,7 @@ get_dataset_names () const
   // collect the names of dof
   // and cell data
   typedef
-  typename std::vector<std::shared_ptr<internal::DataOut::DataEntryBase<DoFHandlerType> > >::const_iterator
+  typename std::vector<std::shared_ptr<internal::DataOutImplementation::DataEntryBase<DoFHandlerType> > >::const_iterator
   data_iterator;
 
   for (data_iterator  d=dof_data.begin();
@@ -1213,7 +1213,7 @@ DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::get_vector_data_range
 
   // collect the ranges of dof and cell data
   typedef
-  typename std::vector<std::shared_ptr<internal::DataOut::DataEntryBase<DoFHandlerType> > >::const_iterator
+  typename std::vector<std::shared_ptr<internal::DataOutImplementation::DataEntryBase<DoFHandlerType> > >::const_iterator
   data_iterator;
 
   unsigned int output_component = 0;
@@ -1233,14 +1233,14 @@ DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::get_vector_data_range
           // deal with vectors
           Assert (i+patch_space_dim <=
                   (*d)->n_output_variables,
-                  Exceptions::DataOut::ExcInvalidVectorDeclaration (i,
-                                                                    (*d)->names[i]));
+                  Exceptions::DataOutImplementation::ExcInvalidVectorDeclaration (i,
+                      (*d)->names[i]));
           for (unsigned int dd=1; dd<patch_space_dim; ++dd)
             Assert ((*d)->data_component_interpretation[i+dd]
                     ==
                     DataComponentInterpretation::component_is_part_of_vector,
-                    Exceptions::DataOut::ExcInvalidVectorDeclaration (i,
-                                                                      (*d)->names[i]));
+                    Exceptions::DataOutImplementation::ExcInvalidVectorDeclaration (i,
+                        (*d)->names[i]));
 
           // all seems alright, so figure out
           // whether there is a common name
@@ -1311,7 +1311,7 @@ std::vector<std::shared_ptr<dealii::hp::FECollection<DoFHandlerType::dimension,
   for (unsigned int i=0; i<this->dof_data.size(); ++i)
     {
       Assert (dof_data[i]->dof_handler != nullptr,
-              Exceptions::DataOut::ExcNoDoFHandlerSelected ());
+              Exceptions::DataOutImplementation::ExcNoDoFHandlerSelected ());
 
       // avoid creating too many finite elements and doing a lot of work on
       // initializing FEValues downstream: if two DoFHandlers are the same

--- a/include/deal.II/numerics/data_out_faces.h
+++ b/include/deal.II/numerics/data_out_faces.h
@@ -28,7 +28,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DataOutFaces
+  namespace DataOutFacesImplementation
   {
     /**
      * A derived class for use in the DataOutFaces class. This is a class for
@@ -36,7 +36,7 @@ namespace internal
      * documentation of the WorkStream context.
      */
     template <int dim, int spacedim>
-    struct ParallelData : public internal::DataOut::ParallelDataBase<dim,spacedim>
+    struct ParallelData : public internal::DataOutImplementation::ParallelDataBase<dim,spacedim>
     {
       ParallelData (const unsigned int n_datasets,
                     const unsigned int n_subdivisions,
@@ -227,7 +227,7 @@ private:
    * Build one patch. This function is called in a WorkStream context.
    */
   void build_one_patch (const FaceDescriptor *cell_and_face,
-                        internal::DataOutFaces::ParallelData<dimension, dimension> &data,
+                        internal::DataOutFacesImplementation::ParallelData<dimension, dimension> &data,
                         DataOutBase::Patch<dimension-1,space_dimension> &patch);
 };
 

--- a/include/deal.II/numerics/data_out_rotation.h
+++ b/include/deal.II/numerics/data_out_rotation.h
@@ -28,7 +28,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DataOutRotation
+  namespace DataOutRotationImplementation
   {
     /**
      * A derived class for use in the DataOutFaces class. This is a class for
@@ -36,7 +36,7 @@ namespace internal
      * documentation of the WorkStream class.
      */
     template <int dim, int spacedim>
-    struct ParallelData : public internal::DataOut::ParallelDataBase<dim,spacedim>
+    struct ParallelData : public internal::DataOutImplementation::ParallelDataBase<dim,spacedim>
     {
       ParallelData (const unsigned int n_datasets,
                     const unsigned int n_subdivisions,
@@ -199,7 +199,7 @@ private:
    */
   void
   build_one_patch (const cell_iterator *cell,
-                   internal::DataOutRotation::ParallelData<dimension, space_dimension> &data,
+                   internal::DataOutRotationImplementation::ParallelData<dimension, space_dimension> &data,
                    std::vector<DataOutBase::Patch<dimension+1,space_dimension+1> > &my_patches);
 };
 

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -44,7 +44,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace PointValueHistory
+  namespace PointValueHistoryImplementation
   {
     /**
      * A class that stores the data needed to reference the support points
@@ -590,7 +590,7 @@ private:
   /**
    * Save the location and other mesh info about support points.
    */
-  std::vector <internal::PointValueHistory::PointGeometryData <dim> >
+  std::vector <internal::PointValueHistoryImplementation::PointGeometryData <dim> >
   point_geometry_data;
 
 

--- a/source/base/parallel.cc
+++ b/source/base/parallel.cc
@@ -21,7 +21,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace Vector
+  namespace VectorImplementation
   {
     // set minimum grain size. this value has been determined by experiments
     // with the actual dealii::Vector implementation and takes vectorization
@@ -35,7 +35,7 @@ namespace internal
   }
 
 
-  namespace SparseMatrix
+  namespace SparseMatrixImplementation
   {
     // set this value to 1/16 of the value of the minimum grain size of
     // vectors (a factor of 4 because we assume that sparse matrix-vector

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -706,7 +706,7 @@ namespace Polynomials
 
   namespace internal
   {
-    namespace LagrangeEquidistant
+    namespace LagrangeEquidistantImplementation
     {
       std::vector<Point<1> >
       generate_equidistant_unit_points (const unsigned int n)
@@ -725,7 +725,7 @@ namespace Polynomials
   LagrangeEquidistant::LagrangeEquidistant (const unsigned int n,
                                             const unsigned int support_point)
     :
-    Polynomial<double> (internal::LagrangeEquidistant::
+    Polynomial<double> (internal::LagrangeEquidistantImplementation::
                         generate_equidistant_unit_points (n),
                         support_point)
   {

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -1602,7 +1602,7 @@ QProjector<dim>::project_to_subface(const SubQuadrature       &quadrature,
 
 namespace internal
 {
-  namespace QIterated
+  namespace QIteratedImplementation
   {
     namespace
     {
@@ -1743,7 +1743,7 @@ template <>
 QIterated<1>::QIterated (const Quadrature<1> &base_quadrature,
                          const unsigned int   n_copies)
   :
-  Quadrature<1> (internal::QIterated::uses_both_endpoints(base_quadrature) ?
+  Quadrature<1> (internal::QIteratedImplementation::uses_both_endpoints(base_quadrature) ?
                  (base_quadrature.size()-1) * n_copies + 1 :
                  base_quadrature.size() * n_copies)
 {
@@ -1751,7 +1751,7 @@ QIterated<1>::QIterated (const Quadrature<1> &base_quadrature,
   Assert (base_quadrature.size() > 0, ExcNotInitialized());
   Assert (n_copies > 0, ExcZero());
 
-  if (!internal::QIterated::uses_both_endpoints(base_quadrature))
+  if (!internal::QIteratedImplementation::uses_both_endpoints(base_quadrature))
     // we don't have to skip some
     // points in order to get a
     // reasonable quadrature formula

--- a/source/base/symmetric_tensor.inst.in
+++ b/source/base/symmetric_tensor.inst.in
@@ -24,7 +24,7 @@ for (deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
 
     namespace internal
     \{
-    namespace SymmetricTensor
+    namespace SymmetricTensorImplementation
     \{
     template
     void
@@ -81,7 +81,7 @@ for (number : REAL_SCALARS)
 {
     namespace internal
     \{
-    namespace SymmetricTensor
+    namespace SymmetricTensorImplementation
     \{
     template
     struct Inverse<4,3,number>;
@@ -120,7 +120,7 @@ for (number : REAL_SCALARS)
 
     namespace internal
     \{
-    namespace SymmetricTensor
+    namespace SymmetricTensorImplementation
     \{
     template
     std::array<std::pair<number, Tensor<1,2,number> >,2>

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -43,7 +43,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace Timer
+  namespace TimerImplementation
   {
     namespace
     {
@@ -124,7 +124,7 @@ CPUClock::time_point CPUClock::now() noexcept
 #else
 #  warning "Unsupported platform. Porting not finished."
 #endif
-  return time_point(internal::Timer::from_seconds<duration>(system_cpu_duration));
+  return time_point(internal::TimerImplementation::from_seconds<duration>(system_cpu_duration));
 }
 
 
@@ -196,24 +196,24 @@ double Timer::stop ()
       cpu_times.last_lap_time = cpu_clock_type::now() - cpu_times.current_lap_start_time;
 
       last_lap_wall_time_data = Utilities::MPI::min_max_avg
-                                (internal::Timer::to_seconds(wall_times.last_lap_time),
+                                (internal::TimerImplementation::to_seconds(wall_times.last_lap_time),
                                  mpi_communicator);
       if (sync_lap_times)
         {
-          wall_times.last_lap_time = internal::Timer::from_seconds<decltype(wall_times)::duration_type>
+          wall_times.last_lap_time = internal::TimerImplementation::from_seconds<decltype(wall_times)::duration_type>
                                      (last_lap_wall_time_data.max);
-          cpu_times.last_lap_time = internal::Timer::from_seconds<decltype(cpu_times)::duration_type>
+          cpu_times.last_lap_time = internal::TimerImplementation::from_seconds<decltype(cpu_times)::duration_type>
                                     (Utilities::MPI::min_max_avg
-                                     (internal::Timer::to_seconds(cpu_times.last_lap_time),
+                                     (internal::TimerImplementation::to_seconds(cpu_times.last_lap_time),
                                       mpi_communicator).max);
         }
       wall_times.accumulated_time += wall_times.last_lap_time;
       cpu_times.accumulated_time += cpu_times.last_lap_time;
       accumulated_wall_time_data = Utilities::MPI::min_max_avg
-                                   (internal::Timer::to_seconds(wall_times.accumulated_time),
+                                   (internal::TimerImplementation::to_seconds(wall_times.accumulated_time),
                                     mpi_communicator);
     }
-  return internal::Timer::to_seconds(cpu_times.accumulated_time);
+  return internal::TimerImplementation::to_seconds(cpu_times.accumulated_time);
 }
 
 
@@ -222,7 +222,7 @@ double Timer::cpu_time() const
 {
   if (running)
     {
-      const double running_time = internal::Timer::to_seconds
+      const double running_time = internal::TimerImplementation::to_seconds
                                   (cpu_clock_type::now()
                                    - cpu_times.current_lap_start_time
                                    + cpu_times.accumulated_time);
@@ -230,7 +230,7 @@ double Timer::cpu_time() const
     }
   else
     {
-      return Utilities::MPI::sum (internal::Timer::to_seconds(cpu_times.accumulated_time),
+      return Utilities::MPI::sum (internal::TimerImplementation::to_seconds(cpu_times.accumulated_time),
                                   mpi_communicator);
     }
 }
@@ -239,14 +239,14 @@ double Timer::cpu_time() const
 
 double Timer::last_cpu_time() const
 {
-  return internal::Timer::to_seconds(cpu_times.last_lap_time);
+  return internal::TimerImplementation::to_seconds(cpu_times.last_lap_time);
 }
 
 
 
 double Timer::get_lap_time() const
 {
-  return internal::Timer::to_seconds(wall_times.last_lap_time);
+  return internal::TimerImplementation::to_seconds(wall_times.last_lap_time);
 }
 
 
@@ -268,14 +268,14 @@ double Timer::wall_time () const
   else
     current_elapsed_wall_time = wall_times.accumulated_time;
 
-  return internal::Timer::to_seconds(current_elapsed_wall_time);
+  return internal::TimerImplementation::to_seconds(current_elapsed_wall_time);
 }
 
 
 
 double Timer::last_wall_time () const
 {
-  return internal::Timer::to_seconds(wall_times.last_lap_time);
+  return internal::TimerImplementation::to_seconds(wall_times.last_lap_time);
 }
 
 
@@ -285,8 +285,8 @@ void Timer::reset ()
   wall_times.reset();
   cpu_times.reset();
   running = false;
-  internal::Timer::clear_timing_data(last_lap_wall_time_data);
-  internal::Timer::clear_timing_data(accumulated_wall_time_data);
+  internal::TimerImplementation::clear_timing_data(last_lap_wall_time_data);
+  internal::TimerImplementation::clear_timing_data(accumulated_wall_time_data);
 }
 
 

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -76,7 +76,7 @@ namespace parallel
 
         // release unused vector memory because we will have very different
         // vectors now
-        ::dealii::internal::GrowingVectorMemory::release_all_unused_memory();
+        ::dealii::internal::GrowingVectorMemoryImplementation::release_all_unused_memory();
       }
 #endif
   }
@@ -103,7 +103,7 @@ namespace parallel
   {
     // release unused vector memory because the vector layout is going to look
     // very different now
-    ::dealii::internal::GrowingVectorMemory::release_all_unused_memory();
+    ::dealii::internal::GrowingVectorMemoryImplementation::release_all_unused_memory();
   }
 
   template <int dim, int spacedim>

--- a/source/dofs/dof_accessor.cc
+++ b/source/dofs/dof_accessor.cc
@@ -97,7 +97,7 @@ DoFCellAccessor<DoFHandlerType,lda>::update_cell_dof_indices_cache () const
 
   Assert (this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
 
-  internal::DoFCellAccessor::Implementation::
+  internal::DoFCellAccessorImplementation::Implementation::
   update_cell_dof_indices_cache (*this);
 }
 
@@ -112,7 +112,7 @@ DoFCellAccessor<DoFHandlerType,lda>::set_dof_indices (const std::vector<types::g
 
   Assert (this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
 
-  internal::DoFCellAccessor::Implementation::
+  internal::DoFCellAccessorImplementation::Implementation::
   set_dof_indices (*this, local_dof_indices);
 }
 

--- a/source/dofs/dof_faces.cc
+++ b/source/dofs/dof_faces.cc
@@ -22,7 +22,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     std::size_t
     DoFFaces<1>::memory_consumption () const

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -64,17 +64,17 @@ namespace internal
 namespace internal
 {
   template <int dim, int spacedim>
-  std::string policy_to_string(const dealii::internal::DoFHandler::Policy::PolicyBase<dim,spacedim> &policy)
+  std::string policy_to_string(const dealii::internal::DoFHandlerImplementation::Policy::PolicyBase<dim,spacedim> &policy)
   {
     std::string policy_name;
-    if (dynamic_cast<const typename dealii::internal::DoFHandler::Policy::Sequential<dealii::DoFHandler<dim,spacedim> >*>(&policy)
-        || dynamic_cast<const typename dealii::internal::DoFHandler::Policy::Sequential<dealii::hp::DoFHandler<dim,spacedim> >*>(&policy))
+    if (dynamic_cast<const typename dealii::internal::DoFHandlerImplementation::Policy::Sequential<dealii::DoFHandler<dim,spacedim> >*>(&policy)
+        || dynamic_cast<const typename dealii::internal::DoFHandlerImplementation::Policy::Sequential<dealii::hp::DoFHandler<dim,spacedim> >*>(&policy))
       policy_name = "Policy::Sequential<";
-    else if (dynamic_cast<const typename dealii::internal::DoFHandler::Policy::ParallelDistributed<dealii::DoFHandler<dim,spacedim> >*>(&policy)
-             || dynamic_cast<const typename dealii::internal::DoFHandler::Policy::ParallelDistributed<dealii::hp::DoFHandler<dim,spacedim> >*>(&policy))
+    else if (dynamic_cast<const typename dealii::internal::DoFHandlerImplementation::Policy::ParallelDistributed<dealii::DoFHandler<dim,spacedim> >*>(&policy)
+             || dynamic_cast<const typename dealii::internal::DoFHandlerImplementation::Policy::ParallelDistributed<dealii::hp::DoFHandler<dim,spacedim> >*>(&policy))
       policy_name = "Policy::ParallelDistributed<";
-    else if (dynamic_cast<const typename dealii::internal::DoFHandler::Policy::ParallelShared<dealii::DoFHandler<dim,spacedim> >*>(&policy)
-             || dynamic_cast<const typename dealii::internal::DoFHandler::Policy::ParallelShared<dealii::hp::DoFHandler<dim,spacedim> >*>(&policy))
+    else if (dynamic_cast<const typename dealii::internal::DoFHandlerImplementation::Policy::ParallelShared<dealii::DoFHandler<dim,spacedim> >*>(&policy)
+             || dynamic_cast<const typename dealii::internal::DoFHandlerImplementation::Policy::ParallelShared<dealii::hp::DoFHandler<dim,spacedim> >*>(&policy))
       policy_name = "Policy::ParallelShared<";
     else
       AssertThrow(false, ExcNotImplemented());
@@ -84,7 +84,7 @@ namespace internal
   }
 
 
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     // access class
     // dealii::DoFHandler instead of
@@ -280,7 +280,7 @@ namespace internal
 
         for (unsigned int i=0; i<dof_handler.tria->n_levels(); ++i)
           {
-            dof_handler.levels.emplace_back (new internal::DoFHandler::DoFLevel<1>);
+            dof_handler.levels.emplace_back (new internal::DoFHandlerImplementation::DoFLevel<1>);
 
             dof_handler.levels.back()->dof_object.dofs
             .resize (dof_handler.tria->n_raw_cells(i) *
@@ -306,7 +306,7 @@ namespace internal
 
         for (unsigned int i=0; i<dof_handler.tria->n_levels(); ++i)
           {
-            dof_handler.levels.emplace_back (new internal::DoFHandler::DoFLevel<2>);
+            dof_handler.levels.emplace_back (new internal::DoFHandlerImplementation::DoFLevel<2>);
 
             dof_handler.levels.back()->dof_object.dofs
             .resize (dof_handler.tria->n_raw_cells(i) *
@@ -319,7 +319,7 @@ namespace internal
                      numbers::invalid_dof_index);
           }
 
-        dof_handler.faces = std_cxx14::make_unique<internal::DoFHandler::DoFFaces<2>> ();
+        dof_handler.faces = std_cxx14::make_unique<internal::DoFHandlerImplementation::DoFFaces<2>> ();
         // avoid access to n_raw_lines when there are no cells
         if (dof_handler.tria->n_cells() > 0)
           {
@@ -342,7 +342,7 @@ namespace internal
 
         for (unsigned int i=0; i<dof_handler.tria->n_levels(); ++i)
           {
-            dof_handler.levels.emplace_back (new internal::DoFHandler::DoFLevel<3>);
+            dof_handler.levels.emplace_back (new internal::DoFHandlerImplementation::DoFLevel<3>);
 
             dof_handler.levels.back()->dof_object.dofs
             .resize (dof_handler.tria->n_raw_cells(i) *
@@ -354,7 +354,7 @@ namespace internal
                      dof_handler.get_fe().dofs_per_cell,
                      numbers::invalid_dof_index);
           }
-        dof_handler.faces = std_cxx14::make_unique<internal::DoFHandler::DoFFaces<3>> ();
+        dof_handler.faces = std_cxx14::make_unique<internal::DoFHandlerImplementation::DoFFaces<3>> ();
 
         // avoid access to n_raw_lines when there are no cells
         if (dof_handler.tria->n_cells() > 0)
@@ -383,7 +383,7 @@ namespace internal
 
         for (unsigned int i = 0; i < n_levels; ++i)
           {
-            dof_handler.mg_levels.emplace_back (new internal::DoFHandler::DoFLevel<1>);
+            dof_handler.mg_levels.emplace_back (new internal::DoFHandlerImplementation::DoFLevel<1>);
             dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines (i) * dofs_per_line, numbers::invalid_dof_index);
           }
 
@@ -439,11 +439,11 @@ namespace internal
 
         for (unsigned int i = 0; i < n_levels; ++i)
           {
-            dof_handler.mg_levels.emplace_back (std_cxx14::make_unique<internal::DoFHandler::DoFLevel<2>> ());
+            dof_handler.mg_levels.emplace_back (std_cxx14::make_unique<internal::DoFHandlerImplementation::DoFLevel<2>> ());
             dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_quads (i) * fe.dofs_per_quad, numbers::invalid_dof_index);
           }
 
-        dof_handler.mg_faces = std_cxx14::make_unique<internal::DoFHandler::DoFFaces<2>> ();
+        dof_handler.mg_faces = std_cxx14::make_unique<internal::DoFHandlerImplementation::DoFFaces<2>> ();
         dof_handler.mg_faces->lines.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines () * fe.dofs_per_line, numbers::invalid_dof_index);
 
         const unsigned int &n_vertices = tria.n_vertices ();
@@ -498,11 +498,11 @@ namespace internal
 
         for (unsigned int i = 0; i < n_levels; ++i)
           {
-            dof_handler.mg_levels.emplace_back (std_cxx14::make_unique<internal::DoFHandler::DoFLevel<3>> ());
+            dof_handler.mg_levels.emplace_back (std_cxx14::make_unique<internal::DoFHandlerImplementation::DoFLevel<3>> ());
             dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_hexs (i) * fe.dofs_per_hex, numbers::invalid_dof_index);
           }
 
-        dof_handler.mg_faces = std_cxx14::make_unique<internal::DoFHandler::DoFFaces<3>> ();
+        dof_handler.mg_faces = std_cxx14::make_unique<internal::DoFHandlerImplementation::DoFFaces<3>> ();
         dof_handler.mg_faces->lines.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines () * fe.dofs_per_line, numbers::invalid_dof_index);
         dof_handler.mg_faces->quads.dofs = std::vector<types::global_dof_index> (tria.n_raw_quads () * fe.dofs_per_quad, numbers::invalid_dof_index);
 
@@ -552,8 +552,8 @@ namespace internal
       types::global_dof_index
       get_dof_index (
         const DoFHandler<1, spacedim> &dof_handler,
-        const std::unique_ptr<internal::DoFHandler::DoFLevel<1> > &mg_level,
-        const std::unique_ptr<internal::DoFHandler::DoFFaces<1> > &,
+        const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<1> > &mg_level,
+        const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<1> > &,
         const unsigned int obj_index,
         const unsigned int fe_index,
         const unsigned int local_index,
@@ -565,7 +565,7 @@ namespace internal
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<2> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<2> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 1>)
+      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<2> > &, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<2> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 1>)
       {
         return mg_faces->lines.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
@@ -573,7 +573,7 @@ namespace internal
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<2> > &mg_level, const std::unique_ptr<internal::DoFHandler::DoFFaces<2> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 2>)
+      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<2> > &mg_level, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<2> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 2>)
       {
         return mg_level->dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
@@ -581,7 +581,7 @@ namespace internal
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 1>)
+      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 1>)
       {
         return mg_faces->lines.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
@@ -589,7 +589,7 @@ namespace internal
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 2>)
+      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 2>)
       {
         return mg_faces->quads.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
@@ -597,49 +597,49 @@ namespace internal
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &mg_level, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 3>)
+      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<3> > &mg_level, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<3> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 3>)
       {
         return mg_level->dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<1, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<1> > &mg_level, const std::unique_ptr<internal::DoFHandler::DoFFaces<1> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
+      void set_dof_index (const DoFHandler<1, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<1> > &mg_level, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<1> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
       {
         mg_level->dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<2> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<2> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
+      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<2> > &, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<2> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
       {
         mg_faces->lines.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<2> > &mg_level, const std::unique_ptr<internal::DoFHandler::DoFFaces<2> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 2>)
+      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<2> > &mg_level, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<2> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 2>)
       {
         mg_level->dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
+      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
       {
         mg_faces->lines.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 2>)
+      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<3> > &, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<3> > &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 2>)
       {
         mg_faces->quads.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandler::DoFLevel<3> > &mg_level, const std::unique_ptr<internal::DoFHandler::DoFFaces<3> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 3>)
+      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, const std::unique_ptr<internal::DoFHandlerImplementation::DoFLevel<3> > &mg_level, const std::unique_ptr<internal::DoFHandlerImplementation::DoFFaces<3> > &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 3>)
       {
         mg_level->dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
@@ -661,13 +661,13 @@ DoFHandler<dim,spacedim>::DoFHandler (const Triangulation<dim,spacedim> &tria)
   if (dynamic_cast<const parallel::shared::Triangulation< dim, spacedim>*>
       (&tria)
       != nullptr)
-    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelShared<DoFHandler<dim,spacedim> >> (*this);
+    policy = std_cxx14::make_unique<internal::DoFHandlerImplementation::Policy::ParallelShared<DoFHandler<dim,spacedim> >> (*this);
   else if (dynamic_cast<const parallel::distributed::Triangulation< dim, spacedim >*>
            (&tria)
            == nullptr)
-    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::Sequential<DoFHandler<dim,spacedim> >> (*this);
+    policy = std_cxx14::make_unique<internal::DoFHandlerImplementation::Policy::Sequential<DoFHandler<dim,spacedim> >> (*this);
   else
-    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >> (*this);
+    policy = std_cxx14::make_unique<internal::DoFHandlerImplementation::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >> (*this);
 }
 
 
@@ -707,11 +707,11 @@ initialize(const Triangulation<dim,spacedim> &t,
 
   // decide whether we need a sequential or a parallel distributed policy
   if (dynamic_cast<const parallel::shared::Triangulation< dim, spacedim>*> (&t) != nullptr)
-    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelShared<DoFHandler<dim,spacedim> >> (*this);
+    policy = std_cxx14::make_unique<internal::DoFHandlerImplementation::Policy::ParallelShared<DoFHandler<dim,spacedim> >> (*this);
   else if (dynamic_cast<const parallel::distributed::Triangulation< dim, spacedim >*> (&t) != nullptr)
-    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >> (*this);
+    policy = std_cxx14::make_unique<internal::DoFHandlerImplementation::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >> (*this);
   else
-    policy = std_cxx14::make_unique<internal::DoFHandler::Policy::Sequential<DoFHandler<dim,spacedim> >> (*this);
+    policy = std_cxx14::make_unique<internal::DoFHandlerImplementation::Policy::Sequential<DoFHandler<dim,spacedim> >> (*this);
 
   distribute_dofs(fe);
 }
@@ -1022,7 +1022,7 @@ void DoFHandler<dim,spacedim>::distribute_dofs (const FiniteElement<dim,spacedim
   // know them on some cell (i.e. get
   // back invalid_dof_index)
   clear_space ();
-  internal::DoFHandler::Implementation::reserve_space (*this);
+  internal::DoFHandlerImplementation::Implementation::reserve_space (*this);
 
   // hand things off to the policy
   number_cache = policy->distribute_dofs ();
@@ -1056,7 +1056,7 @@ void DoFHandler<dim, spacedim>::distribute_mg_dofs ()
 
   clear_mg_space();
 
-  internal::DoFHandler::Implementation::reserve_space_mg (*this);
+  internal::DoFHandlerImplementation::Implementation::reserve_space_mg (*this);
   mg_number_cache = policy->distribute_mg_dofs ();
 
   // initialize the block info object
@@ -1192,7 +1192,7 @@ template <int dim, int spacedim>
 unsigned int
 DoFHandler<dim,spacedim>::max_couplings_between_dofs () const
 {
-  return internal::DoFHandler::Implementation::max_couplings_between_dofs (*this);
+  return internal::DoFHandlerImplementation::Implementation::max_couplings_between_dofs (*this);
 }
 
 
@@ -1258,10 +1258,10 @@ DoFHandler<dim, spacedim>::get_dof_index (const unsigned int obj_level,
                                           const unsigned int fe_index,
                                           const unsigned int local_index) const
 {
-  return internal::DoFHandler::Implementation::get_dof_index (*this, this->mg_levels[obj_level],
-                                                              this->mg_faces, obj_index,
-                                                              fe_index, local_index,
-                                                              std::integral_constant<int, structdim> ());
+  return internal::DoFHandlerImplementation::Implementation::get_dof_index (*this, this->mg_levels[obj_level],
+         this->mg_faces, obj_index,
+         fe_index, local_index,
+         std::integral_constant<int, structdim> ());
 }
 
 
@@ -1274,14 +1274,14 @@ void DoFHandler<dim, spacedim>::set_dof_index (const unsigned int obj_level,
                                                const unsigned int local_index,
                                                const types::global_dof_index global_index) const
 {
-  internal::DoFHandler::Implementation::set_dof_index (*this,
-                                                       this->mg_levels[obj_level],
-                                                       this->mg_faces,
-                                                       obj_index,
-                                                       fe_index,
-                                                       local_index,
-                                                       global_index,
-                                                       std::integral_constant<int, structdim> ());
+  internal::DoFHandlerImplementation::Implementation::set_dof_index (*this,
+      this->mg_levels[obj_level],
+      this->mg_faces,
+      obj_index,
+      fe_index,
+      local_index,
+      global_index,
+      std::integral_constant<int, structdim> ());
 }
 
 

--- a/source/dofs/dof_handler.inst.in
+++ b/source/dofs/dof_handler.inst.in
@@ -19,12 +19,12 @@ for (deal_II_dimension : DIMENSIONS)
     namespace internal
     \{
     template const types::global_dof_index * dummy<deal_II_dimension,deal_II_dimension> ();
-    template std::string policy_to_string(const dealii::internal::DoFHandler::Policy::
+    template std::string policy_to_string(const dealii::internal::DoFHandlerImplementation::Policy::
                                           PolicyBase<deal_II_dimension,deal_II_dimension> &);
 
 #if deal_II_dimension < 3
     template const types::global_dof_index * dummy<deal_II_dimension,deal_II_dimension+1> ();
-    template std::string policy_to_string(const dealii::internal::DoFHandler::Policy::
+    template std::string policy_to_string(const dealii::internal::DoFHandlerImplementation::Policy::
                                           PolicyBase<deal_II_dimension,deal_II_dimension+1> &);
 #endif
     \}

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -50,7 +50,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     namespace Policy
     {
@@ -641,13 +641,13 @@ namespace internal
                 (include_vertex[vertex_index] == true))
               {
                 const unsigned int n_active_fe_indices
-                  = dealii::internal::DoFAccessor::Implementation::
+                  = dealii::internal::DoFAccessorImplementation::Implementation::
                     n_active_vertex_fe_indices (dof_handler, vertex_index);
                 if (n_active_fe_indices > 1)
                   {
                     const unsigned int
                     first_fe_index
-                      = dealii::internal::DoFAccessor::Implementation::
+                      = dealii::internal::DoFAccessorImplementation::Implementation::
                         nth_active_vertex_fe_index (dof_handler, vertex_index, 0);
 
                     // loop over all the other FEs with which we want
@@ -656,7 +656,7 @@ namespace internal
                       {
                         const unsigned int
                         other_fe_index
-                          = dealii::internal::DoFAccessor::Implementation::
+                          = dealii::internal::DoFAccessorImplementation::Implementation::
                             nth_active_vertex_fe_index (dof_handler, vertex_index, f);
 
                         // make sure the entry in the equivalence
@@ -679,13 +679,13 @@ namespace internal
                         for (unsigned int i=0; i<identities.size(); ++i)
                           {
                             const types::global_dof_index lower_dof_index
-                              = dealii::internal::DoFAccessor::Implementation::
+                              = dealii::internal::DoFAccessorImplementation::Implementation::
                                 get_vertex_dof_index (dof_handler,
                                                       vertex_index,
                                                       first_fe_index,
                                                       identities[i].first);
                             const types::global_dof_index higher_dof_index
-                              = dealii::internal::DoFAccessor::Implementation::
+                              = dealii::internal::DoFAccessorImplementation::Implementation::
                                 get_vertex_dof_index (dof_handler,
                                                       vertex_index,
                                                       other_fe_index,
@@ -1653,7 +1653,7 @@ namespace internal
                ++vertex_index)
             {
               const unsigned int n_active_fe_indices
-                = dealii::internal::DoFAccessor::Implementation::
+                = dealii::internal::DoFAccessorImplementation::Implementation::
                   n_active_vertex_fe_indices (dof_handler, vertex_index);
 
               // if this vertex is unused, then we really ought not to have allocated
@@ -1669,13 +1669,13 @@ namespace internal
               for (unsigned int f=0; f<n_active_fe_indices; ++f)
                 {
                   const unsigned int fe_index
-                    = dealii::internal::DoFAccessor::Implementation::
+                    = dealii::internal::DoFAccessorImplementation::Implementation::
                       nth_active_vertex_fe_index (dof_handler, vertex_index, f);
 
                   for (unsigned int d=0; d<dof_handler.get_fe(fe_index).dofs_per_vertex; ++d)
                     {
                       const types::global_dof_index old_dof_index
-                        = dealii::internal::DoFAccessor::Implementation::
+                        = dealii::internal::DoFAccessorImplementation::Implementation::
                           get_vertex_dof_index(dof_handler,
                                                vertex_index,
                                                fe_index,
@@ -1694,7 +1694,7 @@ namespace internal
                                 ExcInternalError());
 
                       if (old_dof_index != numbers::invalid_dof_index)
-                        dealii::internal::DoFAccessor::Implementation::
+                        dealii::internal::DoFAccessorImplementation::Implementation::
                         set_vertex_dof_index (dof_handler,
                                               vertex_index,
                                               fe_index,

--- a/source/dofs/dof_handler_policy.inst.in
+++ b/source/dofs/dof_handler_policy.inst.in
@@ -19,7 +19,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 #if deal_II_dimension <= deal_II_space_dimension
     namespace internal
     \{
-    namespace DoFHandler
+    namespace DoFHandlerImplementation
     \{
     namespace Policy
     \{

--- a/source/dofs/dof_objects.cc
+++ b/source/dofs/dof_objects.cc
@@ -23,7 +23,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     template <int dim>
     std::size_t
@@ -64,7 +64,7 @@ namespace internal
 // explicit instantiations
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
 #include "dof_objects.inst"
   }

--- a/source/dofs/number_cache.cc
+++ b/source/dofs/number_cache.cc
@@ -23,7 +23,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DoFHandler
+  namespace DoFHandlerImplementation
   {
     NumberCache::NumberCache ()
       :

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -1197,7 +1197,7 @@ typename FiniteElement<dim,spacedim>::InternalDataBase *
 FiniteElement<dim,spacedim>::get_face_data (const UpdateFlags       flags,
                                             const Mapping<dim,spacedim>      &mapping,
                                             const Quadrature<dim-1> &quadrature,
-                                            dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                                            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   return get_data (flags, mapping,
                    QProjector<dim>::project_to_all_faces(quadrature),
@@ -1211,7 +1211,7 @@ typename FiniteElement<dim,spacedim>::InternalDataBase *
 FiniteElement<dim,spacedim>::get_subface_data (const UpdateFlags        flags,
                                                const Mapping<dim,spacedim>      &mapping,
                                                const Quadrature<dim-1> &quadrature,
-                                               dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                                               dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   return get_data (flags, mapping,
                    QProjector<dim>::project_to_all_subfaces(quadrature),

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -260,7 +260,7 @@ FE_DGPNonparametric<dim,spacedim>::
 get_data (const UpdateFlags                                                    update_flags,
           const Mapping<dim,spacedim> &,
           const Quadrature<dim> &,
-          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
 {
   // generate a new data object
   typename FiniteElement<dim,spacedim>::InternalDataBase *data
@@ -287,9 +287,9 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
                 const Quadrature<dim> &,
                 const Mapping<dim,spacedim> &,
                 const typename Mapping<dim,spacedim>::InternalDataBase &,
-                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                 const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   Assert (fe_internal.update_each & update_quadrature_points, ExcInternalError());
 
@@ -333,9 +333,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                      const Quadrature<dim-1>                                             &,
                      const Mapping<dim,spacedim> &,
                      const typename Mapping<dim,spacedim>::InternalDataBase &,
-                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                     const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                      const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                     dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   Assert (fe_internal.update_each & update_quadrature_points, ExcInternalError());
 
@@ -380,9 +380,9 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const Quadrature<dim-1>                                             &,
                         const Mapping<dim,spacedim> &,
                         const typename Mapping<dim,spacedim>::InternalDataBase &,
-                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                         const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                        dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   Assert (fe_internal.update_each & update_quadrature_points, ExcInternalError());
 

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -335,7 +335,7 @@ typename FiniteElement<dim,spacedim>::InternalDataBase *
 FE_Enriched<dim,spacedim>::get_face_data (const UpdateFlags      update_flags,
                                           const Mapping<dim,spacedim>    &mapping,
                                           const Quadrature<dim-1> &quadrature,
-                                          internal::FEValues::FiniteElementRelatedData< dim, spacedim >        &output_data) const
+                                          internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim >        &output_data) const
 {
   return setup_data(std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase>(fe_system->get_face_data(update_flags,mapping,quadrature,output_data)),
                     update_flags,
@@ -348,7 +348,7 @@ typename FiniteElement<dim,spacedim>::InternalDataBase *
 FE_Enriched<dim,spacedim>::get_subface_data (const UpdateFlags      update_flags,
                                              const Mapping<dim,spacedim>    &mapping,
                                              const Quadrature<dim-1> &quadrature,
-                                             dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                                             dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   return setup_data(std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase>(fe_system->get_subface_data(update_flags,mapping,quadrature,output_data)),
                     update_flags,
@@ -361,7 +361,7 @@ typename FiniteElement<dim,spacedim>::InternalDataBase *
 FE_Enriched<dim,spacedim>::get_data (const UpdateFlags      flags,
                                      const Mapping<dim,spacedim>    &mapping,
                                      const Quadrature<dim> &quadrature,
-                                     internal::FEValues::FiniteElementRelatedData< dim, spacedim >   &output_data) const
+                                     internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim >   &output_data) const
 {
   return setup_data(std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase>(fe_system->get_data(flags,mapping,quadrature,output_data)),
                     flags,
@@ -463,9 +463,9 @@ FE_Enriched<dim,spacedim>::fill_fe_values (const typename Triangulation< dim, sp
                                            const Quadrature< dim > &quadrature,
                                            const Mapping< dim, spacedim > &mapping,
                                            const typename Mapping< dim, spacedim >::InternalDataBase &mapping_internal,
-                                           const dealii::internal::FEValues::MappingRelatedData< dim, spacedim > &mapping_data,
+                                           const dealii::internal::FEValuesImplementation::MappingRelatedData< dim, spacedim > &mapping_data,
                                            const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
-                                           internal::FEValues::FiniteElementRelatedData< dim, spacedim > &output_data
+                                           internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim > &output_data
                                           ) const
 {
   Assert (dynamic_cast<const InternalData *> (&fe_internal) != nullptr,
@@ -499,9 +499,9 @@ FE_Enriched<dim,spacedim>::fill_fe_face_values
  const Quadrature< dim-1 > &quadrature,
  const Mapping< dim, spacedim > &mapping,
  const typename Mapping< dim, spacedim >::InternalDataBase &mapping_internal,
- const dealii::internal::FEValues::MappingRelatedData< dim, spacedim > &mapping_data,
+ const dealii::internal::FEValuesImplementation::MappingRelatedData< dim, spacedim > &mapping_data,
  const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
- internal::FEValues::FiniteElementRelatedData< dim, spacedim > &output_data
+ internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim > &output_data
 ) const
 {
   Assert (dynamic_cast<const InternalData *> (&fe_internal) != nullptr,
@@ -536,9 +536,9 @@ FE_Enriched<dim,spacedim>::fill_fe_subface_values
  const Quadrature< dim-1 > &quadrature,
  const Mapping< dim, spacedim > &mapping,
  const typename Mapping< dim, spacedim >::InternalDataBase &mapping_internal,
- const dealii::internal::FEValues::MappingRelatedData< dim, spacedim > &mapping_data,
+ const dealii::internal::FEValuesImplementation::MappingRelatedData< dim, spacedim > &mapping_data,
  const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
- internal::FEValues::FiniteElementRelatedData< dim, spacedim > &output_data
+ internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim > &output_data
 ) const
 {
   Assert (dynamic_cast<const InternalData *> (&fe_internal) != nullptr,
@@ -572,9 +572,9 @@ void
 FE_Enriched<dim,spacedim>::multiply_by_enrichment
 (const Quadrature<dim_1> &quadrature,
  const InternalData &fe_data,
- const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
+ const internal::FEValuesImplementation::MappingRelatedData<dim,spacedim> &mapping_data,
  const typename Triangulation< dim, spacedim >::cell_iterator &cell,
- internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const
+ internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &output_data) const
 {
   // mapping_data will contain quadrature points on the real element.
   // fe_internal is needed to get update flags
@@ -602,7 +602,7 @@ FE_Enriched<dim,spacedim>::multiply_by_enrichment
         base_fe      = base_element(base_no);
         typename FiniteElement<dim,spacedim>::InternalDataBase &
         base_fe_data = fe_data.get_fe_data(base_no);
-        internal::FEValues::FiniteElementRelatedData<dim,spacedim> &
+        internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &
         base_data    = fe_data.get_fe_output_object(base_no);
 
         const UpdateFlags base_flags = base_fe_data.update_each;
@@ -942,7 +942,7 @@ InternalData::get_fe_data (const unsigned int base_no) const
 
 
 template <int dim, int spacedim>
-internal::FEValues::FiniteElementRelatedData<dim,spacedim> &
+internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &
 FE_Enriched<dim,spacedim>::
 InternalData::get_fe_output_object (const unsigned int base_no) const
 {

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -29,7 +29,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace FE_FaceQ
+  namespace FE_FaceQImplementation
   {
     namespace
     {
@@ -49,7 +49,7 @@ template <int dim, int spacedim>
 FE_FaceQ<dim,spacedim>::FE_FaceQ (const unsigned int degree)
   :
   FE_PolyFace<TensorProductPolynomials<dim-1>, dim, spacedim>
-  (TensorProductPolynomials<dim-1>(Polynomials::generate_complete_Lagrange_basis(internal::FE_FaceQ::get_QGaussLobatto_points(degree))),
+  (TensorProductPolynomials<dim-1>(Polynomials::generate_complete_Lagrange_basis(internal::FE_FaceQImplementation::get_QGaussLobatto_points(degree))),
    FiniteElementData<dim>(get_dpo_vector(degree), 1, degree, FiniteElementData<dim>::L2),
    std::vector<bool>(1,true))
 {
@@ -62,7 +62,7 @@ FE_FaceQ<dim,spacedim>::FE_FaceQ (const unsigned int degree)
       this->unit_face_support_points[0][d] = 0.5;
   else
     {
-      std::vector<Point<1> > points = internal::FE_FaceQ::get_QGaussLobatto_points(degree);
+      std::vector<Point<1> > points = internal::FE_FaceQImplementation::get_QGaussLobatto_points(degree);
 
       unsigned int k=0;
       for (unsigned int iz=0; iz <= ((codim>2) ? this->degree : 0) ; ++iz)
@@ -681,9 +681,9 @@ fill_fe_values(const typename Triangulation<1,spacedim>::cell_iterator &,
                const Quadrature<1> &,
                const Mapping<1,spacedim> &,
                const typename Mapping<1,spacedim>::InternalDataBase &,
-               const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &,
+               const dealii::internal::FEValuesImplementation::MappingRelatedData<1, spacedim> &,
                const typename FiniteElement<1,spacedim>::InternalDataBase &,
-               dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &) const
+               dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &) const
 {
   // Do nothing, since we do not have values in the interior
 }
@@ -698,9 +698,9 @@ fill_fe_face_values (const typename Triangulation<1,spacedim>::cell_iterator &,
                      const Quadrature<0> &,
                      const Mapping<1,spacedim> &,
                      const typename Mapping<1,spacedim>::InternalDataBase &,
-                     const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &,
+                     const dealii::internal::FEValuesImplementation::MappingRelatedData<1, spacedim> &,
                      const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
-                     dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &output_data) const
+                     dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const
 {
   const unsigned int foffset = face;
   if (fe_internal.update_each & update_values)
@@ -721,9 +721,9 @@ fill_fe_subface_values (const typename Triangulation<1,spacedim>::cell_iterator 
                         const Quadrature<0> &,
                         const Mapping<1,spacedim> &,
                         const typename Mapping<1,spacedim>::InternalDataBase &,
-                        const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &,
+                        const dealii::internal::FEValuesImplementation::MappingRelatedData<1, spacedim> &,
                         const typename FiniteElement<1,spacedim>::InternalDataBase &,
-                        dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &) const
+                        dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &) const
 {
   Assert(false, ExcMessage("There are no sub-face values to fill in 1D!"));
 }

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -103,7 +103,7 @@ typename FiniteElement<dim,spacedim>::InternalDataBase *
 FE_Nothing<dim,spacedim>::get_data (const UpdateFlags                                                    /*update_flags*/,
                                     const Mapping<dim,spacedim>                                         &/*mapping*/,
                                     const Quadrature<dim>                                               &/*quadrature*/,
-                                    dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+                                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
 {
   // Create a default data object.  Normally we would then
   // need to resize things to hold the appropriate numbers
@@ -123,9 +123,9 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
                 const Quadrature<dim> &,
                 const Mapping<dim,spacedim> &,
                 const typename Mapping<dim,spacedim>::InternalDataBase &,
-                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &,
                 const typename FiniteElement<dim,spacedim>::InternalDataBase &,
-                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &) const
 {
   // leave data fields empty
 }
@@ -140,9 +140,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                      const Quadrature<dim-1>                                             &,
                      const Mapping<dim,spacedim> &,
                      const typename Mapping<dim,spacedim>::InternalDataBase &,
-                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                     const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &,
                      const typename FiniteElement<dim,spacedim>::InternalDataBase &,
-                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &) const
+                     dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &) const
 {
   // leave data fields empty
 }
@@ -158,9 +158,9 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const Quadrature<dim-1>                                             &,
                         const Mapping<dim,spacedim> &,
                         const typename Mapping<dim,spacedim>::InternalDataBase &,
-                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &,
                         const typename FiniteElement<dim,spacedim>::InternalDataBase &,
-                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &) const
+                        dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &) const
 {
   // leave data fields empty
 }

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -128,7 +128,7 @@ FiniteElement<2,2>::InternalDataBase *
 FE_P1NC::get_data (const UpdateFlags update_flags,
                    const Mapping<2,2> &,
                    const Quadrature<2> &quadrature,
-                   dealii::internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const
+                   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const
 {
   FiniteElement<2,2>::InternalDataBase *data = new FiniteElement<2,2>::InternalDataBase;
 
@@ -150,7 +150,7 @@ FiniteElement<2,2>::InternalDataBase *
 FE_P1NC::get_face_data (const UpdateFlags update_flags,
                         const Mapping<2,2> &,
                         const Quadrature<1> &quadrature,
-                        dealii::internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const
+                        dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const
 {
   FiniteElement<2,2>::InternalDataBase *data = new FiniteElement<2,2>::InternalDataBase;
 
@@ -172,7 +172,7 @@ FiniteElement<2,2>::InternalDataBase *
 FE_P1NC::get_subface_data (const UpdateFlags update_flags,
                            const Mapping<2,2> &,
                            const Quadrature<1> &quadrature,
-                           dealii::internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const
+                           dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const
 {
   FiniteElement<2,2>::InternalDataBase *data = new FiniteElement<2,2>::InternalDataBase;
 
@@ -196,9 +196,9 @@ FE_P1NC::fill_fe_values (const Triangulation<2,2>::cell_iterator           &cell
                          const Quadrature<2> &,
                          const Mapping<2,2> &,
                          const Mapping<2,2>::InternalDataBase &,
-                         const internal::FEValues::MappingRelatedData<2,2> &mapping_data,
+                         const internal::FEValuesImplementation::MappingRelatedData<2,2> &mapping_data,
                          const FiniteElement<2,2>::InternalDataBase        &fe_internal,
-                         internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const
+                         internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const
 {
   const UpdateFlags flags(fe_internal.update_each);
 
@@ -230,9 +230,9 @@ FE_P1NC::fill_fe_face_values (const Triangulation<2,2>::cell_iterator           
                               const Quadrature<1>                                       &quadrature,
                               const Mapping<2,2>                                        &mapping,
                               const Mapping<2,2>::InternalDataBase &,
-                              const dealii::internal::FEValues::MappingRelatedData<2,2> &,
+                              const dealii::internal::FEValuesImplementation::MappingRelatedData<2,2> &,
                               const InternalDataBase                                    &fe_internal,
-                              dealii::internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const
+                              dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const
 {
   const UpdateFlags flags(fe_internal.update_each);
 
@@ -271,9 +271,9 @@ FE_P1NC::fill_fe_subface_values (const Triangulation<2,2>::cell_iterator        
                                  const Quadrature<1>                                       &quadrature,
                                  const Mapping<2,2>                                        &mapping,
                                  const Mapping<2,2>::InternalDataBase &,
-                                 const dealii::internal::FEValues::MappingRelatedData<2,2> &,
+                                 const dealii::internal::FEValuesImplementation::MappingRelatedData<2,2> &,
                                  const InternalDataBase                                    &fe_internal,
-                                 dealii::internal::FEValues::FiniteElementRelatedData<2,2> &output_data) const
+                                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const
 {
   const UpdateFlags flags(fe_internal.update_each);
 

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -36,9 +36,9 @@ fill_fe_values (const Triangulation<1,2>::cell_iterator &,
                 const Quadrature<1>                                       &quadrature,
                 const Mapping<1,2>                                        &mapping,
                 const Mapping<1,2>::InternalDataBase                      &mapping_internal,
-                const dealii::internal::FEValues::MappingRelatedData<1,2> &mapping_data,
+                const dealii::internal::FEValuesImplementation::MappingRelatedData<1,2> &mapping_data,
                 const FiniteElement<1,2>::InternalDataBase                &fe_internal,
-                dealii::internal::FEValues::FiniteElementRelatedData<1,2> &output_data) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1,2> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -96,9 +96,9 @@ fill_fe_values (const Triangulation<2,3>::cell_iterator &,
                 const Quadrature<2>                                       &quadrature,
                 const Mapping<2,3>                                        &mapping,
                 const Mapping<2,3>::InternalDataBase                      &mapping_internal,
-                const dealii::internal::FEValues::MappingRelatedData<2,3> &mapping_data,
+                const dealii::internal::FEValuesImplementation::MappingRelatedData<2,3> &mapping_data,
                 const FiniteElement<2,3>::InternalDataBase                &fe_internal,
-                dealii::internal::FEValues::FiniteElementRelatedData<2,3> &output_data) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,3> &output_data) const
 {
 
   // assert that the following dynamics
@@ -154,9 +154,9 @@ fill_fe_values (const Triangulation<1,2>::cell_iterator &,
                 const Quadrature<1>                                       &quadrature,
                 const Mapping<1,2>                                        &mapping,
                 const Mapping<1,2>::InternalDataBase                      &mapping_internal,
-                const dealii::internal::FEValues::MappingRelatedData<1,2> &mapping_data,
+                const dealii::internal::FEValuesImplementation::MappingRelatedData<1,2> &mapping_data,
                 const FiniteElement<1,2>::InternalDataBase                &fe_internal,
-                dealii::internal::FEValues::FiniteElementRelatedData<1,2> &output_data) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1,2> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -214,9 +214,9 @@ fill_fe_values (const Triangulation<2,3>::cell_iterator &,
                 const Quadrature<2>                                       &quadrature,
                 const Mapping<2,3>                                        &mapping,
                 const Mapping<2,3>::InternalDataBase                      &mapping_internal,
-                const dealii::internal::FEValues::MappingRelatedData<2,3> &mapping_data,
+                const dealii::internal::FEValuesImplementation::MappingRelatedData<2,3> &mapping_data,
                 const FiniteElement<2,3>::InternalDataBase                &fe_internal,
-                dealii::internal::FEValues::FiniteElementRelatedData<2,3> &output_data) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,3> &output_data) const
 {
   Assert (dynamic_cast<const InternalData *> (&fe_internal) != nullptr, ExcInternalError());
   const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -314,9 +314,9 @@ fill_fe_values
  const Quadrature<dim>                                               &quadrature,
  const Mapping<dim,spacedim>                                         &mapping,
  const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
- const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+ const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
  const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
- dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+ dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -788,9 +788,9 @@ fill_fe_face_values
  const Quadrature<dim-1>                                             &quadrature,
  const Mapping<dim,spacedim>                                         &mapping,
  const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
- const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+ const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
  const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
- dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+ dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -1263,9 +1263,9 @@ fill_fe_subface_values
  const Quadrature<dim-1>                                             &quadrature,
  const Mapping<dim,spacedim>                                         &mapping,
  const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
- const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+ const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
  const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
- dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+ dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -32,7 +32,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace FESystem
+  namespace FESystemImplementation
   {
     namespace
     {
@@ -97,7 +97,7 @@ InternalData::set_fe_data (const unsigned int base_no,
 
 
 template <int dim, int spacedim>
-internal::FEValues::FiniteElementRelatedData<dim,spacedim> &
+internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &
 FESystem<dim,spacedim>::
 InternalData::get_fe_output_object (const unsigned int base_no) const
 {
@@ -277,7 +277,7 @@ FESystem<dim,spacedim>::FESystem (
   FiniteElement<dim,spacedim> (FETools::Compositing::multiply_dof_numbers(fes, multiplicities),
                                FETools::Compositing::compute_restriction_is_additive_flags (fes, multiplicities),
                                FETools::Compositing::compute_nonzero_components(fes, multiplicities)),
-  base_elements(internal::FESystem::count_nonzeros(multiplicities))
+  base_elements(internal::FESystemImplementation::count_nonzeros(multiplicities))
 {
   initialize(fes, multiplicities);
 }
@@ -888,7 +888,7 @@ FESystem<dim,spacedim>::
 get_data (const UpdateFlags                                                    flags,
           const Mapping<dim,spacedim>                                         &mapping,
           const Quadrature<dim>                                               &quadrature,
-          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
 {
   // create an internal data object and set the update flags we will need
   // to deal with. the current object does not make use of these flags,
@@ -914,7 +914,7 @@ get_data (const UpdateFlags                                                    f
   // function is called
   for (unsigned int base_no=0; base_no<this->n_base_elements(); ++base_no)
     {
-      internal::FEValues::FiniteElementRelatedData<dim,spacedim> &base_fe_output_object
+      internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &base_fe_output_object
         = data->get_fe_output_object(base_no);
       base_fe_output_object.initialize (quadrature.size(), base_element(base_no),
                                         flags | base_element(base_no).requires_update_flags(flags));
@@ -944,7 +944,7 @@ FESystem<dim,spacedim>::
 get_face_data (const UpdateFlags                                                    flags,
                const Mapping<dim,spacedim>                                         &mapping,
                const Quadrature<dim-1>                                             &quadrature,
-               dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+               dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
 {
   // create an internal data object and set the update flags we will need
   // to deal with. the current object does not make use of these flags,
@@ -970,7 +970,7 @@ get_face_data (const UpdateFlags                                                
   // function is called
   for (unsigned int base_no=0; base_no<this->n_base_elements(); ++base_no)
     {
-      internal::FEValues::FiniteElementRelatedData<dim,spacedim> &base_fe_output_object
+      internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &base_fe_output_object
         = data->get_fe_output_object(base_no);
       base_fe_output_object.initialize (quadrature.size(), base_element(base_no),
                                         flags | base_element(base_no).requires_update_flags(flags));
@@ -1002,7 +1002,7 @@ FESystem<dim,spacedim>::
 get_subface_data (const UpdateFlags                                                    flags,
                   const Mapping<dim,spacedim>                                         &mapping,
                   const Quadrature<dim-1>                                             &quadrature,
-                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
 {
   // create an internal data object and set the update flags we will need
   // to deal with. the current object does not make use of these flags,
@@ -1028,7 +1028,7 @@ get_subface_data (const UpdateFlags                                             
   // function is called
   for (unsigned int base_no=0; base_no<this->n_base_elements(); ++base_no)
     {
-      internal::FEValues::FiniteElementRelatedData<dim,spacedim> &base_fe_output_object
+      internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &base_fe_output_object
         = data->get_fe_output_object(base_no);
       base_fe_output_object.initialize (quadrature.size(), base_element(base_no),
                                         flags | base_element(base_no).requires_update_flags(flags));
@@ -1059,9 +1059,9 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator       
                 const Quadrature<dim>                                               &quadrature,
                 const Mapping<dim,spacedim>                                         &mapping,
                 const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                 const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   compute_fill(mapping, cell, invalid_face_number, invalid_face_number,
                quadrature, cell_similarity, mapping_internal, fe_internal,
@@ -1078,9 +1078,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator  
                      const Quadrature<dim-1>                                             &quadrature,
                      const Mapping<dim,spacedim>                                         &mapping,
                      const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                     const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                      const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                     dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   compute_fill (mapping, cell, face_no, invalid_face_number, quadrature,
                 CellSimilarity::none, mapping_internal, fe_internal,
@@ -1099,9 +1099,9 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const Quadrature<dim-1>                                             &quadrature,
                         const Mapping<dim,spacedim>                                         &mapping,
                         const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                         const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                        dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   compute_fill (mapping, cell, face_no, sub_no, quadrature,
                 CellSimilarity::none, mapping_internal, fe_internal,
@@ -1122,8 +1122,8 @@ compute_fill (const Mapping<dim,spacedim>                      &mapping,
               const CellSimilarity::Similarity                  cell_similarity,
               const typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
               const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
-              const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-              internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const
+              const internal::FEValuesImplementation::MappingRelatedData<dim,spacedim> &mapping_data,
+              internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -1157,7 +1157,7 @@ compute_fill (const Mapping<dim,spacedim>                      &mapping,
         base_fe      = base_element(base_no);
         typename FiniteElement<dim,spacedim>::InternalDataBase &
         base_fe_data = fe_data.get_fe_data(base_no);
-        internal::FEValues::FiniteElementRelatedData<dim,spacedim> &
+        internal::FEValuesImplementation::FiniteElementRelatedData<dim,spacedim> &
         base_data    = fe_data.get_fe_output_object(base_no);
 
         // fill_fe_face_values needs argument Quadrature<dim-1> for both cases
@@ -1478,7 +1478,7 @@ void FESystem<dim,spacedim>::initialize (const std::vector<const FiniteElement<d
           ExcDimensionMismatch (fes.size(), multiplicities.size()) );
   Assert (fes.size() > 0,
           ExcMessage ("Need to pass at least one finite element."));
-  Assert (internal::FESystem::count_nonzeros(multiplicities) > 0,
+  Assert (internal::FESystemImplementation::count_nonzeros(multiplicities) > 0,
           ExcMessage("You only passed FiniteElements with multiplicity 0."));
 
   // Note that we need to skip every fe with multiplicity 0 in the following block of code

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2521,7 +2521,7 @@ get_interpolated_dof_values (const IndexSet &,
 
 namespace internal
 {
-  namespace FEValues
+  namespace FEValuesImplementation
   {
     template <int dim, int spacedim>
     void

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -37,7 +37,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 
     namespace internal
     \{
-    namespace FEValues
+    namespace FEValuesImplementation
     \{
     template class MappingRelatedData<deal_II_dimension, deal_II_space_dimension>;
     template class FiniteElementRelatedData<deal_II_dimension, deal_II_space_dimension>;

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -341,7 +341,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 const CellSimilarity::Similarity                           cell_similarity,
                 const Quadrature<dim>                                     &quadrature,
                 const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // convert data object to internal data for this class. fails with
   // an exception if that is not possible
@@ -435,7 +435,7 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                      const unsigned int                                         face_no,
                      const Quadrature<dim-1>                                   &quadrature,
                      const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                     internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                     internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -525,7 +525,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const unsigned int                                         subface_no,
                         const Quadrature<dim-1>                                   &quadrature,
                         const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                        internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                        internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // convert data object to internal data for this class. fails with
   // an exception if that is not possible

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -521,7 +521,7 @@ MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::get_subface_data
 
 namespace internal
 {
-  namespace MappingFEField
+  namespace MappingFEFieldImplementation
   {
     namespace
     {
@@ -1087,7 +1087,7 @@ namespace internal
                                const unsigned int               subface_no,
                                const std::vector<double>        &weights,
                                const typename dealii::MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::InternalData &data,
-                               internal::FEValues::MappingRelatedData<dim,spacedim>         &output_data)
+                               internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>         &output_data)
       {
         const UpdateFlags update_flags = data.update_each;
 
@@ -1229,7 +1229,7 @@ namespace internal
                               const FiniteElement<dim, spacedim>                                &fe,
                               const ComponentMask                                               &fe_mask,
                               const std::vector<unsigned int>                                   &fe_to_real,
-                              internal::FEValues::MappingRelatedData<dim,spacedim>              &output_data)
+                              internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>              &output_data)
       {
         maybe_compute_q_points<dim,spacedim,VectorType,DoFHandlerType>
         (data_set,
@@ -1305,7 +1305,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 const CellSimilarity::Similarity                           cell_similarity,
                 const Quadrature<dim>                                     &quadrature,
                 const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
@@ -1322,12 +1322,12 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
 
   update_internal_dofs(cell, data);
 
-  internal::MappingFEField::maybe_compute_q_points<dim,spacedim,VectorType,DoFHandlerType>
+  internal::MappingFEFieldImplementation::maybe_compute_q_points<dim,spacedim,VectorType,DoFHandlerType>
   (QProjector<dim>::DataSetDescriptor::cell (),
    data, euler_dof_handler->get_fe(), fe_mask, fe_to_real,
    output_data.quadrature_points);
 
-  internal::MappingFEField::maybe_update_Jacobians<dim,spacedim,VectorType,DoFHandlerType>
+  internal::MappingFEFieldImplementation::maybe_update_Jacobians<dim,spacedim,VectorType,DoFHandlerType>
   (cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell (),
    data, euler_dof_handler->get_fe(), fe_mask, fe_to_real);
@@ -1431,35 +1431,35 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
     }
 
   // calculate derivatives of the Jacobians
-  internal::MappingFEField::maybe_update_jacobian_grads<dim,spacedim,VectorType,DoFHandlerType>
+  internal::MappingFEFieldImplementation::maybe_update_jacobian_grads<dim,spacedim,VectorType,DoFHandlerType>
   (cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell(),
    data, euler_dof_handler->get_fe(), fe_mask, fe_to_real,
    output_data.jacobian_grads);
 
   // calculate derivatives of the Jacobians pushed forward to real cell coordinates
-  internal::MappingFEField::maybe_update_jacobian_pushed_forward_grads<dim,spacedim,VectorType,DoFHandlerType>
+  internal::MappingFEFieldImplementation::maybe_update_jacobian_pushed_forward_grads<dim,spacedim,VectorType,DoFHandlerType>
   (cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell(),
    data, euler_dof_handler->get_fe(), fe_mask, fe_to_real,
    output_data.jacobian_pushed_forward_grads);
 
   // calculate hessians of the Jacobians
-  internal::MappingFEField::maybe_update_jacobian_2nd_derivatives<dim,spacedim,VectorType,DoFHandlerType>
+  internal::MappingFEFieldImplementation::maybe_update_jacobian_2nd_derivatives<dim,spacedim,VectorType,DoFHandlerType>
   (cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell(),
    data, euler_dof_handler->get_fe(), fe_mask, fe_to_real,
    output_data.jacobian_2nd_derivatives);
 
   // calculate hessians of the Jacobians pushed forward to real cell coordinates
-  internal::MappingFEField::maybe_update_jacobian_pushed_forward_2nd_derivatives<dim,spacedim,VectorType,DoFHandlerType>
+  internal::MappingFEFieldImplementation::maybe_update_jacobian_pushed_forward_2nd_derivatives<dim,spacedim,VectorType,DoFHandlerType>
   (cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell(),
    data, euler_dof_handler->get_fe(), fe_mask, fe_to_real,
    output_data.jacobian_pushed_forward_2nd_derivatives);
 
   // calculate gradients of the hessians of the Jacobians
-  internal::MappingFEField::maybe_update_jacobian_3rd_derivatives<dim,spacedim,VectorType,DoFHandlerType>
+  internal::MappingFEFieldImplementation::maybe_update_jacobian_3rd_derivatives<dim,spacedim,VectorType,DoFHandlerType>
   (cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell(),
    data, euler_dof_handler->get_fe(), fe_mask, fe_to_real,
@@ -1467,7 +1467,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
 
   // calculate gradients of the hessians of the Jacobians pushed forward to real
   // cell coordinates
-  internal::MappingFEField::maybe_update_jacobian_pushed_forward_3rd_derivatives<dim,spacedim,VectorType,DoFHandlerType>
+  internal::MappingFEFieldImplementation::maybe_update_jacobian_pushed_forward_3rd_derivatives<dim,spacedim,VectorType,DoFHandlerType>
   (cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell(),
    data, euler_dof_handler->get_fe(), fe_mask, fe_to_real,
@@ -1485,7 +1485,7 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                      const unsigned int                                         face_no,
                      const Quadrature<dim-1>                                   &quadrature,
                      const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                     internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                     internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
@@ -1495,7 +1495,7 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
 
   update_internal_dofs(cell, data);
 
-  internal::MappingFEField::do_fill_fe_face_values<dim,spacedim,VectorType,DoFHandlerType>
+  internal::MappingFEFieldImplementation::do_fill_fe_face_values<dim,spacedim,VectorType,DoFHandlerType>
   (*this,
    cell, face_no, numbers::invalid_unsigned_int,
    QProjector<dim>::DataSetDescriptor::
@@ -1519,7 +1519,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const unsigned int                                         subface_no,
                         const Quadrature<dim-1>                                   &quadrature,
                         const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                        internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                        internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
@@ -1529,7 +1529,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
   update_internal_dofs(cell, data);
 
-  internal::MappingFEField::do_fill_fe_face_values<dim,spacedim,VectorType,DoFHandlerType>
+  internal::MappingFEFieldImplementation::do_fill_fe_face_values<dim,spacedim,VectorType,DoFHandlerType>
   (*this,
    cell, face_no, numbers::invalid_unsigned_int,
    QProjector<dim>::DataSetDescriptor::
@@ -1548,7 +1548,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
 namespace internal
 {
-  namespace MappingFEField
+  namespace MappingFEFieldImplementation
   {
     namespace
     {
@@ -1662,7 +1662,7 @@ transform (const ArrayView<const Tensor<1,dim> >                  &input,
 {
   AssertDimension (input.size(), output.size());
 
-  internal::MappingFEField::transform_fields<dim,spacedim,1,VectorType,DoFHandlerType>(input, mapping_type, mapping_data, output);
+  internal::MappingFEFieldImplementation::transform_fields<dim,spacedim,1,VectorType,DoFHandlerType>(input, mapping_type, mapping_data, output);
 }
 
 
@@ -1677,7 +1677,7 @@ transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
 {
   AssertDimension (input.size(), output.size());
 
-  internal::MappingFEField::transform_differential_forms<dim,spacedim,1,VectorType,DoFHandlerType>(input, mapping_type, mapping_data, output);
+  internal::MappingFEFieldImplementation::transform_differential_forms<dim,spacedim,1,VectorType,DoFHandlerType>(input, mapping_type, mapping_data, output);
 }
 
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -344,7 +344,7 @@ MappingManifold<dim,spacedim>::get_subface_data (const UpdateFlags update_flags,
 
 namespace internal
 {
-  namespace MappingManifold
+  namespace MappingManifoldImplementation
   {
     namespace
     {
@@ -477,7 +477,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 const CellSimilarity::Similarity                           cell_similarity,
                 const Quadrature<dim>                                     &quadrature,
                 const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // ensure that the following static_cast is really correct:
   Assert (dynamic_cast<const InternalData *>(&internal_data) != nullptr,
@@ -489,12 +489,12 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   data.store_vertices(cell);
   data.manifold = &(cell->get_manifold());
 
-  internal::MappingManifold::maybe_compute_q_points<dim,spacedim>
+  internal::MappingManifoldImplementation::maybe_compute_q_points<dim,spacedim>
   (QProjector<dim>::DataSetDescriptor::cell (),
    data,
    output_data.quadrature_points);
 
-  internal::MappingManifold::maybe_update_Jacobians<dim,spacedim>
+  internal::MappingManifoldImplementation::maybe_update_Jacobians<dim,spacedim>
   (QProjector<dim>::DataSetDescriptor::cell (),
    data);
 
@@ -618,7 +618,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
 
 namespace internal
 {
-  namespace MappingManifold
+  namespace MappingManifoldImplementation
   {
     namespace
     {
@@ -641,7 +641,7 @@ namespace internal
        const unsigned int                                                  n_q_points,
        const std::vector<double>                                          &weights,
        const typename dealii::MappingManifold<dim,spacedim>::InternalData &data,
-       internal::FEValues::MappingRelatedData<dim,spacedim>               &output_data)
+       internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>               &output_data)
       {
         const UpdateFlags update_flags = data.update_each;
 
@@ -793,7 +793,7 @@ namespace internal
        const typename QProjector<dim>::DataSetDescriptor                   data_set,
        const Quadrature<dim-1>                                            &quadrature,
        const typename dealii::MappingManifold<dim,spacedim>::InternalData &data,
-       internal::FEValues::MappingRelatedData<dim,spacedim>               &output_data)
+       internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>               &output_data)
       {
         data.store_vertices(cell);
 
@@ -1139,7 +1139,7 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                      const unsigned int                                         face_no,
                      const Quadrature<dim-1>                                   &quadrature,
                      const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                     internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                     internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // ensure that the following cast is really correct:
   Assert ((dynamic_cast<const InternalData *>(&internal_data) != nullptr),
@@ -1147,7 +1147,7 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
   const InternalData &data
     = static_cast<const InternalData &>(internal_data);
 
-  internal::MappingManifold::do_fill_fe_face_values
+  internal::MappingManifoldImplementation::do_fill_fe_face_values
   (*this,
    cell, face_no, numbers::invalid_unsigned_int,
    QProjector<dim>::DataSetDescriptor::face (face_no,
@@ -1170,7 +1170,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const unsigned int                                         subface_no,
                         const Quadrature<dim-1>                                   &quadrature,
                         const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                        internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                        internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // ensure that the following cast is really correct:
   Assert ((dynamic_cast<const InternalData *>(&internal_data) != nullptr),
@@ -1178,7 +1178,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
   const InternalData &data
     = static_cast<const InternalData &>(internal_data);
 
-  internal::MappingManifold::do_fill_fe_face_values
+  internal::MappingManifoldImplementation::do_fill_fe_face_values
   (*this,
    cell, face_no, subface_no,
    QProjector<dim>::DataSetDescriptor::subface (face_no, subface_no,
@@ -1202,7 +1202,7 @@ transform (const ArrayView<const Tensor<1, dim> >                  &input,
            const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
            const ArrayView<Tensor<1, spacedim> >                   &output) const
 {
-  internal::MappingManifold::transform_fields(input, mapping_type, mapping_data, output);
+  internal::MappingManifoldImplementation::transform_fields(input, mapping_type, mapping_data, output);
 }
 
 
@@ -1215,7 +1215,7 @@ transform (const ArrayView<const DerivativeForm<1, dim,spacedim> >  &input,
            const typename Mapping<dim,spacedim>::InternalDataBase   &mapping_data,
            const ArrayView<Tensor<2, spacedim> >                    &output) const
 {
-  internal::MappingManifold::transform_differential_forms(input, mapping_type, mapping_data, output);
+  internal::MappingManifoldImplementation::transform_differential_forms(input, mapping_type, mapping_data, output);
 }
 
 
@@ -1231,13 +1231,13 @@ transform (const ArrayView<const Tensor<2, dim> >                  &input,
   switch (mapping_type)
     {
     case mapping_contravariant:
-      internal::MappingManifold::transform_fields(input, mapping_type, mapping_data, output);
+      internal::MappingManifoldImplementation::transform_fields(input, mapping_type, mapping_data, output);
       return;
 
     case mapping_piola_gradient:
     case mapping_contravariant_gradient:
     case mapping_covariant_gradient:
-      internal::MappingManifold::transform_gradients(input, mapping_type, mapping_data, output);
+      internal::MappingManifoldImplementation::transform_gradients(input, mapping_type, mapping_data, output);
       return;
     default:
       Assert(false, ExcNotImplemented());
@@ -1308,7 +1308,7 @@ transform (const ArrayView<const  Tensor<3,dim> >                  &input,
     case mapping_piola_hessian:
     case mapping_contravariant_hessian:
     case mapping_covariant_hessian:
-      internal::MappingManifold::transform_hessians(input, mapping_type, mapping_data, output);
+      internal::MappingManifoldImplementation::transform_hessians(input, mapping_type, mapping_data, output);
       return;
     default:
       Assert(false, ExcNotImplemented());

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -223,7 +223,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 const CellSimilarity::Similarity                           cell_similarity,
                 const Quadrature<dim>                                     &quadrature,
                 const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
@@ -278,7 +278,7 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                      const unsigned int                                         face_no,
                      const Quadrature<dim-1>                                   &quadrature,
                      const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                     internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                     internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
@@ -320,7 +320,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const unsigned int                                         subface_no,
                         const Quadrature<dim-1>                                   &quadrature,
                         const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                        internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                        internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -133,7 +133,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 const CellSimilarity::Similarity,
                 const Quadrature<dim>                                     &quadrature,
                 const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // call the function of the base class, but ignoring
   // any potentially detected cell similarity between

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -247,7 +247,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 const CellSimilarity::Similarity,
                 const Quadrature<dim>                                     &quadrature,
                 const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // call the function of the base class, but ignoring
   // any potentially detected cell similarity between

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -52,7 +52,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace MappingQGeneric
+  namespace MappingQGenericImplementation
   {
     namespace
     {
@@ -223,7 +223,7 @@ namespace internal
         const std::vector<unsigned int>
         renumber (FETools::
                   lexicographic_to_hierarchic_numbering
-                  (FiniteElementData<dim> (internal::MappingQGeneric::get_dpo_vector<dim>
+                  (FiniteElementData<dim> (internal::MappingQGenericImplementation::get_dpo_vector<dim>
                                            (data.polynomial_degree), 1, data.polynomial_degree)));
 
         std::vector<double> values;
@@ -737,7 +737,7 @@ initialize (const UpdateFlags      update_flags,
 
               const unsigned int n_shape_values = fe.n_dofs_per_cell();
               const unsigned int max_size = std::max(n_q_points,n_shape_values);
-              const unsigned int vec_length = VectorizedArray<double>::n_array_elements;
+              const unsigned int vec_length = dealii::VectorizedArray<double>::n_array_elements;
               const unsigned int n_comp = 1+ (spacedim-1)/vec_length;
 
               scratch.resize((dim-1)*max_size);
@@ -918,7 +918,7 @@ compute_shape_function_values (const std::vector<Point<dim> > &unit_points)
 
 namespace internal
 {
-  namespace MappingQGeneric
+  namespace MappingQGenericImplementation
   {
     namespace
     {
@@ -1265,7 +1265,7 @@ namespace internal
                 mdata.compute_shape_function_values(std::vector<Point<dim> > (1, p_unit_trial));
 
                 // f(x)
-                Point<spacedim> p_real_trial = internal::MappingQGeneric::compute_mapped_location_of_point<dim,spacedim>(mdata);
+                Point<spacedim> p_real_trial = internal::MappingQGenericImplementation::compute_mapped_location_of_point<dim,spacedim>(mdata);
                 const Tensor<1,spacedim> f_trial = p_real_trial-p;
 
 #ifdef DEBUG_TRANSFORM_REAL_TO_UNIT_CELL
@@ -2114,8 +2114,8 @@ MappingQGeneric<dim,spacedim>::MappingQGeneric (const unsigned int p)
   polynomial_degree(p),
   line_support_points(this->polynomial_degree+1),
   fe_q(dim == 3 ? new FE_Q<dim>(this->polynomial_degree) : nullptr),
-  support_point_weights_perimeter_to_interior (internal::MappingQGeneric::compute_support_point_weights_perimeter_to_interior(this->polynomial_degree, dim)),
-  support_point_weights_cell (internal::MappingQGeneric::compute_support_point_weights_cell<dim>(this->polynomial_degree))
+  support_point_weights_perimeter_to_interior (internal::MappingQGenericImplementation::compute_support_point_weights_perimeter_to_interior(this->polynomial_degree, dim)),
+  support_point_weights_cell (internal::MappingQGenericImplementation::compute_support_point_weights_cell<dim>(this->polynomial_degree))
 {
   Assert (p >= 1, ExcMessage ("It only makes sense to create polynomial mappings "
                               "with a polynomial degree greater or equal to one."));
@@ -2171,7 +2171,7 @@ transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_it
   const std::vector<unsigned int>
   renumber (FETools::
             lexicographic_to_hierarchic_numbering
-            (FiniteElementData<dim> (internal::MappingQGeneric::get_dpo_vector<dim>
+            (FiniteElementData<dim> (internal::MappingQGenericImplementation::get_dpo_vector<dim>
                                      (polynomial_degree), 1, polynomial_degree)));
 
   const std::vector<Point<spacedim> > support_points
@@ -2240,7 +2240,7 @@ transform_real_to_unit_cell_internal
 
   // dispatch to the various specializations for spacedim=dim,
   // spacedim=dim+1, etc
-  return internal::MappingQGeneric::do_transform_real_to_unit_cell_internal<1>(cell, p, initial_p_unit, *mdata);
+  return internal::MappingQGenericImplementation::do_transform_real_to_unit_cell_internal<1>(cell, p, initial_p_unit, *mdata);
 }
 
 template <>
@@ -2266,7 +2266,7 @@ transform_real_to_unit_cell_internal
 
   // dispatch to the various specializations for spacedim=dim,
   // spacedim=dim+1, etc
-  return internal::MappingQGeneric::do_transform_real_to_unit_cell_internal<2>(cell, p, initial_p_unit, *mdata);
+  return internal::MappingQGenericImplementation::do_transform_real_to_unit_cell_internal<2>(cell, p, initial_p_unit, *mdata);
 }
 
 template <>
@@ -2292,7 +2292,7 @@ transform_real_to_unit_cell_internal
 
   // dispatch to the various specializations for spacedim=dim,
   // spacedim=dim+1, etc
-  return internal::MappingQGeneric::do_transform_real_to_unit_cell_internal<3>(cell, p, initial_p_unit, *mdata);
+  return internal::MappingQGenericImplementation::do_transform_real_to_unit_cell_internal<3>(cell, p, initial_p_unit, *mdata);
 }
 
 template <>
@@ -2318,7 +2318,7 @@ transform_real_to_unit_cell_internal
 
   // dispatch to the various specializations for spacedim=dim,
   // spacedim=dim+1, etc
-  return internal::MappingQGeneric::do_transform_real_to_unit_cell_internal_codim1<1>(cell, p, initial_p_unit, *mdata);
+  return internal::MappingQGenericImplementation::do_transform_real_to_unit_cell_internal_codim1<1>(cell, p, initial_p_unit, *mdata);
 }
 
 template <>
@@ -2344,7 +2344,7 @@ transform_real_to_unit_cell_internal
 
   // dispatch to the various specializations for spacedim=dim,
   // spacedim=dim+1, etc
-  return internal::MappingQGeneric::do_transform_real_to_unit_cell_internal_codim1<2>(cell, p, initial_p_unit, *mdata);
+  return internal::MappingQGenericImplementation::do_transform_real_to_unit_cell_internal_codim1<2>(cell, p, initial_p_unit, *mdata);
 }
 
 template <>
@@ -2603,7 +2603,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 const CellSimilarity::Similarity                           cell_similarity,
                 const Quadrature<dim>                                     &quadrature,
                 const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // ensure that the following static_cast is really correct:
   Assert (dynamic_cast<const InternalData *>(&internal_data) != nullptr,
@@ -2634,7 +2634,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
 
   if (dim>1 && data.tensor_product_quadrature)
     {
-      internal::MappingQGeneric::maybe_update_q_points_Jacobians_and_grads_tensor<dim, spacedim>
+      internal::MappingQGenericImplementation::maybe_update_q_points_Jacobians_and_grads_tensor<dim, spacedim>
       (computed_cell_similarity,
        data,
        output_data.quadrature_points,
@@ -2642,48 +2642,48 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
     }
   else
     {
-      internal::MappingQGeneric::maybe_compute_q_points<dim,spacedim>
+      internal::MappingQGenericImplementation::maybe_compute_q_points<dim,spacedim>
       (QProjector<dim>::DataSetDescriptor::cell (),
        data,
        output_data.quadrature_points);
 
-      internal::MappingQGeneric::maybe_update_Jacobians<dim,spacedim>
+      internal::MappingQGenericImplementation::maybe_update_Jacobians<dim,spacedim>
       (computed_cell_similarity,
        QProjector<dim>::DataSetDescriptor::cell (),
        data);
 
-      internal::MappingQGeneric::maybe_update_jacobian_grads<dim,spacedim>
+      internal::MappingQGenericImplementation::maybe_update_jacobian_grads<dim,spacedim>
       (computed_cell_similarity,
        QProjector<dim>::DataSetDescriptor::cell (),
        data,
        output_data.jacobian_grads);
     }
 
-  internal::MappingQGeneric::maybe_update_jacobian_pushed_forward_grads<dim,spacedim>
+  internal::MappingQGenericImplementation::maybe_update_jacobian_pushed_forward_grads<dim,spacedim>
   (computed_cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell (),
    data,
    output_data.jacobian_pushed_forward_grads);
 
-  internal::MappingQGeneric::maybe_update_jacobian_2nd_derivatives<dim,spacedim>
+  internal::MappingQGenericImplementation::maybe_update_jacobian_2nd_derivatives<dim,spacedim>
   (computed_cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell (),
    data,
    output_data.jacobian_2nd_derivatives);
 
-  internal::MappingQGeneric::maybe_update_jacobian_pushed_forward_2nd_derivatives<dim,spacedim>
+  internal::MappingQGenericImplementation::maybe_update_jacobian_pushed_forward_2nd_derivatives<dim,spacedim>
   (computed_cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell (),
    data,
    output_data.jacobian_pushed_forward_2nd_derivatives);
 
-  internal::MappingQGeneric::maybe_update_jacobian_3rd_derivatives<dim,spacedim>
+  internal::MappingQGenericImplementation::maybe_update_jacobian_3rd_derivatives<dim,spacedim>
   (computed_cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell (),
    data,
    output_data.jacobian_3rd_derivatives);
 
-  internal::MappingQGeneric::maybe_update_jacobian_pushed_forward_3rd_derivatives<dim,spacedim>
+  internal::MappingQGenericImplementation::maybe_update_jacobian_pushed_forward_3rd_derivatives<dim,spacedim>
   (computed_cell_similarity,
    QProjector<dim>::DataSetDescriptor::cell (),
    data,
@@ -2810,7 +2810,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
 
 namespace internal
 {
-  namespace MappingQGeneric
+  namespace MappingQGenericImplementation
   {
     namespace
     {
@@ -2832,7 +2832,7 @@ namespace internal
                                const unsigned int               n_q_points,
                                const std::vector<double>        &weights,
                                const typename dealii::MappingQGeneric<dim,spacedim>::InternalData &data,
-                               internal::FEValues::MappingRelatedData<dim,spacedim>         &output_data)
+                               internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>         &output_data)
       {
         const UpdateFlags update_flags = data.update_each;
 
@@ -2983,7 +2983,7 @@ namespace internal
                               const typename QProjector<dim>::DataSetDescriptor                  data_set,
                               const Quadrature<dim-1>                                           &quadrature,
                               const typename dealii::MappingQGeneric<dim,spacedim>::InternalData      &data,
-                              internal::FEValues::MappingRelatedData<dim,spacedim>              &output_data)
+                              internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>              &output_data)
       {
         if (dim>1 && data.tensor_product_quadrature)
           {
@@ -3045,7 +3045,7 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                      const unsigned int                                         face_no,
                      const Quadrature<dim-1>                                   &quadrature,
                      const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                     internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                     internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // ensure that the following cast is really correct:
   Assert ((dynamic_cast<const InternalData *>(&internal_data) != nullptr),
@@ -3068,7 +3068,7 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
       data.cell_of_current_support_points = cell;
     }
 
-  internal::MappingQGeneric::do_fill_fe_face_values
+  internal::MappingQGenericImplementation::do_fill_fe_face_values
   (*this,
    cell, face_no, numbers::invalid_unsigned_int,
    QProjector<dim>::DataSetDescriptor::face (face_no,
@@ -3091,7 +3091,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const unsigned int                                         subface_no,
                         const Quadrature<dim-1>                                   &quadrature,
                         const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                        internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const
+                        internal::FEValuesImplementation::MappingRelatedData<dim,spacedim>      &output_data) const
 {
   // ensure that the following cast is really correct:
   Assert ((dynamic_cast<const InternalData *>(&internal_data) != nullptr),
@@ -3114,7 +3114,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
       data.cell_of_current_support_points = cell;
     }
 
-  internal::MappingQGeneric::do_fill_fe_face_values
+  internal::MappingQGenericImplementation::do_fill_fe_face_values
   (*this,
    cell, face_no, subface_no,
    QProjector<dim>::DataSetDescriptor::subface (face_no, subface_no,
@@ -3132,7 +3132,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
 namespace internal
 {
-  namespace MappingQGeneric
+  namespace MappingQGenericImplementation
   {
     namespace
     {
@@ -3465,7 +3465,7 @@ transform (const ArrayView<const Tensor<1, dim> >                  &input,
            const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
            const ArrayView<Tensor<1, spacedim> >                   &output) const
 {
-  internal::MappingQGeneric::transform_fields(input, mapping_type, mapping_data, output);
+  internal::MappingQGenericImplementation::transform_fields(input, mapping_type, mapping_data, output);
 }
 
 
@@ -3478,7 +3478,7 @@ transform (const ArrayView<const DerivativeForm<1, dim,spacedim> >  &input,
            const typename Mapping<dim,spacedim>::InternalDataBase   &mapping_data,
            const ArrayView<Tensor<2, spacedim> >                    &output) const
 {
-  internal::MappingQGeneric::transform_differential_forms(input, mapping_type, mapping_data, output);
+  internal::MappingQGenericImplementation::transform_differential_forms(input, mapping_type, mapping_data, output);
 }
 
 
@@ -3494,13 +3494,13 @@ transform (const ArrayView<const Tensor<2, dim> >                  &input,
   switch (mapping_type)
     {
     case mapping_contravariant:
-      internal::MappingQGeneric::transform_fields(input, mapping_type, mapping_data, output);
+      internal::MappingQGenericImplementation::transform_fields(input, mapping_type, mapping_data, output);
       return;
 
     case mapping_piola_gradient:
     case mapping_contravariant_gradient:
     case mapping_covariant_gradient:
-      internal::MappingQGeneric::transform_gradients(input, mapping_type, mapping_data, output);
+      internal::MappingQGenericImplementation::transform_gradients(input, mapping_type, mapping_data, output);
       return;
     default:
       Assert(false, ExcNotImplemented());
@@ -3571,7 +3571,7 @@ transform (const ArrayView<const  Tensor<3,dim> >                  &input,
     case mapping_piola_hessian:
     case mapping_contravariant_hessian:
     case mapping_covariant_hessian:
-      internal::MappingQGeneric::transform_hessians(input, mapping_type, mapping_data, output);
+      internal::MappingQGenericImplementation::transform_hessians(input, mapping_type, mapping_data, output);
       return;
     default:
       Assert(false, ExcNotImplemented());

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -60,7 +60,7 @@ SubCellData::check_consistency (const unsigned int dim) const
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
 
     NumberCache<1>::NumberCache ()
@@ -1051,14 +1051,14 @@ namespace
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
     // make sure that if in the following we
     // write Triangulation<dim,spacedim>
     // we mean the *class*
     // dealii::Triangulation, not the
     // enclosing namespace
-    // internal::Triangulation
+    // internal::TriangulationImplementation
     using dealii::Triangulation;
 
     /**
@@ -1308,7 +1308,7 @@ namespace internal
       static
       void compute_number_cache (const Triangulation<dim,spacedim>       &triangulation,
                                  const unsigned int                       level_objects,
-                                 internal::Triangulation::NumberCache<1> &number_cache)
+                                 internal::TriangulationImplementation::NumberCache<1> &number_cache)
       {
         typedef
         typename Triangulation<dim,spacedim>::line_iterator line_iterator;
@@ -1394,7 +1394,7 @@ namespace internal
       static
       void compute_number_cache (const Triangulation<dim,spacedim>       &triangulation,
                                  const unsigned int                       level_objects,
-                                 internal::Triangulation::NumberCache<2> &number_cache)
+                                 internal::TriangulationImplementation::NumberCache<2> &number_cache)
       {
         // update lines and n_levels in number_cache. since we don't
         // access any of these numbers, we can do this in the
@@ -1402,11 +1402,11 @@ namespace internal
         Threads::Task<void> update_lines
           = Threads::new_task ((void (*)(const Triangulation<dim,spacedim> &,
                                          const unsigned int,
-                                         internal::Triangulation::NumberCache<1> &))
+                                         internal::TriangulationImplementation::NumberCache<1> &))
                                (&compute_number_cache<dim,spacedim>),
                                triangulation,
                                level_objects,
-                               static_cast<internal::Triangulation::NumberCache<1>&>
+                               static_cast<internal::TriangulationImplementation::NumberCache<1>&>
                                (number_cache));
 
         typedef
@@ -1498,7 +1498,7 @@ namespace internal
       static
       void compute_number_cache (const Triangulation<dim,spacedim>       &triangulation,
                                  const unsigned int                       level_objects,
-                                 internal::Triangulation::NumberCache<3> &number_cache)
+                                 internal::TriangulationImplementation::NumberCache<3> &number_cache)
       {
         // update quads, lines and n_levels in number_cache. since we
         // don't access any of these numbers, we can do this in the
@@ -1506,11 +1506,11 @@ namespace internal
         Threads::Task<void> update_quads_and_lines
           = Threads::new_task ((void (*)(const Triangulation<dim,spacedim> &,
                                          const unsigned int,
-                                         internal::Triangulation::NumberCache<2> &))
+                                         internal::TriangulationImplementation::NumberCache<2> &))
                                (&compute_number_cache<dim,spacedim>),
                                triangulation,
                                level_objects,
-                               static_cast<internal::Triangulation::NumberCache<2>&>
+                               static_cast<internal::TriangulationImplementation::NumberCache<2>&>
                                (number_cache));
 
         typedef
@@ -1645,7 +1645,7 @@ namespace internal
         std::vector<std::vector<int> > lines_at_vertex (v.size());
 
         // reserve enough space
-        triangulation.levels.push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>());
+        triangulation.levels.push_back (std_cxx14::make_unique<internal::TriangulationImplementation::TriaLevel<dim>>());
         triangulation.levels[0]->reserve_space (cells.size(), dim, spacedim);
         triangulation.levels[0]->cells.reserve_space (0, cells.size());
 
@@ -1657,7 +1657,7 @@ namespace internal
             while (next_free_line->used())
               ++next_free_line;
 
-            next_free_line->set (internal::Triangulation
+            next_free_line->set (internal::TriangulationImplementation
                                  ::TriaObject<1> (cells[cell].vertices[0],
                                                   cells[cell].vertices[1]));
             next_free_line->set_used_flag ();
@@ -1922,8 +1922,8 @@ namespace internal
         }
 
         // reserve enough space
-        triangulation.levels.push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>());
-        triangulation.faces = std_cxx14::make_unique<internal::Triangulation::TriaFaces<dim>> ();
+        triangulation.levels.push_back (std_cxx14::make_unique<internal::TriangulationImplementation::TriaLevel<dim>>());
+        triangulation.faces = std_cxx14::make_unique<internal::TriangulationImplementation::TriaFaces<dim>> ();
         triangulation.levels[0]->reserve_space (cells.size(), dim, spacedim);
         triangulation.faces->lines.reserve_space (0,needed_lines.size());
         triangulation.levels[0]->cells.reserve_space (0,cells.size());
@@ -1937,8 +1937,8 @@ namespace internal
           for (i = needed_lines.begin();
                line!=triangulation.end_line(); ++line, ++i)
             {
-              line->set (internal::Triangulation::TriaObject<1>(i->first.first,
-                                                                i->first.second));
+              line->set (internal::TriangulationImplementation::TriaObject<1>(i->first.first,
+                         i->first.second));
               line->set_used_flag ();
               line->clear_user_flag ();
               line->clear_user_data ();
@@ -1965,10 +1965,10 @@ namespace internal
                                            cells[c].vertices[GeometryInfo<dim>::line_to_cell_vertices(line, 0)],
                                            cells[c].vertices[GeometryInfo<dim>::line_to_cell_vertices(line, 1)])];
 
-              cell->set (internal::Triangulation::TriaObject<2> (lines[0]->index(),
-                                                                 lines[1]->index(),
-                                                                 lines[2]->index(),
-                                                                 lines[3]->index()));
+              cell->set (internal::TriangulationImplementation::TriaObject<2> (lines[0]->index(),
+                         lines[1]->index(),
+                         lines[2]->index(),
+                         lines[3]->index()));
 
               cell->set_used_flag ();
               cell->set_material_id (cells[c].material_id);
@@ -2120,18 +2120,18 @@ namespace internal
 
 
       /**
-       * Invent an object which compares two internal::Triangulation::TriaObject<2>
+       * Invent an object which compares two internal::TriangulationImplementation::TriaObject<2>
        * against each other. This comparison is needed in order to establish a map
        * of TriaObject<2> to iterators in the Triangulation<3,3>::create_triangulation
        * function.
        *
        * Since this comparison is not canonical, we do not include it into the
-       * general internal::Triangulation::TriaObject<2> class.
+       * general internal::TriangulationImplementation::TriaObject<2> class.
        */
       struct QuadComparator
       {
-        inline bool operator () (const internal::Triangulation::TriaObject<2> &q1,
-                                 const internal::Triangulation::TriaObject<2> &q2) const
+        inline bool operator () (const internal::TriangulationImplementation::TriaObject<2> &q1,
+                                 const internal::TriangulationImplementation::TriaObject<2> &q2) const
         {
           // here is room to
           // optimize the repeated
@@ -2290,8 +2290,8 @@ namespace internal
         // actually set up data structures
         // for the lines
         // reserve enough space
-        triangulation.levels.push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>());
-        triangulation.faces = std_cxx14::make_unique<internal::Triangulation::TriaFaces<dim>> ();
+        triangulation.levels.push_back (std_cxx14::make_unique<internal::TriangulationImplementation::TriaLevel<dim>>());
+        triangulation.faces = std_cxx14::make_unique<internal::TriangulationImplementation::TriaFaces<dim>> ();
         triangulation.levels[0]->reserve_space (cells.size(), dim, spacedim);
         triangulation.faces->lines.reserve_space (0,needed_lines.size());
 
@@ -2303,8 +2303,8 @@ namespace internal
                    typename Triangulation<dim,spacedim>::line_iterator>::iterator i;
           for (i = needed_lines.begin(); line!=triangulation.end_line(); ++line, ++i)
             {
-              line->set (internal::Triangulation::TriaObject<1>(i->first.first,
-                                                                i->first.second));
+              line->set (internal::TriangulationImplementation::TriaObject<1>(i->first.first,
+                         i->first.second));
               line->set_used_flag ();
               line->clear_user_flag ();
               line->clear_user_data ();
@@ -2330,7 +2330,7 @@ namespace internal
         // note that QuadComparator is a
         // class declared and defined in
         // this file
-        std::map<internal::Triangulation::TriaObject<2>,
+        std::map<internal::TriangulationImplementation::TriaObject<2>,
             std::pair<typename Triangulation<dim,spacedim>::quad_iterator,
             std::array<bool,GeometryInfo<dim>::lines_per_face> >,
             QuadComparator>
@@ -2401,7 +2401,7 @@ namespace internal
                     }
 
 
-                internal::Triangulation::TriaObject<2>
+                internal::TriangulationImplementation::TriaObject<2>
                 quad(face_line_list[0],
                      face_line_list[1],
                      face_line_list[2],
@@ -2445,7 +2445,7 @@ namespace internal
                 // new one and instead
                 // later set the
                 // face_orientation flag
-                const internal::Triangulation::TriaObject<2>
+                const internal::TriangulationImplementation::TriaObject<2>
                 test_quad_1(quad.face(2), quad.face(3),
                             quad.face(0), quad.face(1)),//face_orientation=false, face_flip=false, face_rotation=false
                                       test_quad_2(quad.face(0), quad.face(1),
@@ -2482,7 +2482,7 @@ namespace internal
         {
           typename Triangulation<dim,spacedim>::raw_quad_iterator
           quad = triangulation.begin_raw_quad();
-          typename std::map<internal::Triangulation::TriaObject<2>,
+          typename std::map<internal::TriangulationImplementation::TriaObject<2>,
                    std::pair<typename Triangulation<dim,spacedim>::quad_iterator,
                    std::array<bool,GeometryInfo<dim>::lines_per_face> >,
                    QuadComparator>
@@ -2566,7 +2566,7 @@ namespace internal
                       face_line_list[l]=needed_lines[inverse_line_list[GeometryInfo<dim>::
                                                                        face_to_cell_lines(face,l)]]->index();
 
-                  internal::Triangulation::TriaObject<2>
+                  internal::TriangulationImplementation::TriaObject<2>
                   quad(face_line_list[0],
                        face_line_list[1],
                        face_line_list[2],
@@ -2595,7 +2595,7 @@ namespace internal
                       // then. construct all
                       // possibilities and check
                       // them one after the other
-                      const internal::Triangulation::TriaObject<2>
+                      const internal::TriangulationImplementation::TriaObject<2>
                       test_quad_1(quad.face(2), quad.face(3),
                                   quad.face(0), quad.face(1)),//face_orientation=false, face_flip=false, face_rotation=false
                                             test_quad_2(quad.face(0), quad.face(1),
@@ -2672,7 +2672,7 @@ namespace internal
 
               // make the cell out of
               // these iterators
-              cell->set (internal::Triangulation
+              cell->set (internal::TriangulationImplementation
                          ::TriaObject<3> (face_iterator[0]->index(),
                                           face_iterator[1]->index(),
                                           face_iterator[2]->index(),
@@ -2936,10 +2936,10 @@ namespace internal
             // and because boundary quad
             // orientation does not carry
             // any information.
-            internal::Triangulation::TriaObject<2>
+            internal::TriangulationImplementation::TriaObject<2>
             quad_compare_1(line[0]->index(), line[1]->index(),
                            line[2]->index(), line[3]->index());
-            internal::Triangulation::TriaObject<2>
+            internal::TriangulationImplementation::TriaObject<2>
             quad_compare_2(line[2]->index(), line[3]->index(),
                            line[0]->index(), line[1]->index());
 
@@ -3641,10 +3641,10 @@ namespace internal
                           const unsigned int switch_1_user_index=switch_1->user_index();
                           const bool switch_1_user_flag=switch_1->user_flag_set();
 
-                          switch_1->set(internal::Triangulation::TriaObject<2>(switch_2->line_index(0),
-                                                                               switch_2->line_index(1),
-                                                                               switch_2->line_index(2),
-                                                                               switch_2->line_index(3)));
+                          switch_1->set(internal::TriangulationImplementation::TriaObject<2>(switch_2->line_index(0),
+                                        switch_2->line_index(1),
+                                        switch_2->line_index(2),
+                                        switch_2->line_index(3)));
                           switch_1->set_line_orientation(0, switch_2->line_orientation(0));
                           switch_1->set_line_orientation(1, switch_2->line_orientation(1));
                           switch_1->set_line_orientation(2, switch_2->line_orientation(2));
@@ -3657,10 +3657,10 @@ namespace internal
                           else
                             switch_1->clear_user_flag();
 
-                          switch_2->set(internal::Triangulation::TriaObject<2>(switch_1_lines[0],
-                                                                               switch_1_lines[1],
-                                                                               switch_1_lines[2],
-                                                                               switch_1_lines[3]));
+                          switch_2->set(internal::TriangulationImplementation::TriaObject<2>(switch_1_lines[0],
+                                        switch_1_lines[1],
+                                        switch_1_lines[2],
+                                        switch_1_lines[3]));
                           switch_2->set_line_orientation(0, switch_1_line_orientations[0]);
                           switch_2->set_line_orientation(1, switch_1_line_orientations[1]);
                           switch_2->set_line_orientation(2, switch_1_line_orientations[2]);
@@ -4067,13 +4067,13 @@ namespace internal
                 new_lines[l]=cell->line(face_no)->child(c);
             Assert(l==8, ExcInternalError());
 
-            new_lines[8] ->set (internal::Triangulation::
+            new_lines[8] ->set (internal::TriangulationImplementation::
                                 TriaObject<1>(new_vertices[6], new_vertices[8]));
-            new_lines[9] ->set (internal::Triangulation::
+            new_lines[9] ->set (internal::TriangulationImplementation::
                                 TriaObject<1>(new_vertices[8], new_vertices[7]));
-            new_lines[10]->set (internal::Triangulation::
+            new_lines[10]->set (internal::TriangulationImplementation::
                                 TriaObject<1>(new_vertices[4], new_vertices[8]));
-            new_lines[11]->set (internal::Triangulation::
+            new_lines[11]->set (internal::TriangulationImplementation::
                                 TriaObject<1>(new_vertices[8], new_vertices[5]));
           }
         else if (ref_case==RefinementCase<dim>::cut_x)
@@ -4089,7 +4089,7 @@ namespace internal
             new_lines[3]=cell->line(2)->child(1);
             new_lines[4]=cell->line(3)->child(0);
             new_lines[5]=cell->line(3)->child(1);
-            new_lines[6]->set (internal::Triangulation::
+            new_lines[6]->set (internal::TriangulationImplementation::
                                TriaObject<1>(new_vertices[6], new_vertices[7]));
           }
         else
@@ -4106,7 +4106,7 @@ namespace internal
             new_lines[3]=cell->line(1)->child(1);
             new_lines[4]=cell->line(2);
             new_lines[5]=cell->line(3);
-            new_lines[6]->set (internal::Triangulation::
+            new_lines[6]->set (internal::TriangulationImplementation::
                                TriaObject<1>(new_vertices[4], new_vertices[5]));
           }
 
@@ -4155,22 +4155,22 @@ namespace internal
             //   .-10.11-.
             //   0   8   2
             //   .-4-.-5-.
-            subcells[0]->set (internal::Triangulation::
+            subcells[0]->set (internal::TriangulationImplementation::
                               TriaObject<2>(new_lines[0]->index(),
                                             new_lines[8]->index(),
                                             new_lines[4]->index(),
                                             new_lines[10]->index()));
-            subcells[1]->set (internal::Triangulation::
+            subcells[1]->set (internal::TriangulationImplementation::
                               TriaObject<2>(new_lines[8]->index(),
                                             new_lines[2]->index(),
                                             new_lines[5]->index(),
                                             new_lines[11]->index()));
-            subcells[2]->set (internal::Triangulation::
+            subcells[2]->set (internal::TriangulationImplementation::
                               TriaObject<2>(new_lines[1]->index(),
                                             new_lines[9]->index(),
                                             new_lines[10]->index(),
                                             new_lines[6]->index()));
-            subcells[3]->set (internal::Triangulation::
+            subcells[3]->set (internal::TriangulationImplementation::
                               TriaObject<2>(new_lines[9]->index(),
                                             new_lines[3]->index(),
                                             new_lines[11]->index(),
@@ -4190,12 +4190,12 @@ namespace internal
             //   0   6   1
             //   |   |   |
             //   .-2-.-3-.
-            subcells[0]->set (internal::Triangulation::
+            subcells[0]->set (internal::TriangulationImplementation::
                               TriaObject<2>(new_lines[0]->index(),
                                             new_lines[6]->index(),
                                             new_lines[2]->index(),
                                             new_lines[4]->index()));
-            subcells[1]->set (internal::Triangulation::
+            subcells[1]->set (internal::TriangulationImplementation::
                               TriaObject<2>(new_lines[6]->index(),
                                             new_lines[1]->index(),
                                             new_lines[3]->index(),
@@ -4216,12 +4216,12 @@ namespace internal
             //   .---6---.
             //   0       2
             //   .---4---.
-            subcells[0]->set (internal::Triangulation::
+            subcells[0]->set (internal::TriangulationImplementation::
                               TriaObject<2>(new_lines[0]->index(),
                                             new_lines[2]->index(),
                                             new_lines[4]->index(),
                                             new_lines[6]->index()));
-            subcells[1]->set (internal::Triangulation::
+            subcells[1]->set (internal::TriangulationImplementation::
                               TriaObject<2>(new_lines[1]->index(),
                                             new_lines[3]->index(),
                                             new_lines[6]->index(),
@@ -4294,7 +4294,7 @@ namespace internal
               if (cell->refine_flag_set())
                 {
                   triangulation.levels
-                  .push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>());
+                  .push_back (std_cxx14::make_unique<internal::TriangulationImplementation::TriaLevel<dim>>());
                   break;
                 }
         }
@@ -4419,7 +4419,7 @@ namespace internal
                   // insert first child
                   cell->set_children (0, first_child->index());
                   first_child->clear_children ();
-                  first_child->set (internal::Triangulation
+                  first_child->set (internal::TriangulationImplementation
                                     ::TriaObject<1> (cell->vertex_index(0),
                                                      next_unused_vertex));
                   first_child->set_material_id (cell->material_id());
@@ -4434,7 +4434,7 @@ namespace internal
                   first_child->face(1)->set_manifold_id(cell->manifold_id());
 
                   // reset neighborship info (refer to
-                  // internal::Triangulation::TriaLevel<0> for
+                  // internal::TriangulationImplementation::TriaLevel<0> for
                   // details)
                   first_child->set_neighbor (1, second_child);
                   if (cell->neighbor(0).state() != IteratorState::valid)
@@ -4469,7 +4469,7 @@ namespace internal
 
                   // insert second child
                   second_child->clear_children ();
-                  second_child->set (internal::Triangulation
+                  second_child->set (internal::TriangulationImplementation
                                      ::TriaObject<1>(next_unused_vertex,
                                                      cell->vertex_index(1)));
                   second_child->set_neighbor (0, first_child);
@@ -4537,7 +4537,7 @@ namespace internal
               if (cell->used())
                 if (cell->refine_flag_set())
                   {
-                    triangulation.levels.push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>());
+                    triangulation.levels.push_back (std_cxx14::make_unique<internal::TriangulationImplementation::TriaLevel<dim>>());
                     break;
                   }
           }
@@ -4777,10 +4777,10 @@ namespace internal
                   Assert (children[0]->used() == false, ExcMessage("Internal error: We want to use a cell during refinement that should be unused, but turns out not to be."));
                   Assert (children[1]->used() == false, ExcMessage("Internal error: We want to use a cell during refinement that should be unused, but turns out not to be."));
 
-                  children[0]->set (internal::Triangulation
+                  children[0]->set (internal::TriangulationImplementation
                                     ::TriaObject<1>(line->vertex_index(0),
                                                     next_unused_vertex));
-                  children[1]->set (internal::Triangulation
+                  children[1]->set (internal::TriangulationImplementation
                                     ::TriaObject<1>(next_unused_vertex,
                                                     line->vertex_index(1)));
 
@@ -4899,7 +4899,7 @@ namespace internal
               if (cell->used())
                 if (cell->refine_flag_set())
                   {
-                    triangulation.levels.push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>());
+                    triangulation.levels.push_back (std_cxx14::make_unique<internal::TriangulationImplementation::TriaLevel<dim>>());
                     break;
                   }
           }
@@ -5217,10 +5217,10 @@ namespace internal
                   Assert (children[0]->used() == false, ExcMessage("Internal error: We want to use a cell during refinement that should be unused, but turns out not to be."));
                   Assert (children[1]->used() == false, ExcMessage("Internal error: We want to use a cell during refinement that should be unused, but turns out not to be."));
 
-                  children[0]->set (internal::Triangulation
+                  children[0]->set (internal::TriangulationImplementation
                                     ::TriaObject<1>(line->vertex_index(0),
                                                     next_unused_vertex));
-                  children[1]->set (internal::Triangulation
+                  children[1]->set (internal::TriangulationImplementation
                                     ::TriaObject<1>(next_unused_vertex,
                                                     line->vertex_index(1)));
 
@@ -5342,7 +5342,7 @@ namespace internal
                         vertex_indices[1]=quad->line(1)->child(0)->vertex_index(1);
                       }
 
-                    new_line->set (internal::Triangulation::
+                    new_line->set (internal::TriangulationImplementation::
                                    TriaObject<1>(vertex_indices[0], vertex_indices[1]));
                     new_line->set_used_flag();
                     new_line->clear_user_flag();
@@ -5378,12 +5378,12 @@ namespace internal
 
                     if (aniso_quad_ref_case==RefinementCase<dim-1>::cut_x)
                       {
-                        new_quads[0]->set (internal::Triangulation
+                        new_quads[0]->set (internal::TriangulationImplementation
                                            ::TriaObject<2>(quad->line_index(0),
                                                            new_line->index(),
                                                            quad->line(2)->child(index[0][quad->line_orientation(2)])->index(),
                                                            quad->line(3)->child(index[0][quad->line_orientation(3)])->index()));
-                        new_quads[1]->set (internal::Triangulation
+                        new_quads[1]->set (internal::TriangulationImplementation
                                            ::TriaObject<2>(new_line->index(),
                                                            quad->line_index(1),
                                                            quad->line(2)->child(index[1][quad->line_orientation(2)])->index(),
@@ -5391,12 +5391,12 @@ namespace internal
                       }
                     else
                       {
-                        new_quads[0]->set (internal::Triangulation
+                        new_quads[0]->set (internal::TriangulationImplementation
                                            ::TriaObject<2>(quad->line(0)->child(index[0][quad->line_orientation(0)])->index(),
                                                            quad->line(1)->child(index[0][quad->line_orientation(1)])->index(),
                                                            quad->line_index(2),
                                                            new_line->index()));
-                        new_quads[1]->set (internal::Triangulation
+                        new_quads[1]->set (internal::TriangulationImplementation
                                            ::TriaObject<2>(quad->line(0)->child(index[1][quad->line_orientation(0)])->index(),
                                                            quad->line(1)->child(index[1][quad->line_orientation(1)])->index(),
                                                            new_line->index(),
@@ -5508,8 +5508,8 @@ namespace internal
                               {
                                 Assert(!old_child[i]->has_children(), ExcInternalError());
 
-                                new_child[i]->set(internal::Triangulation::TriaObject<1>(old_child[i]->vertex_index(0),
-                                                                                         old_child[i]->vertex_index(1)));
+                                new_child[i]->set(internal::TriangulationImplementation::TriaObject<1>(old_child[i]->vertex_index(0),
+                                                  old_child[i]->vertex_index(1)));
                                 new_child[i]->set_boundary_id_internal(old_child[i]->boundary_id());
                                 new_child[i]->set_manifold_id(old_child[i]->manifold_id());
                                 new_child[i]->set_user_index(old_child[i]->user_index());
@@ -5605,10 +5605,10 @@ namespace internal
                             const int switch_1_first_child_pair=(switch_1_refinement_case ? switch_1->child_index(0) : -1);
                             const int switch_1_second_child_pair=(switch_1_refinement_case==RefinementCase<dim-1>::cut_xy ? switch_1->child_index(2) : -1);
 
-                            switch_1->set(internal::Triangulation::TriaObject<2>(switch_2->line_index(0),
-                                                                                 switch_2->line_index(1),
-                                                                                 switch_2->line_index(2),
-                                                                                 switch_2->line_index(3)));
+                            switch_1->set(internal::TriangulationImplementation::TriaObject<2>(switch_2->line_index(0),
+                                          switch_2->line_index(1),
+                                          switch_2->line_index(2),
+                                          switch_2->line_index(3)));
                             switch_1->set_line_orientation(0, switch_2->line_orientation(0));
                             switch_1->set_line_orientation(1, switch_2->line_orientation(1));
                             switch_1->set_line_orientation(2, switch_2->line_orientation(2));
@@ -5628,10 +5628,10 @@ namespace internal
                             if (switch_2->refinement_case()==RefinementCase<dim-1>::cut_xy)
                               switch_1->set_children(2, switch_2->child_index(2));
 
-                            switch_2->set(internal::Triangulation::TriaObject<2>(switch_1_lines[0],
-                                                                                 switch_1_lines[1],
-                                                                                 switch_1_lines[2],
-                                                                                 switch_1_lines[3]));
+                            switch_2->set(internal::TriangulationImplementation::TriaObject<2>(switch_1_lines[0],
+                                          switch_1_lines[1],
+                                          switch_1_lines[2],
+                                          switch_1_lines[3]));
                             switch_2->set_line_orientation(0, switch_1_line_orientations[0]);
                             switch_2->set_line_orientation(1, switch_1_line_orientations[1]);
                             switch_2->set_line_orientation(2, switch_1_line_orientations[2]);
@@ -5748,10 +5748,10 @@ namespace internal
                             Assert (children[0]->used() == false, ExcMessage("Internal error: We want to use a cell during refinement that should be unused, but turns out not to be."));
                             Assert (children[1]->used() == false, ExcMessage("Internal error: We want to use a cell during refinement that should be unused, but turns out not to be."));
 
-                            children[0]->set (internal::Triangulation::
+                            children[0]->set (internal::TriangulationImplementation::
                                               TriaObject<1>(middle_line->vertex_index(0),
                                                             next_unused_vertex));
-                            children[1]->set (internal::Triangulation::
+                            children[1]->set (internal::TriangulationImplementation::
                                               TriaObject<1>(next_unused_vertex,
                                                             middle_line->vertex_index(1)));
 
@@ -5853,13 +5853,13 @@ namespace internal
                           next_unused_vertex
                         };
 
-                    new_lines[0]->set (internal::Triangulation::
+                    new_lines[0]->set (internal::TriangulationImplementation::
                                        TriaObject<1>(vertex_indices[2], vertex_indices[4]));
-                    new_lines[1]->set (internal::Triangulation::
+                    new_lines[1]->set (internal::TriangulationImplementation::
                                        TriaObject<1>(vertex_indices[4], vertex_indices[3]));
-                    new_lines[2]->set (internal::Triangulation::
+                    new_lines[2]->set (internal::TriangulationImplementation::
                                        TriaObject<1>(vertex_indices[0], vertex_indices[4]));
-                    new_lines[3]->set (internal::Triangulation::
+                    new_lines[3]->set (internal::TriangulationImplementation::
                                        TriaObject<1>(vertex_indices[4], vertex_indices[1]));
 
                     for (unsigned int i=0; i<4; ++i)
@@ -5934,7 +5934,7 @@ namespace internal
                     // note these quads as children to the present one
                     quad->set_children (0, new_quads[0]->index());
                     quad->set_children (2, new_quads[2]->index());
-                    new_quads[0]->set (internal::Triangulation
+                    new_quads[0]->set (internal::TriangulationImplementation
                                        ::TriaObject<2>(line_indices[0],
                                                        line_indices[8],
                                                        line_indices[4],
@@ -5942,22 +5942,22 @@ namespace internal
 
                     quad->set_refinement_case(RefinementCase<2>::cut_xy);
 
-                    new_quads[0]->set (internal::Triangulation
+                    new_quads[0]->set (internal::TriangulationImplementation
                                        ::TriaObject<2>(line_indices[0],
                                                        line_indices[8],
                                                        line_indices[4],
                                                        line_indices[10]));
-                    new_quads[1]->set (internal::Triangulation
+                    new_quads[1]->set (internal::TriangulationImplementation
                                        ::TriaObject<2>(line_indices[8],
                                                        line_indices[2],
                                                        line_indices[5],
                                                        line_indices[11]));
-                    new_quads[2]->set (internal::Triangulation
+                    new_quads[2]->set (internal::TriangulationImplementation
                                        ::TriaObject<2>(line_indices[1],
                                                        line_indices[9],
                                                        line_indices[10],
                                                        line_indices[6]));
-                    new_quads[3]->set (internal::Triangulation
+                    new_quads[3]->set (internal::TriangulationImplementation
                                        ::TriaObject<2>(line_indices[9],
                                                        line_indices[3],
                                                        line_indices[11],
@@ -6337,7 +6337,7 @@ namespace internal
 
                       // set up the new quad, line numbering is as
                       // indicated above
-                      new_quads[0]->set (internal::Triangulation
+                      new_quads[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[0],
                                                          line_indices[1],
                                                          line_indices[2],
@@ -6402,14 +6402,14 @@ namespace internal
 
                       };
 
-                      new_hexes[0]->set (internal::Triangulation
+                      new_hexes[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[1],
                                                          quad_indices[0],
                                                          quad_indices[3],
                                                          quad_indices[5],
                                                          quad_indices[7],
                                                          quad_indices[9]));
-                      new_hexes[1]->set (internal::Triangulation
+                      new_hexes[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[0],
                                                          quad_indices[2],
                                                          quad_indices[4],
@@ -6531,7 +6531,7 @@ namespace internal
 
                       // set up the new quad, line numbering is as
                       // indicated above
-                      new_quads[0]->set (internal::Triangulation
+                      new_quads[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[2],
                                                          line_indices[3],
                                                          line_indices[0],
@@ -6596,14 +6596,14 @@ namespace internal
 
                       };
 
-                      new_hexes[0]->set (internal::Triangulation
+                      new_hexes[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[1],
                                                          quad_indices[3],
                                                          quad_indices[5],
                                                          quad_indices[0],
                                                          quad_indices[7],
                                                          quad_indices[9]));
-                      new_hexes[1]->set (internal::Triangulation
+                      new_hexes[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[2],
                                                          quad_indices[4],
                                                          quad_indices[0],
@@ -6727,7 +6727,7 @@ namespace internal
 
                       // set up the new quad, line numbering is as
                       // indicated above
-                      new_quads[0]->set (internal::Triangulation
+                      new_quads[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[0],
                                                          line_indices[1],
                                                          line_indices[2],
@@ -6792,14 +6792,14 @@ namespace internal
                         hex->face(5)->index()      //10
                       };
 
-                      new_hexes[0]->set (internal::Triangulation
+                      new_hexes[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[1],
                                                          quad_indices[3],
                                                          quad_indices[5],
                                                          quad_indices[7],
                                                          quad_indices[9],
                                                          quad_indices[0]));
-                      new_hexes[1]->set (internal::Triangulation
+                      new_hexes[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[2],
                                                          quad_indices[4],
                                                          quad_indices[6],
@@ -6831,7 +6831,7 @@ namespace internal
                       //
 
                       // first, create the new internal line
-                      new_lines[0]->set (internal::Triangulation::
+                      new_lines[0]->set (internal::TriangulationImplementation::
                                          TriaObject<1>(middle_vertex_index<dim,spacedim>(hex->face(4)),
                                                        middle_vertex_index<dim,spacedim>(hex->face(5))));
 
@@ -7015,22 +7015,22 @@ namespace internal
                       //  |   |   |      |   |   |
                       //  *---*---*y     *-6-*-7-*
 
-                      new_quads[0]->set (internal::Triangulation
+                      new_quads[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[2],
                                                          line_indices[12],
                                                          line_indices[4],
                                                          line_indices[8]));
-                      new_quads[1]->set (internal::Triangulation
+                      new_quads[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[12],
                                                          line_indices[3],
                                                          line_indices[5],
                                                          line_indices[9]));
-                      new_quads[2]->set (internal::Triangulation
+                      new_quads[2]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[6],
                                                          line_indices[10],
                                                          line_indices[0],
                                                          line_indices[12]));
-                      new_quads[3]->set (internal::Triangulation
+                      new_quads[3]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[7],
                                                          line_indices[11],
                                                          line_indices[12],
@@ -7114,28 +7114,28 @@ namespace internal
                         hex->face(5)->isotropic_child_index(GeometryInfo<dim>::standard_to_real_face_vertex(3,f_or[5],f_fl[5],f_ro[5]))
                       };
 
-                      new_hexes[0]->set (internal::Triangulation
+                      new_hexes[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[4],
                                                          quad_indices[0],
                                                          quad_indices[8],
                                                          quad_indices[2],
                                                          quad_indices[12],
                                                          quad_indices[16]));
-                      new_hexes[1]->set (internal::Triangulation
+                      new_hexes[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[0],
                                                          quad_indices[6],
                                                          quad_indices[9],
                                                          quad_indices[3],
                                                          quad_indices[13],
                                                          quad_indices[17]));
-                      new_hexes[2]->set (internal::Triangulation
+                      new_hexes[2]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[5],
                                                          quad_indices[1],
                                                          quad_indices[2],
                                                          quad_indices[10],
                                                          quad_indices[14],
                                                          quad_indices[18]));
-                      new_hexes[3]->set (internal::Triangulation
+                      new_hexes[3]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[1],
                                                          quad_indices[7],
                                                          quad_indices[3],
@@ -7167,7 +7167,7 @@ namespace internal
                       //
 
                       // first, create the new internal line
-                      new_lines[0]->set (internal::Triangulation::
+                      new_lines[0]->set (internal::TriangulationImplementation::
                                          TriaObject<1>(middle_vertex_index<dim,spacedim>(hex->face(2)),
                                                        middle_vertex_index<dim,spacedim>(hex->face(3))));
 
@@ -7351,22 +7351,22 @@ namespace internal
                       //   /    /    /      /    /    /
                       //  *----*----*x     *--6-*--7-*
 
-                      new_quads[0]->set (internal::Triangulation
+                      new_quads[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[0],
                                                          line_indices[12],
                                                          line_indices[6],
                                                          line_indices[10]));
-                      new_quads[1]->set (internal::Triangulation
+                      new_quads[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[12],
                                                          line_indices[1],
                                                          line_indices[7],
                                                          line_indices[11]));
-                      new_quads[2]->set (internal::Triangulation
+                      new_quads[2]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[4],
                                                          line_indices[8],
                                                          line_indices[2],
                                                          line_indices[12]));
-                      new_quads[3]->set (internal::Triangulation
+                      new_quads[3]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[5],
                                                          line_indices[9],
                                                          line_indices[12],
@@ -7460,28 +7460,28 @@ namespace internal
                       // *---*---*
                       // | 0 | 2 |
                       // *---*---*
-                      new_hexes[0]->set (internal::Triangulation
+                      new_hexes[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[4],
                                                          quad_indices[2],
                                                          quad_indices[8],
                                                          quad_indices[12],
                                                          quad_indices[16],
                                                          quad_indices[0]));
-                      new_hexes[1]->set (internal::Triangulation
+                      new_hexes[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[5],
                                                          quad_indices[3],
                                                          quad_indices[9],
                                                          quad_indices[13],
                                                          quad_indices[0],
                                                          quad_indices[18]));
-                      new_hexes[2]->set (internal::Triangulation
+                      new_hexes[2]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[2],
                                                          quad_indices[6],
                                                          quad_indices[10],
                                                          quad_indices[14],
                                                          quad_indices[17],
                                                          quad_indices[1]));
-                      new_hexes[3]->set (internal::Triangulation
+                      new_hexes[3]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[3],
                                                          quad_indices[7],
                                                          quad_indices[11],
@@ -7514,7 +7514,7 @@ namespace internal
 
                       // first, create the new
                       // internal line
-                      new_lines[0]->set (internal::Triangulation::
+                      new_lines[0]->set (internal::TriangulationImplementation::
                                          TriaObject<1>(middle_vertex_index<dim,spacedim>(hex->face(0)),
                                                        middle_vertex_index<dim,spacedim>(hex->face(1))));
 
@@ -7694,22 +7694,22 @@ namespace internal
                       //   /    0    /      6         10
                       //  *---------*x     *----0----*
 
-                      new_quads[0]->set (internal::Triangulation
+                      new_quads[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[6],
                                                          line_indices[10],
                                                          line_indices[0],
                                                          line_indices[12]));
-                      new_quads[1]->set (internal::Triangulation
+                      new_quads[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[7],
                                                          line_indices[11],
                                                          line_indices[12],
                                                          line_indices[1]));
-                      new_quads[2]->set (internal::Triangulation
+                      new_quads[2]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[2],
                                                          line_indices[12],
                                                          line_indices[4],
                                                          line_indices[8]));
-                      new_quads[3]->set (internal::Triangulation
+                      new_quads[3]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[12],
                                                          line_indices[3],
                                                          line_indices[5],
@@ -7794,28 +7794,28 @@ namespace internal
                         hex->face(5)->child_index(1-child_at_origin[hex->face(5)->refinement_case()-1][f_fl[5]][f_ro[5]])
                       };
 
-                      new_hexes[0]->set (internal::Triangulation
+                      new_hexes[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[4],
                                                          quad_indices[8],
                                                          quad_indices[12],
                                                          quad_indices[2],
                                                          quad_indices[16],
                                                          quad_indices[0]));
-                      new_hexes[1]->set (internal::Triangulation
+                      new_hexes[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[5],
                                                          quad_indices[9],
                                                          quad_indices[2],
                                                          quad_indices[14],
                                                          quad_indices[17],
                                                          quad_indices[1]));
-                      new_hexes[2]->set (internal::Triangulation
+                      new_hexes[2]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[6],
                                                          quad_indices[10],
                                                          quad_indices[13],
                                                          quad_indices[3],
                                                          quad_indices[0],
                                                          quad_indices[18]));
-                      new_hexes[3]->set (internal::Triangulation
+                      new_hexes[3]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[7],
                                                          quad_indices[11],
                                                          quad_indices[3],
@@ -7894,17 +7894,17 @@ namespace internal
                             next_unused_vertex
                           };
 
-                      new_lines[0]->set (internal::Triangulation::
+                      new_lines[0]->set (internal::TriangulationImplementation::
                                          TriaObject<1>(vertex_indices[2], vertex_indices[6]));
-                      new_lines[1]->set (internal::Triangulation::
+                      new_lines[1]->set (internal::TriangulationImplementation::
                                          TriaObject<1>(vertex_indices[6], vertex_indices[3]));
-                      new_lines[2]->set (internal::Triangulation::
+                      new_lines[2]->set (internal::TriangulationImplementation::
                                          TriaObject<1>(vertex_indices[0], vertex_indices[6]));
-                      new_lines[3]->set (internal::Triangulation::
+                      new_lines[3]->set (internal::TriangulationImplementation::
                                          TriaObject<1>(vertex_indices[6], vertex_indices[1]));
-                      new_lines[4]->set (internal::Triangulation::
+                      new_lines[4]->set (internal::TriangulationImplementation::
                                          TriaObject<1>(vertex_indices[4], vertex_indices[6]));
-                      new_lines[5]->set (internal::Triangulation::
+                      new_lines[5]->set (internal::TriangulationImplementation::
                                          TriaObject<1>(vertex_indices[6], vertex_indices[5]));
 
                       // again, first collect some data about the
@@ -8102,62 +8102,62 @@ namespace internal
                       //   / 8  / 9  /      2   24    6
                       //  *----*----*x     *--8-*--9-*
 
-                      new_quads[0]->set (internal::Triangulation
+                      new_quads[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[10],
                                                          line_indices[28],
                                                          line_indices[16],
                                                          line_indices[24]));
-                      new_quads[1]->set (internal::Triangulation
+                      new_quads[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[28],
                                                          line_indices[14],
                                                          line_indices[17],
                                                          line_indices[25]));
-                      new_quads[2]->set (internal::Triangulation
+                      new_quads[2]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[11],
                                                          line_indices[29],
                                                          line_indices[24],
                                                          line_indices[20]));
-                      new_quads[3]->set (internal::Triangulation
+                      new_quads[3]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[29],
                                                          line_indices[15],
                                                          line_indices[25],
                                                          line_indices[21]));
-                      new_quads[4]->set (internal::Triangulation
+                      new_quads[4]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[18],
                                                          line_indices[26],
                                                          line_indices[0],
                                                          line_indices[28]));
-                      new_quads[5]->set (internal::Triangulation
+                      new_quads[5]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[26],
                                                          line_indices[22],
                                                          line_indices[1],
                                                          line_indices[29]));
-                      new_quads[6]->set (internal::Triangulation
+                      new_quads[6]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[19],
                                                          line_indices[27],
                                                          line_indices[28],
                                                          line_indices[4]));
-                      new_quads[7]->set (internal::Triangulation
+                      new_quads[7]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[27],
                                                          line_indices[23],
                                                          line_indices[29],
                                                          line_indices[5]));
-                      new_quads[8]->set (internal::Triangulation
+                      new_quads[8]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[2],
                                                          line_indices[24],
                                                          line_indices[8],
                                                          line_indices[26]));
-                      new_quads[9]->set (internal::Triangulation
+                      new_quads[9]->set (internal::TriangulationImplementation
                                          ::TriaObject<2>(line_indices[24],
                                                          line_indices[6],
                                                          line_indices[9],
                                                          line_indices[27]));
-                      new_quads[10]->set (internal::Triangulation
+                      new_quads[10]->set (internal::TriangulationImplementation
                                           ::TriaObject<2>(line_indices[3],
                                                           line_indices[25],
                                                           line_indices[26],
                                                           line_indices[12]));
-                      new_quads[11]->set (internal::Triangulation
+                      new_quads[11]->set (internal::TriangulationImplementation
                                           ::TriaObject<2>(line_indices[25],
                                                           line_indices[7],
                                                           line_indices[27],
@@ -8289,28 +8289,28 @@ namespace internal
                       };
 
                       // bottom children
-                      new_hexes[0]->set (internal::Triangulation
+                      new_hexes[0]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[12],
                                                          quad_indices[0],
                                                          quad_indices[20],
                                                          quad_indices[4],
                                                          quad_indices[28],
                                                          quad_indices[8]));
-                      new_hexes[1]->set (internal::Triangulation
+                      new_hexes[1]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[0],
                                                          quad_indices[16],
                                                          quad_indices[22],
                                                          quad_indices[6],
                                                          quad_indices[29],
                                                          quad_indices[9]));
-                      new_hexes[2]->set (internal::Triangulation
+                      new_hexes[2]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[13],
                                                          quad_indices[1],
                                                          quad_indices[4],
                                                          quad_indices[24],
                                                          quad_indices[30],
                                                          quad_indices[10]));
-                      new_hexes[3]->set (internal::Triangulation
+                      new_hexes[3]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[1],
                                                          quad_indices[17],
                                                          quad_indices[6],
@@ -8319,28 +8319,28 @@ namespace internal
                                                          quad_indices[11]));
 
                       // top children
-                      new_hexes[4]->set (internal::Triangulation
+                      new_hexes[4]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[14],
                                                          quad_indices[2],
                                                          quad_indices[21],
                                                          quad_indices[5],
                                                          quad_indices[8],
                                                          quad_indices[32]));
-                      new_hexes[5]->set (internal::Triangulation
+                      new_hexes[5]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[2],
                                                          quad_indices[18],
                                                          quad_indices[23],
                                                          quad_indices[7],
                                                          quad_indices[9],
                                                          quad_indices[33]));
-                      new_hexes[6]->set (internal::Triangulation
+                      new_hexes[6]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[15],
                                                          quad_indices[3],
                                                          quad_indices[5],
                                                          quad_indices[25],
                                                          quad_indices[10],
                                                          quad_indices[34]));
-                      new_hexes[7]->set (internal::Triangulation
+                      new_hexes[7]->set (internal::TriangulationImplementation
                                          ::TriaObject<3>(quad_indices[3],
                                                          quad_indices[19],
                                                          quad_indices[7],
@@ -8846,7 +8846,7 @@ Triangulation (Triangulation<dim, spacedim> &&tria)
   vertex_to_boundary_id_map_1d(std::move(tria.vertex_to_boundary_id_map_1d)),
   vertex_to_manifold_id_map_1d(std::move(tria.vertex_to_manifold_id_map_1d))
 {
-  tria.number_cache = internal::Triangulation::NumberCache<dim>();
+  tria.number_cache = internal::TriangulationImplementation::NumberCache<dim>();
 }
 
 
@@ -8869,7 +8869,7 @@ Triangulation<dim, spacedim>::operator= (Triangulation<dim, spacedim> &&tria)
   vertex_to_boundary_id_map_1d = std::move(tria.vertex_to_boundary_id_map_1d);
   vertex_to_manifold_id_map_1d = std::move(tria.vertex_to_manifold_id_map_1d);
 
-  tria.number_cache = internal::Triangulation::NumberCache<dim>();
+  tria.number_cache = internal::TriangulationImplementation::NumberCache<dim>();
 
   return *this;
 }
@@ -9075,7 +9075,7 @@ Triangulation<dim, spacedim>::get_manifold (const types::manifold_id m_number) c
 
   // if we have not found an entry connected with number, we return
   // the default (flat) manifold
-  return internal::Triangulation::get_default_flat_manifold<dim,spacedim>();
+  return internal::TriangulationImplementation::get_default_flat_manifold<dim,spacedim>();
 }
 
 
@@ -9160,7 +9160,7 @@ copy_triangulation (const Triangulation<dim, spacedim> &other_tria)
   smooth_grid            = other_tria.smooth_grid;
 
   if (dim > 1)
-    faces = std_cxx14::make_unique<internal::Triangulation::TriaFaces<dim>> (*other_tria.faces);
+    faces = std_cxx14::make_unique<internal::TriangulationImplementation::TriaFaces<dim>> (*other_tria.faces);
 
   typename std::map<types::manifold_id,
            SmartPointer<const Manifold<dim,spacedim>, Triangulation<dim, spacedim> > >::const_iterator
@@ -9171,7 +9171,7 @@ copy_triangulation (const Triangulation<dim, spacedim> &other_tria)
 
   levels.reserve (other_tria.levels.size());
   for (unsigned int level=0; level<other_tria.levels.size(); ++level)
-    levels.push_back (std_cxx14::make_unique<internal::Triangulation::TriaLevel<dim>>
+    levels.push_back (std_cxx14::make_unique<internal::TriangulationImplementation::TriaLevel<dim>>
                       (*other_tria.levels[level]));
 
   number_cache = other_tria.number_cache;
@@ -9237,7 +9237,7 @@ create_triangulation (const std::vector<Point<spacedim> >    &v,
   // because sometimes other objects are already attached to it:
   try
     {
-      internal::Triangulation::Implementation::create_triangulation (v, cells, subcelldata, *this);
+      internal::TriangulationImplementation::Implementation::create_triangulation (v, cells, subcelldata, *this);
     }
   catch (...)
     {
@@ -9247,7 +9247,7 @@ create_triangulation (const std::vector<Point<spacedim> >    &v,
 
   // update our counts of the various elements of a triangulation, and set
   // active_cell_indices of all cells
-  internal::Triangulation::Implementation
+  internal::TriangulationImplementation::Implementation
   ::compute_number_cache (*this, levels.size(), number_cache);
   reset_active_cell_indices ();
 
@@ -9580,7 +9580,7 @@ namespace
 {
   // clear user data of cells
   template <int dim>
-  void clear_user_data (std::vector<std::unique_ptr<internal::Triangulation::TriaLevel<dim>>> &levels)
+  void clear_user_data (std::vector<std::unique_ptr<internal::TriangulationImplementation::TriaLevel<dim>>> &levels)
   {
     for (unsigned int level=0; level<levels.size(); ++level)
       levels[level]->cells.clear_user_data();
@@ -9588,19 +9588,19 @@ namespace
 
 
   // clear user data of faces
-  void clear_user_data (internal::Triangulation::TriaFaces<1> *)
+  void clear_user_data (internal::TriangulationImplementation::TriaFaces<1> *)
   {
     // nothing to do in 1d
   }
 
 
-  void clear_user_data (internal::Triangulation::TriaFaces<2> *faces)
+  void clear_user_data (internal::TriangulationImplementation::TriaFaces<2> *faces)
   {
     faces->lines.clear_user_data();
   }
 
 
-  void clear_user_data (internal::Triangulation::TriaFaces<3> *faces)
+  void clear_user_data (internal::TriangulationImplementation::TriaFaces<3> *faces)
   {
     faces->lines.clear_user_data();
     faces->quads.clear_user_data();
@@ -9620,16 +9620,16 @@ void Triangulation<dim,spacedim>::clear_user_data ()
 
 namespace
 {
-  void clear_user_flags_line (std::vector<std::unique_ptr<internal::Triangulation::TriaLevel<1>>> &levels,
-                              internal::Triangulation::TriaFaces<1> *)
+  void clear_user_flags_line (std::vector<std::unique_ptr<internal::TriangulationImplementation::TriaLevel<1>>> &levels,
+                              internal::TriangulationImplementation::TriaFaces<1> *)
   {
     for (unsigned int level=0; level<levels.size(); ++level)
       levels[level]->cells.clear_user_flags();
   }
 
   template <int dim>
-  void clear_user_flags_line (std::vector<std::unique_ptr<internal::Triangulation::TriaLevel<dim>>> &,
-                              internal::Triangulation::TriaFaces<dim> *faces)
+  void clear_user_flags_line (std::vector<std::unique_ptr<internal::TriangulationImplementation::TriaLevel<dim>>> &,
+                              internal::TriangulationImplementation::TriaFaces<dim> *faces)
   {
     faces->lines.clear_user_flags();
   }
@@ -9646,22 +9646,22 @@ void Triangulation<dim,spacedim>::clear_user_flags_line ()
 
 namespace
 {
-  void clear_user_flags_quad (std::vector<std::unique_ptr<internal::Triangulation::TriaLevel<1>>> &,
-                              internal::Triangulation::TriaFaces<1> *)
+  void clear_user_flags_quad (std::vector<std::unique_ptr<internal::TriangulationImplementation::TriaLevel<1>>> &,
+                              internal::TriangulationImplementation::TriaFaces<1> *)
   {
     // nothing to do in 1d
   }
 
-  void clear_user_flags_quad (std::vector<std::unique_ptr<internal::Triangulation::TriaLevel<2>>> &levels,
-                              internal::Triangulation::TriaFaces<2> *)
+  void clear_user_flags_quad (std::vector<std::unique_ptr<internal::TriangulationImplementation::TriaLevel<2>>> &levels,
+                              internal::TriangulationImplementation::TriaFaces<2> *)
   {
     for (unsigned int level=0; level<levels.size(); ++level)
       levels[level]->cells.clear_user_flags();
   }
 
   template <int dim>
-  void clear_user_flags_quad (std::vector<std::unique_ptr<internal::Triangulation::TriaLevel<dim>>> &,
-                              internal::Triangulation::TriaFaces<dim> *faces)
+  void clear_user_flags_quad (std::vector<std::unique_ptr<internal::TriangulationImplementation::TriaLevel<dim>>> &,
+                              internal::TriangulationImplementation::TriaFaces<dim> *faces)
   {
     faces->quads.clear_user_flags();
   }
@@ -9678,21 +9678,21 @@ void Triangulation<dim,spacedim>::clear_user_flags_quad ()
 
 namespace
 {
-  void clear_user_flags_hex (std::vector<std::unique_ptr<internal::Triangulation::TriaLevel<1>>> &,
-                             internal::Triangulation::TriaFaces<1> *)
+  void clear_user_flags_hex (std::vector<std::unique_ptr<internal::TriangulationImplementation::TriaLevel<1>>> &,
+                             internal::TriangulationImplementation::TriaFaces<1> *)
   {
     // nothing to do in 1d
   }
 
 
-  void clear_user_flags_hex (std::vector<std::unique_ptr<internal::Triangulation::TriaLevel<2>>> &,
-                             internal::Triangulation::TriaFaces<2> *)
+  void clear_user_flags_hex (std::vector<std::unique_ptr<internal::TriangulationImplementation::TriaLevel<2>>> &,
+                             internal::TriangulationImplementation::TriaFaces<2> *)
   {
     // nothing to do in 2d
   }
 
-  void clear_user_flags_hex (std::vector<std::unique_ptr<internal::Triangulation::TriaLevel<3>>> &levels,
-                             internal::Triangulation::TriaFaces<3> *)
+  void clear_user_flags_hex (std::vector<std::unique_ptr<internal::TriangulationImplementation::TriaLevel<3>>> &levels,
+                             internal::TriangulationImplementation::TriaFaces<3> *)
   {
     for (unsigned int level=0; level<levels.size(); ++level)
       levels[level]->cells.clear_user_flags();
@@ -11003,11 +11003,11 @@ Triangulation<dim, spacedim>::end_hex () const
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
     inline
     unsigned int
-    n_cells (const internal::Triangulation::NumberCache<1> &c)
+    n_cells (const internal::TriangulationImplementation::NumberCache<1> &c)
     {
       return c.n_lines;
     }
@@ -11015,7 +11015,7 @@ namespace internal
 
     inline
     unsigned int
-    n_active_cells (const internal::Triangulation::NumberCache<1> &c)
+    n_active_cells (const internal::TriangulationImplementation::NumberCache<1> &c)
     {
       return c.n_active_lines;
     }
@@ -11023,7 +11023,7 @@ namespace internal
 
     inline
     unsigned int
-    n_cells (const internal::Triangulation::NumberCache<2> &c)
+    n_cells (const internal::TriangulationImplementation::NumberCache<2> &c)
     {
       return c.n_quads;
     }
@@ -11031,7 +11031,7 @@ namespace internal
 
     inline
     unsigned int
-    n_active_cells (const internal::Triangulation::NumberCache<2> &c)
+    n_active_cells (const internal::TriangulationImplementation::NumberCache<2> &c)
     {
       return c.n_active_quads;
     }
@@ -11039,7 +11039,7 @@ namespace internal
 
     inline
     unsigned int
-    n_cells (const internal::Triangulation::NumberCache<3> &c)
+    n_cells (const internal::TriangulationImplementation::NumberCache<3> &c)
     {
       return c.n_hexes;
     }
@@ -11047,7 +11047,7 @@ namespace internal
 
     inline
     unsigned int
-    n_active_cells (const internal::Triangulation::NumberCache<3> &c)
+    n_active_cells (const internal::TriangulationImplementation::NumberCache<3> &c)
     {
       return c.n_active_hexes;
     }
@@ -11059,14 +11059,14 @@ namespace internal
 template <int dim, int spacedim>
 unsigned int Triangulation<dim, spacedim>::n_cells () const
 {
-  return internal::Triangulation::n_cells (number_cache);
+  return internal::TriangulationImplementation::n_cells (number_cache);
 }
 
 
 template <int dim, int spacedim>
 unsigned int Triangulation<dim, spacedim>::n_active_cells () const
 {
-  return internal::Triangulation::n_active_cells (number_cache);
+  return internal::TriangulationImplementation::n_active_cells (number_cache);
 }
 
 template <int dim, int spacedim>
@@ -11840,7 +11840,7 @@ Triangulation<dim, spacedim>::clear_despite_subscriptions()
 
   manifold.clear();
 
-  number_cache = internal::Triangulation::NumberCache<dim>();
+  number_cache = internal::TriangulationImplementation::NumberCache<dim>();
 }
 
 
@@ -11851,13 +11851,13 @@ Triangulation<dim,spacedim>::execute_refinement ()
   const DistortedCellList
   cells_with_distorted_children
     =
-      internal::Triangulation::Implementation::
+      internal::TriangulationImplementation::Implementation::
       execute_refinement (*this, check_for_distorted_cells);
 
 
 
   // re-compute number of lines
-  internal::Triangulation::Implementation
+  internal::TriangulationImplementation::Implementation
   ::compute_number_cache (*this, levels.size(), number_cache);
 
 #ifdef DEBUG
@@ -11934,12 +11934,12 @@ void Triangulation<dim, spacedim>::execute_coarsening ()
           // inform all listeners that cell coarsening is going to happen
           signals.pre_coarsening_on_cell(cell);
           // use a separate function, since this is dimension specific
-          internal::Triangulation::Implementation
+          internal::TriangulationImplementation::Implementation
           ::delete_children (*this, cell, line_cell_count, quad_cell_count);
         }
 
   // re-compute number of lines and quads
-  internal::Triangulation::Implementation
+  internal::TriangulationImplementation::Implementation
   ::compute_number_cache (*this, levels.size(), number_cache);
 
   // in principle no user flags should be set any more at this point
@@ -12135,7 +12135,7 @@ void Triangulation<dim, spacedim>::fix_coarsen_flags ()
         if (cell->user_flag_set())
           // if allowed: flag the
           // children for coarsening
-          if (internal::Triangulation::Implementation::template coarsening_allowed<dim,spacedim>(cell))
+          if (internal::TriangulationImplementation::Implementation::template coarsening_allowed<dim,spacedim>(cell))
             for (unsigned int c=0; c<cell->n_children(); ++c)
               {
                 Assert (cell->child(c)->refine_flag_set()==false,
@@ -12927,7 +12927,7 @@ bool Triangulation<dim,spacedim>::prepare_coarsening_and_refinement ()
       //  volume or at least with a part, that is negative, if the
       //  cell is refined anisotropically. we have to check, whether
       //  that can happen
-      internal::Triangulation::Implementation::prevent_distorted_boundary_cells(*this);
+      internal::TriangulationImplementation::Implementation::prevent_distorted_boundary_cells(*this);
 
       /////////////////////////////////
       // STEP 6:
@@ -13260,7 +13260,7 @@ bool Triangulation<dim,spacedim>::prepare_coarsening_and_refinement ()
       //    take care that no double refinement
       //    is done at each line in 3d or higher
       //    dimensions.
-      internal::Triangulation::Implementation::prepare_refinement_dim_dependent (*this);
+      internal::TriangulationImplementation::Implementation::prepare_refinement_dim_dependent (*this);
 
       //////////////////////////////////////
       // STEP 8:

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1084,7 +1084,7 @@ const unsigned int TriaAccessorBase<structdim, dim, spacedim>::structure_dimensi
 template <int structdim, int dim, int spacedim>
 void
 TriaAccessor<structdim, dim, spacedim>::
-set (const internal::Triangulation::TriaObject<structdim> &object) const
+set (const internal::TriangulationImplementation::TriaObject<structdim> &object) const
 {
   this->objects().cells[this->present_index] = object;
 }

--- a/source/grid/tria_faces.cc
+++ b/source/grid/tria_faces.cc
@@ -22,7 +22,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
 
     std::size_t

--- a/source/grid/tria_levels.cc
+++ b/source/grid/tria_levels.cc
@@ -21,7 +21,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
     template <int dim>
     void
@@ -204,8 +204,8 @@ namespace internal
 }
 
 
-template class internal::Triangulation::TriaLevel<1>;
-template class internal::Triangulation::TriaLevel<2>;
+template class internal::TriangulationImplementation::TriaLevel<1>;
+template class internal::TriangulationImplementation::TriaLevel<2>;
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/source/grid/tria_objects.cc
+++ b/source/grid/tria_objects.cc
@@ -28,7 +28,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace Triangulation
+  namespace TriangulationImplementation
   {
     template <class G>
     void

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -65,7 +65,7 @@ namespace internal
 {
   namespace hp
   {
-    namespace DoFHandler
+    namespace DoFHandlerImplementation
     {
       // access class dealii::hp::DoFHandler instead of namespace
       // internal::hp::DoFHandler, etc
@@ -967,11 +967,11 @@ namespace hp
   {
     // decide whether we need a sequential or a parallel shared/distributed policy
     if (dynamic_cast<const parallel::shared::Triangulation< dim, spacedim>*> (&*this->tria) != nullptr)
-      policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelShared<DoFHandler<dim,spacedim> >> (*this);
+      policy = std_cxx14::make_unique<internal::DoFHandlerImplementation::Policy::ParallelShared<DoFHandler<dim,spacedim> >> (*this);
     else if (dynamic_cast<const parallel::distributed::Triangulation< dim, spacedim >*> (&*this->tria) != nullptr)
-      policy = std_cxx14::make_unique<internal::DoFHandler::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >> (*this);
+      policy = std_cxx14::make_unique<internal::DoFHandlerImplementation::Policy::ParallelDistributed<DoFHandler<dim,spacedim> >> (*this);
     else
-      policy = std_cxx14::make_unique<internal::DoFHandler::Policy::Sequential<DoFHandler<dim,spacedim> >> (*this);
+      policy = std_cxx14::make_unique<internal::DoFHandlerImplementation::Policy::Sequential<DoFHandler<dim,spacedim> >> (*this);
 
     create_active_fe_table ();
 
@@ -1284,7 +1284,7 @@ namespace hp
 
     // at the beginning, make sure every processor knows the
     // active_fe_indices on both its own cells and all ghost cells
-    dealii::internal::hp::DoFHandler::Implementation::communicate_active_fe_indices (*this);
+    dealii::internal::hp::DoFHandlerImplementation::Implementation::communicate_active_fe_indices (*this);
 
     // If an underlying shared::Tria allows artificial cells,
     // then save the current set of subdomain ids, and set
@@ -1325,7 +1325,7 @@ namespace hp
 
 
     // then allocate space for all the other tables
-    dealii::internal::hp::DoFHandler::Implementation::reserve_space (*this);
+    dealii::internal::hp::DoFHandlerImplementation::Implementation::reserve_space (*this);
 
 
     // now undo the subdomain modification
@@ -1448,7 +1448,7 @@ namespace hp
   DoFHandler<dim, spacedim>::max_couplings_between_dofs () const
   {
     Assert (finite_elements != nullptr, ExcNoFESelected());
-    return dealii::internal::hp::DoFHandler::Implementation::max_couplings_between_dofs (*this);
+    return dealii::internal::hp::DoFHandlerImplementation::Implementation::max_couplings_between_dofs (*this);
   }
 
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1887,7 +1887,7 @@ namespace TrilinosWrappers
 
   namespace internal
   {
-    namespace SparseMatrix
+    namespace SparseMatrixImplementation
     {
       template <typename VectorType>
       inline
@@ -1924,7 +1924,7 @@ namespace TrilinosWrappers
     (void)src;
     (void)dst;
 
-    internal::SparseMatrix::check_vector_map_equality(*matrix, src, dst);
+    internal::SparseMatrixImplementation::check_vector_map_equality(*matrix, src, dst);
     const size_type dst_local_size = internal::end(dst) - internal::begin(dst);
     AssertDimension (dst_local_size, static_cast<size_type>(matrix->RangeMap().NumMyPoints()));
     const size_type src_local_size = internal::end(src) - internal::begin(src);
@@ -1951,7 +1951,7 @@ namespace TrilinosWrappers
     Assert (&src != &dst, ExcSourceEqualsDestination());
     Assert (matrix->Filled(), ExcMatrixNotCompressed());
 
-    internal::SparseMatrix::check_vector_map_equality(*matrix, dst, src);
+    internal::SparseMatrixImplementation::check_vector_map_equality(*matrix, dst, src);
     const size_type dst_local_size = internal::end(dst) - internal::begin(dst);
     AssertDimension (dst_local_size, static_cast<size_type>(matrix->DomainMap().NumMyPoints()));
     const size_type src_local_size = internal::end(src) - internal::begin(src);
@@ -2411,7 +2411,7 @@ namespace TrilinosWrappers
 #endif
     }
 
-    namespace LinearOperator
+    namespace LinearOperatorImplementation
     {
 
       TrilinosPayload::TrilinosPayload ()

--- a/source/lac/vector_memory.cc
+++ b/source/lac/vector_memory.cc
@@ -32,7 +32,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace GrowingVectorMemory
+  namespace GrowingVectorMemoryImplementation
   {
     void release_all_unused_memory()
     {

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -33,7 +33,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DataOut
+  namespace DataOutImplementation
   {
     template <int dim, int spacedim>
     ParallelData<dim,spacedim>::
@@ -64,7 +64,7 @@ void
 DataOut<dim,DoFHandlerType>::
 build_one_patch
 (const std::pair<cell_iterator, unsigned int>                                                *cell_and_index,
- internal::DataOut::ParallelData<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &scratch_data,
+ internal::DataOutImplementation::ParallelData<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &scratch_data,
  const unsigned int                                                                           n_subdivisions,
  const CurvedCellRegion                                                                       curved_cell_region)
 {
@@ -156,15 +156,15 @@ build_one_patch
                   // gradient etc.
                   if (update_flags & update_values)
                     this->dof_data[dataset]->get_function_values (this_fe_patch_values,
-                                                                  internal::DataOut::ComponentExtractor::real_part,
+                                                                  internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                   scratch_data.patch_values_scalar.solution_values);
                   if (update_flags & update_gradients)
                     this->dof_data[dataset]->get_function_gradients (this_fe_patch_values,
-                                                                     internal::DataOut::ComponentExtractor::real_part,
+                                                                     internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                      scratch_data.patch_values_scalar.solution_gradients);
                   if (update_flags & update_hessians)
                     this->dof_data[dataset]->get_function_hessians (this_fe_patch_values,
-                                                                    internal::DataOut::ComponentExtractor::real_part,
+                                                                    internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                     scratch_data.patch_values_scalar.solution_hessians);
 
                   if (update_flags & update_quadrature_points)
@@ -188,15 +188,15 @@ build_one_patch
                   // derivative...
                   if (update_flags & update_values)
                     this->dof_data[dataset]->get_function_values (this_fe_patch_values,
-                                                                  internal::DataOut::ComponentExtractor::real_part,
+                                                                  internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                   scratch_data.patch_values_system.solution_values);
                   if (update_flags & update_gradients)
                     this->dof_data[dataset]->get_function_gradients (this_fe_patch_values,
-                                                                     internal::DataOut::ComponentExtractor::real_part,
+                                                                     internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                      scratch_data.patch_values_system.solution_gradients);
                   if (update_flags & update_hessians)
                     this->dof_data[dataset]->get_function_hessians (this_fe_patch_values,
-                                                                    internal::DataOut::ComponentExtractor::real_part,
+                                                                    internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                     scratch_data.patch_values_system.solution_hessians);
 
                   if (update_flags & update_quadrature_points)
@@ -228,7 +228,7 @@ build_one_patch
               {
                 // first output the real part of the solution vector
                 this->dof_data[dataset]->get_function_values (this_fe_patch_values,
-                                                              internal::DataOut::ComponentExtractor::real_part,
+                                                              internal::DataOutImplementation::ComponentExtractor::real_part,
                                                               scratch_data.patch_values_scalar.solution_values);
                 for (unsigned int q=0; q<n_q_points; ++q)
                   patch.data(offset,q) = scratch_data.patch_values_scalar.solution_values[q];
@@ -237,7 +237,7 @@ build_one_patch
                 if (this->dof_data[dataset]->is_complex_valued() == true)
                   {
                     this->dof_data[dataset]->get_function_values (this_fe_patch_values,
-                                                                  internal::DataOut::ComponentExtractor::imaginary_part,
+                                                                  internal::DataOutImplementation::ComponentExtractor::imaginary_part,
                                                                   scratch_data.patch_values_scalar.solution_values);
                     for (unsigned int q=0; q<n_q_points; ++q)
                       patch.data(offset+1,q) = scratch_data.patch_values_scalar.solution_values[q];
@@ -250,7 +250,7 @@ build_one_patch
                 // same as above: first the real part
                 const unsigned int stride = (this->dof_data[dataset]->is_complex_valued() ? 2 : 1);
                 this->dof_data[dataset]->get_function_values (this_fe_patch_values,
-                                                              internal::DataOut::ComponentExtractor::real_part,
+                                                              internal::DataOutImplementation::ComponentExtractor::real_part,
                                                               scratch_data.patch_values_system.solution_values);
                 for (unsigned int component=0; component<n_components;
                      ++component)
@@ -262,7 +262,7 @@ build_one_patch
                 if (this->dof_data[dataset]->is_complex_valued() == true)
                   {
                     this->dof_data[dataset]->get_function_values (this_fe_patch_values,
-                                                                  internal::DataOut::ComponentExtractor::imaginary_part,
+                                                                  internal::DataOutImplementation::ComponentExtractor::imaginary_part,
                                                                   scratch_data.patch_values_system.solution_values);
                     for (unsigned int component=0; component<n_components;
                          ++component)
@@ -290,7 +290,7 @@ build_one_patch
               {
                 const double value
                   = this->cell_data[dataset]->get_cell_data_value (cell_and_index->second,
-                                                                   internal::DataOut::ComponentExtractor::real_part);
+                                                                   internal::DataOutImplementation::ComponentExtractor::real_part);
                 for (unsigned int q=0; q<n_q_points; ++q)
                   patch.data(offset,q) = value;
               }
@@ -300,7 +300,7 @@ build_one_patch
                 {
                   const double value
                     = this->cell_data[dataset]->get_cell_data_value (cell_and_index->second,
-                                                                     internal::DataOut::ComponentExtractor::imaginary_part);
+                                                                     internal::DataOutImplementation::ComponentExtractor::imaginary_part);
                   for (unsigned int q=0; q<n_q_points; ++q)
                     patch.data(offset+1,q) = value;
                 }
@@ -385,13 +385,13 @@ void DataOut<dim,DoFHandlerType>::build_patches
   Assert (dim==DoFHandlerType::dimension, ExcDimensionMismatch(dim, DoFHandlerType::dimension));
 
   Assert (this->triangulation != nullptr,
-          Exceptions::DataOut::ExcNoTriangulationSelected());
+          Exceptions::DataOutImplementation::ExcNoTriangulationSelected());
 
   const unsigned int n_subdivisions = (n_subdivisions_ != 0)
                                       ? n_subdivisions_
                                       : this->default_subdivisions;
   Assert (n_subdivisions >= 1,
-          Exceptions::DataOut::ExcInvalidNumberOfSubdivisions(n_subdivisions));
+          Exceptions::DataOutImplementation::ExcInvalidNumberOfSubdivisions(n_subdivisions));
 
   this->validate_dataset_names();
 
@@ -497,7 +497,7 @@ void DataOut<dim,DoFHandlerType>::build_patches
           ExcMessage("The update of normal vectors may not be requested for evaluation of "
                      "data on cells via DataPostprocessor."));
 
-  internal::DataOut::ParallelData<DoFHandlerType::dimension, DoFHandlerType::space_dimension>
+  internal::DataOutImplementation::ParallelData<DoFHandlerType::dimension, DoFHandlerType::space_dimension>
   thread_data (n_datasets, n_subdivisions,
                n_postprocessor_outputs,
                mapping,

--- a/source/numerics/data_out.inst.in
+++ b/source/numerics/data_out.inst.in
@@ -18,7 +18,7 @@
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
 {
     namespace internal \{
-    namespace DataOut \{
+    namespace DataOutImplementation \{
 #if deal_II_dimension <= deal_II_space_dimension
     template struct ParallelData<deal_II_dimension,deal_II_space_dimension>;
 #endif

--- a/source/numerics/data_out_dof_data.inst.in
+++ b/source/numerics/data_out_dof_data.inst.in
@@ -155,7 +155,7 @@ for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
 for (deal_II_dimension : DIMENSIONS)
 {
     namespace internal \{
-    namespace DataOut \{
+    namespace DataOutImplementation \{
     template struct ParallelDataBase<deal_II_dimension,deal_II_dimension>;
     \}
     \}
@@ -165,7 +165,7 @@ for (deal_II_dimension : DIMENSIONS)
 for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
 {
     namespace internal \{
-    namespace DataOut \{
+    namespace DataOutImplementation \{
     template
     void
     ParallelDataBase<deal_II_dimension,deal_II_dimension>::

--- a/source/numerics/data_out_dof_data_codim.inst.in
+++ b/source/numerics/data_out_dof_data_codim.inst.in
@@ -79,7 +79,7 @@ for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
 {
     namespace internal \{
-    namespace DataOut \{
+    namespace DataOutImplementation \{
 #if deal_II_dimension < deal_II_space_dimension
     template struct ParallelDataBase<deal_II_dimension,deal_II_space_dimension>;
 #endif
@@ -91,7 +91,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
 for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
 {
     namespace internal \{
-    namespace DataOut \{
+    namespace DataOutImplementation \{
 #if deal_II_dimension < deal_II_space_dimension
     template
     void

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -45,7 +45,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace DataOutRotation
+  namespace DataOutRotationImplementation
   {
     template <int dim, int spacedim>
     ParallelData<dim,spacedim>::
@@ -57,7 +57,7 @@ namespace internal
                   const std::vector<std::shared_ptr<dealii::hp::FECollection<dim,spacedim> > > &finite_elements,
                   const UpdateFlags update_flags)
       :
-      internal::DataOut::
+      internal::DataOutImplementation::
       ParallelDataBase<dim,spacedim> (n_datasets,
                                       n_subdivisions,
                                       n_postprocessor_outputs,
@@ -94,7 +94,7 @@ template <int dim, typename DoFHandlerType>
 void
 DataOutRotation<dim,DoFHandlerType>::
 build_one_patch (const cell_iterator                                                 *cell,
-                 internal::DataOutRotation::ParallelData<dimension, space_dimension> &data,
+                 internal::DataOutRotationImplementation::ParallelData<dimension, space_dimension> &data,
                  std::vector<DataOutBase::Patch<dimension+1,space_dimension+1> >     &my_patches)
 {
   if (dim == 3)
@@ -204,15 +204,15 @@ build_one_patch (const cell_iterator                                            
                       // value, gradient etc.
                       if (update_flags & update_values)
                         this->dof_data[dataset]->get_function_values (fe_patch_values,
-                                                                      internal::DataOut::ComponentExtractor::real_part,
+                                                                      internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                       data.patch_values_scalar.solution_values);
                       if (update_flags & update_gradients)
                         this->dof_data[dataset]->get_function_gradients (fe_patch_values,
-                                                                         internal::DataOut::ComponentExtractor::real_part,
+                                                                         internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                          data.patch_values_scalar.solution_gradients);
                       if (update_flags & update_hessians)
                         this->dof_data[dataset]->get_function_hessians (fe_patch_values,
-                                                                        internal::DataOut::ComponentExtractor::real_part,
+                                                                        internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                         data.patch_values_scalar.solution_hessians);
 
                       if (update_flags & update_quadrature_points)
@@ -236,15 +236,15 @@ build_one_patch (const cell_iterator                                            
                       // its derivative...
                       if (update_flags & update_values)
                         this->dof_data[dataset]->get_function_values (fe_patch_values,
-                                                                      internal::DataOut::ComponentExtractor::real_part,
+                                                                      internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                       data.patch_values_system.solution_values);
                       if (update_flags & update_gradients)
                         this->dof_data[dataset]->get_function_gradients (fe_patch_values,
-                                                                         internal::DataOut::ComponentExtractor::real_part,
+                                                                         internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                          data.patch_values_system.solution_gradients);
                       if (update_flags & update_hessians)
                         this->dof_data[dataset]->get_function_hessians (fe_patch_values,
-                                                                        internal::DataOut::ComponentExtractor::real_part,
+                                                                        internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                         data.patch_values_system.solution_hessians);
 
                       if (update_flags & update_quadrature_points)
@@ -294,7 +294,7 @@ build_one_patch (const cell_iterator                                            
               else if (n_components == 1)
                 {
                   this->dof_data[dataset]->get_function_values (fe_patch_values,
-                                                                internal::DataOut::ComponentExtractor::real_part,
+                                                                internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                 data.patch_values_scalar.solution_values);
 
                   switch (dimension)
@@ -327,7 +327,7 @@ build_one_patch (const cell_iterator                                            
                 {
                   data.resize_system_vectors(n_components);
                   this->dof_data[dataset]->get_function_values (fe_patch_values,
-                                                                internal::DataOut::ComponentExtractor::real_part,
+                                                                internal::DataOutImplementation::ComponentExtractor::real_part,
                                                                 data.patch_values_system.solution_values);
 
                   for (unsigned int component=0; component<n_components;
@@ -375,7 +375,7 @@ build_one_patch (const cell_iterator                                            
                                  typename Triangulation<dimension,space_dimension>::active_cell_iterator(*cell));
               const double value
                 = this->cell_data[dataset]->get_cell_data_value (cell_number,
-                                                                 internal::DataOut::ComponentExtractor::real_part);
+                                                                 internal::DataOutImplementation::ComponentExtractor::real_part);
               switch (dimension)
                 {
                 case 1:
@@ -416,13 +416,13 @@ void DataOutRotation<dim,DoFHandlerType>::build_patches (const unsigned int n_pa
   // template parameter
   Assert (dim==dimension, ExcDimensionMismatch(dim, dimension));
   Assert (this->triangulation != nullptr,
-          Exceptions::DataOut::ExcNoTriangulationSelected());
+          Exceptions::DataOutImplementation::ExcNoTriangulationSelected());
 
   const unsigned int n_subdivisions = (nnnn_subdivisions != 0)
                                       ? nnnn_subdivisions
                                       : this->default_subdivisions;
   Assert (n_subdivisions >= 1,
-          Exceptions::DataOut::ExcInvalidNumberOfSubdivisions(n_subdivisions));
+          Exceptions::DataOutImplementation::ExcInvalidNumberOfSubdivisions(n_subdivisions));
 
   this->validate_dataset_names();
 
@@ -465,7 +465,7 @@ void DataOutRotation<dim,DoFHandlerType>::build_patches (const unsigned int n_pa
     else
       n_postprocessor_outputs[dataset] = 0;
 
-  internal::DataOutRotation::ParallelData<dimension, space_dimension>
+  internal::DataOutRotationImplementation::ParallelData<dimension, space_dimension>
   thread_data (n_datasets,
                n_subdivisions, n_patches_per_circle,
                n_postprocessor_outputs,
@@ -486,7 +486,7 @@ void DataOutRotation<dim,DoFHandlerType>::build_patches (const unsigned int n_pa
                    &all_cells[0]+all_cells.size(),
                    std::bind(&DataOutRotation<dim,DoFHandlerType>::build_one_patch,
                              this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
-                   std::bind(&internal::DataOutRotation
+                   std::bind(&internal::DataOutRotationImplementation
                              ::append_patch_to_list<dim,space_dimension>,
                              std::placeholders::_1, std::ref(this->patches)),
                    thread_data,

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -164,7 +164,7 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::add_data_vector (const Vector<nu
     const std::vector<std::string> &names)
 {
   Assert (dof_handler != nullptr,
-          Exceptions::DataOut::ExcNoDoFHandlerSelected ());
+          Exceptions::DataOutImplementation::ExcNoDoFHandlerSelected ());
   // either cell data and one name,
   // or dof data and n_components names
   Assert (((vec.size() == dof_handler->get_triangulation().n_active_cells()) &&
@@ -172,16 +172,16 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::add_data_vector (const Vector<nu
           ||
           ((vec.size() == dof_handler->n_dofs()) &&
            (names.size() == dof_handler->get_fe(0).n_components())),
-          Exceptions::DataOut::ExcInvalidNumberOfNames (names.size(),
-                                                        dof_handler->get_fe(0).n_components()));
+          Exceptions::DataOutImplementation::ExcInvalidNumberOfNames (names.size(),
+              dof_handler->get_fe(0).n_components()));
   for (unsigned int i=0; i<names.size(); ++i)
     Assert (names[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
                                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                        "0123456789_<>()") == std::string::npos,
-            Exceptions::DataOut::ExcInvalidCharacter (names[i],
-                                                      names[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
-                                                          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                          "0123456789_<>()")));
+            Exceptions::DataOutImplementation::ExcInvalidCharacter (names[i],
+                names[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
+                                           "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                           "0123456789_<>()")));
 
   if (vec.size() == dof_handler->n_dofs())
     {
@@ -237,9 +237,9 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::build_patches (const unsigned in
                                 : this->default_subdivisions;
 
   Assert (n_subdivisions >= 1,
-          Exceptions::DataOut::ExcInvalidNumberOfSubdivisions(n_subdivisions));
+          Exceptions::DataOutImplementation::ExcInvalidNumberOfSubdivisions(n_subdivisions));
   Assert (dof_handler != nullptr,
-          Exceptions::DataOut::ExcNoDoFHandlerSelected());
+          Exceptions::DataOutImplementation::ExcNoDoFHandlerSelected());
 
   this->validate_dataset_names();
 

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -37,7 +37,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace PointValueHistory
+  namespace PointValueHistoryImplementation
   {
 /// Only a constructor needed for this class (a struct really)
     template <int dim>
@@ -298,7 +298,7 @@ void PointValueHistory<dim>
       .push_back (local_dof_indices[current_fe_index [component]]);
     }
 
-  internal::PointValueHistory::PointGeometryData<dim>
+  internal::PointValueHistoryImplementation::PointGeometryData<dim>
   new_point_geometry_data (location, current_points, new_solution_indices);
   point_geometry_data.push_back (new_point_geometry_data);
 
@@ -415,7 +415,7 @@ void PointValueHistory<dim>
           new_solution_indices.push_back (local_dof_indices[current_fe_index[point][component]]);
         }
 
-      internal::PointValueHistory::PointGeometryData<dim> new_point_geometry_data (locations[point], current_points[point], new_solution_indices);
+      internal::PointValueHistoryImplementation::PointGeometryData<dim> new_point_geometry_data (locations[point], current_points[point], new_solution_indices);
 
       point_geometry_data.push_back (new_point_geometry_data);
 
@@ -578,7 +578,7 @@ PointValueHistory<dim>::evaluate_field (const std::string &vector_name,
 
   unsigned int n_stored = mask->second.n_selected_components(dof_handler->get_fe(0).n_components ());
 
-  typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
+  typename std::vector <internal::PointValueHistoryImplementation::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
   for (unsigned int data_store_index = 0; point != point_geometry_data.end (); ++point, ++data_store_index)
     {
       // Look up the components to add
@@ -653,7 +653,7 @@ PointValueHistory<dim>::evaluate_field (const std::vector <std::string> &vector_
                                 Tensor< 2, dim, typename VectorType::value_type >()));
 
   // Loop over points and find correct cell
-  typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
+  typename std::vector <internal::PointValueHistoryImplementation::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
   for (unsigned int data_store_index = 0; point != point_geometry_data.end (); ++point, ++data_store_index)
     {
       // we now have a point to query, need to know what cell it is in
@@ -839,7 +839,7 @@ void PointValueHistory<dim>
 
   unsigned int n_stored = mask->second.n_selected_components(dof_handler->get_fe(0).n_components ());
 
-  typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
+  typename std::vector <internal::PointValueHistoryImplementation::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
   Vector <number> value (dof_handler->get_fe(0).n_components());
   for (unsigned int data_store_index = 0; point != point_geometry_data.end (); ++point, ++data_store_index)
     {
@@ -967,7 +967,7 @@ void PointValueHistory<dim>
       // the number of dofs has changed.
       //AssertThrow (!triangulation_changed, ExcDoFHandlerChanged ());
 
-      typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
+      typename std::vector <internal::PointValueHistoryImplementation::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
       for (unsigned int data_store_index = 0; point != point_geometry_data.end (); ++point, ++data_store_index)
         {
           // for each point, open a file to
@@ -1087,7 +1087,7 @@ Vector<double> PointValueHistory<dim>
 
   Vector<double> dof_vector (dof_handler->n_dofs ());
 
-  typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
+  typename std::vector <internal::PointValueHistoryImplementation::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
   for (; point != point_geometry_data.end (); ++point)
     {
       for (unsigned int component = 0; component < dof_handler->get_fe(0).n_components (); component++)
@@ -1108,7 +1108,7 @@ void PointValueHistory<dim>
   AssertThrow (!triangulation_changed, ExcDoFHandlerChanged ());
 
   std::vector <std::vector <Point <dim> > > actual_points;
-  typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
+  typename std::vector <internal::PointValueHistoryImplementation::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
 
   for (; point != point_geometry_data.end (); ++point)
     {
@@ -1140,7 +1140,7 @@ void PointValueHistory<dim>
   std::vector<Point<dim> > evaluation_points;
 
   // Loop over points and find correct cell
-  typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
+  typename std::vector <internal::PointValueHistoryImplementation::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
   for (unsigned int data_store_index = 0; point != point_geometry_data.end (); ++point, ++data_store_index)
     {
       // we now have a point to query,
@@ -1178,7 +1178,7 @@ void PointValueHistory<dim>
   out << "Have_dof_handler: " << have_dof_handler << "\n";
   out << "Geometric Data" << "\n";
 
-  typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
+  typename std::vector <internal::PointValueHistoryImplementation::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
   if (point == point_geometry_data.end ())
     {
       out << "No points stored currently\n";

--- a/tests/data_out/data_out_11.debug.output
+++ b/tests/data_out/data_out_11.debug.output
@@ -1,4 +1,4 @@
 
-DEAL::Exceptions::DataOut::ExcInvalidNumberOfNames (deduced_names.size(), dof_handler->get_fe(0).n_components())
-DEAL::Exceptions::DataOut::ExcInvalidNumberOfNames (deduced_names.size(), dof_handler->get_fe(0).n_components())
+DEAL::Exceptions::DataOutImplementation::ExcInvalidNumberOfNames (deduced_names.size(), dof_handler->get_fe(0).n_components())
+DEAL::Exceptions::DataOutImplementation::ExcInvalidNumberOfNames (deduced_names.size(), dof_handler->get_fe(0).n_components())
 DEAL::OK

--- a/tests/lac/gmres_eigenvalues.cc
+++ b/tests/lac/gmres_eigenvalues.cc
@@ -100,7 +100,7 @@ void test (unsigned int variant)
         eigenvalues[i] = matrix.eigenvalue(i);
 
       std::sort(eigenvalues.begin(), eigenvalues.end(),
-                internal::SolverGMRES::complex_less_pred);
+                internal::SolverGMRESImplementation::complex_less_pred);
 
       deallog << "Actual eigenvalues:        ";
       for (unsigned int i=0; i<n; ++i)

--- a/tests/lac/linear_operator_01.cc
+++ b/tests/lac/linear_operator_01.cc
@@ -102,7 +102,7 @@ int main()
 
   // Create to distinct linear operators:
 
-  typedef dealii::internal::LinearOperator::EmptyPayload Payload;
+  typedef dealii::internal::LinearOperatorImplementation::EmptyPayload Payload;
   LinearOperator<LeftVector, RightVector, Payload> multiply2;
   multiply2.vmult = [](LeftVector &v, const RightVector &u)
   {

--- a/tests/lac/linear_operator_01a.cc
+++ b/tests/lac/linear_operator_01a.cc
@@ -105,7 +105,7 @@ int main()
 
   // Create to distinct linear operators:
 
-  typedef dealii::internal::LinearOperator::EmptyPayload Payload;
+  typedef dealii::internal::LinearOperatorImplementation::EmptyPayload Payload;
   LinearOperator<LeftVector, RightVector, Payload> multiply2;
   multiply2.vmult = [](LeftVector &v, const RightVector &u)
   {

--- a/tests/lac/linear_operator_10.cc
+++ b/tests/lac/linear_operator_10.cc
@@ -53,7 +53,7 @@ test_preconditioner (const MATRIX &A,
   const auto lo_A = linear_operator<VECTOR>(A);
   // Note: The above should be equivalent to the following:
   //
-  //  typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PAYLOAD;
+  //  typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PAYLOAD;
   //  const auto lo_A = linear_operator<VECTOR,VECTOR,PAYLOAD>(A);
 
   PRECONDITIONER preconditioner;
@@ -97,7 +97,7 @@ test_preconditioner (const MATRIX &A,
     const auto lo_A_inv_approx = linear_operator<VECTOR,VECTOR>(A, preconditioner);
     // Note: The above should be equivalent to the following:
     //
-    //    typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PAYLOAD;
+    //    typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PAYLOAD;
     //    const auto lo_A_inv_approx = linear_operator<VECTOR,VECTOR,PAYLOAD>(A, preconditioner);
 
     // Singular operation
@@ -121,7 +121,7 @@ test_preconditioner (const MATRIX &A,
   {
     // Stand-alone
     deallog.push("S.A.");
-    typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PAYLOAD;
+    typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PAYLOAD;
     const auto lo_A_inv_approx = linear_operator<VECTOR,VECTOR,PAYLOAD>(preconditioner);
 
     // Singular operation
@@ -153,7 +153,7 @@ test_solver (const MATRIX &A,
   const auto lo_A = linear_operator<VECTOR>(A);
   // Note: The above should be equivalent to the following:
   //
-  //  typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PAYLOAD;
+  //  typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PAYLOAD;
   //  const auto lo_A = linear_operator<VECTOR,VECTOR,PAYLOAD>(A);
 
   SolverControl solver_control (100, 1.0e-10);
@@ -366,7 +366,7 @@ int main(int argc, char *argv[])
     //   // test_solver<SLVR> (A, b);
     //
     //   typedef dealii::TrilinosWrappers::MPI::Vector VectorType;
-    //   typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PayloadType;
+    //   typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PayloadType;
     //   // TODO: Full template expansion required for composite operator. Can one prevent this?
     //   //       i.e. is 'const auto lo_A = linear_operator<VectorType>(A);' possible?
     //   const auto lo_A = linear_operator<VectorType,VectorType,PayloadType>(A);

--- a/tests/lac/linear_operator_10a.cc
+++ b/tests/lac/linear_operator_10a.cc
@@ -59,7 +59,7 @@ test_preconditioner (const MATRIX &A,
   const auto lo_A = linear_operator<VECTOR>(A);
   // Note: The above should be equivalent to the following:
   //
-  //  typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PAYLOAD;
+  //  typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PAYLOAD;
   //  const auto lo_A = linear_operator<VECTOR,VECTOR,PAYLOAD>(A);
 
   PRECONDITIONER preconditioner;
@@ -103,7 +103,7 @@ test_preconditioner (const MATRIX &A,
     const auto lo_A_inv_approx = linear_operator<VECTOR,VECTOR>(A, preconditioner);
     // Note: The above should be equivalent to the following:
     //
-    //    typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PAYLOAD;
+    //    typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PAYLOAD;
     //    const auto lo_A_inv_approx = linear_operator<VECTOR,VECTOR,PAYLOAD>(A, preconditioner);
 
     // Singular operation
@@ -127,7 +127,7 @@ test_preconditioner (const MATRIX &A,
   {
     // Stand-alone
     deallog.push("S.A.");
-    typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PAYLOAD;
+    typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PAYLOAD;
     const auto lo_A_inv_approx = linear_operator<VECTOR,VECTOR,PAYLOAD>(preconditioner);
 
     // Singular operation
@@ -159,7 +159,7 @@ test_solver (const MATRIX &A,
   const auto lo_A = linear_operator<VECTOR>(A);
   // Note: The above should be equivalent to the following:
   //
-  //  typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PAYLOAD;
+  //  typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PAYLOAD;
   //  const auto lo_A = linear_operator<VECTOR,VECTOR,PAYLOAD>(A);
 
   SolverControl solver_control (100, 1.0e-10, false,false);

--- a/tests/lac/linear_operator_13.cc
+++ b/tests/lac/linear_operator_13.cc
@@ -144,7 +144,7 @@ void evaluate_ops (const TrilinosWrappers::BlockSparseMatrix &matrix,
   const double tol = 1e-12;
   typedef dealii::TrilinosWrappers::SparseMatrix MatrixType;
   typedef dealii::TrilinosWrappers::MPI::Vector       VectorType;
-  typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PayloadType;
+  typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PayloadType;
   typedef typename PayloadType::VectorType       PayloadVectorType;
   typedef dealii::types::global_dof_index        size_type;
 

--- a/tests/lac/linear_operator_14.cc
+++ b/tests/lac/linear_operator_14.cc
@@ -181,7 +181,7 @@ void evaluate_ops (const TrilinosWrappers::BlockSparseMatrix &matrix,
   const double tol = 1e-12;
   typedef dealii::TrilinosWrappers::SparseMatrix MatrixType;
   typedef dealii::TrilinosWrappers::MPI::Vector  VectorType;
-  typedef dealii::TrilinosWrappers::internal::LinearOperator::TrilinosPayload PayloadType;
+  typedef dealii::TrilinosWrappers::internal::LinearOperatorImplementation::TrilinosPayload PayloadType;
   typedef typename PayloadType::VectorType       PayloadVectorType;
   typedef dealii::types::global_dof_index        size_type;
 

--- a/tests/lac/solver_signals.cc
+++ b/tests/lac/solver_signals.cc
@@ -65,7 +65,7 @@ void output_hessenberg_matrix(const FullMatrix<NUMBER> &H,const std::string &tex
 }
 
 template <class NUMBER>
-void output_arnoldi_vectors_norms(const internal::SolverGMRES::TmpVectors<Vector<NUMBER> > &tmp_vector,const std::string &text)
+void output_arnoldi_vectors_norms(const internal::SolverGMRESImplementation::TmpVectors<Vector<NUMBER> > &tmp_vector,const std::string &text)
 {
   deallog << text << std::endl;
   for (unsigned int i=0; i<tmp_vector.size(); ++i)

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -620,11 +620,11 @@ struct EnableFPE
 
 namespace internal
 {
-  namespace Vector
+  namespace VectorImplementation
   {
     extern unsigned int minimum_parallel_grain_size;
   }
-  namespace SparseMatrix
+  namespace SparseMatrixImplementation
   {
     extern unsigned int minimum_parallel_grain_size;
   }
@@ -634,8 +634,8 @@ struct SetGrainSizes
 {
   SetGrainSizes ()
   {
-    internal::Vector::minimum_parallel_grain_size = 2;
-    internal::SparseMatrix::minimum_parallel_grain_size = 2;
+    internal::VectorImplementation::minimum_parallel_grain_size = 2;
+    internal::SparseMatrixImplementation::minimum_parallel_grain_size = 2;
   }
 } set_grain_sizes;
 


### PR DESCRIPTION
Supersedes #5985. This PR appends an `Implementation` postfix to all namespaces that also appear as class names to avoid any ambiguities between the two. See #5985 for the initial problem.