### PR TITLE
Make sure not to attach a PropertyPool if not asked for

### DIFF
--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -148,7 +148,7 @@ namespace Particles
      * by @p property_pool.
      */
     Particle (const void *&begin_data,
-              PropertyPool &property_pool);
+              PropertyPool *const = nullptr);
 
     /**
      * Move constructor for Particle, creates a particle from an existing

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -830,7 +830,7 @@ namespace Particles
 
         typename std::multimap<internal::LevelInd,Particle <dim,spacedim> >::iterator recv_particle =
           received_particles.insert(std::make_pair(internal::LevelInd(cell->level(),cell->index()),
-                                                   Particle<dim,spacedim>(recv_data_it,*property_pool)));
+                                                   Particle<dim,spacedim>(recv_data_it,property_pool.get())));
 
         if (load_callback)
           recv_data_it = load_callback(particle_iterator(received_particles,recv_particle),
@@ -1060,11 +1060,11 @@ namespace Particles
 #ifdef DEAL_II_WITH_CXX14
             position_hint = particles.emplace_hint(position_hint,
                                                    std::make_pair(cell->level(),cell->index()),
-                                                   Particle<dim,spacedim>(pdata,*property_pool));
+                                                   Particle<dim,spacedim>(pdata,property_pool.get()));
 #else
             position_hint = particles.insert(position_hint,
                                              std::make_pair(std::make_pair(cell->level(),cell->index()),
-                                                            Particle<dim,spacedim>(pdata,*property_pool)));
+                                                            Particle<dim,spacedim>(pdata,property_pool.get())));
 #endif
             ++position_hint;
           }
@@ -1082,11 +1082,11 @@ namespace Particles
 #ifdef DEAL_II_WITH_CXX14
             position_hint = particles.emplace_hint(position_hint,
                                                    std::make_pair(cell->level(),cell->index()),
-                                                   Particle<dim,spacedim>(pdata,*property_pool));
+                                                   Particle<dim,spacedim>(pdata,property_pool.get()));
 #else
             position_hint = particles.insert(position_hint,
                                              std::make_pair(std::make_pair(cell->level(),cell->index()),
-                                                            Particle<dim,spacedim>(pdata,*property_pool)));
+                                                            Particle<dim,spacedim>(pdata,property_pool.get())));
 #endif
             const Point<dim> p_unit = mapping->transform_real_to_unit_cell(cell, position_hint->second.get_location());
             position_hint->second.set_reference_location(p_unit);
@@ -1104,7 +1104,7 @@ namespace Particles
 
         for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
           {
-            Particle<dim,spacedim> p (pdata,*property_pool);
+            Particle<dim,spacedim> p (pdata,property_pool.get());
 
             for (unsigned int child_index = 0; child_index < GeometryInfo<dim>::max_children_per_cell; ++child_index)
               {

--- a/tests/particles/particle_06.output
+++ b/tests/particles/particle_06.output
@@ -1,0 +1,55 @@
+
+DEAL::Particle location: 0.300000
+DEAL::Particle reference location: 0.200000
+DEAL::Particle index: 7
+DEAL::Particle properties: 0.150000 0.450000 0.750000
+DEAL::Copy particle location: 0.300000
+DEAL::Copy particle reference location: 0.200000
+DEAL::Copy particle index: 7
+DEAL::Copy particle properties: 0.150000 0.450000 0.750000
+DEAL::OK
+DEAL::Particle location: 0.300000 0.500000
+DEAL::Particle reference location: 0.200000
+DEAL::Particle index: 7
+DEAL::Particle properties: 0.150000 0.450000 0.750000
+DEAL::Copy particle location: 0.300000 0.500000
+DEAL::Copy particle reference location: 0.200000
+DEAL::Copy particle index: 7
+DEAL::Copy particle properties: 0.150000 0.450000 0.750000
+DEAL::OK
+DEAL::Particle location: 0.300000 0.500000 0.700000
+DEAL::Particle reference location: 0.200000
+DEAL::Particle index: 7
+DEAL::Particle properties: 0.150000 0.450000 0.750000
+DEAL::Copy particle location: 0.300000 0.500000 0.700000
+DEAL::Copy particle reference location: 0.200000
+DEAL::Copy particle index: 7
+DEAL::Copy particle properties: 0.150000 0.450000 0.750000
+DEAL::OK
+DEAL::Particle location: 0.300000 0.500000
+DEAL::Particle reference location: 0.200000 0.400000
+DEAL::Particle index: 7
+DEAL::Particle properties: 0.150000 0.450000 0.750000
+DEAL::Copy particle location: 0.300000 0.500000
+DEAL::Copy particle reference location: 0.200000 0.400000
+DEAL::Copy particle index: 7
+DEAL::Copy particle properties: 0.150000 0.450000 0.750000
+DEAL::OK
+DEAL::Particle location: 0.300000 0.500000 0.700000
+DEAL::Particle reference location: 0.200000 0.400000
+DEAL::Particle index: 7
+DEAL::Particle properties: 0.150000 0.450000 0.750000
+DEAL::Copy particle location: 0.300000 0.500000 0.700000
+DEAL::Copy particle reference location: 0.200000 0.400000
+DEAL::Copy particle index: 7
+DEAL::Copy particle properties: 0.150000 0.450000 0.750000
+DEAL::OK
+DEAL::Particle location: 0.300000 0.500000 0.700000
+DEAL::Particle reference location: 0.200000 0.400000 0.600000
+DEAL::Particle index: 7
+DEAL::Particle properties: 0.150000 0.450000 0.750000
+DEAL::Copy particle location: 0.300000 0.500000 0.700000
+DEAL::Copy particle reference location: 0.200000 0.400000 0.600000
+DEAL::Copy particle index: 7
+DEAL::Copy particle properties: 0.150000 0.450000 0.750000
+DEAL::OK


### PR DESCRIPTION
Previously, we were always trying to copy properties in the 
```
Particle<dim,spacedim>::Particle (const void *&data, 
                                  PropertyPool &new_property_pool)
```
constructor. This access invalid memory in case a default `PropertyPool` was passed.
Also, the documentation is talking about a pointer to a `PropertPool` object instead of a reference.
Using a pointer intead, seems to be the most reasonable choice indeed. Hence, I changed the interface (again?) and also allow to pass a `nullptr` by default.
