### PR TITLE
Check the result of a dynamic_cast.

### DIFF
--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -374,10 +374,9 @@ transform (const ArrayView<const Tensor<1,dim> >                  &input,
            const ArrayView<Tensor<1,spacedim> >                   &output) const
 {
   AssertDimension (input.size(), output.size());
-  Assert ((dynamic_cast<const typename MappingQ<dim,spacedim>::InternalData *> (&mapping_data)
-           != nullptr),
-          ExcInternalError());
+
   const InternalData *data = dynamic_cast<const InternalData *>(&mapping_data);
+  Assert (data != nullptr, ExcInternalError());
 
   // check whether we should in fact work on the Q1 portion of it
   if (data->use_mapping_q1_on_current_cell)


### PR DESCRIPTION
Fixes what we tried to fix in #6143.
In particular, I think the problem just was that we checked before that a `dynamic_cast` suceeds and then do it again which `coverity` doesn't understand. In fact, it should be suffient to `dynamic_cast` only once and check the result.