### PR TITLE
harden cmake deprecation check

### DIFF
--- a/cmake/checks/check_01_compiler_features.cmake
+++ b/cmake/checks/check_01_compiler_features.cmake
@@ -322,6 +322,12 @@ CHECK_CXX_SOURCE_COMPILES(
           int old_fn () { return 0; }
           int (*fn_ptr)() = old_fn;
 
+          struct [[deprecated]] bob
+          {
+            [[deprecated]] bob(int i);
+            [[deprecated]] void test();
+          };
+
           int main () {}
   "
   DEAL_II_COMPILER_HAS_CXX14_ATTRIBUTE_DEPRECATED
@@ -332,6 +338,12 @@ CHECK_CXX_SOURCE_COMPILES(
           __attribute__((deprecated)) int old_fn ();
           int old_fn () { return 0; }
           int (*fn_ptr)() = old_fn;
+
+          struct __attribute__((deprecated)) bob
+          {
+            __attribute__((deprecated)) bob(int i);
+            __attribute__((deprecated)) void test();
+          };
 
           int main () {}
   "


### PR DESCRIPTION
It turns out MSVC 2015 passes the CXX14 check for the deprecated
attribute, but then complains when it is used in a constructor:
E:\jenkins\workspace\workspace\dealii-windows-
compile\CC\msvc2015\label\win\include\deal.II/base/table_indices.h(129):
error C2416: attribute 'deprecated' cannot be applied in this context

Fix this.