### PR TITLE
 Improve readability of GridTools::compute_*_point_locations' return value

### DIFF
--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -451,13 +451,13 @@ namespace Functions
   {
     // Calling the GridTools routine and preparing output
     auto cell_qpoint_map = GridTools::compute_point_locations(cache,points,cell_hint.get());
-    const auto &tria_cells = std::get<0>(cell_qpoint_map);
+    const auto &tria_cells = cell_qpoint_map.cells;
     cells.resize(tria_cells.size());
     unsigned int i = 0;
     for (const auto &c: tria_cells)
       cells[i++] = typename DoFHandlerType::cell_iterator(*c,dh);
-    qpoints = std::get<1>(cell_qpoint_map);
-    maps = std::get<2>(cell_qpoint_map);
+    qpoints = cell_qpoint_map.qpoints;
+    maps = cell_qpoint_map.maps;
     return cells.size();
   }
 

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -70,20 +70,13 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
                                   const std::vector<bool>  &);
 
     template
-    std::tuple< std::vector< typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator >,
-                std::vector< std::vector< Point< deal_II_dimension > > >, std::vector< std::vector< unsigned int > > >
+    PointLocations<deal_II_dimension, deal_II_space_dimension>
     compute_point_locations(const Cache< deal_II_dimension, deal_II_space_dimension > &,
                             const std::vector< Point< deal_II_space_dimension > > &,
                             const typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator &);
 
     template
