### PR TITLE
Remove double word typos.

### DIFF
--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -599,7 +599,7 @@ namespace Step16
 
   // @sect4{LaplaceProblem::run}
 
-  // Like several of the functions above, this is almost exactly a copy of of
+  // Like several of the functions above, this is almost exactly a copy of
   // the corresponding function in step-6. The only difference is the call to
   // <code>assemble_multigrid</code> that takes care of forming the matrices
   // on every level that we need in the multigrid method.

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -410,7 +410,7 @@ namespace Step22
   // reduces the bandwidth of the matrix, or maybe more importantly: in such a
   // way that the ILU is as close as possible to a real LU decomposition. On
   // the other hand, we need to preserve the block structure of velocity and
-  // pressure already seen in in step-20 and step-21. This is done in two
+  // pressure already seen in step-20 and step-21. This is done in two
   // steps: First, all dofs are renumbered to improve the ILU and then we
   // renumber once again by components. Since
   // <code>DoFRenumbering::component_wise</code> does not touch the

--- a/examples/step-31/doc/results.dox
+++ b/examples/step-31/doc/results.dox
@@ -393,7 +393,7 @@ $
   =
   \beta
   \|\mathbf{u}\|_{L^\infty(K)} h_K
-$ to eliminate the effect of of the constant $c_R$ (we know that
+$ to eliminate the effect of the constant $c_R$ (we know that
 solutions are stable by using this version of $\nu(T)$ as an artificial
 viscosity, but that we can improve things -- i.e. make the solution
 sharper -- by using the more complicated formula for this artificial

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -913,7 +913,7 @@ namespace Step50
   // @sect4{LaplaceProblem::run}
 
   // Like several of the functions above, this
-  // is almost exactly a copy of of the
+  // is almost exactly a copy of the
   // corresponding function in step-6. The only
   // difference is the call to
   // <code>assemble_multigrid</code> that takes

--- a/examples/step-54/doc/intro.dox
+++ b/examples/step-54/doc/intro.dox
@@ -109,7 +109,7 @@ does. In a second step, all the new nodes will be projected onto the
 normal projection is available, the point which is closest to the
 shape---typically lying on the shape boundary---is selected.  If the shape is
 composed of several sub-shapes, the projection is carried out onto every
-single sub-shape, and the closest projection point point is selected.
+single sub-shape, and the closest projection point is selected.
 
 <img src="https://www.dealii.org/images/steps/developer/step-54.NormalProjectionEdge.png" alt="" width="500">
 <img src="https://www.dealii.org/images/steps/developer/step-54.NormalProjection.png" alt="" width="500">

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -703,7 +703,7 @@ namespace Utilities
                     &(size_all_data[0]), 1, MPI_INT,
                     comm);
 
-      // Now computing the the displacement, relative to recvbuf,
+      // Now computing the displacement, relative to recvbuf,
       // at which to store the incoming buffer
       std::vector<int> rdispls(n_procs);
       rdispls[0] = 0;

--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -35,7 +35,7 @@ DEAL_II_NAMESPACE_OPEN
  * [0,1]x[0,1], etc.
  *
  * There are a number of derived classes, denoting concrete integration
- * formulae. Their names names prefixed by <tt>Q</tt>. Refer to the list of
+ * formulae. Their names are prefixed by <tt>Q</tt>. Refer to the list of
  * derived classes for more details.
  *
  * The schemes for higher dimensions are typically tensor products of the one-

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -125,7 +125,7 @@ public:
 
   /**
    * Declare an array type which can be used to initialize an object of this
-   * type statically. In case of a a tensor of rank 0 this is just the scalar
+   * type statically. In case of a tensor of rank 0 this is just the scalar
    * number type Number.
    */
   typedef Number array_type;

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -38,8 +38,8 @@ struct CPUClock
 {
   /**
    * Duration type. Windows measures CPU times, by default, in multiples of
-   * 1/64th of a second and and POSIX uses microseconds, so go with
-   * microseconds for uniformity.
+   * 1/64th of a second and POSIX uses microseconds, so go with microseconds
+   * for uniformity.
    */
   typedef std::chrono::microseconds duration;
 

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -358,8 +358,8 @@ namespace Utilities
   /**
    * Optimized replacement for <tt>std::lower_bound</tt> for searching within
    * the range of column indices. Slashes execution time by approximately one
-   * half for the present application, partly because because the binary
-   * search is replaced by a linear search for small loop lengths.
+   * half for the present application, partly because the binary search is
+   * replaced by a linear search for small loop lengths.
    *
    * Another reason for this function is rather obscure: when using the GCC
    * libstdc++ function std::lower_bound, complexity is O(log(N)) as required.

--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -931,7 +931,7 @@ namespace DoFRenumbering
    *
    * The cells are sorted such that the centers of cells numbered higher are further
    * downstream with respect to the constant vector @p direction than the
-   * centers of of cells numbered lower. Even if this yields a downstream numbering with
+   * centers of cells numbered lower. Even if this yields a downstream numbering with
    * respect to the flux on the edges for fairly general grids, this might not
    * be guaranteed for all meshes.
    *

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1053,7 +1053,7 @@ public:
    * here.
    *
    * The matrix @p P is the concatenation, not the sum of the cell matrices @p
-   * P_i. That is, if the same non-zero entry <tt>j,k</tt> exists in in two
+   * P_i. That is, if the same non-zero entry <tt>j,k</tt> exists in two
    * different child matrices @p P_i, the value should be the same in both
    * matrices and it is copied into the matrix @p P only once.
    *
@@ -1244,7 +1244,7 @@ public:
 
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.#dofs_per_face</tt> times <tt>this->#dofs_per_face</tt>.
    *
@@ -1962,7 +1962,7 @@ public:
    * points associated with the other shape functions.
    *
    * In composed elements (i.e. for the FESystem class), the result will be
-   * true if all all the base elements have defined support points. FE_Nothing
+   * true if all the base elements have defined support points. FE_Nothing
    * is a special case in FESystems, because it has 0 support points and
    * has_support_points() is false, but an FESystem containing an FE_Nothing
    * among other elements will return true.

--- a/include/deal.II/fe/fe_dgp.h
+++ b/include/deal.II/fe/fe_dgp.h
@@ -398,7 +398,7 @@ public:
    */
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element. The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
    *
@@ -413,7 +413,7 @@ public:
                                  FullMatrix<double>       &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element. The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
    *

--- a/include/deal.II/fe/fe_dgp_monomial.h
+++ b/include/deal.II/fe/fe_dgp_monomial.h
@@ -386,7 +386,7 @@ public:
                             FullMatrix<double>           &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element. The size of the matrix is then @p
    * dofs_per_face times <tt>source.dofs_per_face</tt>.
    *
@@ -401,7 +401,7 @@ public:
                                  FullMatrix<double>       &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element. The size of the matrix is then @p
    * dofs_per_face times <tt>source.dofs_per_face</tt>.
    *

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -378,7 +378,7 @@ public:
   unsigned int get_degree () const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element. The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
    *
@@ -393,7 +393,7 @@ public:
                                  FullMatrix<double>       &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element. The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
    *

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -134,7 +134,7 @@ public:
                             FullMatrix<double>           &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element. The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
    *
@@ -149,7 +149,7 @@ public:
                                  FullMatrix<double>       &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element. The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
    *
@@ -194,7 +194,7 @@ public:
    * single child cell is returned here.
    *
    * The matrix @p P is the concatenation, not the sum of the cell matrices @p
-   * P_i. That is, if the same non-zero entry <tt>j,k</tt> exists in in two
+   * P_i. That is, if the same non-zero entry <tt>j,k</tt> exists in two
    * different child matrices @p P_i, the value should be the same in both
    * matrices and it is copied into the matrix @p P only once.
    *

--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -353,7 +353,7 @@ public:
   virtual bool hp_constraints_are_implemented () const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
    *
@@ -369,7 +369,7 @@ public:
                                  FullMatrix<double>       &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the
+   * Return the matrix interpolating from a face of one element to the
    * subface of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
    *

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -83,7 +83,7 @@ public:
                                                           std::vector<double>                &nodal_values) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>. This
    * element only provides interpolation matrices for elements of the same
@@ -95,7 +95,7 @@ public:
                                  FullMatrix<double>       &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>. This
    * element only provides interpolation matrices for elements of the same
@@ -233,7 +233,7 @@ public:
   requires_update_flags (const UpdateFlags update_flags) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>. This
    * element only provides interpolation matrices for elements of the same
@@ -245,7 +245,7 @@ public:
                                  FullMatrix<double>       &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>. This
    * element only provides interpolation matrices for elements of the same
@@ -469,7 +469,7 @@ public:
   virtual std::string get_name () const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>. This
    * element only provides interpolation matrices for elements of the same
@@ -481,7 +481,7 @@ public:
                                  FullMatrix<double>       &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>. This
    * element only provides interpolation matrices for elements of the same

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -239,7 +239,7 @@ public:
    * single child cell is returned here.
    *
    * The matrix @p P is the concatenation, not the sum of the cell matrices @p
-   * P_i. That is, if the same non-zero entry <tt>j,k</tt> exists in in two
+   * P_i. That is, if the same non-zero entry <tt>j,k</tt> exists in two
    * different child matrices @p P_i, the value should be the same in both
    * matrices and it is copied into the matrix @p P only once.
    *

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -220,7 +220,7 @@ public:
                             FullMatrix<double>       &interpolation_matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element. The size of the matrix is then
    * <tt>source.#dofs_per_face</tt> times <tt>this->#dofs_per_face</tt>.
    *
@@ -235,7 +235,7 @@ public:
 
 
   /**
-   * Return the matrix interpolating from a face of of one element to the
+   * Return the matrix interpolating from a face of one element to the
    * subface of the neighboring element. The size of the matrix is then
    * <tt>source.#dofs_per_face</tt> times <tt>this->#dofs_per_face</tt>.
    *
@@ -269,4 +269,3 @@ private:
 DEAL_II_NAMESPACE_CLOSE
 
 #endif
-

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -62,7 +62,7 @@ public:
 
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>. The
    * FE_Q element family only provides interpolation matrices for elements of
@@ -75,7 +75,7 @@ public:
                                  FullMatrix<double>       &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>. The
    * FE_Q element family only provides interpolation matrices for elements of
@@ -130,7 +130,7 @@ public:
    * single child cell is returned here.
    *
    * The matrix @p P is the concatenation, not the sum of the cell matrices @p
-   * P_i. That is, if the same non-zero entry <tt>j,k</tt> exists in in two
+   * P_i. That is, if the same non-zero entry <tt>j,k</tt> exists in two
    * different child matrices @p P_i, the value should be the same in both
    * matrices and it is copied into the matrix @p P only once.
    *

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -740,7 +740,7 @@ public:
    * single child cell is returned here.
    *
    * The matrix @p P is the concatenation, not the sum of the cell matrices @p
-   * P_i. That is, if the same non-zero entry <tt>j,k</tt> exists in in two
+   * P_i. That is, if the same non-zero entry <tt>j,k</tt> exists in two
    * different child matrices @p P_i, the value should be the same in both
    * matrices and it is copied into the matrix @p P only once.
    *
@@ -846,7 +846,7 @@ public:
   virtual bool hp_constraints_are_implemented () const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
    *
@@ -863,7 +863,7 @@ public:
 
 
   /**
-   * Return the matrix interpolating from a face of of one element to the
+   * Return the matrix interpolating from a face of one element to the
    * subface of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
    *

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -985,7 +985,7 @@ namespace FETools
                                  &p4est_cell,
                                  dealii::internal::p4est::functions<dim>::quadrant_compare);
 
-      // if neither this cell nor one one of it's children belongs to us, don't do anything
+      // if neither this cell nor one of it's children belongs to us, don't do anything
       if (idx == -1 && (dealii::internal::p4est::functions<dim>::
                         quadrant_overlaps_tree (const_cast<typename dealii::internal::p4est::types<dim>::tree *>(&tree),
                                                 &p4est_cell)

--- a/include/deal.II/fe/fe_trace.h
+++ b/include/deal.II/fe/fe_trace.h
@@ -95,7 +95,7 @@ public:
   virtual bool hp_constraints_are_implemented () const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>. This
    * element only provides interpolation matrices for elements of the same
@@ -107,7 +107,7 @@ public:
                                  FullMatrix<double>       &matrix) const;
 
   /**
-   * Return the matrix interpolating from a face of of one element to the face
+   * Return the matrix interpolating from a face of one element to the face
    * of the neighboring element.  The size of the matrix is then
    * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>. This
    * element only provides interpolation matrices for elements of the same

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -1137,7 +1137,7 @@ namespace FEValuesViews
 
     /**
      * A typedef for the type of the divergence of the view this class
-     * represents. Here, for a set of of <code>(dim*dim + dim)/2</code> unique
+     * represents. Here, for a set of <code>(dim*dim + dim)/2</code> unique
      * components of the finite element representing a symmetric second-order
      * tensor, the divergence of course is a * <code>Tensor@<1,dim@></code>.
      *

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -444,7 +444,7 @@ public:
     /**
       * In case the quadrature rule given represents a tensor product
       * we need to store the evaluations of the 1d polynomials at the
-      * the 1d quadrature quadrature points. That is what this variable is for.
+      * the 1d quadrature points. That is what this variable is for.
       */
     internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<double>> shape_info;
 

--- a/include/deal.II/grid/grid_refinement.h
+++ b/include/deal.II/grid/grid_refinement.h
@@ -310,7 +310,7 @@ namespace GridRefinement
    * threshold for refinement, but only flag up to @p max_to_mark cells.
    *
    * The vector @p criteria contains a nonnegative value for each active cell,
-   * ordered in the canonical order of of Triangulation::active_cell_iterator.
+   * ordered in the canonical order of Triangulation::active_cell_iterator.
    *
    * The cells are only flagged for refinement, they are not actually refined.
    * To do so, you have to call
@@ -330,7 +330,7 @@ namespace GridRefinement
    * threshold for coarsening.
    *
    * The vector @p criteria contains a nonnegative value for each active cell,
-   * ordered in the canonical order of of Triangulation::active_cell_iterator.
+   * ordered in the canonical order of Triangulation::active_cell_iterator.
    *
    * The cells are only flagged for coarsening, they are not actually
    * coarsened. To do so, you have to call

--- a/include/deal.II/grid/grid_reordering.h
+++ b/include/deal.II/grid/grid_reordering.h
@@ -254,7 +254,7 @@ DeclExceptionMsg (ExcMeshNotOrientable,
  * which we could order as <tt>(9 6 7 10)</tt> above). However, since opposite
  * lines have to have the same direction, this in turn would force us to
  * rotate the cell left of it, and then the one left to that, and so on until
- * we reach the left end of the grid. This is therefore an example we we have
+ * we reach the left end of the grid. This is therefore an example we have
  * to track back right until the first column of three cells to find a
  * consistent ordering, if we had initially ordered them uniformly.
  *
@@ -288,7 +288,7 @@ DeclExceptionMsg (ExcMeshNotOrientable,
  * These two examples demonstrate that if we have added a certain number of
  * cells in some orientation of faces and can't add the next one without
  * introducing faces that had already been added in another direction, then it
- * might not be sufficient to only rotate cells in the neighborhood of the the
+ * might not be sufficient to only rotate cells in the neighborhood of the
  * cell that we failed to add. It might be necessary to go back a long way and
  * rotate cells that have been entered long ago.
  *

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -208,7 +208,7 @@ namespace GridTools
   /**
    * Return the point on the geometrical object @object closest to the given
    * point @p trial_point. For example, if @p object is a one-dimensional line
-   * or edge, then the the returned point will be a point on the geodesic that
+   * or edge, then the returned point will be a point on the geodesic that
    * connects the vertices as the manifold associated with the object sees it
    * (i.e., the geometric line may be curved if it lives in a higher
    * dimensional space). If the iterator points to a quadrilateral in a higher

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -147,7 +147,7 @@ private:
  * south poles.  Consider for instance the pair of points
  * $x_1=(1,\pi/3,0)$ and $x_2=(1,\pi/3,\pi)$ in polar
  * coordinates (lying on the surface of a sphere with radius one, on
- * a parallel at at height $\pi/3$). In this case connecting the points
+ * a parallel at height $\pi/3$). In this case connecting the points
  * with a straight line in polar coordinates would take the long road
  * around the globe, without passing through the north pole.
  *

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -751,7 +751,7 @@ namespace internal
  * cells are flagged for refinement to smooth the grid. This enlarges the
  * number of resulting cells but makes the grid more regular, thus leading to
  * better approximation properties and, above all, making the handling of data
- * structures and algorithms much much easier. To be honest, this is mostly an
+ * structures and algorithms much easier. To be honest, this is mostly an
  * algorithmic step than one needed by the finite element method.
  *
  * To coarsen a grid, the same way as above is possible by using

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -805,7 +805,7 @@ public:
 
   /**
    * Return whether the face with index @p face is rotated by 180 degrees (@p
-   * true) or or not (@p false). In 1d and 2d, this is always @p false, but in
+   * true) or not (@p false). In 1d and 2d, this is always @p false, but in
    * 3d it may be different, see the respective discussion in the
    * documentation of the GeometryInfo class.
    *
@@ -816,7 +816,7 @@ public:
 
   /**
    * Return whether the face with index @p face is rotated by 90 degrees (@p
-   * true) or or not (@p false). In 1d and 2d, this is always @p false, but in
+   * true) or not (@p false). In 1d and 2d, this is always @p false, but in
    * 3d it may be different, see the respective discussion in the
    * documentation of the GeometryInfo class.
    *

--- a/include/deal.II/lac/cuda_sparse_matrix.h
+++ b/include/deal.II/lac/cuda_sparse_matrix.h
@@ -180,7 +180,7 @@ namespace CUDAWrappers
                     const LinearAlgebra::CUDAWrappers::Vector<Number> &src) const;
 
     /**
-     * Return the square of the norm of the vector $v$ with respect to the the
+     * Return the square of the norm of the vector $v$ with respect to the
      * norm induced by this matrix, i.e., $\left(v,Mv\right)$. This is useful,
      * e.g., in the finite context, where the $L_2$ norm of a function equals
      * the matrix norm with respect to the mass matrix of the vector

--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -494,7 +494,7 @@ public:
                      const bool transpose=false);
 
   /**
-   * Estimate the the condition number of a SPD matrix in the $l_1$-norm.
+   * Estimate the condition number of a SPD matrix in the $l_1$-norm.
    * The matrix has to be in the Cholesky state (see compute_cholesky_factorization()).
    * The reciprocal of the
    * condition number is returned in order to avoid the possibility of

--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -47,7 +47,7 @@ namespace CUDAWrappers
    * quadrature points and cell integrations. In functionality, this class is
    * similar to FEValues<dim>.
    *
-   * This class class has five template arguments:
+   * This class has five template arguments:
    *
    * @ptaram dim Dimension in which this class is to be used
    *

--- a/include/deal.II/numerics/data_postprocessor.h
+++ b/include/deal.II/numerics/data_postprocessor.h
@@ -442,7 +442,7 @@ public:
    * cell, via the first argument. Not all of the member vectors of this
    * argument will be filled with data -- in fact, derivatives and other
    * quantities will only be contain valid data if the corresponding flags
-   * are returned by by an overloaded version of the get_needed_update_flags()
+   * are returned by an overridden version of the get_needed_update_flags()
    * function (implemented in a user's derived class).
    * Otherwise those vectors will be in an unspecified state.
    *
@@ -992,7 +992,7 @@ private:
  *   };
  * @endcode
  *
- * Using this class in in step-8 leads to the following visualization:
+ * Using this class in step-8 leads to the following visualization:
  *
  * @image html data_postprocessor_tensor_2.png
  *

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -1838,7 +1838,7 @@ namespace VectorTools
    * There are cases where one cell contributes two tangential directions and
    * another one only one; for example, this would happen if both top and
    * front faces of the left cell belong to the boundary selected whereas only
-   * the top face of the right cell belongs to it, maybe indicating the the
+   * the top face of the right cell belongs to it, maybe indicating that the
    * entire front part of the domain is a smooth manifold whereas the top
    * really forms two separate manifolds that meet in a ridge, and that
    * normal-flux boundary conditions are only desired on the front manifold

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -647,7 +647,7 @@ namespace SUNDIALS
      *
      * @param[out] j_is_current: a boolean to be filled in by setup_jacobian(). The value
      * should be set to `true` if the Jacobian data is current after the call,
-     * and should be set set to `false` if its Jacobian data is not current. If
+     * and should be set to `false` if its Jacobian data is not current. If
      * setup_jacobian() calls for re-evaluation of Jacobian data (based on
      * convfail and ARKode state data), then it should set `j_is_current` to
      * `true` unconditionally, otherwise an infinite loop can result.


### PR DESCRIPTION
This commit removes typos consisting of an accidentally repeated
word. Attached below is the python script I used to find them.

It is worth noting that there is a large false positive rate here, for
example, in tria_accessor.h we have the sentence

```c
/**
 * [...] As a
 * consequence, it exists in the mesh to ensure that each processor has all
 * coarse mesh cells and that the 2:1 ratio of neighboring cells is
 * maintained, but it is not one of the cells we should work on on the
 * current processor. [...]
 */
```
Here 'on on' is correct.

script:
```python
import sys

SKIP = ["//", "*", "}", "|", "};", ">", "\"", "|", "/",
        "numbers::invalid_unsigned_int,",  "std::string,", "int,"]

with open(sys.argv[1], 'r') as handle:
    previous_line = ""
    for line_n, line in enumerate(handle):
        line = line.strip()
        previous_words = previous_line.split()
        words = line.split()
        # ignore comment blocks '*' and comment starts '//' at the beginning of
        # each line.
        if len(words) == 0:
            continue
        if words[0] in ["*", "//"]:
            words = words[1:]

        # See if the last word on the previous line is equal to the first word
        # on the current line.
        if len(previous_words) != 0:
            if words[0] not in SKIP and previous_words[-1] == words[0]:
                print(sys.argv[1] + ":{}: {}".format(line_n + 1, previous_line))
                print(sys.argv[1] + ":{}: {}".format(line_n + 2, line))
        previous_line = line

        for left_word, right_word in zip(words[:-1], words[1:]):
            if left_word == right_word and left_word not in SKIP:
                print(sys.argv[1] + ":{}: {}".format(line_n + 1, line))
```