### PR TITLE
Fix llvm-6 clang-tidy performance findings

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -103,7 +103,7 @@ public:
    * Move constructor. Create a new aligned vector by stealing the contents of
    * @p vec.
    */
-  AlignedVector (AlignedVector<T> &&vec);
+  AlignedVector (AlignedVector<T> &&vec) noexcept;
 
   /**
    * Assignment to the input vector @p vec.
@@ -117,7 +117,7 @@ public:
    * Move assignment operator.
    */
   AlignedVector &
-  operator = (AlignedVector<T> &&vec);
+  operator = (AlignedVector<T> &&vec) noexcept;
 
   /**
    * Change the size of the vector. It keeps old elements previously available
@@ -694,11 +694,11 @@ AlignedVector<T>::AlignedVector (const AlignedVector<T> &vec)
 
 template < class T >
 inline
-AlignedVector<T>::AlignedVector (AlignedVector<T> &&vec)
-  :
-  _data (vec._data),
-  _end_data (vec._end_data),
-  _end_allocated (vec._end_allocated)
+AlignedVector<T>::AlignedVector (AlignedVector<T> &&vec) noexcept
+:
+_data (vec._data),
+      _end_data (vec._end_data),
+      _end_allocated (vec._end_allocated)
 {
   vec._data = nullptr;
   vec._end_data = nullptr;
@@ -723,7 +723,7 @@ AlignedVector<T>::operator = (const AlignedVector<T> &vec)
 template < class T >
 inline
 AlignedVector<T> &
-AlignedVector<T>::operator = (AlignedVector<T> &&vec)
+AlignedVector<T>::operator = (AlignedVector<T> &&vec) noexcept
 {
   clear();
 

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -122,13 +122,13 @@ public:
    * Move constructor. Create a new IndexSet by transferring the internal data
    * of the input set.
    */
-  IndexSet (IndexSet &&is);
+  IndexSet (IndexSet &&is) noexcept;
 
   /**
    * Move assignment operator. Transfer the internal data of the input set into
    * the current one.
    */
-  IndexSet &operator= (IndexSet &&is);
+  IndexSet &operator= (IndexSet &&is) noexcept;
 
 #ifdef DEAL_II_WITH_TRILINOS
   /**
@@ -1390,12 +1390,12 @@ IndexSet::IndexSet (const size_type size)
 
 
 inline
-IndexSet::IndexSet (IndexSet &&is)
-  :
-  ranges (std::move(is.ranges)),
-  is_compressed (is.is_compressed),
-  index_space_size (is.index_space_size),
-  largest_range (is.largest_range)
+IndexSet::IndexSet (IndexSet &&is) noexcept
+:
+ranges (std::move(is.ranges)),
+       is_compressed (is.is_compressed),
+       index_space_size (is.index_space_size),
+       largest_range (is.largest_range)
 {
   is.ranges.clear ();
   is.is_compressed = true;
@@ -1408,7 +1408,7 @@ IndexSet::IndexSet (IndexSet &&is)
 
 
 inline
-IndexSet &IndexSet::operator= (IndexSet &&is)
+IndexSet &IndexSet::operator= (IndexSet &&is) noexcept
 {
   ranges = std::move (is.ranges);
   is_compressed = is.is_compressed;

--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -137,7 +137,7 @@ public:
    * Move constructor. Construct a new quadrature object by transferring the
    * internal data of another quadrature object.
    */
-  Quadrature (Quadrature<dim> &&) = default;
+  Quadrature (Quadrature<dim> &&) noexcept = default;
 
   /**
    * Construct a quadrature formula from given vectors of quadrature points
@@ -177,7 +177,7 @@ public:
    * Move assignment operator. Moves all data from another quadrature object
    * to this object.
    */
