### PR TITLE
Fix a test by increasing the precision of output.

### DIFF
--- a/tests/fe/rt_bubbles_2.cc
+++ b/tests/fe/rt_bubbles_2.cc
@@ -158,6 +158,7 @@ int
 main()
 {
   initlog();
+  deallog << std::setprecision(7);
   deallog << std::fixed;
 
   for (unsigned int degree=1; degree<4; ++degree)


### PR DESCRIPTION
The test outputs 6 digits, so if there is a difference in the 7th digit that
leads to different 6-digit-rounding, then that produces a difference that is
exactly at the numdiff threshold and the test fails.

Fix this by outputting 7 digits. The difference between the current output
and the stored output is then at most one half of the numdiff tolerance,
and the test succeeds.