### PR TITLE
Allow to run the testsuite with valgrind

### DIFF
--- a/doc/developers/testsuite.html
+++ b/doc/developers/testsuite.html
@@ -292,6 +292,33 @@ xx: ===============================    OUTPUT END   ============================
     </p>
 
 
+    <a name="memcheck"></a>
+     <h3>Running with valgrind</h3>
+
+     <p>
+       The testsuite can also be run using <a href="http://valgrind.org/">valgrind</a>
+       to check for <i>memory corruption</i> in the library.
+     </p>
+
+     <p>
+       You can do so by invoking
+ <pre>
+ ctest -DMEMORYCHECK=ON <...> -S ../tests/run_testsuite.cmake
+ </pre>
+       when running the testsuite, or directly by
+ <pre>
+ ctest <...> -S ../tests/run_memorycheck.cmake
+ </pre>
+     </p>
+
+     <p>
+       At the end of all of this, results will be shown in a separate section
+       "Dynamic Analysis" at the
+       <a href="http://cdash.kyomu.43-1.org/index.php?project=deal.II&display=project"
+       target="_top">deal.II cdash site</a>.
+     </p>
+
+
     <a name="coverage"></a>
     <h3>Generating coverage information</h3>
 

--- a/doc/news/changes/minor/20180311DanielArndt
+++ b/doc/news/changes/minor/20180311DanielArndt
@@ -1,0 +1,4 @@
+New: The testsuite can be run using valgrind via
+'ctest -S ../tests/run_memorycheck.cmake'.
+<br>
+(Daniel Arndt, 2018/03/11)


### PR DESCRIPTION
Fixes #6018. Example results can be found at https://cdash.kyomu.43-1.org/viewDynamicAnalysis.php?buildid=16224.

As expected running `valgrind` for the `MPI` doesn't work cleanly. I am not sure if we want to add some suppression file.