### PR TITLE
Add a necessary include file.

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -30,6 +30,7 @@
 #include <deal.II/fe/mapping_q1.h>
 #include <deal.II/fe/mapping_q.h>
 #include <deal.II/fe/mapping_q_generic.h>
+#include <deal.II/fe/fe_q.h>
 
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/tria.h>


### PR DESCRIPTION
This include file is currently transitively imported via mapping_q_generic.h, but
that may change at some point in the future. Since it's needed in grid_tools.cc, add
it explicitly.