### PR TITLE
Avoid using 'info' as a word.

### DIFF
--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -2401,8 +2401,8 @@ namespace DoFTools
    * @image html support_point_dofs2.png
    * </p>
    *
-   * To generate the mesh and the support point info in a single gnuplot file,
-   * use code similar to
+   * To generate the mesh and the support point information in a
+   * single gnuplot file, use code similar to
    * @code
    * std::ofstream out("gnuplot.gpl");
    * out << "plot '-' using 1:2 with lines, '-' with labels point pt 2 offset 1,1" << std::endl;

--- a/include/deal.II/lac/solver_selector.h
+++ b/include/deal.II/lac/solver_selector.h
@@ -136,37 +136,37 @@ public:
   void set_control(SolverControl &ctrl);
 
   /**
-   * Set the additional data. For more info see the @p Solver class.
+   * Set the additional data. For more information see the @p Solver class.
    */
   void set_data(const typename SolverRichardson<VectorType>
                 ::AdditionalData &data);
 
   /**
-   * Set the additional data. For more info see the @p Solver class.
+   * Set the additional data. For more information see the @p Solver class.
    */
   void set_data(const typename SolverCG<VectorType>
                 ::AdditionalData &data);
 
   /**
-   * Set the additional data. For more info see the @p Solver class.
+   * Set the additional data. For more information see the @p Solver class.
    */
   void set_data(const typename SolverMinRes<VectorType>
                 ::AdditionalData &data);
 
   /**
-   * Set the additional data. For more info see the @p Solver class.
+   * Set the additional data. For more information see the @p Solver class.
    */
   void set_data(const typename SolverBicgstab<VectorType>
                 ::AdditionalData &data);
 
   /**
-   * Set the additional data. For more info see the @p Solver class.
+   * Set the additional data. For more information see the @p Solver class.
    */
   void set_data(const typename SolverGMRES<VectorType>
                 ::AdditionalData &data);
 
   /**
-   * Set the additional data. For more info see the @p Solver class.
+   * Set the additional data. For more information see the @p Solver class.
    */
   void set_data(const typename SolverFGMRES<VectorType>
                 ::AdditionalData &data);

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -346,7 +346,7 @@ private:
   std::vector<double> Ax;
 
   /**
-   * Control and info arrays for the solver routines.
+   * Control and work arrays for the solver routines.
    */
   std::vector<double> control;
 };

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -58,7 +58,7 @@ template <typename> class VectorizedArray;
  * @tparam Number Arithmetic type of the underlying array elements.
  *
  * @tparam size Compile-time array lengths. By default at -1, which means that
- * the run-time info stored in the matrices passed to the reinit()
+ * the run-time information stored in the matrices passed to the reinit()
  * function is used.
  *
  * @author Martin Kronbichler and Julius Witte, 2017
@@ -206,7 +206,7 @@ private:
  * float and double numbers.
  *
  * @tparam size Compile-time array lengths. By default at -1, which means that
- * the run-time info stored in the matrices passed to the reinit()
+ * the run-time information stored in the matrices passed to the reinit()
  * function is used.
  *
  * @author Martin Kronbichler and Julius Witte, 2017

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -1951,7 +1951,7 @@ public:
   /**
    * Constructor for the reduced functionality. Similar to the other
    * constructor with FiniteElement argument but using another
-   * FEEvaluationBase object to provide info about the geometry. This allows
+   * FEEvaluationBase object to provide information about the geometry. This allows
    * several FEEvaluation objects to share the geometry evaluation, i.e., the
    * underlying mapping and quadrature points do only need to be evaluated
    * once. Make sure to not pass an optional object around when you intend to

--- a/include/deal.II/meshworker/assembler.h
+++ b/include/deal.II/meshworker/assembler.h
@@ -120,7 +120,7 @@ namespace MeshWorker
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
        *
-       * The info object refers to a cell if <code>!face</code>, or else to an
+       * The @p info object refers to a cell if <code>!face</code>, or else to an
        * interior or boundary face.
        */
       template <class DOFINFO>
