### PR TITLE
Only invert bits up to the maximum possible in ~CacheUpdateFlags

### DIFF
--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -121,8 +121,8 @@ namespace GridTools
   operator ~ (const CacheUpdateFlags f1)
   {
     return static_cast<CacheUpdateFlags> (
-             ~static_cast<unsigned int> (f1)
-           );
+             static_cast<unsigned int> (f1) ^
+             static_cast<unsigned int> (update_all));
   }
 
 


### PR DESCRIPTION
This prevents trying to assign to large values to a `CacheUpdateFlags` variable.