### PR TITLE
make zero_out_ghosts() const

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -331,7 +331,7 @@ namespace LinearAlgebra
        * vector is forbidden and an exception is thrown. Only write access to
        * ghost elements is allowed in this state.
        */
-      void zero_out_ghosts ();
+      void zero_out_ghosts () const;
 
       /**
        * Return if this Vector contains ghost elements.

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -285,7 +285,7 @@ namespace LinearAlgebra
 
     template <typename Number>
     void
-    BlockVector<Number>::zero_out_ghosts ()
+    BlockVector<Number>::zero_out_ghosts () const
     {
       for (unsigned int block=0; block<this->n_blocks(); ++block)
         this->block(block).zero_out_ghosts();

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -501,7 +501,7 @@ namespace LinearAlgebra
        * vector is forbidden and an exception is thrown. Only write access to
        * ghost elements is allowed in this state.
        */
-      void zero_out_ghosts ();
+      void zero_out_ghosts () const;
 
       /**
        * Return whether the vector currently is in a state where ghost values

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -515,7 +515,7 @@ namespace LinearAlgebra
 
     template <typename Number>
     void
-    Vector<Number>::zero_out_ghosts ()
+    Vector<Number>::zero_out_ghosts () const
     {
       std::fill_n (&values[partitioner->local_size()],
                    partitioner->n_ghost_indices(),


### PR DESCRIPTION
fixes https://github.com/dealii/dealii/issues/6197

p.s. I was surprized that I did not need to cast-away `const`.