@@ -217,7 +217,7 @@ namespace MeshWorker
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
        *
-       * The info object refers to a cell if <code>!face</code>, or else to an
+       * The @p info object refers to a cell if <code>!face</code>, or else to an
        * interior or boundary face.
        */
       template <class DOFINFO>
@@ -341,7 +341,7 @@ namespace MeshWorker
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
        *
-       * The info object refers to a cell if <code>!face</code>, or else to an
+       * The @p info object refers to a cell if <code>!face</code>, or else to an
        * interior or boundary face.
        */
       template <class DOFINFO>

--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -78,7 +78,7 @@ namespace MeshWorker
     /**
      * The number of the current face on the current cell.
      *
-     * This number is numbers::invalid_unsigned_int if the info object was
+     * This number is numbers::invalid_unsigned_int if the @p info object was
      * initialized with a cell.
      */
     unsigned int face_number;
@@ -86,7 +86,7 @@ namespace MeshWorker
     /**
      * The number of the current subface on the current face
      *
-     * This number is numbers::invalid_unsigned_int if the info object was not
+     * This number is numbers::invalid_unsigned_int if the @p info object was not
      * initialized with a subface.
      */
     unsigned int sub_number;
@@ -226,7 +226,7 @@ namespace MeshWorker
     void reset();
 
     /**
-     * After all info objects have been filled appropriately, use the
+     * After all DOFINFO objects have been filled appropriately, use the
      * ASSEMBLER object to assemble them into the global data. See
      * MeshWorker::Assembler for available classes.
      */

--- a/include/deal.II/meshworker/functional.h
+++ b/include/deal.II/meshworker/functional.h
@@ -53,7 +53,7 @@ namespace MeshWorker
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
        *
-       * The info object refers to a cell if <code>!face</code>, or else to an
+       * The @p info object refers to a cell if <code>!face</code>, or else to an
        * interior or boundary face.
        */
       template <class DOFINFO>
@@ -122,7 +122,7 @@ namespace MeshWorker
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
        *
-       * The info object refers to a cell if <code>!face</code>, or else to an
+       * The @p info object refers to a cell if <code>!face</code>, or else to an
        * interior or boundary face.
        */
       template <class DOFINFO>

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -284,7 +284,7 @@ namespace MeshWorker
   public:
 
     /**
-     * The type of the info object for cells.
+     * The type of the @p info object for cells.
      */
     typedef IntegrationInfo<dim, spacedim> CellInfo;
 
@@ -524,24 +524,24 @@ namespace MeshWorker
     void post_faces(const DoFInfoBox<dim, DOFINFO> &);
 
     /**
-     * The info object for a cell.
+     * The @p info object for a cell.
      */
     CellInfo cell;
     /**
-     * The info object for a boundary face.
+     * The @p info object for a boundary face.
      */
     CellInfo boundary;
     /**
-     * The info object for a regular interior face, seen from the first cell.
+     * The @p info object for a regular interior face, seen from the first cell.
      */
     CellInfo face;
     /**
-     * The info object for the refined side of an interior face seen from the
+     * The @p info object for the refined side of an interior face seen from the
      * first cell.
      */
     CellInfo subface;
     /**
-     * The info object for an interior face, seen from the other cell.
+     * The @p info object for an interior face, seen from the other cell.
      */
     CellInfo neighbor;
 

--- a/include/deal.II/meshworker/local_results.h
+++ b/include/deal.II/meshworker/local_results.h
@@ -40,7 +40,7 @@ class BlockIndices;
  * integration_loop() instead.
  *
  * The loop() depends on certain objects handed to it as arguments. These
- * objects are of two types, info objects like DoFInfo and IntegrationInfo and
+ * objects are of two types, @p info objects like DoFInfo and IntegrationInfo and
  * worker objects like LocalWorker and IntegrationWorker.
  *
  * Worker objects usually do two different jobs: first, they compute the local
