### PR TITLE
Convert the various Mapping::get_*_data() functions to return std::unique_ptr.

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -646,7 +646,7 @@ protected:
    * the returned object, knowing its real (derived) type.
    */
   virtual
-  InternalDataBase *
+  std::unique_ptr<InternalDataBase>
   get_data (const UpdateFlags      update_flags,
             const Quadrature<dim> &quadrature) const = 0;
 
@@ -678,7 +678,7 @@ protected:
    * the returned object, knowing its real (derived) type.
    */
   virtual
-  InternalDataBase *
+  std::unique_ptr<InternalDataBase>
   get_face_data (const UpdateFlags        update_flags,
                  const Quadrature<dim-1> &quadrature) const = 0;
 
@@ -711,7 +711,7 @@ protected:
    * the returned object, knowing its real (derived) type.
    */
   virtual
-  InternalDataBase *
+  std::unique_ptr<InternalDataBase>
   get_subface_data (const UpdateFlags        update_flags,
                     const Quadrature<dim-1> &quadrature) const = 0;
 

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -200,19 +200,19 @@ private:
 
   // documentation can be found in Mapping::get_data()
   virtual
-  typename Mapping<dim, spacedim>::InternalDataBase *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const override;
 
   // documentation can be found in Mapping::get_face_data()
   virtual
-  typename Mapping<dim, spacedim>::InternalDataBase *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
-  typename Mapping<dim, spacedim>::InternalDataBase *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const override;
 

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -445,19 +445,19 @@ private:
 
   // documentation can be found in Mapping::get_data()
   virtual
-  InternalData *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const override;
 
   // documentation can be found in Mapping::get_face_data()
   virtual
-  typename Mapping<dim,spacedim>::InternalDataBase *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
-  typename Mapping<dim,spacedim>::InternalDataBase *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const override;
 

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -341,19 +341,19 @@ public:
 
   // documentation can be found in Mapping::get_data()
   virtual
-  InternalData *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const override;
 
   // documentation can be found in Mapping::get_face_data()
   virtual
-  InternalData *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
-  InternalData *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const override;
 

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -277,19 +277,19 @@ protected:
 
   // documentation can be found in Mapping::get_data()
   virtual
-  InternalData *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const override;
 
   // documentation can be found in Mapping::get_face_data()
   virtual
-  InternalData *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
-  InternalData *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const override;
 

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -534,19 +534,19 @@ public:
 
   // documentation can be found in Mapping::get_data()
   virtual
-  InternalData *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const override;
 
   // documentation can be found in Mapping::get_face_data()
   virtual
-  InternalData *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const override;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
-  InternalData *
+  std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const override;
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3964,8 +3964,8 @@ FEValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
                                    *this->mapping,
                                    quadrature,
                                    this->finite_element_output);
-  Threads::Task<typename Mapping<dim,spacedim>::InternalDataBase * >
-  mapping_get_data;
+  Threads::Task<std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>>
+      mapping_get_data;
   if (flags & update_mapping)
     mapping_get_data = Threads::new_task (&Mapping<dim,spacedim>::get_data,
                                           *this->mapping,
@@ -3977,7 +3977,7 @@ FEValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
   if (flags & update_mapping)
-    this->mapping_data.reset (mapping_get_data.return_value());
+    this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data = std_cxx14::make_unique<typename Mapping<dim,spacedim>::InternalDataBase> ();
 }
@@ -4214,8 +4214,8 @@ FEFaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
                                    *this->mapping,
                                    this->quadrature,
                                    this->finite_element_output);
-  Threads::Task<typename Mapping<dim,spacedim>::InternalDataBase *>
-  mapping_get_data;
+  Threads::Task<std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>>
+      mapping_get_data;
   if (flags & update_mapping)
     mapping_get_data = Threads::new_task (&Mapping<dim,spacedim>::get_face_data,
                                           *this->mapping,
@@ -4227,7 +4227,7 @@ FEFaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
   if (flags & update_mapping)
-    this->mapping_data.reset (mapping_get_data.return_value());
+    this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data = std_cxx14::make_unique<typename Mapping<dim,spacedim>::InternalDataBase> ();
 }
