### PR TITLE
Improve assertions

### DIFF
--- a/contrib/styles/astyle.rc
+++ b/contrib/styles/astyle.rc
@@ -18,7 +18,6 @@
 --style=gnu
 
 --convert-tabs
---indent-preprocessor
 --indent=spaces=2
 --indent-namespaces
 --keep-one-line-blocks

--- a/doc/doxygen/headers/exceptions.h
+++ b/doc/doxygen/headers/exceptions.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2013 by the deal.II authors
+// Copyright (C) 2003 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -21,10 +21,10 @@
  * deal.II.
  *
  * <h2>Brief overview</h2>
- * 
+ *
  * Exceptions are used in two different ways:
  * <ul>
- * 
+ *
  *   <li> Static assertions: These are checks that are only enabled in debug
  *   mode, not in release (or optimized, production) mode. In deal.II, static
  *   assertions are typically used to check that parameters to functions satisfy
@@ -114,7 +114,7 @@
  *     DeclException2 (ExcDomain, int, int,
  *                     << "Index= " << arg1 << "Upper Bound= " << arg2);
  *  @endcode
- *  
+ *
  *  This declares an exception class named <tt>ExcDomain</tt>, which
  *  has two variables as additional information (named <tt>arg1</tt>
  *  and <tt>arg2</tt> by default) and which outputs the given sequence
@@ -147,7 +147,9 @@
  *  @code
  *    #ifdef DEBUG
  *        if (!(cond))
- *              issue error of class ExcDomain(n,dim)
+ *          {
+ *            // issue error of class ExcDomain(n,dim)
+ *          }
  *    #else
  *        // do nothing
  *    #endif
@@ -168,52 +170,44 @@
  *  following sequence:
  *  @code
  *    if (!(cond))
- *      deal_II_exceptions::internals::issue_error_assert_1
+ *      deal_II_exceptions::internals::issue_error_noreturn
  *             (__FILE__,
  *              __LINE__,
  *              __PRETTY_FUNCTION__,
  *              #cond,
  *              #exc,
- *              &exc);
+ *              exc);
  *  @endcode
- *  
+ *
  *  (Note that function names and exact calling sequences may change
  *  over time, but the general principle remains the same.) I.e., if
  *  the given condition is violated, then the file and line in which
  *  the exception occurred as well as the condition itself and the call
  *  sequence of the exception object is passed to the
- *  deal_II_exceptions::internals::issue_error_assert_1()
+ *  deal_II_exceptions::internals::issue_error_noreturn()
  *  function. Additionally an object of the form given by <tt>exc</tt>
  *  is created (this is normally an unnamed object like in
  *  <tt>ExcDomain (n, dim)</tt> of class <tt>ExcDomain</tt>) and
  *  transferred to this function.
  *
- *  <tt>__PRETTY__FUNCTION__</tt> is a macro defined by some compilers and
+ *  <tt>__PRETTY_FUNCTION__</tt> is a macro defined by some compilers and
  *  gives the name of the function. If another compiler is used, we
  *  try to set this function to something reasonable, if the compiler
  *  provides us with that, and <tt>"(not available)"</tt> otherwise.
  *
- *  In <tt>issue_error_assert</tt>, the given data is transferred into
- *  the <tt>exc</tt> object by calling the set_fields() function;
- *  after that, the general error info is printed onto
- *  <tt>std::cerr</tt> using the PrintError() function of <tt>exc</tt>
- *  and finally the exception specific data is printed using the user
- *  defined function PrintError() (which is normally created using the
- *  <tt>DeclException (...)</tt> macro family. If it can be obtained
- *  from the operating system, the output may also contain a
- *  stacktrace to show where the error happened. Several of the
- *  @ref Tutorial programs show a typical output.
+ *  In <tt>issue_error_noreturn</tt>, the given data is transferred into the
+ *  <tt>exc</tt> object by calling the set_fields() function; Afterwards the
+ *  program is either aborted (and information about the exception is printed
+ *  to deallog) or the exception is thrown. The <tt>Assert</tt> macro does the
+ *  first path (print and abort); <tt>AssertThrow</tt> does the second
+ *  (throw). This behavior is consistent with the descriptions of static and
+ *  dynamic assertions earlier in this document. If it can be obtained from
+ *  the operating system, the output may also contain a stacktrace to show
+ *  where the error happened. Several of the @ref Tutorial programs show a
+ *  typical output.
  *
- *  After printing all this information,
- *  deal_II_exceptions::internals::abort() is called (with one
- *  exception, see the end of this section). This terminates the
- *  program, which is the right thing to do for this kind of error
- *  checking since it is used to detect programming errors rather than
- *  run-time errors; a program can, by definition, not recover from
- *  programming errors.
- *
- *  If the preprocessor variable <tt>DEBUG</tt> is not set, then nothing
- *  happens, i.e. the <tt>Assert</tt> macro is expanded to <tt>{}</tt>.
+ *  If the preprocessor variable <tt>DEBUG</tt> is not set then the
+ *  <tt>Assert</tt> macro is expanded to <tt>{}</tt>.
  *
  *  Sometimes, there is no useful condition for an exception other
  *  than that the program flow should not have reached a certain point,
@@ -274,15 +268,17 @@
  *  @endcode
  *  and catch it using the statement
  *  @code
- *    try {
- *      do_something ();
- *    }
- *    catch (std::exception &e) {
- *      std::cerr << "Exception occurred:" << std::endl
- *           << e.what ()
- *           << std::endl;
- *      do_something_to_reciver ();
- *    };
+ *    try
+ *      {
+ *        do_something ();
+ *      }
+ *    catch (std::exception &e)
+ *      {
+ *        std::cerr << "Exception occurred:" << std::endl
+ *                  << e.what ()
+ *                  << std::endl;
+ *        do_something_to_receiver ();
+ *      }
  *  @endcode
  *  <tt>std::exception</tt> is a standard <tt>C++</tt> class providing basic functionality for
  *  exceptions, such as the virtual function <tt>what()</tt> that returns some
@@ -340,24 +336,27 @@
  *  case there two types, corresponding to the <tt>X</tt> in
  *  <tt>DeclExceptionX</tt>) and finally the output
  *  sequence with which you can print additional information.
