### PR TITLE
CUDA: doxygen fixes

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -200,6 +200,8 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_DISABLE_EXTRA_DIAGNOSTICS= \
                          DEAL_II_DEPRECATED= \
                          DEAL_II_CUDA_HOST_DEV= \
+                         DEAL_II_ALWAYS_INLINE= \
+                         __device__= \
                          DEAL_II_P4EST_VERSION_GTE=1 \
                          DEAL_II_TRILINOS_VERSION_GTE=1
 

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -223,7 +223,7 @@ namespace numbers
      * general template is chosen for types not equal to std::complex, this
      * function simply returns the square of the given number.
      *
-     * @ingroup CUDAWrappers
+     * @see CUDAWrappers
      */
     static
     DEAL_II_CUDA_HOST_DEV

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -133,7 +133,7 @@ public:
   /**
    * Constructor. Set to zero.
    *
-   * @ingroup CUDAWrappers
+   * @see CUDAWrappers
    */
   DEAL_II_CUDA_HOST_DEV Tensor ();
 
@@ -183,7 +183,7 @@ public:
    * This is the non-const conversion operator that returns a writable
    * reference.
    *
-   * @ingroup CUDAWrappers
+   * @see CUDAWrappers
    */
   DEAL_II_CUDA_HOST_DEV operator Number &();
 
@@ -193,7 +193,7 @@ public:
    *
    * This is the const conversion operator that returns a read-only reference.
    *
-   * @ingroup CUDAWrappers
+   * @see CUDAWrappers
    */
   DEAL_II_CUDA_HOST_DEV operator const Number &() const;
 
@@ -244,7 +244,7 @@ public:
   /**
    * Multiply the scalar with a <tt>factor</tt>.
    *
-   * @ingroup CUDAWrappers
+   * @see CUDAWrappers
    */
   template <typename OtherNumber>
   DEAL_II_CUDA_HOST_DEV Tensor &operator *= (const OtherNumber &factor);
@@ -285,7 +285,7 @@ public:
    * Return the square of the Frobenius-norm of a tensor, i.e. the sum of the
    * absolute squares of all entries.
    *
-   * @ingroup CUDAWrappers
+   * @see CUDAWrappers
    */
   DEAL_II_CUDA_HOST_DEV real_type norm_square () const;
 
@@ -409,7 +409,7 @@ public:
   /**
    * Constructor. Initialize all entries to zero.
    *
-   * @ingroup CUDAWrappers
+   * @see CUDAWrappers
    */
   DEAL_II_CUDA_HOST_DEV Tensor ();
 
@@ -441,14 +441,14 @@ public:
   /**
    * Read-Write access operator.
    *
-   * @ingroup CUDAWrappers
+   * @see CUDAWrappers
    */
   DEAL_II_CUDA_HOST_DEV value_type &operator [] (const unsigned int i);
 
   /**
    * Read-only access operator.
    *
-   * @ingroup CUDAWrappers
+   * @see CUDAWrappers
    */
   DEAL_II_CUDA_HOST_DEV const value_type &operator[](const unsigned int i) const;
 
@@ -530,7 +530,7 @@ public:
    * Scale the tensor by <tt>factor</tt>, i.e. multiply all components by
    * <tt>factor</tt>.
    *
-   * @ingroup CUDAWrappers
+   * @see CUDAWrappers
    */
   template <typename OtherNumber>
   DEAL_II_CUDA_HOST_DEV Tensor &operator *= (const OtherNumber &factor);
@@ -572,7 +572,7 @@ public:
    * Return the square of the Frobenius-norm of a tensor, i.e. the sum of the
    * absolute squares of all entries.
    *
-   * @ingroup CUDAWrappers
+   * @see CUDAWrappers
    */
   DEAL_II_CUDA_HOST_DEV typename numbers::NumberTraits<Number>::real_type norm_square() const;
 

--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -42,7 +42,7 @@ namespace LinearAlgebra
      *
      * @note Only float and double are supported.
      *
-     * @ingroup CUDAWrappers
+     * @see CUDAWrappers
      * @ingroup Vectors
      * @author Karl Ljungkvist, Bruno Turcksin, 2016
      */


### PR DESCRIPTION
- disable DEAL_II_ALWAYS_INLINE and __device__ in doxygen documentation
- avoid @ingroup for member functions because they will be moved not
copied to the group