### PR TITLE
Update SymmetricTensor class for AD numbers

### DIFF
--- a/doc/news/changes/minor/20180412Jean-PaulPelteret-3
+++ b/doc/news/changes/minor/20180412Jean-PaulPelteret-3
@@ -1,0 +1,9 @@
+Fixed: When using diagonal SymmetricTensors with automatic-differentiable numbers, computations
+using the eigenvalue() and eigenvector() functions would return correct values of the
+eigenvalues/vectors. However, the derivatives of these values/vectors were incorrect as
+the sensitivities of the eigenvalues/vectors with respect to one another was not encoded
+in the returned result. Therefore, under these specific conditions the returned result is now
+a more coarse approximation for the eigenvalues/vectors but with the trade-off that a
+meaningful approximation of the derivative of the result can now be computed.
+<br>
+(Jean-Paul Pelteret, 2018/04/12)

--- a/doc/news/changes/minor/20180412Jean-PaulPelteret-4
+++ b/doc/news/changes/minor/20180412Jean-PaulPelteret-4
@@ -1,0 +1,4 @@
+Fixed: The SymmetricTensor class was previously not instantiated for
+auto-differentiable numbers.
+<br>
+(Jean-Paul Pelteret, 2018/04/12)

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1313,7 +1313,7 @@ namespace internal
         Number diagonal_sum = internal::NumberType<Number>::value(0.0);
         for (unsigned int i=0; i<N; ++i)
           diagonal_sum += std::fabs(tmp.data[i][i]);
-        const Number typical_diagonal_element = diagonal_sum/N;
+        const Number typical_diagonal_element = diagonal_sum/static_cast<double>(N);
         (void)typical_diagonal_element;
 
         unsigned int p[N];