- *  
+ *
  *  The syntax of the output sequence is a bit weird but gets
  *  clearer once you see how this macro is defined (again schematically, actual
  *  function names and definitions may change over time and be different):
  *  @code
- *  class name : public ExceptionBase {
- *    public:
- *      name (const type1 a1, const type2 a2) :
- *                     arg1 (a1), arg2(a2) {};
- *      virtual void print_info (std::ostream &out) const {
- *        out outsequence << std::endl;
- *      };
- *    private:
- *      type1 arg1;
- *      type2 arg2;
+ *  class name : public ExceptionBase
+ *  {
+ *  public:
+ *    name (const type1 a1, const type2 a2) : arg1 (a1), arg2(a2)
+ *    {}
+ *
+ *    virtual void print_info (std::ostream &out) const
+ *    {
+ *      out << "    " outsequence << std::endl;
+ *    }
+ *  private:
+ *    type1 arg1;
+ *    type2 arg2;
  *  };
  *  @endcode
- *   
+ *
  *  If declared as specified, you can later use this exception class
  *  in the following manner:
  *  @code
@@ -369,15 +368,15 @@
  *  @code
  *    --------------------------------------------------------
  *    An error occurred in line <301> of file <exc-test.cc>.
- *    The violated condition was: 
+ *    The violated condition was:
  *      i<m
  *    The name and call sequence of the exception was:
  *      MyExc2(i,m)
- *    Additional Information: 
+ *    Additional Information:
  *      i=5, m=3
  *    --------------------------------------------------------
  *  @endcode
- *  
+ *
  *  Obviously for the <tt>DeclException0(name)</tt> macro, no types and
  *  also no output sequence is allowed.
  *

--- a/doc/doxygen/scripts/filter
+++ b/doc/doxygen/scripts/filter
@@ -35,12 +35,35 @@ while (<>)
     # We don't let doxygen put everything into a namespace
     # dealii. consequently, doxygen can't link references that contain an
     # explicit dealii:: qualification. remove it and replace it by the
-    # global scope
+    # global scope.
+    #
+    # Try to detect whether or not ::dealii:: is part of a macro (e.g., Assert)
+    # continuation line (line ending in '\'): if it is then replace it with
+    # spaces. This keeps the '\'s aligned, e.g., the following snippet (which is
+    # part of the definition of Assert)
+    #
+    # ::dealii::internals::abort(__LINE__,             \ # part of macro
+    #                            __PRETTY_FUNCTION__)
+    #
+    # will be converted to
+    #
+    #         ::internals::abort(__LINE__,             \ # part of macro
+    #                            __PRETTY_FUNCTION__)
+    #
+    # so the '\' is kept in the same column.
     #
     # Now, as of doxygen 1.5, this still produces the wrong result, but
     # that's not our fault. This is reported here:
     #    http://bugzilla.gnome.org/show_bug.cgi?id=365053
-    s/(::)?dealii::/::/g;
+    if (m/^ *(::)?dealii::.*\\$/)
+    {
+        s/::dealii::(.*)\\$/::\1        \\/g;
+        s/dealii::(.*)\\$/\1        \\/g;
+    }
+    else
+    {
+        s/(::)?dealii::/::/g;
+    }
 
     # Replace all occurrences of something like step-xx by
     #    @ref step_xx "step-xx"

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -347,15 +347,25 @@ namespace deal_II_exceptions
  * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
  */
 #ifdef DEBUG
-#define Assert(cond, exc)                                                   \
+#  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
+#    define Assert(cond, exc)                                                 \
+  {                                                                           \
+    if (__builtin_expect(!(cond), false))                                     \
+      ::dealii::deal_II_exceptions::internals::                               \
+      issue_error(::dealii::deal_II_exceptions::internals::abort_on_exception,\
+                  __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc); \
+  }
+#  else
+#    define Assert(cond, exc)                                                 \
   {                                                                           \
     if (!(cond))                                                              \
       ::dealii::deal_II_exceptions::internals::                               \
       issue_error(::dealii::deal_II_exceptions::internals::abort_on_exception,\
                   __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc); \
   }
+#  endif
 #else
-#define Assert(cond, exc)                                                   \
+#define Assert(cond, exc)                                                     \
   {}
 #endif
 
@@ -377,7 +387,17 @@ namespace deal_II_exceptions
  * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
  */
 #ifdef DEBUG
-#define AssertNothrow(cond, exc)                                              \
+#  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
+#    define AssertNothrow(cond, exc)                                            \
+  {                                                                             \
+    if (__builtin_expect(!(cond), false))                                       \
+      ::dealii::deal_II_exceptions::internals::                                 \
+      issue_error_nothrow(                                                      \
+          ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,  \
+          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);           \
+  }
+#  else
+#    define AssertNothrow(cond, exc)                                            \
   {                                                                             \
     if (!(cond))                                                                \
       ::dealii::deal_II_exceptions::internals::                                 \
@@ -385,6 +405,7 @@ namespace deal_II_exceptions
           ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,  \
           __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);           \
   }
+#  endif
 #else
 #define AssertNothrow(cond, exc)                                              \
   {}
@@ -408,7 +429,7 @@ namespace deal_II_exceptions
  * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
  */
 #ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#define AssertThrow(cond, exc)                                              \
+#define AssertThrow(cond, exc)                                                \
   {                                                                           \
     if (__builtin_expect(!(cond), false))                                     \
       ::dealii::deal_II_exceptions::internals::                               \
@@ -416,7 +437,7 @@ namespace deal_II_exceptions
                   __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc); \
   }
 #else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-#define AssertThrow(cond, exc)                                              \
