### PR TITLE
Simplify a resize statement.

### DIFF
--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -653,7 +653,7 @@ namespace internal
         {
           std::vector<dealii::Vector<typename VectorType::value_type> > tmp(patch_values_system.size());
           for (unsigned int i = 0; i < patch_values_system.size(); i++)
-            tmp[i].reinit(patch_values_system[i]);
+            tmp[i].reinit(patch_values_system[i].size());
 
           fe_patch_values.get_function_values (*vector, tmp);
 


### PR DESCRIPTION
In particular, it is not necessary to actually copy the data of the
template vector here -- we really only care about its size.