### PR TITLE
Added map_boundary_to_manifold_ids.

### DIFF
--- a/doc/news/changes/minor/20180413LucaHeltai
+++ b/doc/news/changes/minor/20180413LucaHeltai
@@ -1,0 +1,5 @@
+New: GridTools::map_boundary_to_manifold_ids() allows you to set manifold ids on the 
+boundary according to a given map of boundary to manifold ids. 
+<br>
+(Luca Heltai, 2018/04/13)
+

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2275,7 +2275,7 @@ namespace GridTools
    *
    * This function copies the boundary ids of the boundary faces and
    * edges that are present in the parameter @p src_boundary_ids to
-   * the corresponding manifold_id in @p dst_manifold_ids, of the same
+   * the corresponding manifold id in @p dst_manifold_ids, of the same
    * faces and edges.
    *
    * If the optional parameter @p reset_boundary_ids is non empty,

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2273,14 +2273,14 @@ namespace GridTools
    * Map the given boundary ids to the given manifold ids on faces and
    * edges at the boundary.
    *
-   * This function copies the boundary_ids of the boundary faces and
+   * This function copies the boundary ids of the boundary faces and
    * edges that are present in the parameter @p src_boundary_ids to
    * the corresponding manifold_id in @p dst_manifold_ids, of the same
    * faces and edges.
    *
    * If the optional parameter @p reset_boundary_ids is non empty,
    * each boundary id in @p src_boundary_ids, is replaced with the
-   * corresponding boudnary id in @p reset_boundary_ids.
+   * corresponding boundary id in @p reset_boundary_ids.
    *
    * An exception is thrown if the size of the input vectors do not
    * match. If a boundary id indicated in @p src_boundary_ids is not
