### PR TITLE
Add a necessary #include file.

### DIFF
--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -27,6 +27,7 @@
 #include <deal.II/lac/vector_operation.h>
 
 #include <cstring>
+#include <cstdlib>
 #include <iomanip>
 
 #ifdef DEAL_II_WITH_TRILINOS


### PR DESCRIPTION
We now reference the 'free' function in the .h file. We need to '#include' the necessary
header file.

This is a follow-up to #6387.