### PR TITLE
Separate a note from 'The commented program'

### DIFF
--- a/examples/step-4/doc/intro.dox
+++ b/examples/step-4/doc/intro.dox
@@ -139,3 +139,4 @@ be written this way. A typical example is the need to use the keyword
 this already, then several of these difficulties are explained in the deal.II
 Frequently Asked Questions (FAQ) linked to from the <a
 href="http://www.dealii.org/">deal.II homepage</a>.
+


### PR DESCRIPTION
Currently, "The commented program" is part of a note in the [documentation to `step-4`](https://www.dealii.org/developer/doxygen/deal.II/step_4.html). Fix this.