@@ -2296,7 +2296,7 @@ namespace GridTools
   void map_boundary_to_manifold_ids(const std::vector<types::boundary_id> &src_boundary_ids,
                                     const std::vector<types::manifold_id> &dst_manifold_ids,
                                     Triangulation<dim, spacedim> &tria,
-                                    const std::vector<types::boundary_id> &reset_boundary_ids= {});
+                                    const std::vector<types::boundary_id> &reset_boundary_ids = {});
 
   /**
    * Copy material ids to manifold ids. The default manifold_id for new

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2270,6 +2270,35 @@ namespace GridTools
                                     const bool reset_boundary_ids=false);
 
   /**
+   * Map the given boundary ids to the given manifold ids on faces and
+   * edges at the boundary.
+   *
+   * This function copies the boundary_ids of the boundary faces and
+   * edges that are present in the parameter @p src_boundary_ids to
+   * the corresponding manifold_id in @p dst_manifold_ids, of the same
+   * faces and edges.
+   *
+   * If the optional parameter @p reset_boundary_ids is non empty,
+   * each boundary id in @p src_boundary_ids, is replaced with the
+   * corresponding boudnary id in @p reset_boundary_ids.
+   *
+   * An exception is thrown if the size of the input vectors do not
+   * match. If a boundary id indicated in @p src_boundary_ids is not
+   * present in the triangulation, it is simply ignored during the
+   * process.
+   *
+   * @ingroup manifold
+   * @relatesalso boundary
+   *
+   * @author Luca Heltai, 2018
+   */
+  template <int dim, int spacedim>
+  void map_boundary_to_manifold_ids(const std::vector<types::boundary_id> &src_boundary_ids,
+                                    const std::vector<types::manifold_id> &dst_manifold_ids,
+                                    Triangulation<dim, spacedim> &tria,
+                                    const std::vector<types::boundary_id> &reset_boundary_ids= {});
+
+  /**
    * Copy material ids to manifold ids. The default manifold_id for new
    * Triangulation objects is numbers::invalid_manifold_id. When refinements
    * occurs, the Triangulation asks where to locate new points to the

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -3273,11 +3273,11 @@ next_cell:
            cell != tria.end(); ++cell)
         for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
           if (cell->face(f)->at_boundary())
-            for (signed int e=0; e<static_cast<signed int>(GeometryInfo<dim>::lines_per_face); ++e)
+            for (unsigned int e=0; e<GeometryInfo<dim>::lines_per_face; ++e)
               {
-                auto bid = cell->face(f)->line(e)->boundary_id();
-                auto ind = std::find(src_boundary_ids.begin(), src_boundary_ids.end(), bid)-
-                           src_boundary_ids.begin();
+                const auto bid = cell->face(f)->line(e)->boundary_id();
+                const auto ind = std::find(src_boundary_ids.begin(), src_boundary_ids.end(), bid)-
+                                 src_boundary_ids.begin();
                 if ((unsigned int)ind < src_boundary_ids.size())
                   cell->face(f)->line(e)->set_manifold_id(dst_manifold_ids[ind]);
               }
@@ -3289,9 +3289,9 @@ next_cell:
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->face(f)->at_boundary())
           {
-            auto bid = cell->face(f)->boundary_id();
-            auto ind = std::find(src_boundary_ids.begin(), src_boundary_ids.end(), bid)-
-                       src_boundary_ids.begin();
+            const auto bid = cell->face(f)->boundary_id();
+            const auto ind = std::find(src_boundary_ids.begin(), src_boundary_ids.end(), bid)-
+                             src_boundary_ids.begin();
 
             if ((unsigned int)ind < src_boundary_ids.size())
               {
@@ -3302,11 +3302,11 @@ next_cell:
               }
 
             if (dim >= 3)
-              for (signed int e=0; e<static_cast<signed int>(GeometryInfo<dim>::lines_per_face); ++e)
+              for (unsigned int e=0; e<GeometryInfo<dim>::lines_per_face; ++e)
                 {
-                  auto bid = cell->face(f)->line(e)->boundary_id();
-                  auto ind = std::find(src_boundary_ids.begin(), src_boundary_ids.end(), bid)-
-                             src_boundary_ids.begin();
+                  const auto bid = cell->face(f)->line(e)->boundary_id();
+                  const auto ind = std::find(src_boundary_ids.begin(), src_boundary_ids.end(), bid)-
+                                   src_boundary_ids.begin();
                   if ((unsigned int)ind < src_boundary_ids.size())
                     cell->face(f)->line(e)->set_boundary_id(reset_boundary_ids[ind]);
                 }

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -284,9 +284,16 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
     namespace GridTools \{
     template void copy_boundary_to_manifold_id<deal_II_dimension, deal_II_space_dimension>
     (Triangulation<deal_II_dimension, deal_II_space_dimension> &, const bool);
+
     template void copy_material_to_manifold_id<deal_II_dimension, deal_II_space_dimension>
     (Triangulation<deal_II_dimension, deal_II_space_dimension> &, const bool);
 
+    template void map_boundary_to_manifold_ids<deal_II_dimension, deal_II_space_dimension>
+    (const std::vector<types::boundary_id> &,
+     const std::vector<types::manifold_id> &,
+    Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+    const std::vector<types::boundary_id> &);
+    
     template
     void regularize_corner_cells
     (Triangulation<deal_II_dimension,deal_II_space_dimension> &, double);

--- a/tests/manifold/map_boundary_to_manifold_id_01.cc
+++ b/tests/manifold/map_boundary_to_manifold_id_01.cc
@@ -1,0 +1,84 @@
+//----------------------------  manifold_id_02.cc  ---------------------------
+//    Copyright (C) 2018 by the deal.II authors
+//
+//    This file is subject to LGPL and may not be  distributed
+//    without copyright and license information. Please refer
+//    to the file deal.II/doc/license.html for the  text  and
+//    further information on this license.
+//
+//----------------------------  manifold_id_02.cc  ---------------------------
+
+
+// Test the function map_boundary_to_manifold_ids
+
+#include "../tests.h"
+
+
+// all include files you need here
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_out.h>
+
+template<int dim, int spacedim>
+void print_info(const Triangulation<dim,spacedim> &tria)
+{
+  for (auto cell = tria.begin_active(); cell != tria.end(); ++cell)
+    {
+      deallog << "C: " << cell
+              << ", manifold id: " << (int)cell->manifold_id() << std::endl;
+      for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+        {
+          deallog << "f: " << cell->face(f)
+                  << ", boundary id: " << (int)cell->face(f)->boundary_id()
+                  << ", manifold id: " << (int)cell->face(f)->manifold_id() << std::endl;
+          if (dim >=3)
+            for (signed int e=0; e<static_cast<signed int>(GeometryInfo<dim>::lines_per_face); ++e)
+              deallog << "e: " << cell->face(f)->line(e)
+                      << ", boundary id: " << (int)cell->face(f)->line(e)->boundary_id()
+                      << ", manifold id: " << (int)cell->face(f)->line(e)->manifold_id() << std::endl;
+        }
+    }
+}
+
+// Helper function
+template <int dim, int spacedim>
+void test()
+{
+  deallog << "Testing dim=" << dim
+          << ", spacedim="<< spacedim << std::endl;
+
+  deallog << "Default" << std::endl;
+  Triangulation<dim,spacedim> tria;
+  GridGenerator::hyper_cube (tria, 0, 1, true);
+  print_info(tria);
+
+  // Test setting all manifold ids to 0
+  deallog << "All manifold ids to 0" << std::endl;
+  auto bids = tria.get_boundary_ids();
+  std::vector<types::manifold_id> mids(bids.size(), 0);
+  GridTools::map_boundary_to_manifold_ids(bids, mids, tria);
+  print_info(tria);
+
+  // Test resetting all boundary ids to 1, and all manifold ids to 2
+  mids = std::vector<types::manifold_id>(bids.size(), 2);
+  std::vector<types::boundary_id> rbids(bids.size(), 1);
+  GridTools::map_boundary_to_manifold_ids(bids, mids, tria, rbids);
+  print_info(tria);
+}
+
+int main ()
+{
+  initlog();
+  test<1,1>();
+  test<1,2>();
+  test<1,3>();
+  test<2,2>();
+  test<2,3>();
+  test<3,3>();
+
+  return 0;
+}
+

--- a/tests/manifold/map_boundary_to_manifold_id_01.output
+++ b/tests/manifold/map_boundary_to_manifold_id_01.output
@@ -1,0 +1,169 @@
+
+DEAL::Testing dim=1, spacedim=1
+DEAL::Default
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 0, boundary id: 0, manifold id: -1
+DEAL::f: 1, boundary id: 1, manifold id: -1
+DEAL::All manifold ids to 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 0, boundary id: 0, manifold id: 0
+DEAL::f: 1, boundary id: 1, manifold id: 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 0, boundary id: 1, manifold id: 2
+DEAL::f: 1, boundary id: 1, manifold id: 2
+DEAL::Testing dim=1, spacedim=2
+DEAL::Default
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 0, boundary id: 0, manifold id: -1
+DEAL::f: 1, boundary id: 1, manifold id: -1
+DEAL::All manifold ids to 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 0, boundary id: 0, manifold id: 0
+DEAL::f: 1, boundary id: 1, manifold id: 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 0, boundary id: 1, manifold id: 2
+DEAL::f: 1, boundary id: 1, manifold id: 2
+DEAL::Testing dim=1, spacedim=3
+DEAL::Default
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 0, boundary id: 0, manifold id: -1
+DEAL::f: 1, boundary id: 1, manifold id: -1
+DEAL::All manifold ids to 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 0, boundary id: 0, manifold id: 0
+DEAL::f: 1, boundary id: 1, manifold id: 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 0, boundary id: 1, manifold id: 2
+DEAL::f: 1, boundary id: 1, manifold id: 2
+DEAL::Testing dim=2, spacedim=2
+DEAL::Default
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 1, boundary id: 0, manifold id: -1
+DEAL::f: 2, boundary id: 1, manifold id: -1
+DEAL::f: 0, boundary id: 2, manifold id: -1
+DEAL::f: 3, boundary id: 3, manifold id: -1
+DEAL::All manifold ids to 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 1, boundary id: 0, manifold id: 0
+DEAL::f: 2, boundary id: 1, manifold id: 0
+DEAL::f: 0, boundary id: 2, manifold id: 0
+DEAL::f: 3, boundary id: 3, manifold id: 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 1, boundary id: 1, manifold id: 2
+DEAL::f: 2, boundary id: 1, manifold id: 2
+DEAL::f: 0, boundary id: 1, manifold id: 2
+DEAL::f: 3, boundary id: 1, manifold id: 2
+DEAL::Testing dim=2, spacedim=3
+DEAL::Default
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 1, boundary id: 0, manifold id: -1
+DEAL::f: 2, boundary id: 1, manifold id: -1
+DEAL::f: 0, boundary id: 2, manifold id: -1
+DEAL::f: 3, boundary id: 3, manifold id: -1
+DEAL::All manifold ids to 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 1, boundary id: 0, manifold id: 0
+DEAL::f: 2, boundary id: 1, manifold id: 0
+DEAL::f: 0, boundary id: 2, manifold id: 0
+DEAL::f: 3, boundary id: 3, manifold id: 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 1, boundary id: 1, manifold id: 2
+DEAL::f: 2, boundary id: 1, manifold id: 2
+DEAL::f: 0, boundary id: 1, manifold id: 2
+DEAL::f: 3, boundary id: 1, manifold id: 2
+DEAL::Testing dim=3, spacedim=3
+DEAL::Default
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 2, boundary id: 0, manifold id: -1
+DEAL::e: 2, boundary id: 0, manifold id: -1
+DEAL::e: 6, boundary id: 0, manifold id: -1
+DEAL::e: 1, boundary id: 0, manifold id: -1
+DEAL::e: 9, boundary id: 0, manifold id: -1
+DEAL::f: 3, boundary id: 1, manifold id: -1
+DEAL::e: 4, boundary id: 0, manifold id: -1
+DEAL::e: 7, boundary id: 0, manifold id: -1
+DEAL::e: 3, boundary id: 0, manifold id: -1
+DEAL::e: 10, boundary id: 0, manifold id: -1
+DEAL::f: 0, boundary id: 2, manifold id: -1
+DEAL::e: 0, boundary id: 0, manifold id: -1
+DEAL::e: 8, boundary id: 0, manifold id: -1
+DEAL::e: 2, boundary id: 0, manifold id: -1
+DEAL::e: 4, boundary id: 0, manifold id: -1
+DEAL::f: 4, boundary id: 3, manifold id: -1
+DEAL::e: 5, boundary id: 0, manifold id: -1
+DEAL::e: 11, boundary id: 0, manifold id: -1
+DEAL::e: 6, boundary id: 0, manifold id: -1
+DEAL::e: 7, boundary id: 0, manifold id: -1
+DEAL::f: 1, boundary id: 4, manifold id: -1
+DEAL::e: 1, boundary id: 0, manifold id: -1
+DEAL::e: 3, boundary id: 0, manifold id: -1
+DEAL::e: 0, boundary id: 0, manifold id: -1
+DEAL::e: 5, boundary id: 0, manifold id: -1
+DEAL::f: 5, boundary id: 5, manifold id: -1
+DEAL::e: 9, boundary id: 0, manifold id: -1
+DEAL::e: 10, boundary id: 0, manifold id: -1
+DEAL::e: 8, boundary id: 0, manifold id: -1
+DEAL::e: 11, boundary id: 0, manifold id: -1
+DEAL::All manifold ids to 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 2, boundary id: 0, manifold id: 0
+DEAL::e: 2, boundary id: 0, manifold id: 0
+DEAL::e: 6, boundary id: 0, manifold id: 0
+DEAL::e: 1, boundary id: 0, manifold id: 0
+DEAL::e: 9, boundary id: 0, manifold id: 0
+DEAL::f: 3, boundary id: 1, manifold id: 0
+DEAL::e: 4, boundary id: 0, manifold id: 0
+DEAL::e: 7, boundary id: 0, manifold id: 0
+DEAL::e: 3, boundary id: 0, manifold id: 0
+DEAL::e: 10, boundary id: 0, manifold id: 0
+DEAL::f: 0, boundary id: 2, manifold id: 0
+DEAL::e: 0, boundary id: 0, manifold id: 0
+DEAL::e: 8, boundary id: 0, manifold id: 0
+DEAL::e: 2, boundary id: 0, manifold id: 0
+DEAL::e: 4, boundary id: 0, manifold id: 0
+DEAL::f: 4, boundary id: 3, manifold id: 0
+DEAL::e: 5, boundary id: 0, manifold id: 0
+DEAL::e: 11, boundary id: 0, manifold id: 0
+DEAL::e: 6, boundary id: 0, manifold id: 0
+DEAL::e: 7, boundary id: 0, manifold id: 0
+DEAL::f: 1, boundary id: 4, manifold id: 0
+DEAL::e: 1, boundary id: 0, manifold id: 0
+DEAL::e: 3, boundary id: 0, manifold id: 0
+DEAL::e: 0, boundary id: 0, manifold id: 0
+DEAL::e: 5, boundary id: 0, manifold id: 0
+DEAL::f: 5, boundary id: 5, manifold id: 0
+DEAL::e: 9, boundary id: 0, manifold id: 0
+DEAL::e: 10, boundary id: 0, manifold id: 0
+DEAL::e: 8, boundary id: 0, manifold id: 0
+DEAL::e: 11, boundary id: 0, manifold id: 0
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 2, boundary id: 1, manifold id: 2
+DEAL::e: 2, boundary id: 1, manifold id: 2
+DEAL::e: 6, boundary id: 1, manifold id: 2
+DEAL::e: 1, boundary id: 1, manifold id: 2
+DEAL::e: 9, boundary id: 1, manifold id: 2
+DEAL::f: 3, boundary id: 1, manifold id: 2
+DEAL::e: 4, boundary id: 1, manifold id: 2
+DEAL::e: 7, boundary id: 1, manifold id: 2
+DEAL::e: 3, boundary id: 1, manifold id: 2
+DEAL::e: 10, boundary id: 1, manifold id: 2
+DEAL::f: 0, boundary id: 1, manifold id: 2
+DEAL::e: 0, boundary id: 1, manifold id: 2
+DEAL::e: 8, boundary id: 1, manifold id: 2
+DEAL::e: 2, boundary id: 1, manifold id: 2
+DEAL::e: 4, boundary id: 1, manifold id: 2
+DEAL::f: 4, boundary id: 1, manifold id: 2
+DEAL::e: 5, boundary id: 1, manifold id: 2
+DEAL::e: 11, boundary id: 1, manifold id: 2
+DEAL::e: 6, boundary id: 1, manifold id: 2
+DEAL::e: 7, boundary id: 1, manifold id: 2
+DEAL::f: 1, boundary id: 1, manifold id: 2
+DEAL::e: 1, boundary id: 1, manifold id: 2
+DEAL::e: 3, boundary id: 1, manifold id: 2
+DEAL::e: 0, boundary id: 1, manifold id: 2
+DEAL::e: 5, boundary id: 1, manifold id: 2
+DEAL::f: 5, boundary id: 1, manifold id: 2
+DEAL::e: 9, boundary id: 1, manifold id: 2
+DEAL::e: 10, boundary id: 1, manifold id: 2
+DEAL::e: 8, boundary id: 1, manifold id: 2
+DEAL::e: 11, boundary id: 1, manifold id: 2

--- a/tests/manifold/map_boundary_to_manifold_id_02.cc
+++ b/tests/manifold/map_boundary_to_manifold_id_02.cc
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test the function map_boundary_to_manifold_ids for edges in 3d
+
+#include "../tests.h"
+
+
+// all include files you need here
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_out.h>
+
+template<int dim, int spacedim>
+void print_info(const Triangulation<dim,spacedim> &tria)
+{
+  for (auto cell = tria.begin_active(); cell != tria.end(); ++cell)
+    {
+      deallog << "C: " << cell
+              << ", manifold id: " << (int)cell->manifold_id() << std::endl;
+      for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+        {
+          deallog << "f: " << cell->face(f)
+                  << ", boundary id: " << (int)cell->face(f)->boundary_id()
+                  << ", manifold id: " << (int)cell->face(f)->manifold_id() << std::endl;
+          if (dim >=3)
+            for (signed int e=0; e<static_cast<signed int>(GeometryInfo<dim>::lines_per_face); ++e)
+              deallog << "e: " << cell->face(f)->line(e)
+                      << ", boundary id: " << (int)cell->face(f)->line(e)->boundary_id()
+                      << ", manifold id: " << (int)cell->face(f)->line(e)->manifold_id() << std::endl;
+        }
+    }
+}
+
+// Helper function
+template <int dim, int spacedim>
+void test()
+{
+  deallog << "Testing dim=" << dim
+          << ", spacedim="<< spacedim << std::endl;
+
+  deallog << "Default" << std::endl;
+  Triangulation<dim,spacedim> tria;
+  GridGenerator::hyper_cube (tria, 0, 1, true);
+  print_info(tria);
+  deallog << std::endl;
+
+  // Set the edge manifolds to something interesting
+  deallog << "Set edge manifold IDs" << std::endl;
+  for (auto cell = tria.begin_active(); cell != tria.end(); ++cell)
+    {
+      for (signed int e=0; e<static_cast<signed int>(GeometryInfo<dim>::lines_per_cell); ++e)
+        cell->line(e)->set_manifold_id(e);
+      for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+        {
+          cell->face(f)->set_boundary_id(f);
+          for (signed int e=0; e<static_cast<signed int>(GeometryInfo<dim>::lines_per_face); ++e)
+            cell->face(f)->line(e)->set_boundary_id(f);
+        }
+    }
+  print_info(tria);
+  deallog << std::endl;
+
+  // Test
+
+  // Test setting all manifold ids to an offset of the boundary id
+  deallog << "All manifold ids to offset boundary id" << std::endl;
+  auto bids = tria.get_boundary_ids();
+  std::vector<types::manifold_id> mids(bids.size(), 0);
+  for (unsigned int i=0; i<bids.size(); ++i)
+    mids[i] = 10 + bids[i];
+  GridTools::map_boundary_to_manifold_ids(bids, mids, tria);
+  print_info(tria);
+
+  // Test setting all manifold ids to an offset of the boundary id
+  // and then resetting the boundary ids
+  deallog << "All manifold ids to offset boundary id + boundary id reset" << std::endl;
+  for (unsigned int i=0; i<bids.size(); ++i)
+    mids[i] = 20 + bids[i];
+  std::vector<types::boundary_id> rbids(bids.size(), 1);
+  GridTools::map_boundary_to_manifold_ids(bids, mids, tria, rbids);
+  print_info(tria);
+}
+
+int main ()
+{
+  initlog();
+  test<3,3>();
+
+  return 0;
+}
+

--- a/tests/manifold/map_boundary_to_manifold_id_02.output
+++ b/tests/manifold/map_boundary_to_manifold_id_02.output
@@ -1,0 +1,132 @@
+
+DEAL::Testing dim=3, spacedim=3
+DEAL::Default
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 2, boundary id: 0, manifold id: -1
+DEAL::e: 2, boundary id: 0, manifold id: -1
+DEAL::e: 6, boundary id: 0, manifold id: -1
+DEAL::e: 1, boundary id: 0, manifold id: -1
+DEAL::e: 9, boundary id: 0, manifold id: -1
+DEAL::f: 3, boundary id: 1, manifold id: -1
+DEAL::e: 4, boundary id: 0, manifold id: -1
+DEAL::e: 7, boundary id: 0, manifold id: -1
+DEAL::e: 3, boundary id: 0, manifold id: -1
+DEAL::e: 10, boundary id: 0, manifold id: -1
+DEAL::f: 0, boundary id: 2, manifold id: -1
+DEAL::e: 0, boundary id: 0, manifold id: -1
+DEAL::e: 8, boundary id: 0, manifold id: -1
+DEAL::e: 2, boundary id: 0, manifold id: -1
+DEAL::e: 4, boundary id: 0, manifold id: -1
+DEAL::f: 4, boundary id: 3, manifold id: -1
+DEAL::e: 5, boundary id: 0, manifold id: -1
+DEAL::e: 11, boundary id: 0, manifold id: -1
+DEAL::e: 6, boundary id: 0, manifold id: -1
+DEAL::e: 7, boundary id: 0, manifold id: -1
+DEAL::f: 1, boundary id: 4, manifold id: -1
+DEAL::e: 1, boundary id: 0, manifold id: -1
+DEAL::e: 3, boundary id: 0, manifold id: -1
+DEAL::e: 0, boundary id: 0, manifold id: -1
+DEAL::e: 5, boundary id: 0, manifold id: -1
+DEAL::f: 5, boundary id: 5, manifold id: -1
+DEAL::e: 9, boundary id: 0, manifold id: -1
+DEAL::e: 10, boundary id: 0, manifold id: -1
+DEAL::e: 8, boundary id: 0, manifold id: -1
+DEAL::e: 11, boundary id: 0, manifold id: -1
+DEAL::
+DEAL::Set edge manifold IDs
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 2, boundary id: 0, manifold id: -1
+DEAL::e: 2, boundary id: 2, manifold id: 8
+DEAL::e: 6, boundary id: 3, manifold id: 10
+DEAL::e: 1, boundary id: 4, manifold id: 0
+DEAL::e: 9, boundary id: 5, manifold id: 4
+DEAL::f: 3, boundary id: 1, manifold id: -1
+DEAL::e: 4, boundary id: 2, manifold id: 9
+DEAL::e: 7, boundary id: 3, manifold id: 11
+DEAL::e: 3, boundary id: 4, manifold id: 1
+DEAL::e: 10, boundary id: 5, manifold id: 5
+DEAL::f: 0, boundary id: 2, manifold id: -1
+DEAL::e: 0, boundary id: 4, manifold id: 2
+DEAL::e: 8, boundary id: 5, manifold id: 6
+DEAL::e: 2, boundary id: 2, manifold id: 8
+DEAL::e: 4, boundary id: 2, manifold id: 9
+DEAL::f: 4, boundary id: 3, manifold id: -1
+DEAL::e: 5, boundary id: 4, manifold id: 3
+DEAL::e: 11, boundary id: 5, manifold id: 7
+DEAL::e: 6, boundary id: 3, manifold id: 10
+DEAL::e: 7, boundary id: 3, manifold id: 11
+DEAL::f: 1, boundary id: 4, manifold id: -1
+DEAL::e: 1, boundary id: 4, manifold id: 0
+DEAL::e: 3, boundary id: 4, manifold id: 1
+DEAL::e: 0, boundary id: 4, manifold id: 2
+DEAL::e: 5, boundary id: 4, manifold id: 3
+DEAL::f: 5, boundary id: 5, manifold id: -1
+DEAL::e: 9, boundary id: 5, manifold id: 4
+DEAL::e: 10, boundary id: 5, manifold id: 5
+DEAL::e: 8, boundary id: 5, manifold id: 6
+DEAL::e: 11, boundary id: 5, manifold id: 7
+DEAL::
+DEAL::All manifold ids to offset boundary id
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 2, boundary id: 0, manifold id: 10
+DEAL::e: 2, boundary id: 2, manifold id: 12
+DEAL::e: 6, boundary id: 3, manifold id: 13
+DEAL::e: 1, boundary id: 4, manifold id: 14
+DEAL::e: 9, boundary id: 5, manifold id: 15
+DEAL::f: 3, boundary id: 1, manifold id: 11
+DEAL::e: 4, boundary id: 2, manifold id: 12
+DEAL::e: 7, boundary id: 3, manifold id: 13
+DEAL::e: 3, boundary id: 4, manifold id: 14
+DEAL::e: 10, boundary id: 5, manifold id: 15
+DEAL::f: 0, boundary id: 2, manifold id: 12
+DEAL::e: 0, boundary id: 4, manifold id: 14
+DEAL::e: 8, boundary id: 5, manifold id: 15
+DEAL::e: 2, boundary id: 2, manifold id: 12
+DEAL::e: 4, boundary id: 2, manifold id: 12
+DEAL::f: 4, boundary id: 3, manifold id: 13
+DEAL::e: 5, boundary id: 4, manifold id: 14
+DEAL::e: 11, boundary id: 5, manifold id: 15
+DEAL::e: 6, boundary id: 3, manifold id: 13
+DEAL::e: 7, boundary id: 3, manifold id: 13
+DEAL::f: 1, boundary id: 4, manifold id: 14
+DEAL::e: 1, boundary id: 4, manifold id: 14
+DEAL::e: 3, boundary id: 4, manifold id: 14
+DEAL::e: 0, boundary id: 4, manifold id: 14
+DEAL::e: 5, boundary id: 4, manifold id: 14
+DEAL::f: 5, boundary id: 5, manifold id: 15
+DEAL::e: 9, boundary id: 5, manifold id: 15
+DEAL::e: 10, boundary id: 5, manifold id: 15
+DEAL::e: 8, boundary id: 5, manifold id: 15
+DEAL::e: 11, boundary id: 5, manifold id: 15
+DEAL::All manifold ids to offset boundary id + boundary id reset
+DEAL::C: 0.0, manifold id: -1
+DEAL::f: 2, boundary id: 1, manifold id: 20
+DEAL::e: 2, boundary id: 1, manifold id: 22
+DEAL::e: 6, boundary id: 1, manifold id: 23
+DEAL::e: 1, boundary id: 1, manifold id: 24
+DEAL::e: 9, boundary id: 1, manifold id: 25
+DEAL::f: 3, boundary id: 1, manifold id: 21
+DEAL::e: 4, boundary id: 1, manifold id: 22
+DEAL::e: 7, boundary id: 1, manifold id: 23
+DEAL::e: 3, boundary id: 1, manifold id: 24
+DEAL::e: 10, boundary id: 1, manifold id: 25
+DEAL::f: 0, boundary id: 1, manifold id: 22
+DEAL::e: 0, boundary id: 1, manifold id: 24
+DEAL::e: 8, boundary id: 1, manifold id: 25
+DEAL::e: 2, boundary id: 1, manifold id: 22
+DEAL::e: 4, boundary id: 1, manifold id: 22
+DEAL::f: 4, boundary id: 1, manifold id: 23
+DEAL::e: 5, boundary id: 1, manifold id: 24
+DEAL::e: 11, boundary id: 1, manifold id: 25
+DEAL::e: 6, boundary id: 1, manifold id: 23
+DEAL::e: 7, boundary id: 1, manifold id: 23
+DEAL::f: 1, boundary id: 1, manifold id: 24
+DEAL::e: 1, boundary id: 1, manifold id: 24
+DEAL::e: 3, boundary id: 1, manifold id: 24
+DEAL::e: 0, boundary id: 1, manifold id: 24
+DEAL::e: 5, boundary id: 1, manifold id: 24
+DEAL::f: 5, boundary id: 1, manifold id: 25
+DEAL::e: 9, boundary id: 1, manifold id: 25
+DEAL::e: 10, boundary id: 1, manifold id: 25
+DEAL::e: 8, boundary id: 1, manifold id: 25
+DEAL::e: 11, boundary id: 1, manifold id: 25


### PR DESCRIPTION
@jppelteret , is this similar to what you had in mind?

I'm not sure about the container types. This could be done also with a 

```
std::map<types::boundary_id, types::manifold_id> boundary_to_manifold_ids;
```
and an optional
```
std::map<types::boundary_id, types::boundary_id> new_boundary_ids;
```
But this seemed to be a little easier. What do people think?