### PR TITLE
Fix VectorTools::integrate_difference()

### DIFF
--- a/doc/news/changes/minor/20180329Bangerth
+++ b/doc/news/changes/minor/20180329Bangerth
@@ -1,0 +1,25 @@
+Fixed: The VectorTools::integrate_difference() function allows users
+to provide a weight function that can also serve as a component mask
+to select individual components of the solution vector for error
+computation. For components not selected, such a mask would then
+simply be zero.
+<br>
+In some cases, the solution vector contains NaN numbers, for example
+when one uses the FE_FaceQ element for certain components of the
+solution vector and uses a quadrature formula for error evaluation
+that has quadrature points in the interior of the cell. For any
+"regular" solution component for which the component mask has a zero
+weight, the value of that component will be multiplied by zero and
+consequently does not add anything to the error computation. However,
+if the NaNs of a FE_FaceQ are multiplied with zero weights, the result
+is still a NaN, and adding it to the values times weights of the other
+components results in NaNs -- in effect rendering it impossible to get
+any information out of the VectorTools::integrate_difference()
+function if one of the finite elements involved is FE_FaceQ.
+<br>
+This is now fixed by simply skipping vector components for which the
+weight vector is zero. This has the same result as before for all
+"normal" situations, but also properly skips the NaN case outlined
+above.
+<br>
+(Wolfgang Bangerth, 2018/03/29)

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -83,8 +83,17 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
                 const typename FiniteElement<dim,spacedim>::InternalDataBase &,
                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &) const
 {
-  // Do nothing, since we do not have
-  // values in the interior
+  // Do nothing, since we do not have values in the interior. Since
+  // FEValues initializes the output variables for this function
+  // with invalid values, this means that we simply leave them at
+  // the invalid values -- typically, signaling NaNs. This means
+  // that when you later look at those components of shape
+  // functions or solution vectors that correspond to the
+  // face element, you will see signaling_NaNs. This simply means
+  // that you should not use them -- the shape functions and the
+  // solution do not actually live inside the cell, and so any
+  // attempt at evaluating it there *should* yield an invalid
+  // result.
 }
 
 

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -7089,7 +7089,8 @@ namespace VectorTools
             {
               Number sum = 0;
               for (unsigned int k=0; k<n_components; ++k)
-                sum += data.psi_values[q](k) * data.weight_vectors[q](k);
+                if (data.weight_vectors[q](k) != 0)
+                  sum += data.psi_values[q](k) * data.weight_vectors[q](k);
               diff_mean += sum * fe_values.JxW(q);
             }
           break;
@@ -7102,9 +7103,10 @@ namespace VectorTools
             {
               double sum = 0;
               for (unsigned int k=0; k<n_components; ++k)
-                sum += std::pow(
-                         static_cast<double>(numbers::NumberTraits<Number>::abs_square(data.psi_values[q](k))),
-                         exponent/2.) * data.weight_vectors[q](k);
+                if (data.weight_vectors[q](k) != 0)
+                  sum += std::pow(static_cast<double>(numbers::NumberTraits<Number>::abs_square(data.psi_values[q](k))),
+                                  exponent/2.) *
+                         data.weight_vectors[q](k);
               diff += sum * fe_values.JxW(q);
             }
 
@@ -7120,8 +7122,9 @@ namespace VectorTools
             {
               double sum = 0;
               for (unsigned int k=0; k<n_components; ++k)
-                sum += numbers::NumberTraits<Number>::abs_square(data.psi_values[q](k)) *
-                       data.weight_vectors[q](k);
+                if (data.weight_vectors[q](k) != 0)
+                  sum += numbers::NumberTraits<Number>::abs_square(data.psi_values[q](k)) *
+                         data.weight_vectors[q](k);
               diff += sum * fe_values.JxW(q);
             }
           // Compute the root only, if no derivative values are added later
@@ -7133,8 +7136,9 @@ namespace VectorTools
         case W1infty_norm:
           for (unsigned int q=0; q<n_q_points; ++q)
             for (unsigned int k=0; k<n_components; ++k)
-              diff = std::max (diff, double(std::abs(data.psi_values[q](k)*
-                                                     data.weight_vectors[q](k))));
+              if (data.weight_vectors[q](k) != 0)
+                diff = std::max (diff, double(std::abs(data.psi_values[q](k)*
+                                                       data.weight_vectors[q](k))));
           break;
 
         case H1_seminorm:
