### PR TITLE
mpi: add helper function to print PID and hostname and wait

### DIFF
--- a/doc/news/changes/minor/20180321DenisDavydov
+++ b/doc/news/changes/minor/20180321DenisDavydov
@@ -1,0 +1,4 @@
+New: Add Utilities::MPI::wait(const MPI_Comm &mpi_communicator) to
+facilitate debugging MPI programs.
+<br>
+(Denis Davydov, 2018/03/21)

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -86,6 +86,36 @@ namespace Utilities
     unsigned int this_mpi_process (const MPI_Comm &mpi_communicator);
 
     /**
+     * This function will print process id and host name on each MPI process
+     * and wait until the user enters any character before proceeding.
+     * It is intended to facilitate attachment of serial debuggers to MPI programs,
+     * see https://www.open-mpi.org/faq/?category=debugging#serial-debuggers .
+     *
+     * After adding this function, one would typically run an executable with
+     * \code{.sh}
+     * mpiexec -np 2 xterm -e <path-to-exec>
+     * \endcode
+     * to get process IDs and then attach a debugger. For example, in
+     * Visual Studio Code on macOS you can achieve this via the following _attach_ configuration:
+     * \code{.json}
+     * {
+     *  "version": "0.2.0",
+     *  "configurations": [
+     *    {
+     *      "name": "(lldb) Attach",
+     *      "type": "cppdbg",
+     *      "request": "attach",
+     *      "program": "<path-to-exec>",
+     *      "processId": "\${command:pickProcess}",
+     *      "MIMode": "lldb"
+     *    }
+     *  ]
+     * }
+     * \endcode
+     */
+    void wait(const MPI_Comm &mpi_communicator);
+
+    /**
      * Consider an unstructured communication pattern where every process in
      * an MPI universe wants to send some data to a subset of the other
      * processors. To do that, the other processors need to know who to expect

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -64,14 +64,23 @@ namespace Utilities
     void wait(const MPI_Comm &mpi_communicator)
     {
       // see https://www.open-mpi.org/faq/?category=debugging#serial-debuggers
-      std::cout << "PID " << ::getpid()
-                << " rank " << Utilities::MPI::this_mpi_process(mpi_communicator)
-                << " on " << Utilities::System::get_hostname()
-                << " ready for attach." << std::endl;
-
-      char a;
-      if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
+      const unsigned int np = Utilities::MPI::n_mpi_processes(mpi_communicator);
+      const unsigned int myid = Utilities::MPI::this_mpi_process(mpi_communicator);
+      for (unsigned int p =0; p < np; ++p )
         {
+          if (p==myid)
+            std::cout << "PID " << ::getpid()
+                      << " rank " << myid
+                      << " on " << Utilities::System::get_hostname()
+                      << " ready for attach." << std::endl;
+#ifdef DEAL_II_WITH_MPI
+          MPI_Barrier(mpi_communicator);
+#endif
+        }
+
+      if (myid == 0)
+        {
+          char a;
           std::cout << "Type any character and press Enter/Return to start: " << std::flush;
           std::cin >> a;
         }

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -61,6 +61,26 @@ namespace Utilities
 
   namespace MPI
   {
+    void wait(const MPI_Comm &mpi_communicator)
+    {
+      // see https://www.open-mpi.org/faq/?category=debugging#serial-debuggers
+      std::cout << "PID " << ::getpid()
+                << " rank " << Utilities::MPI::this_mpi_process(mpi_communicator)
+                << " on " << Utilities::System::get_hostname()
+                << " ready for attach." << std::endl;
+
+      char a;
+      if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
+        {
+          std::cout << "Type any character and press Enter/Return to start: " << std::flush;
+          std::cin >> a;
+        }
+
+#ifdef DEAL_II_WITH_MPI
+      MPI_Barrier(mpi_communicator);
+#endif
+    }
+
 #ifdef DEAL_II_WITH_MPI
     unsigned int n_mpi_processes (const MPI_Comm &mpi_communicator)
     {


### PR DESCRIPTION
I was looking around how to attach a debugger without running
```
mpirun -np 4 xterm -e lldb -f <my_exec> -- <params>
```
or alike.

I think this could be useful for users and developers.