### PR TITLE
Utilize the C++11 constructors of std::[io]stream taking a std::string.

### DIFF
--- a/examples/step-10/step-10.cc
+++ b/examples/step-10/step-10.cc
@@ -140,7 +140,7 @@ namespace Step10
                                    + "_mapping_q_"
                                    + Utilities::to_string(degree)
                                    + ".dat";
-            std::ofstream gnuplot_file (filename.c_str());
+            std::ofstream gnuplot_file (filename);
 
             // Then write out the triangulation to this file. The last
             // argument of the function is a pointer to a mapping object. This

--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -571,7 +571,7 @@ namespace Step12
     {
       const std::string filename = "grid-" + std::to_string(cycle) + ".eps";
       deallog << "Writing grid to <" << filename << ">" << std::endl;
-      std::ofstream eps_output (filename.c_str());
+      std::ofstream eps_output (filename);
 
       GridOut grid_out;
       grid_out.write_eps (triangulation, eps_output);
@@ -581,7 +581,7 @@ namespace Step12
     {
       const std::string filename = "sol-" + std::to_string(cycle) + ".gnuplot";
       deallog << "Writing solution to <" << filename << ">" << std::endl;
-      std::ofstream gnuplot_output (filename.c_str());
+      std::ofstream gnuplot_output (filename);
 
       DataOut<dim> data_out;
       data_out.attach_dof_handler (dof_handler);

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -1333,7 +1333,7 @@ namespace Step18
 
     // With the so-completed filename, let us open a file and write the data
     // we have generated into it:
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
     data_out.write_vtu (output);
 
     // The record files must be written only once and not by each processor,
@@ -1353,7 +1353,7 @@ namespace Step18
         visit_master_filename = ("solution-" +
                                  Utilities::int_to_string(timestep_no,4) +
                                  ".visit");
-        std::ofstream visit_master (visit_master_filename.c_str());
+        std::ofstream visit_master (visit_master_filename);
         DataOutBase::write_visit_record (visit_master, filenames);
 
         // Similarly, we write the paraview .pvtu:
@@ -1361,7 +1361,7 @@ namespace Step18
         pvtu_master_filename = ("solution-" +
                                 Utilities::int_to_string(timestep_no,4) +
                                 ".pvtu");
-        std::ofstream pvtu_master (pvtu_master_filename.c_str());
+        std::ofstream pvtu_master (pvtu_master_filename);
         data_out.write_pvtu_record (pvtu_master, filenames);
 
         // Finally, we write the paraview record, that references all .pvtu files and

--- a/examples/step-19/step-19.cc
+++ b/examples/step-19/step-19.cc
@@ -372,7 +372,7 @@ namespace Step19
     DataOutReader<dim,spacedim> merged_data;
 
     {
-      std::ifstream input (input_file_names[0].c_str());
+      std::ifstream input (input_file_names[0]);
       AssertThrow (input, ExcIO());
 
       merged_data.read (input);
@@ -382,7 +382,7 @@ namespace Step19
     // object, and then merge that into the first object declared above:
     for (unsigned int i=1; i<input_file_names.size(); ++i)
       {
-        std::ifstream input (input_file_names[i].c_str());
+        std::ifstream input (input_file_names[i]);
         AssertThrow (input, ExcIO());
 
         DataOutReader<dim,spacedim> additional_data;
@@ -398,7 +398,7 @@ namespace Step19
     // the command line. Note that this ensures that if the library acquires
     // the ability to output in other output formats, this program will be
     // able to make use of this ability without having to be changed!
-    std::ofstream output_stream (output_file.c_str());
+    std::ofstream output_stream (output_file);
     AssertThrow (output_stream, ExcIO());
 
     const DataOutBase::OutputFormat format
@@ -436,7 +436,7 @@ namespace Step19
     AssertThrow (input_file_names.size() > 0,
                  ExcMessage ("No input files specified."));
 
-    std::ifstream input(input_file_names[0].c_str());
+    std::ifstream input(input_file_names[0]);
     AssertThrow (input, ExcIO());
 
     const std::pair<unsigned int, unsigned int>

--- a/examples/step-23/step-23.cc
+++ b/examples/step-23/step-23.cc
@@ -459,7 +459,7 @@ namespace Step23
     const std::string filename = "solution-" +
                                  Utilities::int_to_string (timestep_number, 3) +
                                  ".gnuplot";
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
     data_out.write_gnuplot (output);
   }
 

--- a/examples/step-24/step-24.cc
+++ b/examples/step-24/step-24.cc
@@ -459,7 +459,7 @@ namespace Step24
     const std::string filename =  "solution-" +
                                   Utilities::int_to_string (timestep_number, 3) +
                                   ".gnuplot";
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
     data_out.write_gnuplot (output);
   }
 

--- a/examples/step-25/step-25.cc
+++ b/examples/step-25/step-25.cc
@@ -579,7 +579,7 @@ namespace Step25
                                   Utilities::int_to_string (timestep_number, 3) +
                                   ".vtk";
 
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
     data_out.write_vtk (output);
   }
 

--- a/examples/step-26/step-26.cc
+++ b/examples/step-26/step-26.cc
@@ -309,7 +309,7 @@ namespace Step26
     const std::string filename = "solution-"
                                  + Utilities::int_to_string(timestep_number, 3) +
                                  ".vtk";
-    std::ofstream output(filename.c_str());
+    std::ofstream output(filename);
     data_out.write_vtk(output);
   }
 

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -474,7 +474,7 @@ namespace Step27
       const std::string filename = "solution-" +
                                    Utilities::int_to_string (cycle, 2) +
                                    ".vtk";