-  Quadrature &operator = (Quadrature<dim> &&) = default;
+  Quadrature &operator = (Quadrature<dim> &&) = default; // NOLINT
 
   /**
    * Test for equality of two quadratures.

--- a/include/deal.II/base/quadrature_lib.h
+++ b/include/deal.II/base/quadrature_lib.h
@@ -257,7 +257,7 @@ public:
    * Move constructor. We cannot rely on the move constructor for `Quadrature`,
    * since it does not know about the additional member `fraction` of this class.
    */
-  QGaussLogR(QGaussLogR<dim> &&) = default;
+  QGaussLogR(QGaussLogR<dim> &&) noexcept = default;
 
 protected:
   /**
@@ -548,7 +548,7 @@ public:
    * Move constructor. We cannot rely on the move constructor for `Quadrature`,
    * since it does not know about the additional member `ep` of this class.
    */
-  QGaussRadauChebyshev(QGaussRadauChebyshev<dim> &&) = default;
+  QGaussRadauChebyshev(QGaussRadauChebyshev<dim> &&) noexcept = default;
 
 private:
   const EndPoint ep;

--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -79,7 +79,7 @@ public:
    * An object inheriting from Subscriptor can only be moved if no other
    * objects are subscribing to it.
    */
-  Subscriptor(Subscriptor &&);
+  Subscriptor(Subscriptor &&) noexcept;
 
   /**
    * Destructor, asserting that the counter is zero.
@@ -99,7 +99,7 @@ public:
    *
    * Asserts that the counter for the moved object is zero.
    */
-  Subscriptor &operator = (Subscriptor &&);
+  Subscriptor &operator = (Subscriptor &&) noexcept;
 
   /**
    * Subscribes a user of the object. The subscriber may be identified by text

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -447,7 +447,7 @@ public:
   /**
    * Move constructor. Transfers the contents of another Table.
    */
-  TableBase (TableBase<N,T> &&src);
+  TableBase (TableBase<N,T> &&src) noexcept;
 
   /**
    * Destructor. Free allocated memory.
@@ -478,7 +478,7 @@ public:
    * Move assignment operator. Transfer all elements of <tt>src</tt> into the
    * table.
    */
-  TableBase<N,T> &operator = (TableBase<N,T> &&src);
+  TableBase<N,T> &operator = (TableBase<N,T> &&src) noexcept;
 
   /**
    * Test for equality of two tables.
@@ -1655,11 +1655,11 @@ TableBase<N,T>::TableBase (const TableBase<N,T2> &src)
 
 
 template <int N, typename T>
-TableBase<N,T>::TableBase (TableBase<N,T> &&src)
-  :
-  Subscriptor (std::move(src)),
-  values (std::move(src.values)),
-  table_size (src.table_size)
+TableBase<N,T>::TableBase (TableBase<N,T> &&src) noexcept
+:
+Subscriptor (std::move(src)),
+            values (std::move(src.values)),
+            table_size (src.table_size)
 {
   src.table_size = TableIndices<N>();
 }
@@ -1829,7 +1829,7 @@ TableBase<N,T>::operator = (const TableBase<N,T2> &m)
 template <int N, typename T>
 inline
 TableBase<N,T> &
-TableBase<N,T>::operator = (TableBase<N,T> &&m)
+TableBase<N,T>::operator = (TableBase<N,T> &&m) noexcept
 {
   static_cast<Subscriptor &>(*this) = std::move(m);
   values = std::move(m.values);

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -757,7 +757,7 @@ public:
   /**
    * Move constructor.
    */
-  FiniteElement (FiniteElement<dim, spacedim> &&) = default;
+  FiniteElement (FiniteElement<dim, spacedim> &&) = default; // NOLINT
 
   /**
    * Copy constructor.

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -492,7 +492,7 @@ public:
   /**
    * Move constructor.
    */
-  FESystem (FESystem<dim,spacedim> &&) = default;
+  FESystem (FESystem<dim,spacedim> &&) = default; // NOLINT
 
   /**
    * Destructor.

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3188,7 +3188,7 @@ namespace GridTools
       {
         CellId::binary_type value;
         ar &value;
-        cell_ids.emplace_back(std::move(value));
+        cell_ids.emplace_back(value);
       }
     ar &data;
   }

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1646,12 +1646,12 @@ public:
    * Create a new triangulation by stealing the internal data of another
    * triangulation.
    */
