### PR TITLE
deprecate operator* between 2 second order symmetric tensors

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -719,10 +719,12 @@ public:
    * There are global functions <tt>double_contract</tt> that do the same work
    * as this operator, but rather than returning the result as a return value,
    * they write it into the first argument to the function.
+   *
+   * @deprecated This operator is deprecated, used `double_contract<0,0,1,1>(A,B)` instead.
    */
   template <typename OtherNumber>
   typename internal::SymmetricTensorAccessors::double_contraction_result<rank_,2,dim,Number,OtherNumber>::type
-  operator * (const SymmetricTensor<2,dim,OtherNumber> &s) const;
+  operator * (const SymmetricTensor<2,dim,OtherNumber> &s) const DEAL_II_DEPRECATED;
 
   /**
    * Contraction over two indices of the present object with the rank-4


### PR DESCRIPTION
so the majority is for the option

> deprecate operator* for symmetric tensor and rely on double_contract() to do A:B. We would still have operator* for 4th order symmetric and second order which is a valid operation.

now, how do we actually split declaration of this operator into the case when rank=4 and 2 and deprecate the latter? I will play around with it, but if someone has immediate idea, let me know.

fixes https://github.com/dealii/dealii/issues/6260

