### PR TITLE
Fix bug in patterns.h

### DIFF
--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1389,15 +1389,17 @@ namespace Patterns
                                    const std::unique_ptr<Patterns::PatternBase>
                                    &p = Convert<T>::to_pattern())
       {
-        std::string str;
-        if (std::is_same<T, unsigned char>() || std::is_same<T, signed char>())
-          str = std::to_string((int)value);
+        std::stringstream str;
+        if (std::is_same<T, unsigned char>::value ||
+            std::is_same<T, signed char>::value   ||
+            std::is_same<T, char>::value)
+          str << (int)value;
         else  if (std::is_same<T,bool>::value)
-          str = value ? "true" : "false";
+          str << (value ? "true" : "false");
         else
-          str = std::to_string(value);
-        AssertThrow(p->match(str), ExcNoMatch(str, *p));
-        return str;
+          str << value;
+        AssertThrow(p->match(str.str()), ExcNoMatch(str.str(), *p));
+        return str.str();
       }
 
       static T to_value(const std::string &s,
@@ -1411,7 +1413,9 @@ namespace Patterns
         else
           {
             std::istringstream is(s);
-            if (std::is_same<T, unsigned char>::value || std::is_same<T, signed char>::value)
+            if (std::is_same<T, unsigned char>::value ||
+                std::is_same<T, signed char>::value   ||
+                std::is_same<T, char>::value)
               {
                 int i;
                 is >> i;

--- a/tests/parameter_handler/pattern_tools_02.output
+++ b/tests/parameter_handler/pattern_tools_02.output
@@ -1,43 +1,43 @@
 
 DEAL::Pattern  : [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 1...1 (inclusive)]
-DEAL::To String: 1.000000
-DEAL::To value : 1.000000
+DEAL::To String: 1
+DEAL::To value : 1
 DEAL::Pattern  : [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 2...2 (inclusive)]
-DEAL::To String: 2.000000, 3.000000
-DEAL::To value : 2.000000, 3.000000
+DEAL::To String: 2, 3
+DEAL::To value : 2, 3
 DEAL::Pattern  : [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 3...3 (inclusive)]
-DEAL::To String: 3.000000, 4.000000, 5.000000
-DEAL::To value : 3.000000, 4.000000, 5.000000
+DEAL::To String: 3, 4, 5
+DEAL::To value : 3, 4, 5
 DEAL::Pattern  : [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 1...1 (inclusive)]
-DEAL::To String: 0.000000
-DEAL::To value : 0.000000
+DEAL::To String: 0
+DEAL::To value : 0
 DEAL::Pattern  : [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 2...2 (inclusive)]
-DEAL::To String: 0.000000, 0.000000
-DEAL::To value : 0.000000, 0.000000
+DEAL::To String: 0, 0
+DEAL::To value : 0, 0
 DEAL::Pattern  : [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 3...3 (inclusive)]
-DEAL::To String: 0.000000, 0.000000, 0.000000
-DEAL::To value : 0.000000, 0.000000, 0.000000
+DEAL::To String: 0, 0, 0
+DEAL::To value : 0, 0, 0
 DEAL::Pattern  : [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 2...2 (inclusive)]
-DEAL::To String: 1.000000, 2.000000
-DEAL::To value : 1.000000, 2.000000
+DEAL::To String: 1, 2
+DEAL::To value : 1, 2
 DEAL::Pattern  : [Map of <[Integer range -2147483648...2147483647 (inclusive)]>:<[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 1...1 (inclusive)]
-DEAL::To String: 1:2.000000
-DEAL::To value : 1:2.000000
+DEAL::To String: 1:2
+DEAL::To value : 1:2
 DEAL::Pattern  : [List of <[List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 1...1 (inclusive)]> of length 1...1 (inclusive) separated by <;>]
-DEAL::To String: 0.000000
-DEAL::To value : 0.000000
+DEAL::To String: 0
+DEAL::To value : 0
 DEAL::Pattern  : [List of <[List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 2...2 (inclusive)]> of length 2...2 (inclusive) separated by <;>]
-DEAL::To String: 0.000000, 0.000000; 0.000000, 0.000000
-DEAL::To value : 0.000000, 0.000000; 0.000000, 0.000000
+DEAL::To String: 0, 0; 0, 0
+DEAL::To value : 0, 0; 0, 0
 DEAL::Pattern  : [List of <[List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 3...3 (inclusive)]> of length 3...3 (inclusive) separated by <;>]
-DEAL::To String: 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000
-DEAL::To value : 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000
+DEAL::To String: 0, 0, 0; 0, 0, 0; 0, 0, 0
+DEAL::To value : 0, 0, 0; 0, 0, 0; 0, 0, 0
 DEAL::Pattern  : [List of <[List of <[List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 1...1 (inclusive)]> of length 1...1 (inclusive) separated by <;>]> of length 1...1 (inclusive) separated by <|>]
-DEAL::To String: 0.000000
-DEAL::To value : 0.000000
+DEAL::To String: 0
+DEAL::To value : 0
 DEAL::Pattern  : [List of <[List of <[List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 2...2 (inclusive)]> of length 2...2 (inclusive) separated by <;>]> of length 2...2 (inclusive) separated by <|>]
-DEAL::To String: 0.000000, 0.000000; 0.000000, 0.000000| 0.000000, 0.000000; 0.000000, 0.000000
-DEAL::To value : 0.000000, 0.000000; 0.000000, 0.000000| 0.000000, 0.000000; 0.000000, 0.000000
+DEAL::To String: 0, 0; 0, 0| 0, 0; 0, 0
+DEAL::To value : 0, 0; 0, 0| 0, 0; 0, 0
 DEAL::Pattern  : [List of <[List of <[List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 3...3 (inclusive)]> of length 3...3 (inclusive) separated by <;>]> of length 3...3 (inclusive) separated by <|>]
-DEAL::To String: 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000| 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000| 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000
-DEAL::To value : 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000| 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000| 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000; 0.000000, 0.000000, 0.000000
+DEAL::To String: 0, 0, 0; 0, 0, 0; 0, 0, 0| 0, 0, 0; 0, 0, 0; 0, 0, 0| 0, 0, 0; 0, 0, 0; 0, 0, 0
+DEAL::To value : 0, 0, 0; 0, 0, 0; 0, 0, 0| 0, 0, 0; 0, 0, 0; 0, 0, 0| 0, 0, 0; 0, 0, 0; 0, 0, 0

--- a/tests/parameter_handler/pattern_tools_05.output
+++ b/tests/parameter_handler/pattern_tools_05.output
@@ -1,13 +1,13 @@
 
 DEAL::Pattern  : [Map of <[Integer]>:<[List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 3...3 (inclusive)]> of length 0...4294967295 (inclusive) separated by <;>]
-DEAL::To String: 0:1.000000, 2.000000, 3.000000; 2:1.000000, 2.000000, 3.000000
-DEAL::To value : 0:1.000000, 2.000000, 3.000000; 2:1.000000, 2.000000, 3.000000
+DEAL::To String: 0:1, 2, 3; 2:1, 2, 3
+DEAL::To value : 0:1, 2, 3; 2:1, 2, 3
 DEAL::Pattern  : [Map of <[Integer]>:<[List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 2...2 (inclusive)]> of length 0...4294967295 (inclusive) separated by <;>]
-DEAL::To String: 0:4.000000, 5.000000; 2:4.000000, 5.000000
-DEAL::To value : 0:4.000000, 5.000000; 2:4.000000, 5.000000
+DEAL::To String: 0:4, 5; 2:4, 5
+DEAL::To value : 0:4, 5; 2:4, 5
 DEAL::Pattern  : [Map of <[Integer]>:<[List of <[List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 3...3 (inclusive)]> of length 0...4294967295 (inclusive) separated by <;>]> of length 0...4294967295 (inclusive) separated by <|>]
-DEAL::To String: 0:1.000000, 2.000000, 3.000000; 1.000000, 2.000000, 3.000000| 2:1.000000, 2.000000, 3.000000; 1.000000, 2.000000, 3.000000
-DEAL::To value : 0:1.000000, 2.000000, 3.000000; 1.000000, 2.000000, 3.000000| 2:1.000000, 2.000000, 3.000000; 1.000000, 2.000000, 3.000000
+DEAL::To String: 0:1, 2, 3; 1, 2, 3| 2:1, 2, 3; 1, 2, 3
+DEAL::To value : 0:1, 2, 3; 1, 2, 3| 2:1, 2, 3; 1, 2, 3
 DEAL::Pattern  : [Map of <[Integer]>:<[List of <[List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 2...2 (inclusive)]> of length 0...4294967295 (inclusive) separated by <;>]> of length 0...4294967295 (inclusive) separated by <|>]
-DEAL::To String: 0:4.000000, 5.000000; 4.000000, 5.000000| 2:4.000000, 5.000000; 4.000000, 5.000000
-DEAL::To value : 0:4.000000, 5.000000; 4.000000, 5.000000| 2:4.000000, 5.000000; 4.000000, 5.000000
+DEAL::To String: 0:4, 5; 4, 5| 2:4, 5; 4, 5
+DEAL::To value : 0:4, 5; 4, 5| 2:4, 5; 4, 5

--- a/tests/parameter_handler/pattern_tools_11.cc
+++ b/tests/parameter_handler/pattern_tools_11.cc
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2005 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Check Convert<...>::to_string() for small numbers, and make sure
+// we don't break anything for integral types
+
+#include "../tests.h"
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/std_cxx14/memory.h>
+#include <memory>
+#include <tuple>
+
+int main()
+{
+  initlog();
+
+  double        a = 1e-12;
+  int           i = -1;
+  unsigned int  j = 3;
+  unsigned char c =   3;
+  signed   char c1 = -3;
+  char          c2 = -3;
+  bool          b = false;
+
+  auto t = std::make_tuple(a,i,j,c,c1,c2,b);
+
+  auto s = Patterns::Tools::Convert<decltype(t)>::to_string(t);
+  auto tt = Patterns::Tools::Convert<decltype(t)>::to_value(s);
+  auto r = Patterns::Tools::Convert<decltype(t)>::to_string(tt);
+
+  deallog << "String: " << s
+          << ", roundtrip: " << r << std::endl;
+}

--- a/tests/parameter_handler/pattern_tools_11.output
+++ b/tests/parameter_handler/pattern_tools_11.output
@@ -1,0 +1,2 @@
+
+DEAL::String: 1e-12 : -1 : 3 : 3 : -3 : -3 : false, roundtrip: 1e-12 : -1 : 3 : 3 : -3 : -3 : false


### PR DESCRIPTION
When using small double numbers (for example for tolerances in iterative solvers), this would create a bug:

~~~
double tol = 1e-12;
prm.add_parameter("Tolerance", a);
~~~

the parameter file would get as a default value:
~~~
set Tolerance = 0.000000
~~~

It turns out that `Patterns::Tools` was using `std::to_string` to go from a double number to the actual string for the default parameter. This in turns won't work, because `std::to_string` is equivalent to actually writing plain old `printf('%6f', d)`, i.e., it is only good for  relatively large`float` numbers, and it will silently underflow for small double numbers (like the tolerance above).

Here I simply revert to using `std::stringstream`, which instead is perfectly aware of the difference between `double` and `float`.

