### PR TITLE
Mark a couple of functions as '[[noreturn]]'.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -241,6 +241,7 @@ namespace deal_II_exceptions
      * error message provided by @p exc and calling <tt>std::abort()</tt>, or
      * throws @p exc instead.
      */
+    [[noreturn]]
     void abort (const ExceptionBase &exc);
 
     /**

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -392,6 +392,7 @@ namespace StandardExceptions
 
 namespace
 {
+  [[noreturn]]
   void internal_abort (const ExceptionBase &exc) noexcept
   {
     // first print the error
@@ -464,6 +465,7 @@ namespace deal_II_exceptions
 
 
 
+    [[noreturn]]
     void abort (const ExceptionBase &exc)
     {
       if (dealii::deal_II_exceptions::abort_on_exception)


### PR DESCRIPTION
As discussed in #6143.