### PR TITLE
CMake: Do not require a special name for TRACK="Continuous"

### DIFF
--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -62,9 +62,9 @@
 #                            directory (without actually running the
 #                            testsuite)
 #
-#       "Regression Tests" - Reserved for the "official" regression tester
+#       "Regression Tests" - Reserved for "official" regression testers
 #
-#       "Continuous"       - Reserved for the "official" regression tester
+#       "Continuous"       - Reserved for "official" regression testers
 #
 #   CONFIG_FILE
 #     - A configuration file (see ../doc/users/config.sample)
@@ -243,11 +243,10 @@ ENDIF()
 
 MESSAGE("-- CTEST_SITE:             ${CTEST_SITE}")
 
-IF( TRACK MATCHES "^(Regression Tests|Continuous)$"
-    AND NOT CTEST_SITE MATCHES "^(simserv04|tester)$" )
+IF(TRACK MATCHES "^Regression Tests$" AND NOT CTEST_SITE MATCHES "^tester$")
   MESSAGE(FATAL_ERROR "
 I'm sorry ${CTEST_SITE}, I'm afraid I can't do that.
-The TRACK \"Regression Tests\" or \"Continuous\" is not for you.
+The TRACK \"Regression Tests\" is not for you.
 "
     )
 ENDIF()


### PR DESCRIPTION
We have a number of different testing sites nowadays that check different
aspects of the library. I would like to make these tests results more official
by:

 - keeping "Regression Tests" for the "tester" results (server in Minneapolis)

 - reducing the number of submission of "simserv04" to three (later two, when I
   have migrated the 64bit indices test to "tester")

 - let CUDA8, CUDA9, davyddenubuntu and simerv02 submit to TRACK="Continuous"

I think this would greatly improve the organization of tests.