@@ -4382,8 +4382,8 @@ FESubfaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
                                    *this->mapping,
                                    this->quadrature,
                                    this->finite_element_output);
-  Threads::Task<typename Mapping<dim,spacedim>::InternalDataBase *>
-  mapping_get_data;
+  Threads::Task<std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>>
+      mapping_get_data;
   if (flags & update_mapping)
     mapping_get_data = Threads::new_task (&Mapping<dim,spacedim>::get_subface_data,
                                           *this->mapping,
@@ -4395,7 +4395,7 @@ FESubfaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
   if (flags & update_mapping)
-    this->mapping_data.reset (mapping_get_data.return_value());
+    this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data = std_cxx14::make_unique<typename Mapping<dim,spacedim>::InternalDataBase> ();
 }

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -89,29 +89,28 @@ MappingCartesian<dim, spacedim>::requires_update_flags (const UpdateFlags in) co
 
 
 template <int dim, int spacedim>
-typename Mapping<dim, spacedim>::InternalDataBase *
+std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
 MappingCartesian<dim, spacedim>::get_data (const UpdateFlags      update_flags,
                                            const Quadrature<dim> &q) const
 {
-  InternalData *data = new InternalData (q);
+  auto data = std_cxx14::make_unique<InternalData> (q);
 
   // store the flags in the internal data object so we can access them
   // in fill_fe_*_values(). use the transitive hull of the required
   // flags
   data->update_each = requires_update_flags(update_flags);
 
-  return data;
+  return std::move(data);
 }
 
 
 
 template <int dim, int spacedim>
