### PR TITLE
Tests: Add an output variant for metis_01a for 64bit metis

### DIFF
--- a/tests/metis/metis_01a.output.64bit-metis
+++ b/tests/metis/metis_01a.output.64bit-metis
@@ -1,0 +1,15 @@
+
+DEAL::METIS inputs:
+DEAL::IDXTYPEWIDTH=64
+DEAL::4 1 5
+DEAL::0 2 5 8 10 
+DEAL::0 1 1 0 2 2 1 3 3 2 
+DEAL::-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 
+DEAL::4
+DEAL::METIS outputs:
+DEAL::3
+DEAL::0 3
+DEAL::1 4
+DEAL::2 1
+DEAL::3 0
+DEAL::


### PR DESCRIPTION
In case deal.II is configured with 64bit support for blas the output of
this metis test changes from "IDXTYPEWIDTH=32" to "IDXTYPEWIDTH=64".
Provide an output variant for this.