### PR TITLE
Gnuplot compression

### DIFF
--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -3926,9 +3926,7 @@ namespace internal
       for (LineList::const_iterator line=line_list.begin();
            line!=line_list.end(); ++line)
         if (eps_flags_base.color_lines_level && (line->level > 0))
-          // lines colored according to
-          // refinement level,
-          // contributed by J�rg
+          // lines colored according to refinement level, contributed by Jörg
           // R. Weimar
           out << line->level
               << " l "

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -3219,11 +3219,8 @@ namespace internal
                   << '\n';
             }
           else
-            // cell is at boundary and we
-            // are to treat curved
-            // boundaries. so loop over
-            // all faces and draw them as
-            // small pieces of lines
+            // cell is at boundary and we are to treat curved boundaries. so
+            // loop over all faces and draw them as small pieces of lines
             {
               for (unsigned int face_no=0;
                    face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
@@ -3232,11 +3229,8 @@ namespace internal
                   face = cell->face(face_no);
                   if (face->at_boundary() || gnuplot_flags.curved_inner_cells)
                     {
-                      // compute offset
-                      // of quadrature
-                      // points within
-                      // set of projected
-                      // points
+                      // compute offset of quadrature points within set of
+                      // projected points
                       const unsigned int offset=face_no*n_points;
                       for (unsigned int i=0; i<n_points; ++i)
                         out << (mapping->transform_unit_to_real_cell
@@ -3250,11 +3244,8 @@ namespace internal
                     }
                   else
                     {
-                      // if, however, the
-                      // face is not at
-                      // the boundary,
-                      // then draw it as
-                      // usual
+                      // if, however, the face is not at the boundary, then
+                      // draw it as usual
                       out << face->vertex(0)
                           << ' ' << cell->level()
                           << ' ' << static_cast<unsigned int>(cell->material_id())


### PR DESCRIPTION
I recently generated a lot of gnuplot output for creating nice SVG grids. Some of the output files were quite large and I implemented a compression scheme that cuts down the file size by about 50% for curved grids by only using one line segment for straight faces (instead of the user provided subdivision, which is really intended for only curved faces).

This will probably end up breaking a ton of tests. I'm putting it up as a PR now just so I do not forget about it; I'll finish it up when 9.0 is done.