-  Triangulation (Triangulation<dim, spacedim> &&tria);
+  Triangulation (Triangulation<dim, spacedim> &&tria) noexcept;
 
   /**
    * Move assignment operator.
    */
-  Triangulation &operator = (Triangulation<dim, spacedim> &&tria);
+  Triangulation &operator = (Triangulation<dim, spacedim> &&tria) noexcept;
 
   /**
    * Delete the object and all levels of the hierarchy.

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -92,13 +92,13 @@ namespace hp
     /**
      * Move constructor.
      */
-    FECollection (FECollection<dim,spacedim> &&fe_collection) = default;
+    FECollection (FECollection<dim,spacedim> &&fe_collection) noexcept = default;
 
     /**
      * Move assignment operator.
      */
     FECollection<dim, spacedim> &
-    operator= (FECollection<dim,spacedim> &&fe_collection) = default;
+    operator= (FECollection<dim,spacedim> &&fe_collection) = default; // NOLINT
 
     /**
      * Add a finite element. This function generates a copy of the given

--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -78,7 +78,7 @@ public:
    * Move constructor. Initialize a new object by stealing the internal data of
    * another BlockIndices object.
    */
-  BlockIndices (BlockIndices &&b);
+  BlockIndices (BlockIndices &&b) noexcept;
 
   /**
    * Copy constructor.
@@ -180,7 +180,7 @@ public:
    * Move assignment operator. Move another BlockIndices object onto the
    * current one by transferring its contents.
    */
-  BlockIndices &operator = (BlockIndices &&);
+  BlockIndices &operator = (BlockIndices &&) noexcept;
 
   /**
    * Compare whether two objects are the same, i.e. whether the number of
@@ -304,10 +304,10 @@ BlockIndices::BlockIndices (const std::vector<size_type> &block_sizes)
 
 
 inline
-BlockIndices::BlockIndices (BlockIndices &&b)
-  :
-  n_blocks(b.n_blocks),
-  start_indices(std::move(b.start_indices))
+BlockIndices::BlockIndices (BlockIndices &&b) noexcept
+:
+n_blocks(b.n_blocks),
+         start_indices(std::move(b.start_indices))
 {
   b.n_blocks = 0;
   b.start_indices = std::vector<size_type>(1, 0);
@@ -423,7 +423,7 @@ BlockIndices::operator = (const BlockIndices &b)
 
 inline
 BlockIndices &
-BlockIndices::operator = (BlockIndices &&b)
+BlockIndices::operator = (BlockIndices &&b) noexcept
 {
   start_indices = std::move(b.start_indices);
   n_blocks = b.n_blocks;

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -113,7 +113,7 @@ public:
    * Move constructor. Creates a new vector by stealing the internal data of
    * the given argument vector.
    */
-  BlockVector (BlockVector<Number> &&/*v*/) = default;
+  BlockVector (BlockVector<Number> &&/*v*/) noexcept = default;
 
   /**
    * Copy constructor taking a BlockVector of another data type. This will
@@ -200,7 +200,7 @@ public:
    * Move the given vector. This operator replaces the present vector with
    * the contents of the given argument vector.
    */
-  BlockVector<Number> &operator= (BlockVector<Number> &&/*v*/) = default;
+  BlockVector<Number> &operator= (BlockVector<Number> &&/*v*/) = default; // NOLINT
 
   /**
    * Copy operator for template arguments of different types. Resize the

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -566,7 +566,7 @@ public:
    * object if the underlying <code>VectorType</code> is move-constructible,
    * otherwise they are copied.
    */