-    std::tuple<
-        std::vector< typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator >,
-        std::vector< std::vector< Point<deal_II_dimension> > >,
-        std::vector< std::vector< unsigned int > >,
-        std::vector< std::vector< Point<deal_II_space_dimension> > >,
-        std::vector< std::vector< unsigned int > >
-        >
+    DistributedPointLocations<deal_II_dimension, deal_II_space_dimension>
     distributed_compute_point_locations
     (const Cache< deal_II_dimension, deal_II_space_dimension >   &,
      const std::vector< Point< deal_II_space_dimension > >       &,

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -310,9 +310,9 @@ namespace Particles
     GridTools::Cache<dim,spacedim> cache(*triangulation, *mapping);
     auto point_locations = GridTools::compute_point_locations(cache, positions);
 
-    auto &cells = std::get<0>(point_locations);
-    auto &local_positions = std::get<1>(point_locations);
-    auto &index_map = std::get<2>(point_locations);
+    auto &cells = point_locations.cells;
+    auto &local_positions = point_locations.qpoints;
+    auto &index_map = point_locations.maps;
 
     if (cells.size() == 0)
       return;

--- a/tests/grid/compute_point_locations_01.cc
+++ b/tests/grid/compute_point_locations_01.cc
@@ -62,20 +62,20 @@ void test_compute_pt_loc(unsigned int n_points)
   GridTools::Cache<dim,dim> cache(tria);
 
   auto cell_qpoint_map = GridTools::compute_point_locations(cache,points);
-  size_t n_cells = std::get<0>(cell_qpoint_map).size();
+  size_t n_cells = cell_qpoint_map.cells.size();
 
   deallog << "Points found in " << n_cells << " cells" << std::endl;
 
   // testing if the transformation is correct:
   // For each cell check if the quadrature points in the i-th FE
-  // are the same as std::get<2>(cell_qpoint_map)[i]
-  for (unsigned int i=0; i<std::get<0>(cell_qpoint_map).size(); ++i)
+  // are the same as cell_qpoint_map.maps[i]
+  for (unsigned int i=0; i<cell_qpoint_map.cells.size(); ++i)
     {
-      auto &cell = std::get<0>(cell_qpoint_map)[i];
-      auto &quad = std::get<1>(cell_qpoint_map)[i];
-      auto &local_map = std::get<2>(cell_qpoint_map)[i];
+      auto &cell = cell_qpoint_map.cells[i];
+      auto &quad = cell_qpoint_map.qpoints[i];
+      auto &local_map = cell_qpoint_map.maps[i];
 
-      // Given the std::get<1>(cell_qpoint_map) of the current cell, compute the real points
+      // Given the cell_qpoint_map.qpoints of the current cell, compute the real points
       FEValues<dim> fev(fe, quad, update_quadrature_points);
       fev.reinit(cell);
       const auto &real_quad = fev.get_quadrature_points();

--- a/tests/grid/compute_point_locations_02.cc
+++ b/tests/grid/compute_point_locations_02.cc
@@ -69,20 +69,20 @@ void test_compute_pt_loc(unsigned int n_points)
   auto my_pair = GridTools::find_active_cell_around_point
                  (cache, points[0]);
   auto cell_qpoint_map = GridTools::compute_point_locations(cache,points,my_pair.first);
-  size_t n_cells = std::get<0>(cell_qpoint_map).size();
+  size_t n_cells = cell_qpoint_map.cells.size();
 
   deallog << "Points found in " << n_cells << " cells" << std::endl;
 
   // testing if the transformation is correct:
   // For each cell check if the quadrature points in the i-th FE
-  // are the same as std::get<2>(cell_qpoint_map)[i]
-  for (unsigned int i=0; i<std::get<0>(cell_qpoint_map).size(); ++i)
+  // are the same as cell_qpoint_map.maps[i]
+  for (unsigned int i=0; i<cell_qpoint_map.cells.size(); ++i)
     {
-      auto &cell = std::get<0>(cell_qpoint_map)[i];
-      auto &quad = std::get<1>(cell_qpoint_map)[i];
-      auto &local_map = std::get<2>(cell_qpoint_map)[i];
+      auto &cell = cell_qpoint_map.cells[i];
+      auto &quad = cell_qpoint_map.qpoints[i];
+      auto &local_map = cell_qpoint_map.maps[i];
 
-      // Given the std::get<1>(cell_qpoint_map) of the current cell, compute the real points
+      // Given the cell_qpoint_map.qpoints of the current cell, compute the real points
       FEValues<dim> fev(fe, quad, update_quadrature_points);
       fev.reinit(cell);
       const auto &real_quad = fev.get_quadrature_points();

--- a/tests/grid/distributed_compute_point_locations_01.cc
+++ b/tests/grid/distributed_compute_point_locations_01.cc
@@ -62,9 +62,9 @@ void test_compute_pt_loc(unsigned int n_points)
   // Testing in serial against the serial version
   auto cell_qpoint_map = GridTools::compute_point_locations(cache,points);
 
-  auto &serial_cells = std::get<0>(cell_qpoint_map);
-  auto &serial_qpoints = std::get<1>(cell_qpoint_map);
-  size_t n_cells = std::get<0>(output_tuple).size();
+  auto &serial_cells = cell_qpoint_map.cells;
+  auto &serial_qpoints = cell_qpoint_map.qpoints;
+  size_t n_cells = output_tuple.cells.size();
 
   deallog << "Points found in " << n_cells << " cells" << std::endl;
 
@@ -72,11 +72,11 @@ void test_compute_pt_loc(unsigned int n_points)
   // the serial one
   for (unsigned int c=0; c<n_cells; ++c)
     {
-      auto &cell = std::get<0>(output_tuple)[c];
-      auto &quad = std::get<1>(output_tuple)[c];
-      auto &local_map = std::get<2>(output_tuple)[c];
-      auto &original_points = std::get<3>(output_tuple)[c];
-      auto &ranks = std::get<4>(output_tuple)[c];
+      auto &cell = output_tuple.cells[c];
+      auto &quad = output_tuple.qpoints[c];
+      auto &local_map = output_tuple.maps[c];
+      auto &original_points = output_tuple.points[c];
+      auto &ranks = output_tuple.owners[c];
 
       auto pos_cell = std::find(serial_cells.begin(),serial_cells.end(),cell);
       for (auto r: ranks)

--- a/tests/grid/distributed_compute_point_locations_02.cc
+++ b/tests/grid/distributed_compute_point_locations_02.cc
@@ -125,10 +125,10 @@ void test_compute_pt_loc(unsigned int ref_cube, unsigned int ref_sphere)
   auto output_tuple = distributed_compute_point_locations
                       (cache,loc_owned_points,local_bbox);
   deallog << "Comparing results" << std::endl;
-  const auto &output_cells = std::get<0>(output_tuple);
-  const auto &output_qpoints = std::get<1>(output_tuple);
-  const auto &output_points = std::get<3>(output_tuple);
-  const auto &output_ranks = std::get<4>(output_tuple);
+  const auto &output_cells = output_tuple.cells;
+  const auto &output_qpoints = output_tuple.qpoints;
+  const auto &output_points = output_tuple.points;
+  const auto &output_ranks = output_tuple.owners;
 
   // Comparing the output with the previously computed computed result
   bool test_passed = true;


### PR DESCRIPTION
This is one approach to resolve #5986.
Here, we store the return type in separate struct. This also allows as to annotate the individual components a bit better. Since these functions don't exist in release `8.5`, this change does not introduce compatibility issues with previous versions (but only with respect to the current developer branch).