### PR TITLE
ScaLAPACKMatrix: add eigensolver routines using MRRR algorithm

### DIFF
--- a/include/deal.II/lac/lapack_templates.h
+++ b/include/deal.II/lac/lapack_templates.h
@@ -221,6 +221,25 @@ extern "C"
                 dealii::types::blas_int *m, float *w, float *z,
                 const dealii::types::blas_int *ldz, float *work, const dealii::types::blas_int *lwork, dealii::types::blas_int *iwork,
                 dealii::types::blas_int *ifail, dealii::types::blas_int *info);
+  // Same functionality as dsyev_ but using MRRR algorithm and with more options:
+  // E.g. compute only eigenvalues in a specific dealii::types::blas_interval,
+  // Compute only eigenvalues with a specific index.
+  void dsyevr_(const char *jobz, const char *range,
+               const char *uplo, const dealii::types::blas_int *n, double *A, const dealii::types::blas_int *lda,
+               const double *vl, const double *vu,
+               const dealii::types::blas_int *il, const dealii::types::blas_int *iu, const double *abstol,
+               dealii::types::blas_int *m, double *w, double *z,
+               const dealii::types::blas_int *ldz, dealii::types::blas_int *isuppz,
+               double *work, dealii::types::blas_int *lwork, dealii::types::blas_int *iwork,
+               dealii::types::blas_int *liwork, dealii::types::blas_int *info);
+  void ssyevr_(const char *jobz, const char *range,
+               const char *uplo, const dealii::types::blas_int *n, float *A, const dealii::types::blas_int *lda,
+               const float *vl, const float *vu,
+               const dealii::types::blas_int *il, const dealii::types::blas_int *iu, const float *abstol,
+               dealii::types::blas_int *m, float *w, float *z,
+               const dealii::types::blas_int *ldz, dealii::types::blas_int *isuppz,
+               float *work, dealii::types::blas_int *lwork, dealii::types::blas_int *iwork,
+               dealii::types::blas_int *liwork, dealii::types::blas_int *info);
 // Generalized eigenvalues and eigenvectors of
 // 1: A*x = lambda*B*x; 2: A*B*x = lambda*x; 3: B*A*x = lambda*x
 // A and B are symmetric and B is definite
@@ -336,6 +355,9 @@ extern "C"
                float *A,
                const dealii::types::blas_int *lda,
                dealii::types::blas_int *info);
+// dlamch and slamch help determining machine precision
+  double dlamch_(const char *chmach);
+  float slamch_(const char *chmach);
 }
 
 DEAL_II_NAMESPACE_OPEN
