### PR TITLE
Fix compute_local_to_global_vertex_index_map.

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2140,8 +2140,10 @@ next_cell:
     const unsigned int n_cpu = Utilities::MPI::n_mpi_processes(triangulation.get_communicator());
     std::vector<types::global_vertex_index> indices(n_cpu);
     int ierr = MPI_Allgather(&next_index, 1, DEAL_II_DOF_INDEX_MPI_TYPE, indices.data(),
-                             indices.size(), DEAL_II_DOF_INDEX_MPI_TYPE, triangulation.get_communicator());
+                             1, DEAL_II_DOF_INDEX_MPI_TYPE, triangulation.get_communicator());
     AssertThrowMPI(ierr);
+    Assert(indices.begin() + triangulation.locally_owned_subdomain() < indices.end(),
+           ExcInternalError());
     const types::global_vertex_index shift = std::accumulate(indices.begin(),
                                                              indices.begin()+triangulation.locally_owned_subdomain(),
                                                              types::global_vertex_index(0));


### PR DESCRIPTION
The MPI_Allgather call should have the same value inputs for the second and fifth arguments.

This took a *lot* longer to debug than I'd like to admit. Amazingly, this only fails for me in debug mode and only on my workstation.

We should probably put this on 9.0.