### PR TITLE
Consistently mark all virtual functions of FE_Nothing as 'override'.

### DIFF
--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -97,7 +97,7 @@ public:
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
   /**
    * Return a string that uniquely identifies a finite element. In this case
@@ -105,12 +105,12 @@ public:
    */
   virtual
   std::string
-  get_name() const;
+  get_name() const override;
 
   // for documentation, see the FiniteElement base class
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   /**
    * Return the value of the @p ith shape function at the point @p p. @p p is
@@ -121,7 +121,7 @@ public:
    */
   virtual
   double
-  shape_value (const unsigned int i, const Point<dim> &p) const;
+  shape_value (const unsigned int i, const Point<dim> &p) const override;
 
   virtual
   void
@@ -132,7 +132,7 @@ public:
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                   const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -143,7 +143,7 @@ public:
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -155,7 +155,7 @@ public:
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                           const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   /**
    * Prepare internal data structures and fill in values independent of the
@@ -171,7 +171,7 @@ public:
   get_data (const UpdateFlags                                                    update_flags,
             const Mapping<dim,spacedim>                                         &mapping,
             const Quadrature<dim>                                               &quadrature,
-            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -189,25 +189,25 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
 
 
 
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   virtual
   bool
-  hp_constraints_are_implemented () const;
+  hp_constraints_are_implemented () const override;
 
   /**
    * Return the matrix interpolating from the given finite element to the
@@ -217,7 +217,7 @@ public:
   virtual
   void
   get_interpolation_matrix (const FiniteElement<dim,spacedim> &source_fe,
-                            FullMatrix<double>       &interpolation_matrix) const;
+                            FullMatrix<double>       &interpolation_matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -231,7 +231,7 @@ public:
   virtual
   void
   get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source_fe,
-                                 FullMatrix<double>       &interpolation_matrix) const;
+                                 FullMatrix<double>       &interpolation_matrix) const override;
 
 
   /**
@@ -247,7 +247,7 @@ public:
   void
   get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source_fe,
                                     const unsigned int index,
-                                    FullMatrix<double>  &interpolation_matrix) const;
+                                    FullMatrix<double>  &interpolation_matrix) const override;
 
   /**
    * @return true if the FE dominates any other.


### PR DESCRIPTION
Apparently there are compilers that warn if one function is so marked, but not all. Thus,
be consistent.

Specifically, one of the testers failed for #6441 with the following error message:
```
[339/821] Building CXX object source/numerics/CMakeFiles/obj_numerics_debug.dir/vector_tools_boundary.cc.o
FAILED: source/numerics/CMakeFiles/obj_numerics_debug.dir/vector_tools_boundary.cc.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DDEBUG -DTBB_DO_ASSERT=1 -DTBB_USE_DEBUG -Isource/numerics -Iinclude -I/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include -I/Users/cib-osx/auto-dealii-tjhei-osx/dealii/bundled/tbb-2018_U2/include -I/Users/cib-osx/auto-dealii-tjhei-osx/dealii/bundled/boost-1.62.0/include -I/Users/cib-osx/auto-dealii-tjhei-osx/dealii/bundled/umfpack/UMFPACK/Include -I/Users/cib-osx/auto-dealii-tjhei-osx/dealii/bundled/umfpack/AMD/Include -I/Users/cib-osx/auto-dealii-tjhei-osx/dealii/bundled/muparser_v2_2_4/include -pedantic -fPIC -Wall -Wextra -Wpointer-arith -Wwrite-strings -Wsynth -Wsign-compare -Wswitch -Woverloaded-virtual -Wno-deprecated-declarations -Qunused-arguments -Wno-unsupported-friend -Wno-undefined-var-template -openmp-simd -std=c++11 -ftemplate-depth=1024 -Werror -Wno-parentheses -Wno-unused-local-typedefs -O0 -ggdb -Wa,--compress-debug-sections -MD -MT source/numerics/CMakeFiles/obj_numerics_debug.dir/vector_tools_boundary.cc.o -MF source/numerics/CMakeFiles/obj_numerics_debug.dir/vector_tools_boundary.cc.o.d -o source/numerics/CMakeFiles/obj_numerics_debug.dir/vector_tools_boundary.cc.o -c /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:100:3: error: 'clone' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  clone() const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:4329:23: note: in instantiation of template class 'dealii::FE_Nothing<2, 2>' requested here
                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != nullptr)
                      ^
source/numerics/vector_tools_boundary.inst:5462:7: note: in instantiation of function template specialization 'dealii::VectorTools::project_boundary_values_curl_conforming<2>' requested here
 void project_boundary_values_curl_conforming< 2 >
      ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:797:3: note: overridden virtual function is here
  clone() const = 0;
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:108:3: error: 'get_name' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  get_name() const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:809:23: note: overridden virtual function is here
  virtual std::string get_name () const = 0;
                      ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:113:3: error: 'requires_update_flags' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  requires_update_flags (const UpdateFlags update_flags) const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:2613:3: note: overridden virtual function is here
  requires_update_flags (const UpdateFlags update_flags) const = 0;
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:124:3: error: 'shape_value' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  shape_value (const unsigned int i, const Point<dim> &p) const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:859:18: note: overridden virtual function is here
  virtual double shape_value (const unsigned int  i,
                 ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:128:3: error: 'fill_fe_values' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:2876:3: note: overridden virtual function is here
  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:139:3: error: 'fill_fe_face_values' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:2929:3: note: overridden virtual function is here
  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:150:3: error: 'fill_fe_subface_values' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:2985:3: note: overridden virtual function is here
  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:171:3: error: 'get_data' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  get_data (const UpdateFlags                                                    update_flags,
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:2693:3: note: overridden virtual function is here
  get_data (const UpdateFlags                                                    update_flags,
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:192:3: error: 'compare_for_face_domination' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:1331:3: note: overridden virtual function is here
  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:198:3: error: 'hp_vertex_dof_identities' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:1302:3: note: overridden virtual function is here
  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:202:3: error: 'hp_line_dof_identities' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:1310:3: note: overridden virtual function is here
  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:206:3: error: 'hp_quad_dof_identities' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:1318:3: note: overridden virtual function is here
  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:210:3: error: 'hp_constraints_are_implemented' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  hp_constraints_are_implemented () const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:1221:16: note: overridden virtual function is here
  virtual bool hp_constraints_are_implemented () const;
               ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:219:3: error: 'get_interpolation_matrix' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  get_interpolation_matrix (const FiniteElement<dim,spacedim> &source_fe,
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:1236:3: note: overridden virtual function is here
  get_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:233:3: error: 'get_face_interpolation_matrix' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source_fe,
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:1258:3: note: overridden virtual function is here
  get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:248:3: error: 'get_subface_interpolation_matrix' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source_fe,
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:1274:3: note: overridden virtual function is here
  get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:100:3: error: 'clone' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  clone() const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:4329:23: note: in instantiation of template class 'dealii::FE_Nothing<3, 3>' requested here
                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != nullptr)
                      ^
source/numerics/vector_tools_boundary.inst:5762:7: note: in instantiation of function template specialization 'dealii::VectorTools::project_boundary_values_curl_conforming<3>' requested here
 void project_boundary_values_curl_conforming< 3 >
      ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:797:3: note: overridden virtual function is here
  clone() const = 0;
  ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:108:3: error: 'get_name' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  get_name() const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:809:23: note: overridden virtual function is here
  virtual std::string get_name () const = 0;
                      ^
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/source/numerics/vector_tools_boundary.cc:17:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/numerics/vector_tools.templates.h:46:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/operators.h:29:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/fe_evaluation.h:28:
In file included from /Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/matrix_free/mapping_data_on_the_fly.h:29:
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe_nothing.h:113:3: error: 'requires_update_flags' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  requires_update_flags (const UpdateFlags update_flags) const;
  ^
/Users/cib-osx/auto-dealii-tjhei-osx/dealii/include/deal.II/fe/fe.h:2613:3: note: overridden virtual function is here
  requires_update_flags (const UpdateFlags update_flags) const = 0;
  ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
[340/821] Building CXX object source/numerics/CMakeFiles/obj_numerics_debug.dir/vector_tools_point_gradient.cc.o
[341/821] Building CXX object source/numerics/CMakeFiles/obj_numerics_debug.dir/vector_tools_constraints.cc.o
[342/821] Building CXX object source/numerics/CMakeFiles/obj_numerics_debug.dir/matrix_creator.cc.o
[343/821] Building CXX object source/numerics/CMakeFiles/obj_numerics_debug.dir/matrix_creator_inst2.cc.o
[344/821] Building CXX object source/numerics/CMakeFiles/obj_numerics_debug.dir/matrix_creator_inst3.cc.o
ninja: build stopped: subcommand failed.
```
(See here for the full log: https://tjhei.info/cib/dealii-tjhei-osx/49cf4f61a45d6e363b488bc13b384f82f8f47984/log . But I suspect this will eventually disappear.)

