### PR TITLE
Allow setup_astyle.sh to be used on macOS as well

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -36,7 +36,7 @@ if test ! -d source -o ! -d include -o ! -d examples ; then
 fi
 
 # Add the location 'setup_astyle.sh' installs astyle to to the local PATH.
-ASTYLE_PATH="$(realpath contrib/utilities)/programs/astyle/build/gcc/bin"
+ASTYLE_PATH="$(cd "$(dirname "$0")" && pwd)/programs/astyle/bin"
 export PATH=$ASTYLE_PATH:$PATH
 
 if test ! -f contrib/styles/astyle.rc ; then


### PR DESCRIPTION
Supersedes (or builds on) #6186.
Now, `setup_astyle` && `indent`  combination should also work on `macOS`.
In particular, I also had to replace `wget` as well. Furthermore, this PR also make sure that the install files really end up in the `contrib/utilities/programs/astyle` and that the executable is installed into a more general place.