### PR TITLE
introduce LA::d::Vector::add_local() and sadd_local() to avoid to man…

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -944,11 +944,20 @@ namespace LinearAlgebra
           // below we make this work gracefully for identity-like matrices in
           // which case the two loops over j won't do any work as A(j,i)==0
           const unsigned int k = std::min(i,m-1);
-          V.block(i).sadd(s,matrix(k,i)*b, this->block(k));
+          V.block(i).sadd_local(s,matrix(k,i)*b, this->block(k));
           for (unsigned int j = 0  ; j < k; j++)
-            V.block(i).add (matrix(j,i)*b, this->block(j));
+            V.block(i).add_local (matrix(j,i)*b, this->block(j));
           for (unsigned int j = k+1; j < m; j++)
-            V.block(i).add (matrix(j,i)*b, this->block(j));
+            V.block(i).add_local (matrix(j,i)*b, this->block(j));
+        }
+
+      if (V.block(0).vector_is_ghosted)
+        {
+          for (unsigned int i = 0; i < n; i++)
+            Assert (V.block(i).vector_is_ghosted,
+                    ExcMessage("All blocks should be either in ghosted state or not."));
+
+          V.update_ghost_values();
         }
     }
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1060,6 +1060,20 @@ namespace LinearAlgebra
                       << "that this vector can access.");
 
     private:
+
+      /**
+       * Simple addition of a multiple of a vector, i.e. <tt>*this += a*V</tt>
+       * without MPI communication.
+       */
+      void add_local(const Number a, const VectorSpaceVector<Number> &V);
+
+      /**
+       * Scaling and simple addition of a multiple of a vector, i.e. <tt>*this =
+       * s*(*this)+a*V</tt> without MPI communication.
+       */
+      void sadd_local(const Number s, const Number a,
+                      const VectorSpaceVector<Number> &V);
+
       /**
        * Local part of all_zero().
        */

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -839,8 +839,8 @@ namespace LinearAlgebra
 
     template <typename Number>
     void
-    Vector<Number>::add (const Number a,
-                         const VectorSpaceVector<Number> &vv)
+    Vector<Number>::add_local (const Number a,
+                               const VectorSpaceVector<Number> &vv)
     {
       // Downcast. Throws an exception if invalid.
       Assert(dynamic_cast<const Vector<Number> *>(&vv)!=nullptr,
@@ -857,6 +857,16 @@ namespace LinearAlgebra
       internal::VectorOperations::Vectorization_add_av<Number> vector_add(values.get(), v.values.get(), a);
       internal::VectorOperations::parallel_for(vector_add, 0, partitioner->local_size(),
                                                thread_loop_partitioner);
+    }
+
+
+
+    template <typename Number>
+    void
+    Vector<Number>::add (const Number a,
+                         const VectorSpaceVector<Number> &vv)
+    {
+      add_local(a,vv);
 
       if (vector_is_ghosted)
         update_ghost_values();
@@ -930,9 +940,9 @@ namespace LinearAlgebra
 
     template <typename Number>
     void
-    Vector<Number>::sadd (const Number x,
-                          const Number a,
-                          const VectorSpaceVector<Number> &vv)
+    Vector<Number>::sadd_local (const Number x,
+                                const Number a,
+                                const VectorSpaceVector<Number> &vv)
     {
       // Downcast. Throws an exception if invalid.
       Assert(dynamic_cast<const Vector<Number> *>(&vv)!=nullptr,
@@ -946,6 +956,17 @@ namespace LinearAlgebra
       internal::VectorOperations::Vectorization_sadd_xav<Number> vector_sadd(values.get(), v.values.get(), a, x);
       internal::VectorOperations::parallel_for(vector_sadd, 0, partitioner->local_size(),
                                                thread_loop_partitioner);
+    }
+
+
+
+    template <typename Number>
+    void
+    Vector<Number>::sadd (const Number x,
+                          const Number a,
+                          const VectorSpaceVector<Number> &vv)
+    {
+      sadd_local(x,a,vv);
 
       if (vector_is_ghosted)
         update_ghost_values();


### PR DESCRIPTION
…y communication in LA::d::BlockVector::mmult()

p.s. noticed this when I got 20x slowdown compared to the previous version of `mmult()` function 
```
      (*this) = Number();  /// <— calls zero_out_ghosts() ==> vector_is_ghosted = false
      for (unsigned int i = 0; i < n; i++)
        for (unsigned int j = 0; j < m; j++)
          this->block(i).add (matrix(j,i), V.block(j));
```
that by accident disabled all communication inside each `add()`.

p.s. this is a follow-up to https://github.com/dealii/dealii/pull/5937