@@ -7158,9 +7162,10 @@ namespace VectorTools
             {
               double sum = 0;
               for (unsigned int k=0; k<n_components; ++k)
-                sum += std::pow(
-                         data.psi_grads[q][k].norm_square(),
-                         exponent/2.) * data.weight_vectors[q](k);
+                if (data.weight_vectors[q](k) != 0)
+                  sum += std::pow(
+                           data.psi_grads[q][k].norm_square(),
+                           exponent/2.) * data.weight_vectors[q](k);
               diff += sum * fe_values.JxW(q);
             }
           diff = std::pow(diff, 1./exponent);
@@ -7172,8 +7177,9 @@ namespace VectorTools
             {
               double sum = 0;
               for (unsigned int k=0; k<n_components; ++k)
-                sum += data.psi_grads[q][k].norm_square() *
-                       data.weight_vectors[q](k);
+                if (data.weight_vectors[q](k) != 0)
+                  sum += data.psi_grads[q][k].norm_square() *
+                         data.weight_vectors[q](k);
               diff += sum * fe_values.JxW(q);
             }
           diff = std::sqrt(diff);
@@ -7197,7 +7203,8 @@ namespace VectorTools
               Number sum = 0;
               // take the trace of the derivatives scaled by the weight and square it
               for (unsigned int k=idx; k<idx+dim; ++k)
-                sum += data.psi_grads[q][k][k-idx] * std::sqrt(data.weight_vectors[q](k));
+                if (data.weight_vectors[q](k) != 0)
+                  sum += data.psi_grads[q][k][k-idx] * std::sqrt(data.weight_vectors[q](k));
               diff += numbers::NumberTraits<Number>::abs_square(sum) * fe_values.JxW(q);
             }
           diff = std::sqrt(diff);
@@ -7209,10 +7216,11 @@ namespace VectorTools
           double t = 0;
           for (unsigned int q=0; q<n_q_points; ++q)
             for (unsigned int k=0; k<n_components; ++k)
-              for (unsigned int d=0; d<dim; ++d)
-                t = std::max(t,
-                             double(std::abs(data.psi_grads[q][k][d]) *
-                                    data.weight_vectors[q](k)));
+              if (data.weight_vectors[q](k) != 0)
+                for (unsigned int d=0; d<dim; ++d)
+                  t = std::max(t,
+                               double(std::abs(data.psi_grads[q][k][d]) *
+                                      data.weight_vectors[q](k)));
 
           // then add seminorm to norm if that had previously been computed
           diff += t;

