### PR TITLE
License header updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ License as published by the Free Software Foundation; either version
 The full text of the GNU Lesser General Public version 2.1 is quoted
 below.
 
-The subdirectories "bundled/" and "contrib/" contain third party software.
+The subdirectory "bundled/" contains third party software.
 PLEASE NOTE THAT THE SOFTWARE THERE IS COPYRIGHTED BY OTHERS THAN THE
 deal.II AUTHORS, but is included by permission. For details, consult the
 stated licenses there.

--- a/contrib/python-bindings/include/cell_accessor_wrapper.h
+++ b/contrib/python-bindings/include/cell_accessor_wrapper.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/contrib/python-bindings/include/point_wrapper.h
+++ b/contrib/python-bindings/include/point_wrapper.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/contrib/python-bindings/source/export_cell_accessor.cc
+++ b/contrib/python-bindings/source/export_cell_accessor.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/contrib/python-bindings/source/export_point.cc
+++ b/contrib/python-bindings/source/export_point.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/contrib/python-bindings/source/point_wrapper.cc
+++ b/contrib/python-bindings/source/point_wrapper.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/contrib/python-bindings/source/wrappers.cc
+++ b/contrib/python-bindings/source/wrappers.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/contrib/python-bindings/tests/point_wrapper.py
+++ b/contrib/python-bindings/tests/point_wrapper.py
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------
 #
-# Copyright (C) 2016 by the deal.II authors
+# Copyright (C) 2016 - 2017 by the deal.II authors
 #
 # This file is part of the deal.II library.
 #

--- a/contrib/python-bindings/tests/triangulation_wrapper.py
+++ b/contrib/python-bindings/tests/triangulation_wrapper.py
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------
 #
-# Copyright (C) 2016 by the deal.II authors
+# Copyright (C) 2016 - 2017 by the deal.II authors
 #
 # This file is part of the deal.II library.
 #

--- a/contrib/utilities/dotgdbinit.py
+++ b/contrib/utilities/dotgdbinit.py
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------
 #
-# Copyright (C) 2015 by the deal.II authors
+# Copyright (C) 2015 - 2017 by the deal.II authors
 #
 # This file is part of the deal.II library.
 #

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013, 2015, 2016 by the deal.II authors
+## Copyright (C) 2012 - 2018 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/contrib/utilities/makeofflinedoc.sh
+++ b/contrib/utilities/makeofflinedoc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2018 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/contrib/utilities/update-copyright
+++ b/contrib/utilities/update-copyright
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2015, 2016 by the deal.II authors
+## Copyright (C) 2015 - 2018 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -25,15 +25,23 @@ if test ! -d source -o ! -d include -o ! -d examples ; then
 fi
 
 
-files="`echo include/deal.II/*/*h \
-             source/*/*cc \
-             source/*/*in \
-             examples/*/*.cc`
-       `find cmake/ | egrep '\.(cmake|in|cc)$'`
-       `find . -name CMakeLists.txt`
-       `find tests/ | egrep '\.(h|cc)$'`
-       `find doc/ | egrep '\.html$'`
-       "
+files="
+  $(echo contrib/*/*.{py,sh} \
+         contrib/python-bindings/CMakeLists.txt \
+         contrib/python-bindings/*/*.{h,cc,py} \
+         contrib/utilities/{update-copyright,indent} \
+         doc/doxygen/*/*.{h,h.in} \
+         doc/doxygen/scripts/{create_anchors,filter,intro2toc,program*,*.pl} \
+         doc/screen.css \
+         examples/*/*.cc \
+         include/deal.II/*/*h \
+         source/*/*.{cc,in})
+  $(find cmake/ | egrep '\.(cmake|in|cc)$')
+  $(find . -name CMakeLists.txt)
+  $(find tests/ | egrep '\.(h|cc)$')
+  $(find doc/ | egrep '\.html$')
+"
+
 
 for i in $files ; do
   # get the last year this file was modified from the git log.

