### PR TITLE
Direct solvers on GPU

### DIFF
--- a/cmake/modules/FindCUDA.cmake
+++ b/cmake/modules/FindCUDA.cmake
@@ -43,7 +43,10 @@ IF(CUDA_FOUND)
   MESSAGE(STATUS "Configured to use CUDA installation at ${CUDA_TOOLKIT_ROOT_DIR}")
 ENDIF()
 
-SET(_cuda_libraries ${CUDA_LIBRARIES} ${CUDA_cusparse_LIBRARY})
+# cuSOLVER requires OpenMP
+FIND_PACKAGE(OpenMP)
+SET(_cuda_libraries ${CUDA_LIBRARIES} ${CUDA_cusparse_LIBRARY}
+  ${CUDA_cusolver_LIBRARY} ${OpenMP_CXX_FLAGS})
 SET(_cuda_include_dirs ${CUDA_INCLUDE_DIRS})
 DEAL_II_PACKAGE_HANDLE(CUDA
   LIBRARIES REQUIRED _cuda_libraries
@@ -57,7 +60,6 @@ DEAL_II_PACKAGE_HANDLE(CUDA
     CUDA_cufft_LIBRARY
     CUDA_cupti_LIBRARY
     CUDA_curand_LIBRARY
-    CUDA_cusolver_LIBRARY
     CUDA_HOST_COMPILER
     CUDA_nppc_LIBRARY
     CUDA_nppi_LIBRARY

--- a/doc/news/changes/minor/20180423BrunoTurcksin
+++ b/doc/news/changes/minor/20180423BrunoTurcksin
@@ -1,0 +1,4 @@
+New: Add direct solvers (Cholesky and LU factorization) to solve problems on the
+GPU
+<br>
+(Bruno Turcksin, 2018/04/23)

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -23,6 +23,7 @@
 #include <ostream>
 
 #ifdef DEAL_II_WITH_CUDA
+#include <cusolverSp.h>
 #include <cusparse.h>
 #endif
 
@@ -1088,6 +1089,12 @@ namespace deal_II_exceptions
      * function but there is no equivalent function for cuSPARSE.
      */
     std::string get_cusparse_error_string(const cusparseStatus_t error_code);
+
+    /**
+     * Return a string given an error code. This is similar to the cudaGetErrorString
+     * function but there is no equivalent function for cuSOLVER.
+     */
+    std::string get_cusolver_error_string(const cusolverStatus_t error_code);
 #endif
   } /*namespace internals*/
 
@@ -1318,6 +1325,15 @@ AssertThrow(error_code == MPI_SUCCESS, dealii::ExcMPI(error_code))
                                               get_cusparse_error_string(error_code)))
 #else
 #define AssertCusparse(error_code) { (void) (error_code); }
+#endif
+
+#ifdef DEBUG
+#define AssertCusolver(error_code) Assert(error_code == CUSOLVER_STATUS_SUCCESS, \
+                                          dealii::ExcCusparseError( \
+                                              dealii::deal_II_exceptions::internals:: \
+                                              get_cusolver_error_string(error_code)))
+#else
+#define AssertCusolver(error_code) { (void) (error_code); }
 #endif
 
 #endif

