### PR TITLE
Fix cone_04

### DIFF
--- a/tests/bits/cone_04.cc
+++ b/tests/bits/cone_04.cc
@@ -29,9 +29,9 @@ void check ()
 
   Triangulation<dim> triangulation;
   GridGenerator::truncated_cone (triangulation);
-  GridTools::transform ([](const Point<dim> &p)
+  GridTools::transform ([](const Point<3> &p)
   {
-    return Point<dim> (-p[1], p[0], p[2]);
+    return Point<3> (-p[1], p[0], p[2]);
   },
   triangulation);
   static const CylindricalManifold<dim> boundary(1);


### PR DESCRIPTION
This test is [failing](https://cdash.kyomu.43-1.org/testDetails.php?test=76457484&build=16535) for `clang-4` which seems to dislike the way the `constexpr` variable is treated as template parameter in the lambda function. So let us just be explicit that we are only interested in `dim==3` here.