--- a/contrib/utilities/wrapcomments.py
+++ b/contrib/utilities/wrapcomments.py
@@ -2,7 +2,7 @@
 
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2016 by the deal.II authors
+## Copyright (C) 2016 - 2018 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/headers/boundary.h
+++ b/doc/doxygen/headers/boundary.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/c++11.h
+++ b/doc/doxygen/headers/c++11.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014, 2015 by the deal.II authors
+// Copyright (C) 2014 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/coding_conventions.h
+++ b/doc/doxygen/headers/coding_conventions.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2016 by the deal.II authors
+// Copyright (C) 1998 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/concepts.h
+++ b/doc/doxygen/headers/concepts.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 by the deal.II authors
+// Copyright (C) 2015 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/constraints.h
+++ b/doc/doxygen/headers/constraints.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2015 by the deal.II authors
+// Copyright (C) 2010 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/distributed.h
+++ b/doc/doxygen/headers/distributed.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2016 by the deal.II authors
+// Copyright (C) 2009 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/dofs.h
+++ b/doc/doxygen/headers/dofs.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/fe.h
+++ b/doc/doxygen/headers/fe.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2013 by the deal.II authors
+// Copyright (C) 2003 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/fe_vs_mapping_vs_fevalues.h
+++ b/doc/doxygen/headers/fe_vs_mapping_vs_fevalues.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 by the deal.II authors
+// Copyright (C) 2015 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/functions.h
+++ b/doc/doxygen/headers/functions.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2013 by the deal.II authors
+// Copyright (C) 2006 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/geodynamics.h
+++ b/doc/doxygen/headers/geodynamics.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2013 by the deal.II authors
+// Copyright (C) 2009 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/geometry_and_primitives.h
+++ b/doc/doxygen/headers/geometry_and_primitives.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2013 by the deal.II authors
+// Copyright (C) 2006 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/global_dof_index.h
+++ b/doc/doxygen/headers/global_dof_index.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 by the deal.II authors
+// Copyright (C) 2013 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2016 by the deal.II authors
+// Copyright (C) 2005 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/grid.h
+++ b/doc/doxygen/headers/grid.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2013 by the deal.II authors
+// Copyright (C) 2003 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/hp.h
+++ b/doc/doxygen/headers/hp.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2013 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/instantiations.h
+++ b/doc/doxygen/headers/instantiations.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2013 by the deal.II authors
+// Copyright (C) 2005 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/integrators.h
+++ b/doc/doxygen/headers/integrators.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2013 by the deal.II authors
+// Copyright (C) 2010 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/io.h
+++ b/doc/doxygen/headers/io.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2013 by the deal.II authors
+// Copyright (C) 2005 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/iterators.h
+++ b/doc/doxygen/headers/iterators.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013, 2015 by the deal.II authors
+// Copyright (C) 2013 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/laoperators.h
+++ b/doc/doxygen/headers/laoperators.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 by the deal.II authors
+// Copyright (C) 2015 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/main.h
+++ b/doc/doxygen/headers/main.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2014 by the deal.II authors
+// Copyright (C) 2006 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/manifold.h
+++ b/doc/doxygen/headers/manifold.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/matrices.h
+++ b/doc/doxygen/headers/matrices.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2013, 2015 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/mesh_worker.h
+++ b/doc/doxygen/headers/mesh_worker.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2013 by the deal.II authors
+// Copyright (C) 2010 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/mg.h
+++ b/doc/doxygen/headers/mg.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2013 by the deal.II authors
+// Copyright (C) 2003 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/multithreading.h
+++ b/doc/doxygen/headers/multithreading.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/namespace_dealii.h
+++ b/doc/doxygen/headers/namespace_dealii.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 by the deal.II authors
+// Copyright (C) 2013 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/parallel.h
+++ b/doc/doxygen/headers/parallel.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2013 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/petsc.h
+++ b/doc/doxygen/headers/petsc.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2013 by the deal.II authors
+// Copyright (C) 2003 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/physics.h
+++ b/doc/doxygen/headers/physics.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/polynomials.h
+++ b/doc/doxygen/headers/polynomials.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2013 by the deal.II authors
+// Copyright (C) 2005 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/quadrature.h
+++ b/doc/doxygen/headers/quadrature.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2013 by the deal.II authors
+// Copyright (C) 2005 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/slepc.h
+++ b/doc/doxygen/headers/slepc.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2011 - 2013 by the deal.II authors
+// Copyright (C) 2011 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/solvers.h
+++ b/doc/doxygen/headers/solvers.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2013 by the deal.II authors
+// Copyright (C) 2003 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/trilinos.h
+++ b/doc/doxygen/headers/trilinos.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2013 by the deal.II authors
+// Copyright (C) 2008 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/utilities.h
+++ b/doc/doxygen/headers/utilities.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2013 by the deal.II authors
+// Copyright (C) 2006 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/vector_memory.h
+++ b/doc/doxygen/headers/vector_memory.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2013 by the deal.II authors
+// Copyright (C) 2003 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/vector_valued.h
+++ b/doc/doxygen/headers/vector_valued.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2014 by the deal.II authors
+// Copyright (C) 2008 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/scripts/code-gallery.pl
+++ b/doc/doxygen/scripts/code-gallery.pl
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2016 by the deal.II authors
+## Copyright (C) 2016 - 2018 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/scripts/create_anchors
+++ b/doc/doxygen/scripts/create_anchors
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2007 - 2013 by the deal.II authors
+## Copyright (C) 2007 - 2014 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/scripts/filter
+++ b/doc/doxygen/scripts/filter
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2007 - 2014, 2016 by the deal.II authors
+## Copyright (C) 2007 - 2018 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/scripts/intro2toc
+++ b/doc/doxygen/scripts/intro2toc
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2006 - 2013 by the deal.II authors
+## Copyright (C) 2006 - 2014 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2013, 2015, 2016 by the deal.II authors
+## Copyright (C) 2013 - 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/scripts/make_step.pl
+++ b/doc/doxygen/scripts/make_step.pl
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2013, 2016 by the deal.II authors
+## Copyright (C) 2013 - 2018 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/scripts/program2doxyplain
+++ b/doc/doxygen/scripts/program2doxyplain
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2006 - 2013, 2015 by the deal.II authors
+## Copyright (C) 2006 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/scripts/program2html
+++ b/doc/doxygen/scripts/program2html
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2006 - 2013 by the deal.II authors
+## Copyright (C) 2006 - 2014 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/scripts/program2plain
+++ b/doc/doxygen/scripts/program2plain
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2010 - 2013 by the deal.II authors
+## Copyright (C) 2010 - 2014 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/scripts/program2toc
+++ b/doc/doxygen/scripts/program2toc
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2006 - 2013 by the deal.II authors
+## Copyright (C) 2006 - 2014 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/scripts/validate-xrefs.pl
+++ b/doc/doxygen/scripts/validate-xrefs.pl
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2006 - 2013 by the deal.II authors
+## Copyright (C) 2006 - 2014 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/doxygen/tutorial/tutorial.h.in
+++ b/doc/doxygen/tutorial/tutorial.h.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2016 by the deal.II authors
+// Copyright (C) 2005 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/examples/step-10/step-10.cc
+++ b/examples/step-10/step-10.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2001 - 2017 by the deal.II authors
+ * Copyright (C) 2001 - 2018 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *

