### PR TITLE
Fix invalid number of particle properties in a test

### DIFF
--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -56,11 +56,12 @@ namespace Particles
     /**
      * Constructor. Stores the number of properties per reserved slot.
      */
-    PropertyPool (const unsigned int n_properties_per_slot=1);
+    PropertyPool (const unsigned int n_properties_per_slot);
 
     /**
      * Return a new handle that allows accessing the reserved block
-     * of memory.
+     * of memory. If the number of properties is zero this will return an
+     * invalid handle.
      */
     Handle allocate_properties_array ();
 

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -33,7 +33,11 @@ namespace Particles
   PropertyPool::Handle
   PropertyPool::allocate_properties_array ()
   {
-    return new double[n_properties];
+    PropertyPool::Handle handle = PropertyPool::invalid_handle;
+    if (n_properties > 0)
+      handle = new double[n_properties];
+
+    return handle;
   }
 
 

--- a/tests/particles/particle_04.cc
+++ b/tests/particles/particle_04.cc
@@ -55,7 +55,7 @@ void test ()
     particle.write_data(write_pointer);
 
     const void *read_pointer = static_cast<const void *> (&data.front());
-    Particles::PropertyPool pool;
+    Particles::PropertyPool pool(0);
     const Particles::Particle<dim,spacedim> new_particle(read_pointer,pool);
 
     deallog << "Copy particle location: " << new_particle.get_location() << std::endl

--- a/tests/particles/particle_04.cc
+++ b/tests/particles/particle_04.cc
@@ -55,7 +55,7 @@ void test ()
     particle.write_data(write_pointer);
 
     const void *read_pointer = static_cast<const void *> (&data.front());
-    Particles::PropertyPool pool(0);
+    Particles::PropertyPool pool;
     const Particles::Particle<dim,spacedim> new_particle(read_pointer,pool);
 
     deallog << "Copy particle location: " << new_particle.get_location() << std::endl

--- a/tests/particles/property_pool_01.cc
+++ b/tests/particles/property_pool_01.cc
@@ -26,7 +26,7 @@
 void test ()
 {
   {
-    Particles::PropertyPool pool;
+    Particles::PropertyPool pool(1);
 
     typename Particles::PropertyPool::Handle handle = pool.allocate_properties_array();
 


### PR DESCRIPTION
This fixes the same issue as #6393, but in a less intrusive manner. The fix is not as good though (It does not prevent others from calling this constructor in a wrong way). Also it illustrates that the default value of 1 for the constructor can be confusing. On the other hand one can argue that creating a property pool only makes sense if you have at least one property, so 1 should be the reasonable default.

Either way: This should end up in the release if we decide to use this instead of #6393. We can also merge both, but that changes the interface of the particles so maybe it is a bit dangerous that short before the release?