### PR TITLE
Guard HDF5 specific ScaLAPACK implementation

### DIFF
--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -1179,6 +1179,7 @@ NumberType ScaLAPACKMatrix<NumberType>::norm_symmetric(const char type) const
 
 
 
+#ifdef DEAL_II_WITH_HDF5
 namespace internal
 {
   namespace
@@ -1239,6 +1240,7 @@ namespace internal
     }
   }
 }
+#endif
 
 
 


### PR DESCRIPTION
We only need these functions when compiling with `DEAL_II_WITH_HDF5=ON`. When compiling with `ScaLAPACK` and without `HDF5` the current version results in a compilation error.