### PR TITLE
Call the correct deleter for ReadWriteVector::values

### DIFF
--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -610,7 +610,7 @@ namespace LinearAlgebra
     /**
      * Pointer to the array of local elements of this vector.
      */
-    std::unique_ptr<Number[], decltype (free) *> values = std::unique_ptr<Number[], decltype (free) *> (nullptr, free);
+    std::unique_ptr<Number[], decltype (free) *> values;
 
     /**
      * For parallel loops with TBB, this member variable stores the affinity
@@ -668,6 +668,9 @@ namespace LinearAlgebra
   template <typename Number>
   inline
   ReadWriteVector<Number>::ReadWriteVector ()
+    :
+    Subscriptor(),
+    values(nullptr, free)
   {
     // virtual functions called in constructors and destructors never use the
     // override in a derived class
@@ -681,7 +684,8 @@ namespace LinearAlgebra
   inline
   ReadWriteVector<Number>::ReadWriteVector (const ReadWriteVector<Number> &v)
     :
-    Subscriptor()
+    Subscriptor(),
+    values(nullptr, free)
   {
     this->operator=(v);
   }
@@ -691,6 +695,9 @@ namespace LinearAlgebra
   template <typename Number>
   inline
   ReadWriteVector<Number>::ReadWriteVector (const size_type size)
+    :
+    Subscriptor(),
+    values(nullptr, free)
   {
     // virtual functions called in constructors and destructors never use the
     // override in a derived class
@@ -703,6 +710,9 @@ namespace LinearAlgebra
   template <typename Number>
   inline
   ReadWriteVector<Number>::ReadWriteVector (const IndexSet &locally_stored_indices)
+    :
+    Subscriptor(),
+    values(nullptr, free)
   {
     // virtual functions called in constructors and destructors never use the
     // override in a derived class

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -610,7 +610,7 @@ namespace LinearAlgebra
     /**
      * Pointer to the array of local elements of this vector.
      */
-    std::unique_ptr<Number[]> values;
+    std::unique_ptr<Number[], decltype (free) *> values = std::unique_ptr<Number[], decltype (free) *> (nullptr, free);
 
     /**
      * For parallel loops with TBB, this member variable stores the affinity


### PR DESCRIPTION
The memory for `ReadWriteVector::values` is allocated in `Utilities::System::posix_memalign` (https://github.com/dealii/dealii/blob/master/include/deal.II/lac/read_write_vector.templates.h#L63)
which in turn either calls `::posix_memalign` or `malloc` (https://github.com/dealii/dealii/blob/master/source/base/utilities.cc#L731). Hence, the memory is allocated by `malloc` in the end and the correct deleter is `free` and not `delete[]`.
Detected running with `-fsanitize-address`.