-  BlockVectorBase (BlockVectorBase &&/*V*/) = default;
+  BlockVectorBase (BlockVectorBase &&/*V*/) noexcept = default;
 
   /**
    * Update internal structures after resizing vectors. Whenever you reinited
@@ -751,7 +751,7 @@ public:
    * vector into the current object if `VectorType` is
    * move-constructible, otherwise copy them.
    */
-  BlockVectorBase &operator= (BlockVectorBase &&/*V*/) = default;
+  BlockVectorBase &operator= (BlockVectorBase &&/*V*/) = default; // NOLINT
 
   /**
    * Copy operator for template arguments of different types.

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -547,7 +547,7 @@ public:
    * Move construction allows an object to be returned from a function or
    * packed into a tuple even when the class cannot be copy-constructed.
    */
-  SparseMatrix (SparseMatrix<number> &&m);
+  SparseMatrix (SparseMatrix<number> &&m) noexcept;
 
   /**
    * Constructor. Takes the given matrix sparsity structure to represent the
@@ -594,7 +594,7 @@ public:
    * Move assignment operator. This operator replaces the present matrix with
    * @p m by transferring the internal data of @p m.
    */
-  SparseMatrix<number> &operator = (SparseMatrix<number> &&m);
+  SparseMatrix<number> &operator = (SparseMatrix<number> &&m) noexcept;
 
   /**
    * Copy operator: initialize the matrix with the identity matrix. This

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -72,12 +72,12 @@ SparseMatrix<number>::SparseMatrix (const SparseMatrix &m)
 
 
 template <typename number>
-SparseMatrix<number>::SparseMatrix (SparseMatrix<number> &&m)
-  :
-  Subscriptor(std::move(m)),
-  cols(m.cols),
-  val(std::move(m.val)),
-  max_len(m.max_len)
+SparseMatrix<number>::SparseMatrix (SparseMatrix<number> &&m) noexcept
+:
+Subscriptor(std::move(m)),
+            cols(m.cols),
+            val(std::move(m.val)),
+            max_len(m.max_len)
 {
   m.cols = nullptr;
   m.val = nullptr;
@@ -104,7 +104,7 @@ SparseMatrix<number>::operator = (const SparseMatrix<number> &m)
 
 template <typename number>
 SparseMatrix<number> &
-SparseMatrix<number>::operator = (SparseMatrix<number> &&m)
+SparseMatrix<number>::operator = (SparseMatrix<number> &&m) noexcept
 {
   cols = m.cols;
   val = std::move(m.val);

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -126,7 +126,7 @@ namespace TrilinosWrappers
        * Move constructor. Creates a new vector by stealing the internal data
        * of the vector @p v.
        */
-      BlockVector (BlockVector &&v);
+      BlockVector (BlockVector &&v) noexcept;
 
       /**
        * Creates a block vector consisting of <tt>num_blocks</tt> components,
@@ -155,7 +155,7 @@ namespace TrilinosWrappers
        * Move the given vector. This operator replaces the present vector with
        * @p v by efficiently swapping the internal data structures.
        */
-      BlockVector &operator= (BlockVector &&v);
+      BlockVector &operator= (BlockVector &&v) noexcept;
 
       /**
        * Another copy function. This one takes a deal.II block vector and
@@ -343,7 +343,7 @@ namespace TrilinosWrappers
 
 
     inline
-    BlockVector::BlockVector (BlockVector &&v)
+    BlockVector::BlockVector (BlockVector &&v) noexcept
     {
       // initialize a minimal, valid object and swap
       reinit (0);

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -568,7 +568,7 @@ namespace TrilinosWrappers
      * Move constructor. Create a new sparse matrix by stealing the internal
      * data.
      */
-    SparseMatrix (SparseMatrix  &&other);
+    SparseMatrix (SparseMatrix  &&other) noexcept;
 
     /**
      * Copy constructor is deleted.

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -318,7 +318,7 @@ namespace TrilinosWrappers
      * Move constructor. Create a new sparse matrix by stealing the internal
      * data.
      */
