### PR TITLE
Support for PETSc in MGTransferPrebuilt (multigrid)

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -168,6 +168,7 @@ VECTORS_WITH_MATRIX := { Vector<double>;
 
                          @DEAL_II_EXPAND_TRILINOS_MPI_VECTOR@;
                          @DEAL_II_EXPAND_EPETRA_VECTOR@;
+                         @DEAL_II_EXPAND_PETSC_MPI_VECTOR@;
                        }
 
 // Matrices

--- a/doc/news/changes/minor/20180521AlexanderKnieps
+++ b/doc/news/changes/minor/20180521AlexanderKnieps
@@ -1,0 +1,5 @@
+Improved: MGTransferPrebuilt now supports
+PETScWrappers::MPI::Vector and
+PETScWrappers::MPI::SparseMatrix.
+<br>
+(Alexander Knieps, 2018/05/21)

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -382,7 +382,6 @@ namespace PETScWrappers
       //if (preset_nonzero_locations == true)
       if (local_rows.n_elements()>0)
         {
-          Assert(local_columns.n_elements()>0, ExcInternalError());
           // MatMPIAIJSetPreallocationCSR
           // can be used to allocate the sparsity
           // pattern of a matrix

--- a/source/multigrid/mg_level_global_transfer.inst.in
+++ b/source/multigrid/mg_level_global_transfer.inst.in
@@ -81,4 +81,16 @@ for(deal_II_dimension : DIMENSIONS)
     MGLevelGlobalTransfer<TrilinosWrappers::MPI::Vector>::copy_from_mg_add (const DoFHandler<deal_II_dimension>&, TrilinosWrappers::MPI::Vector&,
             const MGLevelObject<TrilinosWrappers::MPI::Vector>&) const;
 #endif
+
+#ifdef DEAL_II_WITH_PETSC
+    template void
+    MGLevelGlobalTransfer<PETScWrappers::MPI::Vector>::copy_to_mg (
+        const DoFHandler<deal_II_dimension>&, MGLevelObject<PETScWrappers::MPI::Vector>&, const PETScWrappers::MPI::Vector&) const;
+    template void
+    MGLevelGlobalTransfer<PETScWrappers::MPI::Vector>::copy_from_mg (const DoFHandler<deal_II_dimension>&, PETScWrappers::MPI::Vector&,
+            const MGLevelObject<PETScWrappers::MPI::Vector>&) const;
+    template void
+    MGLevelGlobalTransfer<PETScWrappers::MPI::Vector>::copy_from_mg_add (const DoFHandler<deal_II_dimension>&, PETScWrappers::MPI::Vector&,
+            const MGLevelObject<PETScWrappers::MPI::Vector>&) const;
+#endif
 }

--- a/tests/multigrid/transfer_04b.cc
+++ b/tests/multigrid/transfer_04b.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// check mg transfer in parallel for trilinos vectors
+// check mg transfer in parallel for PETSc vectors
 
 #include "../tests.h"
 #include <deal.II/base/function.h>
@@ -35,7 +35,7 @@
 #include <deal.II/multigrid/mg_transfer.h>
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 #include <deal.II/numerics/data_out.h>
-#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/petsc_parallel_vector.h>
 
 #include <algorithm>
 
@@ -119,7 +119,7 @@ void check_fe(FiniteElement<dim> &fe)
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
   dofh.distribute_mg_dofs(fe);
