### PR TITLE
Do not make a variable in step-35 static.

### DIFF
--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -1298,7 +1298,7 @@ namespace Step35
             ((dim + 1)*dof_handler_velocity.n_dofs() +
              dof_handler_pressure.n_dofs()),
             ExcInternalError());
-    static Vector<double> joint_solution (joint_dof_handler.n_dofs());
+    Vector<double> joint_solution (joint_dof_handler.n_dofs());
     std::vector<types::global_dof_index> loc_joint_dof_indices (joint_fe.dofs_per_cell),
         loc_vel_dof_indices (fe_velocity.dofs_per_cell),
         loc_pres_dof_indices (fe_pressure.dofs_per_cell);


### PR DESCRIPTION
Static variables are only initialized once at the beginning of the run. Here,
we have a vector that is marked as 'static' but this really only works because
we never do mesh refinement in this program and consequently (i) the originally
set size continues to be correct, and (ii) the code below sets every vector
element, rather than add to it.