--- a/include/deal.II/lac/cuda_solver_direct.h
+++ b/include/deal.II/lac/cuda_solver_direct.h
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_cuda_solver_direct_h
+#define dealii_cuda_solver_direct_h
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_CUDA
+#include <deal.II/base/cuda.h>
+#include <deal.II/lac/cuda_sparse_matrix.h>
+#include <deal.II/lac/cuda_vector.h>
+#include <deal.II/lac/solver_control.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace CUDAWrappers
+{
+  /**
+   * Direct solvers. These solvers call cuSOLVER underneath.
+   *
+   * @note Instantiations for this template are provided for <tt>@<float@></tt>
+   * and <tt>@<double@></tt>.
+   *
+   * @ingroup CUDAWrappers
+   * @author Bruno Turcksin
+   * @date 2018
+   */
+  template <typename Number>
+  class SolverDirect
+  {
+  public:
+    struct AdditionalData
+    {
+      /**
+       * Set the additional data field to the desired solver.
+       */
+      explicit
+      AdditionalData (const std::string &solver_type = "LU_dense");
+
+      /**
+       * Set the solver type. Possibilities are:
+       * <ul>
+       * <li> "Cholesky" which performs a Cholesky decomposition on the device </li>
+       * <li> "LU_dense" which converts the sparse matrix to a dense matrix and
+       * uses LU factorization </li>
+       * <li> "LU_host" which uses LU factorization on the host </li>
+       * </ul>
+       */
+      std::string solver_type;
+    };
+
+    /**
+     * Constructor. Takes the solver control object and creates the solver.
+     */
+    SolverDirect(const Utilities::CUDA::Handle &handle,
+                 SolverControl &cn,
+                 const AdditionalData &data = AdditionalData());
+
+    /**
+     * Destructor.
+     */
+    virtual ~SolverDirect() = default;
+
+    /**
+     * Solve the linear system <tt>Ax=b</tt>.
+     */
+    void solve(const SparseMatrix<Number> &A,
+               LinearAlgebra::CUDAWrappers::Vector<Number> &x,
+               const LinearAlgebra::CUDAWrappers::Vector<Number> &b);
+
+    /**
+     * Access to object that controls convergence.
+     */
+    SolverControl &control() const;
+
+  private:
+    /**
+     * Handle
+     */
+    const Utilities::CUDA::Handle &cuda_handle;
+
+    /**
+     * Reference to the object that controls convergence of the iterative
+     * solver. In fact, for these Trilinos wrappers, Trilinos does so itself,
+     * but we copy the data from this object before starting the solution
+     * process, and copy the data back into it afterwards.
+     */
+    SolverControl &solver_control;
+
+    /**
+     * Store a copy of the flags for this particular solver.
+     */
+    const AdditionalData additional_data;
+  };
+}
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif
+
+#endif

--- a/include/deal.II/lac/cuda_sparse_matrix.h
+++ b/include/deal.II/lac/cuda_sparse_matrix.h
@@ -247,8 +247,8 @@ namespace CUDAWrappers
      * the cuSPARSE matrix description.
      */
     std::tuple<Number *, int *, int *, cusparseMatDescr_t>