-      std::ofstream output (filename.c_str());
+      std::ofstream output (filename);
       data_out.write_vtk (output);
     }
 

--- a/examples/step-28/step-28.cc
+++ b/examples/step-28/step-28.cc
@@ -1153,7 +1153,7 @@ namespace Step28
     data_out.add_data_vector (solution, "solution");
     data_out.build_patches ();
 
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
     data_out.write_vtu (output);
   }
 

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -863,7 +863,7 @@ namespace Step29
     const std::string filename = output_file +
                                  data_out.default_suffix();
 
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
 
     // The solution vectors $v$ and $w$ are added to the DataOut object in the
     // usual way:

--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -875,7 +875,7 @@ namespace Step30
 
     filename += refine_type + ".eps";
     std::cout << "Writing grid to <" << filename << ">..." << std::endl;
-    std::ofstream eps_output (filename.c_str());
+    std::ofstream eps_output (filename);
 
     GridOut grid_out;
     grid_out.write_eps (triangulation, eps_output);
@@ -886,7 +886,7 @@ namespace Step30
 
     filename += refine_type + ".gnuplot";
     std::cout << "Writing grid to <" << filename << ">..." << std::endl;
-    std::ofstream gnuplot_grid_output (filename.c_str());
+    std::ofstream gnuplot_grid_output (filename);
 
     grid_out.write_gnuplot (triangulation, gnuplot_grid_output);
 
@@ -897,7 +897,7 @@ namespace Step30
     filename += refine_type + ".gnuplot";
     std::cout << "Writing solution to <" << filename << ">..."
               << std::endl;
-    std::ofstream gnuplot_output (filename.c_str());
+    std::ofstream gnuplot_output (filename);
 
     DataOut<dim> data_out;
     data_out.attach_dof_handler (dof_handler);

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -1032,13 +1032,13 @@ namespace Step32
     ParameterHandler prm;
     BoussinesqFlowProblem<dim>::Parameters::declare_parameters (prm);
 
-    std::ifstream parameter_file (parameter_filename.c_str());
+    std::ifstream parameter_file (parameter_filename);
 
     if (!parameter_file)
       {
         parameter_file.close ();
 
-        std::ofstream parameter_out (parameter_filename.c_str());
+        std::ofstream parameter_out (parameter_filename);
         prm.print_parameters (parameter_out,
                               ParameterHandler::Text);
 
@@ -3404,7 +3404,7 @@ namespace Step32
                                   Utilities::int_to_string
                                   (triangulation.locally_owned_subdomain(), 4) +
                                   ".vtu");
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
     data_out.write_vtu (output);
 
 
@@ -3428,14 +3428,14 @@ namespace Step32
         pvtu_master_filename = ("solution-" +
                                 Utilities::int_to_string (out_index, 5) +
                                 ".pvtu");
-        std::ofstream pvtu_master (pvtu_master_filename.c_str());
+        std::ofstream pvtu_master (pvtu_master_filename);
         data_out.write_pvtu_record (pvtu_master, filenames);
 
         const std::string
         visit_master_filename = ("solution-" +
                                  Utilities::int_to_string (out_index, 5) +
                                  ".visit");
-        std::ofstream visit_master (visit_master_filename.c_str());
+        std::ofstream visit_master (visit_master_filename);
         DataOutBase::write_visit_record (visit_master, filenames);
       }
 

--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -2305,7 +2305,7 @@ namespace Step33
     std::string filename = "solution-" +
                            Utilities::int_to_string (output_file_number, 3) +
                            ".vtk";
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
     data_out.write_vtk (output);
 
     ++output_file_number;
