### PR TITLE
Fix gcc-8 warnings in bundled boost

### DIFF
--- a/bundled/boost-1.62.0/include/boost/archive/text_oarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/text_oarchive.hpp
@@ -65,10 +65,10 @@ protected:
         basic_text_oprimitive<std::ostream>::save(t);
     }
     void save(const version_type & t){
-        save(static_cast<const unsigned int>(t));
+        save(static_cast<unsigned int>(t));
     }
     void save(const boost::serialization::item_version_type & t){
-        save(static_cast<const unsigned int>(t));
+        save(static_cast<unsigned int>(t));
     }
     BOOST_ARCHIVE_DECL void 
     save(const char * t);

--- a/bundled/boost-1.62.0/include/boost/archive/text_woarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/text_woarchive.hpp
@@ -78,10 +78,10 @@ protected:
         basic_text_oprimitive<std::wostream>::save(t);
     }
     void save(const version_type & t){
-        save(static_cast<const unsigned int>(t));
+        save(static_cast<unsigned int>(t));
     }
     void save(const boost::serialization::item_version_type & t){
-        save(static_cast<const unsigned int>(t));
+        save(static_cast<unsigned int>(t));
     }
     BOOST_WARCHIVE_DECL void
     save(const char * t);

--- a/bundled/boost-1.62.0/include/boost/archive/xml_oarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/xml_oarchive.hpp
@@ -65,11 +65,11 @@ protected:
     }
     void 
     save(const version_type & t){
-        save(static_cast<const unsigned int>(t));
+        save(static_cast<unsigned int>(t));
     }
     void 
     save(const boost::serialization::item_version_type & t){
-        save(static_cast<const unsigned int>(t));
+        save(static_cast<unsigned int>(t));
     }
     BOOST_ARCHIVE_DECL void 
     save(const char * t);

--- a/bundled/boost-1.62.0/include/boost/archive/xml_woarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/xml_woarchive.hpp
@@ -74,11 +74,11 @@ protected:
     }
     void
     save(const version_type & t){
-        save(static_cast<const unsigned int>(t));
+        save(static_cast<unsigned int>(t));
     }
     void 
     save(const boost::serialization::item_version_type & t){
-        save(static_cast<const unsigned int>(t));
+        save(static_cast<unsigned int>(t));
     }
     BOOST_WARCHIVE_DECL void
     save(const char * t);

--- a/bundled/boost-1.62.0/include/boost/mpl/assert.hpp
+++ b/bundled/boost-1.62.0/include/boost/mpl/assert.hpp
@@ -185,14 +185,12 @@ template< typename P > struct assert_arg_pred_not
 };
 
 template< typename Pred >
-failed ************ (Pred::************ 
-      assert_arg( void (*)(Pred), typename assert_arg_pred<Pred>::type )
-    );
+failed ************ Pred::************
+      assert_arg( void (*)(Pred), typename assert_arg_pred<Pred>::type );
 
 template< typename Pred >
-failed ************ (boost::mpl::not_<Pred>::************ 
-      assert_not_arg( void (*)(Pred), typename assert_arg_pred_not<Pred>::type )
-    );
+failed ************ boost::mpl::not_<Pred>::************
+      assert_not_arg( void (*)(Pred), typename assert_arg_pred_not<Pred>::type );
 
 template< typename Pred >
 AUX778076_ASSERT_ARG(assert<false>)


### PR DESCRIPTION
All of these are unnecessary and `gcc-8` complains about it.