### PR TITLE
Make a cast possible by providing an rvalue reference.

### DIFF
--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -879,7 +879,7 @@ FE_NedelecSZ<dim>::get_data (
       Assert (false, ExcNotImplemented ());
     }
     }
-  return data;
+  return std::move(data);
 }
 
 template <int dim>


### PR DESCRIPTION
In some compiler implementations, the conversion of std::unique_ptr<Derived> to std::unique_ptr<Base>
is only possible if the converted-from object is provided as an rvalue reference. Make this possible
by using std::move where necessary in the implementation of FE_NedelecSZ.

This ought to fix #6557.