### PR TITLE
Make comparator const

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6625,7 +6625,7 @@ namespace VectorTools
     struct PointComparator
     {
       bool operator ()(const std::array<types::global_dof_index,dim> &p1,
-                       const std::array<types::global_dof_index,dim> &p2)
+                       const std::array<types::global_dof_index,dim> &p2) const
       {
         for (unsigned int d=0; d<dim; ++d)
           if (p1[d] < p2[d])


### PR DESCRIPTION
This should get rid off the [compiler warnings](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=329) for the `libc++` builds.