### PR TITLE
Let GridTools::minimal/maximal_cell_diameter return global values

### DIFF
--- a/doc/news/changes/minor/20180325DanielArndt
+++ b/doc/news/changes/minor/20180325DanielArndt
@@ -1,5 +1,5 @@
 Fixed: GridTools::minimal_cell_diameter() and GridTools::maximal_cell_diameter()
-return the maximal respectively minimal cell diameter of the non-artifical part
-of a Triangulation object.
+return the maximal respectively minimal cell diameter over the whole mesh for
+parallel::distributed::Triangulation object, too.
 <br>
 (Daniel Arndt, 2018/03/25)

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -154,16 +154,15 @@ namespace GridTools
                  const Mapping<dim,spacedim> &mapping = (StaticMappingQ1<dim,spacedim>::mapping));
 
   /**
-   * Return the diameter of the smallest active cell of the non-artificial part
-   * of a triangulation. See step-24 for an example of use of this function.
+   * Return the diameter of the smallest active cell of a triangulation. See
+   * step-24 for an example of use of this function.
    */
   template <int dim, int spacedim>
   double
   minimal_cell_diameter (const Triangulation<dim, spacedim> &triangulation);
 
   /**
-   * Return the diameter of the largest active cell of the non-artificial part
-   * of a triangulation.
+   * Return the diameter of the largest active cell of a triangulation.
    */
   template <int dim, int spacedim>
   double

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2712,7 +2712,18 @@ next_cell:
       if (!cell->is_artificial())
         min_diameter = std::min (min_diameter,
                                  cell->diameter());
-    return min_diameter;
+
+    double global_min_diameter = 0;
+
+#ifdef DEAL_II_WITH_MPI
+    if (const parallel::Triangulation<dim,spacedim> *p_tria
+        = dynamic_cast<const parallel::Triangulation<dim,spacedim>*>(&triangulation))
+      global_min_diameter = Utilities::MPI::min (min_diameter, p_tria->get_communicator());
+    else
+#endif
+      global_min_diameter = min_diameter;
+
+    return global_min_diameter;
   }
 
 
@@ -2726,7 +2737,18 @@ next_cell:
       if (!cell->is_artificial())
         max_diameter = std::max (max_diameter,
                                  cell->diameter());
-    return max_diameter;
+
+    double global_max_diameter = 0;
+
+#ifdef DEAL_II_WITH_MPI
+    if (const parallel::Triangulation<dim,spacedim> *p_tria
+        = dynamic_cast<const parallel::Triangulation<dim,spacedim>*>(&triangulation))
+      global_max_diameter = Utilities::MPI::max (max_diameter, p_tria->get_communicator());
+    else
+#endif
+      global_max_diameter = max_diameter;
+
+    return global_max_diameter;
   }
 
 


### PR DESCRIPTION
As requested by @bangerth, we do the reduction over all the processes inside of `GridTools::minimal/maximal_cell_diameter` now.