### PR TITLE
Fix vectorized scatter for AVX-512

### DIFF
--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -700,12 +700,13 @@ no_constraint:
                   // do not use interleaved storage if two vectorized
                   // components point to the same field (scatter not possible)
                   for (unsigned int k=0; k<ndofs; ++k)
-                    for (unsigned int j=1; j<n_comp; ++j)
-                      if (dof_indices[j*ndofs+k] == dof_indices[k])
-                        {
-                          index_storage_variants[dof_access_cell][i] = IndexStorageVariants::full;
-                          break;
-                        }
+                    for (unsigned int l=0; l<n_comp; ++l)
+                      for (unsigned int j=l+1; j<n_comp; ++j)
+                        if (dof_indices[j*ndofs+k] == dof_indices[l*ndofs+k])
+                          {
+                            index_storage_variants[dof_access_cell][i] = IndexStorageVariants::full;
+                            break;
+                          }
                   if (index_storage_variants[dof_access_cell][i] != IndexStorageVariants::full)
                     {
                       unsigned int *interleaved_dof_indices =


### PR DESCRIPTION
Must check for all (l,j) pairs for possible conflicts in scatter. My test run on a machine with AVX-512 showed a few unexpected failures:
http://cdash.kyomu.43-1.org/viewTest.php?onlyfailed&buildid=1169

```
matrix_free/matrix_vector_04.release
matrix_free/matrix_vector_04.debug
matrix_free/matrix_vector_04b.release
matrix_free/matrix_vector_04b.debug
matrix_free/matrix_vector_mg.release
matrix_free/matrix_vector_mg.debug
mpi/step-37.mpirun=7.debug
mpi/step-37.mpirun=7.release
```
This commit should fix these issues.