### PR TITLE
create CUDA doxygen module

### DIFF
--- a/doc/doxygen/headers/cuda.h
+++ b/doc/doxygen/headers/cuda.h
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+/**
+ * @defgroup CUDAWrappers CUDA Wrappers
+ *
+ * The classes in this module are concerned with the description of features
+ * to be run on GPUs using CUDA.
+ */

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -199,6 +199,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_ENABLE_EXTRA_DIAGNOSTICS= \
                          DEAL_II_DISABLE_EXTRA_DIAGNOSTICS= \
                          DEAL_II_DEPRECATED= \
+                         DEAL_II_CUDA_HOST_DEV= \
                          DEAL_II_P4EST_VERSION_GTE=1 \
                          DEAL_II_TRILINOS_VERSION_GTE=1
 

--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -31,6 +31,9 @@ template <typename Number> class ReadWriteVector;
 
 namespace LinearAlgebra
 {
+  /**
+   * A Namespace for the CUDA vectors.
+   */
   namespace CUDAWrappers
   {
     /**

--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -25,6 +25,9 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+/**
+ * Namespace for the CUDA wrappers
+ */
 namespace CUDAWrappers
 {
   namespace internal


### PR DESCRIPTION
- create the CUDA doxygen module so that ``@ingroup`` works
- document namespaces so documentation is generated
- remove ``DEAL_II_CUDA_HOST_DEV`` from documentation (see http://www.dealii.org/developer/doxygen/deal.II/classTensor.html#a2822a574f88510af91208783e84f9ac1 )