### PR TITLE
Revert "Mark a few file-specific variables as static."

### DIFF
--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -42,21 +42,21 @@ DEAL_II_NAMESPACE_OPEN
 namespace deal_II_exceptions
 {
 
-  static std::string additional_assert_output;
+  std::string additional_assert_output;
 
   void set_additional_assert_output (const char *const p)
   {
     additional_assert_output = p;
   }
 
-  static bool show_stacktrace = true;
+  bool show_stacktrace = true;
 
   void suppress_stacktrace_in_exceptions ()
   {
     show_stacktrace = false;
   }
 
-  static bool abort_on_exception = true;
+  bool abort_on_exception = true;
 
   void disable_abort_on_exception ()
   {

--- a/source/lac/constraint_matrix.cc
+++ b/source/lac/constraint_matrix.cc
@@ -1475,7 +1475,7 @@ ONLY_MATRIX_FUNCTIONS(PETScWrappers::MPI::BlockSparseMatrix);
 namespace internals
 {
 #define SCRATCH_INITIALIZER(MatrixScalar,VectorScalar,Name)                  \
-  static ConstraintMatrixData<MatrixScalar,VectorScalar>::ScratchData scratch_data_initializer_##Name; \
+  ConstraintMatrixData<MatrixScalar,VectorScalar>::ScratchData scratch_data_initializer_##Name; \
   template <> Threads::ThreadLocalStorage<ConstraintMatrixData<MatrixScalar,VectorScalar>::ScratchData> \
   ConstraintMatrixData<MatrixScalar,VectorScalar>::scratch_data(scratch_data_initializer_##Name)
 


### PR DESCRIPTION
This reverts commit 28611bfaf785b9459fc2c7259e31fb097496e24b. There is probably a more elegant way to fix this but lets just do the conservative thing and revert this for now.

tests.h adds is own extern declaration to access variables declared in exceptions.cc, so they cannot be static.

Fixes a failure here:
https://cdash.kyomu.43-1.org/testDetails.php?test=8727803&build=1416

I am amazed that the test suite passed with 28611bfaf785.

Ping @tamiko :)