### PR TITLE
Simplify a function that returns an array.

### DIFF
--- a/doc/news/changes/incompatibilities/20180509Bangerth
+++ b/doc/news/changes/incompatibilities/20180509Bangerth
@@ -1,0 +1,7 @@
+Changed: The PolynomialSpace::compute_index() and
+PolynomialsP::directional_degree() functions used to return their
+information through an array that they received as a reference
+argument. Instead, they now return a `std::array<unsigned int,dim>`
+by value.
+<br>
+(Wolfgang Bangerth, 2018/05/09)

--- a/include/deal.II/base/polynomial_space.h
+++ b/include/deal.II/base/polynomial_space.h
@@ -213,12 +213,14 @@ protected:
 
   /**
    * Compute numbers in x, y and z direction. Given an index <tt>n</tt> in the
-   * d-dimensional polynomial space, compute the indices i,j,k such that
+   * d-dimensional polynomial space, return the indices i,j,k such that
    * <i>p<sub>n</sub>(x,y,z) =
    * p<sub>i</sub>(x)p<sub>j</sub>(y)p<sub>k</sub>(z)</i>.
+   *
+   * In 1d and 2d, obviously only i and i,j are returned.
    */
-  void compute_index (const unsigned int n,
-                      unsigned int      (&index)[dim>0?dim:1]) const;
+  std::array<unsigned int,dim>
+  compute_index (const unsigned int n) const;
 
 private:
   /**
@@ -246,14 +248,11 @@ private:
 /* -------------- declaration of explicit specializations --- */
 
 template <>
-void PolynomialSpace<1>::compute_index(const unsigned int n,
-                                       unsigned int      (&index)[1]) const;
+std::array<unsigned int,1> PolynomialSpace<1>::compute_index(const unsigned int n) const;
 template <>
-void PolynomialSpace<2>::compute_index(const unsigned int n,
-                                       unsigned int      (&index)[2]) const;
+std::array<unsigned int,2> PolynomialSpace<2>::compute_index(const unsigned int n) const;
 template <>
-void PolynomialSpace<3>::compute_index(const unsigned int n,
-                                       unsigned int      (&index)[3]) const;
+std::array<unsigned int,3> PolynomialSpace<3>::compute_index(const unsigned int n) const;
 
 
 
