### PR TITLE
Add Codecov support

### DIFF
--- a/contrib/utilities/download_codecov_bash.sh
+++ b/contrib/utilities/download_codecov_bash.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2018 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+#
+# This script downloads the global coverage report uploader for Codecov.
+# If you are running the testsuite to create coverage information and
+# the codecov uploader is present, there is also a report uploaded to
+# https://codecov.io/gh/dealii/dealii.
+#
+
+PRG="$(cd "$(dirname "$0")" && pwd)/programs"
+CODECOV_PATH="${PRG}/codecov"
+
+if [ ! -d "$PRG" ]
+then
+    echo "create folder $PRG"
+    mkdir "$PRG"
+fi
+
+# codecov
+if [ ! -d "$CODECOV_PATH" ]
+then
+    echo "Downloading codecov-bash."
+    mkdir "$CODECOV_PATH"
+    curl -s "https://codecov.io/bash" > $CODECOV_PATH/codecov-bash.sh
+fi

--- a/doc/developers/testsuite.html
+++ b/doc/developers/testsuite.html
@@ -373,6 +373,11 @@ ctest <...> -S ../tests/run_coverage.cmake
       "Coverage" at the
       <a href="http://cdash.kyomu.43-1.org/index.php?project=deal.II&display=project"
       target="_top">deal.II cdash site</a>.
+      In case you download the coverage report uploader for Codecov via
+      <code>contrib/utilities/download_codecov_bash.sh</code>, the coverage
+      report will also be uploaded to the
+      <a href="https://codecov.io/gh/dealii/dealii"
+      target="_top">Codecov dashboard</a>.
     </p>
 
 

--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -412,13 +412,20 @@ COVERAGE=TRUE.
       )
   ENDIF()
 
-  FIND_PROGRAM(GCOV_COMMAND NAMES gcov)
-  IF(GCOV_COMMAND MATCHES "-NOTFOUND")
-    MESSAGE(FATAL_ERROR "
-Coverage enabled but could not find the gcov executable. Please install
-gcov, which is part of the GNU Compiler Collection.
-"
-      )
+  IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    FIND_PROGRAM(GCOV_COMMAND NAMES llvm-cov)
+    SET(GCOV_COMMAND "${GCOV_COMMAND} gcov")
+    IF(GCOV_COMMAND MATCHES "-NOTFOUND")
+      MESSAGE(FATAL_ERROR "Coverage enabled but could not find the
+                           llvm-cov executable, which is part of LLVM.")
+    ENDIF()
+  ELSE()
+    FIND_PROGRAM(GCOV_COMMAND NAMES gcov)
+    IF(GCOV_COMMAND MATCHES "-NOTFOUND")
+      MESSAGE(FATAL_ERROR "Coverage enabled but could not find the
+                           gcov executable, which is part of the
+                           GNU Compiler Collection.")
+    ENDIF()
   ENDIF()
 
   SET(CTEST_COVERAGE_COMMAND "${GCOV_COMMAND}")
@@ -540,7 +547,10 @@ IF("${_res}" STREQUAL "0")
     IF(COVERAGE)
       CREATE_TARGETDIRECTORIES_TXT()
       MESSAGE("-- Running CTEST_COVERAGE()")
-      CTEST_COVERAGE()
+      #CTEST_COVERAGE()
+      FILE(DOWNLOAD "https://codecov.io/bash" "${CMAKE_CURRENT_BINARY_DIR}/tests/codecov-bash")
+      EXECUTE_PROCESS(COMMAND bash "${CMAKE_CURRENT_BINARY_DIR}/tests/codecov-bash"
+                              "-t ac85e7ce-5316-4bc1-a237-2fe724028c7b" "-x '${GCOV_COMMAND}'")
       CLEAR_TARGETDIRECTORIES_TXT()
     ENDIF(COVERAGE)
 
@@ -583,4 +593,4 @@ IF("${_res}" STREQUAL "0")
   MESSAGE("-- Submission successful. Goodbye!")
 ENDIF()
 
-# .oO( This script is freaky 584 lines long... )
+# .oO( This script is freaky 596 lines long... )

--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -547,10 +547,14 @@ IF("${_res}" STREQUAL "0")
     IF(COVERAGE)
       CREATE_TARGETDIRECTORIES_TXT()
       MESSAGE("-- Running CTEST_COVERAGE()")
-      #CTEST_COVERAGE()
-      FILE(DOWNLOAD "https://codecov.io/bash" "${CMAKE_CURRENT_BINARY_DIR}/tests/codecov-bash")
-      EXECUTE_PROCESS(COMMAND bash "${CMAKE_CURRENT_BINARY_DIR}/tests/codecov-bash"
-                              "-t ac85e7ce-5316-4bc1-a237-2fe724028c7b" "-x '${GCOV_COMMAND}'")
+      CTEST_COVERAGE()
+      SET (CODE_COV_BASH "${CMAKE_CURRENT_LIST_DIR}/../contrib/utilities/programs/codecov/codecov-bash.sh")
+      IF (EXISTS ${CODE_COV_BASH})
+        MESSAGE("-- Running codecov-bash")
+        EXECUTE_PROCESS(COMMAND bash "${CODE_COV_BASH}"
+                                     "-t ac85e7ce-5316-4bc1-a237-2fe724028c7b" "-x '${GCOV_COMMAND}'"
+                        OUTPUT_QUIET)
+      ENDIF()
       CLEAR_TARGETDIRECTORIES_TXT()
     ENDIF(COVERAGE)
 
@@ -593,4 +597,4 @@ IF("${_res}" STREQUAL "0")
   MESSAGE("-- Submission successful. Goodbye!")
 ENDIF()
 
-# .oO( This script is freaky 596 lines long... )
+# .oO( This script is freaky 600 lines long... )


### PR DESCRIPTION
When running the testsuite witch checking for coverage also report to [Codecov](https://codecov.io/gh/dealii/dealii) which also allows for merging reports for a single commit and has a much nicer interface compared to the one provided by `CDash`.