-    get_cusparse_matrix();
-    //@}
+    get_cusparse_matrix() const;
+    //*}
 
   private:
     /**

--- a/source/base/cuda.cu
+++ b/source/base/cuda.cu
@@ -27,6 +27,12 @@ namespace Utilities
   {
     Handle::Handle()
     {
+      cusolverStatus_t cusolver_error_code = cusolverDnCreate(&cusolver_dn_handle);
+      AssertCusolver(cusolver_error_code);
+
+      cusolver_error_code = cusolverSpCreate(&cusolver_sp_handle);
+      AssertCusolver(cusolver_error_code);
+
       cusparseStatus_t cusparse_error_code = cusparseCreate(&cusparse_handle);
       AssertCusparse(cusparse_error_code);
     }
@@ -39,6 +45,12 @@ namespace Utilities
           ::release_unused_memory();
       dealii::GrowingVectorMemory<LinearAlgebra::CUDAWrappers::Vector<double>>
           ::release_unused_memory();
+
+      cusolverStatus_t cusolver_error_code = cusolverDnDestroy(cusolver_dn_handle);
+      AssertCusolver(cusolver_error_code);
+
+      cusolver_error_code = cusolverSpDestroy(cusolver_sp_handle);
+      AssertCusolver(cusolver_error_code);
 
       cusparseStatus_t cusparse_error_code = cusparseDestroy(cusparse_handle);
       AssertCusparse(cusparse_error_code);

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -522,6 +522,48 @@ namespace deal_II_exceptions
         }
         }
     }
+
+
+
+    std::string get_cusolver_error_string(cusolverStatus_t error_code)
+    {
+      std::string message;
+      switch (error_code)
+        {
+        case CUSOLVER_STATUS_NOT_INITIALIZED:
+        {
+          return "The cuSolver library was not initialized";
+        }
+        case CUSOLVER_STATUS_ALLOC_FAILED:
+        {
+          return "Resource allocation failed inside the cuSolver library";
+        }
+        case CUSOLVER_STATUS_INVALID_VALUE:
+        {
+          return "An unsupported value of a parameter was passed to the function";
+        }
+        case CUSOLVER_STATUS_ARCH_MISMATCH:
+        {
+          return "The function requires a feature absent from the device architecture";
+        }
+        case CUSOLVER_STATUS_EXECUTION_FAILED:
+        {
+          return "The GPU program failed to execute";
+        }
+        case CUSOLVER_STATUS_INTERNAL_ERROR:
+        {
+          return "An internal cuSolver operation failed";
+        }
+        case CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
+        {
+          return "The matrix type is not supported by this function";
+        }
+        default:
+        {
+          return "Unknown error";
+        }
+        }
+    }
 #endif
 
   } /*namespace internals*/

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -146,8 +146,9 @@ ENDIF()
 IF(DEAL_II_WITH_CUDA)
   SET(_separate_src
     ${_separate_src}
-    cuda_vector.cu
+    cuda_solver_direct.cu
     cuda_sparse_matrix.cu
+    cuda_vector.cu
   )
 ENDIF()
 

