### PR TITLE
Use the appropriate type to state a zero.

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -2759,7 +2759,7 @@ namespace internal
                             LinearAlgebra::distributed::Vector<Number> &vec) const
     {
       if (range_index == numbers::invalid_unsigned_int)
-        vec = 0;
+        vec = Number();
       else
         {
           const unsigned int mf_component = find_vector_in_mf(vec, false);


### PR DESCRIPTION
Specifically, make sure that a statement also compiles if we are working with
complex-valued data.

I found this in an attempt to make `VectorTools::project()` work also for complex-valued vectors. That turned out to be a bigger project than I wanted to tackle, but these little issues are still worth addressing in case someone else wants to get back to the bigger goal at a later time.