### PR TITLE
CMake: Make Adol-C check for boost pool more specific.

### DIFF
--- a/cmake/modules/FindADOLC.cmake
+++ b/cmake/modules/FindADOLC.cmake
@@ -81,7 +81,7 @@ IF(EXISTS ${ADOLC_SETTINGS_H})
   # Check whether ADOL-C is configured to use the Boost pool allocator
   #
   FILE(STRINGS "${ADOLC_SETTINGS_H}" ADOLC_BOOST_POOL_STRING
-    REGEX "#define USE_BOOST_POOL"
+    REGEX "#define USE_BOOST_POOL 1"
     )
   IF(NOT "${ADOLC_BOOST_POOL_STRING}" STREQUAL "")
     SET(ADOLC_WITH_BOOST_ALLOCATOR TRUE)


### PR DESCRIPTION
Apparently there are three states for this preprocessor definition:
- Non-existent (i.e. undefined)
- Defined and equal to zero (#define USE_BOOST_POOL 0)
- Defined and equal to one (#define USE_BOOST_POOL 1)

Follow up to #6335 and #6347