### PR TITLE
Avoid accessing invalid memory in base/utilities_pack_unpack_04

### DIFF
--- a/tests/base/utilities_pack_unpack_04.cc
+++ b/tests/base/utilities_pack_unpack_04.cc
@@ -34,8 +34,10 @@ void check (const T (&object)[N])
   T unpacked[N];
   Utilities::unpack(buffer, unpacked);
 
-  deallog << "Buffer size check: " << (buffer.size() == sizeof(T)*N ? "OK" : "Failed") << std::endl;
-  deallog << "memcmp check: " << (std::memcmp(buffer.data(), &object, buffer.size()) == 0 ? "OK" : "Failed") << std::endl;
+  const bool equal_sizes = (buffer.size() == sizeof(T)*N);
+  deallog << "Buffer size check: " << (equal_sizes ? "OK" : "Failed") << std::endl;
+  if (equal_sizes)
+    deallog << "memcmp check: " << (std::memcmp(buffer.data(), &object, buffer.size()) == 0 ? "OK" : "Failed") << std::endl;
 
   bool equal=true;
   for (unsigned int i=0; i<N; ++i)

--- a/tests/base/utilities_pack_unpack_04.output
+++ b/tests/base/utilities_pack_unpack_04.output
@@ -3,6 +3,5 @@ DEAL::Buffer size check: OK
 DEAL::memcmp check: OK
 DEAL::direct cmp: OK
 DEAL::Buffer size check: Failed
-DEAL::memcmp check: Failed
 DEAL::direct cmp: OK
 DEAL::OK!


### PR DESCRIPTION
If the buffer size check already fails, `std::memcmp` is trying to access invalid memory.