@@ -1326,6 +1348,145 @@ syevx (const char *, const char *, const char *, const types::blas_int *, float 
 #endif
 
 
+// Template wrapper for LAPACK functions dsyevr and ssyevr
+template <typename number>
+inline void
+syevr(const char * /*jobz*/,
+      const char * /*range*/,
+      const char * /*uplo*/,
+      const types::blas_int * /*n*/,
+      number * /*A*/,
+      const types::blas_int * /*lda*/,
+      const number * /*vl*/,
+      const number * /*vu*/,
+      const types::blas_int * /*il*/,
+      const types::blas_int * /*iu*/,
+      const number * /*abstol*/,
+      types::blas_int * /*m*/,
+      number * /*w*/,
+      number * /*z*/,
+      const types::blas_int * /*ldz*/,
+      types::blas_int * /*isuppz*/,
+      number * /*work*/,
+      types::blas_int * /*lwork*/,
+      types::blas_int * /*iwork*/,
+      types::blas_int * /*liwork*/,
+      types::blas_int * /*info*/)
+{
+  Assert(false, ExcNotImplemented());
+}
+
+
+#ifdef DEAL_II_WITH_LAPACK
+inline void
+syevr(const char *jobz,
+      const char *range,
+      const char *uplo,
+      const types::blas_int *n,
+      double *A,
+      const types::blas_int *lda,
+      const double *vl,
+      const double *vu,
+      const types::blas_int *il,
+      const types::blas_int *iu,
+      const double *abstol,
+      types::blas_int *m,
+      double *w,
+      double *z,
+      const types::blas_int *ldz,
+      types::blas_int *isuppz,
+      double *work,
+      types::blas_int *lwork,
+      types::blas_int *iwork,
+      types::blas_int *liwork,
+      types::blas_int *info)
+{
+  dsyevr_(jobz,range,uplo,n,A,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info);
+}
+#else
+inline void
+syevr(const char * /*jobz*/,
+      const char * /*range*/,
+      const char * /*uplo*/,
+      const types::blas_int * /*n*/,
+      double * /*A*/,
+      const types::blas_int * /*lda*/,
+      const double * /*vl*/,
+      const double * /*vu*/,
+      const types::blas_int * /*il*/,
+      const types::blas_int * /*iu*/,
+      const double * /*abstol*/,
+      types::blas_int * /*m*/,
+      double * /*w*/,
+      double * /*z*/,
+      const types::blas_int * /*ldz*/,
+      types::blas_int * /*isuppz*/,
+      double * /*work*/,
+      types::blas_int * /*lwork*/,
+      types::blas_int * /*iwork*/,
+      types::blas_int * /*liwork*/,
+      types::blas_int * /*info*/)
+{
+  Assert (false, LAPACKSupport::ExcMissing("dsyevr"));
+}
+#endif
+
+
+#ifdef DEAL_II_WITH_LAPACK
+inline void
+syevr(const char *jobz,
+      const char *range,
+      const char *uplo,
+      const types::blas_int *n,
+      float *A,
+      const types::blas_int *lda,
+      const float *vl,
+      const float *vu,
+      const types::blas_int *il,
+      const types::blas_int *iu,
+      const float *abstol,
+      types::blas_int *m,
+      float *w,
+      float *z,
+      const types::blas_int *ldz,
+      types::blas_int *isuppz,
+      float *work,
+      types::blas_int *lwork,
+      types::blas_int *iwork,
+      types::blas_int *liwork,
+      types::blas_int *info)
+{
+  ssyevr_(jobz,range,uplo,n,A,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info);
+}
+#else
+inline void
+syevr(const char * /*jobz*/,
+      const char * /*range*/,
+      const char * /*uplo*/,
+      const types::blas_int * /*n*/,
+      float * /*A*/,
+      const types::blas_int * /*lda*/,
+      const float * /*vl*/,
+      const float * /*vu*/,
+      const types::blas_int * /*il*/,
+      const types::blas_int * /*iu*/,
+      const float * /*abstol*/,
+      types::blas_int * /*m*/,
+      float * /*w*/,
+      float * /*z*/,
+      const types::blas_int * /*ldz*/,
+      types::blas_int * /*isuppz*/,
+      float * /*work*/,
+      types::blas_int * /*lwork*/,
+      types::blas_int * /*iwork*/,
+      types::blas_int * /*liwork*/,
+      types::blas_int * /*info*/)
+{
+  Assert (false, LAPACKSupport::ExcMissing("ssyevr"));
+}
+#endif
+
+
 /// Template wrapper for LAPACK functions dsygv and ssygv
 template <typename number1, typename number2, typename number3, typename number4>
 inline void
@@ -1619,6 +1780,42 @@ lascl(const char *, const types::blas_int *, const types::blas_int *, const floa
 }
 #endif
 
+
+/// Template wrapper for LAPACK functions dlamch and slamch
+template <typename number>
+inline void
+lamch(const char * /*chmach*/, number & /*precision*/)
+{
+  Assert(false, ExcNotImplemented());
+}
+
+#ifdef DEAL_II_WITH_LAPACK
+inline void
+lamch(const char *chmach, double &precision)
+{
+  precision = dlamch_(chmach);
+}
+#else
+inline void
+lamch(const char * /*chmach*/, double & /*precision*/)
+{
+  Assert(false, LAPACKSupport::ExcMissing("dlamch"));
+}
+#endif
+
+#ifdef DEAL_II_WITH_LAPACK
+inline void
+lamch(const char *chmach, float &precision)
+{
+  precision = slamch_(chmach);
+}
+#else
+inline void
+lamch(const char * /*chmach*/, float & /*precision*/)
+{
+  Assert(false, LAPACKSupport::ExcMissing("slamch"));
+}
+#endif
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/lac/lapack_templates.h
+++ b/include/deal.II/lac/lapack_templates.h
@@ -1403,36 +1403,7 @@ syevr(const char *jobz,
 {
   dsyevr_(jobz,range,uplo,n,A,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info);
 }
-#else
-inline void
-syevr(const char * /*jobz*/,
-      const char * /*range*/,
-      const char * /*uplo*/,
-      const types::blas_int * /*n*/,
-      double * /*A*/,
-      const types::blas_int * /*lda*/,
-      const double * /*vl*/,
-      const double * /*vu*/,
-      const types::blas_int * /*il*/,
-      const types::blas_int * /*iu*/,
-      const double * /*abstol*/,
-      types::blas_int * /*m*/,
-      double * /*w*/,
-      double * /*z*/,
-      const types::blas_int * /*ldz*/,
-      types::blas_int * /*isuppz*/,
-      double * /*work*/,
-      types::blas_int * /*lwork*/,
-      types::blas_int * /*iwork*/,
-      types::blas_int * /*liwork*/,
-      types::blas_int * /*info*/)
-{
-  Assert (false, LAPACKSupport::ExcMissing("dsyevr"));
-}
-#endif
 
-
-#ifdef DEAL_II_WITH_LAPACK
 inline void
 syevr(const char *jobz,
       const char *range,
@@ -1457,32 +1428,6 @@ syevr(const char *jobz,
       types::blas_int *info)
 {
   ssyevr_(jobz,range,uplo,n,A,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info);
-}
-#else
-inline void
-syevr(const char * /*jobz*/,
-      const char * /*range*/,
-      const char * /*uplo*/,
-      const types::blas_int * /*n*/,
-      float * /*A*/,
-      const types::blas_int * /*lda*/,
-      const float * /*vl*/,
-      const float * /*vu*/,
-      const types::blas_int * /*il*/,
-      const types::blas_int * /*iu*/,
-      const float * /*abstol*/,
-      types::blas_int * /*m*/,
-      float * /*w*/,
-      float * /*z*/,
-      const types::blas_int * /*ldz*/,
-      types::blas_int * /*isuppz*/,
-      float * /*work*/,
-      types::blas_int * /*lwork*/,
-      types::blas_int * /*iwork*/,
-      types::blas_int * /*liwork*/,
-      types::blas_int * /*info*/)
-{
-  Assert (false, LAPACKSupport::ExcMissing("ssyevr"));
 }
 #endif
 
@@ -1795,25 +1740,11 @@ lamch(const char *chmach, double &precision)
 {
   precision = dlamch_(chmach);
 }
-#else
-inline void
-lamch(const char * /*chmach*/, double & /*precision*/)
-{
-  Assert(false, LAPACKSupport::ExcMissing("dlamch"));
-}
-#endif
 
-#ifdef DEAL_II_WITH_LAPACK
 inline void
 lamch(const char *chmach, float &precision)
 {
   precision = slamch_(chmach);
-}
-#else
-inline void
-lamch(const char * /*chmach*/, float & /*precision*/)
-{
-  Assert(false, LAPACKSupport::ExcMissing("slamch"));
 }
 #endif
 

--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -423,7 +423,7 @@ public:
 
   /**
    * Computing selected eigenvalues and, optionally, the eigenvectors of the real symmetric
-   * matrix $A \in \mathbb{R}^{M \times M}$ using the MRRR algorithm.
+   * matrix $\mathbf{A} \in \mathbb{R}^{M \times M}$ using the MRRR algorithm.
    *
    * The eigenvalues/eigenvectors are selected by prescribing a range of indices @p index_limits.
    *
@@ -439,7 +439,8 @@ public:
                                                              const bool compute_eigenvectors);
 
   /**
-   * Computing selected eigenvalues and, optionally, the eigenvectors using the MRRR algorithm.
+   * Computing selected eigenvalues and, optionally, the eigenvectors of the real symmetric
+   * matrix $\mathbf{A} \in \mathbb{R}^{M \times M}$ using the MRRR algorithm.
    * The eigenvalues/eigenvectors are selected by prescribing a range of values @p value_limits for the eigenvalues.
    *
    * If successful, the computed eigenvalues are arranged in ascending order.
@@ -635,14 +636,19 @@ private:
                                                  std::make_pair(std::numeric_limits<NumberType>::quiet_NaN(),std::numeric_limits<NumberType>::quiet_NaN()));
 
   /**
-   * Computing selected eigenvalues and, optionally, the eigenvectors using the MRRR algorithm.
+   * Computing selected eigenvalues and, optionally, the eigenvectors of the real symmetric
+   * matrix $\mathbf{A} \in \mathbb{R}^{M \times M}$ using the MRRR algorithm.
    * The eigenvalues/eigenvectors are selected by either prescribing a range of indices @p index_limits
    * or a range of values @p value_limits for the eigenvalues. The function will throw an exception
    * if both ranges are prescribed (meaning that both ranges differ from the default value)
    * as this ambiguity is prohibited.
+   *
+   * By calling this function the original content of the matrix will be overwritten.
+   * If requested, the eigenvectors are stored in the columns of the matrix.
+   * Also in the case that just the eigenvalues are required,
+   * the content of the matrix will be overwritten.
+   *
    * If successful, the computed eigenvalues are arranged in ascending order.
-   * The eigenvectors are stored in the columns of the matrix, thereby
-   * overwriting the original content of the matrix.
    */
   std::vector<NumberType> eigenpairs_symmetric_MRRR(const bool compute_eigenvectors,
                                                     const std::pair<unsigned int,unsigned int> &index_limits=

--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -422,6 +422,34 @@ public:
                                                         const bool compute_eigenvectors);
 
   /**
+   * Computing selected eigenvalues and, optionally, the eigenvectors of the real symmetric
+   * matrix $A \in \mathbb{R}^{M \times M}$ using the MRRR algorithm.
+   *
+   * The eigenvalues/eigenvectors are selected by prescribing a range of indices @p index_limits.
+   *
+   * If successful, the computed eigenvalues are arranged in ascending order.
+   * The eigenvectors are stored in the columns of the matrix, thereby
+   * overwriting the original content of the matrix.
+   *
+   * If all eigenvalues/eigenvectors have to be computed, pass the closed interval $ \left[ 0, M-1 \right] $ in @p index_limits.
+   *
+   * Pass the closed interval $ \left[ M-r, M-1 \right] $ if the $r$ largest eigenvalues/eigenvectors are desired.
+   */
+  std::vector<NumberType> eigenpairs_symmetric_by_index_MRRR(const std::pair<unsigned int,unsigned int> &index_limits,
+                                                             const bool compute_eigenvectors);
+
+  /**
+   * Computing selected eigenvalues and, optionally, the eigenvectors using the MRRR algorithm.
+   * The eigenvalues/eigenvectors are selected by prescribing a range of values @p value_limits for the eigenvalues.
+   *
+   * If successful, the computed eigenvalues are arranged in ascending order.
+   * The eigenvectors are stored in the columns of the matrix, thereby
+   * overwriting the original content of the matrix.
+   */
+  std::vector<NumberType> eigenpairs_symmetric_by_value_MRRR(const std::pair<NumberType,NumberType> &value_limits,
+                                                             const bool compute_eigenvectors);
+
+  /**
   * Computing the singular value decomposition (SVD) of a
   * matrix $A \in \mathbb{R}^{M \times N}$, optionally computing the left and/or right
   * singular vectors. The SVD is written as $A = U * \Sigma * V^T$
@@ -605,6 +633,22 @@ private:
                                                  std::make_pair(numbers::invalid_unsigned_int,numbers::invalid_unsigned_int),
                                                const std::pair<NumberType,NumberType> &value_limits=
                                                  std::make_pair(std::numeric_limits<NumberType>::quiet_NaN(),std::numeric_limits<NumberType>::quiet_NaN()));
+
+  /**
+   * Computing selected eigenvalues and, optionally, the eigenvectors using the MRRR algorithm.
+   * The eigenvalues/eigenvectors are selected by either prescribing a range of indices @p index_limits
+   * or a range of values @p value_limits for the eigenvalues. The function will throw an exception
+   * if both ranges are prescribed (meaning that both ranges differ from the default value)
+   * as this ambiguity is prohibited.
+   * If successful, the computed eigenvalues are arranged in ascending order.
+   * The eigenvectors are stored in the columns of the matrix, thereby
+   * overwriting the original content of the matrix.
+   */
+  std::vector<NumberType> eigenpairs_symmetric_MRRR(const bool compute_eigenvectors,
+                                                    const std::pair<unsigned int,unsigned int> &index_limits=
+                                                      std::make_pair(numbers::invalid_unsigned_int,numbers::invalid_unsigned_int),
+                                                    const std::pair<NumberType,NumberType> &value_limits=
+                                                      std::make_pair(std::numeric_limits<NumberType>::quiet_NaN(),std::numeric_limits<NumberType>::quiet_NaN()));
 
   /*
    * Stores the distributed matrix in @p filename

--- a/include/deal.II/lac/scalapack.templates.h
+++ b/include/deal.II/lac/scalapack.templates.h
@@ -743,6 +743,61 @@ extern "C"
                const int *IC,
                const int *JC,
                const int *DESCC);
+
+  /**
+   *  psyevr computes selected eigenvalues and, optionally, eigenvectors
+   *  of a real symmetric matrix A using a parallel implementation of the MRR algorithm.
+   *  Eigenvalues/vectors can be selected by specifying a range of values
+   *  or a range of indices for the desired eigenvalues.
+   */
+  void pdsyevr_(const char *jobz,
+                const char *range,
+                const char *uplo,
+                const int *n,
+                double *A,
+                const int *IA,
+                const int *JA,
+                const int *DESCA,
+                const double *VL,
+                const double *VU,
+                const int *IL,
+                const int *IU,
+                int *m,
+                int *nz,
+                double *w,
+                double *Z,
+                const int *IZ,
+                const int *JZ,
+                const int *DESCZ,
+                double *work,
+                int *lwork,
+                int *iwork,
+                int *liwork,
+                int *info);
+  void pssyevr_(const char *jobz,
+                const char *range,
+                const char *uplo,
+                const int *n,
+                float *A,
+                const int *IA,
+                const int *JA,
+                const int *DESCA,
+                const float *VL,
+                const float *VU,
+                const int *IL,
+                const int *IU,
+                int *m,
+                int *nz,
+                float *w,
+                float *Z,
+                const int *IZ,
+                const int *JZ,
+                const int *DESCZ,
+                float *work,
+                int *lwork,
+                int *iwork,
+                int *liwork,
+                int *info);
 }
 
 
@@ -1650,6 +1705,92 @@ inline void ptran(const int *m,
                   const int *DESCC)
 {
   pstran_(m,n,alpha,A,IA,JA,DESCA,beta,C,IC,JC,DESCC);
+}
+
+
+template <typename number>
+inline void psyevr(const char * /*jobz*/,
+                   const char * /*range*/,
+                   const char * /*uplo*/,
+                   const int * /*n*/,
+                   number * /*A*/,
+                   const int * /*IA*/,
+                   const int * /*JA*/,
+                   const int * /*DESCA*/,
+                   const number * /*VL*/,
+                   const number * /*VU*/,
+                   const int * /*IL*/,
+                   const int * /*IU*/,
+                   int * /*m*/,
+                   int * /*nz*/,
+                   number * /*w*/,
+                   number * /*Z*/,
+                   const int * /*IZ*/,
+                   const int * /*JZ*/,
+                   const int * /*DESCZ*/,
+                   number * /*work*/,
+                   int * /*lwork*/,
+                   int * /*iwork*/,
+                   int * /*liwork*/,
+                   int * /*info*/)
+{
+  Assert (false, dealii::ExcNotImplemented());
+}
+
+inline void psyevr(const char *jobz,
+                   const char *range,
+                   const char *uplo,
+                   const int *n,
+                   double *A,
+                   const int *IA,
+                   const int *JA,
+                   const int *DESCA,
+                   const double *VL,
+                   const double *VU,
+                   const int *IL,
+                   const int *IU,
+                   int *m,
+                   int *nz,
+                   double *w,
+                   double *Z,
+                   const int *IZ,
+                   const int *JZ,
+                   const int *DESCZ,
+                   double *work,
+                   int *lwork,
+                   int *iwork,
+                   int *liwork,
+                   int *info)
+{
+  pdsyevr_(jobz,range,uplo,n,A,IA,JA,DESCA,VL,VU,IL,IU,m,nz,w,Z,IZ,JZ,DESCZ,work,lwork,iwork,liwork,info);
+}
+
+inline void psyevr(const char *jobz,
+                   const char *range,
+                   const char *uplo,
+                   const int *n,
+                   float *A,
+                   const int *IA,
+                   const int *JA,
+                   const int *DESCA,
+                   const float *VL,
+                   const float *VU,
+                   const int *IL,
+                   const int *IU,
+                   int *m,
+                   int *nz,
+                   float *w,
+                   float *Z,
+                   const int *IZ,
+                   const int *JZ,
+                   const int *DESCZ,
+                   float *work,
+                   int *lwork,
+                   int *iwork,
+                   int *liwork,
+                   int *info)
+{
+  pssyevr_(jobz,range,uplo,n,A,IA,JA,DESCA,VL,VU,IL,IU,m,nz,w,Z,IZ,JZ,DESCZ,work,lwork,iwork,liwork,info);
 }
 
 #endif // DEAL_II_WITH_SCALAPACK

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -911,6 +911,185 @@ ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric(const bool compute_eigenvector
 
 
 template <typename NumberType>
+std::vector<NumberType> ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric_by_index_MRRR(const std::pair<unsigned int,unsigned int> &index_limits,
+    const bool compute_eigenvectors)
+{
+  // Check validity of index limits.
+  Assert (index_limits.first < (unsigned int)n_rows,ExcIndexRange(index_limits.first,0,n_rows));
+  Assert (index_limits.second < (unsigned int)n_rows,ExcIndexRange(index_limits.second,0,n_rows));
+
+  std::pair<unsigned int,unsigned int> idx = std::make_pair(std::min(index_limits.first,index_limits.second),
+                                                            std::max(index_limits.first,index_limits.second));
+
+  // Compute all eigenvalues/eigenvectors.
+  if (idx.first==0 && idx.second==(unsigned int)n_rows-1)
+    return eigenpairs_symmetric_MRRR(compute_eigenvectors);
+  else
+    return eigenpairs_symmetric_MRRR(compute_eigenvectors,idx);
+}
+
+
+
+template <typename NumberType>
+std::vector<NumberType> ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric_by_value_MRRR(const std::pair<NumberType,NumberType> &value_limits,
+    const bool compute_eigenvectors)
+{
+  Assert (!std::isnan(value_limits.first),ExcMessage("value_limits.first is NaN"));
+  Assert (!std::isnan(value_limits.second),ExcMessage("value_limits.second is NaN"));
+
+  std::pair<unsigned int,unsigned int> indices = std::make_pair(numbers::invalid_unsigned_int,numbers::invalid_unsigned_int);
+
+  return eigenpairs_symmetric_MRRR(compute_eigenvectors,indices,value_limits);
+}
+
+
+
+template <typename NumberType>
+std::vector<NumberType>
+ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric_MRRR(const bool compute_eigenvectors,
+                                                       const std::pair<unsigned int, unsigned int> &eigenvalue_idx,
+                                                       const std::pair<NumberType,NumberType> &eigenvalue_limits)
+{
+  Assert (state == LAPACKSupport::matrix,
+          ExcMessage("Matrix has to be in Matrix state before calling this function."));
+  Assert (property == LAPACKSupport::symmetric,
+          ExcMessage("Matrix has to be symmetric for this operation."));
+
+  Threads::Mutex::ScopedLock lock(mutex);
+
+  const bool use_values = (std::isnan(eigenvalue_limits.first) || std::isnan(eigenvalue_limits.second)) ? false : true;
+  const bool use_indices = ((eigenvalue_idx.first==numbers::invalid_unsigned_int) || (eigenvalue_idx.second==numbers::invalid_unsigned_int)) ? false : true;
+
+  Assert(!(use_values && use_indices),ExcMessage("Prescribing both the index and value range for the eigenvalues is ambiguous"));
+
+  // If computation of eigenvectors is not required, use a sufficiently small distributed matrix.
+  std::unique_ptr<ScaLAPACKMatrix<NumberType>> eigenvectors = compute_eigenvectors ?
+                                                              std_cxx14::make_unique<ScaLAPACKMatrix<NumberType>>(n_rows,grid,row_block_size) :
+                                                              std_cxx14::make_unique<ScaLAPACKMatrix<NumberType>>(grid->n_process_rows,grid->n_process_columns,grid,1,1);
+
+  eigenvectors->property = property;
+  // Number of eigenvalues to be returned from psyevr; upon successful exit ev contains the m seclected eigenvalues in ascending order.
+  int m = n_rows;
+  std::vector<NumberType> ev(n_rows);
+
+  // Number of eigenvectors to be returned;
+  // Upon successful exit the first m=nz columns contain the selected eigenvectors (only if jobz=='V').
+  int nz=0;
+
+  if (grid->mpi_process_is_active)
+    {
+      int info = 0;
+      /*
+       * For jobz==N only eigenvalues are computed, for jobz='V' also the eigenvectors of the matrix are computed.
+       */
+      char jobz = compute_eigenvectors ? 'V' : 'N';
+      char range='A';
+      // Default value is to compute all eigenvalues and optionally eigenvectors.
+      bool all_eigenpairs=true;
+      NumberType vl=NumberType(),vu=NumberType();
+      int il=1,iu=1;
+
+      // Index range for eigenvalues is not specified.
+      if (!use_indices)
+        {
+          // Interval for eigenvalues is not specified and consequently all eigenvalues/eigenpairs will be computed.
+          if (!use_values)
+            {
+              range = 'A';
+              all_eigenpairs = true;
+            }
+          else
+            {
+              range = 'V';
+              all_eigenpairs = false;
+              vl = std::min(eigenvalue_limits.first,eigenvalue_limits.second);
+              vu = std::max(eigenvalue_limits.first,eigenvalue_limits.second);
+            }
+        }
+      else
+        {
+          range = 'I';
+          all_eigenpairs = false;
+          // As Fortran starts counting/indexing from 1 unlike C/C++, where it starts from 0.
+          il = std::min(eigenvalue_idx.first,eigenvalue_idx.second) + 1;
+          iu = std::max(eigenvalue_idx.first,eigenvalue_idx.second) + 1;
+        }
+      NumberType *A_loc = &this->values[0];
+
+      /*
+       * By setting lwork to -1 a workspace query for optimal length of work is performed.
+       */
+      int lwork=-1;
+      int liwork=-1;
+      NumberType *eigenvectors_loc = (compute_eigenvectors ? &eigenvectors->values[0] : nullptr);
+      work.resize(1);
+      iwork.resize (1);
+
+      psyevr(&jobz, &range, &uplo, &n_rows, A_loc, &submatrix_row, &submatrix_column, descriptor,
+             &vl, &vu, &il, &iu, &m, &nz, ev.data(),
+             eigenvectors_loc, &eigenvectors->submatrix_row, &eigenvectors->submatrix_column, eigenvectors->descriptor,
+             work.data(), &lwork, iwork.data(), &liwork, &info);
+
+      AssertThrow (info==0, LAPACKSupport::ExcErrorCode("psyevr", info));
+
+      lwork=work[0];
+      work.resize(lwork);
+      liwork = iwork[0];
+      iwork.resize(liwork);
+
+      psyevr(&jobz, &range, &uplo, &n_rows, A_loc, &submatrix_row, &submatrix_column, descriptor,
+             &vl, &vu, &il, &iu, &m, &nz, ev.data(),
+             eigenvectors_loc, &eigenvectors->submatrix_row, &eigenvectors->submatrix_column, eigenvectors->descriptor,
+             work.data(), &lwork, iwork.data(), &liwork, &info);
+
+      AssertThrow (info==0, LAPACKSupport::ExcErrorCode("psyevr", info));
+
+      if (compute_eigenvectors)
+        AssertThrow(m==nz,ExcMessage("psyevr failed to compute all eigenvectors for the selected eigenvalues"));
+
+      // If eigenvectors are queried, copy eigenvectors to original matrix.
+      // As the temporary matrix eigenvectors has identical dimensions and
+      // block-cyclic distribution we simply swap the local array.
+      if (compute_eigenvectors)
+        this->values.swap(eigenvectors->values);
+
+      // Adapt the size of ev to fit m upon return.
+      while ((int)ev.size() > m)
+        ev.pop_back();
+    }
+  /*
+   * Send number of computed eigenvalues to inactive processes.
+   */
+  grid->send_to_inactive(&m, 1);
+
+  /*
+   * Inactive processes have to resize array of eigenvalues.
+   */
+  if (! grid->mpi_process_is_active)
+    ev.resize(m);
+  /*
+   * Send the eigenvalues to processors not being part of the process grid.
+   */
+  grid->send_to_inactive(ev.data(), ev.size());
+
+  /*
+   * If only eigenvalues are queried, the content of the matrix will be destroyed.
+   * If the eigenpairs are queried, matrix A on exit stores the eigenvectors in the columns.
+   */
+  if (compute_eigenvectors)
+    {
+      property = LAPACKSupport::Property::general;
+      state = LAPACKSupport::eigenvalues;
+    }
+  else
+    state = LAPACKSupport::unusable;
+
+  return ev;
+}
+
+
+
+template <typename NumberType>
 std::vector<NumberType> ScaLAPACKMatrix<NumberType>::compute_SVD(ScaLAPACKMatrix<NumberType> *U,
     ScaLAPACKMatrix<NumberType> *VT)
 {

--- a/tests/scalapack/scalapack_15.cc
+++ b/tests/scalapack/scalapack_15.cc
@@ -132,7 +132,7 @@ void test(const unsigned int size, const unsigned int block_size, const NumberTy
   for (unsigned int i=0; i<max_n_eigenvalues; ++i)
     {
       const NumberType product = p_eigenvectors_[i] * s_eigenvectors_[i];
-      //the requirement for alignment of the eigenvectors has to be released (primarily for floats)
+      //the requirement for alignment of the eigenvectors has to be released
       AssertThrow (std::abs(std::abs(product)-1) < tol*10,
                    ExcInternalError());
     }

--- a/tests/scalapack/scalapack_15.cc
+++ b/tests/scalapack/scalapack_15.cc
@@ -1,0 +1,158 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include "../tests.h"
+#include "../lapack/create_matrix.h"
+
+// test eigenpairs_symmetric_by_index_MRRR(const std::pair<unsigned int,unsigned int> &, const bool)
+// for all eigenvalues with eigenvectors
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/timer.h>
+#include <deal.II/base/multithread_info.h>
+#include <deal.II/base/process_grid.h>
+
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/lapack_full_matrix.h>
+#include <deal.II/lac/lapack_templates.h>
+#include <deal.II/lac/scalapack.h>
+
+#include <fstream>
+#include <iostream>
+#include <algorithm>
+#include <memory>
+
+
+template <typename NumberType>
+void test(const unsigned int size, const unsigned int block_size, const NumberType tol)
+{
+  MPI_Comm mpi_communicator(MPI_COMM_WORLD);
+  const unsigned int n_mpi_processes(Utilities::MPI::n_mpi_processes(mpi_communicator));
+  const unsigned int this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator));
+
+  ConditionalOStream pcout (std::cout, (this_mpi_process ==0));
+
+  std::shared_ptr<Utilities::MPI::ProcessGrid> grid = std::make_shared<Utilities::MPI::ProcessGrid>(mpi_communicator,size,size,block_size,block_size);
+
+  pcout << size << " " << block_size << " " << grid->get_process_grid_rows() << " " << grid->get_process_grid_columns() << std::endl;
+
+  const unsigned int n_eigenvalues = size;
+  const unsigned int max_n_eigenvalues = 5;
+
+  // Create SPD matrices of requested size:
+  FullMatrix<NumberType> full_A(size);
+  std::vector<NumberType> eigenvalues_Lapack(size);
+  std::vector<Vector<NumberType>> s_eigenvectors_ (max_n_eigenvalues,Vector<NumberType>(size));
+  std::vector<Vector<NumberType>> p_eigenvectors_ (max_n_eigenvalues,Vector<NumberType>(size));
+  FullMatrix<NumberType> p_eigenvectors (size,size);
+
+  ScaLAPACKMatrix<NumberType> scalapack_syevr (size, grid, block_size);
+  scalapack_syevr.set_property(LAPACKSupport::Property::symmetric);
+
+  create_spd (full_A);
+  scalapack_syevr = full_A;
+
+  //Lapack as reference
+  {
+    std::vector<NumberType> lapack_A(size*size);
+    for (unsigned int i = 0; i < size; ++i)
+      for (unsigned int j = 0; j < size; ++j)
+        lapack_A[i*size+j] = full_A(i,j);
+
+    int info; //Variable containing information about the successful exit of the lapack routine
+    char jobz = 'V';  //'V': all eigenpairs of A are computed
+    char uplo = 'U';  //storage format of the matrix A; not so important as matrix is symmetric
+    char range = 'I'; //the il-th through iu-th eigenvalues will be found
+    int LDA = size;   //leading dimension of the matrix A
+    NumberType vl=0, vu=0;
+    int il=1, iu=size;
+    char sign = 'S';
+    NumberType abstol;
+    lamch(&sign,abstol);
+    abstol *= 2;
+    int m=0;
+    std::vector<NumberType> eigenvectors(size*size);
+    int LDZ=size;
+    std::vector<int> isuppz(2*size);
+    int lwork=-1;      //length of vector/array work
+    std::vector<NumberType> work(1);
+    int liwork=-1;      //length of vector/array iwork
+    std::vector<int> iwork(1);
+    //by setting lwork to -1 a workspace query for work is done
+    //as matrix is symmetric: LDA == size of matrix
+    syevr(&jobz, &range, &uplo, &LDA, lapack_A.data(), &LDA, &vl, &vu, &il, &iu,
+          &abstol, &m, eigenvalues_Lapack.data(), eigenvectors.data(), &LDZ, isuppz.data(),
+          work.data(), &lwork, iwork.data(), &liwork, &info);
+
+    lwork=work[0];
+    work.resize (lwork);
+    liwork=iwork[0];
+    iwork.resize(liwork);
+
+    syevr(&jobz, &range, &uplo, &LDA, lapack_A.data(), &LDA, &vl, &vu, &il, &iu,
+          &abstol, &m, eigenvalues_Lapack.data(), eigenvectors.data(), &LDZ, isuppz.data(),
+          work.data(), &lwork, iwork.data(), &liwork, &info);
+
+    AssertThrow (info==0, LAPACKSupport::ExcErrorCode("syevr", info));
+    for (int i=0; i<max_n_eigenvalues; ++i)
+      for (int j=0; j<size; ++j)
+        s_eigenvectors_[i][j] = eigenvectors[(size-1-i)*size+j];
+  }
+
+  // the actual test:
+
+  pcout << "comparing " << max_n_eigenvalues << " eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:" << std::endl;
+  const std::vector<NumberType> eigenvalues_psyer = scalapack_syevr.eigenpairs_symmetric_by_index_MRRR(std::make_pair(0,size-1),true);
+  scalapack_syevr.copy_to(p_eigenvectors);
+  for (unsigned int i=0; i<max_n_eigenvalues; ++i)
+    AssertThrow ( std::abs(eigenvalues_psyer[n_eigenvalues-i-1]-eigenvalues_Lapack[n_eigenvalues-i-1]) / std::abs(eigenvalues_Lapack[n_eigenvalues-i-1]) < tol,
+                  ExcInternalError());
+
+  pcout << "   with respect to the given tolerance the eigenvalues coincide" << std::endl;
+
+  for (unsigned int i=0; i<max_n_eigenvalues; ++i)
+    for (unsigned int j=0; j<size; ++j)
+      p_eigenvectors_[i][j] = p_eigenvectors(j,size-1-i);
+
+  //product of eigenvectors computed using Lapack and ScaLapack has to be either 1 or -1
+  for (unsigned int i=0; i<max_n_eigenvalues; ++i)
+    {
+      const NumberType product = p_eigenvectors_[i] * s_eigenvectors_[i];
+      //the requirement for alignment of the eigenvectors has to be released (primarily for floats)
+      AssertThrow (std::abs(std::abs(product)-1) < tol*10,
+                   ExcInternalError());
+    }
+  pcout << "   with respect to the given tolerance also the eigenvectors coincide" << std::endl << std::endl;
+}
+
+
+
+int main (int argc,char **argv)
+{
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+
+  const std::vector<unsigned int> sizes = {{200,400,600}};
+  const std::vector<unsigned int> blocks = {{32,64}};
+
+  const double tol = 1e-10;
+
+  for (const auto &s : sizes)
+    for (const auto &b : blocks)
+      if (b <= s)
+        test<double>(s,b,tol);
+}

--- a/tests/scalapack/scalapack_15.mpirun=1.output
+++ b/tests/scalapack/scalapack_15.mpirun=1.output
@@ -1,0 +1,30 @@
+200 32 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+200 64 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 32 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 64 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 32 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 64 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+

--- a/tests/scalapack/scalapack_15.mpirun=10.output
+++ b/tests/scalapack/scalapack_15.mpirun=10.output
@@ -1,0 +1,30 @@
+200 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+200 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+

--- a/tests/scalapack/scalapack_15.mpirun=4.output
+++ b/tests/scalapack/scalapack_15.mpirun=4.output
@@ -1,0 +1,30 @@
+200 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+200 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+

--- a/tests/scalapack/scalapack_15.mpirun=5.output
+++ b/tests/scalapack/scalapack_15.mpirun=5.output
@@ -1,0 +1,30 @@
+200 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+200 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+

--- a/tests/scalapack/scalapack_15_a.cc
+++ b/tests/scalapack/scalapack_15_a.cc
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include "../tests.h"
+#include "../lapack/create_matrix.h"
+
+// test eigenpairs_symmetric_by_index_MRRR(const std::pair<unsigned int,unsigned int> &, const bool)
+// for all eigenvalues without eigenvectors
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/timer.h>
+#include <deal.II/base/multithread_info.h>
+#include <deal.II/base/process_grid.h>
+
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/lapack_full_matrix.h>
+#include <deal.II/lac/lapack_templates.h>
+#include <deal.II/lac/scalapack.h>
+
+#include <fstream>
+#include <iostream>
+#include <algorithm>
+#include <memory>
+
+
+template <typename NumberType>
+void test(const unsigned int size, const unsigned int block_size, const NumberType tol)
+{
+  MPI_Comm mpi_communicator(MPI_COMM_WORLD);
+  const unsigned int n_mpi_processes(Utilities::MPI::n_mpi_processes(mpi_communicator));
+  const unsigned int this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator));
+
+  ConditionalOStream pcout (std::cout, (this_mpi_process ==0));
+
+  std::shared_ptr<Utilities::MPI::ProcessGrid> grid = std::make_shared<Utilities::MPI::ProcessGrid>(mpi_communicator,size,size,block_size,block_size);
+
+  pcout << size << " " << block_size << " " << grid->get_process_grid_rows() << " " << grid->get_process_grid_columns() << std::endl;
+
+  const unsigned int n_eigenvalues = size;
+  const unsigned int max_n_eigenvalues = 5;
+
+  // Create SPD matrices of requested size:
+  FullMatrix<NumberType> full_A(size);
+  std::vector<NumberType> eigenvalues_Lapack(size);
+  std::vector<Vector<NumberType>> s_eigenvectors_ (max_n_eigenvalues,Vector<NumberType>(size));
+  std::vector<Vector<NumberType>> p_eigenvectors_ (max_n_eigenvalues,Vector<NumberType>(size));
+  FullMatrix<NumberType> p_eigenvectors (size,size);
+
+  ScaLAPACKMatrix<NumberType> scalapack_syevr (size, grid, block_size);
+  scalapack_syevr.set_property(LAPACKSupport::Property::symmetric);
+
+  create_spd (full_A);
+  scalapack_syevr = full_A;
+
+  //Lapack as reference
+  {
+    std::vector<NumberType> lapack_A(size*size);
+    for (unsigned int i = 0; i < size; ++i)
+      for (unsigned int j = 0; j < size; ++j)
+        lapack_A[i*size+j] = full_A(i,j);
+
+    int info; //Variable containing information about the successful exit of the lapack routine
+    char jobz = 'N';  //'N': all eigenvalues of A are computed
+    char uplo = 'U';  //storage format of the matrix A; not so important as matrix is symmetric
+    char range = 'I'; //the il-th through iu-th eigenvalues will be found
+    int LDA = size;   //leading dimension of the matrix A
+    NumberType vl=0, vu=0;
+    int il=1, iu=size;
+    char sign = 'S';
+    NumberType abstol;
+    lamch(&sign,abstol);
+    abstol *= 2;
+    int m=0;
+    std::vector<NumberType> eigenvectors(size*size); //will not be referenced
+    int LDZ=size;
+    std::vector<int> isuppz(2*size);
+    int lwork=-1;      //length of vector/array work
+    std::vector<NumberType> work(1);
+    int liwork=-1;      //length of vector/array iwork
+    std::vector<int> iwork(1);
+    //by setting lwork to -1 a workspace query for work is done
+    //as matrix is symmetric: LDA == size of matrix
+    syevr(&jobz, &range, &uplo, &LDA, lapack_A.data(), &LDA, &vl, &vu, &il, &iu,
+          &abstol, &m, eigenvalues_Lapack.data(), eigenvectors.data(), &LDZ, isuppz.data(),
+          work.data(), &lwork, iwork.data(), &liwork, &info);
+
+    lwork=work[0];
+    work.resize (lwork);
+    liwork=iwork[0];
+    iwork.resize(liwork);
+
+    syevr(&jobz, &range, &uplo, &LDA, lapack_A.data(), &LDA, &vl, &vu, &il, &iu,
+          &abstol, &m, eigenvalues_Lapack.data(), eigenvectors.data(), &LDZ, isuppz.data(),
+          work.data(), &lwork, iwork.data(), &liwork, &info);
+  }
+
+  // the actual test:
+
+  pcout << "comparing " << max_n_eigenvalues << " eigenvalues computed using LAPACK and ScaLAPACK p_syevr:" << std::endl;
+  const std::vector<NumberType> eigenvalues_psyer = scalapack_syevr.eigenpairs_symmetric_by_index_MRRR(std::make_pair(0,size-1),false);
+  scalapack_syevr.copy_to(p_eigenvectors);
+  for (unsigned int i=0; i<max_n_eigenvalues; ++i)
+    AssertThrow ( std::abs(eigenvalues_psyer[n_eigenvalues-i-1]-eigenvalues_Lapack[n_eigenvalues-i-1]) / std::abs(eigenvalues_Lapack[n_eigenvalues-i-1]) < tol,
+                  ExcInternalError());
+
+  pcout << "   with respect to the given tolerance the eigenvalues coincide" << std::endl;
+}
+
+
+
+int main (int argc,char **argv)
+{
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+
+  const std::vector<unsigned int> sizes = {{200,400,600}};
+  const std::vector<unsigned int> blocks = {{32,64}};
+
+  const double tol = 1e-10;
+
+  for (const auto &s : sizes)
+    for (const auto &b : blocks)
+      if (b <= s)
+        test<double>(s,b,tol);
+}

--- a/tests/scalapack/scalapack_15_a.mpirun=1.output
+++ b/tests/scalapack/scalapack_15_a.mpirun=1.output
@@ -1,0 +1,18 @@
+200 32 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 1 1
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_15_a.mpirun=10.output
+++ b/tests/scalapack/scalapack_15_a.mpirun=10.output
@@ -1,0 +1,18 @@
+200 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 3 3
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_15_a.mpirun=4.output
+++ b/tests/scalapack/scalapack_15_a.mpirun=4.output
@@ -1,0 +1,18 @@
+200 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_15_a.mpirun=5.output
+++ b/tests/scalapack/scalapack_15_a.mpirun=5.output
@@ -1,0 +1,18 @@
+200 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+200 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+400 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+400 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+600 32 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+600 64 2 2
+comparing 5 eigenvalues computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide

--- a/tests/scalapack/scalapack_15_b.cc
+++ b/tests/scalapack/scalapack_15_b.cc
@@ -1,0 +1,158 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include "../tests.h"
+#include "../lapack/create_matrix.h"
+
+// test eigenpairs_symmetric_by_index_MRRR(const std::pair<unsigned int,unsigned int> &, const bool)
+// for the largest eigenvalues with eigenvectors
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/timer.h>
+#include <deal.II/base/multithread_info.h>
+#include <deal.II/base/process_grid.h>
+
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/lapack_full_matrix.h>
+#include <deal.II/lac/lapack_templates.h>
+#include <deal.II/lac/scalapack.h>
+
+#include <fstream>
+#include <iostream>
+#include <algorithm>
+#include <memory>
+
+
+template <typename NumberType>
+void test(const unsigned int size, const unsigned int block_size, const NumberType tol)
+{
+  MPI_Comm mpi_communicator(MPI_COMM_WORLD);
+  const unsigned int n_mpi_processes(Utilities::MPI::n_mpi_processes(mpi_communicator));
+  const unsigned int this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator));
+
+  ConditionalOStream pcout (std::cout, (this_mpi_process ==0));
+
+  std::shared_ptr<Utilities::MPI::ProcessGrid> grid = std::make_shared<Utilities::MPI::ProcessGrid>(mpi_communicator,size,size,block_size,block_size);
+
+  pcout << size << " " << block_size << " " << grid->get_process_grid_rows() << " " << grid->get_process_grid_columns() << std::endl;
+
+  const unsigned int n_eigenvalues = size;
+  const unsigned int max_n_eigenvalues = 5;
+
+  // Create SPD matrices of requested size:
+  FullMatrix<NumberType> full_A(size);
+  std::vector<NumberType> eigenvalues_Lapack(size);
+  std::vector<Vector<NumberType>> s_eigenvectors_ (max_n_eigenvalues,Vector<NumberType>(size));
+  std::vector<Vector<NumberType>> p_eigenvectors_ (max_n_eigenvalues,Vector<NumberType>(size));
+  FullMatrix<NumberType> p_eigenvectors (size,size);
+
+  ScaLAPACKMatrix<NumberType> scalapack_syevr (size, grid, block_size);
+  scalapack_syevr.set_property(LAPACKSupport::Property::symmetric);
+
+  create_spd (full_A);
+  scalapack_syevr = full_A;
+
+  //Lapack as reference
+  {
+    std::vector<NumberType> lapack_A(size*size);
+    for (unsigned int i = 0; i < size; ++i)
+      for (unsigned int j = 0; j < size; ++j)
+        lapack_A[i*size+j] = full_A(i,j);
+
+    int info; //Variable containing information about the successful exit of the lapack routine
+    char jobz = 'V';  //'V': eigenpairs of A are computed
+    char uplo = 'U';  //storage format of the matrix A; not so important as matrix is symmetric
+    char range = 'I'; //the il-th through iu-th eigenvalues will be found
+    int LDA = size;   //leading dimension of the matrix A
+    NumberType vl=0, vu=0;
+    int il=size-max_n_eigenvalues+1, iu=size;
+    char sign = 'S';
+    NumberType abstol;
+    lamch(&sign,abstol);
+    abstol *= 2;
+    int m=0;
+    std::vector<NumberType> eigenvectors(size*size);
+    int LDZ=size;
+    std::vector<int> isuppz(2*size);
+    int lwork=-1;      //length of vector/array work
+    std::vector<NumberType> work(1);
+    int liwork=-1;      //length of vector/array iwork
+    std::vector<int> iwork(1);
+    //by setting lwork to -1 a workspace query for work is done
+    //as matrix is symmetric: LDA == size of matrix
+    syevr(&jobz, &range, &uplo, &LDA, lapack_A.data(), &LDA, &vl, &vu, &il, &iu,
+          &abstol, &m, eigenvalues_Lapack.data(), eigenvectors.data(), &LDZ, isuppz.data(),
+          work.data(), &lwork, iwork.data(), &liwork, &info);
+
+    lwork=work[0];
+    work.resize (lwork);
+    liwork=iwork[0];
+    iwork.resize(liwork);
+
+    syevr(&jobz, &range, &uplo, &LDA, lapack_A.data(), &LDA, &vl, &vu, &il, &iu,
+          &abstol, &m, eigenvalues_Lapack.data(), eigenvectors.data(), &LDZ, isuppz.data(),
+          work.data(), &lwork, iwork.data(), &liwork, &info);
+
+    AssertThrow (info==0, LAPACKSupport::ExcErrorCode("syevr", info));
+    for (int i=0; i<max_n_eigenvalues; ++i)
+      for (int j=0; j<size; ++j)
+        s_eigenvectors_[i][j] = eigenvectors[(max_n_eigenvalues-1-i)*size+j];
+  }
+
+  // the actual test:
+
+  pcout << "comparing " << max_n_eigenvalues << " eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:" << std::endl;
+  const std::vector<NumberType> eigenvalues_psyer = scalapack_syevr.eigenpairs_symmetric_by_index_MRRR(std::make_pair(size-max_n_eigenvalues,size-1),true);
+  scalapack_syevr.copy_to(p_eigenvectors);
+  for (unsigned int i=0; i<max_n_eigenvalues; ++i)
+    AssertThrow ( std::abs(eigenvalues_psyer[max_n_eigenvalues-i-1]-eigenvalues_Lapack[max_n_eigenvalues-i-1]) / std::abs(eigenvalues_Lapack[max_n_eigenvalues-i-1]) < tol,
+                  ExcInternalError());
+
+  pcout << "   with respect to the given tolerance the eigenvalues coincide" << std::endl;
+
+  for (unsigned int i=0; i<max_n_eigenvalues; ++i)
+    for (unsigned int j=0; j<size; ++j)
+      p_eigenvectors_[i][j] = p_eigenvectors(j,max_n_eigenvalues-1-i);
+
+  //product of eigenvectors computed using Lapack and ScaLapack has to be either 1 or -1
+  for (unsigned int i=0; i<max_n_eigenvalues; ++i)
+    {
+      const NumberType product = p_eigenvectors_[i] * s_eigenvectors_[i];
+      //the requirement for alignment of the eigenvectors has to be released (primarily for floats)
+      AssertThrow (std::abs(std::abs(product)-1) < tol*10,
+                   ExcInternalError());
+    }
+  pcout << "   with respect to the given tolerance also the eigenvectors coincide" << std::endl << std::endl;
+}
+
+
+
+int main (int argc,char **argv)
+{
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+
+  const std::vector<unsigned int> sizes = {{200,400,600}};
+  const std::vector<unsigned int> blocks = {{32,64}};
+
+  const double tol = 1e-10;
+
+  for (const auto &s : sizes)
+    for (const auto &b : blocks)
+      if (b <= s)
+        test<double>(s,b,tol);
+}

