### PR TITLE
tests: make distributed_grids/1d_grid robust

### DIFF
--- a/tests/distributed_grids/1d_grid.cc
+++ b/tests/distributed_grids/1d_grid.cc
@@ -33,6 +33,6 @@ int main(int argc, char *argv[])
     }
   catch (const std::exception &exc)
     {
-      deallog << exc.what() << std::endl;
+      deallog << "This test has to throw an exception" << std::endl;
     }
 }

--- a/tests/distributed_grids/1d_grid.debug.output
+++ b/tests/distributed_grids/1d_grid.debug.output
@@ -1,11 +1,2 @@
 
-DEAL::
---------------------------------------------------------
-An error occurred in file <tria.cc> in function
-    dealii::parallel::distributed::Triangulation<1, 1>::Triangulation(MPI_Comm, const typename dealii::Triangulation<1, spacedim>::MeshSmoothing, const dealii::parallel::distributed::Triangulation<1, spacedim>::Settings) [dim = 1, spacedim = 1]
-The violated condition was: 
-    false
-Additional information: 
-    (none)
---------------------------------------------------------
-
+DEAL::This test has to throw an exception


### PR DESCRIPTION
The sole purpose of this test is to compile successfully (and
subsequently dying with a runtime exception). Unfortunately, the actual
exception message is very compiler dependent.

Thus, let's ignore the actual contents of the error message and simply
check for the fact that we abort by setting the "expect=run" constraint
(i.e., test is expected to fail in the "run" stage).