-typename Mapping<dim, spacedim>::InternalDataBase *
+std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
 MappingCartesian<dim, spacedim>::get_face_data (const UpdateFlags update_flags,
                                                 const Quadrature<dim-1>& quadrature) const
 {
-  InternalData *data
-    = new InternalData (QProjector<dim>::project_to_all_faces(quadrature));
+  auto data = std_cxx14::make_unique<InternalData> (QProjector<dim>::project_to_all_faces(quadrature));
 
   // verify that we have computed the transitive hull of the required
   // flags and that FEValues has faithfully passed them on to us
@@ -122,18 +121,17 @@ MappingCartesian<dim, spacedim>::get_face_data (const UpdateFlags update_flags,
   // in fill_fe_*_values()
   data->update_each = update_flags;
 
-  return data;
+  return std::move(data);
 }
 
 
 
 template <int dim, int spacedim>
-typename Mapping<dim, spacedim>::InternalDataBase *
+std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
 MappingCartesian<dim, spacedim>::get_subface_data (const UpdateFlags update_flags,
                                                    const Quadrature<dim-1> &quadrature) const
 {
-  InternalData *data
-    = new InternalData (QProjector<dim>::project_to_all_subfaces(quadrature));
+  auto data = std_cxx14::make_unique<InternalData> (QProjector<dim>::project_to_all_subfaces(quadrature));
 
   // verify that we have computed the transitive hull of the required
   // flags and that FEValues has faithfully passed them on to us
@@ -144,7 +142,7 @@ MappingCartesian<dim, spacedim>::get_subface_data (const UpdateFlags update_flag
   // in fill_fe_*_values()
   data->update_each = update_flags;
 
-  return data;
+  return std::move(data);
 }
 
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -300,44 +300,44 @@ MappingManifold<dim,spacedim>::requires_update_flags (const UpdateFlags in) cons
 
 
 template <int dim, int spacedim>
-typename MappingManifold<dim,spacedim>::InternalData *
+std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
 MappingManifold<dim,spacedim>::get_data (const UpdateFlags update_flags,
                                          const Quadrature<dim> &q) const
 {
-  InternalData *data = new InternalData();
+  auto data = std_cxx14::make_unique<InternalData>();
   data->initialize (this->requires_update_flags(update_flags), q, q.size());
 
-  return data;
+  return std::move(data);
 }
 
 
 
 template <int dim, int spacedim>
-typename MappingManifold<dim,spacedim>::InternalData *
+std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
 MappingManifold<dim,spacedim>::get_face_data (const UpdateFlags        update_flags,
                                               const Quadrature<dim-1> &quadrature) const
 {
-  InternalData *data = new InternalData();
+  auto data = std_cxx14::make_unique<InternalData>();
   data->initialize_face (this->requires_update_flags(update_flags),
                          QProjector<dim>::project_to_all_faces(quadrature),
                          quadrature.size());
 
-  return data;
+  return std::move(data);
 }
 
 
 
 template <int dim, int spacedim>
-typename MappingManifold<dim,spacedim>::InternalData *
+std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
 MappingManifold<dim,spacedim>::get_subface_data (const UpdateFlags update_flags,
                                                  const Quadrature<dim-1>& quadrature) const
 {
-  InternalData *data = new InternalData();
+  auto data = std_cxx14::make_unique<InternalData>();
   data->initialize_face (this->requires_update_flags(update_flags),
                          QProjector<dim>::project_to_all_subfaces(quadrature),
                          quadrature.size());
 
-  return data;
+  return std::move(data);
 }
 
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -144,73 +144,79 @@ MappingQ<dim,spacedim>::requires_update_flags (const UpdateFlags in) const
 
 
 template <int dim, int spacedim>
-typename MappingQ<dim,spacedim>::InternalData *
+std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
 MappingQ<dim,spacedim>::get_data (const UpdateFlags update_flags,
                                   const Quadrature<dim> &quadrature) const
 {
-  InternalData *data = new InternalData;
+  auto data = std_cxx14::make_unique<InternalData>();
 
   // build the Q1 and Qp internal data objects in parallel
-  Threads::Task<typename MappingQGeneric<dim,spacedim>::InternalData *>
-  do_get_data = Threads::new_task (&MappingQGeneric<dim,spacedim>::get_data,
-                                   *qp_mapping,
-                                   update_flags,
-                                   quadrature);
+  Threads::Task<std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>>
+      do_get_data = Threads::new_task (&MappingQGeneric<dim,spacedim>::get_data,
+                                       *qp_mapping,
+                                       update_flags,
+                                       quadrature);
 
   if (!use_mapping_q_on_all_cells)
-    data->mapping_q1_data.reset (q1_mapping->get_data (update_flags, quadrature));
+    data->mapping_q1_data.reset (dynamic_cast<typename MappingQGeneric<dim,spacedim>::InternalData *>
+                                 (q1_mapping->get_data (update_flags, quadrature).release()));
 
   // wait for the task above to finish and use returned value
-  data->mapping_qp_data.reset (do_get_data.return_value());
-  return data;
+  data->mapping_qp_data.reset (dynamic_cast<typename MappingQGeneric<dim,spacedim>::InternalData *>
+                               (do_get_data.return_value().release()));
+  return std::move(data);
 }
 
 
 
 template <int dim, int spacedim>
-typename MappingQ<dim,spacedim>::InternalData *
+std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
 MappingQ<dim,spacedim>::get_face_data (const UpdateFlags update_flags,
                                        const Quadrature<dim-1>& quadrature) const
 {
-  InternalData *data = new InternalData;
+  auto data = std_cxx14::make_unique<InternalData>();
 
   // build the Q1 and Qp internal data objects in parallel
-  Threads::Task<typename MappingQGeneric<dim,spacedim>::InternalData *>
-  do_get_data = Threads::new_task (&MappingQGeneric<dim,spacedim>::get_face_data,
-                                   *qp_mapping,
-                                   update_flags,
-                                   quadrature);
+  Threads::Task<std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>>
+      do_get_data = Threads::new_task (&MappingQGeneric<dim,spacedim>::get_face_data,
+                                       *qp_mapping,
+                                       update_flags,
+                                       quadrature);
 
   if (!use_mapping_q_on_all_cells)
-    data->mapping_q1_data.reset (q1_mapping->get_face_data (update_flags, quadrature));
+    data->mapping_q1_data.reset (dynamic_cast<typename MappingQGeneric<dim,spacedim>::InternalData *>
+                                 (q1_mapping->get_face_data (update_flags, quadrature).release()));
 
   // wait for the task above to finish and use returned value
-  data->mapping_qp_data.reset (do_get_data.return_value());
-  return data;
+  data->mapping_qp_data.reset (dynamic_cast<typename MappingQGeneric<dim,spacedim>::InternalData *>
+                               (do_get_data.return_value().release()));
+  return std::move(data);
 }
 
 
 
 template <int dim, int spacedim>
-typename MappingQ<dim,spacedim>::InternalData *
+std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
 MappingQ<dim,spacedim>::get_subface_data (const UpdateFlags update_flags,
                                           const Quadrature<dim-1>& quadrature) const
 {
-  InternalData *data = new InternalData;
+  auto data = std_cxx14::make_unique<InternalData>();
 
   // build the Q1 and Qp internal data objects in parallel
-  Threads::Task<typename MappingQGeneric<dim,spacedim>::InternalData *>
-  do_get_data = Threads::new_task (&MappingQGeneric<dim,spacedim>::get_subface_data,
-                                   *qp_mapping,
-                                   update_flags,
-                                   quadrature);
+  Threads::Task<std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>>
+      do_get_data = Threads::new_task (&MappingQGeneric<dim,spacedim>::get_subface_data,
+                                       *qp_mapping,
+                                       update_flags,
+                                       quadrature);
 
   if (!use_mapping_q_on_all_cells)
-    data->mapping_q1_data.reset (q1_mapping->get_subface_data (update_flags, quadrature));
+    data->mapping_q1_data.reset (dynamic_cast<typename MappingQGeneric<dim,spacedim>::InternalData *>
+                                 (q1_mapping->get_subface_data (update_flags, quadrature).release()));
 
   // wait for the task above to finish and use returned value
-  data->mapping_qp_data.reset (do_get_data.return_value());
-  return data;
+  data->mapping_qp_data.reset (dynamic_cast<typename MappingQGeneric<dim,spacedim>::InternalData *>
+                               (do_get_data.return_value().release()));
+  return std::move(data);
 }
 
 

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -2233,8 +2233,8 @@ transform_real_to_unit_cell_internal
   UpdateFlags update_flags = update_quadrature_points | update_jacobians;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::unique_ptr<InternalData> mdata (get_data(update_flags,
-                                                point_quadrature));
+  std::unique_ptr<InternalData> mdata (dynamic_cast<InternalData *>(get_data(update_flags,
+                                       point_quadrature).release()));
 
   mdata->mapping_support_points = this->compute_mapping_support_points (cell);
 
@@ -2259,8 +2259,8 @@ transform_real_to_unit_cell_internal
   UpdateFlags update_flags = update_quadrature_points | update_jacobians;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::unique_ptr<InternalData> mdata (get_data(update_flags,
-                                                point_quadrature));
+  std::unique_ptr<InternalData> mdata (dynamic_cast<InternalData *>(get_data(update_flags,
+                                       point_quadrature).release()));
 
   mdata->mapping_support_points = this->compute_mapping_support_points (cell);
 
@@ -2285,8 +2285,8 @@ transform_real_to_unit_cell_internal
   UpdateFlags update_flags = update_quadrature_points | update_jacobians;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::unique_ptr<InternalData> mdata (get_data(update_flags,
-                                                point_quadrature));
+  std::unique_ptr<InternalData> mdata (dynamic_cast<InternalData *>(get_data(update_flags,
+                                       point_quadrature).release()));
 
   mdata->mapping_support_points = this->compute_mapping_support_points (cell);
 
@@ -2294,6 +2294,8 @@ transform_real_to_unit_cell_internal
   // spacedim=dim+1, etc
   return internal::MappingQGenericImplementation::do_transform_real_to_unit_cell_internal<3>(cell, p, initial_p_unit, *mdata);
 }
+
+
 
 template <>
 Point<1>
@@ -2311,8 +2313,8 @@ transform_real_to_unit_cell_internal
   UpdateFlags update_flags = update_quadrature_points | update_jacobians;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::unique_ptr<InternalData> mdata (get_data(update_flags,
-                                                point_quadrature));
+  std::unique_ptr<InternalData> mdata (dynamic_cast<InternalData *>(get_data(update_flags,
+                                       point_quadrature).release()));
 
   mdata->mapping_support_points = this->compute_mapping_support_points (cell);
 
@@ -2320,6 +2322,8 @@ transform_real_to_unit_cell_internal
   // spacedim=dim+1, etc
   return internal::MappingQGenericImplementation::do_transform_real_to_unit_cell_internal_codim1<1>(cell, p, initial_p_unit, *mdata);
 }
