### PR TITLE
PETSc: Port to version 3.9.0

### DIFF
--- a/doc/external-libs/petsc.html
+++ b/doc/external-libs/petsc.html
@@ -37,7 +37,7 @@
 
     <p style="color: red"><b>Note:</b> The most recent version of PETSc
       that has been reported to be compatible with
-      <acronym>deal.II</acronym> is version 3.7.6. If you use a later
+      <acronym>deal.II</acronym> is version 3.9.0. If you use a later
       version than this and encounter problems, let us
       know. <acronym>deal.II</acronym> does not support versions of PETSc prior
       to 3.3.0.

--- a/doc/news/changes/minor/20180423MatthiasMaier
+++ b/doc/news/changes/minor/20180423MatthiasMaier
@@ -1,0 +1,5 @@
+Updated: deal.II is now compatible with PETSc version 3.9.0, SLEPC version
+3.9.0
+<br>
+(Matthias Maier, 2018/04/23)
+

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -755,13 +755,21 @@ namespace PETScWrappers
          * factorization here we start to see differences with the base
          * class solve function
          */
+#if DEAL_II_PETSC_VERSION_LT(3, 9, 0)
         ierr = PCFactorSetMatSolverPackage (solver_data->pc, MATSOLVERMUMPS);
+#else
+        ierr = PCFactorSetMatSolverType (solver_data->pc, MATSOLVERMUMPS);
+#endif
         AssertThrow (ierr == 0, ExcPETScError (ierr));
 
         /**
          * set up the package to call for the factorization
          */
+#if DEAL_II_PETSC_VERSION_LT(3, 9, 0)
         ierr = PCFactorSetUpMatSolverPackage (solver_data->pc);
+#else
+        ierr = PCFactorSetUpMatSolverType (solver_data->pc);
+#endif
         AssertThrow (ierr == 0, ExcPETScError(ierr));
 
         /**


### PR DESCRIPTION
In version 3.9.0 *SolverPackage was renamed to *SolverType. Guard the two
instances where we call such functions.