### PR TITLE
Fix various issues reported by coverity

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -516,7 +516,8 @@ namespace Utilities
           else
             {
               const int ierr = MPI_Finalize();
-              AssertThrowMPI(ierr);
+              (void) ierr;
+              AssertNothrow(ierr == MPI_SUCCESS, dealii::ExcMPI(ierr));
             }
         }
 #endif

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -150,6 +150,7 @@ FE_PolyTensor<PolynomialType,dim,spacedim>::FE_PolyTensor
   FiniteElement<dim,spacedim> (fe_data,
                                restriction_is_additive_flags,
                                nonzero_components),
+  mapping_type(MappingType::mapping_none),
   poly_space(PolynomialType(degree))
 {
   cached_point(0) = -1;

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -1530,7 +1530,7 @@ void GridIn<dim, spacedim>::read_msh (std::istream &in)
       else if (cell_type == 15)
         {
           // read the indices of nodes given
-          unsigned int node_index;
+          unsigned int node_index = 0;
           switch (gmsh_file_format)
             {
             case 1:
@@ -1544,6 +1544,8 @@ void GridIn<dim, spacedim>::read_msh (std::istream &in)
               in >> node_index;
               break;
             }
+            default:
+              Assert(false, ExcInternalError());
             }
 
           // we only care about boundary indicators assigned to individual

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -2738,7 +2738,7 @@ void GridIn<dim, spacedim>::skip_comment_lines (std::istream &in,
   char c;
   // loop over the following comment
   // lines
-  while ((c=in.get()) == comment_start)
+  while (in.get(c) && c == comment_start)
     // loop over the characters after
     // the comment starter
     while (in.get() != '\n')
@@ -2747,7 +2747,8 @@ void GridIn<dim, spacedim>::skip_comment_lines (std::istream &in,
 
   // put back first character of
   // first non-comment line
-  in.putback (c);
+  if (in)
+    in.putback (c);
 
   // at last: skip additional empty lines, if present
   skip_empty_lines(in);

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -1074,7 +1074,7 @@ void TimeStepBase_Tria<dim>::refine_grid (const RefinementData refinement_data)
     {
       Triangulation<dim> *previous_tria
         = dynamic_cast<const TimeStepBase_Tria<dim>*>(previous_timestep)->tria;
-
+      Assert(previous_tria != nullptr, ExcInternalError());
 
       // if we used the dual estimator, we
       // computed the error information on


### PR DESCRIPTION
- `GridIn::read_ucd` used an `unsigned int` instead of `types::material_id`.
- In `GridIn::read_skip_comment_lines`, `std::istream.get()` returned an `int` instead of a char. Use the other overload instead.
- `Abaqus_to_UCD<dim>::write_out_avs_ucd` modified the given `std::ostream` without restoring the previous formatting options.
- Replace `AssertThrowMPI` in the destructor of `Utilities::MPI::MPI_InitFinalize`.
- Check a `dynamic_cast` in `TimeDependent::refine_grid`.
- Initialize `mapping_type` in the constructor of `FE_PolyTensor`.
- Avoid using an uninitialized value in `GridIn::read_mesh`.
