### PR TITLE
Make sure that also the output of the embedded value is on the deformed grid

### DIFF
--- a/examples/step-60/step-60.cc
+++ b/examples/step-60/step-60.cc
@@ -966,7 +966,9 @@ namespace Step60
                                                ComponentMask(), ComponentMask(),
                                                *embedded_mapping);
 
-      VectorTools::interpolate(*embedded_dh, embedded_value_function, embedded_value);
+      VectorTools::interpolate(*embedded_mapping,
+                               *embedded_dh, embedded_value_function,
+                               embedded_value);
     }
   }
 


### PR DESCRIPTION
This was not used in the computation, but only on the output file, on the deformed grid.

(thanks @GivAlz  for spotting this)