### PR TITLE
Use the appropriate type to state a constant.

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1590,7 +1590,7 @@ namespace MatrixFreeOperators
     const unsigned int local_size = inverse_diagonal_vector.local_size();
     for (unsigned int i=0; i<local_size; ++i)
       inverse_diagonal_vector.local_element(i)
-        =1./inverse_diagonal_vector.local_element(i);
+        = Number(1.)/inverse_diagonal_vector.local_element(i);
 
     inverse_diagonal_vector.update_ghost_values();
     diagonal_vector.update_ghost_values();


### PR DESCRIPTION
Specifically, make sure that a statement also compiles if we are working with
complex-valued data.

I found this in an attempt to make `VectorTools::project()` work also for complex-valued vectors. That turned out to be a bigger project than I wanted to tackle, but these little issues are still worth addressing in case someone else wants to get back to the bigger goal at a later time.