### PR TITLE
GridGenerator::extrude_triangulation overload

### DIFF
--- a/doc/news/changes/minor/20180405WeixiongZheng
+++ b/doc/news/changes/minor/20180405WeixiongZheng
@@ -1,0 +1,5 @@
+New: Extend GridGenerator::extrude_triangulation to using exact slicing z-axis
+values and reimplement the exsiting GridGenerator::extrude_triangulation using
+the newly developed overload.
+<br>
+(Weixiong Zheng, 2018/04/05)

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1038,7 +1038,6 @@ namespace GridGenerator
                                            const std::set<typename Triangulation<dim, spacedim>::active_cell_iterator> &cells_to_remove,
                                            Triangulation<dim, spacedim>       &result);
 
-
   /**
    * Take a 2d Triangulation that is being extruded in z direction by the
    * total height of @p height using @p n_slices slices (minimum is 2). The
@@ -1054,6 +1053,26 @@ namespace GridGenerator
                          const unsigned int         n_slices,
                          const double               height,
                          Triangulation<3,3>        &result);
+
+  /**
+   * Overload of the previous function. Take a 2d Triangulation that is being
+   * extruded. Differing from the previous function taking height and number of
+   * slices for uniform extrusion, this function takes z-axis values
+   * @p slice_coordinates where the slicing will happen. The boundary indicators
+   * of the faces of @p input are going to be assigned to the corresponding side
+   * walls in z direction. The bottom and top get the next two free boundary
+   * indicators.
+   *
+   * @note The 2d input triangulation @p input must be a coarse mesh that has
+   * no refined cells.
+   *
+   * @author Weixiong Zheng, 2018
+   */
+  void
+  extrude_triangulation (const Triangulation<2, 2>             &input,
+                         const std::vector<double> &slice_coordinates,
+                         Triangulation<3,3>                   &result);
+
 
   /**
    * Given an input triangulation @p in_tria, this function makes a new flat

--- a/tests/grid/extrude_orientation_03.cc
+++ b/tests/grid/extrude_orientation_03.cc
@@ -13,13 +13,11 @@
 //
 // ---------------------------------------------------------------------
 
-
-
-// Test GridGenerator::extrude. 2d meshes are always correctly
-// edge-oriented, and so if we stack them one on top of the other, we
-// should also get a 3d mesh for which both edge and face orientations
-// are correct -- or so I thought, but this turns out to not be true,
-// see https://github.com/dealii/dealii/issues/1013
+// Test GridGenerator::extrude_triangulation taking slice z-coordinate values.
+// This test is just a replicate of the one in extrude_orientation_02.cc except
+// that the newly created overload of GridGenerator::extrude_triangulation is
+// tested for face and edge orientations for the resulting 3d mesh.
+// See https://github.com/dealii/dealii/issues/6158.
 //
 // test this for a circle extruded to a cylinder
 
@@ -43,7 +41,8 @@ void test()
     }
 
   Triangulation<3> tr3;
-  GridGenerator::extrude_triangulation(tr, 2, 1.0, tr3);
+  std::vector<double> slice_points = {0, 0.1, 0.5};
+  GridGenerator::extrude_triangulation(tr, slice_points, tr3);
 
   for (Triangulation<3>::active_cell_iterator c=tr3.begin_active();
        c!=tr3.end(); ++c)

--- a/tests/grid/extrude_orientation_03.output
+++ b/tests/grid/extrude_orientation_03.output
@@ -1,0 +1,216 @@
+
+DEAL::2d cell 0.0 has the following face orientations:
+DEAL::    true
+DEAL::    true
+DEAL::    true
+DEAL::    true
+DEAL::2d cell 0.1 has the following face orientations:
+DEAL::    true
+DEAL::    true
+DEAL::    true
+DEAL::    true
+DEAL::2d cell 0.2 has the following face orientations:
+DEAL::    true
+DEAL::    true
+DEAL::    true
+DEAL::    true
+DEAL::2d cell 0.3 has the following face orientations:
+DEAL::    true
+DEAL::    true
+DEAL::    true
+DEAL::    true
+DEAL::2d cell 0.4 has the following face orientations:
+DEAL::    true
+DEAL::    true
+DEAL::    true
+DEAL::    true
+DEAL::3d cell 0.0 has the following face orientation/flips and edge orientations:
+DEAL::    face=0 -> true/false
+DEAL::    face=1 -> true/false
+DEAL::    face=2 -> true/false
+DEAL::    face=3 -> true/false
+DEAL::    face=4 -> true/false
+DEAL::    face=5 -> true/false
+DEAL::    edge=0 -> true
+DEAL::    edge=1 -> true
+DEAL::    edge=2 -> true
+DEAL::    edge=3 -> true
+DEAL::    edge=4 -> true
+DEAL::    edge=5 -> true
+DEAL::    edge=6 -> true
+DEAL::    edge=7 -> true
+DEAL::    edge=8 -> true
+DEAL::    edge=9 -> true
+DEAL::    edge=10 -> true
+DEAL::    edge=11 -> true
+DEAL::3d cell 0.1 has the following face orientation/flips and edge orientations:
+DEAL::    face=0 -> true/false
+DEAL::    face=1 -> true/false
+DEAL::    face=2 -> true/false
+DEAL::    face=3 -> true/false
+DEAL::    face=4 -> true/false
+DEAL::    face=5 -> true/false
+DEAL::    edge=0 -> true
+DEAL::    edge=1 -> true
+DEAL::    edge=2 -> true
+DEAL::    edge=3 -> true
+DEAL::    edge=4 -> true
+DEAL::    edge=5 -> true
+DEAL::    edge=6 -> true
+DEAL::    edge=7 -> true
+DEAL::    edge=8 -> true
+DEAL::    edge=9 -> true
+DEAL::    edge=10 -> true
+DEAL::    edge=11 -> true
+DEAL::3d cell 0.2 has the following face orientation/flips and edge orientations:
+DEAL::    face=0 -> true/false
+DEAL::    face=1 -> true/false
+DEAL::    face=2 -> false/false
+DEAL::    face=3 -> true/false
+DEAL::    face=4 -> true/false
+DEAL::    face=5 -> true/false
+DEAL::    edge=0 -> true
+DEAL::    edge=1 -> true
+DEAL::    edge=2 -> true
+DEAL::    edge=3 -> true
+DEAL::    edge=4 -> true
+DEAL::    edge=5 -> true
+DEAL::    edge=6 -> true
+DEAL::    edge=7 -> true
+DEAL::    edge=8 -> true
+DEAL::    edge=9 -> true
+DEAL::    edge=10 -> true
+DEAL::    edge=11 -> true
+DEAL::3d cell 0.3 has the following face orientation/flips and edge orientations:
+DEAL::    face=0 -> true/false
+DEAL::    face=1 -> true/false
+DEAL::    face=2 -> false/false
+DEAL::    face=3 -> true/false
+DEAL::    face=4 -> true/false
+DEAL::    face=5 -> true/false
+DEAL::    edge=0 -> true
+DEAL::    edge=1 -> true
+DEAL::    edge=2 -> true
+DEAL::    edge=3 -> true
+DEAL::    edge=4 -> true
+DEAL::    edge=5 -> true
+DEAL::    edge=6 -> true
+DEAL::    edge=7 -> true
+DEAL::    edge=8 -> true
+DEAL::    edge=9 -> true
+DEAL::    edge=10 -> true
+DEAL::    edge=11 -> true
+DEAL::3d cell 0.4 has the following face orientation/flips and edge orientations:
+DEAL::    face=0 -> true/false
+DEAL::    face=1 -> true/false
+DEAL::    face=2 -> true/false
+DEAL::    face=3 -> true/false
+DEAL::    face=4 -> true/false
+DEAL::    face=5 -> true/false
+DEAL::    edge=0 -> true
+DEAL::    edge=1 -> true
+DEAL::    edge=2 -> true
+DEAL::    edge=3 -> true
+DEAL::    edge=4 -> true
+DEAL::    edge=5 -> true
+DEAL::    edge=6 -> true
+DEAL::    edge=7 -> true
+DEAL::    edge=8 -> true
+DEAL::    edge=9 -> true
+DEAL::    edge=10 -> true
+DEAL::    edge=11 -> true
+DEAL::3d cell 0.5 has the following face orientation/flips and edge orientations:
+DEAL::    face=0 -> true/false
+DEAL::    face=1 -> true/false
+DEAL::    face=2 -> true/false
+DEAL::    face=3 -> true/false
+DEAL::    face=4 -> true/false
+DEAL::    face=5 -> true/false
+DEAL::    edge=0 -> true
+DEAL::    edge=1 -> true
+DEAL::    edge=2 -> true
+DEAL::    edge=3 -> true
+DEAL::    edge=4 -> true
+DEAL::    edge=5 -> true
+DEAL::    edge=6 -> true
+DEAL::    edge=7 -> true
+DEAL::    edge=8 -> true
+DEAL::    edge=9 -> true
+DEAL::    edge=10 -> true
+DEAL::    edge=11 -> true
+DEAL::3d cell 0.6 has the following face orientation/flips and edge orientations:
+DEAL::    face=0 -> true/false
+DEAL::    face=1 -> true/false
+DEAL::    face=2 -> true/false
+DEAL::    face=3 -> false/false
+DEAL::    face=4 -> true/false
+DEAL::    face=5 -> true/false
+DEAL::    edge=0 -> true
+DEAL::    edge=1 -> true
+DEAL::    edge=2 -> true
+DEAL::    edge=3 -> true
+DEAL::    edge=4 -> true
+DEAL::    edge=5 -> true
+DEAL::    edge=6 -> true
+DEAL::    edge=7 -> true
+DEAL::    edge=8 -> true
+DEAL::    edge=9 -> true
+DEAL::    edge=10 -> true
+DEAL::    edge=11 -> true
+DEAL::3d cell 0.7 has the following face orientation/flips and edge orientations:
+DEAL::    face=0 -> true/false
+DEAL::    face=1 -> true/false
+DEAL::    face=2 -> true/false
+DEAL::    face=3 -> false/false
+DEAL::    face=4 -> true/false
+DEAL::    face=5 -> true/false
+DEAL::    edge=0 -> true
+DEAL::    edge=1 -> true
+DEAL::    edge=2 -> true
+DEAL::    edge=3 -> true
+DEAL::    edge=4 -> true
+DEAL::    edge=5 -> true
+DEAL::    edge=6 -> true
+DEAL::    edge=7 -> true
+DEAL::    edge=8 -> true
+DEAL::    edge=9 -> true
+DEAL::    edge=10 -> true
+DEAL::    edge=11 -> true
+DEAL::3d cell 0.8 has the following face orientation/flips and edge orientations:
+DEAL::    face=0 -> true/false
+DEAL::    face=1 -> false/false
+DEAL::    face=2 -> true/false
+DEAL::    face=3 -> false/false
+DEAL::    face=4 -> true/false
+DEAL::    face=5 -> true/false
+DEAL::    edge=0 -> true
+DEAL::    edge=1 -> true
+DEAL::    edge=2 -> true
+DEAL::    edge=3 -> true
+DEAL::    edge=4 -> true
+DEAL::    edge=5 -> true
+DEAL::    edge=6 -> true
+DEAL::    edge=7 -> true
+DEAL::    edge=8 -> true
+DEAL::    edge=9 -> true
+DEAL::    edge=10 -> true
+DEAL::    edge=11 -> true
+DEAL::3d cell 0.9 has the following face orientation/flips and edge orientations:
+DEAL::    face=0 -> true/false
+DEAL::    face=1 -> false/false
+DEAL::    face=2 -> true/false
+DEAL::    face=3 -> false/false
+DEAL::    face=4 -> true/false
+DEAL::    face=5 -> true/false
+DEAL::    edge=0 -> true
+DEAL::    edge=1 -> true
+DEAL::    edge=2 -> true
+DEAL::    edge=3 -> true
+DEAL::    edge=4 -> true
+DEAL::    edge=5 -> true
+DEAL::    edge=6 -> true
+DEAL::    edge=7 -> true
+DEAL::    edge=8 -> true
+DEAL::    edge=9 -> true
+DEAL::    edge=10 -> true
+DEAL::    edge=11 -> true


### PR DESCRIPTION
This PR references #6158 . The main work is an overload of existing `GridGenerator::extrude_triangulation`. The difference is this PR generalizes where each slicing should happen exactly on z-axis.