-    SparsityPattern (SparsityPattern &&other);
+    SparsityPattern (SparsityPattern &&other) noexcept;
 
     /**
      * Copy constructor. Sets the calling sparsity pattern to be the same as

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -501,7 +501,7 @@ namespace TrilinosWrappers
        * Move constructor. Creates a new vector by stealing the internal data
        * of the vector @p v.
        */
-      Vector (Vector &&v);
+      Vector (Vector &&v) noexcept;
 
       /**
        * Destructor.
@@ -646,7 +646,7 @@ namespace TrilinosWrappers
        * Move the given vector. This operator replaces the present vector with
        * @p v by efficiently swapping the internal data structures.
        */
-      Vector &operator= (Vector &&v);
+      Vector &operator= (Vector &&v) noexcept;
 
       /**
        * Another copy function. This one takes a deal.II vector and copies it

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -151,7 +151,7 @@ public:
    * Move constructor. Creates a new vector by stealing the internal data of
    * the vector @p v.
    */
-  Vector (Vector<Number> &&v);
+  Vector (Vector<Number> &&v) noexcept;
 
   /**
    * Copy constructor taking a vector of another data type. This will fail if
@@ -341,7 +341,7 @@ public:
    * the internal data of the vector @p v and resets @p v to the state it would
    * have after being newly default-constructed.
    */
-  Vector<Number> &operator= (Vector<Number> &&v);
+  Vector<Number> &operator= (Vector<Number> &&v) noexcept;
 
   /**
    * Copy the given vector. Resize the present vector if necessary.

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -60,13 +60,13 @@ Vector<Number>::Vector (const Vector<Number> &v)
 
 
 template <typename Number>
-Vector<Number>::Vector (Vector<Number> &&v)
-  :
-  Subscriptor(std::move(v)),
-  vec_size(v.vec_size),
-  max_vec_size(v.max_vec_size),
-  values(std::move(v.values)),
-  thread_loop_partitioner(std::move(v.thread_loop_partitioner))
+Vector<Number>::Vector (Vector<Number> &&v) noexcept
+:
+Subscriptor(std::move(v)),
+            vec_size(v.vec_size),
+            max_vec_size(v.max_vec_size),
+            values(std::move(v.values)),
+            thread_loop_partitioner(std::move(v.thread_loop_partitioner))
 {
   v.vec_size = 0;
   v.max_vec_size = 0;
@@ -220,7 +220,7 @@ Vector<Number>::operator= (const Vector<Number> &v)
 template <typename Number>
 inline
 Vector<Number> &
-Vector<Number>::operator= (Vector<Number> &&v)
+Vector<Number>::operator= (Vector<Number> &&v) noexcept
 {
   Subscriptor::operator=(std::move(v));
 

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -200,13 +200,13 @@ public:
      * Move constructor: this creates a new Pointer by stealing the internal
      * data owned by @p p.
      */
-    Pointer(Pointer &&p) = default;
+    Pointer(Pointer &&p) noexcept = default;
 
     /**
      * Move operator: this releases the vector owned by the current Pointer
      * and then steals the internal data owned by @p p.
      */
-    Pointer &operator = (Pointer &&p) = default;
+    Pointer &operator = (Pointer &&p) noexcept = default;
 
     /**
      * Constructor. This constructor automatically allocates a vector from

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -154,7 +154,7 @@ namespace Particles
      * Move constructor for Particle, creates a particle from an existing
      * one by stealing its state.
      */
-    Particle (Particle<dim,spacedim> &&particle);
+    Particle (Particle<dim,spacedim> &&particle) noexcept;
 
     /**
      * Copy assignment operator.
@@ -164,7 +164,7 @@ namespace Particles
     /**
      * Move assignment operator.
      */