--- a/tests/scalapack/scalapack_15_b.cc
+++ b/tests/scalapack/scalapack_15_b.cc
@@ -132,7 +132,7 @@ void test(const unsigned int size, const unsigned int block_size, const NumberTy
   for (unsigned int i=0; i<max_n_eigenvalues; ++i)
     {
       const NumberType product = p_eigenvectors_[i] * s_eigenvectors_[i];
-      //the requirement for alignment of the eigenvectors has to be released (primarily for floats)
+      //the requirement for alignment of the eigenvectors has to be released
       AssertThrow (std::abs(std::abs(product)-1) < tol*10,
                    ExcInternalError());
     }

--- a/tests/scalapack/scalapack_15_b.mpirun=1.output
+++ b/tests/scalapack/scalapack_15_b.mpirun=1.output
@@ -1,0 +1,30 @@
+200 32 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+200 64 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 32 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 64 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 32 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 64 1 1
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+

--- a/tests/scalapack/scalapack_15_b.mpirun=10.output
+++ b/tests/scalapack/scalapack_15_b.mpirun=10.output
@@ -1,0 +1,30 @@
+200 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+200 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 32 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 64 3 3
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+

--- a/tests/scalapack/scalapack_15_b.mpirun=4.output
+++ b/tests/scalapack/scalapack_15_b.mpirun=4.output
@@ -1,0 +1,30 @@
+200 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+200 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+

--- a/tests/scalapack/scalapack_15_b.mpirun=5.output
+++ b/tests/scalapack/scalapack_15_b.mpirun=5.output
@@ -1,0 +1,30 @@
+200 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+200 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+400 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 32 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+
+600 64 2 2
+comparing 5 eigenvalues and eigenvectors computed using LAPACK and ScaLAPACK p_syevr:
+   with respect to the given tolerance the eigenvalues coincide
+   with respect to the given tolerance also the eigenvectors coincide
+


### PR DESCRIPTION
In the process I added some LAPACK wrappers, which are used in the tests.
The MRRR algorithm in `p_syevr` is said to be more accurate for close eigenvalues and more memory efficient than the standard eigenvalue routines `p_syev`/`p_syevx`.