### PR TITLE
Make using astyle for indenting a bit easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ cache:
     - programs
 
 install:
-    - export PATH=$PWD/programs/astyle/build/gcc/bin:$PATH
     - ./contrib/utilities/setup_astyle.sh 
 
 script: 

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -30,15 +30,14 @@
 # from a build directory.
 #
 
-# Add the location 'setup_astyle.sh' installs astyle to to the local PATH.
-THIS_PATH="$(dirname $0)"              # relative
-THIS_PATH="$( cd $THIS_PATH && pwd )"  # absolutized and normalized
-export PATH=$THIS_PATH/programs/astyle/build/gcc/bin/:$PATH
-
 if test ! -d source -o ! -d include -o ! -d examples ; then
   echo "*** This script must be run from the top-level directory of deal.II."
   exit 1
 fi
+
+# Add the location 'setup_astyle.sh' installs astyle to to the local PATH.
+ASTYLE_PATH="$(realpath contrib/utilities)/programs/astyle/build/gcc/bin"
+export PATH=$ASTYLE_PATH:$PATH
 
 if test ! -f contrib/styles/astyle.rc ; then
   echo "*** No style file contrib/styles/astyle.rc found."

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -30,6 +30,11 @@
 # from a build directory.
 #
 
+# Add the location 'setup_astyle.sh' installs astyle to to the local PATH.
+THIS_PATH="$(dirname $0)"            # relative
+THIS_PATH="$( cd $THIS_PATH && pwd )"  # absolutized and normalized
+export PATH=$THIS_PATH/programs/astyle/build/gcc/bin/:$PATH
+
 if test ! -d source -o ! -d include -o ! -d examples ; then
   echo "*** This script must be run from the top-level directory of deal.II."
   exit 1
@@ -40,16 +45,17 @@ if test ! -f contrib/styles/astyle.rc ; then
   exit 1
 fi
 
-if test -z "`which astyle`" ; then
+if test -z "$(command -v astyle)" ; then
   echo "*** No astyle program found."
   echo "***"
   echo "*** You can download astyle from http://astyle.sourceforge.net/"
   echo "*** Note that you will need exactly version 2.04 (no newer or"
   echo "*** older version will yield the correct indentation)."
+  echo "*** You can run the 'setup_astyle.sh' script for that."
   exit 1
 fi
 
-if test "`astyle --version 2>&1`" != "Artistic Style Version 2.04" ; then
+if test "$(astyle --version 2>&1)" != "Artistic Style Version 2.04" ; then
   echo "*** Found a version of astyle different than the required version 2.04."
   exit 1
 fi
@@ -58,41 +64,40 @@ fi
 
 # collect all header and source files and process them in batches of 50 files
 # with up to 10 in parallel
-find tests include source examples \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print | xargs -n 50 -P 10 astyle --options=contrib/styles/astyle.rc
+find tests include source examples \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print0 | xargs -0 -n 50 -P 10 astyle --options=contrib/styles/astyle.rc
 
 # use the same process to set file permissions for all source files
-find tests include source examples \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print | xargs -n 50 -P 10 chmod 644
+find tests include source examples \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print0 | xargs -0 -n 50 -P 10 chmod 644
 
-# convert dos formatted files to unix file format by stripping out 
+# convert dos formatted files to unix file format by stripping out
 # carriage returns (15=0x0D):
 dos_to_unix()
 {
     f=$1
-    tr -d '\015' <$f >$f.tmp
-    diff -q $f $f.tmp >/dev/null || mv $f.tmp $f
-    rm -f $f.tmp
+    tr -d '\015' <"$f" >"$f.tmp"
+    diff -q "$f" "$f.tmp" >/dev/null || mv "$f.tmp" "$f"
+    rm -f "$f.tmp"
 }
 export -f dos_to_unix
