### PR TITLE
Fix fe/fe_nedelec_sz_non_rect_2d

### DIFF
--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -879,7 +879,7 @@ FE_NedelecSZ<dim>::get_data (
       Assert (false, ExcNotImplemented ());
     }
     }
-  return data;
+  return std::move(data);
 }
 
 template <int dim>

--- a/tests/fe/fe_nedelec_sz_non_rect_2d.cc
+++ b/tests/fe/fe_nedelec_sz_non_rect_2d.cc
@@ -78,7 +78,7 @@ namespace polytest
   class SimplePolynomial : public Function<dim>
   {
   public:
-    SimplePolynomial() : Function<dim>() {}
+    SimplePolynomial() : Function<dim>(2) {}
     void vector_value_list (const std::vector<Point<dim> > &points,
                             std::vector<Vector<double> >   &values) const;
 


### PR DESCRIPTION
[`CDash`](https://cdash.kyomu.43-1.org/testDetails.php?test=10047743&build=1635) reported this test failing due to the specifying the wrong number of components in the `Function` base class.