### PR TITLE
Avoid using functionality removed in libc++ for C++17

### DIFF
--- a/bundled/boost-1.62.0/include/boost/container/string.hpp
+++ b/bundled/boost-1.62.0/include/boost/container/string.hpp
@@ -535,7 +535,7 @@ class basic_string
       bool operator()(const typename Tr::char_type& x) const
       {
          return std::find_if(m_first, m_last,
-                        std::bind1st(Eq_traits<Tr>(), x)) == m_last;
+                             [](const argument_type &ch) {return Eq_traits<Tr>(x, ch)}) == m_last;
       }
    };
    #endif   //#ifndef BOOST_CONTAINER_DOXYGEN_INVOKED
@@ -2116,7 +2116,7 @@ class basic_string
          pointer finish = addr + sz;
          const const_iterator result =
             std::find_if(addr + pos, finish,
-                  std::bind2nd(Eq_traits<Traits>(), c));
+                         [](const argument_type &ch) {return Eq_traits<Tr>(ch, c)});
          return result != finish ? result - begin() : npos;
       }
    }
@@ -2176,7 +2176,7 @@ class basic_string
          const const_iterator last = begin() + container_detail::min_value(len - 1, pos) + 1;
          const_reverse_iterator rresult =
             std::find_if(const_reverse_iterator(last), rend(),
-                  std::bind2nd(Eq_traits<Traits>(), c));
+                         [](const argument_type &ch) {return Eq_traits<Tr>(ch, c)});
          return rresult != rend() ? (rresult.base() - 1) - begin() : npos;
       }
    }
@@ -2319,8 +2319,8 @@ class basic_string
          const pointer addr   = this->priv_addr();
          const pointer finish = addr + this->priv_size();
          const const_iterator result
-            = std::find_if(addr + pos, finish,
-                     std::not1(std::bind2nd(Eq_traits<Traits>(), c)));
+            = std::find_if_not(addr + pos, finish,
+                               [](const argument_type &ch) {return Eq_traits<Tr>(ch, c)});
          return result != finish ? result - begin() : npos;
       }
    }
@@ -2375,8 +2375,8 @@ class basic_string
       else {
          const const_iterator last = begin() + container_detail::min_value(len - 1, pos) + 1;
          const const_reverse_iterator rresult =
-            std::find_if(const_reverse_iterator(last), rend(),
-                  std::not1(std::bind2nd(Eq_traits<Traits>(), c)));
+            std::find_if_not(const_reverse_iterator(last), rend(),
+                             [](const argument_type &ch) {return Eq_traits<Tr>(ch, c)});
          return rresult != rend() ? (rresult.base() - 1) - begin() : npos;
       }
    }

