### PR TITLE
Removed double include in grid_tools.h

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -19,7 +19,6 @@
 
 #include <deal.II/base/bounding_box.h>
 #include <deal.II/base/config.h>
-#include <deal.II/base/bounding_box.h>
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/mapping.h>


### PR DESCRIPTION
Removing the second `#include <deal.II/base/bounding_box.h>` from grid_tools.h