### PR TITLE
Bugfix: Close #ifdef at the right point

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -507,10 +507,10 @@ namespace internal
       return 0;
     }
 
+#endif  // ifndef DOXYGEN
+
   } // end of namespace MatrixFreeFunctions
 } // end of namespace internal
-
-#endif  // ifndef DOXYGEN
 
 DEAL_II_NAMESPACE_CLOSE
 


### PR DESCRIPTION
This was found by cppcheck that rightfully complains about the #endif
statement closing at the wrong position.