@@ -3113,22 +3113,6 @@ enum struct SymmetricTensorEigenvectorMethod
 
 
 /**
- * Return the eigenvalues and eigenvectors of a symmetric 1x1 tensor of rank 2.
- *
- * @relatesalso SymmetricTensor
- * @author Jean-Paul Pelteret, 2017
- */
-template <typename Number>
-std::array<std::pair<Number, Tensor<1,1,Number> >,1>
-eigenvectors (const SymmetricTensor<2,1,Number>           &T,
-              const SymmetricTensorEigenvectorMethod /*method*/ = SymmetricTensorEigenvectorMethod::ql_implicit_shifts)
-{
-  return { {std::make_pair(T[0][0], Tensor<1,1,Number>({1.0}))} };
-}
-
-
-
-/**
  * Return the eigenvalues and eigenvectors of a real-valued rank-2 symmetric
  * tensor $T$. The array of matched eigenvalue and eigenvector pairs is sorted
  * in descending order (determined by the eigenvalues).
@@ -3158,30 +3142,7 @@ eigenvectors (const SymmetricTensor<2,1,Number>           &T,
 template <int dim, typename Number>
 std::array<std::pair<Number, Tensor<1,dim,Number> >,dim>
 eigenvectors (const SymmetricTensor<2,dim,Number>         &T,
-              const SymmetricTensorEigenvectorMethod  method = SymmetricTensorEigenvectorMethod::ql_implicit_shifts)
-{
-  std::array<std::pair<Number, Tensor<1,dim,Number> >,dim> eig_vals_vecs;
-
-  switch (method)
-    {
-    case SymmetricTensorEigenvectorMethod::hybrid:
-      eig_vals_vecs = internal::SymmetricTensorImplementation::hybrid(T);
-      break;
-    case SymmetricTensorEigenvectorMethod::ql_implicit_shifts:
-      eig_vals_vecs = internal::SymmetricTensorImplementation::ql_implicit_shifts(T);
-      break;
-    case SymmetricTensorEigenvectorMethod::jacobi:
-      eig_vals_vecs = internal::SymmetricTensorImplementation::jacobi(T);
-      break;
-    default:
-      AssertThrow(false, ExcNotImplemented());
-    }
-
-  // Sort in descending order before output.
-  std::sort(eig_vals_vecs.begin(), eig_vals_vecs.end(),
-            internal::SymmetricTensorImplementation::SortEigenValuesVectors<dim,Number>());
-  return eig_vals_vecs;
-}
+              const SymmetricTensorEigenvectorMethod       method = SymmetricTensorEigenvectorMethod::ql_implicit_shifts);
 
 
 

--- a/source/base/symmetric_tensor.cc
+++ b/source/base/symmetric_tensor.cc
@@ -16,12 +16,8 @@
 #include <deal.II/base/config.h>
 
 // Required for instantiation of template functions
-#ifdef DEAL_II_WITH_TRILINOS
-
-#  include <Sacado.hpp>
-
+#include <deal.II/differentiation/ad/adolc_product_types.h>
 #include <deal.II/differentiation/ad/sacado_product_types.h>
-#endif
 
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/symmetric_tensor.templates.h>

--- a/source/base/symmetric_tensor.inst.in
+++ b/source/base/symmetric_tensor.inst.in
@@ -22,49 +22,50 @@ for (deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
     template
     class SymmetricTensor<4,deal_II_dimension,number>;
 
-    namespace internal
-    \{
-    namespace SymmetricTensorImplementation
-    \{
     template
-    void
-    tridiagonalize<deal_II_dimension, number>
-    (const dealii::SymmetricTensor<2,deal_II_dimension,number> &,
-     dealii::Tensor<2,deal_II_dimension,number>                &,
-     std::array<number,deal_II_dimension>                      &,
-     std::array<number,deal_II_dimension-1>                    &);
+    std::array<number,deal_II_dimension>
+    eigenvalues (const SymmetricTensor<2,deal_II_dimension,number> &);
 
     template
     std::array<std::pair<number, Tensor<1,deal_II_dimension,number> >,deal_II_dimension>
-    ql_implicit_shifts<deal_II_dimension, number>
-    (const dealii::SymmetricTensor<2,deal_II_dimension,number> &);
+    eigenvectors (const SymmetricTensor<2,deal_II_dimension,number> &,
+                  const SymmetricTensorEigenvectorMethod);
+}
+
+for (deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_ADOLC_REAL_SCALARS)
+{
+    template
+    class SymmetricTensor<2,deal_II_dimension,number>;
+
+    template
+    class SymmetricTensor<4,deal_II_dimension,number>;
+
+    template
+    std::array<number,deal_II_dimension>
+    eigenvalues (const SymmetricTensor<2,deal_II_dimension,number> &);
 
     template
     std::array<std::pair<number, Tensor<1,deal_II_dimension,number> >,deal_II_dimension>
-    jacobi<deal_II_dimension, number>
-    (dealii::SymmetricTensor<2,deal_II_dimension,number>);
+    eigenvectors (const SymmetricTensor<2,deal_II_dimension,number> &,
+                  const SymmetricTensorEigenvectorMethod);
+}
 
-#ifdef DEAL_II_WITH_TRILINOS
+for (deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_TRILINOS_SACADO_REAL_SCALARS)
+{
     template
-    void
-    tridiagonalize<deal_II_dimension,Sacado::Fad::DFad<number> >
-    (const dealii::SymmetricTensor<2,deal_II_dimension,Sacado::Fad::DFad<number> > &,
-     dealii::Tensor<2,deal_II_dimension,Sacado::Fad::DFad<number> >                &,
-     std::array<Sacado::Fad::DFad<number>,deal_II_dimension>                       &,
-     std::array<Sacado::Fad::DFad<number>,deal_II_dimension-1>                     &);
+    class SymmetricTensor<2,deal_II_dimension,number>;
 
     template
-    std::array<std::pair<Sacado::Fad::DFad<number>, Tensor<1,deal_II_dimension,Sacado::Fad::DFad<number> > >,deal_II_dimension>
-    ql_implicit_shifts<deal_II_dimension,Sacado::Fad::DFad<number> >
-    (const dealii::SymmetricTensor<2,deal_II_dimension,Sacado::Fad::DFad<number> > &);
+    class SymmetricTensor<4,deal_II_dimension,number>;
 
     template
-    std::array<std::pair<Sacado::Fad::DFad<number>, Tensor<1,deal_II_dimension,Sacado::Fad::DFad<number> > >,deal_II_dimension>
-    jacobi<deal_II_dimension,Sacado::Fad::DFad<number> >
-    (dealii::SymmetricTensor<2,deal_II_dimension,Sacado::Fad::DFad<number> >);
-#endif
-    \}
-    \}
+    std::array<number,deal_II_dimension>
+    eigenvalues (const SymmetricTensor<2,deal_II_dimension,number> &);
+
+    template
+    std::array<std::pair<number, Tensor<1,deal_II_dimension,number> >,deal_II_dimension>
+    eigenvectors (const SymmetricTensor<2,deal_II_dimension,number> &,
+                  const SymmetricTensorEigenvectorMethod);
 }
 
 for (deal_II_dimension : DIMENSIONS; number : COMPLEX_SCALARS)
@@ -79,66 +80,21 @@ for (deal_II_dimension : DIMENSIONS; number : COMPLEX_SCALARS)
 
 for (number : REAL_SCALARS)
 {
-    namespace internal
-    \{
-    namespace SymmetricTensorImplementation
-    \{
-    template
-    struct Inverse<4,3,number>;
-    \}
-    \}
-
     template
     SymmetricTensor<4,3,number>
     invert (const SymmetricTensor<4,3,number> &t);
+}
 
+for (number : DIFFERENTIABLE_ADOLC_REAL_SCALARS)
+{
     template
-    std::array<number,1>
-    eigenvalues (const SymmetricTensor<2,1,number> &);
+    SymmetricTensor<4,3,number>
+    invert (const SymmetricTensor<4,3,number> &t);
+}
 
+for (number : DIFFERENTIABLE_TRILINOS_SACADO_REAL_SCALARS)
+{
     template
-    std::array<number,2>
-    eigenvalues (const SymmetricTensor<2,2,number> &);
-
-    template
-    std::array<number,3>
-    eigenvalues (const SymmetricTensor<2,3,number> &);
-
-#ifdef DEAL_II_WITH_TRILINOS
-    template
-    std::array<Sacado::Fad::DFad<number>,1>
-    eigenvalues (const SymmetricTensor<2,1,Sacado::Fad::DFad<number> > &);
-
-    template
-    std::array<Sacado::Fad::DFad<number>,2>
-    eigenvalues (const SymmetricTensor<2,2,Sacado::Fad::DFad<number> > &);
-
-    template
-    std::array<Sacado::Fad::DFad<number>,3>
-    eigenvalues (const SymmetricTensor<2,3,Sacado::Fad::DFad<number> > &);
-#endif
-
-    namespace internal
-    \{
-    namespace SymmetricTensorImplementation
-    \{
-    template
-    std::array<std::pair<number, Tensor<1,2,number> >,2>
-    hybrid (const dealii::SymmetricTensor<2,2,number> &);
-
-    template
-    std::array<std::pair<number, Tensor<1,3,number> >,3>
-    hybrid (const dealii::SymmetricTensor<2,3,number> &A);
-
-#ifdef DEAL_II_WITH_TRILINOS
-    template
-    std::array<std::pair<Sacado::Fad::DFad<number>, Tensor<1,2,Sacado::Fad::DFad<number> > >,2>
-    hybrid (const dealii::SymmetricTensor<2,2,Sacado::Fad::DFad<number> > &);
-
-    template
-    std::array<std::pair<Sacado::Fad::DFad<number>, Tensor<1,3,Sacado::Fad::DFad<number> > >,3>
-    hybrid (const dealii::SymmetricTensor<2,3,Sacado::Fad::DFad<number> > &A);
-#endif
-    \}
-    \}
+    SymmetricTensor<4,3,number>
+    invert (const SymmetricTensor<4,3,number> &t);
 }


### PR DESCRIPTION
- Fix issue with eigenvalue/vector calculations for symmetric tensors of AD numbers when the input tensor is diagonal.
- Fix issue with the compilation of 'SymmetricTensor::invert()' when using Sacado numbers.
- Instantiate SymmetricTensor class for all AD numbers
- Simplify instantiation of non-member template functions (i.e. those related to eigenvalue/vector calculations)

Blocked by #6230