--- a/source/lac/cuda_solver_direct.cu
+++ b/source/lac/cuda_solver_direct.cu
@@ -1,0 +1,352 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/lac/cuda_solver_direct.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace CUDAWrappers
+{
+  namespace internal
+  {
+    void cusparsecsr2dense(cusparseHandle_t cusparse_handle,
+                           const SparseMatrix<float> &matrix,
+                           float *dense_matrix_dev)
+    {
+      auto cusparse_matrix = matrix.get_cusparse_matrix();
+
+      cusparseStatus_t cusparse_error_code =
+        cusparseScsr2dense(
+          cusparse_handle, matrix.m(), matrix.n(),
+          std::get<3>(cusparse_matrix), std::get<0>(cusparse_matrix),
+          std::get<2>(cusparse_matrix), std::get<1>(cusparse_matrix),
+          dense_matrix_dev, matrix.m());
+      AssertCusparse(cusparse_error_code);
+    }
+
+
+
+    void cusparsecsr2dense(cusparseHandle_t cusparse_handle,
+                           const SparseMatrix<double> &matrix,
+                           double *dense_matrix_dev)
+    {
+      auto cusparse_matrix = matrix.get_cusparse_matrix();
+
+      cusparseStatus_t cusparse_error_code =
+        cusparseDcsr2dense(
+          cusparse_handle, matrix.m(), matrix.n(),
+          std::get<3>(cusparse_matrix), std::get<0>(cusparse_matrix),
+          std::get<2>(cusparse_matrix), std::get<1>(cusparse_matrix),
+          dense_matrix_dev, matrix.m());
+      AssertCusparse(cusparse_error_code);
+    }
+
+
+
+    void cusolverDngetrf_buffer_size(cusolverDnHandle_t cusolver_dn_handle, int m,
+                                     int n, float *dense_matrix_dev,
+                                     int &workspace_size)
+    {
+      cusolverStatus_t cusolver_error_code = cusolverDnSgetrf_bufferSize(
+                                               cusolver_dn_handle, m, n, dense_matrix_dev, m, &workspace_size);
+      AssertCusolver(cusolver_error_code);
+    }
+
+
+
+    void cusolverDngetrf_buffer_size(cusolverDnHandle_t cusolver_dn_handle, int m,
+                                     int n, double *dense_matrix_dev,
+                                     int &workspace_size)
+    {
+      cusolverStatus_t cusolver_error_code = cusolverDnDgetrf_bufferSize(
+                                               cusolver_dn_handle, m, n, dense_matrix_dev, m, &workspace_size);
+      AssertCusolver(cusolver_error_code);
+    }
+
+
+
+    void cusolverDngetrf(cusolverDnHandle_t cusolver_dn_handle, int m, int n,
+                         float *dense_matrix_dev, float *workspace_dev,
+                         int *pivot_dev, int *info_dev)
+    {
+      cusolverStatus_t cusolver_error_code =
+        cusolverDnSgetrf(cusolver_dn_handle, m, n, dense_matrix_dev, m,
+                         workspace_dev, pivot_dev, info_dev);
+      AssertCusolver(cusolver_error_code);
+    }
+
+
+
+    void cusolverDngetrf(cusolverDnHandle_t cusolver_dn_handle, int m, int n,
+                         double *dense_matrix_dev, double *workspace_dev,
+                         int *pivot_dev, int *info_dev)
+    {
+      cusolverStatus_t cusolver_error_code =
+        cusolverDnDgetrf(cusolver_dn_handle, m, n, dense_matrix_dev, m,
+                         workspace_dev, pivot_dev, info_dev);
+      AssertCusolver(cusolver_error_code);
+    }
+
+
+
+    void cusolverDngetrs(cusolverDnHandle_t cusolver_dn_handle, int m,
+                         float *dense_matrix_dev, int *pivot_dev, float *b,
+                         int *info_dev)
+    {
+      const int n_rhs = 1;
+      cusolverStatus_t cusolver_error_code =
+        cusolverDnSgetrs(cusolver_dn_handle, CUBLAS_OP_N, m, n_rhs,
+                         dense_matrix_dev, m, pivot_dev, b, m, info_dev);
+      AssertCusolver(cusolver_error_code);
+    }
+
+
+
+    void cusolverDngetrs(cusolverDnHandle_t cusolver_dn_handle, int m,
+                         double *dense_matrix_dev, int *pivot_dev, double *b,
+                         int *info_dev)
+    {
+      const int n_rhs = 1;
+      cusolverStatus_t cusolver_error_code =
+        cusolverDnDgetrs(cusolver_dn_handle, CUBLAS_OP_N, m, n_rhs,
+                         dense_matrix_dev, m, pivot_dev, b, m, info_dev);
+      AssertCusolver(cusolver_error_code);
+    }
+
+
+
+    void cusolverSpcsrlsvluHost(cusolverSpHandle_t cusolver_sp_handle,
+                                const unsigned int n_rows, const unsigned int nnz,
+                                cusparseMatDescr_t descr, const float *val_host,
+                                const int *row_ptr_host, const int *column_index_host,
+                                const float *b_host, float *x_host)
+    {
+      int singularity = 0;
+      cusolverStatus_t cusolver_error_code = cusolverSpScsrlsvluHost(
+                                               cusolver_sp_handle, n_rows, nnz, descr, val_host, row_ptr_host,
+                                               column_index_host, b_host, 0., 1, x_host, &singularity);
+      AssertCusolver(cusolver_error_code);
+      Assert(singularity == -1, ExcMessage("Coarse matrix is singular"));
+    }
+
+
+
+    void cusolverSpcsrlsvluHost(cusolverSpHandle_t cusolver_sp_handle,
+                                const unsigned int n_rows, unsigned int nnz,
+                                cusparseMatDescr_t descr, const double *val_host,
+                                const int *row_ptr_host, const int *column_index_host,
+                                const double *b_host, double *x_host)
+    {
+      int singularity = 0;
+      cusolverStatus_t cusolver_error_code = cusolverSpDcsrlsvluHost(
+                                               cusolver_sp_handle, n_rows, nnz, descr, val_host, row_ptr_host,
+                                               column_index_host, b_host, 0., 1, x_host, &singularity);
+      AssertCusolver(cusolver_error_code);
+      Assert(singularity == -1, ExcMessage("Coarse matrix is singular"));
+    }
+
+
+
+    void cholesky_factorization(cusolverSpHandle_t cusolver_sp_handle,
+                                const SparseMatrix<float> &matrix,
+                                const float *b, float *x)
+    {
+      auto cusparse_matrix = matrix.get_cusparse_matrix();
+      int singularity = 0;
+
+      cusolverStatus_t cusolver_error_code = cusolverSpScsrlsvchol(
+                                               cusolver_sp_handle, matrix.m(), matrix.n_nonzero_elements(),
+                                               std::get<3>(cusparse_matrix), std::get<0>(cusparse_matrix),
+                                               std::get<2>(cusparse_matrix), std::get<1>(cusparse_matrix), b, 0., 0, x,
+                                               &singularity);
+      AssertCusolver(cusolver_error_code);
+      Assert(singularity == -1, ExcMessage("Coarse matrix is not SPD"));
+    }
+
+
+
+    void cholesky_factorization(cusolverSpHandle_t cusolver_sp_handle,
+                                const SparseMatrix<double> &matrix,
+                                const double *b, double *x)
+    {
+      auto cusparse_matrix = matrix.get_cusparse_matrix();
+      int singularity = 0;
+
+      cusolverStatus_t cusolver_error_code = cusolverSpDcsrlsvchol(
+                                               cusolver_sp_handle, matrix.m(), matrix.n_nonzero_elements(),
+                                               std::get<3>(cusparse_matrix), std::get<0>(cusparse_matrix),
+                                               std::get<2>(cusparse_matrix), std::get<1>(cusparse_matrix), b, 0., 0, x,
+                                               &singularity);
+      AssertCusolver(cusolver_error_code);
+      Assert(singularity == -1, ExcMessage("Coarse matrix is not SPD"));
+    }
+
+
+
+    template <typename Number>
+    void lu_factorization(cusparseHandle_t cusparse_handle,
+                          cusolverDnHandle_t cusolver_dn_handle,
+                          const SparseMatrix<Number> &matrix,
+                          const Number *b_dev, Number *x_dev)
+    {
+      // Change the format of the matrix from sparse to dense
+      unsigned int const m = matrix.m();
+      unsigned int const n = matrix.n();
+      Assert(m == n, ExcMessage("The matrix is not square"));
+      Number *dense_matrix_dev;
+      Utilities::CUDA::malloc(dense_matrix_dev, m * n);
+
+      // Change the format of matrix to dense
+      internal::cusparsecsr2dense(cusparse_handle, matrix, dense_matrix_dev);
+
+      // Create the working space
+      int workspace_size = 0;
+      internal::cusolverDngetrf_buffer_size(cusolver_dn_handle, m, n,
+                                            dense_matrix_dev, workspace_size);
+      Assert(workspace_size > 0, ExcMessage("No workspace was allocated"));
+      Number *workspace_dev;
+      Utilities::CUDA::malloc(workspace_dev, workspace_size);
+
+      // LU factorization
+      int *pivot_dev;
+      Utilities::CUDA::malloc(pivot_dev, m);
+      int *info_dev;
+      Utilities::CUDA::malloc(info_dev, 1);
+
+      internal::cusolverDngetrf(cusolver_dn_handle, m, n, dense_matrix_dev,
+                                workspace_dev, pivot_dev, info_dev);
+
+#ifdef DEBUG
+      int info = 0;
+      cudaError_t cuda_error_code_debug =
+        cudaMemcpy(&info, info_dev, sizeof(int), cudaMemcpyDeviceToHost);
+      AssertCuda(cuda_error_code_debug);
+      Assert(info == 0, ExcMessage("There was a problem during the LU factorization"));
+#endif
+
+      // Solve Ax = b
+      cudaError_t cuda_error_code = cudaMemcpy(x_dev, b_dev, m * sizeof(Number),
+                                               cudaMemcpyDeviceToDevice);
+      AssertCuda(cuda_error_code);
+      internal::cusolverDngetrs(cusolver_dn_handle, m, dense_matrix_dev, pivot_dev,
+                                x_dev, info_dev);
+#ifdef DEBUG
+      cuda_error_code =
+        cudaMemcpy(&info, info_dev, sizeof(int), cudaMemcpyDeviceToHost);
+      AssertCuda(cuda_error_code);
+      Assert(info == 0, ExcMessage("There was a problem during the LU solve"));
+#endif
+
+      // Free the memory allocated
+      Utilities::CUDA::free(dense_matrix_dev);
+      Utilities::CUDA::free(workspace_dev);
+      Utilities::CUDA::free(pivot_dev);
+      Utilities::CUDA::free(info_dev);
+    }
+
+
+
+    template <typename Number>
+    void lu_factorization(cusolverSpHandle_t cusolver_sp_handle,
+                          const SparseMatrix<Number> &matrix,
+                          const Number *b_dev, Number *x_dev)
+    {
+      // cuSOLVER does not support LU factorization of sparse matrix on the device,
+      // so we need to move everything to the host first and then back to the host.
+      const unsigned int nnz = matrix.n_nonzero_elements();
+      const unsigned int n_rows = matrix.m();
+      std::vector<Number> val_host(nnz);
+      std::vector<int> column_index_host(nnz);
+      std::vector<int> row_ptr_host(n_rows + 1);
+      auto cusparse_matrix = matrix.get_cusparse_matrix();
+      Utilities::CUDA::copy_to_host(std::get<0>(cusparse_matrix), val_host);
+      Utilities::CUDA::copy_to_host(std::get<1>(cusparse_matrix), column_index_host);
+      Utilities::CUDA::copy_to_host(std::get<2>(cusparse_matrix), row_ptr_host);
+      std::vector<Number> b_host(n_rows);
+      Utilities::CUDA::copy_to_host(b_dev, b_host);
+      std::vector<Number> x_host(n_rows);
+      Utilities::CUDA::copy_to_host(x_dev, x_host);
+
+      internal::cusolverSpcsrlsvluHost(
+        cusolver_sp_handle, n_rows, nnz, std::get<3>(cusparse_matrix), val_host.data(),
+        row_ptr_host.data(), column_index_host.data(), b_host.data(),
+        x_host.data());
+
+      // Move the solution back to the device
+      Utilities::CUDA::copy_to_dev(x_host, x_dev);
+    }
+  }
+
+
+
+  template <typename Number>
+  SolverDirect<Number>::AdditionalData::
+  AdditionalData(const std::string &solver_type)
+    :
+    solver_type(solver_type)
+  {}
+
+
+
+  template <typename Number>
+  SolverDirect<Number>::SolverDirect(const Utilities::CUDA::Handle &handle,
+                                     SolverControl  &cn,
+                                     const AdditionalData &data)
+    :
+    cuda_handle(handle),
+    solver_control(cn),
+    additional_data(data.solver_type)
+  {}
+
+
+
+  template <typename Number>
+  SolverControl &SolverDirect<Number>::control() const
+  {
+    return solver_control;
+  }
+
+
+
+  template <typename Number>
+  void SolverDirect<Number>::solve(const SparseMatrix<Number> &A,
+                                   LinearAlgebra::CUDAWrappers::Vector<Number> &x,
+                                   const LinearAlgebra::CUDAWrappers::Vector<Number> &b)
+  {
+    if (additional_data.solver_type == "Cholesky")
+      internal::cholesky_factorization(cuda_handle.cusolver_sp_handle, A,
+                                       b.get_values(), x.get_values());
+    else if (additional_data.solver_type == "LU_dense")
+      internal::lu_factorization(cuda_handle.cusparse_handle,
+                                 cuda_handle.cusolver_dn_handle, A,
+                                 b.get_values(), x.get_values());
+    else if (additional_data.solver_type == "LU_host")
+      internal::lu_factorization(cuda_handle.cusolver_sp_handle, A,
+                                 b.get_values(), x.get_values());
+    else
+      AssertThrow(false, ExcMessage("The provided solver name " +
+                                    additional_data.solver_type + " is invalid."));
+
+    // Force the SolverControl object to report convergence
+    solver_control.check(0, 0);
+  }
+
+
+  // Explicit Instanationation
+  template class SolverDirect<float>;
+  template class SolverDirect<double>;
+}
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/cuda_sparse_matrix.cu
+++ b/source/lac/cuda_sparse_matrix.cu
@@ -52,11 +52,11 @@ namespace CUDAWrappers
                                                CUSPARSE_OPERATION_TRANSPOSE :
                                                CUSPARSE_OPERATION_NON_TRANSPOSE;
 
