### PR TITLE
Fix warning about missing return statement in ICC

### DIFF
--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1133,6 +1133,8 @@ namespace internal
           return 0;
         else
           Assert(false, ExcNotImplemented("Not possible in dim=" + std::to_string(dim)));
+
+        return numbers::invalid_unsigned_int;
       }
 
 


### PR DESCRIPTION
This was introduced in #6210.

The return statement for `dim` not `1, 2, 3` should not be reached, but we must still return a value.