### PR TITLE
Follow convention with placement of 'break' statement.

### DIFF
--- a/examples/step-54/step-54.cc
+++ b/examples/step-54/step-54.cc
@@ -286,8 +286,9 @@ namespace Step54
         OpenCASCADE::NormalProjectionBoundary<2,3>
         normal_projector(bow_surface, tolerance);
         tria.set_manifold(1,normal_projector);
+
+        break;
       }
-      break;
 
       // @p If surface_projection_kind value is @p DirectionalProjection, we select the
       // OpenCASCADE::DirectionalProjectionBoundary class. The new mesh points will
@@ -301,8 +302,9 @@ namespace Step54
         OpenCASCADE::DirectionalProjectionBoundary<2,3>
         directional_projector(bow_surface, Point<3>(0.0,1.0,0.0), tolerance);
         tria.set_manifold(1,directional_projector);
+
+        break;
       }
-      break;
 
       // As a third option, if @p surface_projection_kind value
       // is @p NormalToMeshProjection, we select the
@@ -318,8 +320,9 @@ namespace Step54
         OpenCASCADE::NormalToMeshProjectionBoundary<2,3>
         normal_to_mesh_projector(bow_surface, tolerance);
         tria.set_manifold(1,normal_to_mesh_projector);
+
+        break;
       }
-      break;
 
       // Finally, we use good software cleanliness by ensuring that this
       // really covers all possible options of the @p case statement. If we


### PR DESCRIPTION
This is a follow-up to #6415: The code as it was was not technically wrong,
but the placement of the 'break' statement might still be misleading to new-comers
that are under the impression that the 'case X:' things in a 'switch' statement
are something special and not, in fact, just regular labels. Either way, follow
our usual convention.