### PR TITLE
Make FiniteElement::operator== virtual.

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1335,17 +1335,24 @@ public:
   /**
    * Comparison operator.
    *
-   * The implementation in the current class checks for equality of the name
-   * returned by get_name() and for equality of the constraint matrix, as well
-   * as all of the fields in FiniteElementData. This covers most cases where
-   * elements can differ, but there are cases of derived elements that are
-   * different and for which the current function still returns @p true.
-   * For these cases, derived classes should overload this function.
+   * The implementation in the current class checks for equality of the
+   * following pieces of information between the current object and the one
+   * given as argument, in this order:
+   * - the dynamic type (i.e., the type of the most derived class) of the
+   *   current object and of the given object,
+   * - the name returned by get_name(),
+   * - as all of the fields in FiniteElementData,
+   * - constraint matrices,
+   * - restriction matrices,
+   * - prolongation matrices of this object and the argument.
    *
-   * We do not compare the matrix arrays #restriction and #prolongation.
+   * This covers most cases where elements can differ, but there are
+   * cases of derived elements that are different and for which the
+   * current function still returns @p true. For these cases, derived
+   * classes should overload this function.
    */
   virtual
-  bool operator == (const FiniteElement<dim,spacedim> &) const;
+  bool operator == (const FiniteElement<dim,spacedim> &fe) const;
 
   /**
    * Non-equality comparison operator. Defined in terms of the equality comparison operator.

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1333,13 +1333,18 @@ public:
   //@}
 
   /**
-   * Comparison operator. We also check for equality of the name returned by
-   * get_name() and for equality of the constraint matrix, which is quite an
-   * expensive operation.  Do therefore use this function with care, if
-   * possible only for debugging purposes.
+   * Comparison operator.
+   *
+   * The implementation in the current class checks for equality of the name
+   * returned by get_name() and for equality of the constraint matrix, as well
+   * as all of the fields in FiniteElementData. This covers most cases where
+   * elements can differ, but there are cases of derived elements that are
+   * different and for which the current function still returns @p true.
+   * For these cases, derived classes should overload this function.
    *
    * We do not compare the matrix arrays #restriction and #prolongation.
    */
+  virtual
   bool operator == (const FiniteElement<dim,spacedim> &) const;
 
   /**

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1342,14 +1342,25 @@ public:
    *   current object and of the given object,
    * - the name returned by get_name(),
    * - as all of the fields in FiniteElementData,
-   * - constraint matrices,
-   * - restriction matrices,
-   * - prolongation matrices of this object and the argument.
+   * - constraint matrices.
    *
    * This covers most cases where elements can differ, but there are
    * cases of derived elements that are different and for which the
    * current function still returns @p true. For these cases, derived
    * classes should overload this function.
+   *
+   * @note This operator specifically does not check the following
+   *   member variables of the current class:
+   *   - restriction matrices,
+   *   - prolongation matrices of this object and the argument.
+   *  This is because these member variables may be initialized only
+   *  on demand by derived classes, rather than being available immediately.
+   *  Consequently, comparing these members would not only be costly because
+   *  these are generall big arrays, but also because their computation may
+   *  be expensive. On the other hand, derived classes for which these
+   *  arrays may differ for two objects even though the above list compares
+   *  as equal, will probably want to implement their own operator==()
+   *  anyway.
    */
   virtual
   bool operator == (const FiniteElement<dim,spacedim> &fe) const;

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <functional>
 #include <numeric>
+#include <typeinfo>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -937,10 +938,20 @@ template <int dim, int spacedim>
 bool
 FiniteElement<dim,spacedim>::operator == (const FiniteElement<dim,spacedim> &f) const
 {
-  return ((static_cast<const FiniteElementData<dim>&>(*this) ==
-           static_cast<const FiniteElementData<dim>&>(f)) &&
-          (interface_constraints == f.interface_constraints) &&
-          (this->get_name() == f.get_name()));
+  // Compare fields in roughly increasing order of how expensive the
+  // comparison is
+  return ((typeid(*this) == typeid(f))
+          &&
+          (this->get_name() == f.get_name())
+          &&
+          (static_cast<const FiniteElementData<dim>&>(*this) ==
+           static_cast<const FiniteElementData<dim>&>(f))
+          &&
+          (interface_constraints == f.interface_constraints)
+          &&
+          (restriction == f.restriction)
+          &&
+          (prolongation == f.prolongation));
 }
 
 

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -947,11 +947,7 @@ FiniteElement<dim,spacedim>::operator == (const FiniteElement<dim,spacedim> &f) 
           (static_cast<const FiniteElementData<dim>&>(*this) ==
            static_cast<const FiniteElementData<dim>&>(f))
           &&
-          (interface_constraints == f.interface_constraints)
-          &&
-          (restriction == f.restriction)
-          &&
-          (prolongation == f.prolongation));
+          (interface_constraints == f.interface_constraints));
 }
 
 


### PR DESCRIPTION
Also provide a bit more documentation about what it does.

This is a follow-up to #6325, #6330, and all of the associated
tests. We might still want to add operator== to some of the
derived classes, but this is for sure the necessary first
step.