### PR TITLE
reorder_vertices for 1 and 2d #6207

### DIFF
--- a/doc/news/changes/minor/20180409WeixiongZheng
+++ b/doc/news/changes/minor/20180409WeixiongZheng
@@ -1,0 +1,4 @@
+New: Add Triangulation<dim,spacedim>::reorder_vertices to reorder vertices
+when generating 1d and 2d triangulations.
+<br>
+(Weixiong Zheng, 2018/04/09)

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1999,6 +1999,17 @@ public:
                        const SubCellData &                 subcelldata);
 
   /**
+   * Given vertices @p vertices in a cell, reorder them in cannonical way.
+   *
+   * @note This function only works for dim=1 and 2 with the restriction of
+   * dim=spacedim.
+   *
+   * @author Weixiong Zheng, 2018
+   */
+  static void
+  reorder_vertices(std::vector<Point<spacedim>> &points);
+
+  /**
    * For backward compatibility, only. This function takes the cell data in
    * the ordering as requested by deal.II versions up to 5.2, converts it to
    * the new (lexicographic) ordering and calls create_triangulation().

--- a/tests/grid/tria_reorder_vertices.cc
+++ b/tests/grid/tria_reorder_vertices.cc
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test: Triangulation<dim, spacedim>::reverse_vertices
+
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include "../tests.h"
+
+void
+test()
+{
+  // 1d test
+  std::vector<Point<1>> p_1d   = {Point<1>(1.), Point<1>(-1.)};
+  std::vector<Point<1>> ref_1d = {Point<1>(-1.), Point<1>(1.)};
+  Triangulation<1, 1>::reorder_vertices(p_1d);
+  for (int i = 0; i < 2; ++i)
+    AssertThrow(p_1d[i].distance(ref_1d[i]) < 1.0e-15,
+                ExcMessage("1d test fail"));
+  deallog << "1D test okay" << std::endl;
+
+  // 2d test
+  // corner case test with points on axis
+  std::vector<Point<2>> p1 = {Point<2>(-1., 0.),
+                              Point<2>(1., 0.),
+                              Point<2>(0., -1.),
+                              Point<2>(0., 1.)};
+  std::vector<Point<2>> r1 = {Point<2>(0., -1.),
+                              Point<2>(1., 0.),
+                              Point<2>(-1., 0.),
+                              Point<2>(0., 1.)};
+
+  // regular case test
+  std::vector<Point<2>> p2 = {Point<2>(-1.5, 0.1),
+                              Point<2>(1., 0.3),
+                              Point<2>(-0.2, -1.),
+                              Point<2>(0., 1.)};
+  std::vector<Point<2>> r2 = {Point<2>(-0.2, -1.),
+                              Point<2>(1., 0.3),
+                              Point<2>(-1.5, 0.1),
+                              Point<2>(0., 1.)};
+  // reorder vertices
+  Triangulation<2, 2>::reorder_vertices(p1);
+  Triangulation<2, 2>::reorder_vertices(p2);
+
+  for (int i = 0; i < 4; ++i)
+    {
+      AssertThrow(p1[i].distance(r1[i]) < 1.0e-15,
+                  ExcMessage("2d corner case test fail"));
+      AssertThrow(p2[i].distance(r2[i]) < 1.0e-15,
+                  ExcMessage("2d regular test fail"));
+    }
+  deallog << "2D test okay" << std::endl;
+}
+
+
+int
+main()
+{
+  init_log();
+
+  test();
+
+  return 0;
+}

--- a/tests/grid/tria_reorder_vertices.output
+++ b/tests/grid/tria_reorder_vertices.output
@@ -1,0 +1,3 @@
+
+DEAL::1D test okay
+DEAL::2D test okay


### PR DESCRIPTION
1. Added Triangulation<1,1> and <2,2>::reorder_vertices
2. Test cases added
3. Doc/news/minor added