### PR TITLE
Move parsing of external.conf at the end.

### DIFF
--- a/cmake/cpack-mac-bundle/dealii.conf.in
+++ b/cmake/cpack-mac-bundle/dealii.conf.in
@@ -34,10 +34,6 @@ fi
 export PATH=$DEAL_II_RESOURCES/bin:$PATH
 export DEAL_II_DIR=$DEAL_II_RESOURCES
 
-# Do whatever the external library tells us to
-if [ -f $DEAL_II_RESOURCES/@DEAL_II_CPACK_EXTERNAL_LIBS@/external.conf ]; then
-    . $DEAL_II_RESOURCES/@DEAL_II_CPACK_EXTERNAL_LIBS@/external.conf
-fi
 
 if [ -z "$DEAL_II_CONF_SILENT" ]; then
     # Clear screen
@@ -85,4 +81,9 @@ if ! [[ -x /usr/bin/xcodebuild ]]; then
     Please install XCode before you continue.
 
 EOF
+fi
+
+# Lastly, do whatever the external library installation tells us to
+if [ -f $DEAL_II_RESOURCES/@DEAL_II_CPACK_EXTERNAL_LIBS@/external.conf ]; then
+    . $DEAL_II_RESOURCES/@DEAL_II_CPACK_EXTERNAL_LIBS@/external.conf
 fi


### PR DESCRIPTION
This is necessary to print useful messages in the mac bundle package.

I'm creating a dmg image for 9.0.0-rc2 right now. The one for rc1 is here. Unfortunately in that package I forgot to enter the file `external.conf`, so you'll need to configure by yourself (that's why I didn't put in the official release).

https://github.com/luca-heltai/dealii/releases/tag/v9.0.0-rc1