### PR TITLE
Actually fix compute_local_to_global_vertex_index_map.

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2139,8 +2139,8 @@ next_cell:
     // processors and shifting the indices accordingly
     const unsigned int n_cpu = Utilities::MPI::n_mpi_processes(triangulation.get_communicator());
     std::vector<types::global_vertex_index> indices(n_cpu);
-    int ierr = MPI_Allgather(&next_index, 1, DEAL_II_DOF_INDEX_MPI_TYPE, indices.data(),
-                             1, DEAL_II_DOF_INDEX_MPI_TYPE, triangulation.get_communicator());
+    int ierr = MPI_Allgather(&next_index, 1, DEAL_II_VERTEX_INDEX_MPI_TYPE, indices.data(),
+                             1, DEAL_II_VERTEX_INDEX_MPI_TYPE, triangulation.get_communicator());
     AssertThrowMPI(ierr);
     Assert(indices.begin() + triangulation.locally_owned_subdomain() < indices.end(),
            ExcInternalError());


### PR DESCRIPTION
Followup to #6487. In my defense my original fix was right, its just that there was a second bug to fix.

The MPI types do not match the deal.II types, which is causes chaos when we use 32 bit indices.