### PR TITLE
Default copy assignement in Tensor for non-Intel compilers

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -209,10 +209,15 @@ public:
   template <typename OtherNumber>
   Tensor &operator = (const Tensor<0,dim,OtherNumber> &rhs);
 
+#ifdef __INTEL_COMPILER
   /**
    * Assignment from tensors with same underlying scalar type.
+   * This is needed for ICC15 because it can't generate a suitable
+   * copy constructor for Sacado::Rad::ADvar types automatically.
+   * See https://github.com/dealii/dealii/pull/5865.
    */
   Tensor &operator = (const Tensor<0,dim,Number> &rhs);
+#endif
 
   /**
    * This operator assigns a scalar to a tensor. This obviously requires
@@ -813,6 +818,7 @@ Tensor<0,dim,Number> &Tensor<0,dim,Number>::operator = (const Tensor<0,dim,Other
 }
 
 
+#ifdef __INTEL_COMPILER
 template <int dim, typename Number>
 inline
 Tensor<0,dim,Number> &Tensor<0,dim,Number>::operator = (const Tensor<0,dim,Number> &p)
@@ -820,6 +826,7 @@ Tensor<0,dim,Number> &Tensor<0,dim,Number>::operator = (const Tensor<0,dim,Numbe
   value = p.value;
   return *this;
 }
+#endif
 
 
 template <int dim, typename Number>


### PR DESCRIPTION
This another take on the same issue as in #6474:

In #5865, we explicitly defined the copy assignment operator so that ICC-15 can compile.
Now, `gcc-8` complains that `Tensor` is not trivially-copyable. Hence, restrict defining a copy assignment operator to Intel compilers.

I made sure that this compiles with `gcc-8` and `Sacado` support as well as `ICC18`  and `Sacado` support yet.