@@ -2332,7 +2332,7 @@ namespace Step33
       GridIn<dim> grid_in;
       grid_in.attach_triangulation(triangulation);
 
-      std::ifstream input_file(parameters.mesh_filename.c_str());
+      std::ifstream input_file(parameters.mesh_filename);
       Assert (input_file, ExcFileNotOpen(parameters.mesh_filename.c_str()));
 
       grid_in.read_ucd(input_file);

--- a/examples/step-34/step-34.cc
+++ b/examples/step-34/step-34.cc
@@ -1002,7 +1002,7 @@ namespace Step34
 
     const std::string
     filename = Utilities::int_to_string(dim) + "d_external.vtk";
-    std::ofstream file(filename.c_str());
+    std::ofstream file(filename);
 
     data_out.write_vtk(file);
   }
@@ -1030,7 +1030,7 @@ namespace Step34
                              "d_boundary_solution_" +
                              Utilities::int_to_string(cycle) +
                              ".vtk" );
-    std::ofstream file(filename.c_str());
+    std::ofstream file(filename);
 
     dataout.write_vtk(file);
 

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -709,7 +709,7 @@ namespace Step35
 
     {
       std::string filename = "nsbench2.inp";
-      std::ifstream file (filename.c_str());
+      std::ifstream file (filename);
       Assert (file, ExcFileNotOpen (filename.c_str()));
       grid_in.read_ucd (file);
     }
@@ -1354,9 +1354,9 @@ namespace Step35
                               DataOut<dim>::type_dof_data,
                               component_interpretation);
     data_out.build_patches (deg + 1);
-    std::ofstream output (("solution-" +
-                           Utilities::int_to_string (step, 5) +
-                           ".vtk").c_str());
+    std::ofstream output ("solution-" +
+                          Utilities::int_to_string (step, 5) +
+                          ".vtk");
     data_out.write_vtk (output);
   }
 

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -1146,7 +1146,7 @@ namespace Step37
                                  + ".vtu");
 
         std::string master_name = "solution-" + Utilities::to_string(cycle) + ".pvtu";
-        std::ofstream master_output (master_name.c_str());
+        std::ofstream master_output (master_name);
         data_out.write_pvtu_record (master_output, filenames);
       }
   }

--- a/examples/step-38/step-38.cc
+++ b/examples/step-38/step-38.cc
@@ -496,7 +496,7 @@ namespace Step38
     std::string filename ("solution-");
     filename += static_cast<char>('0'+spacedim);
     filename += "d.vtk";
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
     data_out.write_vtk (output);
   }
 

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -871,7 +871,7 @@ namespace Step39
 
     deallog << "Writing solution to <" << filename << ">..."
             << std::endl << std::endl;
-    std::ofstream gnuplot_output (filename.c_str());
+    std::ofstream gnuplot_output (filename);
 
     DataOut<dim> data_out;
     data_out.attach_dof_handler (dof_handler);

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -597,7 +597,7 @@ namespace Step40
                                   "." +
                                   Utilities::int_to_string
                                   (triangulation.locally_owned_subdomain(), 4));
-    std::ofstream output ((filename + ".vtu").c_str());
+    std::ofstream output ((filename + ".vtu"));
     data_out.write_vtu (output);
 
     // The last step is to write a "master record" that lists for the
@@ -619,9 +619,9 @@ namespace Step40
                                Utilities::int_to_string (i, 4) +
                                ".vtu");
 
-        std::ofstream master_output (("solution-" +
-                                      Utilities::int_to_string (cycle, 2) +
-                                      ".pvtu").c_str());
+        std::ofstream master_output ("solution-" +
+                                     Utilities::int_to_string (cycle, 2) +
+                                     ".pvtu");
         data_out.write_pvtu_record (master_output, filenames);
       }
   }

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -601,9 +601,9 @@ namespace Step41
 
     data_out.build_patches ();
 
-    std::ofstream output_vtk ((std::string("output_") +
-                               Utilities::int_to_string (iteration, 3) +
-                               ".vtk").c_str ());
+    std::ofstream output_vtk (std::string("output_") +
+                              Utilities::int_to_string (iteration, 3) +
+                              ".vtk");
     data_out.write_vtk (output_vtk);
   }
 

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -478,7 +478,7 @@ namespace Step42
       nx(0),
       ny(0)
     {
-      std::ifstream f(name.c_str());
+      std::ifstream f(name);
       AssertThrow (f, ExcMessage (std::string("Can't read from file <") +
                                   name + ">!"));
 
@@ -2055,7 +2055,7 @@ namespace Step42
       (output_dir + filename_base + "-"
        + Utilities::int_to_string(triangulation.locally_owned_subdomain(), 4));
 
-    std::ofstream output_vtu((filename + ".vtu").c_str());
+    std::ofstream output_vtu((filename + ".vtu"));
     data_out.write_vtu(output_vtu);
     pcout << output_dir + filename_base << ".pvtu" << std::endl;
 
@@ -2068,10 +2068,10 @@ namespace Step42
                               Utilities::int_to_string(i, 4) +
                               ".vtu");
 
