### PR TITLE
Fix the remaining gcc-8 warnings

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -129,6 +129,7 @@ IF(NOT DEFINED DEAL_II_WITH_CXX17 OR DEAL_II_WITH_CXX17)
     UNSET_IF_CHANGED(CHECK_CXX_FEATURES_FLAGS_CXX17_SAVED
       "${CMAKE_REQUIRED_FLAGS}${DEAL_II_CXX_VERSION_FLAG}"
       DEAL_II_HAVE_CXX17_ATTRIBUTES
+      DEAL_II_HAVE_CXX17_IF_CONSTEXPR
       )
 
     #
@@ -160,10 +161,26 @@ IF(NOT DEFINED DEAL_II_WITH_CXX17 OR DEAL_II_WITH_CXX17)
       "
       DEAL_II_HAVE_CXX17_ATTRIBUTES)
 
+    #
+    # Test that the c++17 if constexpr is supported.
+    #
+    CHECK_CXX_SOURCE_COMPILES(
+      "
+      int main()
+      {
+        constexpr bool flag = false;
+        if constexpr(flag)
+          return 1;
+        return 0;
+      }
+      "
+      DEAL_II_HAVE_CXX17_IF_CONSTEXPR)
+
     RESET_CMAKE_REQUIRED()
   ENDIF()
 
-  IF( DEAL_II_HAVE_CXX17_ATTRIBUTES )
+  IF( DEAL_II_HAVE_CXX17_ATTRIBUTES AND
+      DEAL_II_HAVE_CXX17_IF_CONSTEXPR)
     SET(DEAL_II_HAVE_CXX17 TRUE)
   ELSE()
     IF(NOT _user_provided_cxx_version_flag)

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -40,6 +40,7 @@
 #cmakedefine DEAL_II_WITH_ASSIMP
 #cmakedefine DEAL_II_WITH_CUDA
 #cmakedefine DEAL_II_WITH_CXX14
+#cmakedefine DEAL_II_WITH_CXX17
 #cmakedefine DEAL_II_WITH_GSL
 #cmakedefine DEAL_II_WITH_GMSH
 #cmakedefine DEAL_II_WITH_HDF5

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -335,7 +335,14 @@ namespace Utilities
                                   "vector_operation argument was passed to "
                                   "import_from_ghosted_array_start as is passed "
                                   "to import_from_ghosted_array_finish."));
-          std::memset(ghost_array.data(), 0, sizeof(Number)*ghost_array.size());
+#ifdef DEAL_II_WITH_CXX17
+          if constexpr (std::is_trivial<Number>::value)
+#else
+          if (std::is_trivial<Number>::value)
+#endif
+            std::memset(ghost_array.data(), 0, sizeof(Number)*ghost_array.size());
+          else
+            std::fill(ghost_array.data(), ghost_array.data()+ghost_array.size(), 0);
           return;
         }
 #endif
@@ -407,7 +414,14 @@ namespace Utilities
       if (ghost_array.size()>0)
         {
           Assert(ghost_array.begin()!=nullptr, ExcInternalError());
-          std::memset(ghost_array.data(), 0, sizeof(Number)*n_ghost_indices());
+#ifdef DEAL_II_WITH_CXX17
+          if constexpr (std::is_trivial<Number>::value)
+#else
+          if (std::is_trivial<Number>::value)
+#endif
+            std::memset(ghost_array.data(), 0, sizeof(Number)*n_ghost_indices());
+          else
+            std::fill(ghost_array.data(), ghost_array.data()+n_ghost_indices(), 0);
         }
 
       // clear the compress requests

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1009,14 +1009,15 @@ namespace Utilities
     // we have to work around the fact that GCC 4.8.x claims to be C++
     // conforming, but is not actually as it does not implement
     // std::is_trivially_copyable.
-    if (
 #if __GNUG__ && __GNUC__ < 5
-      __has_trivial_copy(T)
+    if (  __has_trivial_copy(T) && sizeof(T)<256)
 #else
-      std::is_trivially_copyable<T>()
+#  ifdef DEAL_II_WITH_CXX17
+    if constexpr (std::is_trivially_copyable<T>() && sizeof(T)<256)
+#  else
+    if (std::is_trivially_copyable<T>() && sizeof(T)<256)
+#  endif
 #endif
-      &&
-      sizeof(T)<256)
       {
         const size_t previous_size = dest_buffer.size();
         dest_buffer.resize (previous_size + sizeof(T));
@@ -1076,14 +1077,15 @@ namespace Utilities
     // we have to work around the fact that GCC 4.8.x claims to be C++
     // conforming, but is not actually as it does not implement
     // std::is_trivially_copyable.
-    if (
 #if __GNUG__ && __GNUC__ < 5
-      __has_trivial_copy(T)
+    if (  __has_trivial_copy(T) && sizeof(T)<256)
 #else
-      std::is_trivially_copyable<T>()
+#  ifdef DEAL_II_WITH_CXX17
+    if constexpr (std::is_trivially_copyable<T>() && sizeof(T)<256)
+#  else
+    if (std::is_trivially_copyable<T>() && sizeof(T)<256)
+#  endif
 #endif
-      &&
-      sizeof(T)<256)
       {
         Assert (std::distance(cbegin, cend) == sizeof(T), ExcInternalError());
         T object;

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -221,7 +221,16 @@ SparseMatrix<number>::operator = (const double d)
                                             val.get()),
                                   grain_size);
   else if (matrix_size > 0)
-    std::memset (val.get(), 0, matrix_size*sizeof(number));
+    {
+#ifdef DEAL_II_WITH_CXX17
+      if constexpr(std::is_trivial<number>::value)
+#else
+      if (std::is_trivial<number>::value)
+#endif
+        std::memset (val.get(), 0, matrix_size*sizeof(number));
+      else
+        std::fill (val.get(), val.get()+matrix_size, 0);
+    }
 
   return *this;
 }

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -212,9 +212,18 @@ namespace internal
         Assert (end>=begin, ExcInternalError());
 
         if (value == Number())
-          std::memset (dst+begin,0,(end-begin)*sizeof(Number));
-        else
-          std::fill (dst+begin, dst+end, value);
+          {
+#ifdef DEAL_II_WITH_CXX17
+            if constexpr (std::is_trivial<Number>::value)
+#else
+            if (std::is_trivial<Number>::value)
+#endif
+              {
+                std::memset(dst+begin, 0, sizeof(Number)*(end-begin));
+                return;
+              }
+          }
+        std::fill (dst+begin, dst+end, value);
       }
 
       const Number value;
@@ -237,7 +246,15 @@ namespace internal
       {
         Assert (end>=begin, ExcInternalError());
 
-        if (std::is_same<Number,OtherNumber>::value)
+#if __GNUG__ && __GNUC__ < 5
+        if (  __has_trivial_copy(Number) && std::is_same<Number,OtherNumber>::value)
+#else
+#  ifdef DEAL_II_WITH_CXX17
+        if constexpr (std::is_trivially_copyable<Number>()  && std::is_same<Number,OtherNumber>::value)
+#  else
+        if (std::is_trivially_copyable<Number>() && std::is_same<Number,OtherNumber>::value)
+#  endif
+#endif
           std::memcpy(dst+begin, src+begin, (end-begin)*sizeof(Number));
         else
           {


### PR DESCRIPTION
Again, `gcc-8` complains that `std::memset` and `std::memcpy` are called for non-trivial resp. non-trivially-copyable types.
This assumes that C++17-compliant compilers have `if constexpr`.