### PR TITLE
Fix warning for non-const comparator

### DIFF
--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -854,7 +854,7 @@ namespace internal
     struct FaceComparator
     {
       bool operator() (const FaceToCellTopology<length> &face1,
-                       const FaceToCellTopology<length> &face2)
+                       const FaceToCellTopology<length> &face2) const
       {
         for (unsigned int i=0; i<length; ++i)
           if (face1.cells_interior[i] < face2.cells_interior[i])


### PR DESCRIPTION
Fixes the warnings in https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=1203.