### PR TITLE
Parameter Acceptor Proxy.

### DIFF
--- a/doc/news/changes/minor/20180306LucaHeltai
+++ b/doc/news/changes/minor/20180306LucaHeltai
@@ -1,0 +1,5 @@
+New: The ParameterAcceptorProxy class allows you to wrap a class that provides a static member
+declare_parameters and a member parse_parameters into a ParameterAcceptor subclass. 
+<br>
+(Luca Heltai, 2018/03/06)
+

--- a/tests/parameter_handler/parameter_acceptor_parameters/parameter_acceptor_proxy_01.prm
+++ b/tests/parameter_handler/parameter_acceptor_parameters/parameter_acceptor_proxy_01.prm
@@ -1,0 +1,19 @@
+
+# Parameter file generated with 
+# DEAL_II_PACKAGE_VERSION = 9.0.0-pre
+subsection Function 1D
+  set Function constants  = 
+  set Function expression = 0
+  set Variable names      = x,t
+end
+subsection Function 2D
+  set Function constants  = 
+  set Function expression = 0
+  set Variable names      = x,y,t
+end
+subsection Function 3D
+  set Function constants  = 
+  set Function expression = 0
+  set Variable names      = x,y,z,t
+end
+

--- a/tests/parameter_handler/parameter_acceptor_proxy_01.cc
+++ b/tests/parameter_handler/parameter_acceptor_proxy_01.cc
@@ -1,0 +1,36 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2017 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal.II distribution.
+//
+//-----------------------------------------------------------
+
+
+
+#include "../tests.h"
+#include <deal.II/base/parameter_acceptor.h>
+#include <deal.II/base/parsed_function.h>
+
+// Test proxy class
+
+
+int main ()
+{
+  initlog();
+  auto &prm = ParameterAcceptor::prm;
+
+  ParameterAcceptorProxy<Functions::ParsedFunction<1>> f1("Function 1D");
+  ParameterAcceptorProxy<Functions::ParsedFunction<2>> f2("Function 2D");
+  ParameterAcceptorProxy<Functions::ParsedFunction<3>> f3("Function 3D");
+
+  ParameterAcceptor::initialize(SOURCE_DIR"/parameter_acceptor_parameters/parameter_acceptor_proxy_01.prm");
+  prm.log_parameters(deallog);
+}

--- a/tests/parameter_handler/parameter_acceptor_proxy_01.with_muparser=true.output
+++ b/tests/parameter_handler/parameter_acceptor_proxy_01.with_muparser=true.output
@@ -1,0 +1,10 @@
+
+DEAL:parameters:Function 1D::Function constants: 
+DEAL:parameters:Function 1D::Function expression: 0
+DEAL:parameters:Function 1D::Variable names: x,t
+DEAL:parameters:Function 2D::Function constants: 
+DEAL:parameters:Function 2D::Function expression: 0
+DEAL:parameters:Function 2D::Variable names: x,y,t
+DEAL:parameters:Function 3D::Function constants: 
+DEAL:parameters:Function 3D::Function expression: 0
+DEAL:parameters:Function 3D::Variable names: x,y,z,t


### PR DESCRIPTION
This class provides you with the possibility to use existing classes with static member function `declare_parameters` and member function `parse_parameters` with the `ParameterAcceptor` facilities:
~~~
  ParameterAcceptorProxy<Functions::ParsedFunction<2>> f2("Function 2D");
  ParameterAcceptor::initialize("parameters.prm");
~~~
will then work out of the box, without you needing to call `declare_parameters`, and `parse_parameters`.

I'm planning to write a small tutorial program that uses these facilities.