-  typedef TrilinosWrappers::MPI::Vector vector_t;
+  typedef PETScWrappers::MPI::Vector vector_t;
   {
 
 

--- a/tests/multigrid/transfer_04b.with_trilinos=true.mpirun=1.debug.output
+++ b/tests/multigrid/transfer_04b.with_trilinos=true.mpirun=1.debug.output
@@ -1,0 +1,75 @@
+
+DEAL:0::FE_Q<2>(1)
+DEAL:0::cell=0_0: level_subdomain_id=0
+DEAL:0::cell=0_1:0 level_subdomain_id=0
+DEAL:0::cell=0_1:1 level_subdomain_id=0
+DEAL:0::cell=0_1:2 level_subdomain_id=0
+DEAL:0::cell=0_1:3 level_subdomain_id=0
+DEAL:0::cell=0_2:00 level_subdomain_id=0
+DEAL:0::cell=0_2:01 level_subdomain_id=0
+DEAL:0::cell=0_2:02 level_subdomain_id=0
+DEAL:0::cell=0_2:03 level_subdomain_id=0
+DEAL:0::cell=0_2:10 level_subdomain_id=0
+DEAL:0::cell=0_2:11 level_subdomain_id=0
+DEAL:0::cell=0_2:12 level_subdomain_id=0
+DEAL:0::cell=0_2:13 level_subdomain_id=0
+DEAL:0::cell=0_2:20 level_subdomain_id=0
+DEAL:0::cell=0_2:21 level_subdomain_id=0
+DEAL:0::cell=0_2:22 level_subdomain_id=0
+DEAL:0::cell=0_2:23 level_subdomain_id=0
+DEAL:0::cell=0_3:000 level_subdomain_id=0
+DEAL:0::cell=0_3:001 level_subdomain_id=0
+DEAL:0::cell=0_3:002 level_subdomain_id=0
+DEAL:0::cell=0_3:003 level_subdomain_id=0
+DEAL:0::cell=0_3:010 level_subdomain_id=0
+DEAL:0::cell=0_3:011 level_subdomain_id=0
+DEAL:0::cell=0_3:012 level_subdomain_id=0
+DEAL:0::cell=0_3:013 level_subdomain_id=0
+DEAL:0::cell=0_3:020 level_subdomain_id=0
+DEAL:0::cell=0_3:021 level_subdomain_id=0
+DEAL:0::cell=0_3:022 level_subdomain_id=0
+DEAL:0::cell=0_3:023 level_subdomain_id=0
+copy_indices[1]	0	3
+copy_indices[1]	1	5
+copy_indices[1]	2	7
+copy_indices[1]	3	8
+copy_indices[2]	0	8
+copy_indices[2]	1	14
+copy_indices[2]	2	20
+copy_indices[2]	4	3
+copy_indices[2]	5	5
+copy_indices[2]	6	7
+copy_indices[2]	7	4
+copy_indices[2]	8	9
+copy_indices[2]	9	10
+copy_indices[2]	10	11
+copy_indices[2]	11	12
+copy_indices[2]	12	13
+copy_indices[2]	13	6
+copy_indices[2]	14	15
+copy_indices[2]	15	16
+copy_indices[2]	16	17
+copy_indices[2]	17	18
+copy_indices[2]	18	19
+copy_indices[3]	4	8
+copy_indices[3]	5	14
+copy_indices[3]	6	20
+copy_indices[3]	7	11
+copy_indices[3]	13	18
+copy_indices[3]	19	0
+copy_indices[3]	20	1
+copy_indices[3]	21	2
+copy_indices[3]	22	3
+copy_indices[3]	23	4
+copy_indices[3]	24	5
+copy_indices[3]	25	6
+copy_indices[3]	26	7
+copy_indices[3]	27	9
+copy_indices[3]	28	10
+copy_indices[3]	29	12
+copy_indices[3]	30	13
+copy_indices[3]	31	15
+copy_indices[3]	32	16
+copy_indices[3]	33	17
+copy_indices[3]	34	19
+DEAL:0::1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 ok

--- a/tests/multigrid/transfer_04b.with_trilinos=true.mpirun=2.debug.output
+++ b/tests/multigrid/transfer_04b.with_trilinos=true.mpirun=2.debug.output
@@ -1,0 +1,109 @@
+
+DEAL:0::FE_Q<2>(1)
+DEAL:0::cell=0_0: level_subdomain_id=0
+DEAL:0::cell=0_1:0 level_subdomain_id=0
+DEAL:0::cell=0_1:1 level_subdomain_id=1
+DEAL:0::cell=0_1:2 level_subdomain_id=1
+DEAL:0::cell=0_1:3 level_subdomain_id=1
+DEAL:0::cell=0_2:00 level_subdomain_id=0
+DEAL:0::cell=0_2:01 level_subdomain_id=0
+DEAL:0::cell=0_2:02 level_subdomain_id=0
+DEAL:0::cell=0_2:03 level_subdomain_id=1
+DEAL:0::cell=0_2:10 level_subdomain_id=1
+DEAL:0::cell=0_2:11 level_subdomain_id=4294967294
+DEAL:0::cell=0_2:12 level_subdomain_id=1
+DEAL:0::cell=0_2:13 level_subdomain_id=4294967294
+DEAL:0::cell=0_2:20 level_subdomain_id=1
+DEAL:0::cell=0_2:21 level_subdomain_id=1
+DEAL:0::cell=0_2:22 level_subdomain_id=4294967294
+DEAL:0::cell=0_2:23 level_subdomain_id=4294967294
+DEAL:0::cell=0_3:000 level_subdomain_id=0
+DEAL:0::cell=0_3:001 level_subdomain_id=0
+DEAL:0::cell=0_3:002 level_subdomain_id=0
+DEAL:0::cell=0_3:003 level_subdomain_id=0
+DEAL:0::cell=0_3:010 level_subdomain_id=0
+DEAL:0::cell=0_3:011 level_subdomain_id=0
+DEAL:0::cell=0_3:012 level_subdomain_id=0
+DEAL:0::cell=0_3:013 level_subdomain_id=0
+DEAL:0::cell=0_3:020 level_subdomain_id=0
+DEAL:0::cell=0_3:021 level_subdomain_id=0
+DEAL:0::cell=0_3:022 level_subdomain_id=0
+DEAL:0::cell=0_3:023 level_subdomain_id=0
+copy_indices[2]	8	3
+copy_indices[2]	11	4
+copy_indices[2]	14	5
+copy_indices[2]	18	6
+copy_indices[2]	20	7
+copy_indices[3]	0	0
+copy_indices[3]	1	1
+copy_indices[3]	2	2
+copy_indices[3]	3	3
+copy_indices[3]	4	4
+copy_indices[3]	5	5
+copy_indices[3]	6	6
+copy_indices[3]	7	7
+copy_indices[3]	8	8
+copy_indices[3]	9	9
+copy_indices[3]	10	10
+copy_indices[3]	11	11
+copy_indices[3]	12	12
+copy_indices[3]	13	13
+copy_indices[3]	14	14
+copy_indices[3]	15	15
+copy_indices[3]	16	16
+copy_indices[3]	17	17
+copy_indices[3]	18	18
+copy_indices[3]	19	19
+copy_indices[3]	20	20
+copy_ifrom  [1]	21	3
+DEAL:0::1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 ok
+
+DEAL:1::FE_Q<2>(1)
+DEAL:1::cell=0_0: level_subdomain_id=0
+DEAL:1::cell=0_1:0 level_subdomain_id=0
+DEAL:1::cell=0_1:1 level_subdomain_id=1
+DEAL:1::cell=0_1:2 level_subdomain_id=1
+DEAL:1::cell=0_1:3 level_subdomain_id=1
+DEAL:1::cell=0_2:00 level_subdomain_id=0
+DEAL:1::cell=0_2:01 level_subdomain_id=0
+DEAL:1::cell=0_2:02 level_subdomain_id=0
+DEAL:1::cell=0_2:03 level_subdomain_id=1
+DEAL:1::cell=0_2:10 level_subdomain_id=1
+DEAL:1::cell=0_2:11 level_subdomain_id=1
+DEAL:1::cell=0_2:12 level_subdomain_id=1
+DEAL:1::cell=0_2:13 level_subdomain_id=1
+DEAL:1::cell=0_2:20 level_subdomain_id=1
+DEAL:1::cell=0_2:21 level_subdomain_id=1
+DEAL:1::cell=0_2:22 level_subdomain_id=1
+DEAL:1::cell=0_2:23 level_subdomain_id=1
+DEAL:1::cell=0_3:000 level_subdomain_id=4294967294
+DEAL:1::cell=0_3:001 level_subdomain_id=4294967294
+DEAL:1::cell=0_3:002 level_subdomain_id=4294967294
+DEAL:1::cell=0_3:003 level_subdomain_id=0
+DEAL:1::cell=0_3:010 level_subdomain_id=4294967294
+DEAL:1::cell=0_3:011 level_subdomain_id=0
+DEAL:1::cell=0_3:012 level_subdomain_id=0
+DEAL:1::cell=0_3:013 level_subdomain_id=0
+DEAL:1::cell=0_3:020 level_subdomain_id=4294967294
+DEAL:1::cell=0_3:021 level_subdomain_id=0
+DEAL:1::cell=0_3:022 level_subdomain_id=0
+DEAL:1::cell=0_3:023 level_subdomain_id=0
+copy_indices[1]	22	5
+copy_indices[1]	23	7
+copy_indices[1]	24	8
+copy_indices[2]	21	8
+copy_indices[2]	22	14
+copy_indices[2]	23	20
+copy_indices[2]	25	9
+copy_indices[2]	26	10
+copy_indices[2]	27	11
+copy_indices[2]	28	12
+copy_indices[2]	29	13
+copy_indices[2]	30	15
+copy_indices[2]	31	16
+copy_indices[2]	32	17
+copy_indices[2]	33	18
+copy_indices[2]	34	19
+copy_ito    [1]	21	3
+DEAL:1::1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 1.00000 ok
+


### PR DESCRIPTION
Dear DEAL.II team,

as said before in the forum, I want to contribute this small enhancement back into the main branch. If I am making any big mistakes here, I apologize in advance since this is the first time I am contributing back into a bigger project.

Please give feedback on this change so that I can bring it up to the level required for submission into the main branch.

Best regards,

Alexander Knieps.

Summary of the modifications:

cmake/config/template-arguments.in
  + Add PETSc vectors to the list of vectors for MGTransferPrebuilt to be instantiated with

include/deal.II/multigrid/mg_transfer.h
  + Change sparsity pattern argument from const ref to ref so that the pattern can be distributed (*)
  + Add reinit() method for matrices in style of trilinos reinit() method, but with manual distribution of sparsity pattern (**)

include/deal.II/multigrid/mg_transfer.templates.h
  + Add reinit() method for multi-level petsc vectors

 source/lac/petsc_parallel_sparse_matrix.cc
  + Remove assertion that prevents n_local_rows > 0 && n_local_columns == 0 (***)

source/multigrid/mg_level_global_transfer.inst.in
  + Instantiate MGLevelGlobalTransfer with PETSc MPI vectors

Comments:

(*) - There seems to be only one call site to this function which immediately calls clear() on the sparsity pattern after the call, so allowing this method to modify the sparsity pattern seems to be safe.

(**) - The trilinos reinit() function for the matrices takes an argument that allows the sparsity pattern to be distributed by trilinos. This is not supported by the PETSc reinit method, so the sparsity pattern needs to be distributed manually. 

(***) - This assertion was originally placed by Timo Heister in commit 06f4882c7c51ce876464fa4eaff82c363e05b36c (better reinit for PETSc matrix, now identical to Trilinos). I have run a deal.II based program where I had to comment out this assertion, but PETSc itself did not complain and the program worked. I think for multigrid to work with PETSc matrices, this has to go out in some way, since a very coarse level might well have n_dofs < n_processors, and therefore a matrix with n_local_columns == 0 && n_local_rows > 0 is bound to exist when transfering between a level with n_dofs >= n_processors and one with n_dofs < n_processors. If possible, I would like to know why that assertion was put there in the first place before just dropping it.