### PR TITLE
Call find_package(PythonInterp) before find_package(PythonLibs)

### DIFF
--- a/contrib/python-bindings/source/CMakeLists.txt
+++ b/contrib/python-bindings/source/CMakeLists.txt
@@ -17,8 +17,8 @@
 # Find Python:
 #
 
-INCLUDE(FindPythonLibs)
 INCLUDE(FindPythonInterp)
+INCLUDE(FindPythonLibs)
 
 IF(FEATURE_BOOST_BUNDLED_CONFIGURED)
   MESSAGE(FATAL_ERROR


### PR DESCRIPTION
Newer versions of CMake recommend to call  `find_package(PythonInterp)` before `find_package(PythonLibs)` So I just changed the order.