### PR TITLE
Initialize SUN* objects

### DIFF
--- a/source/sundials/kinsol.cc
+++ b/source/sundials/kinsol.cc
@@ -265,8 +265,8 @@ namespace SUNDIALS
     AssertKINSOL(status);
 
 #if DEAL_II_SUNDIALS_VERSION_GTE(3,0,0)
-    SUNMatrix J;
-    SUNLinearSolver LS;
+    SUNMatrix J = nullptr;
+    SUNLinearSolver LS = nullptr;
 #endif
 
     if (solve_jacobian_system)


### PR DESCRIPTION
[CDash](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=1300) complains about the two objects below being uninitialized. Since these are pointers, `nullptr` appears to be appropriate.
Passes the `sundials` tests.