-      cusparseStatus_t error_code;
       // This function performs y = alpha*op(A)*x + beta*y
-      error_code = cusparseScsrmv(handle, cusparse_operation, m, n, nnz,
-                                  &alpha, descr, A_val_dev, A_row_ptr_dev,
-                                  A_column_index_dev, x, &beta, y);
+      cusparseStatus_t error_code = cusparseScsrmv(handle, cusparse_operation,
+                                                   m, n, nnz, &alpha, descr,
+                                                   A_val_dev, A_row_ptr_dev,
+                                                   A_column_index_dev, x, &beta, y);
       AssertCusparse(error_code);
     }
 
@@ -73,11 +73,11 @@ namespace CUDAWrappers
                                                CUSPARSE_OPERATION_TRANSPOSE :
                                                CUSPARSE_OPERATION_NON_TRANSPOSE;
 
-      cusparseStatus_t error_code;
       // This function performs y = alpha*op(A)*x + beta*y
-      error_code = cusparseDcsrmv(handle, cusparse_operation, m, n, nnz,
-                                  &alpha, descr, A_val_dev, A_row_ptr_dev,
-                                  A_column_index_dev, x, &beta, y);
+      cusparseStatus_t error_code = cusparseDcsrmv(handle, cusparse_operation,
+                                                   m, n, nnz, &alpha, descr,
+                                                   A_val_dev, A_row_ptr_dev,
+                                                   A_column_index_dev, x, &beta, y);
       AssertCusparse(error_code);
     }
 
