### PR TITLE
Use dynamic_unique_cast in more places

### DIFF
--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -476,7 +476,7 @@ protected:
      * ownership), we store the cast result in a std::unique_ptr to indicate
      * that InternalData owns the object.
      */
-    InternalData ( std::unique_ptr<typename FESystem<dim,spacedim>::InternalData> fesystem_data);
+    InternalData (std::unique_ptr<typename FESystem<dim,spacedim>::InternalData> fesystem_data);
 
     /**
      * Give read-access to the pointer to a @p InternalData of the @p
@@ -553,7 +553,7 @@ protected:
    */
   template <int dim_1>
   std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase>
-  setup_data (std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase> &&fes_data,
+  setup_data (std::unique_ptr<typename FESystem<dim,spacedim>::InternalData> fes_data,
               const UpdateFlags      flags,
               const Quadrature<dim_1> &quadrature) const;
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -164,7 +164,6 @@ MappingQ<dim,spacedim>::get_data (const UpdateFlags update_flags,
   // wait for the task above to finish and use returned value
   data->mapping_qp_data = Utilities::dynamic_unique_cast<typename MappingQGeneric<dim,spacedim>::InternalData>
                           (std::move(do_get_data.return_value()));
-
   return std::move(data);
 }
 

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -2222,8 +2222,8 @@ Point<1>
 MappingQGeneric<1,1>::
 transform_real_to_unit_cell_internal
 (const Triangulation<1,1>::cell_iterator &cell,
- const Point<1>                            &p,
- const Point<1>                                 &initial_p_unit) const
+ const Point<1>                          &p,
+ const Point<1>                          &initial_p_unit) const
 {
   const int dim = 1;
   const int spacedim = 1;
@@ -2233,8 +2233,8 @@ transform_real_to_unit_cell_internal
   UpdateFlags update_flags = update_quadrature_points | update_jacobians;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::unique_ptr<InternalData> mdata (dynamic_cast<InternalData *>(get_data(update_flags,
-                                       point_quadrature).release()));
+  auto mdata = Utilities::dynamic_unique_cast<InternalData>(get_data(update_flags,
+                                                            point_quadrature));
 
   mdata->mapping_support_points = this->compute_mapping_support_points (cell);
 
@@ -2248,8 +2248,8 @@ Point<2>
 MappingQGeneric<2, 2>::
 transform_real_to_unit_cell_internal
 (const Triangulation<2, 2>::cell_iterator &cell,
- const Point<2>                            &p,
- const Point<2>                                 &initial_p_unit) const
+ const Point<2>                           &p,
+ const Point<2>                           &initial_p_unit) const
 {
   const int dim = 2;
   const int spacedim = 2;
@@ -2259,8 +2259,8 @@ transform_real_to_unit_cell_internal
   UpdateFlags update_flags = update_quadrature_points | update_jacobians;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::unique_ptr<InternalData> mdata (dynamic_cast<InternalData *>(get_data(update_flags,
-                                       point_quadrature).release()));
+  auto mdata = Utilities::dynamic_unique_cast<InternalData>(get_data(update_flags,
+                                                            point_quadrature));
 
   mdata->mapping_support_points = this->compute_mapping_support_points (cell);
 
@@ -2285,8 +2285,8 @@ transform_real_to_unit_cell_internal
   UpdateFlags update_flags = update_quadrature_points | update_jacobians;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::unique_ptr<InternalData> mdata (dynamic_cast<InternalData *>(get_data(update_flags,
-                                       point_quadrature).release()));
+  auto mdata = Utilities::dynamic_unique_cast<InternalData>(get_data(update_flags,
+                                                            point_quadrature));
 
   mdata->mapping_support_points = this->compute_mapping_support_points (cell);
 
@@ -2313,8 +2313,8 @@ transform_real_to_unit_cell_internal
   UpdateFlags update_flags = update_quadrature_points | update_jacobians;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::unique_ptr<InternalData> mdata (dynamic_cast<InternalData *>(get_data(update_flags,
-                                       point_quadrature).release()));
+  auto mdata = Utilities::dynamic_unique_cast<InternalData>(get_data(update_flags,
+                                                            point_quadrature));
 
   mdata->mapping_support_points = this->compute_mapping_support_points (cell);
 
@@ -2341,8 +2341,8 @@ transform_real_to_unit_cell_internal
   UpdateFlags update_flags = update_quadrature_points | update_jacobians;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::unique_ptr<InternalData> mdata (dynamic_cast<InternalData *>(get_data(update_flags,
-                                       point_quadrature).release()));
+  auto mdata = Utilities::dynamic_unique_cast<InternalData>(get_data(update_flags,
+                                                            point_quadrature));
 
   mdata->mapping_support_points = this->compute_mapping_support_points (cell);
 


### PR DESCRIPTION
In particular, this I fixed all places where we can avoid calling `std::unique_ptr::release()`.

Further, I changed the signature of `FE_Enriched::setup_data` such that it matches with its documentation and intent (to take `FESystem<dim,spacedim>::InternalData>`).