--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2001 - 2017 by the deal.II authors
+ * Copyright (C) 2001 - 2018 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *

--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2012 - 2017 by the deal.II authors
+ * Copyright (C) 2012 - 2018 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2017 by the deal.II authors
+// Copyright (C) 2003 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2011 - 2017 by the deal.II authors
+// Copyright (C) 2011 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/fail/arclength_boundary_02.cc
+++ b/tests/fail/arclength_boundary_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/manifold/composition_manifold_01.cc
+++ b/tests/manifold/composition_manifold_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/manifold/composition_manifold_02.cc
+++ b/tests/manifold/composition_manifold_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/manifold/composition_manifold_03.cc
+++ b/tests/manifold/composition_manifold_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/manifold/composition_manifold_04.cc
+++ b/tests/manifold/composition_manifold_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/manifold/flat_manifold_05.cc
+++ b/tests/manifold/flat_manifold_05.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/manifold/flat_manifold_06.cc
+++ b/tests/manifold/flat_manifold_06.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/matrix_free/fe_evaluation_access_1d.cc
+++ b/tests/matrix_free/fe_evaluation_access_1d.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/arclength_boundary_01.cc
+++ b/tests/opencascade/arclength_boundary_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/arclength_boundary_from_iges_01.cc
+++ b/tests/opencascade/arclength_boundary_from_iges_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/arclength_boundary_from_step_01.cc
+++ b/tests/opencascade/arclength_boundary_from_step_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/axis_boundary_02.cc
+++ b/tests/opencascade/axis_boundary_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/create_tria_02.cc
+++ b/tests/opencascade/create_tria_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 by the deal.II authors
+// Copyright (C) 2017 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/create_tria_02.cc
+++ b/tests/opencascade/create_tria_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 - the by the deal.II authors
+// Copyright (C) 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/directional_boundary_01.cc
+++ b/tests/opencascade/directional_boundary_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/iges_create.cc
+++ b/tests/opencascade/iges_create.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/iges_describe.cc
+++ b/tests/opencascade/iges_describe.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/iges_describe_02.cc
+++ b/tests/opencascade/iges_describe_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/iges_write.cc
+++ b/tests/opencascade/iges_write.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/normal_to_mesh_projection_01.cc
+++ b/tests/opencascade/normal_to_mesh_projection_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/normal_to_mesh_projection_02.cc
+++ b/tests/opencascade/normal_to_mesh_projection_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/step_create.cc
+++ b/tests/opencascade/step_create.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/step_describe.cc
+++ b/tests/opencascade/step_describe.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/step_describe_02.cc
+++ b/tests/opencascade/step_describe_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/step_write.cc
+++ b/tests/opencascade/step_write.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2017 by the deal.II authors
+// Copyright (C) 2014 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //


### PR DESCRIPTION
- A couple more copyright header updates
 - Update LICENSE file
   Good news - ./contrib does not contain any third-party stuff any more and
   is exclusively copyrighted by us and licensed under LGPL-2.1 or later.
 - Update a couple of more copyright headers
 - Contrib: Improve update-copyright script