### PR TITLE
Avoid warning regarding unused parameter

### DIFF
--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -258,6 +258,7 @@ namespace SparsityTools
 
       Assert(cell_weights.size() == 0,
              ExcMessage("The cell weighting functionality for Zoltan has not yet been implemented."));
+      (void) cell_weights;
 
       //MPI environment must have been initialized by this point.
       std::unique_ptr<Zoltan> zz = std_cxx14::make_unique<Zoltan>(MPI_COMM_SELF);


### PR DESCRIPTION
CDash [complains](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&onlydeltap&buildid=858) about the unused `cell_weights`.