### PR TITLE
Fix signal handling of transfinite interpolation once cleared

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -832,6 +832,11 @@ public:
   TransfiniteInterpolationManifold();
 
   /**
+   * Destructor.
+   */
+  ~TransfiniteInterpolationManifold();
+
+  /**
    * Make a clone of this Manifold object.
    */
   virtual std::unique_ptr<Manifold<dim,spacedim> > clone() const override;
@@ -996,6 +1001,12 @@ private:
    * use a FlatManifold description.
    */
   FlatManifold<dim> chart_manifold;
+
+  /**
+   * The connection to Triangulation::signals::clear that must be reset once
+   * this class goes out of scope.
+   */
+  boost::signals2::connection clear_signal;
 };
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1347,6 +1347,15 @@ TransfiniteInterpolationManifold<dim,spacedim>::TransfiniteInterpolationManifold
 
 
 
+template <int dim, int spacedim>
+TransfiniteInterpolationManifold<dim,spacedim>::~TransfiniteInterpolationManifold()
+{
+  if (clear_signal.connected())
+    clear_signal.disconnect();
+}
+
+
+
 template<int dim, int spacedim>
 std::unique_ptr<Manifold<dim, spacedim> >
 TransfiniteInterpolationManifold<dim,spacedim>::clone() const
@@ -1366,8 +1375,8 @@ TransfiniteInterpolationManifold<dim,spacedim>
 {
   this->triangulation = &triangulation;
   // in case the triangulatoin is cleared, remove the pointers by a signal
-  triangulation.signals.clear.connect
-  ([&]() -> void {this->triangulation = nullptr; this->level_coarse = -1;});
+  clear_signal = triangulation.signals.clear.connect
+                 ([&]() -> void {this->triangulation = nullptr; this->level_coarse = -1;});
   level_coarse = triangulation.last()->level();
   coarse_cell_is_flat.resize(triangulation.n_cells(level_coarse), false);
   typename Triangulation<dim,spacedim>::active_cell_iterator


### PR DESCRIPTION
As mentioned in #6182, the transfinite interpolation manifold connects a signal to the triangulation to be informed it the triangulation was cleared or deleted. We must disconnect this signal in case the transfinite manifold gets out of scope before the grid, as is the case with the change in #6182. This should fix the failing test:
https://cdash.kyomu.43-1.org/testDetails.php?test=4424692&build=663