-find tests include source examples \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print | xargs -n 1 -P 10 -I {} bash -c 'dos_to_unix "$@"' _ {} 
+find tests include source examples \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print0 | xargs -0 -n 1 -P 10 -I {} bash -c 'dos_to_unix "$@"' _ {}
 
 # format .inst.in files. We need to replace \{ and \} because it confuses
 # astyle.
 format_inst()
 {
     f=$1
-    cp $f $f.tmp
-    sed -i.orig 's#\\{#{ //#g' $f.tmp
-    sed -i.orig 's#\\}#} //#g' $f.tmp
-    astyle --options=none --quiet $f.tmp
-    sed -i.orig 's#{ //#\\{#g' $f.tmp
-    sed -i.orig 's#} //#\\}#g' $f.tmp
-    if ! diff -q $f $f.tmp >/dev/null
+    cp "$f" "$f.tmp"
+    sed -i.orig 's#\\{#{ //#g' "$f.tmp"
+    sed -i.orig 's#\\}#} //#g' "$f.tmp"
+    astyle --options=none --quiet "$f.tmp"
+    sed -i.orig 's#{ //#\\{#g' "$f.tmp"
+    sed -i.orig 's#} //#\\}#g' "$f.tmp"
+    if ! diff -q "$f" "$f.tmp" >/dev/null
     then
-	cp $f.tmp $f
+      cp "$f.tmp" "$f"
     fi
-    rm $f.tmp $f.tmp.orig
+    rm "$f.tmp" "$f.tmp.orig"
 }
+export -f format_inst
 
-for i in `find source -name '*.inst.in'` ; do
-  format_inst $i
-done
+find source -name '*.inst.in' -exec bash -c 'format_inst "$@"' bash {} +

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -31,7 +31,7 @@
 #
 
 # Add the location 'setup_astyle.sh' installs astyle to to the local PATH.
-THIS_PATH="$(dirname $0)"            # relative
+THIS_PATH="$(dirname $0)"              # relative
 THIS_PATH="$( cd $THIS_PATH && pwd )"  # absolutized and normalized
 export PATH=$THIS_PATH/programs/astyle/build/gcc/bin/:$PATH
 

--- a/contrib/utilities/setup_astyle.sh
+++ b/contrib/utilities/setup_astyle.sh
@@ -33,8 +33,13 @@ if [ ! -d "$PRG/astyle" ]
 then
     echo "Downloading and installing astyle."
     mkdir "$PRG/astyle"
-    wget http://downloads.sourceforge.net/project/astyle/astyle/astyle%202.04/astyle_2.04_linux.tar.gz  > /dev/null
-    tar xfz astyle_2.04_linux.tar.gz -C "$PRG" > /dev/null
-    cd "$PRG/astyle/build/gcc"
-    make -j4 > /dev/null
+    wget https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.04/astyle_2.04_linux.tar.gz  > /dev/null
+    if echo "70b37f4853c418d1e2632612967eebf1bdb93dfbe558c51d7d013c9b4e116b60 astyle_2.04_linux.tar.gz" | sha256sum -c; then
+      tar xfz astyle_2.04_linux.tar.gz -C "$PRG" > /dev/null
+      cd "$PRG/astyle/build/gcc" || exit 1
+      make -j4 > /dev/null
+    else
+      echo "*** The downloaded file has the wrong SHA256 checksum!"
+      exit 1
+    fi
 fi

--- a/contrib/utilities/setup_astyle.sh
+++ b/contrib/utilities/setup_astyle.sh
@@ -1,4 +1,24 @@
 #!/bin/sh
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2018 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+#
+# This script downloads and installs astyle-2.04 in programs/astyle/build/gcc.
+# The installed binary is used in the 'indent' script in case astyle is
+# installed by this script.
+#
 
 PRG=$PWD/programs
 


### PR DESCRIPTION
Allow the `astyle` installed by `setup_astyle.sh` to be automatically used in `indent`.
Also apply some suggestions from `ShellCheck`.