### PR TITLE
Disable sc_init

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -363,7 +363,12 @@ namespace Utilities
 
 #ifdef DEAL_II_WITH_P4EST
       //Initialize p4est and libsc components
+#if !(DEAL_II_P4EST_VERSION_GTE(2,0,0,0))
+      // This feature is broken in version 2.0.0 for calls to
+      // MPI_Comm_create_group. Disabling it leads to more verbose
+      // p4est error messages which should be fine.
       sc_init(MPI_COMM_WORLD, 0, 0, nullptr, SC_LP_SILENT);
+#endif
       p4est_init (nullptr, SC_LP_SILENT);
 #endif
 


### PR DESCRIPTION
Fixes #5716 and allows to use `Utilities::MPI::MPI_InitFinalize` in #6375. In other words, this makes `MPI_Comm_create_group` again collective only over the participating group.
For more information, there is a corresponding issue at cburstedde/p4est#30.

From the documentation of `sc_init` https://github.com/cburstedde/libsc/blob/f2c88cf80ca9dfc5038f0ac26a01d5015305dca2/src/sc.h#L649:
```
/** Sets the global program identifier (e.g. the MPI rank) and some flags.
 * This function is optional.
 * This function must only be called before additional threads are created.
 * If this function is not called or called with log_handler == NULL,
 * the default SC log handler will be used.
 * If this function is not called or called with log_threshold == SC_LP_DEFAULT,
 * the default SC log threshold will be used.
 * The default SC log settings can be changed with sc_set_log_defaults ().
[...]
```

In particular, I don't observe any negative changes running the testsuite or `step-40`. A failing test appears to be more verbose with this change.