+#define AssertThrow(cond, exc)                                                \
   {                                                                           \
     if (!(cond))                                                              \
       ::dealii::deal_II_exceptions::internals::                               \

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -348,26 +348,24 @@ namespace deal_II_exceptions
  */
 #ifdef DEBUG
 #  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#    define Assert(cond, exc)                                          \
-  {                                                                    \
-    if (__builtin_expect(!(cond), false))                              \
-      ::dealii::deal_II_exceptions::internals::                        \
-      issue_error_noreturn(                                            \
-          ::dealii::deal_II_exceptions::internals::abort_on_exception, \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);  \
-  }
+#    define Assert(cond, exc)                                                  \
+{                                                                              \
+  if (__builtin_expect(!(cond), false))                                        \
+    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
+        ::dealii::deal_II_exceptions::internals::abort_on_exception,           \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
 #  else
-#    define Assert(cond, exc)                                          \
-  {                                                                    \
-    if (!(cond))                                                       \
-      ::dealii::deal_II_exceptions::internals::                        \
-      issue_error_noreturn(                                            \
-          ::dealii::deal_II_exceptions::internals::abort_on_exception, \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);  \
-  }
+#    define Assert(cond, exc)                                                  \
+{                                                                              \
+  if (!(cond))                                                                 \
+    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
+        ::dealii::deal_II_exceptions::internals::abort_on_exception,           \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
 #  endif
 #else
-#define Assert(cond, exc)                                              \
+#define Assert(cond, exc)                                                      \
   {}
 #endif
 
@@ -390,30 +388,26 @@ namespace deal_II_exceptions
  */
 #ifdef DEBUG
 #  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#    define AssertNothrow(cond, exc)                                            \
-  {                                                                             \
-    if (__builtin_expect(!(cond), false))                                       \
-      ::dealii::deal_II_exceptions::internals::                                 \
-      issue_error_nothrow(                                                      \
-          ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,  \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);           \
-  }
+#    define AssertNothrow(cond, exc)                                           \
+{                                                                              \
+  if (__builtin_expect(!(cond), false))                                        \
+    ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
+        ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
 #  else
-#    define AssertNothrow(cond, exc)                                            \
-  {                                                                             \
-    if (!(cond))                                                                \
-      ::dealii::deal_II_exceptions::internals::                                 \
-      issue_error_nothrow(                                                      \
-          ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,  \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);           \
-  }
+#    define AssertNothrow(cond, exc)                                           \
+{                                                                              \
+  if (!(cond))                                                                 \
+    ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
+        ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
 #  endif
 #else
-#define AssertNothrow(cond, exc)                                                \
+#define AssertNothrow(cond, exc)                                               \
   {}
 #endif
-
-
 
 /**
  * A macro that serves as the main routine in the exception mechanism for dynamic
@@ -431,23 +425,21 @@ namespace deal_II_exceptions
  * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
  */
 #ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#define AssertThrow(cond, exc)                                         \
-  {                                                                    \
-    if (__builtin_expect(!(cond), false))                              \
-      ::dealii::deal_II_exceptions::internals::                        \
-      issue_error_noreturn(                                            \
-          ::dealii::deal_II_exceptions::internals::throw_on_exception, \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);  \
-  }
+#define AssertThrow(cond, exc)                                                 \
+{                                                                              \
+  if (__builtin_expect(!(cond), false))                                        \
+    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
+        ::dealii::deal_II_exceptions::internals::throw_on_exception,           \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
 #else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-#define AssertThrow(cond, exc)                                         \
-  {                                                                    \
-    if (!(cond))                                                       \
-      ::dealii::deal_II_exceptions::internals::                        \
-      issue_error_noreturn(                                            \
-          ::dealii::deal_II_exceptions::internals::throw_on_exception, \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);  \
-  }
+#define AssertThrow(cond, exc)                                                 \
+{                                                                              \
+  if (!(cond))                                                                 \
+    ::dealii::deal_II_exceptions::internals::issue_error_noreturn(             \
+        ::dealii::deal_II_exceptions::internals::throw_on_exception,           \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
 #endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 
 
@@ -1214,7 +1206,6 @@ namespace StandardExceptions
 #endif // DEAL_II_WITH_MPI
 } /*namespace StandardExceptions*/
 
-
 /**
  * Special assertion for dimension mismatch.
  *
@@ -1225,8 +1216,8 @@ namespace StandardExceptions
  * @ingroup Exceptions
  * @author Guido Kanschat 2007
  */
-#define AssertDimension(dim1,dim2) Assert((dim1) == (dim2),       \
-                                          dealii::ExcDimensionMismatch((dim1),(dim2)))
+#define AssertDimension(dim1,dim2) \
+Assert((dim1) == (dim2), dealii::ExcDimensionMismatch((dim1),(dim2)))
 
 
 /**
@@ -1236,8 +1227,9 @@ namespace StandardExceptions
  * @ingroup Exceptions
  * @author Guido Kanschat 2010
  */
-#define AssertVectorVectorDimension(vec,dim1,dim2) AssertDimension((vec).size(), (dim1)) \
-  for (unsigned int i=0;i<dim1;++i) { AssertDimension((vec)[i].size(), (dim2)); }
+#define AssertVectorVectorDimension(vec,dim1,dim2)                             \
+AssertDimension((vec).size(), (dim1));                                         \
+for (unsigned int i=0;i<dim1;++i) {AssertDimension((vec)[i].size(), (dim2));}  \
 
 namespace internal
 {
@@ -1260,12 +1252,11 @@ namespace internal
  * @ingroup Exceptions
  * @author Guido Kanschat 2007
  */
-#define AssertIndexRange(index,range) \
-  Assert((index) < (range), \
-         dealii::ExcIndexRangeType< \
-         typename ::dealii::internal::argument_type< \
-         void(typename std::common_type<decltype(index), \
-              decltype(range)>::type)>::type>((index),0,(range)))
+#define AssertIndexRange(index,range)                                          \
+Assert((index) < (range),                                                      \
+dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<          \
+void(typename std::common_type<decltype(index),                                \
+     decltype(range)>::type)>::type>((index),0,(range)))
 
 /**
  * An assertion that checks whether a number is finite or not. We explicitly
@@ -1276,8 +1267,9 @@ namespace internal
  * @ingroup Exceptions
  * @author Wolfgang Bangerth, 2015
  */
-#define AssertIsFinite(number) Assert(dealii::numbers::is_finite(number), \
-                                      dealii::ExcNumberNotFinite(std::complex<double>(number)))
+#define AssertIsFinite(number)                                                 \
+Assert(dealii::numbers::is_finite(number),                                     \
+dealii::ExcNumberNotFinite(std::complex<double>(number)))
 
 #ifdef DEAL_II_WITH_MPI
 /**
@@ -1290,8 +1282,8 @@ namespace internal
  * @ingroup Exceptions
  * @author David Wells, 2016
  */
-#define AssertThrowMPI(error_code) AssertThrow(error_code == MPI_SUCCESS, \
-                                               dealii::ExcMPI(error_code))
+#define AssertThrowMPI(error_code) \
+AssertThrow(error_code == MPI_SUCCESS, dealii::ExcMPI(error_code))
 #else
 #define AssertThrowMPI(error_code) {}
 #endif // DEAL_II_WITH_MPI

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1117,7 +1117,7 @@ namespace deal_II_exceptions
         ::dealii::deal_II_exceptions::internals::abort_on_exception,           \
         __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
 }
-#  else
+#  else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #    define Assert(cond, exc)                                                  \
 {                                                                              \
   if (!(cond))                                                                 \
@@ -1125,7 +1125,7 @@ namespace deal_II_exceptions
         ::dealii::deal_II_exceptions::internals::abort_on_exception,           \
         __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
 }
-#  endif
+#  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
 #define Assert(cond, exc)                                                      \
   {}
@@ -1157,7 +1157,7 @@ namespace deal_II_exceptions
         ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
         __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
 }
-#  else
+#  else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #    define AssertNothrow(cond, exc)                                           \
 {                                                                              \
   if (!(cond))                                                                 \
@@ -1165,7 +1165,7 @@ namespace deal_II_exceptions
         ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
         __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
 }
-#  endif
+#  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
 #define AssertNothrow(cond, exc)                                               \
   {}

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1111,20 +1111,20 @@ namespace deal_II_exceptions
 #ifdef DEBUG
 #  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
 #    define Assert(cond, exc)                                                  \
-{                                                                              \
-  if (__builtin_expect(!(cond), false))                                        \
-    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
-        ::dealii::deal_II_exceptions::internals::abort_on_exception,           \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
+  {                                                                            \
+    if (__builtin_expect(!(cond), false))                                      \
+      ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(          \
+          ::dealii::deal_II_exceptions::internals::abort_on_exception,         \
+          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);          \
+  }
 #  else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #    define Assert(cond, exc)                                                  \
-{                                                                              \
-  if (!(cond))                                                                 \
-    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
-        ::dealii::deal_II_exceptions::internals::abort_on_exception,           \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
+  {                                                                            \
+    if (!(cond))                                                               \
+      ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(          \
+          ::dealii::deal_II_exceptions::internals::abort_on_exception,         \
+          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);          \
+  }
 #  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
 #define Assert(cond, exc)                                                      \
@@ -1151,20 +1151,20 @@ namespace deal_II_exceptions
 #ifdef DEBUG
 #  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
 #    define AssertNothrow(cond, exc)                                           \
-{                                                                              \
-  if (__builtin_expect(!(cond), false))                                        \
-    ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
-        ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
+  {                                                                              \
+    if (__builtin_expect(!(cond), false))                                        \
+      ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
+          ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
+          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+  }
 #  else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #    define AssertNothrow(cond, exc)                                           \
-{                                                                              \
-  if (!(cond))                                                                 \
-    ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
-        ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
+  {                                                                              \
+    if (!(cond))                                                                 \
+      ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
+          ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
+          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+  }
 #  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
 #define AssertNothrow(cond, exc)                                               \
@@ -1188,20 +1188,20 @@ namespace deal_II_exceptions
  */
 #ifdef DEAL_II_HAVE_BUILTIN_EXPECT
 #define AssertThrow(cond, exc)                                                 \
-{                                                                              \
-  if (__builtin_expect(!(cond), false))                                        \
-    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
-        ::dealii::deal_II_exceptions::internals::throw_on_exception,           \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
+  {                                                                            \
+    if (__builtin_expect(!(cond), false))                                      \
+      ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(          \
+          ::dealii::deal_II_exceptions::internals::throw_on_exception,         \
+          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);          \
+  }
 #else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #define AssertThrow(cond, exc)                                                 \
-{                                                                              \
-  if (!(cond))                                                                 \
-    ::dealii::deal_II_exceptions::internals::issue_error_noreturn(             \
-        ::dealii::deal_II_exceptions::internals::throw_on_exception,           \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
+  {                                                                            \
+    if (!(cond))                                                               \
+      ::dealii::deal_II_exceptions::internals::issue_error_noreturn(           \
+          ::dealii::deal_II_exceptions::internals::throw_on_exception,         \
+          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);          \
+  }
 #endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 
 /**
@@ -1215,7 +1215,7 @@ namespace deal_II_exceptions
  * @author Guido Kanschat 2007
  */
 #define AssertDimension(dim1,dim2) \
-Assert((dim1) == (dim2), dealii::ExcDimensionMismatch((dim1),(dim2)))
+  Assert((dim1) == (dim2), dealii::ExcDimensionMismatch((dim1),(dim2)))
 
 
 /**
@@ -1225,9 +1225,9 @@ Assert((dim1) == (dim2), dealii::ExcDimensionMismatch((dim1),(dim2)))
  * @ingroup Exceptions
  * @author Guido Kanschat 2010
  */
-#define AssertVectorVectorDimension(vec,dim1,dim2)                             \
-AssertDimension((vec).size(), (dim1));                                         \
-for (unsigned int i=0;i<dim1;++i) {AssertDimension((vec)[i].size(), (dim2));}  \
+#define AssertVectorVectorDimension(vec,dim1,dim2)                              \
+  AssertDimension((vec).size(), (dim1));                                        \
+  for (unsigned int i=0;i<dim1;++i) {AssertDimension((vec)[i].size(), (dim2));}
 
 namespace internal
 {
@@ -1251,10 +1251,10 @@ namespace internal
  * @author Guido Kanschat 2007
  */
 #define AssertIndexRange(index,range)                                          \
-Assert((index) < (range),                                                      \
-dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<          \
-void(typename std::common_type<decltype(index),                                \
-     decltype(range)>::type)>::type>((index),0,(range)))
+  Assert((index) < (range),                                                    \
+         dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type< \
+         void(typename std::common_type<decltype(index),                       \
+              decltype(range)>::type)>::type>((index),0,(range)))
 
 /**
  * An assertion that checks whether a number is finite or not. We explicitly
@@ -1266,8 +1266,8 @@ void(typename std::common_type<decltype(index),                                \
  * @author Wolfgang Bangerth, 2015
  */
 #define AssertIsFinite(number)                                                 \
-Assert(dealii::numbers::is_finite(number),                                     \
-dealii::ExcNumberNotFinite(std::complex<double>(number)))
+  Assert(dealii::numbers::is_finite(number),                                   \
+         dealii::ExcNumberNotFinite(std::complex<double>(number)))
 
 #ifdef DEAL_II_WITH_MPI
 /**
@@ -1281,7 +1281,7 @@ dealii::ExcNumberNotFinite(std::complex<double>(number)))
  * @author David Wells, 2016
  */
 #define AssertThrowMPI(error_code) \
-AssertThrow(error_code == MPI_SUCCESS, dealii::ExcMPI(error_code))
+  AssertThrow(error_code == MPI_SUCCESS, dealii::ExcMPI(error_code))
 #else
 #define AssertThrowMPI(error_code) {}
 #endif // DEAL_II_WITH_MPI

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -165,285 +165,6 @@ private:
   mutable std::string what_str;
 };
 
-
-
-/**
- * In this namespace, functions in connection with the Assert and AssertThrow
- * mechanism are declared.
- *
- * @ingroup Exceptions
- */
-namespace deal_II_exceptions
-{
-
-  /**
-   * Set a string that is printed upon output of the message indicating a
-   * triggered <tt>Assert</tt> statement. This string, which is printed in
-   * addition to the usual output may indicate information that is otherwise
-   * not readily available unless we are using a debugger. For example, with
-   * distributed programs on cluster computers, the output of all processes is
-   * redirected to the same console window. In this case, it is convenient to
-   * set as additional name the name of the host on which the program runs, so
-   * that one can see in which instance of the program the exception occurred.
-   *
-   * The string pointed to by the argument is copied, so doesn't need to be
-   * stored after the call to this function.
-   *
-   * Previously set additional output is replaced by the argument given to
-   * this function.
-   *
-   * @see Exceptions
-   */
-  void set_additional_assert_output (const char *const p);
-
-  /**
-   * Calling this function disables printing a stacktrace along with the other
-   * output printed when an exception occurs. Most of the time, you will want
-   * to see such a stacktrace; suppressing it, however, is useful if one wants
-   * to compare the output of a program across different machines and systems,
-   * since the stacktrace shows memory addresses and library names/paths that
-   * depend on the exact setup of a machine.
-   *
-   * @see Exceptions
-   */
-  void suppress_stacktrace_in_exceptions ();
-
-  /**
-   * Calling this function switches off the use of <tt>std::abort()</tt> when
-   * an exception is created using the Assert() macro. Instead, the Exception
-   * will be thrown using 'throw', so it can be caught if desired. Generally,
-   * you want to abort the execution of a program when Assert() is called, but
-   * it needs to be switched off if you want to log all exceptions created, or
-   * if you want to test if an assertion is working correctly. This is done
-   * for example in regression tests. Please note that some fatal errors will
-   * still call abort(), e.g. when an exception is caught during exception
-   * handling.
-   *
-   * @see Exceptions
-   */
-  void disable_abort_on_exception ();
-
-  /**
-   * The functions in this namespace are in connection with the Assert and
-   * AssertThrow mechanism but are solely for internal purposes and are not
-   * for use outside the exception handling and throwing mechanism.
-   *
-   * @ingroup Exceptions
-   */
-  namespace internals
-  {
-
-    /**
-     * Conditionally abort the program.
-     *
-     * Depending on whether deal_II_exceptions::disable_abort_on_exception was
-     * called, this function either aborts the program flow by printing the
-     * error message provided by @p exc and calling <tt>std::abort()</tt>, or
-     * throws @p exc instead.
-     */
-    [[noreturn]]
-    void abort (const ExceptionBase &exc);
-
-    /**
-     * An enum describing how to treat an exception in issue_error.
-     */
-    enum ExceptionHandling
-    {
-      /**
-       * Abort the program by calling <code>std::abort</code> unless
-       * deal_II_exceptions::disable_abort_on_exception has been called: in
-       * that case the program will throw an exception.
-       */
-      abort_on_exception,
-      /**
-       * Throw the exception normally.
-       */
-      throw_on_exception,
-      /**
-       * Call <code>std::abort</code> as long as
-       * deal_II_exceptions::disable_abort_on_exception has not been called:
-       * if it has, then just print a description of the exception to deallog.
-       */
-      abort_nothrow_on_exception
-    };
-
-    /**
-     * This routine does the main work for the exception generation mechanism
-     * used in the <tt>Assert</tt> and <tt>AssertThrow</tt> macros: as the
-     * name implies, this function either ends with a call to <tt>abort</tt>
-     * or throwing an exception.
-     *
-     * The actual exception object (the last argument) is typically an unnamed
-     * object created in place; because we modify it, we can't take it by
-     * const reference, and temporaries don't bind to non-const references.
-     * So take it by value (=copy it) -- the performance implications are
-     * pretty minimal anyway.
-     *
-     * @ref ExceptionBase
-     */
-    template <class ExceptionType>
-    [[noreturn]]
-    void issue_error_noreturn (ExceptionHandling  handling,
-                               const char       *file,
-                               int               line,
-                               const char       *function,
-                               const char       *cond,
-                               const char       *exc_name,
-                               ExceptionType     e)
-    {
-      // Fill the fields of the exception object
-      e.set_fields (file, line, function, cond, exc_name);
-
-      switch (handling)
-        {
-        case abort_on_exception:
-          dealii::deal_II_exceptions::internals::abort(e);
-        case throw_on_exception:
-          throw e;
-        default:
-          // this function should never return; something must have gone wrong
-          // in the error handling code for us to get this far, so throw an
-          // exception.
-          throw ::dealii::StandardExceptions::ExcInternalError();
-        }
-    }
-
-    /**
-     * Exception generation mechanism in case we must not throw.
-     *
-     * @ref ExceptionBase
-     */
-    void issue_error_nothrow (ExceptionHandling,
-                              const char       *file,
-                              int               line,
-                              const char       *function,
-                              const char       *cond,
-                              const char       *exc_name,
-                              ExceptionBase     e) noexcept;
-#ifdef DEAL_II_WITH_CUDA
-    /**
-     * Return a string given an error code. This is similar to the cudaGetErrorString
-     * function but there is no equivalent function for cuSPARSE.
-     */
-    std::string get_cusparse_error_string(const cusparseStatus_t error_code);
-#endif
-  } /*namespace internals*/
-
-} /*namespace deal_II_exceptions*/
-
-
-
-/**
- * A macro that serves as the main routine in the exception mechanism for debug mode
- * error checking. It asserts that a certain condition is fulfilled, otherwise
- * issues an error and aborts the program.
- *
- * A more detailed description can be found in the @ref Exceptions documentation
- * module. It is first used in step-5 and step-6.
- * See also the <tt>ExceptionBase</tt> class for more information.
- *
- * @note Active in DEBUG mode only
- * @ingroup Exceptions
- * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
- */
-#ifdef DEBUG
-#  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#    define Assert(cond, exc)                                                  \
-{                                                                              \
-  if (__builtin_expect(!(cond), false))                                        \
-    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
-        ::dealii::deal_II_exceptions::internals::abort_on_exception,           \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
-#  else
-#    define Assert(cond, exc)                                                  \
-{                                                                              \
-  if (!(cond))                                                                 \
-    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
-        ::dealii::deal_II_exceptions::internals::abort_on_exception,           \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
-#  endif
-#else
-#define Assert(cond, exc)                                                      \
-  {}
-#endif
-
-
-
-/**
- * A variant of the <tt>Assert</tt> macro above that exhibits the same runtime
- * behavior as long as disable_abort_on_exception was not called.
- *
- * However, if disable_abort_on_exception was called, this macro merely prints
- * the exception that would be thrown to deallog and continues normally
- * without throwing an exception.
- *
- * A more detailed description can be found in the @ref Exceptions documentation
- * module, in the discussion about the corner case at the bottom of the page.
- *
- * @note Active in DEBUG mode only
- * @ingroup Exceptions
- * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
- */
-#ifdef DEBUG
-#  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#    define AssertNothrow(cond, exc)                                           \
-{                                                                              \
-  if (__builtin_expect(!(cond), false))                                        \
-    ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
-        ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
-#  else
-#    define AssertNothrow(cond, exc)                                           \
-{                                                                              \
-  if (!(cond))                                                                 \
-    ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
-        ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
-#  endif
-#else
-#define AssertNothrow(cond, exc)                                               \
-  {}
-#endif
-
-/**
- * A macro that serves as the main routine in the exception mechanism for dynamic
- * error checking. It asserts that a certain condition is fulfilled, otherwise
- * throws an exception via the C++ @p throw mechanism. This exception can
- * be caught via a @p catch clause, as is shown in step-6 and all following
- * tutorial programs.
- *
- * A more detailed description can be found in the @ref Exceptions documentation
- * module. It is first used in step-9 and step-13.
- * See also the <tt>ExceptionBase</tt> class for more information.
- *
- * @note Active in both DEBUG and RELEASE modes
- * @ingroup Exceptions
- * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
- */
-#ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#define AssertThrow(cond, exc)                                                 \
-{                                                                              \
-  if (__builtin_expect(!(cond), false))                                        \
-    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
-        ::dealii::deal_II_exceptions::internals::throw_on_exception,           \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
-#else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-#define AssertThrow(cond, exc)                                                 \
-{                                                                              \
-  if (!(cond))                                                                 \
-    ::dealii::deal_II_exceptions::internals::issue_error_noreturn(             \
-        ::dealii::deal_II_exceptions::internals::throw_on_exception,           \
-        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-}
-#endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-
-
-
 #ifndef DOXYGEN
 
 /**
@@ -1205,6 +926,283 @@ namespace StandardExceptions
   };
 #endif // DEAL_II_WITH_MPI
 } /*namespace StandardExceptions*/
+
+
+
+/**
+ * In this namespace, functions in connection with the Assert and AssertThrow
+ * mechanism are declared.
+ *
+ * @ingroup Exceptions
+ */
+namespace deal_II_exceptions
+{
+
+  /**
+   * Set a string that is printed upon output of the message indicating a
+   * triggered <tt>Assert</tt> statement. This string, which is printed in
+   * addition to the usual output may indicate information that is otherwise
+   * not readily available unless we are using a debugger. For example, with
+   * distributed programs on cluster computers, the output of all processes is
+   * redirected to the same console window. In this case, it is convenient to
+   * set as additional name the name of the host on which the program runs, so
+   * that one can see in which instance of the program the exception occurred.
+   *
+   * The string pointed to by the argument is copied, so doesn't need to be
+   * stored after the call to this function.
+   *
+   * Previously set additional output is replaced by the argument given to
+   * this function.
+   *
+   * @see Exceptions
+   */
+  void set_additional_assert_output (const char *const p);
+
+  /**
+   * Calling this function disables printing a stacktrace along with the other
+   * output printed when an exception occurs. Most of the time, you will want
+   * to see such a stacktrace; suppressing it, however, is useful if one wants
+   * to compare the output of a program across different machines and systems,
+   * since the stacktrace shows memory addresses and library names/paths that
+   * depend on the exact setup of a machine.
+   *
+   * @see Exceptions
+   */
+  void suppress_stacktrace_in_exceptions ();
+
+  /**
+   * Calling this function switches off the use of <tt>std::abort()</tt> when
+   * an exception is created using the Assert() macro. Instead, the Exception
+   * will be thrown using 'throw', so it can be caught if desired. Generally,
+   * you want to abort the execution of a program when Assert() is called, but
+   * it needs to be switched off if you want to log all exceptions created, or
+   * if you want to test if an assertion is working correctly. This is done
+   * for example in regression tests. Please note that some fatal errors will
+   * still call abort(), e.g. when an exception is caught during exception
+   * handling.
+   *
+   * @see Exceptions
+   */
+  void disable_abort_on_exception ();
+
+  /**
+   * The functions in this namespace are in connection with the Assert and
+   * AssertThrow mechanism but are solely for internal purposes and are not
+   * for use outside the exception handling and throwing mechanism.
+   *
+   * @ingroup Exceptions
+   */
+  namespace internals
+  {
+
+    /**
+     * Conditionally abort the program.
+     *
+     * Depending on whether deal_II_exceptions::disable_abort_on_exception was
+     * called, this function either aborts the program flow by printing the
+     * error message provided by @p exc and calling <tt>std::abort()</tt>, or
+     * throws @p exc instead.
+     */
+    [[noreturn]]
+    void abort (const ExceptionBase &exc);
+
+    /**
+     * An enum describing how to treat an exception in issue_error.
+     */
+    enum ExceptionHandling
+    {
+      /**
+       * Abort the program by calling <code>std::abort</code> unless
+       * deal_II_exceptions::disable_abort_on_exception has been called: in
+       * that case the program will throw an exception.
+       */
+      abort_on_exception,
+      /**
+       * Throw the exception normally.
+       */
+      throw_on_exception,
+      /**
+       * Call <code>std::abort</code> as long as
+       * deal_II_exceptions::disable_abort_on_exception has not been called:
+       * if it has, then just print a description of the exception to deallog.
+       */
+      abort_nothrow_on_exception
+    };
+
+    /**
+     * This routine does the main work for the exception generation mechanism
+     * used in the <tt>Assert</tt> and <tt>AssertThrow</tt> macros: as the
+     * name implies, this function either ends with a call to <tt>abort</tt>
+     * or throwing an exception.
+     *
+     * The actual exception object (the last argument) is typically an unnamed
+     * object created in place; because we modify it, we can't take it by
+     * const reference, and temporaries don't bind to non-const references.
+     * So take it by value (=copy it) -- the performance implications are
+     * pretty minimal anyway.
+     *
+     * @ref ExceptionBase
+     */
+    template <class ExceptionType>
+    [[noreturn]]
+    void issue_error_noreturn (ExceptionHandling  handling,
+                               const char       *file,
+                               int               line,
+                               const char       *function,
+                               const char       *cond,
+                               const char       *exc_name,
+                               ExceptionType     e)
+    {
+      // Fill the fields of the exception object
+      e.set_fields (file, line, function, cond, exc_name);
+
+      switch (handling)
+        {
+        case abort_on_exception:
+          dealii::deal_II_exceptions::internals::abort(e);
+        case throw_on_exception:
+          throw e;
+        default:
+          // this function should never return; something must have gone wrong
+          // in the error handling code for us to get this far, so throw an
+          // exception.
+          throw ::dealii::StandardExceptions::ExcInternalError();
+        }
+    }
+
+    /**
+     * Exception generation mechanism in case we must not throw.
+     *
+     * @ref ExceptionBase
+     */
+    void issue_error_nothrow (ExceptionHandling,
+                              const char       *file,
+                              int               line,
+                              const char       *function,
+                              const char       *cond,
+                              const char       *exc_name,
+                              ExceptionBase     e) noexcept;
+#ifdef DEAL_II_WITH_CUDA
+    /**
+     * Return a string given an error code. This is similar to the cudaGetErrorString
+     * function but there is no equivalent function for cuSPARSE.
+     */
+    std::string get_cusparse_error_string(const cusparseStatus_t error_code);
+#endif
+  } /*namespace internals*/
+
+} /*namespace deal_II_exceptions*/
+
+
+
+/**
+ * A macro that serves as the main routine in the exception mechanism for debug mode
+ * error checking. It asserts that a certain condition is fulfilled, otherwise
+ * issues an error and aborts the program.
+ *
+ * A more detailed description can be found in the @ref Exceptions documentation
+ * module. It is first used in step-5 and step-6.
+ * See also the <tt>ExceptionBase</tt> class for more information.
+ *
+ * @note Active in DEBUG mode only
+ * @ingroup Exceptions
+ * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
+ */
+#ifdef DEBUG
+#  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
+#    define Assert(cond, exc)                                                  \
+{                                                                              \
+  if (__builtin_expect(!(cond), false))                                        \
+    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
+        ::dealii::deal_II_exceptions::internals::abort_on_exception,           \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
+#  else
+#    define Assert(cond, exc)                                                  \
+{                                                                              \
+  if (!(cond))                                                                 \
+    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
+        ::dealii::deal_II_exceptions::internals::abort_on_exception,           \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
+#  endif
+#else
+#define Assert(cond, exc)                                                      \
+  {}
+#endif
+
+
+
+/**
+ * A variant of the <tt>Assert</tt> macro above that exhibits the same runtime
+ * behavior as long as disable_abort_on_exception was not called.
+ *
+ * However, if disable_abort_on_exception was called, this macro merely prints
+ * the exception that would be thrown to deallog and continues normally
+ * without throwing an exception.
+ *
+ * A more detailed description can be found in the @ref Exceptions documentation
+ * module, in the discussion about the corner case at the bottom of the page.
+ *
+ * @note Active in DEBUG mode only
+ * @ingroup Exceptions
+ * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
+ */
+#ifdef DEBUG
+#  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
+#    define AssertNothrow(cond, exc)                                           \
+{                                                                              \
+  if (__builtin_expect(!(cond), false))                                        \
+    ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
+        ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
+#  else
+#    define AssertNothrow(cond, exc)                                           \
+{                                                                              \
+  if (!(cond))                                                                 \
+    ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
+        ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
+#  endif
+#else
+#define AssertNothrow(cond, exc)                                               \
+  {}
+#endif
+
+/**
+ * A macro that serves as the main routine in the exception mechanism for dynamic
+ * error checking. It asserts that a certain condition is fulfilled, otherwise
+ * throws an exception via the C++ @p throw mechanism. This exception can
+ * be caught via a @p catch clause, as is shown in step-6 and all following
+ * tutorial programs.
+ *
+ * A more detailed description can be found in the @ref Exceptions documentation
+ * module. It is first used in step-9 and step-13.
+ * See also the <tt>ExceptionBase</tt> class for more information.
+ *
+ * @note Active in both DEBUG and RELEASE modes
+ * @ingroup Exceptions
+ * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
+ */
+#ifdef DEAL_II_HAVE_BUILTIN_EXPECT
+#define AssertThrow(cond, exc)                                                 \
+{                                                                              \
+  if (__builtin_expect(!(cond), false))                                        \
+    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
+        ::dealii::deal_II_exceptions::internals::throw_on_exception,           \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
+#else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
+#define AssertThrow(cond, exc)                                                 \
+{                                                                              \
+  if (!(cond))                                                                 \
+    ::dealii::deal_II_exceptions::internals::issue_error_noreturn(             \
+        ::dealii::deal_II_exceptions::internals::throw_on_exception,           \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
+#endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 
 /**
  * Special assertion for dimension mismatch.

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1110,24 +1110,24 @@ namespace deal_II_exceptions
  */
 #ifdef DEBUG
 #  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#    define Assert(cond, exc)                                                  \
-  {                                                                            \
-    if (__builtin_expect(!(cond), false))                                      \
-      ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(          \
-          ::dealii::deal_II_exceptions::internals::abort_on_exception,         \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);          \
-  }
+#    define Assert(cond, exc)                                                \
+{                                                                            \
+  if (__builtin_expect(!(cond), false))                                      \
+    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(          \
+        ::dealii::deal_II_exceptions::internals::abort_on_exception,         \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);          \
+}
 #  else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-#    define Assert(cond, exc)                                                  \
-  {                                                                            \
-    if (!(cond))                                                               \
-      ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(          \
-          ::dealii::deal_II_exceptions::internals::abort_on_exception,         \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);          \
-  }
+#    define Assert(cond, exc)                                                \
+{                                                                            \
+  if (!(cond))                                                               \
+    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(          \
+        ::dealii::deal_II_exceptions::internals::abort_on_exception,         \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);          \
+}
 #  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
-#define Assert(cond, exc)                                                      \
+#define Assert(cond, exc)                                                    \
   {}
 #endif
 
@@ -1150,24 +1150,24 @@ namespace deal_II_exceptions
  */
 #ifdef DEBUG
 #  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#    define AssertNothrow(cond, exc)                                           \
-  {                                                                              \
-    if (__builtin_expect(!(cond), false))                                        \
-      ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
-          ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-  }
+#    define AssertNothrow(cond, exc)                                             \
+{                                                                                \
+  if (__builtin_expect(!(cond), false))                                          \
+    ::dealii::deal_II_exceptions::internals::issue_error_nothrow(                \
+        ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,     \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);              \
+}
 #  else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-#    define AssertNothrow(cond, exc)                                           \
-  {                                                                              \
-    if (!(cond))                                                                 \
-      ::dealii::deal_II_exceptions::internals::issue_error_nothrow(              \
-          ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,   \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
-  }
+#    define AssertNothrow(cond, exc)                                             \
+{                                                                                \
+  if (!(cond))                                                                   \
+    ::dealii::deal_II_exceptions::internals::issue_error_nothrow(                \
+        ::dealii::deal_II_exceptions::internals::abort_nothrow_on_exception,     \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);              \
+}
 #  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
-#define AssertNothrow(cond, exc)                                               \
+#define AssertNothrow(cond, exc)                                                 \
   {}
 #endif
 
@@ -1188,20 +1188,20 @@ namespace deal_II_exceptions
  */
 #ifdef DEAL_II_HAVE_BUILTIN_EXPECT
 #define AssertThrow(cond, exc)                                                 \
-  {                                                                            \
-    if (__builtin_expect(!(cond), false))                                      \
-      ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(          \
-          ::dealii::deal_II_exceptions::internals::throw_on_exception,         \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);          \
-  }
+{                                                                              \
+  if (__builtin_expect(!(cond), false))                                        \
+    ::dealii::deal_II_exceptions::internals:: issue_error_noreturn(            \
+        ::dealii::deal_II_exceptions::internals::throw_on_exception,           \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
 #else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #define AssertThrow(cond, exc)                                                 \
-  {                                                                            \
-    if (!(cond))                                                               \
-      ::dealii::deal_II_exceptions::internals::issue_error_noreturn(           \
-          ::dealii::deal_II_exceptions::internals::throw_on_exception,         \
-          __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);          \
-  }
+{                                                                              \
+  if (!(cond))                                                                 \
+    ::dealii::deal_II_exceptions::internals::issue_error_noreturn(             \
+        ::dealii::deal_II_exceptions::internals::throw_on_exception,           \
+        __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc);            \
+}
 #endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 
 /**
@@ -1251,10 +1251,10 @@ namespace internal
  * @author Guido Kanschat 2007
  */
 #define AssertIndexRange(index,range)                                          \
-  Assert((index) < (range),                                                    \
-         dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type< \
-         void(typename std::common_type<decltype(index),                       \
-              decltype(range)>::type)>::type>((index),0,(range)))
+Assert((index) < (range),                                                      \
+       dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<   \
+       void(typename std::common_type<decltype(index),                         \
+            decltype(range)>::type)>::type>((index),0,(range)))
 
 /**
  * An assertion that checks whether a number is finite or not. We explicitly
@@ -1266,8 +1266,8 @@ namespace internal
  * @author Wolfgang Bangerth, 2015
  */
 #define AssertIsFinite(number)                                                 \
-  Assert(dealii::numbers::is_finite(number),                                   \
-         dealii::ExcNumberNotFinite(std::complex<double>(number)))
+Assert(dealii::numbers::is_finite(number),                                     \
+       dealii::ExcNumberNotFinite(std::complex<double>(number)))
 
 #ifdef DEAL_II_WITH_MPI
 /**
@@ -1280,8 +1280,8 @@ namespace internal
  * @ingroup Exceptions
  * @author David Wells, 2016
  */
-#define AssertThrowMPI(error_code) \
-  AssertThrow(error_code == MPI_SUCCESS, dealii::ExcMPI(error_code))
+#define AssertThrowMPI(error_code)                                             \
+AssertThrow(error_code == MPI_SUCCESS, dealii::ExcMPI(error_code))
 #else
 #define AssertThrowMPI(error_code) {}
 #endif // DEAL_II_WITH_MPI


### PR DESCRIPTION
Fixes #6179 and updates the relevant module documentation.

This commit also cleans up the alignment of `\`s in our online documentation. This could be improved further but the current state is a bit messy; see
https://www.dealii.org/8.5.0/doxygen/deal.II/group__Exceptions.html#ga70a0bb353656e704acf927945277bbc6