### PR TITLE
Pass const scalar arguments by value, rather than reference.

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1370,9 +1370,11 @@ namespace GridTools
   template < class MeshType >
   std::vector< BoundingBox< MeshType::space_dimension > >
   compute_mesh_predicate_bounding_box
-  ( const MeshType &mesh,
+  ( const MeshType                                                              &mesh,
     const std::function<bool (const typename MeshType::active_cell_iterator &)> &predicate,
-    const unsigned int &refinement_level = 0, const bool &allow_merge = false, const unsigned int &max_boxes = numbers::invalid_unsigned_int);
+    const unsigned int                                                          &refinement_level = 0,
+    const bool                                                                  &allow_merge = false,
+    const unsigned int                                                          &max_boxes = numbers::invalid_unsigned_int);
 
   /**
    * Given an array of points, use the global bounding box description obtained using

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1372,9 +1372,9 @@ namespace GridTools
   compute_mesh_predicate_bounding_box
   ( const MeshType                                                              &mesh,
     const std::function<bool (const typename MeshType::active_cell_iterator &)> &predicate,
-    const unsigned int                                                          &refinement_level = 0,
-    const bool                                                                  &allow_merge = false,
-    const unsigned int                                                          &max_boxes = numbers::invalid_unsigned_int);
+    const unsigned int                                                           refinement_level = 0,
+    const bool                                                                   allow_merge = false,
+    const unsigned int                                                           max_boxes = numbers::invalid_unsigned_int);
 
   /**
    * Given an array of points, use the global bounding box description obtained using

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1806,9 +1806,9 @@ next_cell:
   compute_mesh_predicate_bounding_box
   (const MeshType                                                              &mesh,
    const std::function<bool (const typename MeshType::active_cell_iterator &)> &predicate,
-   const unsigned int                                                          &refinement_level,
-   const bool                                                                  &allow_merge,
-   const unsigned int                                                          &max_boxes)
+   const unsigned int                                                           refinement_level,
+   const bool                                                                   allow_merge,
+   const unsigned int                                                           max_boxes)
   {
     // Algorithm brief description: begin with creating bounding boxes of all cells at
     // refinement_level (and coarser levels if there are active cells) which have the predicate

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1804,9 +1804,11 @@ next_cell:
   template < class MeshType >
   std::vector< BoundingBox<MeshType::space_dimension> >
   compute_mesh_predicate_bounding_box
-  (const MeshType &mesh,
+  (const MeshType                                                              &mesh,
    const std::function<bool (const typename MeshType::active_cell_iterator &)> &predicate,
-   const unsigned int &refinement_level,  const bool &allow_merge, const unsigned int &max_boxes)
+   const unsigned int                                                          &refinement_level,
+   const bool                                                                  &allow_merge,
+   const unsigned int                                                          &max_boxes)
   {
     // Algorithm brief description: begin with creating bounding boxes of all cells at
     // refinement_level (and coarser levels if there are active cells) which have the predicate
@@ -1853,7 +1855,7 @@ next_cell:
         std::vector<unsigned int> merged_boxes_idx;
         bool found_neighbors = true;
 
-        // We merge only nighbors which can be expressed by a single bounding box
+        // We merge only neighbors which can be expressed by a single bounding box
         // e.g. in 1d [0,1] and [1,2] can be described with [0,2] without losing anything
         while (found_neighbors)
           {

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -31,8 +31,11 @@ for (X : TRIANGULATIONS; deal_II_dimension : DIMENSIONS ; deal_II_space_dimensio
     template
     std::vector < BoundingBox< deal_II_space_dimension > >
     compute_mesh_predicate_bounding_box< X >
-    (const X &, const std::function<bool (const dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type&)> &,
-     const unsigned int &, const bool&, const unsigned int &);
+    (const X &,
+     const std::function<bool (const dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type&)> &,
+     const unsigned int,
+     const bool,
+     const unsigned int);
     \}
 
 #endif


### PR DESCRIPTION
The first commit is only whitespace changes (plus a typo fix), the second contains
the actual change in question. I broke things this way to make the changes
more obvious for review.