### PR TITLE
Check own subscriptions when assigning in Subscriptor

### DIFF
--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -129,6 +129,7 @@ void Subscriptor::check_no_subscribers () const
 
 Subscriptor &Subscriptor::operator = (const Subscriptor &s)
 {
+  check_no_subscribers();
   object_info = s.object_info;
   return *this;
 }
@@ -137,6 +138,7 @@ Subscriptor &Subscriptor::operator = (const Subscriptor &s)
 
 Subscriptor &Subscriptor::operator = (Subscriptor &&s) noexcept
 {
+  check_no_subscribers();
   s.check_no_subscribers();
   object_info = s.object_info;
   return *this;

--- a/tests/base/assign_subscriptor.cc
+++ b/tests/base/assign_subscriptor.cc
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that Subscriptor objects need to be empty before assigning.
+
+
+#include "../tests.h"
+#include <deal.II/base/subscriptor.h>
+#include <deal.II/base/smartpointer.h>
+#include <iostream>
+#include <vector>
+
+class Test : public Subscriptor
+{};
+
+int main()
+{
+  deal_II_exceptions::disable_abort_on_exception();
+
+  initlog();
+
+  // should work
+  {
+    Subscriptor subscriptor_1;
+    Subscriptor subscriptor_2;
+
+    SmartPointer<Subscriptor> smart (&subscriptor_1);
+
+    subscriptor_2 = subscriptor_1;
+  }
+
+  try
+    {
+      Subscriptor subscriptor_1;
+      Subscriptor subscriptor_2;
+
+      SmartPointer<Subscriptor> smart (&subscriptor_2);
+
+      subscriptor_2 = subscriptor_1;
+    }
+  catch (ExceptionBase &e)
+    {
+      deallog << e.get_exc_name() << std::endl;
+    }
+
+  try
+    {
+      Subscriptor subscriptor_1;
+      Subscriptor subscriptor_2;
+
+      SmartPointer<Subscriptor> smart (&subscriptor_1);
+
+      subscriptor_2 = std::move(subscriptor_1);
+    }
+  catch (ExceptionBase &e)
+    {
+      deallog << e.get_exc_name() << std::endl;
+    }
+
+  try
+    {
+      Subscriptor subscriptor_1;
+      Subscriptor subscriptor_2;
+
+      SmartPointer<Subscriptor> smart (&subscriptor_2);
+
+      subscriptor_2 = std::move(subscriptor_1);
+    }
+  catch (ExceptionBase &e)
+    {
+      deallog << e.get_exc_name() << std::endl;
+    }
+}
+

--- a/tests/base/assign_subscriptor.output
+++ b/tests/base/assign_subscriptor.output
@@ -1,0 +1,34 @@
+
+DEAL::Exception: ExcInUse (counter, object_info->name(), infostring)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <subscriptor.cc> in function
+    void dealii::Subscriptor::check_no_subscribers() const
+The violated condition was: 
+    counter == 0
+Additional information: 
+    (none)
+--------------------------------------------------------
+
+DEAL::Exception: ExcInUse (counter, object_info->name(), infostring)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <subscriptor.cc> in function
+    void dealii::Subscriptor::check_no_subscribers() const
+The violated condition was: 
+    counter == 0
+Additional information: 
+    (none)
+--------------------------------------------------------
+
+DEAL::Exception: ExcInUse (counter, object_info->name(), infostring)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <subscriptor.cc> in function
+    void dealii::Subscriptor::check_no_subscribers() const
+The violated condition was: 
+    counter == 0
+Additional information: 
+    (none)
+--------------------------------------------------------
+


### PR DESCRIPTION
While working on #6330, I noticed that I wasn't warned when using a move constructor that the current (moved to) object is used. We should check that this is not the case.