--- a/tests/vector_tools/integrate_difference_02_nan.cc
+++ b/tests/vector_tools/integrate_difference_02_nan.cc
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test integrate_difference
+//
+// The VectorTools::integrate_difference() function allows users
+// to provide a weight function that can also serve as a component mask
+// to select individual components of the solution vector for error
+// computation. For components not selected, such a mask would then
+// simply be zero.
+//
+// In some cases, the solution vector contains NaN numbers, for example
+// when one uses the FE_FaceQ element for certain components of the
+// solution vector and uses a quadrature formula for error evaluation
+// that has quadrature points in the interior of the cell. For any
+// "regular" solution component for which the component mask has a zero
+// weight, the value of that component will be multiplied by zero and
+// consequently does not add anything to the error computation. However,
+// if the NaNs of a FE_FaceQ are multiplied with zero weights, the result
+// is still a NaN, and adding it to the values times weights of the other
+// components results in NaNs -- in effect rendering it impossible to get
+// any information out of the VectorTools::integrate_difference()
+// function if one of the finite elements involved is FE_FaceQ.
+//
+// This is now fixed by simply skipping vector components for which the
+// weight vector is zero. This has the same result as before for all
+// "normal" situations, but also properly skips the NaN case outlined
+// above.
+
+
+#include "../tests.h"
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/signaling_nan.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_face.h>
+#include <deal.II/fe/fe_system.h>
+
+using namespace dealii;
+
+
+template <int dim>
+void test(VectorTools::NormType norm, double exp = 2.0)
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  FESystem<dim> fe(FE_Q<dim>(1), 1,
+                   FE_FaceQ<dim>(1), 1);
+  DoFHandler<dim> dofh(tria);
+  dofh.distribute_dofs(fe);
+
+  // Create a zero vector. (The values in there are not important,
+  // just that the difference between this and later the exact
+  // solution happens to have signaling_nans in it. It will have these
+  // values because FE_FaceQ refuses to fill FEValues values --
+  // because it's a face element, so this refusal actually makes sense
+  // -- and thus leaves the signaling NaNs from the original invalid
+  // initialization.)
+  Vector<double> solution (dofh.n_dofs ());
+
+  Vector<double> cellwise_errors (tria.n_active_cells());
+  QIterated<dim> quadrature (QTrapez<1>(), 2);
+
+  const ComponentSelectFunction<dim> component_mask (1, 2);
+  VectorTools::integrate_difference (dofh,
+                                     solution,
+                                     ZeroFunction<dim>(2),
+                                     cellwise_errors,
+                                     quadrature,
+                                     norm,
+                                     &component_mask,
+                                     exp);
+
+  const double error
+    = VectorTools::compute_global_error(tria, cellwise_errors, norm, exp);
+
+  deallog << "computed: " << error
+          << std::endl;
+}
+
+
+
+template <int dim>
+void test()
+{
+  deallog << "L2_norm:" << std::endl;
+  test<dim>(VectorTools::L2_norm);
+
+  deallog << "H1_seminorm:" << std::endl;
+  test<dim>(VectorTools::H1_seminorm);
+
+  deallog << "H1_norm:" << std::endl;
+  test<dim>(VectorTools::H1_norm);
+
+  deallog << "L1_norm:" << std::endl;
+  test<dim>(VectorTools::L1_norm);
+
+  deallog << "Linfty_norm:" << std::endl;
+  test<dim>(VectorTools::Linfty_norm);
+
+  deallog << "mean:" << std::endl;
+  test<dim>(VectorTools::mean);
+
+  deallog << "Lp_norm:" << std::endl;
+  test<dim>(VectorTools::Lp_norm, 3.0);
+
+  deallog << "W1p_seminorm:" << std::endl;
+  test<dim>(VectorTools::W1p_seminorm, 3.0);
+
+  deallog << "OK" << std::endl;
+}
+
+
+int main (int argc, char **argv)
+{
+  initlog();
+  test<3>();
+}

--- a/tests/vector_tools/integrate_difference_02_nan.output
+++ b/tests/vector_tools/integrate_difference_02_nan.output
@@ -1,0 +1,18 @@
+
+DEAL::L2_norm:
+DEAL::computed: 0.00000
+DEAL::H1_seminorm:
+DEAL::computed: 0.00000
+DEAL::H1_norm:
+DEAL::computed: 0.00000
+DEAL::L1_norm:
+DEAL::computed: 0.00000
+DEAL::Linfty_norm:
+DEAL::computed: 0.00000
+DEAL::mean:
+DEAL::computed: 0.00000
+DEAL::Lp_norm:
+DEAL::computed: 0.00000
+DEAL::W1p_seminorm:
+DEAL::computed: 0.00000
+DEAL::OK


### PR DESCRIPTION
All sorts of bizarre problems I'm running into today:

The VectorTools::integrate_difference() function allows users
to provide a weight function that can also serve as a component mask
to select individual components of the solution vector for error
computation. For components not selected, such a mask would then
simply be zero.

In some cases, the solution vector contains NaN numbers, for example
when one uses the FE_FaceQ element for certain components of the
solution vector and uses a quadrature formula for error evaluation
that has quadrature points in the interior of the cell. For any
"regular" solution component for which the component mask has a zero
weight, the value of that component will be multiplied by zero and
consequently does not add anything to the error computation. However,
if the NaNs of a FE_FaceQ are multiplied with zero weights, the result
is still a NaN, and adding it to the values times weights of the other
components results in NaNs -- in effect rendering it impossible to get
any information out of the VectorTools::integrate_difference()
function if one of the finite elements involved is FE_FaceQ.

This is now fixed by simply skipping vector components for which the
weight vector is zero. This has the same result as before for all
"normal" situations, but also properly skips the NaN case outlined
above.


For reference: The way these NaNs get into the FEValues output is here:
  https://github.com/dealii/dealii/blob/master/include/deal.II/fe/fe_poly_face.templates.h#L86
I've updated this comment as part of the patch to explain some of the
consequences.

The problem first showed up in a program by @sophy1029 which pointed
me in the right direction with the fix.