### PR TITLE
Avoid creating pointer to invalid memory in get_dof_indices

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -3459,11 +3459,15 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::get_dof_indices
           ExcMessage ("Can't ask for DoF indices on artificial cells."));
   AssertDimension (dof_indices.size(), this->get_fe().dofs_per_cell);
 
-  const types::global_dof_index *cache
-    = this->dof_handler->levels[this->present_level]
-      ->get_cell_cache_start (this->present_index, this->get_fe().dofs_per_cell);
-  for (unsigned int i=0; i<this->get_fe().dofs_per_cell; ++i, ++cache)
-    dof_indices[i] = *cache;
+  const auto dofs_per_cell = this->get_fe().dofs_per_cell;
+  if (dofs_per_cell > 0)
+    {
+      const types::global_dof_index *cache
+        = this->dof_handler->levels[this->present_level]
+          ->get_cell_cache_start (this->present_index, dofs_per_cell);
+      for (unsigned int i=0; i<dofs_per_cell; ++i, ++cache)
+        dof_indices[i] = *cache;
+    }
 }
 
 

--- a/include/deal.II/dofs/dof_levels.h
+++ b/include/deal.II/dofs/dof_levels.h
@@ -122,7 +122,7 @@ namespace internal
               cell_dof_indices_cache.size(),
               ExcInternalError());
 
-      return &cell_dof_indices_cache[obj_index*dofs_per_cell];
+      return cell_dof_indices_cache.data()+(obj_index*dofs_per_cell);
     }
 
 


### PR DESCRIPTION
For `FE_Nothing`, we are trying to access invalid memory in `DoFLevel<dim>::get_cell_cache_start`.