### PR TITLE
Avoid using '**/' at the end of comments.

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -355,7 +355,7 @@ private:
 
   /**
    * A manifold description to be used for get_new_point in 2D.
-   **/
+   */
   const PolarManifold<spacedim> polar_manifold;
 };
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -911,12 +911,12 @@ protected:
 
   /**
    * A pointer to the normal vectors at faces.
-   **/
+   */
   const Tensor<1,dim,VectorizedArray<Number> > *normal_vectors;
 
   /**
    * A pointer to the normal vectors times the jacobian at faces.
-   **/
+   */
   const Tensor<1,dim,VectorizedArray<Number> > *normal_x_jacobian;
 
   /**
@@ -933,7 +933,7 @@ protected:
   /**
    * Flag holding information whether a face is an interior or exterior face
    * according to the defined direction of the normal.  Not used for cells.
-   **/
+   */
   bool is_interior_face;
 
   /**

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -385,7 +385,7 @@ public:
      * the fabric, it may be faster to not overlap and wait for the data to
      * arrive. The default is true, i.e., communication and computation are
      * overlapped.
-     **/
+     */
     bool                overlap_communication_computation;
 
     /**
@@ -394,7 +394,7 @@ public:
      * MatrixFree should have access to all neighbors on locally owned cells,
      * this option enables adding the respective faces at the end of the face
      * range.
-     **/
+     */
     bool                hold_all_faces_to_owned_cells;
 
     /**

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -854,11 +854,9 @@ template <int dim>
 QTelles<dim>::QTelles (
   const Quadrature<1> &base_quad, const Point<dim> &singularity)
   :
-/**
-* We need the explicit implementation if dim == 1. If dim > 1 we use the
-* former implementation and apply a tensorial product to obtain the higher
-* dimensions.
-**/
+  // We need the explicit implementation if dim == 1. If dim > 1 we use the
+  // former implementation and apply a tensorial product to obtain the higher
+  // dimensions.
   Quadrature<dim>(
     dim == 2 ?
     QAnisotropic<dim>(
@@ -877,10 +875,8 @@ template <int dim>
 QTelles<dim>::QTelles (
   const unsigned int n, const Point<dim> &singularity)
   :
-/**
-* In this case we map the standard Gauss Legendre formula using the given
-* singularity point coordinates.
-**/
+  // In this case we map the standard Gauss Legendre formula using the given
+  // singularity point coordinates.
   Quadrature<dim>(QTelles<dim>(QGauss<1>(n), singularity))
 {}
 
@@ -890,15 +886,11 @@ template <>
 QTelles<1>::QTelles (
   const Quadrature<1> &base_quad, const Point<1> &singularity)
   :
-/**
-* We explicitly implement the Telles' variable change if dim == 1.
-**/
+  // We explicitly implement the Telles' variable change if dim == 1.
   Quadrature<1>(base_quad)
 {
-  /**
-  * We define all the constants to be used in the implementation of
-  * Telles' rule
-  **/
+  // We define all the constants to be used in the implementation of
+  // Telles' rule
   const double eta_bar = singularity[0] * 2. - 1.;
   const double eta_star = eta_bar * eta_bar - 1.;
   double gamma_bar;


### PR DESCRIPTION
While correct, we use the 

```
/**
 *
 */
```

everywhere else.