### PR TITLE
Bugfix: Set a value to zero with a floating point literal

### DIFF
--- a/source/non_matching/coupling.cc
+++ b/source/non_matching/coupling.cc
@@ -238,7 +238,7 @@ namespace NonMatching
                 ocell->get_dof_indices(odofs);
 
                 // Reset the matrices.
-                cell_matrix = 0;
+                cell_matrix = typename Matrix::value_type();
 
                 for (unsigned int i=0; i<space_dh.get_fe().dofs_per_cell; ++i)
                   {


### PR DESCRIPTION
Otherwise the deal.II fails to build with
complex-valued PETSc scalar:

```
.../source/non_matching/coupling.cc:241:29: error: ambiguous overload for ‘operator=’
(operand types are ‘dealii::FullMatrix<std::complex<double> >’ and ‘int’)
```

Let's hope this fixes it.