### PR TITLE
Provide a function that returns the version string.

### DIFF
--- a/doc/news/changes/minor/20180309Bangerth
+++ b/doc/news/changes/minor/20180309Bangerth
@@ -1,0 +1,4 @@
+New: The Utilities::dealii_version_string() function returns a string
+representation of the deal.II version being used.
+<br>
+(Wolfgang Bangerth, 2018/03/09)

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -61,6 +61,13 @@ DEAL_II_NAMESPACE_OPEN
  */
 namespace Utilities
 {
+  /**
+   * Return a string of the form "deal.II version x.y.z" where "x.y.z"
+   * identifies the version of deal.II you are using. This information
+   * is also provided by the DEAL_II_PACKAGE_NAME and
+   * DEAL_II_PACKAGE_VERSION preprocessor variables.
+   */
+  std::string dealii_version_string ();
 
   /**
    * Convert a number @p value to a string, with as many digits as given to

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -85,11 +85,22 @@ namespace Utilities
                   << "Can't convert the string " << arg1
                   << " to the desired type");
 
+
+  std::string
+  dealii_version_string ()
+  {
+    return DEAL_II_PACKAGE_NAME " version " DEAL_II_PACKAGE_VERSION;
+  }
+
+
+
   std::string
   int_to_string (const unsigned int value, const unsigned int digits)
   {
     return to_string(value,digits);
   }
+
+
 
   template <typename number>
   std::string


### PR DESCRIPTION
I don't have a test since the output will necessarily change over time. I'm ok
with not having a test.

Fixes #6017.