### PR TITLE
Slightly relax condition for even-odd tensor product value path

### DIFF
--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -390,16 +390,13 @@ namespace internal
             return false;
 
       // shape values should be zero at x=0.5 for all basis functions except
-      // for one which is one
+      // for the middle one
       if (n_q_points_1d%2 == 1 && n_dofs_1d%2 == 1)
         {
           for (unsigned int i=0; i<n_dofs_1d/2; ++i)
             if (std::abs(get_first_array_element(shape_values[i*n_q_points_1d+
                                                               n_q_points_1d/2])) > zero_tol)
               return false;
-          if (std::abs(get_first_array_element(shape_values[(n_dofs_1d/2)*n_q_points_1d+
-                                                            n_q_points_1d/2])-1.)> zero_tol)
-            return false;
         }
 
       // skew-symmetry for gradient, zero of middle basis function in middle

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -1621,9 +1621,9 @@ namespace internal
             if ( type == 0 && contract_over_rows == true && nn%2==1 && mm%2==1 )
               {
                 if (add==false)
-                  out[stride*n_cols]  = xmid;
+                  out[stride*n_cols]  = shapes[mid*offset+n_cols] * xmid;
                 else
-                  out[stride*n_cols] += xmid;
+                  out[stride*n_cols] += shapes[mid*offset+n_cols] * xmid;
               }
             else if (contract_over_rows == true && nn%2==1)
               {
@@ -1665,9 +1665,7 @@ namespace internal
                 else
                   r0 = Number();
 
-                if (type == 0 && mm % 2 == 1)
-                  r0 += xmid;
-                else if (type == 2 && mm % 2 == 1)
+                if ((type == 0 || type == 2) && mm % 2 == 1)
                   r0 += shapes[n_cols*offset+mid] * xmid;
 
                 if (add == false)

--- a/tests/matrix_free/evaluate_1d_shape_02.cc
+++ b/tests/matrix_free/evaluate_1d_shape_02.cc
@@ -42,7 +42,7 @@ void test()
     {
       for (unsigned int i=0; i<M; ++i)
         shape[i][N/2] = 0.;
-      shape[M/2][N/2] = 1;
+      shape[M/2][N/2] = 0.9;
     }
   if (type == 1 && M%2 == 1 && N%2 == 1)
     shape[M/2][N/2] = 0.;

--- a/tests/matrix_free/evaluate_1d_shape_05.cc
+++ b/tests/matrix_free/evaluate_1d_shape_05.cc
@@ -42,7 +42,7 @@ void test()
     {
       for (unsigned int i=0; i<M; ++i)
         shape[i][N/2] = 0.;
-      shape[M/2][N/2] = 1;
+      shape[M/2][N/2] = 0.9;
     }
   if (type == 1 && M%2 == 1 && N%2 == 1)
     shape[M/2][N/2] = 0.;

--- a/tests/matrix_free/evaluate_1d_shape_08.cc
+++ b/tests/matrix_free/evaluate_1d_shape_08.cc
@@ -16,7 +16,7 @@
 
 
 // check the correctness of the 1d evaluation functions used in FEEvaluation,
-// path evaluate_general, when using a double array for coefficients but
+// path evaluate_evenodd, when using a double array for coefficients but
 // VectorizedArray for the input and output vector
 
 #include "../tests.h"
@@ -44,7 +44,7 @@ void test()
     {
       for (unsigned int i=0; i<M; ++i)
         shape[i][N/2] = 0.;
-      shape[M/2][N/2] = 1;
+      shape[M/2][N/2] = 0.9;
     }
   if (type == 1 && M%2 == 1 && N%2 == 1)
     shape[M/2][N/2] = 0.;


### PR DESCRIPTION
We want to be slightly less restrictive for the middle node of the even-odd path because there are application where we might have non-unit value (project between bases of different degree).