### PR TITLE
CMake: Ensure to be compatible with version 3.11 FindBlas.cmake

### DIFF
--- a/cmake/modules/FindLAPACK.cmake
+++ b/cmake/modules/FindLAPACK.cmake
@@ -67,6 +67,15 @@ IF(DEFINED LAPACK_LIBRARIES)
 ENDIF()
 
 #
+# Work around a bug in CMake 3.11 by simply filtering out out
+# "PkgConf::PKGC_BLAS". See bug
+#   https://gitlab.kitware.com/cmake/cmake/issues/17934
+#
+IF(DEFINED BLAS_LIBRARIES)
+  LIST(REMOVE_ITEM BLAS_LIBRARIES "PkgConfig::PKGC_BLAS")
+ENDIF()
+
+#
 # Well, in case of static archives we have to manually pick up the
 # complete link interface. *sigh*
 #


### PR DESCRIPTION
We have to work around some upstream changes [1] that break our project
configuration. Let's simply filter out the "PkgConfig::PKGC_BLAS" string
and hope for the best.

[1] https://gitlab.kitware.com/cmake/cmake/issues/17934