### PR TITLE
Fix a GCC8 warning: use std::move_backward instead of std::memmove

### DIFF
--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -1062,9 +1062,12 @@ namespace internals
           // at least one element when we get here, subtracting 1 works fine.
           data.resize(2*data.size());
           for (size_type i=individual_size.size()-1; i>0; --i)
-            std::memmove(&data[i*row_length*2], &data[i*row_length],
-                         individual_size[i]*
-                         sizeof(std::pair<size_type,double>));
+            {
+              const auto ptr = data.data();
+              std::move_backward(ptr + i*row_length,
+                                 ptr + i*row_length + individual_size[i],
+                                 ptr + i*2*row_length + individual_size[i]);
+            }
           row_length *= 2;
         }
       data[index*row_length+my_length] = pair;


### PR DESCRIPTION
This should fix all of the issues here.

Note that this is for master, not 9.0; we can cherry-pick later.