### PR TITLE
[9.0] Revert "Replace std::memmove by std::move for std::pair"

### DIFF
--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -1062,9 +1062,9 @@ namespace internals
           // at least one element when we get here, subtracting 1 works fine.
           data.resize(2*data.size());
           for (size_type i=individual_size.size()-1; i>0; --i)
-            std::move(data.data()+(i*row_length*2),
-                      data.data()+(i*row_length+2+individual_size[i]),
-                      data.data()+(i*row_length));
+            std::memmove(&data[i*row_length*2], &data[i*row_length],
+                         individual_size[i]*
+                         sizeof(std::pair<size_type,double>));
           row_length *= 2;
         }
       data[index*row_length+my_length] = pair;


### PR DESCRIPTION
This reverts commit 11aef84a644b036b3f7acae2bad252737d8151aa.