### PR TITLE
petsc/solver_02: Make range more forgiving

### DIFF
--- a/tests/petsc/solver_02.cc
+++ b/tests/petsc/solver_02.cc
@@ -61,6 +61,6 @@ int main(int argc, char **argv)
 
     check_solver_within_range(
       solver.solve(A,u,f, preconditioner),
-      control.last_step(), 1120, 1141);
+      control.last_step(), 1050, 1150);
   }
 }

--- a/tests/petsc/solver_02.output
+++ b/tests/petsc/solver_02.output
@@ -1,3 +1,3 @@
 
 DEAL::Size 32 Unknowns 961
-DEAL::Solver stopped within 1120 - 1141 iterations
+DEAL::Solver stopped within 1050 - 1150 iterations


### PR DESCRIPTION
Depending on the PETSc version the solver takes roughly between 1069 and
1141 cycles. Just check for a genereous number of cycles (between 1050
and 1150).