### PR TITLE
Mark Subscriptor::check_no_subscribers as noexcept.

### DIFF
--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -217,11 +217,19 @@ private:
   mutable const std::type_info *object_info;
 
   /**
-   * Check that there are no objects subscribing to this object and throw an
-   * error if there are, in order to guarantee that it is safe to either move
-   * or destroy this object.
+   * Check that there are no objects subscribing to this object. If this check
+   * passes then it is safe to destroy the current object. It this check fails
+   * then this function will either abort or print an error message to deallog
+   * (by using the AssertNothrow mechanism), but will not throw an exception.
+   *
+   * @note Since this function is just a consistency check it does nothing in
+   * release mode.
+   *
+   * @note If this function is called when there is an uncaught exception
+   * then, rather than aborting, this function prints an error message to the
+   * standard error stream and returns.
    */
-  void check_no_subscribers () const;
+  void check_no_subscribers () const noexcept;
 };
 
 //---------------------------------------------------------------------------

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -63,7 +63,7 @@ Subscriptor::~Subscriptor ()
 }
 
 
-void Subscriptor::check_no_subscribers () const
+void Subscriptor::check_no_subscribers () const noexcept
 {
   // Check whether there are still subscriptions to this object. If so, output
   // the actual name of the class to which this object belongs, i.e. the most
@@ -121,7 +121,6 @@ void Subscriptor::check_no_subscribers () const
                     << std::endl;
         }
     }
-
 #endif
 }
 


### PR DESCRIPTION
Follow-up to a029a7f7acb7fe1a9bd30672b23da577af3c1932: since this function should never throw we can mark it as noexcept.

This commit also updates relevant documentation explaining the present behavior.

I am not aware of any reason why this method should not be marked as `noexcept`, particularly since we frequently call it in destructors.