@@ -198,7 +198,7 @@ namespace MeshWorker
    * with matrix(), using the second argument <tt>true</tt>.
    * </ol>
    *
-   * The local matrices initialized by reinit() of the info object and then
+   * The local matrices initialized by reinit() of the @p info object and then
    * assembled into the global system by Assembler classes.
    *
    * @ingroup MeshWorker

--- a/include/deal.II/meshworker/output.h
+++ b/include/deal.II/meshworker/output.h
@@ -84,7 +84,7 @@ namespace MeshWorker
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
        *
-       * The info object refers to a cell if <code>!face</code>, or else to an
+       * The @p info object refers to a cell if <code>!face</code>, or else to an
        * interior or boundary face.
        */
       template <int dim>

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -86,7 +86,7 @@ namespace MeshWorker
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
        *
-       * The info object refers to a cell if <code>!face</code>, or else to an
+       * The @p info object refers to a cell if <code>!face</code>, or else to an
        * interior or boundary face.
        */
       template <class DOFINFO>
@@ -184,7 +184,7 @@ namespace MeshWorker
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
        *
-       * The info object refers to a cell if <code>!face</code>, or else to an
+       * The @p info object refers to a cell if <code>!face</code>, or else to an
        * interior or boundary face.
        */
       template <class DOFINFO>
@@ -199,7 +199,7 @@ namespace MeshWorker
 
       /**
        * Assemble all local matrices associated with an interior face in the
-       * info objects into the global matrix.
+       * @p info1 and @p info2 objects into the global matrix.
        */
       template <class DOFINFO>
       void assemble(const DOFINFO &info1,
@@ -282,7 +282,7 @@ namespace MeshWorker
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
        *
-       * The info object refers to a cell if <code>!face</code>, or else to an
+       * The @p info object refers to a cell if <code>!face</code>, or else to an
        * interior or boundary face.
        */
       template <class DOFINFO>
@@ -295,8 +295,8 @@ namespace MeshWorker
       void assemble(const DOFINFO &info);
 
       /**
-       * Assemble both local matrices in the info objects into the global
-       * matrices.
+       * Assemble both local matrices in the @p info1 and @p info2
+       * objects into the global matrices.
        */
       template <class DOFINFO>
       void assemble(const DOFINFO &info1,
@@ -440,7 +440,7 @@ namespace MeshWorker
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
        *
-       * The info object refers to a cell if <code>!face</code>, or else to an
+       * The @p info object refers to a cell if <code>!face</code>, or else to an
        * interior or boundary face.
        */
       template <class DOFINFO>
@@ -453,8 +453,8 @@ namespace MeshWorker
       void assemble(const DOFINFO &info);
 
       /**
-       * Assemble both local matrices in the info objects into the global
-       * matrix.
+       * Assemble both local matrices in the @p info1 and @p info2
+       * objects into the global matrix.
        */
       template <class DOFINFO>
       void assemble(const DOFINFO &info1,

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -393,7 +393,7 @@ public:
 
   /**
    * Write out a series of .gpl files named base_name + "-00.gpl", base_name +
-   * "-01.gpl" etc. The data file gives info about where the support points
+   * "-01.gpl" etc. The data file gives information about where the support points
    * selected and interpreting the data. If @p n_indep != 0 an additional file
    * base_name + "_indep.gpl" containing key and independent data. The file
    * name agrees with the order the points were added to the class. The names
@@ -588,7 +588,7 @@ private:
   std::map <std::string, std::vector<std::string> > component_names_map;
 
   /**
-   * Save the location and other mesh info about support points.
+   * Save the location and other mesh information about support points.
    */
   std::vector <internal::PointValueHistoryImplementation::PointGeometryData <dim> >
   point_geometry_data;


### PR DESCRIPTION
Use 'information' instead, or if it refers to a variable then at least mark it up.