-        std::ofstream pvtu_master_output((output_dir + filename_base + ".pvtu").c_str());
+        std::ofstream pvtu_master_output((output_dir + filename_base + ".pvtu"));
         data_out.write_pvtu_record(pvtu_master_output, filenames);
 
-        std::ofstream visit_master_output((output_dir + filename_base + ".visit").c_str());
+        std::ofstream visit_master_output((output_dir + filename_base + ".visit"));
         DataOutBase::write_visit_record(visit_master_output, filenames);
       }
 

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -1843,7 +1843,7 @@ namespace Step43
 
     std::string filename = "solution-" +
                            Utilities::int_to_string (timestep_number, 5) + ".vtu";
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
     data_out.write_vtu (output);
   }
 

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -691,7 +691,7 @@ namespace Step45
         pvtu_master_filename = ("solution-" +
                                 Utilities::int_to_string (refinement_cycle, 2) +
                                 ".pvtu");
-        std::ofstream pvtu_master (pvtu_master_filename.c_str());
+        std::ofstream pvtu_master (pvtu_master_filename);
         data_out.write_pvtu_record (pvtu_master, filenames);
       }
   }

--- a/examples/step-47/step-47.cc
+++ b/examples/step-47/step-47.cc
@@ -591,7 +591,7 @@ namespace Step47
         //std::endl; std::cout << F << std::endl;
 
         std::string filename = "vertices.dat";
-        std::ofstream output (filename.c_str());
+        std::ofstream output (filename);
         output << "#vertices of xfem subcells" << std::endl;
         output << v0(0) << "   " << v0(1) << std::endl;
         output << v1(0) << "   " << v1(1) << std::endl;
@@ -718,7 +718,7 @@ namespace Step47
         //std::cout << "Pos " << Pos << std::endl; std::cout << A <<
         //std::endl; std::cout << B << std::endl;
         std::string filename = "vertices.dat";
-        std::ofstream output (filename.c_str());
+        std::ofstream output (filename);
         output << "#vertices of xfem subcells" << std::endl;
         output << A(0) << "   " << A(1) << std::endl;
         output << B(0) << "   " << B(1) << std::endl;
@@ -987,7 +987,7 @@ namespace Step47
     filename += ('0' + cycle);
     filename += ".vtk";
 
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
 
     Postprocessor<dim> postprocessor;
     DataOut<dim,hp::DoFHandler<dim> > data_out;

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -486,9 +486,9 @@ namespace Step48
     const std::string filename =
       "solution-" + Utilities::int_to_string (timestep_number, 3);
 
-    std::ofstream output ((filename +
-                           "." + Utilities::int_to_string (Utilities::MPI::
-                                                           this_mpi_process(MPI_COMM_WORLD),4) + ".vtu").c_str());
+    std::ofstream output (filename +
+                          "." + Utilities::int_to_string (Utilities::MPI::
+                                                          this_mpi_process(MPI_COMM_WORLD),4) + ".vtu");
     data_out.write_vtu (output);
 
     if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
@@ -502,7 +502,7 @@ namespace Step48
                                Utilities::int_to_string (i, 4) +
                                ".vtu");
 
-        std::ofstream master_output ((filename + ".pvtu").c_str());
+        std::ofstream master_output ((filename + ".pvtu"));
         data_out.write_pvtu_record (master_output, filenames);
       }
   }

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -877,7 +877,7 @@ namespace Step50
                                   Utilities::int_to_string
                                   (triangulation.locally_owned_subdomain(), 4) +
                                   ".vtu");
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
     data_out.write_vtu (output);
 
     if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
@@ -893,14 +893,14 @@ namespace Step50
         pvtu_master_filename = ("solution-" +
                                 Utilities::int_to_string (cycle, 5) +
                                 ".pvtu");
-        std::ofstream pvtu_master (pvtu_master_filename.c_str());
+        std::ofstream pvtu_master (pvtu_master_filename);
         data_out.write_pvtu_record (pvtu_master, filenames);
 
         const std::string
         visit_master_filename = ("solution-" +
                                  Utilities::int_to_string (cycle, 5) +
                                  ".visit");
