### PR TITLE
Fix compiling with clang-6

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -3140,7 +3140,7 @@ enum struct SymmetricTensorEigenvectorMethod
  * @author Joachim Kopp, Jean-Paul Pelteret, 2017
  */
 template <int dim, typename Number>
-std::array<std::pair<Number, Tensor<1,dim,Number> >,dim>
+std::array<std::pair<Number, Tensor<1,dim,Number> >,std::integral_constant<int, dim>::value>
 eigenvectors (const SymmetricTensor<2,dim,Number>         &T,
               const SymmetricTensorEigenvectorMethod       method = SymmetricTensorEigenvectorMethod::ql_implicit_shifts);
 

--- a/include/deal.II/base/symmetric_tensor.templates.h
+++ b/include/deal.II/base/symmetric_tensor.templates.h
@@ -802,7 +802,7 @@ namespace internal
 
 
 template <int dim, typename Number>
-std::array<std::pair<Number, Tensor<1,dim,Number> >,dim>
+std::array<std::pair<Number, Tensor<1,dim,Number> >,std::integral_constant<int, dim>::value>
 eigenvectors (const SymmetricTensor<2,dim,Number>         &T,
               const SymmetricTensorEigenvectorMethod       method)
 {

--- a/source/base/symmetric_tensor.inst.in
+++ b/source/base/symmetric_tensor.inst.in
@@ -27,7 +27,7 @@ for (deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
     eigenvalues (const SymmetricTensor<2,deal_II_dimension,number> &);
 
     template
-    std::array<std::pair<number, Tensor<1,deal_II_dimension,number> >,deal_II_dimension>
+    std::array<std::pair<number,Tensor<1,deal_II_dimension,number> >,std::integral_constant<int, deal_II_dimension>::value>
     eigenvectors (const SymmetricTensor<2,deal_II_dimension,number> &,
                   const SymmetricTensorEigenvectorMethod);
 }
@@ -45,7 +45,7 @@ for (deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_ADOLC_REAL_SCALARS)
     eigenvalues (const SymmetricTensor<2,deal_II_dimension,number> &);
 
     template
-    std::array<std::pair<number, Tensor<1,deal_II_dimension,number> >,deal_II_dimension>
+    std::array<std::pair<number,Tensor<1,deal_II_dimension,number> >,std::integral_constant<int, deal_II_dimension>::value>
     eigenvectors (const SymmetricTensor<2,deal_II_dimension,number> &,
                   const SymmetricTensorEigenvectorMethod);
 }
@@ -63,7 +63,7 @@ for (deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_TRILINOS_SACADO_REA
     eigenvalues (const SymmetricTensor<2,deal_II_dimension,number> &);
 
     template
-    std::array<std::pair<number, Tensor<1,deal_II_dimension,number> >,deal_II_dimension>
+    std::array<std::pair<number,Tensor<1,deal_II_dimension,number> >,std::integral_constant<int, deal_II_dimension>::value>
     eigenvectors (const SymmetricTensor<2,deal_II_dimension,number> &,
                   const SymmetricTensorEigenvectorMethod);
 }


### PR DESCRIPTION
`clang-6` couldn't deduce `dim` since the type in `std::array` is `std::size_t` while `dim` is also used as an `int` template argument. Make sure `dim` is only deduced once.