### PR TITLE
Convert an Assert into static_assert.

### DIFF
--- a/include/deal.II/base/table_indices.h
+++ b/include/deal.II/base/table_indices.h
@@ -43,6 +43,9 @@ template <int N>
 class TableIndices
 {
 public:
+  static_assert (N > 0,
+                 "TableIndices objects need to represent at least one index.");
+
 
   /**
    * Default constructor. This constructor sets all indices to zero.
@@ -182,8 +185,6 @@ protected:
 template <int N>
 TableIndices<N>::TableIndices()
 {
-  Assert (N > 0, ExcMessage("Cannot create a TableIndices object of size 0"));
-
   for (unsigned int i=0; i<N; ++i)
     indices[i] = 0;
 }
@@ -271,8 +272,6 @@ TableIndices<N>::TableIndices(const std::size_t index0,
                               const std::size_t index7,
                               const std::size_t index8)
 {
-  Assert (N > 0, ExcMessage("Cannot create a TableIndices object of size 0"));
-
   switch (N)
     {
     case 1:


### PR DESCRIPTION
The TableIndices class had Assert statements in a couple of places
that the number of indices in question is a positive number, not zero.
Proximally, this led to Coverity complaining that a function called in a
noexcept function of Table may in fact throw an exception. The warning
is correct, and is most easily worked around by converting the
assertion into a static_assert -- which has to hold for the entire
class, so that's where I moved it from the affected member functions.

Fixes #6056.