### PR TITLE
Allow Asserts for functions running on host

### DIFF
--- a/cmake/configure/configure_1_cuda.cmake
+++ b/cmake/configure/configure_1_cuda.cmake
@@ -95,6 +95,8 @@ MACRO(FEATURE_CUDA_FIND_EXTERNAL var)
         )
       SET(${var} FALSE)
     ENDIF()
+
+    ADD_FLAGS(DEAL_II_CUDA_FLAGS_DEBUG "-G")
   ENDIF()
 ENDMACRO()
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -780,7 +780,7 @@ inline
 DEAL_II_CUDA_HOST_DEV Tensor<0,dim,Number>::operator Number &()
 {
   // We cannot use Assert inside a CUDA kernel
-#ifndef DEAL_II_WITH_CUDA
+#ifndef __CUDA_ARCH__
   Assert(dim != 0, ExcMessage("Cannot access an object of type Tensor<0,0,Number>"));
 #endif
   return value;
@@ -792,7 +792,7 @@ inline
 DEAL_II_CUDA_HOST_DEV Tensor<0,dim,Number>::operator const Number &() const
 {
   // We cannot use Assert inside a CUDA kernel
-#ifndef DEAL_II_WITH_CUDA
+#ifndef __CUDA_ARCH__
   Assert(dim != 0, ExcMessage("Cannot access an object of type Tensor<0,0,Number>"));
 #endif
   return value;
@@ -910,7 +910,7 @@ typename Tensor<0,dim,Number>::real_type
 DEAL_II_CUDA_HOST_DEV Tensor<0,dim,Number>::norm_square () const
 {
   // We cannot use Assert inside a CUDA kernel
-#ifndef DEAL_II_WITH_CUDA
+#ifndef __CUDA_ARCH__
   Assert(dim != 0, ExcMessage("Cannot access an object of type Tensor<0,0,Number>"));
 #endif
   return numbers::NumberTraits<Number>::abs_square (value);
@@ -1015,7 +1015,7 @@ namespace internal
                std::integral_constant<int, dim>)
     {
       // We cannot use Assert in a CUDA kernel
-#ifndef DEAL_II_WITH_CUDA
+#ifndef __CUDA_ARCH__
       Assert (i<dim, ExcIndexRange(i, 0, dim));
 #endif
       return values[i];
@@ -1030,7 +1030,7 @@ namespace internal
                std::integral_constant<int, 0>)
     {
       // We cannot use Assert in a CUDA kernel
-#ifndef DEAL_II_WITH_CUDA
+#ifndef __CUDA_ARCH__
       Assert(false, ExcMessage("Cannot access elements of an object of type Tensor<rank,0,Number>."));
 #endif
       static ArrayElementType t;


### PR DESCRIPTION
We can find out if a function is called on the host or device using the `__CUDA_ARCH__` preprocessor variable. Even if we have problems calling `Assert` on a kernel we don't need to disable it completely for ` __host__ __device__` functions this way.

Additionally, also set the `-G` debug flag in `Debug` mode.