### PR TITLE
Fix documentation for NonMatching

### DIFF
--- a/include/deal.II/non_matching/coupling.h
+++ b/include/deal.II/non_matching/coupling.h
@@ -28,6 +28,16 @@
 #include <deal.II/lac/constraint_matrix.h>
 
 DEAL_II_NAMESPACE_OPEN
+
+/**
+ * A namespace for functions offering tools to handle two meshes with no
+ * alignment requirements, but where one of the meshes is embedded
+ * inside the other in the real-space.
+ *
+ * Typically these functions allow for computations on the real-space
+ * intersection between the two meshes e.g. surface integrals and
+ * construction of mass matrices.
+ */
 namespace NonMatching
 {
   /**


### PR DESCRIPTION
As @drwells suggested (thank you! I couldn't figure it out...), I'm adding a documentation for the NonMatching namespace so that doxygen compiles the documentation for all functions inside it.

I initially thought about writing something longer but, since functions in coupling.h work with two meshes while the last one handles directly quadrature points, weights and normals, I believe the only common theme is the non-matching meshes intersecting and that's the only thing I documented.

If someone has suggestions or corrections I shall update!
Best,
Giovanni