### PR TITLE
Attempt to fix the undefined symbol VectorImplementation::minimum_parallel_grain_size

### DIFF
--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -751,6 +751,7 @@ namespace parallel
 }
 
 
+#ifndef dealii_parallel_cc
 namespace internal
 {
   namespace VectorImplementation
@@ -783,6 +784,7 @@ namespace internal
   }
 
 } // end of namespace internal
+#endif // deal_ii_parallel_cc
 
 
 /* --------------------------- inline functions ------------------------- */

--- a/source/base/parallel.cc
+++ b/source/base/parallel.cc
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 
 
+#define dealii_parallel_cc
 #include <deal.II/base/parallel.h>
 
 


### PR DESCRIPTION
Attempt to fix #6229.
@luca-heltai Can you try if this improves the situation regarding the undefined symbol?