--- a/bundled/boost-1.62.0/include/boost/date_time/gregorian/greg_facet.hpp
+++ b/bundled/boost-1.62.0/include/boost/date_time/gregorian/greg_facet.hpp
@@ -290,7 +290,11 @@ namespace gregorian {
      * names as a default. */
     catch(std::bad_cast&){
       charT a = '\0';
+#if defined(BOOST_NO_CXX11_SMART_PTR)
       std::auto_ptr< const facet_def > f(create_facet_def(a));
+#else
+      std::unique_ptr< const facet_def > f(create_facet_def(a));
+#endif
       num = date_time::find_match(f->get_short_month_names(), 
                                   f->get_long_month_names(), 
                                   (greg_month::max)(), s); // greg_month spans 1..12, so max returns the array size,
@@ -332,7 +336,11 @@ namespace gregorian {
      * names as a default. */
     catch(std::bad_cast&){
       charT a = '\0';
+#if defined(BOOST_NO_CXX11_SMART_PTR)
       std::auto_ptr< const facet_def > f(create_facet_def(a));
+#else
+      std::unique_ptr< const facet_def > f(create_facet_def(a));
+#endif
       num = date_time::find_match(f->get_short_weekday_names(), 
                                   f->get_long_weekday_names(), 
                                   (greg_weekday::max)() + 1, s); // greg_weekday spans 0..6, so increment is needed

--- a/bundled/boost-1.62.0/include/boost/detail/lightweight_thread.hpp
+++ b/bundled/boost-1.62.0/include/boost/detail/lightweight_thread.hpp
@@ -77,7 +77,11 @@ public:
 
 extern "C" void * lw_thread_routine( void * pv )
 {
+#if defined(BOOST_NO_CXX11_SMART_PTR)
     std::auto_ptr<lw_abstract_thread> pt( static_cast<lw_abstract_thread *>( pv ) );
+#else
+    std::unique_ptr<lw_abstract_thread> pt( static_cast<lw_abstract_thread *>( pv ) );
+#endif
 
     pt->run();
 
@@ -88,7 +92,11 @@ extern "C" void * lw_thread_routine( void * pv )
 
 unsigned __stdcall lw_thread_routine( void * pv )
 {
+#if defined(BOOST_NO_CXX11_SMART_PTR)
     std::auto_ptr<lw_abstract_thread> pt( static_cast<lw_abstract_thread *>( pv ) );
+#else
+    std::unique_ptr<lw_abstract_thread> pt( static_cast<lw_abstract_thread *>( pv ) );
+#endif
 
     pt->run();
 
@@ -117,7 +125,11 @@ private:
 
 template<class F> int lw_thread_create( pthread_t & pt, F f )
 {
+#if defined(BOOST_NO_CXX11_SMART_PTR)
     std::auto_ptr<lw_abstract_thread> p( new lw_thread_impl<F>( f ) );
+#else
+    std::unique_ptr<lw_abstract_thread> p( new lw_thread_impl<F>( f ) );
+#endif
 
     int r = pthread_create( &pt, 0, lw_thread_routine, p.get() );
 

--- a/bundled/boost-1.62.0/include/boost/graph/detail/adjacency_list.hpp
+++ b/bundled/boost-1.62.0/include/boost/graph/detail/adjacency_list.hpp
@@ -289,7 +289,11 @@ namespace boost {
       // invalidation for add_edge() with EdgeList=vecS. Instead we
       // hold a pointer to the property. std::auto_ptr is not
       // a perfect fit for the job, but it is darn close.
+#if defined(BOOST_NO_CXX11_SMART_PTR)
       std::auto_ptr<Property> m_property;
+#else
+      std::unique_ptr<Property> m_property;
+#endif
     };
 #else
     template <class Vertex, class Property>

--- a/bundled/boost-1.62.0/include/boost/graph/distributed/detail/mpi_process_group.ipp
+++ b/bundled/boost-1.62.0/include/boost/graph/distributed/detail/mpi_process_group.ipp
@@ -842,7 +842,7 @@ all_gather(const mpi_process_group& pg, InputIterator first,
 
   // Adjust sizes based on the number of bytes
   std::transform(sizes.begin(), sizes.end(), sizes.begin(),
-                 std::bind2nd(std::multiplies<int>(), sizeof(T)));
+                 [](const int& size){return std::multiplies<int>(size, sizeof(T))});
 
   // Compute displacements
   std::vector<int> displacements;

--- a/bundled/boost-1.62.0/include/boost/iostreams/chain.hpp
+++ b/bundled/boost-1.62.0/include/boost/iostreams/chain.hpp
@@ -243,8 +243,13 @@ private:
             pback_size != -1 ?
                 pback_size :
                 pimpl_->pback_size_;
+#if defined(BOOST_NO_CXX11_SMART_PTR)
         std::auto_ptr<streambuf_t>
             buf(new streambuf_t(t, buffer_size, pback_size));
+#else
+        std::unique_ptr<streambuf_t>
+            buf(new streambuf_t(t, buffer_size, pback_size));
+#endif
         list().push_back(buf.get());
         buf.release();
         if (is_device<component_type>::value) {

--- a/bundled/boost-1.62.0/include/boost/random/uniform_on_sphere.hpp
+++ b/bundled/boost-1.62.0/include/boost/random/uniform_on_sphere.hpp
@@ -225,8 +225,12 @@ public:
                     }
                 } while(sqsum == 0);
                 // for all i: result[i] /= sqrt(sqsum)
-                std::transform(_container.begin(), _container.end(), _container.begin(),
-                               std::bind2nd(std::multiplies<RealType>(), 1/sqrt(sqsum)));
+                RealType inverse_distance = 1 / sqrt(sqsum);
+                for(typename Cont::iterator it = _container.begin();
+                    it != _container.end();
+                    ++it) {
+                    *it *= inverse_distance;
+                }
             }
         }
         return _container;

--- a/bundled/boost-1.62.0/include/boost/random/uniform_on_sphere.hpp
+++ b/bundled/boost-1.62.0/include/boost/random/uniform_on_sphere.hpp
@@ -19,7 +19,7 @@
 
 #include <vector>
 #include <algorithm>     // std::transform
-#include <functional>    // std::bind2nd, std::divides
+#include <functional>    // std::divides
 #include <boost/assert.hpp>
 #include <boost/random/detail/config.hpp>
 #include <boost/random/detail/operators.hpp>

--- a/bundled/boost-1.62.0/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
+++ b/bundled/boost-1.62.0/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
@@ -291,18 +291,10 @@ struct grammar_definition
         helper_list_t&  helpers =
         grammartract_helper_list::do_(self);
 
-# if defined(BOOST_INTEL_CXX_VERSION)
         typedef typename helper_list_t::vector_t::reverse_iterator iterator_t;
 
         for (iterator_t i = helpers.rbegin(); i != helpers.rend(); ++i)
             (*i)->undefine(self);
-# else
-        typedef impl::grammar_helper_base<GrammarT> helper_base_t;
-
-        std::for_each(helpers.rbegin(), helpers.rend(),
-            std::bind2nd(std::mem_fun(&helper_base_t::undefine), self));
-# endif
-
 #else
         (void)self;
 #endif

--- a/bundled/boost-1.62.0/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
+++ b/bundled/boost-1.62.0/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
@@ -156,8 +156,13 @@ struct grammar_definition
             if (definitions[id]!=0)
                 return *definitions[id];
 
+#if defined(BOOST_NO_CXX11_SMART_PTR)
             std::auto_ptr<definition_t>
                 result(new definition_t(target_grammar->derived()));
+#else
+            std::unique_ptr<definition_t>
+                result(new definition_t(target_grammar->derived()));
+#endif
 
 #ifdef BOOST_SPIRIT_THREADSAFE
             boost::unique_lock<boost::mutex> lock(helpers.mutex());

--- a/bundled/boost-1.62.0/include/boost/spirit/home/classic/symbols/impl/tst.ipp
+++ b/bundled/boost-1.62.0/include/boost/spirit/home/classic/symbols/impl/tst.ipp
@@ -62,7 +62,11 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
         tst_node*
         clone() const
         {
+#if defined(BOOST_NO_CXX11_SMART_PTR)
             std::auto_ptr<tst_node> copy(new tst_node(value));
+#else
+            std::unique_ptr<tst_node> copy(new tst_node(value));
+#endif
 
             if (left)
                 copy->left = left->clone();
@@ -75,7 +79,11 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
             }
             else
             {
+#if defined(BOOST_NO_CXX11_SMART_PTR)
                 std::auto_ptr<T> mid_data(new T(*middle.data));
+#else
+                std::unique_ptr<T> mid_data(new T(*middle.data));
+#endif
                 copy->middle.data = mid_data.release();
             }
 

--- a/bundled/boost-1.62.0/include/boost/spirit/home/support/detail/lexer/generator.hpp
+++ b/bundled/boost-1.62.0/include/boost/spirit/home/support/detail/lexer/generator.hpp
@@ -116,10 +116,18 @@ public:
 protected:
     typedef detail::basic_charset<CharT> charset;
     typedef detail::ptr_list<charset> charset_list;
+#if defined(BOOST_NO_CXX11_SMART_PTR)
     typedef std::auto_ptr<charset> charset_ptr;
+#else
+    typedef std::unique_ptr<charset> charset_ptr;
+#endif
     typedef detail::equivset equivset;
     typedef detail::ptr_list<equivset> equivset_list;
+#if defined(BOOST_NO_CXX11_SMART_PTR)
     typedef std::auto_ptr<equivset> equivset_ptr;
+#else
+    typedef std::unique_ptr<equivset> equivset_ptr;
+#endif
     typedef typename charset::index_set index_set;
     typedef std::vector<index_set> index_set_vector;
     typedef detail::basic_parser<CharT> parser;
@@ -377,8 +385,13 @@ protected:
         if (followpos_->empty ()) return npos;
 
         std::size_t index_ = 0;
+#if defined(BOOST_NO_CXX11_SMART_PTR)
         std::auto_ptr<node_set> set_ptr_ (new node_set);
         std::auto_ptr<node_vector> vector_ptr_ (new node_vector);
+#else
+        std::unique_ptr<node_set> set_ptr_ (new node_set);
+        std::unique_ptr<node_vector> vector_ptr_ (new node_vector);
+#endif
 
         for (typename detail::node::node_vector::const_iterator iter_ =
             followpos_->begin (), end_ = followpos_->end ();

--- a/bundled/muparser_v2_2_4/include/muParserBase.h
+++ b/bundled/muparser_v2_2_4/include/muParserBase.h
@@ -288,7 +288,7 @@ private:
     mutable stringbuf_type  m_vStringBuf; ///< String buffer, used for storing string function arguments
     stringbuf_type  m_vStringVarBuf;
 
-    std::auto_ptr<token_reader_type> m_pTokenReader; ///< Managed pointer to the token reader object.
+    std::unique_ptr<token_reader_type> m_pTokenReader; ///< Managed pointer to the token reader object.
 
     funmap_type  m_FunDef;         ///< Map of function names and pointers.
     funmap_type  m_PostOprtDef;    ///< Postfix operator callbacks

--- a/bundled/muparser_v2_2_4/include/muParserToken.h
+++ b/bundled/muparser_v2_2_4/include/muParserToken.h
@@ -69,7 +69,7 @@ namespace mu
       TString m_strTok;   ///< Token string
       TString m_strVal;   ///< Value for string variables
       value_type m_fVal;  ///< the value 
-      std::auto_ptr<ParserCallback> m_pCallback;
+      std::unique_ptr<ParserCallback> m_pCallback;
 
   public:
 

--- a/bundled/muparser_v2_2_4/src/muParserTest.cpp
+++ b/bundled/muparser_v2_2_4/src/muParserTest.cpp
@@ -1258,7 +1258,7 @@ namespace mu
 
       try
       {
-        std::auto_ptr<Parser> p1;
+        std::unique_ptr<Parser> p1;
         Parser  p2, p3;   // three parser objects
                           // they will be used for testing copy and assihnment operators
         // p1 is a pointer since i'm going to delete it in order to test if

--- a/bundled/muparser_v2_2_4/src/muParserTokenReader.cpp
+++ b/bundled/muparser_v2_2_4/src/muParserTokenReader.cpp
@@ -147,7 +147,7 @@ namespace mu
   */
   ParserTokenReader* ParserTokenReader::Clone(ParserBase *a_pParent) const
   {
-    std::auto_ptr<ParserTokenReader> ptr(new ParserTokenReader(*this));
+    std::unique_ptr<ParserTokenReader> ptr(new ParserTokenReader(*this));
     ptr->SetParent(a_pParent);
     return ptr.release();
   }

--- a/cmake/configure/configure_boost.cmake
+++ b/cmake/configure/configure_boost.cmake
@@ -53,6 +53,33 @@ MACRO(FEATURE_BOOST_CONFIGURE_COMMON)
     LIST(APPEND BOOST_USER_DEFINITIONS "BOOST_NO_CXX11_HDR_UNORDERED_MAP")
   ENDIF()
 
+  # Some standard library implementations do not implement std::auto_ptr
+  # (anymore) which was deprecated for C++11 and removed in the C++17 standard.
+  # Older boost versions can't know about this but provide a possibility to
+  # circumvent the issue. Hence, we just check ourselves.
+  PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
+  PUSH_CMAKE_REQUIRED("-Werror")
+
+  CHECK_CXX_SOURCE_COMPILES(
+    "
+    #include <memory>
+
+    int main()
+    {
+      int *i = new int;
+      std::auto_ptr<int> x(i);
+      return 0;
+    }
+    "
+    DEAL_II_HAS_AUTO_PTR)
+
+  RESET_CMAKE_REQUIRED()
+
+  IF( NOT DEAL_II_HAS_AUTO_PTR )
+    LIST(APPEND BOOST_DEFINITIONS "BOOST_NO_AUTO_PTR")
+    LIST(APPEND BOOST_USER_DEFINITIONS "BOOST_NO_AUTO_PTR")
+  ENDIF()
+
   ENABLE_IF_SUPPORTED(BOOST_CXX_FLAGS "-Wno-unused-local-typedefs")
 ENDMACRO()
 


### PR DESCRIPTION
Fixes #6125, fixes #4662.
In particular, circumvent using `std::auto_ptr`, `std::bind1st` and `std::bind2nd` in the bundled packages as they are removed in `libc++`.
`Boost` is already fixed upstream and the changes mainly follow what is done there. `muParser` still needs to be fixed upstream.

We also set `BOOST_NO_AUTO_PTR` for non-bundled `boost` when configuring. This should help to support an external `boost` dependency even if it might not be sufficient for anything but one of the latest `boost` releases.