### PR TITLE
Avoid copies clang-tidy complains about

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2708,7 +2708,7 @@ next_cell:
   minimal_cell_diameter (const Triangulation<dim, spacedim> &triangulation)
   {
     double min_diameter = std::numeric_limits<double>::max();
-    for (const auto cell: triangulation.active_cell_iterators())
+    for (const auto &cell: triangulation.active_cell_iterators())
       if (!cell->is_artificial())
         min_diameter = std::min (min_diameter,
                                  cell->diameter());
@@ -2722,7 +2722,7 @@ next_cell:
   maximal_cell_diameter (const Triangulation<dim, spacedim> &triangulation)
   {
     double max_diameter = 0.;
-    for (const auto cell: triangulation.active_cell_iterators())
+    for (const auto &cell: triangulation.active_cell_iterators())
       if (!cell->is_artificial())
         max_diameter = std::max (max_diameter,
                                  cell->diameter());


### PR DESCRIPTION
`clang-tidy` [complains](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=121) about copying iterators in `GridTools::minimal_cell_diameter` and `GridTools::maximal_cell_diameter` instead of taking references.