### PR TITLE
Fix test for GCC 4.8.4 by doing a conversion explicitly.

### DIFF
--- a/tests/grid/distributed_compute_point_locations_02.cc
+++ b/tests/grid/distributed_compute_point_locations_02.cc
@@ -118,7 +118,8 @@ void test_compute_pt_loc(unsigned int ref_cube, unsigned int ref_sphere)
   // Computing bounding boxes describing the locally owned part of the mesh
   IteratorFilters::LocallyOwnedCell locally_owned_cell_predicate;
   std::vector< BoundingBox<dim> > local_bbox = GridTools::compute_mesh_predicate_bounding_box
-                                               (cache.get_triangulation(), locally_owned_cell_predicate,
+                                               (cache.get_triangulation(),
+                                                std::function<bool (const typename Triangulation<dim>::active_cell_iterator &)>(locally_owned_cell_predicate),
                                                 1, true, 4);
 
   // Obtaining the global mesh description through an all to all communication


### PR DESCRIPTION
This is the same fix as for the _01 test. It is not necessary on newer GCC versions,
but my old GCC 4.8.4 still requires it.