-        std::ofstream visit_master (visit_master_filename.c_str());
+        std::ofstream visit_master (visit_master_filename);
         DataOutBase::write_visit_record (visit_master, filenames);
 
         std::cout << "   wrote " << pvtu_master_filename << std::endl;

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -1204,7 +1204,7 @@ namespace Step51
     filename += "-q" + Utilities::int_to_string(fe.degree,1);
     filename += "-" + Utilities::int_to_string(cycle,2);
     filename += ".vtk";
-    std::ofstream output (filename.c_str());
+    std::ofstream output (filename);
 
     DataOut<dim> data_out;
 
@@ -1235,7 +1235,7 @@ namespace Step51
     face_out += "-q" + Utilities::int_to_string(fe.degree,1);
     face_out += "-" + Utilities::int_to_string(cycle,2);
     face_out += ".vtk";
-    std::ofstream face_output (face_out.c_str());
+    std::ofstream face_output (face_out);
 
 // The <code>DataOutFaces</code> class works analogously to the <code>DataOut</code>
 // class when we have a <code>DoFHandler</code> that defines the solution on

--- a/examples/step-52/step-52.cc
+++ b/examples/step-52/step-52.cc
@@ -453,7 +453,7 @@ namespace Step52
     const std::string filename = "solution-" + method_name + "-" +
                                  Utilities::int_to_string (time_step, 3) +
                                  ".vtu";
-    std::ofstream output(filename.c_str());
+    std::ofstream output(filename);
     data_out.write_vtu(output);
   }
 

--- a/examples/step-53/step-53.cc
+++ b/examples/step-53/step-53.cc
@@ -453,7 +453,7 @@ namespace Step53
 
     // Having done this all, we can now output the mesh into a file of its own:
     const std::string filename = "mesh.vtu";
-    std::ofstream out (filename.c_str());
+    std::ofstream out (filename);
     GridOut grid_out;
     grid_out.write_vtu (triangulation, out);
   }

--- a/examples/step-54/step-54.cc
+++ b/examples/step-54/step-54.cc
@@ -225,7 +225,7 @@ namespace Step54
     // mesh from an external VTK file, and convert it to a deal triangulation.
     std::ifstream in;
 
-    in.open(initial_mesh_filename.c_str());
+    in.open(initial_mesh_filename);
 
     GridIn<2,3> gi;
     gi.attach_triangulation(tria);
@@ -363,7 +363,7 @@ namespace Step54
     const std::string filename = ( output_filename + "_" +
                                    Utilities::int_to_string(cycle) +
                                    ".vtk" );
-    std::ofstream logfile(filename.c_str());
+    std::ofstream logfile(filename);
     GridOut grid_out;
     grid_out.write_vtk(tria, logfile);
   }

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -773,7 +773,7 @@ namespace Step55
                                   "." +
                                   Utilities::int_to_string
                                   (triangulation.locally_owned_subdomain(), 4));
-    std::ofstream output ((filename + ".vtu").c_str());
+    std::ofstream output ((filename + ".vtu"));
     data_out.write_vtu (output);
 
     if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
@@ -788,9 +788,9 @@ namespace Step55
                                Utilities::int_to_string (i, 4) +
                                ".vtu");
 
-        std::ofstream master_output (("solution-" +
-                                      Utilities::int_to_string (cycle, 2) +
-                                      ".pvtu").c_str());
+        std::ofstream master_output ("solution-" +
+                                     Utilities::int_to_string (cycle, 2) +
+                                     ".pvtu");
         data_out.write_pvtu_record (master_output, filenames);
       }
   }

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -1081,7 +1081,7 @@ namespace Step7
     // appropriate for VTK output, open a file, and add the solution vector to
     // the object that will do the actual output:
     vtk_filename += ".vtk";
-    std::ofstream output (vtk_filename.c_str());
+    std::ofstream output (vtk_filename);
 
     DataOut<dim> data_out;
     data_out.attach_dof_handler (dof_handler);
@@ -1198,7 +1198,7 @@ namespace Step7
       }
 
     error_filename += ".tex";
-    std::ofstream error_table_file(error_filename.c_str());
+    std::ofstream error_table_file(error_filename);
 
     convergence_table.write_tex(error_table_file);
 
@@ -1283,7 +1283,7 @@ namespace Step7
           }
         conv_filename += ".tex";
 
-        std::ofstream table_file(conv_filename.c_str());
+        std::ofstream table_file(conv_filename);
         convergence_table.write_tex(table_file);
       }
   }


### PR DESCRIPTION
Previously, we had widely used the constructors that take a char* and for that needed
to call the '.c_str()' function of std::string. This is now no longer necessary in C++11.