### PR TITLE
Make sure is_contiguous() compares addresses, not values, of array objects.

### DIFF
--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -439,7 +439,7 @@ namespace internal
     {
       const auto n = std::distance(first, last);
       for (typename std::decay<decltype(n)>::type i = 0; i < n; ++i)
-        if (*(std::next(first, i)) != *(std::next(std::addressof(*first), i)))
+        if (std::addressof(*(std::next(first, i))) != std::next(std::addressof(*first), i))
           return false;
       return true;
     }

--- a/tests/base/is_contiguous_nan.cc
+++ b/tests/base/is_contiguous_nan.cc
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test that is_contiguous works correctly for arrays that contain
+// signaling NaNs. In the first version of the is_contiguous() helper
+// function, we compared the *objects* pointed to, as opposed to the
+// *addresses* of these objects. This required (i) that these objects
+// have an operator==, and (ii) that a==a for any object 'a'. The
+// latter is not true if 'a' is a double that contains a
+// signaling_nan<double>(), and consequently, the is_contiguous()
+// function returned false for arrays with such entries.
+//
+// The failure of the function to recognize that the array elements
+// are contiguous led to downstream failures of make_array_view().
+
+#include "../tests.h"
+
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/signaling_nan.h>
+
+void test ()
+{
+  std::vector<double> tmp (2);
+  tmp[0] = numbers::signaling_nan<double>();
+  tmp[1] = numbers::signaling_nan<double>();
+  deallog << (internal::ArrayViewHelper::is_contiguous (tmp.begin(), tmp.end())
+              ?
+              "true"
+              :
+              "false")
+          << std::endl;
+}
+
+
+int main()
+{
+  deal_II_exceptions::disable_abort_on_exception();
+  initlog();
+
+  test();
+}

--- a/tests/base/is_contiguous_nan.output
+++ b/tests/base/is_contiguous_nan.output
@@ -1,0 +1,2 @@
+
+DEAL::true


### PR DESCRIPTION
This fixes #6121. It doesn't need a changelog entry since the function is new anyway.