### PR TITLE
Namespace qualify a function call.

### DIFF
--- a/tests/base/mpi_some_to_some_02.cc
+++ b/tests/base/mpi_some_to_some_02.cc
@@ -85,7 +85,7 @@ void test(const unsigned int max_particles,
 
       deallog << "Proc " << my_proc << "/" << n_procs
               << ": sharing with  "
-              << to_string(shared_procs_set) << std::endl;
+              << Patterns::Tools::to_string(shared_procs_set) << std::endl;
       for (unsigned int i=0; i<n_local_particles*shared_fraction; ++i)
         shared_particles[shared_procs[random_index(shared_procs.size())]]
         .push_back(*(particles.begin()+i));


### PR DESCRIPTION
GCC 4.8.4 marks the call as ambiguous between std::to_string and
Patterns::Tools::to_string. Make the compiler happy by being
explicit, whether or not that is actually necessary.