### PR TITLE
Guard accessing values in Vector<Number>::zero_out_ghosts

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -518,7 +518,7 @@ namespace LinearAlgebra
     Vector<Number>::zero_out_ghosts () const
     {
       if (values != nullptr)
-        std::fill_n (&values[partitioner->local_size()],
+        std::fill_n (values.get()+partitioner->local_size(),
                      partitioner->n_ghost_indices(),
                      Number());
       vector_is_ghosted = false;

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -517,9 +517,10 @@ namespace LinearAlgebra
     void
     Vector<Number>::zero_out_ghosts () const
     {
-      std::fill_n (&values[partitioner->local_size()],
-                   partitioner->n_ghost_indices(),
-                   Number());
+      if (values != nullptr)
+        std::fill_n (&values[partitioner->local_size()],
+                     partitioner->n_ghost_indices(),
+                     Number());
       vector_is_ghosted = false;
     }
 


### PR DESCRIPTION
If we are calling `reinit(0)` and the vector was not previously initialized to a larger size, we don't allocate memory and `values` is still a `nullptr`. Make sure that we don't try to dereference `values` in this case.