### PR TITLE
Revert "Default copy assignement in Tensor for non-Intel compilers"

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -212,13 +212,7 @@ public:
   /**
    * Assignment from tensors with same underlying scalar type.
    */
-#ifdef __INTEL_COMPILER
   Tensor &operator = (const Tensor<0,dim,Number> &rhs);
-  // ICC 15 doesn't allow this copy constructor to be defaulted.
-  // see https://github.com/dealii/dealii/pull/5865.
-#else
-  Tensor &operator = (const Tensor<0,dim,Number> &rhs) = default;
-#endif
 
   /**
    * This operator assigns a scalar to a tensor. This obviously requires
@@ -819,7 +813,6 @@ Tensor<0,dim,Number> &Tensor<0,dim,Number>::operator = (const Tensor<0,dim,Other
 }
 
 
-#ifdef __INTEL_COMPILER
 template <int dim, typename Number>
 inline
 Tensor<0,dim,Number> &Tensor<0,dim,Number>::operator = (const Tensor<0,dim,Number> &p)
@@ -827,7 +820,6 @@ Tensor<0,dim,Number> &Tensor<0,dim,Number>::operator = (const Tensor<0,dim,Numbe
   value = p.value;
   return *this;
 }
-#endif
 
 
 template <int dim, typename Number>


### PR DESCRIPTION
This reverts commit 171a9d03e87edcf7d455ecde576546777c112b45.

In reference to #6474