@@ -304,10 +303,9 @@ template <class StreamType>
 void
 PolynomialSpace<dim>::output_indices(StreamType &out) const
 {
-  unsigned int ix[dim];
   for (unsigned int i=0; i<n_pols; ++i)
     {
-      compute_index(i,ix);
+      const std::array<unsigned int,dim> ix = compute_index(i);
       out << i << "\t";
       for (unsigned int d=0; d<dim; ++d)
         out << ix[d] << " ";
@@ -321,8 +319,7 @@ Tensor<order,dim>
 PolynomialSpace<dim>::compute_derivative (const unsigned int i,
                                           const Point<dim> &p) const
 {
-  unsigned int indices[dim];
-  compute_index (i, indices);
+  const std::array<unsigned int,dim> indices = compute_index (i);
 
   double v [dim][order+1];
   {

--- a/include/deal.II/base/polynomials_p.h
+++ b/include/deal.II/base/polynomials_p.h
@@ -71,9 +71,11 @@ public:
   /**
    * For the <tt>n</tt>th polynomial $p_n(x,y,z)=x^i y^j z^k$ this function
    * gives the degrees i,j,k in the x,y,z directions.
+   *
+   * In 1d and 2d, obviously only i and i,j are returned.
    */
-  void directional_degrees(unsigned int n,
-                           unsigned int (&degrees)[dim]) const;
+  std::array<unsigned int,dim>
+  directional_degrees(unsigned int n) const;
 
 private:
 
@@ -100,11 +102,11 @@ PolynomialsP<dim>::degree() const
 
 
 template <int dim>
-inline void
-PolynomialsP<dim>::directional_degrees(unsigned int n,
-                                       unsigned int (&degrees)[dim]) const
+inline
+std::array<unsigned int,dim>
+PolynomialsP<dim>::directional_degrees(unsigned int n) const
 {
-  this->compute_index(n,degrees);
+  return this->compute_index(n);
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/base/polynomial_space.cc
+++ b/source/base/polynomial_space.cc
@@ -49,7 +49,7 @@ compute_index (const unsigned int i) const
 {
   Assert(i<index_map.size(),
          ExcIndexRange(i,0,index_map.size()));
-  return {index_map[i]};
+  return {{index_map[i]}};
 }
 
 
@@ -70,12 +70,14 @@ compute_index (const unsigned int i) const
   unsigned int k=0;
   for (unsigned int iy=0; iy<n_1d; ++iy)
     if (n < k+n_1d-iy)
-      return {n-k, iy};
+      {
+        return {{n-k, iy}};
+      }
     else
       k+=n_1d-iy;
 
   Assert (false, ExcInternalError());
-  return {numbers::invalid_unsigned_int, numbers::invalid_unsigned_int};
+  return {{numbers::invalid_unsigned_int, numbers::invalid_unsigned_int}};
 }
 
 
@@ -100,12 +102,14 @@ compute_index (const unsigned int i) const
   for (unsigned int iz=0; iz<n_1d; ++iz)
     for (unsigned int iy=0; iy<n_1d-iz; ++iy)
       if (n < k+n_1d-iy-iz)
-        return {n-k, iy, iz};
+        {
+          return {{n-k, iy, iz}};
+        }
       else
         k += n_1d-iy-iz;
 
   Assert (false, ExcInternalError());
-  return {numbers::invalid_unsigned_int, numbers::invalid_unsigned_int};
+  return {{numbers::invalid_unsigned_int, numbers::invalid_unsigned_int}};
 }
 
 

--- a/source/base/polynomial_space.cc
+++ b/source/base/polynomial_space.cc
@@ -43,24 +43,21 @@ PolynomialSpace<0>::compute_n_pols (const unsigned int)
 
 
 template <>
-void
+std::array<unsigned int,1>
 PolynomialSpace<1>::
-compute_index (const unsigned int i,
-               unsigned int      (&index)[1]) const
+compute_index (const unsigned int i) const
 {
   Assert(i<index_map.size(),
          ExcIndexRange(i,0,index_map.size()));
-  const unsigned int n=index_map[i];
-  index[0] = n;
+  return {index_map[i]};
 }
 
 
 
 template <>
-void
+std::array<unsigned int,2>
 PolynomialSpace<2>::
-compute_index (const unsigned int i,
-               unsigned int      (&index)[2]) const
+compute_index (const unsigned int i) const
 {
   Assert(i<index_map.size(),
          ExcIndexRange(i,0,index_map.size()));
@@ -73,22 +70,20 @@ compute_index (const unsigned int i,
   unsigned int k=0;
   for (unsigned int iy=0; iy<n_1d; ++iy)
     if (n < k+n_1d-iy)
-      {
-        index[0] = n-k;
-        index[1] = iy;
-        return;
-      }
+      return {n-k, iy};
     else
       k+=n_1d-iy;
+
+  Assert (false, ExcInternalError());
+  return {numbers::invalid_unsigned_int, numbers::invalid_unsigned_int};
 }
 
 
 
 template <>
-void
+std::array<unsigned int,3>
 PolynomialSpace<3>::
-compute_index (const unsigned int i,
-               unsigned int      (&index)[3]) const
+compute_index (const unsigned int i) const
 {
   Assert(i<index_map.size(),
          ExcIndexRange(i,0,index_map.size()));
@@ -105,14 +100,12 @@ compute_index (const unsigned int i,
   for (unsigned int iz=0; iz<n_1d; ++iz)
     for (unsigned int iy=0; iy<n_1d-iz; ++iy)
       if (n < k+n_1d-iy-iz)
-        {
-          index[0] = n-k;
-          index[1] = iy;
-          index[2] = iz;
-          return;
-        }
+        return {n-k, iy, iz};
       else
         k += n_1d-iy-iz;
+
+  Assert (false, ExcInternalError());
+  return {numbers::invalid_unsigned_int, numbers::invalid_unsigned_int};
 }
 
 
@@ -136,8 +129,7 @@ double
 PolynomialSpace<dim>::compute_value (const unsigned int i,
                                      const Point<dim>  &p) const
 {
-  unsigned int ix[dim];
-  compute_index(i,ix);
+  const auto ix = compute_index(i);
   // take the product of the
   // polynomials in the various space
   // directions
@@ -154,8 +146,7 @@ Tensor<1,dim>
 PolynomialSpace<dim>::compute_grad (const unsigned int i,
                                     const Point<dim>  &p) const
 {
-  unsigned int ix[dim];
-  compute_index(i,ix);
+  const auto ix = compute_index(i);
 
   Tensor<1,dim> result;
   for (unsigned int d=0; d<dim; ++d)
@@ -180,8 +171,7 @@ Tensor<2,dim>
 PolynomialSpace<dim>::compute_grad_grad (const unsigned int i,
                                          const Point<dim>  &p) const
 {
-  unsigned int ix[dim];
-  compute_index(i,ix);
+  const auto ix = compute_index(i);
 
   Tensor<2,dim> result;
   for (unsigned int d=0; d<dim; ++d)

--- a/source/fe/fe_dgp_monomial.cc
+++ b/source/fe/fe_dgp_monomial.cc
@@ -415,8 +415,9 @@ FE_DGPMonomial<2>::has_support_on_face (const unsigned int shape_index,
     support_on_face=true;
   else
     {
-      unsigned int degrees[2];
-      this->poly_space.directional_degrees(shape_index, degrees);
+      const std::array<unsigned int,2> degrees
+        = this->poly_space.directional_degrees(shape_index);
+
       if ((face_index==0 && degrees[1]==0) ||
           (face_index==3 && degrees[0]==0))
         support_on_face=true;
@@ -436,8 +437,9 @@ FE_DGPMonomial<3>::has_support_on_face (const unsigned int shape_index,
     support_on_face=true;
   else
     {
-      unsigned int degrees[3];
-      this->poly_space.directional_degrees(shape_index, degrees);
+      const std::array<unsigned int,3> degrees
+        = this->poly_space.directional_degrees(shape_index);
+
       if ((face_index==0 && degrees[1]==0) ||
           (face_index==2 && degrees[2]==0) ||
           (face_index==5 && degrees[0]==0))


### PR DESCRIPTION
Previously, it used a reference to an array as an output argument. Now, we can just
return a std::array<...,dim>.

This is strictly speaking an incompatible change. I suspect that the number of affected
people is going to exceedingly small, though, given that these are classes sort of at
the bottom of the stack and not used in user codes. (They are used in the implementations
of finite element classes.)