+
+
 
 template <>
 Point<2>
@@ -2337,8 +2341,8 @@ transform_real_to_unit_cell_internal
   UpdateFlags update_flags = update_quadrature_points | update_jacobians;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::unique_ptr<InternalData> mdata (get_data(update_flags,
-                                                point_quadrature));
+  std::unique_ptr<InternalData> mdata (dynamic_cast<InternalData *>(get_data(update_flags,
+                                       point_quadrature).release()));
 
   mdata->mapping_support_points = this->compute_mapping_support_points (cell);
 
@@ -2554,44 +2558,44 @@ MappingQGeneric<dim,spacedim>::requires_update_flags (const UpdateFlags in) cons
 
 
 template <int dim, int spacedim>
-typename MappingQGeneric<dim,spacedim>::InternalData *
+std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
 MappingQGeneric<dim,spacedim>::get_data (const UpdateFlags update_flags,
                                          const Quadrature<dim> &q) const
 {
-  InternalData *data = new InternalData(polynomial_degree);
+  auto data = std_cxx14::make_unique<InternalData>(polynomial_degree);
   data->initialize (this->requires_update_flags(update_flags), q, q.size());
 
-  return data;
+  return std::move(data);
 }
 
 
 
 template <int dim, int spacedim>
-typename MappingQGeneric<dim,spacedim>::InternalData *
+std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
 MappingQGeneric<dim,spacedim>::get_face_data (const UpdateFlags        update_flags,
                                               const Quadrature<dim-1> &quadrature) const
 {
-  InternalData *data = new InternalData(polynomial_degree);
+  auto data = std_cxx14::make_unique<InternalData>(polynomial_degree);
   data->initialize_face (this->requires_update_flags(update_flags),
                          QProjector<dim>::project_to_all_faces(quadrature),
                          quadrature.size());
 
-  return data;
+  return std::move(data);
 }
 
 
 
 template <int dim, int spacedim>
-typename MappingQGeneric<dim,spacedim>::InternalData *
+std::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase>
 MappingQGeneric<dim,spacedim>::get_subface_data (const UpdateFlags update_flags,
                                                  const Quadrature<dim-1>& quadrature) const
 {
-  InternalData *data = new InternalData(polynomial_degree);
+  auto data = std_cxx14::make_unique<InternalData>(polynomial_degree);
   data->initialize_face (this->requires_update_flags(update_flags),
                          QProjector<dim>::project_to_all_subfaces(quadrature),
                          quadrature.size());
 
-  return data;
+  return std::move(data);
 }
 
 


### PR DESCRIPTION
This required a number of adjustments in places where we used the fact that we used covariant
return types all over the place. We can't do this any more, and so in a number of places
we have to convert things by hand back to the (known) derived type.

This is the patch promised in #5880, and it complements what @masterleinad
had already proposed in #6113 -- except that it actually works ;-) The
current version of the pull request contains what I had previously posted
in #6114, which I'll rebase out once that is merged separately.