### PR TITLE
Change GridTools::distributed_compute_ptloc to use global description

### DIFF
--- a/doc/news/changes/minor/20180416GiovanniAlzetta
+++ b/doc/news/changes/minor/20180416GiovanniAlzetta
@@ -1,0 +1,5 @@
+Changed: GridTools::distributed_compute_point_locations now takes as input the
+global description of the manifold using bounding boxes.
+<br>
+(Giovanni Alzetta, 2018/04/16)
+

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -683,9 +683,14 @@ namespace GridTools
    * @param[in] local_points the array of points owned by the current process. Every
    *  process can have a different array of points which can be empty and not
    *  contained within the locally owned part of the triangulation
-   * @param[in] local_bbox the description of the locally owned part of the mesh made
-   *  with bounding boxes. It can be obtained from
-   *  GridTools::compute_mesh_predicate_bounding_box
+   * @param[in] global_bboxes a vector of vectors of bounding boxes; it describes
+   *  the locally owned part of the mesh for each process.
+   *  The bounding boxes describing which part of the mesh is locally owned by
+   *  process with rank rk are contained in global_bboxes[rk].
+   *  The local description can be obtained from
+   *  GridTools::compute_mesh_predicate_bounding_box ; then the global one can
+   *  be obtained using either GridTools::exchange_local_bounding_boxes
+   *  or Utilities::MPI::all_gather
    * @return A tuple containing the quadrature information
    *
    * The elements of the output tuple are:
@@ -739,9 +744,9 @@ namespace GridTools
   return_type
 #endif
       distributed_compute_point_locations
-      (const GridTools::Cache<dim,spacedim>                &cache,
-       const std::vector<Point<spacedim> >                 &local_points,
-       const std::vector< BoundingBox<spacedim> >          &local_bbox);
+      (const GridTools::Cache<dim,spacedim>                        &cache,
+       const std::vector<Point<spacedim> >                         &local_points,
+       const std::vector< std::vector< BoundingBox<spacedim> > >   &global_bboxes);
 
   /**
    * Return a map of index:Point<spacedim>, containing the used vertices of the

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -88,9 +88,9 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
         std::vector< std::vector< unsigned int > >
         >
     distributed_compute_point_locations
-    (const Cache< deal_II_dimension, deal_II_space_dimension >   &,
-     const std::vector< Point< deal_II_space_dimension > >       &,
-     const std::vector< BoundingBox< deal_II_space_dimension > > &);
+    (const Cache< deal_II_dimension, deal_II_space_dimension >                  &,
+     const std::vector< Point< deal_II_space_dimension > >                      &,
+     const std::vector< std::vector< BoundingBox< deal_II_space_dimension > > > &);
     \}
 
 #endif

--- a/tests/grid/distributed_compute_point_locations_01.cc
+++ b/tests/grid/distributed_compute_point_locations_01.cc
@@ -55,11 +55,14 @@ void test_compute_pt_loc(unsigned int n_points)
   std::vector< BoundingBox<dim> > local_bbox = GridTools::compute_mesh_predicate_bounding_box
                                                (cache.get_triangulation(),
                                                 std::function<bool (const typename Triangulation<dim>::active_cell_iterator &)>(locally_owned_cell_predicate),
-                                                1, true, 4); // These options should be passed
-  // Using the distributed version of compute point location
+                                                1, true, 4);
 
-  // Using the distributed version
-  auto output_tuple = distributed_compute_point_locations(cache,points,local_bbox);
+  // Obtaining the global mesh description through an all to all communication
+  std::vector< std::vector< BoundingBox<dim> > > global_bboxes;
+  global_bboxes = Utilities::MPI::all_gather(mpi_communicator,local_bbox);
+
+  // Using the distributed version of compute point location
+  auto output_tuple = distributed_compute_point_locations(cache,points,global_bboxes);
   // Testing in serial against the serial version
   auto cell_qpoint_map = GridTools::compute_point_locations(cache,points);
 

--- a/tests/grid/distributed_compute_point_locations_02.cc
+++ b/tests/grid/distributed_compute_point_locations_02.cc
@@ -121,9 +121,13 @@ void test_compute_pt_loc(unsigned int ref_cube, unsigned int ref_sphere)
                                                (cache.get_triangulation(), locally_owned_cell_predicate,
                                                 1, true, 4);
 
+  // Obtaining the global mesh description through an all to all communication
+  std::vector< std::vector< BoundingBox<dim> > > global_bboxes;
+  global_bboxes = Utilities::MPI::all_gather(mpi_communicator,local_bbox);
+
   // Using the distributed version of compute point location
   auto output_tuple = distributed_compute_point_locations
-                      (cache,loc_owned_points,local_bbox);
+                      (cache,loc_owned_points,global_bboxes);
   deallog << "Comparing results" << std::endl;
   const auto &output_cells = std::get<0>(output_tuple);
   const auto &output_qpoints = std::get<1>(output_tuple);


### PR DESCRIPTION
Hi!
 Working on https://github.com/dealii/dealii/pull/6240 I noticed distributed compute point locations currently does a collective communication to obtain the global description of the mesh. This should be avoided since calling the function multiple times results in a number of useless collective communications and since it should be not this function's duty to create the global description of the mesh (I guess in the future this job should be given to an object which creates, handles and updates AABB trees).

I also updated the documentation and tests accordingly.

Best,
Giovanni