### PR TITLE
CMake: Add rpath to example steps

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -92,6 +92,18 @@ IF(DEAL_II_COMPONENT_EXAMPLES)
             PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${DEAL_II_EXECUTABLE_RELDIR}"
             )
+          #
+          # In case CMake is instructed to add rpaths to the library and
+          # exectuble on installation, make sure that we add an additional
+          # rpath to the library location as well:
+          #
+          IF(CMAKE_INSTALL_RPATH_USE_LINK_PATH)
+            SET_TARGET_PROPERTIES(${_name}.${_build_lowercase}
+              PROPERTIES
+              INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${DEAL_II_LIBRARY_RELDIR}"
+              )
+          ENDIF()
+
           ADD_DEPENDENCIES(examples ${_name}.${_build_lowercase})
           INSTALL(TARGETS ${_name}.${_build_lowercase}
             DESTINATION ${DEAL_II_EXAMPLES_RELDIR}/${_name}


### PR DESCRIPTION
Quoting from the documentation [1]
  """
  CMAKE_INSTALL_RPATH_USE_LINK_PATH is an interesting and very useful
  option. When building a target with RPATH, CMake determines the RPATH
  by using the directories of all libraries to which this target links.
  Some of these libraries may be located in the same build tree, e.g.
  libbar.so, these directories are also added to the RPATH. If this
  option is enabled, all these directories except those which are also
  in the build tree will be added to the install RPATH automatically.
  The only directories which may then still be missing from the RPATH
  are the directories where the libraries from the same project (i.e.
  libbar.so) are installed to. If the install directory for the
  libraries is not one of the systems default library directories, you
  have to add this directory yourself to the install RPATH by setting
  CMAKE_INSTALL_RPATH accordingly.
  """

Well, let's simply add the missing rpath to the install location for our
example binaries then. We guard this with
CMAKE_INSTALL_RPATH_USE_LINK_PATH in case augment the INSTALL_RPATH
so that CMake doesn't populate any rpath in case the user doesn't want
that.

[1] https://cmake.org/Wiki/CMake_RPATH_handling

Fixes #6096