### PR TITLE
Introduce face functionality to fe_evaluation.

### DIFF
--- a/tests/matrix_free/fe_evaluation_access_1d.cc
+++ b/tests/matrix_free/fe_evaluation_access_1d.cc
@@ -26,6 +26,6 @@ int main ()
 {
   initlog();
 
-  FEEvaluationAccess<1,1,double> *test; // didn't compile before
+  FEEvaluationAccess<1,1,double,false> *test; // didn't compile before
   deallog <<  "OK" << std::endl;
 }


### PR DESCRIPTION
* Distinguish cell and face type by new template argument `is_face` (present `FEEvaluation`uses `is_face=false`).
* Implement access functions for handling faces such as `get_normal_vector` (will be used in new class `FEFaceEvaluation` in later PR).
* Introduce argument `first_selected_component` to enable multiple finite elements within one dof handler (dof index part will be introduced in later PR).