-    Particle<dim,spacedim> &operator=(Particle<dim,spacedim> &&particle);
+    Particle<dim,spacedim> &operator=(Particle<dim,spacedim> &&particle) noexcept;
 
     /**
      * Destructor. Releases the property handle if it is valid, and

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -46,10 +46,10 @@ Subscriptor::Subscriptor (const Subscriptor &)
 
 
 
-Subscriptor::Subscriptor (Subscriptor &&subscriptor)
-  :
-  counter(0),
-  object_info (subscriptor.object_info)
+Subscriptor::Subscriptor (Subscriptor &&subscriptor) noexcept
+:
+counter(0),
+        object_info (subscriptor.object_info)
 {
   subscriptor.check_no_subscribers();
 }
@@ -135,7 +135,7 @@ Subscriptor &Subscriptor::operator = (const Subscriptor &s)
 
 
 
-Subscriptor &Subscriptor::operator = (Subscriptor &&s)
+Subscriptor &Subscriptor::operator = (Subscriptor &&s) noexcept
 {
   s.check_no_subscribers();
   object_info = s.object_info;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -8829,22 +8829,22 @@ Triangulation (const MeshSmoothing smooth_grid,
 
 template <int dim, int spacedim>
 Triangulation<dim, spacedim>::
-Triangulation (Triangulation<dim, spacedim> &&tria)
-  :
-  Subscriptor(tria),
-  smooth_grid(tria.smooth_grid),
-  periodic_face_pairs_level_0(std::move(tria.periodic_face_pairs_level_0)),
-  periodic_face_map(std::move(tria.periodic_face_map)),
-  levels(std::move(tria.levels)),
-  faces(std::move(tria.faces)),
-  vertices(std::move(tria.vertices)),
-  vertices_used(std::move(tria.vertices_used)),
-  manifold(std::move(tria.manifold)),
-  anisotropic_refinement(tria.anisotropic_refinement),
-  check_for_distorted_cells(tria.check_for_distorted_cells),
-  number_cache(tria.number_cache),
-  vertex_to_boundary_id_map_1d(std::move(tria.vertex_to_boundary_id_map_1d)),
-  vertex_to_manifold_id_map_1d(std::move(tria.vertex_to_manifold_id_map_1d))
+Triangulation (Triangulation<dim, spacedim> &&tria) noexcept
+:
+Subscriptor(std::move(tria)),
+            smooth_grid(tria.smooth_grid),
+            periodic_face_pairs_level_0(std::move(tria.periodic_face_pairs_level_0)),
+            periodic_face_map(std::move(tria.periodic_face_map)),
+            levels(std::move(tria.levels)),
+            faces(std::move(tria.faces)),
+            vertices(std::move(tria.vertices)),
+            vertices_used(std::move(tria.vertices_used)),
+            manifold(std::move(tria.manifold)),
+            anisotropic_refinement(tria.anisotropic_refinement),
+            check_for_distorted_cells(tria.check_for_distorted_cells),
+            number_cache(std::move(tria.number_cache)),
+            vertex_to_boundary_id_map_1d(std::move(tria.vertex_to_boundary_id_map_1d)),
+            vertex_to_manifold_id_map_1d(std::move(tria.vertex_to_manifold_id_map_1d))
 {
   tria.number_cache = internal::Triangulation::NumberCache<dim>();
 }
@@ -8852,7 +8852,7 @@ Triangulation (Triangulation<dim, spacedim> &&tria)
 
 template <int dim, int spacedim>
 Triangulation<dim, spacedim> &
-Triangulation<dim, spacedim>::operator= (Triangulation<dim, spacedim> &&tria)
+Triangulation<dim, spacedim>::operator= (Triangulation<dim, spacedim> &&tria) noexcept
 {
   Subscriptor::operator=(std::move(tria));
 

--- a/source/lac/trilinos_block_vector.cc
+++ b/source/lac/trilinos_block_vector.cc
@@ -59,7 +59,7 @@ namespace TrilinosWrappers
 
 
     BlockVector &
-    BlockVector::operator= (BlockVector &&v)
+    BlockVector::operator= (BlockVector &&v) noexcept
     {
       swap(v);
       return *this;

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -355,14 +355,14 @@ namespace TrilinosWrappers
 
 
 
-  SparseMatrix::SparseMatrix (SparseMatrix &&other)
-    :
-    column_space_map(std::move(other.column_space_map)),
-    matrix(std::move(other.matrix)),
-    nonlocal_matrix(std::move(other.nonlocal_matrix)),
-    nonlocal_matrix_exporter(std::move(other.nonlocal_matrix_exporter)),
-    last_action(other.last_action),
-    compressed(other.compressed)
+  SparseMatrix::SparseMatrix (SparseMatrix &&other) noexcept
+:
+  column_space_map(std::move(other.column_space_map)),
+                   matrix(std::move(other.matrix)),
+                   nonlocal_matrix(std::move(other.nonlocal_matrix)),
+                   nonlocal_matrix_exporter(std::move(other.nonlocal_matrix_exporter)),
+                   last_action(other.last_action),
+                   compressed(other.compressed)
   {
     other.last_action = Zero;
     other.compressed = false;

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -143,12 +143,12 @@ namespace TrilinosWrappers
 
 
 
-  SparsityPattern::SparsityPattern (SparsityPattern &&other)
-    :
-    Subscriptor(std::move(other)),
-    column_space_map(std::move(other.column_space_map)),
-    graph(std::move(other.graph)),
-    nonlocal_graph(std::move(other.nonlocal_graph))
+  SparsityPattern::SparsityPattern (SparsityPattern &&other) noexcept
+:
+  Subscriptor(std::move(other)),
+              column_space_map(std::move(other.column_space_map)),
+              graph(std::move(other.graph)),
+              nonlocal_graph(std::move(other.nonlocal_graph))
   {}
 
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -92,8 +92,9 @@ namespace TrilinosWrappers
 
 
 
-    Vector::Vector (Vector &&v)
-      : Vector()
+    Vector::Vector (Vector &&v) noexcept
+:
+    Vector()
     {
       // initialize a minimal, valid object and swap
       swap(v);
@@ -467,7 +468,7 @@ namespace TrilinosWrappers
 
 
 
-    Vector &Vector::operator= (Vector &&v)
+    Vector &Vector::operator= (Vector &&v) noexcept
     {
       swap(v);
       return *this;

--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -98,13 +98,13 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  Particle<dim,spacedim>::Particle (Particle<dim,spacedim> &&particle)
-    :
-    location (particle.location),
-    reference_location(particle.reference_location),
-    id (particle.id),
-    property_pool(particle.property_pool),
-    properties(particle.properties)
+  Particle<dim,spacedim>::Particle (Particle<dim,spacedim> &&particle) noexcept
+:
+  location (std::move(particle.location)),
+           reference_location(std::move(particle.reference_location)),
+           id (std::move(particle.id)),
+           property_pool(std::move(particle.property_pool)),
+           properties(std::move(particle.properties))
   {
     particle.properties = PropertyPool::invalid_handle;
   }
@@ -140,7 +140,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   Particle<dim,spacedim> &
-  Particle<dim,spacedim>::operator=(Particle<dim,spacedim> &&particle)
+  Particle<dim,spacedim>::operator=(Particle<dim,spacedim> &&particle) noexcept
   {
     if (this != &particle)
       {


### PR DESCRIPTION
The `llvm-6` `clang-tidy` version has gained a few new checks. In particular, there are some suggestions regarding [performance-noexcept-move-constructor](https://clang.llvm.org/extra/clang-tidy/checks/performance-noexcept-move-constructor.html) and [performance-move-constructor-init](https://clang.llvm.org/extra/clang-tidy/checks/performance-move-constructor-init.html).
For the cases where we use `default` `move` constructors and `move assigment` operators, I didn't want to modify the declaration (`[...] noexecpt = default` doesn't work) and marked the places with `NOLINT`.

Admittedly, appending a `noexcept` specifier to the move constructors leads to a strange formatting (which I wasn't able to fix easily; maybe again a reason to switch to `clang-format` at some point...).