### PR TITLE
Bug fix for graph coloring/graph partitioning using Zoltan library.

### DIFF
--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -203,9 +203,6 @@ namespace SparsityTools
       ZOLTAN_ID_PTR nextNborGID = nborGID;
       int *nextNborProc = nborProc;
 
-      Assert( nextNborGID != nullptr , ExcInternalError() );
-      Assert( nextNborProc != nullptr , ExcInternalError() );
-
       //Loop through rows corresponding to indices in globalID implicitly
       for (SparsityPattern::size_type i=0; i < static_cast<SparsityPattern::size_type>(num_obj); ++i)
         {
@@ -215,6 +212,9 @@ namespace SparsityTools
             //Ignore diagonal entries. Not needed for partitioning.
             if ( i != col->column() )
               {
+                Assert( nextNborGID != nullptr , ExcInternalError() );
+                Assert( nextNborProc != nullptr , ExcInternalError() );
+
                 *nextNborGID++ = col->column();
                 *nextNborProc++ = 0;    //All the vertices on processor 0
               }

--- a/tests/zoltan/zoltan_04.cc
+++ b/tests/zoltan/zoltan_04.cc
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2004 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+/*
+ * check GraphColoring::color_sparsity_pattern with 5 nodes with
+ * no connections with each other. All nodes will be colored with
+ * one color.
+ */
+
+
+#include "../tests.h"
+#include <deal.II/base/graph_coloring.h>
+
+
+void fill_graph (DynamicSparsityPattern &graph)
+{
+  //Edges in only one direction
+  graph.add(0,0);
+  graph.add(1,1);
+  graph.add(2,2);
+  graph.add(3,3);
+  graph.add(4,4);
+}
+
+
+int main (int argc, char **argv)
+{
+  //Initialize MPI and Zoltan
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv);
+  MPILogInitAll all;
+
+  //Number of nodes
+  unsigned int num_indices = 5;
+
+  //Create temporary object to hold graph connection info.
+  DynamicSparsityPattern dynamic_sparse_graph;
+  dynamic_sparse_graph.reinit(num_indices,num_indices);
+
+  //fill dynamic sparsity pattern
+  fill_graph(dynamic_sparse_graph);
+
+  //Create sparity pattern to hold graph connection info.
+  SparsityPattern sp_graph;
+  sp_graph.copy_from(dynamic_sparse_graph);
+
+  Assert( num_indices == sp_graph.n_rows() , ExcInternalError() );
+
+  std::vector<unsigned int> color_indices;
+  unsigned int num_colors;
+
+  color_indices.resize(num_indices);
+  num_colors = GraphColoring::color_sparsity_pattern (sp_graph, color_indices);
+
+  //color
+  deallog << "Coloring" << std::endl;
+  deallog << "Number of colors used: " << num_colors << std::endl;
+  for (unsigned int i=0; i<num_indices; i++)
+    {
+      deallog << i << " " << color_indices[i] << std::endl;
+    }
+}

--- a/tests/zoltan/zoltan_04.output
+++ b/tests/zoltan/zoltan_04.output
@@ -1,0 +1,8 @@
+
+DEAL:0::Coloring
+DEAL:0::Number of colors used: 1
+DEAL:0::0 1
+DEAL:0::1 1
+DEAL:0::2 1
+DEAL:0::3 1
+DEAL:0::4 1


### PR DESCRIPTION
For graph partitioning or graph coloring scheme, one of the query functions provides for a given node, the list of neighboring nodes and their processor id. Previously there are assertions that check if the arrays, holding required information, are empty or not at the start. But when multiple nodes with no connection to each other are given to this function, these arrays are empty and needed to be so! Such a scenario occurs while graph coloring unlike graph partitioning.

To avoid this error, i moved the assertions inside the if condition within loops, which will never be true for the case mentioned before (multiple nodes with no connection and hence needed to be colored using a single color!). 

Alternatively, I can remove the assertions completely, given the performance issue, albeit only in debug mode. Please let me know your opinion.