@@ -452,7 +452,7 @@ namespace CUDAWrappers
 
   template <typename Number>
   std::tuple<Number *, int *, int *, cusparseMatDescr_t>
-  SparseMatrix<Number>::get_cusparse_matrix()
+  SparseMatrix<Number>::get_cusparse_matrix() const
   {
     return std::make_tuple(val_dev, column_index_dev, row_ptr_dev, descr);
   }

--- a/tests/cuda/solver_01.cu
+++ b/tests/cuda/solver_01.cu
@@ -75,8 +75,6 @@ int main()
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 
-  GrowingVectorMemory<LinearAlgebra::CUDAWrappers::Vector<double>>::release_unused_memory();
-
   deallog << "OK" <<std::endl;
 
   return 0;

--- a/tests/cuda/solver_02.cu
+++ b/tests/cuda/solver_02.cu
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Check that CUDA direct solvers work
+
+#include "../tests.h"
+#include "../testmatrix.h"
+
+#include <deal.II/base/cuda.h>
+#include <deal.II/lac/cuda_solver_direct.h>
+#include <deal.II/lac/cuda_sparse_matrix.h>
+#include <deal.II/lac/cuda_vector.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/vector.h>
+
+
+void test(Utilities::CUDA::Handle &cuda_handle)
+{
+  // Create the matrix on the host.
+  dealii::SparsityPattern sparsity_pattern;
+  dealii::SparseMatrix<double> matrix;
+  unsigned int const size = 30;
+  std::vector<std::vector<unsigned int>> column_indices(size);
+  for (unsigned int i = 0; i < size; ++i)
+    {
+      unsigned int j_max = std::min(size, i + 2);
+      unsigned int j_min = (i == 0) ? 0 : i - 1;
+      for (unsigned int j = j_min; j < j_max; ++j)
+        column_indices[i].emplace_back(j);
+    }
+  sparsity_pattern.copy_from(size, size, column_indices.begin(),
+                             column_indices.end());
+  matrix.reinit(sparsity_pattern);
+  for (unsigned int i = 0; i < size; ++i)
+    {
+      unsigned int j_max = std::min(size - 1, i + 1);
+      unsigned int j_min = (i == 0) ? 0 : i - 1;
+      matrix.set(i, j_min, -1.);
+      matrix.set(i, j_max, -1.);
+      matrix.set(i, i, 4.);
+    }
+
+  // Generate a random solution and then compute the rhs
+  dealii::Vector<double> sol_ref(size);
+  std::default_random_engine generator;
+  std::normal_distribution<> distribution(10., 2.);
+  for (auto &val : sol_ref)
+    val = distribution(generator);
+
+  dealii::Vector<double> rhs(size);
+  matrix.vmult(rhs, sol_ref);
+
+  // Move the matrix and the rhs to the host
+  CUDAWrappers::SparseMatrix<double> matrix_dev(cuda_handle, matrix);
+
+  LinearAlgebra::CUDAWrappers::Vector<double> rhs_dev(size);
+  LinearAlgebra::ReadWriteVector<double> rhs_host(size);
+  std::copy(rhs.begin(), rhs.end(), rhs_host.begin());
+  rhs_dev.import(rhs_host, VectorOperation::insert);
+
+  LinearAlgebra::CUDAWrappers::Vector<double> solution_dev(size);
+
+  for (auto solver_type: {"Cholesky", "LU_dense", "LU_host"})
+    {
+      // Solve on the device
+      CUDAWrappers::SolverDirect<double>::AdditionalData data(solver_type);
+      SolverControl solver_control;
+
+      CUDAWrappers::SolverDirect<double> solver(cuda_handle, solver_control,
+                                                data);
+      solver.solve(matrix_dev, solution_dev, rhs_dev);
+
+      // Move the result back to the host
+      LinearAlgebra::ReadWriteVector<double> solution_host(size);
+      solution_host.import(solution_dev, VectorOperation::insert);
+
+      // Check the result
+      for (unsigned int i = 0; i < size; ++i)
+        AssertThrow(std::abs(solution_host[i] - sol_ref[i]) < 1e-12,
+                    ExcInternalError());
+      std::cout<<solver_type<<std::endl;
+    }
+}
+
+int main()
+{
+  initlog();
+  deallog.depth_console(0);
+
+  Utilities::CUDA::Handle cuda_handle;
+  test(cuda_handle);
+
+  deallog << "OK" <<std::endl;
+
+  return 0;
+}

--- a/tests/cuda/solver_02.output
+++ b/tests/cuda/solver_02.output
@@ -1,0 +1,8 @@
+
+DEAL::Starting value 0.00000
+DEAL::Convergence step 0 value 0.00000
+DEAL::Starting value 0.00000
+DEAL::Convergence step 0 value 0.00000
+DEAL:cg::Starting value 0.000
+DEAL::Convergence step 0 value 0.00000
+DEAL:cg::Starting value 0.000


### PR DESCRIPTION
This adds direct solvers on the GPUs. There is a lot of code which at first looks duplicated but it's only because the functions in `cusolver` have a slightly different name for `float` and `double`. 

@tamiko can you take a look at the (horrible) change I've made to `cmake/modules/FindCUDA.cmake` This actually kinda works but for one of the solver I get this error: `undefined symbol: omp_get_max_thread` which it's probably due to the way I've added OpenMP. If what I did looks alright, I will just remove the failing solver since the two others work fine.