### PR TITLE
tests: sharedtria/communicate_active_fe_indices_01b add an output variant

### DIFF
--- a/tests/sharedtria/communicate_active_fe_indices_01b.with_metis=true.mpirun=3.output.gcc-7.3.0-x86_64
+++ b/tests/sharedtria/communicate_active_fe_indices_01b.with_metis=true.mpirun=3.output.gcc-7.3.0-x86_64
@@ -1,0 +1,23 @@
+
+DEAL:0:1d::n_dofs: 9
+DEAL:0:1d::n_locally_owned_dofs: 4
+DEAL:0:2d::n_dofs: 81
+DEAL:0:2d::n_locally_owned_dofs: 33
+DEAL:0:3d::n_dofs: 729
+DEAL:0:3d::n_locally_owned_dofs: 291
+
+DEAL:1:1d::n_dofs: 9
+DEAL:1:1d::n_locally_owned_dofs: 4
+DEAL:1:2d::n_dofs: 81
+DEAL:1:2d::n_locally_owned_dofs: 29
+DEAL:1:3d::n_dofs: 729
+DEAL:1:3d::n_locally_owned_dofs: 252
+
+
+DEAL:2:1d::n_dofs: 9
+DEAL:2:1d::n_locally_owned_dofs: 1
+DEAL:2:2d::n_dofs: 81
+DEAL:2:2d::n_locally_owned_dofs: 19
+DEAL:2:3d::n_dofs: 729
+DEAL:2:3d::n_locally_owned_dofs: 186
+


### PR DESCRIPTION
This is another test that has a slightly different output due to a different
metis version and compiler version...