### PR TITLE
enable ROL in doxygen

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -192,6 +192,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_WITH_SUNDIALS=1 \
                          DEAL_II_WITH_THREADS=1 \
                          DEAL_II_WITH_TRILINOS=1 \
+                         DEAL_II_TRILINOS_WITH_ROL=1 \
                          DEAL_II_WITH_UMFPACK=1 \
                          DEAL_II_WITH_ZLIB=1 \
                          DEAL_II_NAMESPACE_OPEN= \


### PR DESCRIPTION
otherwise rol namespace will not be in the documentation