### PR TITLE
 Make sure to use override where appropriate 

### DIFF
--- a/bundled/boost-1.62.0/include/boost/any.hpp
+++ b/bundled/boost-1.62.0/include/boost/any.hpp
@@ -182,12 +182,12 @@ namespace boost
 #endif
         public: // queries
 
-            virtual const boost::typeindex::type_info& type() const BOOST_NOEXCEPT
+            virtual const boost::typeindex::type_info& type() const BOOST_NOEXCEPT override
             {
                 return boost::typeindex::type_id<ValueType>().type_info();
             }
 
-            virtual placeholder * clone() const
+            virtual placeholder * clone() const override
             {
                 return new holder(held);
             }
@@ -233,7 +233,7 @@ namespace boost
 #endif
     {
     public:
-        virtual const char * what() const BOOST_NOEXCEPT_OR_NOTHROW
+        virtual const char * what() const BOOST_NOEXCEPT_OR_NOTHROW override
         {
             return "boost::bad_any_cast: "
                    "failed conversion using boost::any_cast";

--- a/bundled/boost-1.62.0/include/boost/archive/archive_exception.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/archive_exception.hpp
@@ -88,8 +88,8 @@ public:
         const char * e2 = NULL
     ) BOOST_NOEXCEPT;
     BOOST_ARCHIVE_DECL archive_exception(archive_exception const &) BOOST_NOEXCEPT ;
-    virtual BOOST_ARCHIVE_DECL ~archive_exception() BOOST_NOEXCEPT_OR_NOTHROW ;
-    virtual BOOST_ARCHIVE_DECL const char * what() const BOOST_NOEXCEPT_OR_NOTHROW ;
+    virtual BOOST_ARCHIVE_DECL ~archive_exception() BOOST_NOEXCEPT_OR_NOTHROW override ;
+    virtual BOOST_ARCHIVE_DECL const char * what() const BOOST_NOEXCEPT_OR_NOTHROW override ;
 };
 
 }// namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/basic_text_iarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/basic_text_iarchive.hpp
@@ -81,7 +81,7 @@ protected:
     basic_text_iarchive(unsigned int flags) : 
         detail::common_iarchive<Archive>(flags)
     {}
-    ~basic_text_iarchive(){}
+    ~basic_text_iarchive() override{}
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/basic_text_oarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/basic_text_oarchive.hpp
@@ -104,7 +104,7 @@ protected:
         detail::common_oarchive<Archive>(flags),
         delimiter(none)
     {}
-    ~basic_text_oarchive(){}
+    ~basic_text_oarchive() override{}
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/basic_xml_iarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/basic_xml_iarchive.hpp
@@ -105,7 +105,7 @@ protected:
     BOOST_ARCHIVE_OR_WARCHIVE_DECL
     basic_xml_iarchive(unsigned int flags);
     BOOST_ARCHIVE_OR_WARCHIVE_DECL
-    ~basic_xml_iarchive();
+    ~basic_xml_iarchive() override;
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/basic_xml_oarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/basic_xml_oarchive.hpp
@@ -123,7 +123,7 @@ protected:
     BOOST_ARCHIVE_OR_WARCHIVE_DECL
     basic_xml_oarchive(unsigned int flags);
     BOOST_ARCHIVE_OR_WARCHIVE_DECL
-    ~basic_xml_oarchive();
+    ~basic_xml_oarchive() override;
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/codecvt_null.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/codecvt_null.hpp
@@ -49,14 +49,14 @@ class codecvt_null;
 template<>
 class codecvt_null<char> : public std::codecvt<char, char, std::mbstate_t>
 {
-    virtual bool do_always_noconv() const throw() {
+    virtual bool do_always_noconv() const throw() override {
         return true;
     }
 public:
     explicit codecvt_null(std::size_t no_locale_manage = 0) :
         std::codecvt<char, char, std::mbstate_t>(no_locale_manage)
     {}
-    virtual ~codecvt_null(){};
+    virtual ~codecvt_null() override{};
 };
 
 template<>
@@ -71,7 +71,7 @@ class BOOST_SYMBOL_VISIBLE codecvt_null<wchar_t> : public std::codecvt<wchar_t, 
         char * first2,
         char * last2,
         char * & next2
-    ) const;
+    ) const override;
     virtual BOOST_WARCHIVE_DECL std::codecvt_base::result
     do_in(
         std::mbstate_t & state,
@@ -81,18 +81,18 @@ class BOOST_SYMBOL_VISIBLE codecvt_null<wchar_t> : public std::codecvt<wchar_t, 
         wchar_t * first2,
         wchar_t * last2,
         wchar_t * & next2
-    ) const;
-    virtual int do_encoding( ) const throw( ){
+    ) const override;
+    virtual int do_encoding( ) const throw( ) override{
         return sizeof(wchar_t) / sizeof(char);
     }
-    virtual int do_max_length( ) const throw( ){
+    virtual int do_max_length( ) const throw( ) override{
         return do_encoding();
     }
 public:
     explicit codecvt_null(std::size_t no_locale_manage = 0) :
         std::codecvt<wchar_t, char, std::mbstate_t>(no_locale_manage)
     {}
-    virtual ~codecvt_null(){};
+    virtual ~codecvt_null() override{};
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/detail/common_iarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/detail/common_iarchive.hpp
@@ -41,22 +41,22 @@ class BOOST_SYMBOL_VISIBLE common_iarchive :
 {
     friend class interface_iarchive<Archive>;
 private:
-    virtual void vload(version_type & t){
+    virtual void vload(version_type & t) override{
         * this->This() >> t; 
     }
-    virtual void vload(object_id_type & t){
+    virtual void vload(object_id_type & t) override{
         * this->This() >> t;
     }
-    virtual void vload(class_id_type & t){
+    virtual void vload(class_id_type & t) override{
         * this->This() >> t;
     }
-    virtual void vload(class_id_optional_type & t){
+    virtual void vload(class_id_optional_type & t) override{
         * this->This() >> t;
     }
-    virtual void vload(tracking_type & t){
+    virtual void vload(tracking_type & t) override{
         * this->This() >> t;
     }
-    virtual void vload(class_name_type &s){
+    virtual void vload(class_name_type &s) override{
         * this->This() >> s;
     }
 protected:

--- a/bundled/boost-1.62.0/include/boost/archive/detail/common_oarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/detail/common_oarchive.hpp
@@ -39,28 +39,28 @@ class BOOST_SYMBOL_VISIBLE common_oarchive :
 {
     friend class interface_oarchive<Archive>;
 private:
-    virtual void vsave(const version_type t){
+    virtual void vsave(const version_type t) override{
         * this->This() << t;
     }
-    virtual void vsave(const object_id_type t){
+    virtual void vsave(const object_id_type t) override{
         * this->This() << t;
     }
-    virtual void vsave(const object_reference_type t){
+    virtual void vsave(const object_reference_type t) override{
         * this->This() << t;
     }
-    virtual void vsave(const class_id_type t){
+    virtual void vsave(const class_id_type t) override{
         * this->This() << t;
     }
-    virtual void vsave(const class_id_reference_type t){
+    virtual void vsave(const class_id_reference_type t) override{
         * this->This() << t;
     }
-    virtual void vsave(const class_id_optional_type t){
+    virtual void vsave(const class_id_optional_type t) override{
         * this->This() << t;
     }
-    virtual void vsave(const class_name_type & t){
+    virtual void vsave(const class_name_type & t) override{
         * this->This() << t;
     }
-    virtual void vsave(const tracking_type t){
+    virtual void vsave(const tracking_type t) override{
         * this->This() << t;
     }
 protected:

--- a/bundled/boost-1.62.0/include/boost/archive/detail/iserializer.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/detail/iserializer.hpp
@@ -116,7 +116,7 @@ template<class Archive, class T>
 class iserializer : public basic_iserializer
 {
 private:
-    virtual void destroy(/*const*/ void *address) const {
+    virtual void destroy(/*const*/ void *address) const override {
         boost::serialization::access::destroy(static_cast<T *>(address));
     }
 protected:
@@ -134,25 +134,25 @@ public:
         basic_iarchive & ar,
         void *x, 
         const unsigned int file_version
-    ) const BOOST_USED;
-    virtual bool class_info() const {
+    ) const override BOOST_USED;
+    virtual bool class_info() const override {
         return boost::serialization::implementation_level< T >::value 
             >= boost::serialization::object_class_info;
     }
-    virtual bool tracking(const unsigned int /* flags */) const {
+    virtual bool tracking(const unsigned int /* flags */) const override {
         return boost::serialization::tracking_level< T >::value 
                 == boost::serialization::track_always
             || ( boost::serialization::tracking_level< T >::value 
                 == boost::serialization::track_selectively
                 && serialized_as_pointer());
     }
-    virtual version_type version() const {
+    virtual version_type version() const override {
         return version_type(::boost::serialization::version< T >::value);
     }
-    virtual bool is_polymorphic() const {
+    virtual bool is_polymorphic() const override {
         return boost::is_polymorphic< T >::value;
     }
-    virtual ~iserializer(){};
+    virtual ~iserializer() override{};
 };
 
 #ifdef BOOST_MSVC
@@ -287,13 +287,13 @@ class pointer_iserializer :
     public basic_pointer_iserializer
 {
 private:
-    virtual void * heap_allocation() const {
+    virtual void * heap_allocation() const override {
         detail::heap_allocation<T> h;
         T * t = h.get();
         h.release();
         return t;
     }
-    virtual const basic_iserializer & get_basic_serializer() const {
+    virtual const basic_iserializer & get_basic_serializer() const override {
         return boost::serialization::singleton<
             iserializer<Archive, T>
         >::get_const_instance();
@@ -302,11 +302,11 @@ private:
         basic_iarchive & ar, 
         void * x,
         const unsigned int file_version
-    ) const BOOST_USED;
+    ) const override BOOST_USED;
 protected:
     // this should alway be a singleton so make the constructor protected
     pointer_iserializer();
-    ~pointer_iserializer();
+    ~pointer_iserializer() override;
 };
 
 #ifdef BOOST_MSVC

--- a/bundled/boost-1.62.0/include/boost/archive/detail/oserializer.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/detail/oserializer.hpp
@@ -115,23 +115,23 @@ public:
     virtual BOOST_DLLEXPORT void save_object_data(
         basic_oarchive & ar,    
         const void *x
-    ) const BOOST_USED;
-    virtual bool class_info() const {
+    ) const override BOOST_USED;
+    virtual bool class_info() const override {
         return boost::serialization::implementation_level< T >::value 
             >= boost::serialization::object_class_info;
     }
-    virtual bool tracking(const unsigned int /* flags */) const {
+    virtual bool tracking(const unsigned int /* flags */) const override {
         return boost::serialization::tracking_level< T >::value == boost::serialization::track_always
             || (boost::serialization::tracking_level< T >::value == boost::serialization::track_selectively
                 && serialized_as_pointer());
     }
-    virtual version_type version() const {
+    virtual version_type version() const override {
         return version_type(::boost::serialization::version< T >::value);
     }
-    virtual bool is_polymorphic() const {
+    virtual bool is_polymorphic() const override {
         return boost::is_polymorphic< T >::value;
     }
-    virtual ~oserializer(){}
+    virtual ~oserializer() override{}
 };
 
 #ifdef BOOST_MSVC
@@ -164,7 +164,7 @@ class pointer_oserializer :
 {
 private:
     const basic_oserializer & 
-    get_basic_serializer() const {
+    get_basic_serializer() const override {
         return boost::serialization::singleton<
             oserializer<Archive, T>
         >::get_const_instance();
@@ -172,10 +172,10 @@ private:
     virtual BOOST_DLLEXPORT void save_object_ptr(
         basic_oarchive & ar,
         const void * x
-    ) const BOOST_USED;
+    ) const override BOOST_USED;
 public:
     pointer_oserializer();
-    ~pointer_oserializer();
+    ~pointer_oserializer() override;
 };
 
 #ifdef BOOST_MSVC

--- a/bundled/boost-1.62.0/include/boost/archive/iterators/dataflow_exception.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/iterators/dataflow_exception.hpp
@@ -46,7 +46,7 @@ public:
     dataflow_exception(exception_code c = other_exception) : code(c)
     {}
 
-    virtual const char *what( ) const throw( )
+    virtual const char *what( ) const throw( ) override
     {
         const char *msg = "unknown exception code";
         switch(code){

--- a/bundled/boost-1.62.0/include/boost/archive/polymorphic_iarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/polymorphic_iarchive.hpp
@@ -156,7 +156,7 @@ class BOOST_SYMBOL_VISIBLE polymorphic_iarchive :
     public polymorphic_iarchive_impl
 {
 public:
-    virtual ~polymorphic_iarchive(){};
+    virtual ~polymorphic_iarchive() override{};
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/polymorphic_oarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/polymorphic_oarchive.hpp
@@ -140,7 +140,7 @@ class BOOST_SYMBOL_VISIBLE polymorphic_oarchive :
     public polymorphic_oarchive_impl
 {
 public:
-    virtual ~polymorphic_oarchive(){};
+    virtual ~polymorphic_oarchive() override{};
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/text_iarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/text_iarchive.hpp
@@ -89,7 +89,7 @@ protected:
     text_iarchive_impl(std::istream & is, unsigned int flags);
     // don't import inline definitions! leave this as a reminder.
     //BOOST_ARCHIVE_DECL 
-    ~text_iarchive_impl(){};
+    ~text_iarchive_impl() override{};
 };
 
 } // namespace archive
@@ -116,7 +116,7 @@ public:
         // note: added _ to suppress useless gcc warning
         text_iarchive_impl<text_iarchive>(is_, flags)
     {}
-    ~text_iarchive(){}
+    ~text_iarchive() override{}
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/text_oarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/text_oarchive.hpp
@@ -86,7 +86,7 @@ protected:
     text_oarchive_impl(std::ostream & os, unsigned int flags);
     // don't import inline definitions! leave this as a reminder.
     //BOOST_ARCHIVE_DECL 
-    ~text_oarchive_impl(){};
+    ~text_oarchive_impl() override{};
 public:
     BOOST_ARCHIVE_DECL void 
     save_binary(const void *address, std::size_t count);
@@ -103,7 +103,7 @@ public:
         // note: added _ to suppress useless gcc warning
         text_oarchive_impl<text_oarchive>(os_, flags)
     {}
-    ~text_oarchive(){}
+    ~text_oarchive() override{}
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/text_wiarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/text_wiarchive.hpp
@@ -94,7 +94,7 @@ protected:
     }
     BOOST_WARCHIVE_DECL 
     text_wiarchive_impl(std::wistream & is, unsigned int flags);
-    ~text_wiarchive_impl(){};
+    ~text_wiarchive_impl() override{};
 };
 
 } // namespace archive
@@ -120,7 +120,7 @@ public:
     text_wiarchive(std::wistream & is, unsigned int flags = 0) :
         text_wiarchive_impl<text_wiarchive>(is, flags)
     {}
-    ~text_wiarchive(){}
+    ~text_wiarchive() override{}
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/text_woarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/text_woarchive.hpp
@@ -136,7 +136,7 @@ public:
     text_woarchive(std::wostream & os, unsigned int flags = 0) :
         text_woarchive_impl<text_woarchive>(os, flags)
     {}
-    ~text_woarchive(){}
+    ~text_woarchive() override{}
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/xml_archive_exception.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/xml_archive_exception.hpp
@@ -46,7 +46,7 @@ public:
         const char * e2 = NULL
     );
     BOOST_ARCHIVE_DECL xml_archive_exception(xml_archive_exception const &) ;
-    virtual BOOST_ARCHIVE_DECL ~xml_archive_exception() BOOST_NOEXCEPT_OR_NOTHROW ;
+    virtual BOOST_ARCHIVE_DECL ~xml_archive_exception() BOOST_NOEXCEPT_OR_NOTHROW override ;
 };
 
 }// namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/xml_iarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/xml_iarchive.hpp
@@ -101,7 +101,7 @@ protected:
     BOOST_ARCHIVE_DECL 
     xml_iarchive_impl(std::istream & is, unsigned int flags);
     BOOST_ARCHIVE_DECL
-    ~xml_iarchive_impl();
+    ~xml_iarchive_impl() override;
 };
 
 } // namespace archive
@@ -126,7 +126,7 @@ public:
     xml_iarchive(std::istream & is, unsigned int flags = 0) :
         xml_iarchive_impl<xml_iarchive>(is, flags)
     {}
-    ~xml_iarchive(){};
+    ~xml_iarchive() override{};
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/xml_oarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/xml_oarchive.hpp
@@ -86,7 +86,7 @@ protected:
     BOOST_ARCHIVE_DECL 
     xml_oarchive_impl(std::ostream & os, unsigned int flags);
     BOOST_ARCHIVE_DECL 
-    ~xml_oarchive_impl();
+    ~xml_oarchive_impl() override;
 public:
     BOOST_ARCHIVE_DECL
     void save_binary(const void *address, std::size_t count);
@@ -121,7 +121,7 @@ public:
     xml_oarchive(std::ostream & os, unsigned int flags = 0) :
         xml_oarchive_impl<xml_oarchive>(os, flags)
     {}
-    ~xml_oarchive(){}
+    ~xml_oarchive() override{}
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/xml_wiarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/xml_wiarchive.hpp
@@ -106,7 +106,7 @@ protected:
     BOOST_WARCHIVE_DECL 
     xml_wiarchive_impl(std::wistream & is, unsigned int flags) ;
     BOOST_WARCHIVE_DECL 
-    ~xml_wiarchive_impl();
+    ~xml_wiarchive_impl() override;
 };
 
 } // namespace archive
@@ -132,7 +132,7 @@ public:
     xml_wiarchive(std::wistream & is, unsigned int flags = 0) :
         xml_wiarchive_impl<xml_wiarchive>(is, flags)
     {}
-    ~xml_wiarchive(){}
+    ~xml_wiarchive() override{}
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/archive/xml_woarchive.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/xml_woarchive.hpp
@@ -95,7 +95,7 @@ protected:
     BOOST_WARCHIVE_DECL 
     xml_woarchive_impl(std::wostream & os, unsigned int flags);
     BOOST_WARCHIVE_DECL
-    ~xml_woarchive_impl();
+    ~xml_woarchive_impl() override;
 public:
     BOOST_WARCHIVE_DECL void
     save_binary(const void *address, std::size_t count);
@@ -115,7 +115,7 @@ public:
     xml_woarchive(std::wostream & os, unsigned int flags = 0) :
         xml_woarchive_impl<xml_woarchive>(os, flags)
     {}
-    ~xml_woarchive(){}
+    ~xml_woarchive() override{}
 };
 
 } // namespace archive

--- a/bundled/boost-1.62.0/include/boost/detail/utf8_codecvt_facet.hpp
+++ b/bundled/boost-1.62.0/include/boost/detail/utf8_codecvt_facet.hpp
@@ -114,7 +114,7 @@ struct BOOST_SYMBOL_VISIBLE utf8_codecvt_facet :
 {
 public:
     BOOST_UTF8_DECL explicit utf8_codecvt_facet(std::size_t no_locale_manage=0);
-    virtual  ~utf8_codecvt_facet(){}
+    virtual  ~utf8_codecvt_facet() override{}
 protected:
     BOOST_UTF8_DECL virtual std::codecvt_base::result do_in(
         std::mbstate_t& state, 
@@ -124,7 +124,7 @@ protected:
         wchar_t * to, 
         wchar_t * to_end, 
         wchar_t*& to_next
-    ) const;
+    ) const override;
 
     BOOST_UTF8_DECL virtual std::codecvt_base::result do_out(
         std::mbstate_t & state,
@@ -134,7 +134,7 @@ protected:
         char * to,
         char * to_end,
         char * & to_next
-    ) const;
+    ) const override;
 
     bool invalid_continuing_octet(unsigned char octet_1) const {
         return (octet_1 < 0x80|| 0xbf< octet_1);
@@ -156,7 +156,7 @@ protected:
     // ==   total octets - 1.
     BOOST_UTF8_DECL int get_cont_octet_out_count(wchar_t word) const ;
 
-    virtual bool do_always_noconv() const BOOST_NOEXCEPT_OR_NOTHROW {
+    virtual bool do_always_noconv() const BOOST_NOEXCEPT_OR_NOTHROW override {
         return false;
     }
 
@@ -166,12 +166,12 @@ protected:
         char * from,
         char * /*to*/,
         char * & next
-    ) const {
+    ) const override {
         next = from;
         return ok;
     }
 
-    virtual int do_encoding() const BOOST_NOEXCEPT_OR_NOTHROW {
+    virtual int do_encoding() const BOOST_NOEXCEPT_OR_NOTHROW override {
         const int variable_byte_external_encoding=0;
         return variable_byte_external_encoding;
     }
@@ -194,6 +194,7 @@ protected:
         const char * from_end, 
         std::size_t max_limit
     ) const
+      override
 #if BOOST_WORKAROUND(__IBMCPP__, BOOST_TESTED_AT(600))
     throw()
 #endif
@@ -206,7 +207,7 @@ protected:
         );
     }
     // Largest possible value do_length(state,from,from_end,1) could return.
-    virtual int do_max_length() const BOOST_NOEXCEPT_OR_NOTHROW {
+    virtual int do_max_length() const BOOST_NOEXCEPT_OR_NOTHROW override {
         return 6; // largest UTF-8 encoding of a UCS-4 character
     }
 };

--- a/bundled/boost-1.62.0/include/boost/format/exceptions.hpp
+++ b/bundled/boost-1.62.0/include/boost/format/exceptions.hpp
@@ -30,7 +30,7 @@ namespace boost {
         {
         public:
             format_error()  {}
-            virtual const char *what() const throw() {
+            virtual const char *what() const throw() override {
                 return "boost::format_error: "
                     "format generic failure";
             }
@@ -44,7 +44,7 @@ namespace boost {
                 : pos_(pos), next_(size) {}
             std::size_t get_pos() const { return pos_; }
             std::size_t get_next() const { return next_; }
-            virtual const char *what() const throw() {
+            virtual const char *what() const throw() override {
                 return "boost::bad_format_string: format-string is ill-formed";
             }
         };
@@ -57,7 +57,7 @@ namespace boost {
                 : cur_(cur), expected_(expected) {}
             std::size_t get_cur() const { return cur_; }
             std::size_t get_expected() const { return expected_; }
-            virtual const char *what() const throw() {
+            virtual const char *what() const throw() override {
                 return "boost::too_few_args: "
                     "format-string referred to more arguments than were passed";
             }
@@ -71,7 +71,7 @@ namespace boost {
                 : cur_(cur), expected_(expected) {}
             std::size_t get_cur() const { return cur_; }
             std::size_t get_expected() const { return expected_; }
-            virtual const char *what() const throw() {
+            virtual const char *what() const throw() override {
                 return "boost::too_many_args: "
                     "format-string referred to fewer arguments than were passed";
             }
@@ -87,7 +87,7 @@ namespace boost {
             int get_index() const { return index_; }
             int get_beg() const { return beg_; }
             int get_end() const { return end_; }
-            virtual const char *what() const throw() {
+            virtual const char *what() const throw() override {
                 return "boost::out_of_range: "
                     "tried to refer to an argument (or item) number which"
                     " is out of range, according to the format string";

--- a/bundled/boost-1.62.0/include/boost/iostreams/detail/streambuf/indirect_streambuf.hpp
+++ b/bundled/boost-1.62.0/include/boost/iostreams/detail/streambuf/indirect_streambuf.hpp
@@ -66,9 +66,9 @@ public:
     void open(const T& t BOOST_IOSTREAMS_PUSH_PARAMS());
     bool is_open() const;
     void close();
-    bool auto_close() const;
-    void set_auto_close(bool close);
-    bool strict_sync();
+    bool auto_close() const override;
+    void set_auto_close(bool close) override;
+    bool strict_sync() override;
 
     // Declared in linked_streambuf.
     T* component() { return &*obj(); }
@@ -78,24 +78,24 @@ protected:
     //----------virtual functions---------------------------------------------//
 
 #ifndef BOOST_IOSTREAMS_NO_LOCALE
-    void imbue(const std::locale& loc);
+    void imbue(const std::locale& loc) override;
 #endif
 #ifdef BOOST_IOSTREAMS_NO_STREAM_TEMPLATES
     public:
 #endif
-    int_type underflow();
-    int_type pbackfail(int_type c);
-    int_type overflow(int_type c);
-    int sync();
+    int_type underflow() override;
+    int_type pbackfail(int_type c) override;
+    int_type overflow(int_type c) override;
+    int sync() override;
     pos_type seekoff( off_type off, BOOST_IOS::seekdir way,
-                      BOOST_IOS::openmode which );
-    pos_type seekpos(pos_type sp, BOOST_IOS::openmode which);
+                      BOOST_IOS::openmode which ) override;
+    pos_type seekpos(pos_type sp, BOOST_IOS::openmode which) override;
 
     // Declared in linked_streambuf.
-    void set_next(streambuf_type* next);
-    void close_impl(BOOST_IOS::openmode m);
-    const std::type_info& component_type() const { return typeid(T); }
-    void* component_impl() { return component(); }
+    void set_next(streambuf_type* next) override;
+    void close_impl(BOOST_IOS::openmode m) override;
+    const std::type_info& component_type() const override { return typeid(T); }
+    void* component_impl() override { return component(); }
 private:
 
     //----------Accessor functions--------------------------------------------//

--- a/bundled/boost-1.62.0/include/boost/iostreams/filtering_stream.hpp
+++ b/bundled/boost-1.62.0/include/boost/iostreams/filtering_stream.hpp
@@ -89,7 +89,7 @@ protected:
             >::stream_type                                stream_type;
     filtering_stream_base() : stream_type(0) { this->set_chain(&chain_); }
 private:
-    void notify() { this->rdbuf(chain_.empty() ? 0 : &chain_.front()); }
+    void notify() override { this->rdbuf(chain_.empty() ? 0 : &chain_.front()); }
     Chain chain_;
 };
 

--- a/bundled/boost-1.62.0/include/boost/iostreams/stream_buffer.hpp
+++ b/bundled/boost-1.62.0/include/boost/iostreams/stream_buffer.hpp
@@ -84,7 +84,7 @@ public:
     BOOST_IOSTREAMS_STREAMBUF_TYPEDEFS(Tr)
 public:
     stream_buffer() { }
-    ~stream_buffer()
+    ~stream_buffer() override
     { 
         try { 
             if (this->is_open() && this->auto_close()) 

--- a/bundled/boost-1.62.0/include/boost/lexical_cast/bad_lexical_cast.hpp
+++ b/bundled/boost-1.62.0/include/boost/lexical_cast/bad_lexical_cast.hpp
@@ -51,12 +51,12 @@ namespace boost
 #endif
         {}
 
-        virtual const char *what() const BOOST_NOEXCEPT_OR_NOTHROW {
+        virtual const char *what() const BOOST_NOEXCEPT_OR_NOTHROW override {
             return "bad lexical cast: "
                    "source type value could not be interpreted as target";
         }
 
-        virtual ~bad_lexical_cast() BOOST_NOEXCEPT_OR_NOTHROW
+        virtual ~bad_lexical_cast() BOOST_NOEXCEPT_OR_NOTHROW override
         {}
 
 #ifndef BOOST_NO_TYPEID

--- a/bundled/boost-1.62.0/include/boost/numeric/conversion/converter_policies.hpp
+++ b/bundled/boost-1.62.0/include/boost/numeric/conversion/converter_policies.hpp
@@ -136,7 +136,7 @@ class bad_numeric_cast : public std::bad_cast
 {
   public:
 
-    virtual const char * what() const throw()
+    virtual const char * what() const throw() override
       {  return "bad numeric conversion: overflow"; }
 };
 
@@ -144,14 +144,14 @@ class negative_overflow : public bad_numeric_cast
 {
   public:
 
-    virtual const char * what() const throw()
+    virtual const char * what() const throw() override
       {  return "bad numeric conversion: negative overflow"; }
 };
 class positive_overflow : public bad_numeric_cast
 {
   public:
 
-    virtual const char * what() const throw()
+    virtual const char * what() const throw() override
       { return "bad numeric conversion: positive overflow"; }
 };
 

--- a/bundled/boost-1.62.0/include/boost/property_tree/detail/file_parser_error.hpp
+++ b/bundled/boost-1.62.0/include/boost/property_tree/detail/file_parser_error.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace property_tree
         {
         }
 
-        ~file_parser_error() throw()
+        ~file_parser_error() throw() override
             // gcc 3.4.2 complains about lack of throw specifier on compiler
             // generated dtor
         {

--- a/bundled/boost-1.62.0/include/boost/property_tree/detail/rapidxml.hpp
+++ b/bundled/boost-1.62.0/include/boost/property_tree/detail/rapidxml.hpp
@@ -58,7 +58,7 @@ namespace boost { namespace property_tree { namespace detail {namespace rapidxml
 
         //! Gets human readable description of error.
         //! \return Pointer to null terminated description of the error.
-        virtual const char *what() const throw()
+        virtual const char *what() const throw() override
         {
             return m_what;
         }

--- a/bundled/boost-1.62.0/include/boost/property_tree/exceptions.hpp
+++ b/bundled/boost-1.62.0/include/boost/property_tree/exceptions.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace property_tree
         /// @param what The message to associate with this error.
         ptree_error(const std::string &what);
 
-        ~ptree_error() throw();
+        ~ptree_error() throw() override;
     };
 
 
@@ -48,7 +48,7 @@ namespace boost { namespace property_tree
         template<class T> ptree_bad_data(const std::string &what,
                                          const T &data);
 
-        ~ptree_bad_data() throw();
+        ~ptree_bad_data() throw() override;
 
         /// Retrieve the data associated with this error. This is the source
         /// value that failed to be translated. You need to explicitly
@@ -70,7 +70,7 @@ namespace boost { namespace property_tree
         template<class T> ptree_bad_path(const std::string &what,
                                          const T &path);
 
-        ~ptree_bad_path() throw();
+        ~ptree_bad_path() throw() override;
 
         /// Retrieve the invalid path. You need to explicitly specify the
         /// type of path.

--- a/bundled/boost-1.62.0/include/boost/serialization/extended_type_info_no_rtti.hpp
+++ b/bundled/boost-1.62.0/include/boost/serialization/extended_type_info_no_rtti.hpp
@@ -57,12 +57,12 @@ class BOOST_SYMBOL_VISIBLE extended_type_info_no_rtti_0 :
 {
 protected:
     BOOST_SERIALIZATION_DECL extended_type_info_no_rtti_0(const char * key);
-    BOOST_SERIALIZATION_DECL ~extended_type_info_no_rtti_0();
+    BOOST_SERIALIZATION_DECL ~extended_type_info_no_rtti_0() override;
 public:
     virtual BOOST_SERIALIZATION_DECL bool
-    is_less_than(const boost::serialization::extended_type_info &rhs) const ;
+    is_less_than(const boost::serialization::extended_type_info &rhs) const override ;
     virtual BOOST_SERIALIZATION_DECL bool
-    is_equal(const boost::serialization::extended_type_info &rhs) const ;
+    is_equal(const boost::serialization::extended_type_info &rhs) const override ;
 };
 
 } // no_rtti_system
@@ -103,7 +103,7 @@ public:
     {
         key_register();
     }
-    ~extended_type_info_no_rtti(){
+    ~extended_type_info_no_rtti() override{
         key_unregister();
     }
     const extended_type_info *
@@ -121,10 +121,10 @@ public:
     const char * get_key() const{
         return action<guid_defined< T >::value >::invoke();
     }
-    virtual const char * get_debug_info() const{
+    virtual const char * get_debug_info() const override{
         return action<guid_defined< T >::value >::invoke();
     }
-    virtual void * construct(unsigned int count, ...) const{
+    virtual void * construct(unsigned int count, ...) const override{
         // count up the arguments
         std::va_list ap;
         va_start(ap, count);
@@ -145,7 +145,7 @@ public:
             return NULL;
         }
     }
-    virtual void destroy(void const * const p) const{
+    virtual void destroy(void const * const p) const override{
         boost::serialization::access::destroy(
             static_cast<T const *>(p)
         );

--- a/bundled/boost-1.62.0/include/boost/serialization/extended_type_info_typeid.hpp
+++ b/bundled/boost-1.62.0/include/boost/serialization/extended_type_info_typeid.hpp
@@ -52,7 +52,7 @@ namespace typeid_system {
 class BOOST_SYMBOL_VISIBLE extended_type_info_typeid_0 :
     public extended_type_info
 {
-    virtual const char * get_debug_info() const {
+    virtual const char * get_debug_info() const override {
         if(static_cast<const std::type_info *>(0) == m_ti)
             return static_cast<const char *>(0);
         return m_ti->name();
@@ -60,16 +60,16 @@ class BOOST_SYMBOL_VISIBLE extended_type_info_typeid_0 :
 protected:
     const std::type_info * m_ti;
     BOOST_SERIALIZATION_DECL extended_type_info_typeid_0(const char * key);
-    BOOST_SERIALIZATION_DECL ~extended_type_info_typeid_0();
+    BOOST_SERIALIZATION_DECL ~extended_type_info_typeid_0() override;
     BOOST_SERIALIZATION_DECL void type_register(const std::type_info & ti);
     BOOST_SERIALIZATION_DECL void type_unregister();
     BOOST_SERIALIZATION_DECL const extended_type_info *
     get_extended_type_info(const std::type_info & ti) const;
 public:
     virtual BOOST_SERIALIZATION_DECL bool
-    is_less_than(const extended_type_info &rhs) const;
+    is_less_than(const extended_type_info &rhs) const override;
     virtual BOOST_SERIALIZATION_DECL bool
-    is_equal(const extended_type_info &rhs) const;
+    is_equal(const extended_type_info &rhs) const override;
     const std::type_info & get_typeid() const {
         return *m_ti;
     }
@@ -91,7 +91,7 @@ public:
         type_register(typeid(T));
         key_register();
     }
-    ~extended_type_info_typeid(){
+    ~extended_type_info_typeid() override{
         key_unregister();
         type_unregister();
     }
@@ -110,7 +110,7 @@ public:
     const char * get_key() const {
         return boost::serialization::guid< T >();
     }
-    virtual void * construct(unsigned int count, ...) const{
+    virtual void * construct(unsigned int count, ...) const override{
         // count up the arguments
         std::va_list ap;
         va_start(ap, count);
@@ -131,7 +131,7 @@ public:
             return NULL;
         }
     }
-    virtual void destroy(void const * const p) const {
+    virtual void destroy(void const * const p) const override {
         boost::serialization::access::destroy(
             static_cast<T const *>(p)
         );

--- a/bundled/boost-1.62.0/include/boost/serialization/singleton.hpp
+++ b/bundled/boost-1.62.0/include/boost/serialization/singleton.hpp
@@ -101,7 +101,7 @@ class singleton_wrapper : public T
 {
 public:
     static bool m_is_destroyed;
-    ~singleton_wrapper(){
+    ~singleton_wrapper() {
         m_is_destroyed = true;
     }
 };

--- a/bundled/boost-1.62.0/include/boost/serialization/void_cast.hpp
+++ b/bundled/boost-1.62.0/include/boost/serialization/void_cast.hpp
@@ -154,26 +154,26 @@ template <class Derived, class Base>
 class BOOST_SYMBOL_VISIBLE void_caster_primitive :
     public void_caster
 {
-    virtual void const * downcast(void const * const t) const {
+    virtual void const * downcast(void const * const t) const override {
         const Derived * d = 
             boost::serialization::smart_cast<const Derived *, const Base *>(
                 static_cast<const Base *>(t)
             );
         return d;
     }
-    virtual void const * upcast(void const * const t) const {
+    virtual void const * upcast(void const * const t) const override {
         const Base * b = 
             boost::serialization::smart_cast<const Base *, const Derived *>(
                 static_cast<const Derived *>(t)
             );
         return b;
     }
-    virtual bool has_virtual_base() const {
+    virtual bool has_virtual_base() const override {
         return false;
     }
 public:
     void_caster_primitive();
-    virtual ~void_caster_primitive();
+    virtual ~void_caster_primitive() override;
 };
 
 template <class Derived, class Base>
@@ -202,18 +202,18 @@ template <class Derived, class Base>
 class BOOST_SYMBOL_VISIBLE void_caster_virtual_base :
     public void_caster
 {
-    virtual bool has_virtual_base() const {
+    virtual bool has_virtual_base() const override {
         return true;
     }
 public:
-    virtual void const * downcast(void const * const t) const {
+    virtual void const * downcast(void const * const t) const override {
         const Derived * d = 
             dynamic_cast<const Derived *>(
                 static_cast<const Base *>(t)
             );
         return d;
     }
-    virtual void const * upcast(void const * const t) const {
+    virtual void const * upcast(void const * const t) const override {
         const Base * b = 
             dynamic_cast<const Base *>(
                 static_cast<const Derived *>(t)
@@ -221,7 +221,7 @@ public:
         return b;
     }
     void_caster_virtual_base();
-    virtual ~void_caster_virtual_base();
+    virtual ~void_caster_virtual_base() override;
 };
 
 #ifdef BOOST_MSVC

--- a/bundled/boost-1.62.0/include/boost/signals2/connection.hpp
+++ b/bundled/boost-1.62.0/include/boost/signals2/connection.hpp
@@ -145,8 +145,8 @@ namespace boost
           m_slot(new SlotType(slot_in)), _mutex(signal_mutex)
         {
         }
-        virtual ~connection_body() {}
-        virtual bool connected() const
+        virtual ~connection_body() override {}
+        virtual bool connected() const override
         {
           garbage_collecting_lock<mutex_type> local_lock(*_mutex);
           nolock_grab_tracked_objects(local_lock, detail::null_output_iterator());
@@ -191,11 +191,11 @@ namespace boost
           }
         }
         // expose Lockable concept of mutex
-        virtual void lock()
+        virtual void lock() override
         {
           _mutex->lock();
         }
-        virtual void unlock()
+        virtual void unlock() override
         {
           _mutex->unlock();
         }
@@ -208,7 +208,7 @@ namespace boost
           return *m_slot;
         }
       protected:
-        virtual shared_ptr<void> release_slot() const
+        virtual shared_ptr<void> release_slot() const override
         {
           
           shared_ptr<void> released_slot = m_slot;

--- a/bundled/boost-1.62.0/include/boost/signals2/detail/foreign_ptr.hpp
+++ b/bundled/boost-1.62.0/include/boost/signals2/detail/foreign_ptr.hpp
@@ -70,7 +70,7 @@ namespace boost
       public:
         foreign_shared_ptr_impl(const FSP &p): _p(p)
         {}
-        virtual foreign_shared_ptr_impl * clone() const
+        virtual foreign_shared_ptr_impl * clone() const override
         {
           return new foreign_shared_ptr_impl(*this);
         }
@@ -123,15 +123,15 @@ namespace boost
       public:
         foreign_weak_ptr_impl(const FWP &p): _p(p)
         {}
-        virtual foreign_void_shared_ptr lock() const
+        virtual foreign_void_shared_ptr lock() const override
         {
           return foreign_void_shared_ptr(_p.lock());
         }
-        virtual bool expired() const
+        virtual bool expired() const override
         {
           return _p.expired();
         }
-        virtual foreign_weak_ptr_impl * clone() const
+        virtual foreign_weak_ptr_impl * clone() const override
         {
           return new foreign_weak_ptr_impl(*this);
         }

--- a/bundled/boost-1.62.0/include/boost/signals2/detail/signal_template.hpp
+++ b/bundled/boost-1.62.0/include/boost/signals2/detail/signal_template.hpp
@@ -660,7 +660,7 @@ namespace boost
         const group_compare_type &group_compare = group_compare_type()):
         _pimpl(new impl_class(combiner_arg, group_compare))
       {};
-      virtual ~BOOST_SIGNALS2_SIGNAL_CLASS_NAME(BOOST_SIGNALS2_NUM_ARGS)()
+      virtual ~BOOST_SIGNALS2_SIGNAL_CLASS_NAME(BOOST_SIGNALS2_NUM_ARGS)() override
       {
       }
       
@@ -748,7 +748,7 @@ namespace boost
         swap(_pimpl, other._pimpl);
       }
     protected:
-      virtual shared_ptr<void> lock_pimpl() const
+      virtual shared_ptr<void> lock_pimpl() const override
       {
         return _pimpl;
       }

--- a/bundled/boost-1.62.0/include/boost/signals2/expired_slot.hpp
+++ b/bundled/boost-1.62.0/include/boost/signals2/expired_slot.hpp
@@ -20,7 +20,7 @@ namespace boost
     class expired_slot: public bad_weak_ptr
     {
     public:
-      virtual char const * what() const throw()
+      virtual char const * what() const throw() override
       {
         return "boost::signals2::expired_slot";
       }

--- a/bundled/boost-1.62.0/include/boost/signals2/last_value.hpp
+++ b/bundled/boost-1.62.0/include/boost/signals2/last_value.hpp
@@ -25,7 +25,7 @@ namespace boost {
     class no_slots_error: public std::exception
     {
     public:
-      virtual const char* what() const throw() {return "boost::signals2::no_slots_error";}
+      virtual const char* what() const throw() override {return "boost::signals2::no_slots_error";}
     };
 
     template<typename T>

--- a/bundled/boost-1.62.0/include/boost/smart_ptr/bad_weak_ptr.hpp
+++ b/bundled/boost-1.62.0/include/boost/smart_ptr/bad_weak_ptr.hpp
@@ -40,7 +40,7 @@ class bad_weak_ptr: public std::exception
 {
 public:
 
-    virtual char const * what() const throw()
+    virtual char const * what() const throw() override
     {
         return "tr1::bad_weak_ptr";
     }

--- a/bundled/boost-1.62.0/include/boost/smart_ptr/detail/array_count_impl.hpp
+++ b/bundled/boost-1.62.0/include/boost/smart_ptr/detail/array_count_impl.hpp
@@ -24,11 +24,11 @@ namespace boost {
                 : allocator(allocator_) {
             }
 
-            virtual void dispose() {
+            virtual void dispose() override {
                 allocator();
             }
 
-            virtual void destroy() {
+            virtual void destroy() override {
 #if !defined(BOOST_NO_CXX11_ALLOCATOR)
                 typedef typename std::allocator_traits<A>::
                     template rebind_alloc<Y> YA;
@@ -47,11 +47,11 @@ namespace boost {
 #endif                
             }
 
-            virtual void* get_deleter(const sp_typeinfo&) {
+            virtual void* get_deleter(const sp_typeinfo&) override {
                 return &reinterpret_cast<char&>(allocator);
             }
 
-            virtual void* get_untyped_deleter() {
+            virtual void* get_untyped_deleter() override {
                 return &reinterpret_cast<char&>(allocator);
             }
 

--- a/bundled/boost-1.62.0/include/boost/smart_ptr/detail/sp_counted_impl.hpp
+++ b/bundled/boost-1.62.0/include/boost/smart_ptr/detail/sp_counted_impl.hpp
@@ -70,7 +70,7 @@ public:
 #endif
     }
 
-    virtual void dispose() // nothrow
+    virtual void dispose() override // nothrow
     {
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         boost::sp_scalar_destructor_hook( px_, sizeof(X), this );
@@ -78,12 +78,12 @@ public:
         boost::checked_delete( px_ );
     }
 
-    virtual void * get_deleter( sp_typeinfo const & )
+    virtual void * get_deleter( sp_typeinfo const & ) override
     {
         return 0;
     }
 
-    virtual void * get_untyped_deleter()
+    virtual void * get_untyped_deleter() override
     {
         return 0;
     }
@@ -148,17 +148,17 @@ public:
     {
     }
 
-    virtual void dispose() // nothrow
+    virtual void dispose() override // nothrow
     {
         del( ptr );
     }
 
-    virtual void * get_deleter( sp_typeinfo const & ti )
+    virtual void * get_deleter( sp_typeinfo const & ti ) override
     {
         return ti == BOOST_SP_TYPEID(D)? &reinterpret_cast<char&>( del ): 0;
     }
 
-    virtual void * get_untyped_deleter()
+    virtual void * get_untyped_deleter() override
     {
         return &reinterpret_cast<char&>( del );
     }
@@ -217,12 +217,12 @@ public:
     {
     }
 
-    virtual void dispose() // nothrow
+    virtual void dispose() override // nothrow
     {
         d_( p_ );
     }
 
-    virtual void destroy() // nothrow
+    virtual void destroy() override // nothrow
     {
 #if !defined( BOOST_NO_CXX11_ALLOCATOR )
 
@@ -249,12 +249,12 @@ public:
         a2.deallocate( this, 1 );
     }
 
-    virtual void * get_deleter( sp_typeinfo const & ti )
+    virtual void * get_deleter( sp_typeinfo const & ti ) override
     {
         return ti == BOOST_SP_TYPEID( D )? &reinterpret_cast<char&>( d_ ): 0;
     }
 
-    virtual void * get_untyped_deleter()
+    virtual void * get_untyped_deleter() override
     {
         return &reinterpret_cast<char&>( d_ );
     }

--- a/bundled/boost-1.62.0/include/boost/spirit/home/classic/core/non_terminal/impl/rule.ipp
+++ b/bundled/boost-1.62.0/include/boost/spirit/home/classic/core/non_terminal/impl/rule.ipp
@@ -233,16 +233,16 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
         struct concrete_parser : abstract_parser<ScannerT, AttrT>
         {
             concrete_parser(ParserT const& p_) : p(p_) {}
-            virtual ~concrete_parser() {}
+            virtual ~concrete_parser() override {}
 
             virtual typename match_result<ScannerT, AttrT>::type
-            do_parse_virtual(ScannerT const& scan) const
+            do_parse_virtual(ScannerT const& scan) const override
             {
                 return p.parse(scan);
             }
 
             virtual abstract_parser<ScannerT, AttrT>*
-            clone() const
+            clone() const override
             {
                 return new concrete_parser(p);
             }

--- a/bundled/boost-1.62.0/include/boost/system/detail/error_code.ipp
+++ b/bundled/boost-1.62.0/include/boost/system/detail/error_code.ipp
@@ -45,17 +45,17 @@ namespace
   {
   public:
     generic_error_category(){}
-    const char *   name() const BOOST_SYSTEM_NOEXCEPT;
-    std::string    message( int ev ) const;
+    const char *   name() const BOOST_SYSTEM_NOEXCEPT override;
+    std::string    message( int ev ) const override;
   };
 
   class system_error_category : public error_category
   {
   public:
     system_error_category(){}
-    const char *        name() const BOOST_SYSTEM_NOEXCEPT;
-    std::string         message( int ev ) const;
-    error_condition     default_error_condition( int ev ) const BOOST_SYSTEM_NOEXCEPT;
+    const char *        name() const BOOST_SYSTEM_NOEXCEPT override;
+    std::string         message( int ev ) const override;
+    error_condition     default_error_condition( int ev ) const BOOST_SYSTEM_NOEXCEPT override;
   };
 
   //  generic_error_category implementation  ---------------------------------//

--- a/bundled/boost-1.62.0/include/boost/variant/bad_visit.hpp
+++ b/bundled/boost-1.62.0/include/boost/variant/bad_visit.hpp
@@ -28,7 +28,7 @@ struct bad_visit
 {
 public: // std::exception interface
 
-    virtual const char * what() const BOOST_NOEXCEPT_OR_NOTHROW
+    virtual const char * what() const BOOST_NOEXCEPT_OR_NOTHROW override
     {
         return "boost::bad_visit: "
                "failed visitation using boost::apply_visitor";

--- a/bundled/boost-1.62.0/include/boost/variant/get.hpp
+++ b/bundled/boost-1.62.0/include/boost/variant/get.hpp
@@ -42,7 +42,7 @@ class BOOST_SYMBOL_VISIBLE bad_get
 {
 public: // std::exception implementation
 
-    virtual const char * what() const BOOST_NOEXCEPT_OR_NOTHROW
+    virtual const char * what() const BOOST_NOEXCEPT_OR_NOTHROW override
     {
         return "boost::bad_get: "
                "failed value get using boost::get";

--- a/bundled/boost-1.62.0/libs/serialization/src/basic_oarchive.cpp
+++ b/bundled/boost-1.62.0/libs/serialization/src/basic_oarchive.cpp
@@ -178,28 +178,28 @@ basic_oarchive_impl::find(const serialization::extended_type_info & ti) const {
     class bosarg : 
         public basic_oserializer
     {
-        bool class_info() const {
+        bool class_info() const override {
             BOOST_ASSERT(false); 
             return false;
         }
         // returns true if objects should be tracked
-        bool tracking(const unsigned int) const {
+        bool tracking(const unsigned int) const override {
             BOOST_ASSERT(false);
             return false;
         }
         // returns class version
-        version_type version() const {
+        version_type version() const override {
             BOOST_ASSERT(false);
             return version_type(0);
         }
         // returns true if this class is polymorphic
-        bool is_polymorphic() const{
+        bool is_polymorphic() const override{
             BOOST_ASSERT(false);
             return false;
         }
         void save_object_data(      
             basic_oarchive & /*ar*/, const void * /*x*/
-        ) const {
+        ) const override {
             BOOST_ASSERT(false);
         }
     public:

--- a/bundled/boost-1.62.0/libs/serialization/src/extended_type_info.cpp
+++ b/bundled/boost-1.62.0/libs/serialization/src/extended_type_info.cpp
@@ -80,23 +80,23 @@ typedef std::multiset<const extended_type_info *, key_compare> ktmap;
 class extended_type_info_arg : public extended_type_info
 {
     virtual bool
-    is_less_than(const extended_type_info & /*rhs*/) const {
+    is_less_than(const extended_type_info & /*rhs*/) const override {
         BOOST_ASSERT(false);
         return false;
     };
     virtual bool
-    is_equal(const extended_type_info & /*rhs*/) const {
+    is_equal(const extended_type_info & /*rhs*/) const override {
         BOOST_ASSERT(false);
         return false;
     };
-    virtual const char * get_debug_info() const {
+    virtual const char * get_debug_info() const override {
         return get_key();
     }
-    virtual void * construct(unsigned int /*count*/, ...) const{
+    virtual void * construct(unsigned int /*count*/, ...) const override{
         BOOST_ASSERT(false);
         return NULL;
     }
-    virtual void destroy(void const * const /*p*/) const {
+    virtual void destroy(void const * const /*p*/) const override {
         BOOST_ASSERT(false);
     }
 public:
@@ -104,7 +104,7 @@ public:
         extended_type_info(0, key)
     {}
 
-    ~extended_type_info_arg(){
+    ~extended_type_info_arg() override{
     }
 };
 

--- a/bundled/boost-1.62.0/libs/serialization/src/extended_type_info_typeid.cpp
+++ b/bundled/boost-1.62.0/libs/serialization/src/extended_type_info_typeid.cpp
@@ -122,11 +122,11 @@ extended_type_info_typeid_0::type_unregister()
 class extended_type_info_typeid_arg : 
     public extended_type_info_typeid_0
 {
-    virtual void * construct(unsigned int /*count*/, ...) const{
+    virtual void * construct(unsigned int /*count*/, ...) const override{
         BOOST_ASSERT(false);
         return NULL;
     }
-    virtual void destroy(void const * const /*p*/) const {
+    virtual void destroy(void const * const /*p*/) const override {
         BOOST_ASSERT(false);
     }
 public:
@@ -138,7 +138,7 @@ public:
         // be added to the map.
         m_ti = & ti;
     }
-    ~extended_type_info_typeid_arg(){
+    ~extended_type_info_typeid_arg() override{
         m_ti = NULL;
     }
 };

--- a/bundled/boost-1.62.0/libs/serialization/src/void_cast.cpp
+++ b/bundled/boost-1.62.0/libs/serialization/src/void_cast.cpp
@@ -88,13 +88,13 @@ class void_caster_shortcut : public void_caster
         void const * const t
     ) const;
     virtual void const *
-    upcast(void const * const t) const{
+    upcast(void const * const t) const override{
         if(m_includes_virtual_base)
             return vbc_upcast(t);
         return static_cast<const char *> ( t ) - m_difference;
     }
     virtual void const *
-    downcast(void const * const t) const{
+    downcast(void const * const t) const override{
         if(m_includes_virtual_base)
             return vbc_downcast(t);
         return static_cast<const char *> ( t ) + m_difference;
@@ -102,7 +102,7 @@ class void_caster_shortcut : public void_caster
     virtual bool is_shortcut() const {
         return true;
     }
-    virtual bool has_virtual_base() const {
+    virtual bool has_virtual_base() const override {
         return m_includes_virtual_base;
     }
 public:
@@ -118,7 +118,7 @@ public:
     {
         recursive_register(includes_virtual_base);
     }
-    virtual ~void_caster_shortcut(){
+    virtual ~void_caster_shortcut() override{
         recursive_unregister();
     }
 };
@@ -188,16 +188,16 @@ void_caster_shortcut::vbc_upcast(
 class void_caster_argument : public void_caster
 {
     virtual void const *
-    upcast(void const * const /*t*/) const {
+    upcast(void const * const /*t*/) const override {
         BOOST_ASSERT(false);
         return NULL;
     }
     virtual void const *
-    downcast( void const * const /*t*/) const {
+    downcast( void const * const /*t*/) const override {
         BOOST_ASSERT(false);
         return NULL;
     }
-    virtual bool has_virtual_base() const {
+    virtual bool has_virtual_base() const override {
         BOOST_ASSERT(false);
         return false;
     }
@@ -208,7 +208,7 @@ public:
     ) :
         void_caster(derived, base)
     {}
-    virtual ~void_caster_argument(){};
+    virtual ~void_caster_argument() override{};
 };
 
 #ifdef BOOST_MSVC

--- a/bundled/muparser_v2_2_4/include/muParser.h
+++ b/bundled/muparser_v2_2_4/include/muParser.h
@@ -54,11 +54,11 @@ namespace mu
 
     Parser();
 
-    virtual void InitCharSets();
-    virtual void InitFun();
-    virtual void InitConst();
-    virtual void InitOprt();
-    virtual void OnDetectVar(string_type *pExpr, int &nStart, int &nEnd);
+    virtual void InitCharSets() override;
+    virtual void InitFun() override;
+    virtual void InitConst() override;
+    virtual void InitOprt() override;
+    virtual void OnDetectVar(string_type *pExpr, int &nStart, int &nEnd) override;
 
     value_type Diff(value_type *a_Var, 
                     value_type a_fPos, 

--- a/bundled/muparser_v2_2_4/include/muParserBase.h
+++ b/bundled/muparser_v2_2_4/include/muParserBase.h
@@ -209,17 +209,17 @@ private:
       
     protected:
       
-      virtual char_type do_decimal_point() const
+      virtual char_type do_decimal_point() const override
       {
         return m_cDecPoint;
       }
 
-      virtual char_type do_thousands_sep() const
+      virtual char_type do_thousands_sep() const override
       {
         return m_cThousandsSep;
       }
 
-      virtual std::string do_grouping() const 
+      virtual std::string do_grouping() const override
       { 
 		// fix for issue 4: https://code.google.com/p/muparser/issues/detail?id=4
 		// courtesy of Jens Bartsch

--- a/bundled/muparser_v2_2_4/include/muParserInt.h
+++ b/bundled/muparser_v2_2_4/include/muParserInt.h
@@ -128,10 +128,10 @@ private:
 public:
     ParserInt();
 
-    virtual void InitFun();
-    virtual void InitOprt();
-    virtual void InitConst();
-    virtual void InitCharSets();
+    virtual void InitFun() override;
+    virtual void InitOprt() override;
+    virtual void InitConst() override;
+    virtual void InitCharSets() override;
 };
 
 } // namespace mu

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -62,6 +62,7 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wsynth")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wsign-compare")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wswitch")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Woverloaded-virtual")
+ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wsuggest-override")
 
 #
 # Disable Wplacement-new that will trigger a lot of warnings

--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -91,7 +91,7 @@ namespace Step12
     BoundaryValues () {}
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double> &values,
-                             const unsigned int component=0) const;
+                             const unsigned int component=0) const override;
   };
 
   // Given the flow direction, the inflow boundary of the unit square

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -181,7 +181,7 @@ namespace Step13
                             TableHandler       &results_table);
 
       virtual void operator () (const DoFHandler<dim> &dof_handler,
-                                const Vector<double>  &solution) const;
+                                const Vector<double>  &solution) const override;
 
       DeclException1 (ExcEvaluationPointNotFound,
                       Point<dim>,
@@ -374,7 +374,7 @@ namespace Step13
                       const DataOutBase::OutputFormat  output_format);
 
       virtual void operator () (const DoFHandler<dim> &dof_handler,
-                                const Vector<double>  &solution) const;
+                                const Vector<double>  &solution) const override;
     private:
       const std::string               output_name_base;
       const DataOutBase::OutputFormat output_format;
@@ -585,19 +585,19 @@ namespace Step13
               const Quadrature<dim>    &quadrature,
               const Function<dim>      &boundary_values);
       virtual
-      ~Solver ();
+      ~Solver () override;
 
       virtual
       void
-      solve_problem ();
+      solve_problem () override;
 
       virtual
       void
-      postprocess (const Evaluation::EvaluationBase<dim> &postprocessor) const;
+      postprocess (const Evaluation::EvaluationBase<dim> &postprocessor) const override;
 
       virtual
       unsigned int
-      n_dofs () const;
+      n_dofs () const override;
 
       // In the protected section of this class, we first have a number of
       // member variables, of which the use should be clear from the previous
@@ -1103,7 +1103,7 @@ namespace Step13
                     const Function<dim>      &boundary_values);
     protected:
       const SmartPointer<const Function<dim> > rhs_function;
-      virtual void assemble_rhs (Vector<double> &rhs) const;
+      virtual void assemble_rhs (Vector<double> &rhs) const override;
     };
 
 
@@ -1196,7 +1196,7 @@ namespace Step13
                         const Function<dim>      &rhs_function,
                         const Function<dim>      &boundary_values);
 
-      virtual void refine_grid ();
+      virtual void refine_grid () override;
     };
 
 
@@ -1245,7 +1245,7 @@ namespace Step13
                        const Function<dim>      &rhs_function,
                        const Function<dim>      &boundary_values);
 
-      virtual void refine_grid ();
+      virtual void refine_grid () override;
     };
 
 
@@ -1313,7 +1313,7 @@ namespace Step13
     Solution () : Function<dim> () {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component) const;
+                          const unsigned int  component) const override;
   };
 
 
@@ -1338,7 +1338,7 @@ namespace Step13
     RightHandSide () : Function<dim> () {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component) const;
+                          const unsigned int  component) const override;
   };
 
 

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -109,7 +109,7 @@ namespace Step14
       PointValueEvaluation (const Point<dim>   &evaluation_point);
 
       virtual void operator () (const DoFHandler<dim> &dof_handler,
-                                const Vector<double>  &solution) const;
+                                const Vector<double>  &solution) const override;
 
       DeclException1 (ExcEvaluationPointNotFound,
                       Point<dim>,
@@ -324,7 +324,7 @@ namespace Step14
       GridOutput (const std::string &output_name_base);
 
       virtual void operator () (const DoFHandler<dim> &dof_handler,
-                                const Vector<double>  &solution) const;
+                                const Vector<double>  &solution) const override;
     private:
       const std::string output_name_base;
     };
@@ -426,19 +426,19 @@ namespace Step14
               const Quadrature<dim-1>  &face_quadrature,
               const Function<dim>      &boundary_values);
       virtual
-      ~Solver ();
+      ~Solver () override;
 
       virtual
       void
-      solve_problem ();
+      solve_problem () override;
 
       virtual
       void
-      postprocess (const Evaluation::EvaluationBase<dim> &postprocessor) const;
+      postprocess (const Evaluation::EvaluationBase<dim> &postprocessor) const override;
 
       virtual
       unsigned int
-      n_dofs () const;
+      n_dofs () const override;
 
     protected:
       const SmartPointer<const FiniteElement<dim> >  fe;
@@ -763,11 +763,11 @@ namespace Step14
                     const Function<dim>      &boundary_values);
 
       virtual
-      void output_solution () const;
+      void output_solution () const override;
 
     protected:
       const SmartPointer<const Function<dim> > rhs_function;
-      virtual void assemble_rhs (Vector<double> &rhs) const;
+      virtual void assemble_rhs (Vector<double> &rhs) const override;
     };
 
 
@@ -862,7 +862,7 @@ namespace Step14
                         const Function<dim>      &rhs_function,
                         const Function<dim>      &boundary_values);
 
-      virtual void refine_grid ();
+      virtual void refine_grid () override;
     };
 
 
@@ -904,7 +904,7 @@ namespace Step14
                        const Function<dim>      &rhs_function,
                        const Function<dim>      &boundary_values);
 
-      virtual void refine_grid ();
+      virtual void refine_grid () override;
     };
 
 
@@ -968,7 +968,7 @@ namespace Step14
                                const Function<dim>      &boundary_values,
                                const Function<dim>      &weighting_function);
 
-      virtual void refine_grid ();
+      virtual void refine_grid () override;
 
     private:
       const SmartPointer<const Function<dim> > weighting_function;
@@ -1133,14 +1133,14 @@ namespace Step14
     struct SetUp : public SetUpBase<dim>
     {
       virtual
-      const Function<dim>   &get_boundary_values () const;
+      const Function<dim>   &get_boundary_values () const override;
 
       virtual
-      const Function<dim>   &get_right_hand_side () const;
+      const Function<dim>   &get_right_hand_side () const override;
 
 
       virtual
-      void create_coarse_grid (Triangulation<dim> &coarse_grid) const;
+      void create_coarse_grid (Triangulation<dim> &coarse_grid) const override;
 
     private:
       static const typename Traits::BoundaryValues boundary_values;
@@ -1514,7 +1514,7 @@ namespace Step14
       virtual
       void
       assemble_rhs (const DoFHandler<dim> &dof_handler,
-                    Vector<double>        &rhs) const;
+                    Vector<double>        &rhs) const override;
 
       DeclException1 (ExcEvaluationPointNotFound,
                       Point<dim>,
@@ -1746,7 +1746,7 @@ namespace Step14
 
     protected:
       const SmartPointer<const DualFunctional::DualFunctionalBase<dim> > dual_functional;
-      virtual void assemble_rhs (Vector<double> &rhs) const;
+      virtual void assemble_rhs (Vector<double> &rhs) const override;
 
       static const Functions::ZeroFunction<dim> boundary_values;
     };
@@ -1806,21 +1806,21 @@ namespace Step14
 
       virtual
       void
-      solve_problem ();
+      solve_problem () override;
 
       virtual
       void
-      postprocess (const Evaluation::EvaluationBase<dim> &postprocessor) const;
+      postprocess (const Evaluation::EvaluationBase<dim> &postprocessor) const override;
 
       virtual
       unsigned int
-      n_dofs () const;
+      n_dofs () const override;
 
-      virtual void refine_grid ();
+      virtual void refine_grid () override;
 
       virtual
       void
-      output_solution () const;
+      output_solution () const override;
 
     private:
       // In the private section, we have two functions that are used to call

--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -143,7 +143,7 @@ namespace Step15
     BoundaryValues () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 

--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -107,7 +107,7 @@ namespace Step16
   {
   public:
     LaplaceIntegrator();
-    virtual void cell(MeshWorker::DoFInfo<dim> &dinfo, MeshWorker::IntegrationInfo<dim> &info) const;
+    virtual void cell(MeshWorker::DoFInfo<dim> &dinfo, MeshWorker::IntegrationInfo<dim> &info) const override;
   };
 
 

--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -189,10 +189,10 @@ namespace Step17
     RightHandSide ();
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &values) const;
+                               Vector<double>   &values) const override;
 
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> >   &value_list) const;
+                                    std::vector<Vector<double> >   &value_list) const override;
   };
 
 

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -565,12 +565,12 @@ namespace Step18
     virtual
     void
     vector_value (const Point<dim> &p,
-                  Vector<double>   &values) const;
+                  Vector<double>   &values) const override;
 
     virtual
     void
     vector_value_list (const std::vector<Point<dim> > &points,
-                       std::vector<Vector<double> >   &value_list) const;
+                       std::vector<Vector<double> >   &value_list) const override;
   };
 
 
@@ -653,12 +653,12 @@ namespace Step18
     virtual
     void
     vector_value (const Point<dim> &p,
-                  Vector<double>   &values) const;
+                  Vector<double>   &values) const override;
 
     virtual
     void
     vector_value_list (const std::vector<Point<dim> > &points,
-                       std::vector<Vector<double> >   &value_list) const;
+                       std::vector<Vector<double> >   &value_list) const override;
 
   private:
     const double velocity;

--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -128,7 +128,7 @@ namespace Step20
     RightHandSide () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -140,7 +140,7 @@ namespace Step20
     PressureBoundaryValues () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -151,7 +151,7 @@ namespace Step20
     ExactSolution () : Function<dim>(dim+1) {}
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
   };
 
 
@@ -229,7 +229,7 @@ namespace Step20
     KInverse () : TensorFunction<2,dim>() {}
 
     virtual void value_list (const std::vector<Point<dim> > &points,
-                             std::vector<Tensor<2,dim> >    &values) const;
+                             std::vector<Tensor<2,dim> >    &values) const override;
   };
 
 

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -143,7 +143,7 @@ namespace Step21
     PressureRightHandSide () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -168,7 +168,7 @@ namespace Step21
     PressureBoundaryValues () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -195,7 +195,7 @@ namespace Step21
     SaturationBoundaryValues () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -233,10 +233,10 @@ namespace Step21
     InitialValues () : Function<dim>(dim+2) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
 
   };
 
@@ -362,7 +362,7 @@ namespace Step21
       {}
 
       virtual void value_list (const std::vector<Point<dim> > &points,
-                               std::vector<Tensor<2,dim> >    &values) const;
+                               std::vector<Tensor<2,dim> >    &values) const override;
 
     private:
       static std::vector<Point<dim> > centers;

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -183,10 +183,10 @@ namespace Step22
     BoundaryValues () : Function<dim>(dim+1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
   };
 
 
@@ -224,10 +224,10 @@ namespace Step22
     RightHandSide () : Function<dim>(dim+1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
 
   };
 

--- a/examples/step-23/step-23.cc
+++ b/examples/step-23/step-23.cc
@@ -166,7 +166,7 @@ namespace Step23
     InitialValuesU () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -177,7 +177,7 @@ namespace Step23
     InitialValuesV () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -213,7 +213,7 @@ namespace Step23
     RightHandSide () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -238,7 +238,7 @@ namespace Step23
     BoundaryValuesU () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -251,7 +251,7 @@ namespace Step23
     BoundaryValuesV () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 

--- a/examples/step-24/step-24.cc
+++ b/examples/step-24/step-24.cc
@@ -145,7 +145,7 @@ namespace Step24
     {}
 
     virtual double value (const Point<dim> &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
   private:
     struct Source

--- a/examples/step-25/step-25.cc
+++ b/examples/step-25/step-25.cc
@@ -156,7 +156,7 @@ namespace Step25
     ExactSolution (const unsigned int n_components = 1,
                    const double time = 0.) : Function<dim>(n_components, time) {}
     virtual double value (const Point<dim> &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
   };
 
   template <int dim>
@@ -227,7 +227,7 @@ namespace Step25
     {}
 
     virtual double value (const Point<dim> &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
   };
 
   template <int dim>

--- a/examples/step-26/step-26.cc
+++ b/examples/step-26/step-26.cc
@@ -133,7 +133,7 @@ namespace Step26
     {}
 
     virtual double value (const Point<dim> &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
 
   private:
     const double period;
@@ -177,7 +177,7 @@ namespace Step26
   {
   public:
     virtual double value (const Point<dim>  &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
   };
 
 

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -139,7 +139,7 @@ namespace Step27
     RightHandSide () : Function<dim> () {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component) const;
+                          const unsigned int  component) const override;
   };
 
 

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -102,10 +102,10 @@ namespace Step29
     DirichletBoundaryValues() : Function<dim> (2) {};
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &values) const;
+                               Vector<double>   &values) const override;
 
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> >   &value_list) const;
+                                    std::vector<Vector<double> >   &value_list) const override;
   };
 
 
@@ -302,7 +302,7 @@ namespace Step29
     void
     evaluate_vector_field
     (const DataPostprocessorInputs::Vector<dim> &inputs,
-     std::vector<Vector<double> >               &computed_quantities) const;
+     std::vector<Vector<double> >               &computed_quantities) const override;
   };
 
   // In the constructor, we need to call the constructor of the base class

--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -62,7 +62,7 @@ namespace Step30
   public:
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double> &values,
-                             const unsigned int component=0) const;
+                             const unsigned int component=0) const override;
   };
 
 
@@ -72,7 +72,7 @@ namespace Step30
   public:
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double> &values,
-                             const unsigned int component=0) const;
+                             const unsigned int component=0) const override;
   };
 
 

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -133,10 +133,10 @@ namespace Step31
       TemperatureInitialValues () : Function<dim>(1) {}
 
       virtual double value (const Point<dim>   &p,
-                            const unsigned int  component = 0) const;
+                            const unsigned int  component = 0) const override;
 
       virtual void vector_value (const Point<dim> &p,
-                                 Vector<double>   &value) const;
+                                 Vector<double>   &value) const override;
     };
 
 
@@ -166,10 +166,10 @@ namespace Step31
       TemperatureRightHandSide () : Function<dim>(1) {}
 
       virtual double value (const Point<dim>   &p,
-                            const unsigned int  component = 0) const;
+                            const unsigned int  component = 0) const override;
 
       virtual void vector_value (const Point<dim> &p,
-                                 Vector<double>   &value) const;
+                                 Vector<double>   &value) const override;
     };
 
 

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -154,10 +154,10 @@ namespace Step32
       TemperatureInitialValues () : Function<dim>(1) {}
 
       virtual double value (const Point<dim>   &p,
-                            const unsigned int  component = 0) const;
+                            const unsigned int  component = 0) const override;
 
       virtual void vector_value (const Point<dim> &p,
-                                 Vector<double>   &value) const;
+                                 Vector<double>   &value) const override;
     };
 
 
@@ -3155,15 +3155,15 @@ namespace Step32
     void
     evaluate_vector_field
     (const DataPostprocessorInputs::Vector<dim> &inputs,
-     std::vector<Vector<double> >               &computed_quantities) const;
+     std::vector<Vector<double> >               &computed_quantities) const override;
 
-    virtual std::vector<std::string> get_names () const;
+    virtual std::vector<std::string> get_names () const override;
 
     virtual
     std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    get_data_component_interpretation () const;
+    get_data_component_interpretation () const override;
 
-    virtual UpdateFlags get_needed_update_flags () const;
+    virtual UpdateFlags get_needed_update_flags () const override;
 
   private:
     const unsigned int partition;

--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -539,15 +539,15 @@ namespace Step33
       void
       evaluate_vector_field
       (const DataPostprocessorInputs::Vector<dim> &inputs,
-       std::vector<Vector<double> >               &computed_quantities) const;
+       std::vector<Vector<double> >               &computed_quantities) const override;
 
-      virtual std::vector<std::string> get_names () const;
+      virtual std::vector<std::string> get_names () const override;
 
       virtual
       std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      get_data_component_interpretation () const;
+      get_data_component_interpretation () const override;
 
-      virtual UpdateFlags get_needed_update_flags () const;
+      virtual UpdateFlags get_needed_update_flags () const override;
 
     private:
       const bool do_schlieren_plot;

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -312,11 +312,11 @@ namespace Step35
       Velocity (const double initial_time = 0.0);
 
       virtual double value (const Point<dim> &p,
-                            const unsigned int component = 0) const;
+                            const unsigned int component = 0) const override;
 
       virtual void value_list (const std::vector< Point<dim> > &points,
                                std::vector<double> &values,
-                               const unsigned int component = 0) const;
+                               const unsigned int component = 0) const override;
     };
 
 
@@ -363,11 +363,11 @@ namespace Step35
       Pressure (const double initial_time = 0.0);
 
       virtual double value (const Point<dim> &p,
-                            const unsigned int component = 0) const;
+                            const unsigned int component = 0) const override;
 
       virtual void value_list (const std::vector< Point<dim> > &points,
                                std::vector<double> &values,
-                               const unsigned int component = 0) const;
+                               const unsigned int component = 0) const override;
     };
 
     template <int dim>

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -93,7 +93,7 @@ namespace Step37
     Coefficient ()  : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     template <typename number>
     number value (const Point<dim,number> &p,
@@ -101,7 +101,7 @@ namespace Step37
 
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
   };
 
 
@@ -246,15 +246,15 @@ namespace Step37
 
     LaplaceOperator ();
 
-    void clear();
+    void clear() override;
 
     void evaluate_coefficient(const Coefficient<dim> &coefficient_function);
 
-    virtual void compute_diagonal();
+    virtual void compute_diagonal() override;
 
   private:
     virtual void apply_add(LinearAlgebra::distributed::Vector<number> &dst,
-                           const LinearAlgebra::distributed::Vector<number> &src) const;
+                           const LinearAlgebra::distributed::Vector<number> &src) const override;
 
     void local_apply (const MatrixFree<dim,number>                     &data,
                       LinearAlgebra::distributed::Vector<number>       &dst,

--- a/examples/step-38/step-38.cc
+++ b/examples/step-38/step-38.cc
@@ -142,10 +142,10 @@ namespace Step38
     Solution () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
   };
 
@@ -207,7 +207,7 @@ namespace Step38
     RightHandSide () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
   template <>

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -96,13 +96,13 @@ namespace Step39
   {
   public:
     void cell(MeshWorker::DoFInfo<dim> &dinfo,
-              typename MeshWorker::IntegrationInfo<dim> &info) const;
+              typename MeshWorker::IntegrationInfo<dim> &info) const override;
     void boundary(MeshWorker::DoFInfo<dim> &dinfo,
-                  typename MeshWorker::IntegrationInfo<dim> &info) const;
+                  typename MeshWorker::IntegrationInfo<dim> &info) const override;
     void face(MeshWorker::DoFInfo<dim> &dinfo1,
               MeshWorker::DoFInfo<dim> &dinfo2,
               typename MeshWorker::IntegrationInfo<dim> &info1,
-              typename MeshWorker::IntegrationInfo<dim> &info2) const;
+              typename MeshWorker::IntegrationInfo<dim> &info2) const override;
   };
 
 
@@ -158,12 +158,12 @@ namespace Step39
   class RHSIntegrator : public MeshWorker::LocalIntegrator<dim>
   {
   public:
-    void cell(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const;
-    void boundary(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const;
+    void cell(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const override;
+    void boundary(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const override;
     void face(MeshWorker::DoFInfo<dim> &dinfo1,
               MeshWorker::DoFInfo<dim> &dinfo2,
               typename MeshWorker::IntegrationInfo<dim> &info1,
-              typename MeshWorker::IntegrationInfo<dim> &info2) const;
+              typename MeshWorker::IntegrationInfo<dim> &info2) const override;
   };
 
 
@@ -207,12 +207,12 @@ namespace Step39
   class Estimator : public MeshWorker::LocalIntegrator<dim>
   {
   public:
-    void cell(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const;
-    void boundary(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const;
+    void cell(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const override;
+    void boundary(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const override;
     void face(MeshWorker::DoFInfo<dim> &dinfo1,
               MeshWorker::DoFInfo<dim> &dinfo2,
               typename MeshWorker::IntegrationInfo<dim> &info1,
-              typename MeshWorker::IntegrationInfo<dim> &info2) const;
+              typename MeshWorker::IntegrationInfo<dim> &info2) const override;
   };
 
 
@@ -303,12 +303,12 @@ namespace Step39
   class ErrorIntegrator : public MeshWorker::LocalIntegrator<dim>
   {
   public:
-    void cell(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const;
-    void boundary(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const;
+    void cell(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const override;
+    void boundary(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const override;
     void face(MeshWorker::DoFInfo<dim> &dinfo1,
               MeshWorker::DoFInfo<dim> &dinfo2,
               typename MeshWorker::IntegrationInfo<dim> &info1,
-              typename MeshWorker::IntegrationInfo<dim> &info2) const;
+              typename MeshWorker::IntegrationInfo<dim> &info2) const override;
   };
 
   // Here we have the integration on cells. There is currently no good

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -137,7 +137,7 @@ public:
   RightHandSide () : Function<dim>() {}
 
   virtual double value (const Point<dim>   &p,
-                        const unsigned int  component = 0) const;
+                        const unsigned int  component = 0) const override;
 };
 
 
@@ -149,7 +149,7 @@ public:
   BoundaryValues () : Function<dim>() {}
 
   virtual double value (const Point<dim>   &p,
-                        const unsigned int  component = 0) const;
+                        const unsigned int  component = 0) const override;
 };
 
 
@@ -183,7 +183,7 @@ double RightHandSide<dim>::value (const Point<dim> &p,
   for (unsigned int i=0; i<dim; ++i)
     return_value += 4.0 * std::pow(p(i), 4.0);
 
-  return return_value;
+  return 1.;//return_value;
 }
 
 

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -123,7 +123,7 @@ namespace Step41
     RightHandSide () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
   template <int dim>
@@ -145,7 +145,7 @@ namespace Step41
     BoundaryValues () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
   template <int dim>
@@ -169,7 +169,7 @@ namespace Step41
     Obstacle () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
   template <int dim>

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -283,11 +283,11 @@ namespace Step42
 
       virtual
       double value (const Point<dim> &p,
-                    const unsigned int component = 0) const;
+                    const unsigned int component = 0) const override;
 
       virtual
       void vector_value (const Point<dim> &p,
-                         Vector<double> &values) const;
+                         Vector<double> &values) const override;
     };
 
     template <int dim>
@@ -323,11 +323,11 @@ namespace Step42
       BoundaryValues ();
 
       virtual double value (const Point<dim> &p,
-                            const unsigned int component = 0) const;
+                            const unsigned int component = 0) const override;
 
       virtual
       void vector_value (const Point<dim> &p,
-                         Vector<double> &values) const;
+                         Vector<double> &values) const override;
     };
 
 
@@ -375,11 +375,11 @@ namespace Step42
 
       virtual
       double value (const Point<dim> &p,
-                    const unsigned int component = 0) const;
+                    const unsigned int component = 0) const override;
 
       virtual
       void vector_value (const Point<dim> &p,
-                         Vector<double> &values) const;
+                         Vector<double> &values) const override;
 
     private:
       const double z_surface;
@@ -563,11 +563,11 @@ namespace Step42
 
       virtual
       double value (const Point<dim> &p,
-                    const unsigned int component = 0) const;
+                    const unsigned int component = 0) const override;
 
       virtual
       void vector_value (const Point<dim> &p,
-                         Vector<double> &values) const;
+                         Vector<double> &values) const override;
 
     private:
       const BitmapFile<dim> input_obstacle;

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -89,7 +89,7 @@ namespace Step43
     PressureRightHandSide () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -110,7 +110,7 @@ namespace Step43
     PressureBoundaryValues () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -130,7 +130,7 @@ namespace Step43
     SaturationBoundaryValues () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -154,10 +154,10 @@ namespace Step43
     SaturationInitialValues () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
   };
 
 
@@ -239,7 +239,7 @@ namespace Step43
       {}
 
       virtual void value_list (const std::vector<Point<dim> > &points,
-                               std::vector<Tensor<2,dim> >    &values) const;
+                               std::vector<Tensor<2,dim> >    &values) const override;
 
     private:
       static std::vector<Point<dim> > centers;

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -112,10 +112,10 @@ namespace Step45
     BoundaryValues () : Function<dim>(dim+1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
   };
 
 
@@ -149,10 +149,10 @@ namespace Step45
     RightHandSide () : Function<dim>(dim+1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
 
   };
 

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -162,10 +162,10 @@ namespace Step46
     StokesBoundaryValues () : Function<dim>(dim+1+dim) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
   };
 
 
@@ -210,10 +210,10 @@ namespace Step46
     RightHandSide () : Function<dim>(dim+1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
 
   };
 

--- a/examples/step-47/step-47.cc
+++ b/examples/step-47/step-47.cc
@@ -121,11 +121,11 @@ namespace Step47
     Coefficient () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
   };
 
 
@@ -907,15 +907,15 @@ namespace Step47
     void
     evaluate_vector_field
     (const dealii::DataPostprocessorInputs::Vector<dim> &inputs,
-     std::vector<Vector<double> >                       &computed_quantities) const;
+     std::vector<Vector<double> >                       &computed_quantities) const override;
 
-    virtual std::vector<std::string> get_names () const;
+    virtual std::vector<std::string> get_names () const override;
 
     virtual
     std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    get_data_component_interpretation () const;
+    get_data_component_interpretation () const override;
 
-    virtual UpdateFlags get_needed_update_flags () const;
+    virtual UpdateFlags get_needed_update_flags () const override;
   };
 
 

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -250,7 +250,7 @@ namespace Step48
     ExactSolution (const unsigned int n_components = 1,
                    const double time = 0.) : Function<dim>(n_components, time) {}
     virtual double value (const Point<dim> &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
   };
 
   template <int dim>

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -160,11 +160,11 @@ namespace Step50
     Coefficient () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
   };
 
 

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -141,10 +141,10 @@ namespace Step51
     Solution () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
   };
 
 
@@ -201,7 +201,7 @@ namespace Step51
     SolutionAndGradient () : Function<dim>(dim) {}
 
     virtual void vector_value (const Point<dim>   &p,
-                               Vector<double>     &v) const;
+                               Vector<double>     &v) const override;
   };
 
   template <int dim>
@@ -227,7 +227,7 @@ namespace Step51
   public:
     ConvectionVelocity() : TensorFunction<1,dim>() {}
 
-    virtual Tensor<1,dim> value (const Point<dim> &p) const;
+    virtual Tensor<1,dim> value (const Point<dim> &p) const override;
   };
 
 
@@ -272,7 +272,7 @@ namespace Step51
     RightHandSide () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
   private:
     const ConvectionVelocity<dim> convection_velocity;

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -201,7 +201,7 @@ namespace Step55
     RightHandSide () : Function<dim>(dim+1) {}
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
 
   };
 
@@ -229,7 +229,7 @@ namespace Step55
     ExactSolution () : Function<dim>(dim+1) {}
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &value) const;
+                               Vector<double>   &value) const override;
   };
 
   template <int dim>

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -102,9 +102,9 @@ namespace Step56
   public:
     Solution () : Function<dim>(dim+1) {}
     virtual double value (const Point<dim> &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
     virtual Tensor<1,dim> gradient (const Point<dim> &p,
-                                    const unsigned int component = 0) const;
+                                    const unsigned int component = 0) const override;
   };
 
   template <>
@@ -233,7 +233,7 @@ namespace Step56
     RightHandSide () : Function<dim>(dim+1) {}
 
     virtual double value (const Point<dim> &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
   };
 
   template <>

--- a/examples/step-57/step-57.cc
+++ b/examples/step-57/step-57.cc
@@ -153,10 +153,10 @@ namespace Step57
   public:
     BoundaryValues() : Function<dim>(dim+1) {}
     virtual double value(const Point<dim> &p,
-                         const unsigned int component) const;
+                         const unsigned int component) const override;
 
     virtual void   vector_value(const Point <dim>    &p,
-                                Vector<double> &values) const;
+                                Vector<double> &values) const override;
   };
 
   template <int dim>

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -191,10 +191,10 @@ namespace Step7
     Solution () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
   };
 
 
@@ -290,7 +290,7 @@ namespace Step7
     RightHandSide () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -197,10 +197,10 @@ namespace Step9
   public:
     AdvectionField () : TensorFunction<1,dim> () {}
 
-    virtual Tensor<1,dim> value (const Point<dim> &p) const;
+    virtual Tensor<1,dim> value (const Point<dim> &p) const override;
 
     virtual void value_list (const std::vector<Point<dim> > &points,
-                             std::vector<Tensor<1,dim> >    &values) const;
+                             std::vector<Tensor<1,dim> >    &values) const override;
 
     // In previous examples, we have used assertions that throw exceptions in
     // several places. However, we have never seen how such exceptions are
@@ -290,11 +290,11 @@ namespace Step9
     RightHandSide () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
   private:
     static const Point<dim> center_point;
@@ -361,11 +361,11 @@ namespace Step9
     BoundaryValues () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
   };
 
 

--- a/include/deal.II/algorithms/newton.h
+++ b/include/deal.II/algorithms/newton.h
@@ -94,9 +94,9 @@ namespace Algorithms
      * are not used by Newton, but will be handed down to the objects
      * #residual and #inverse_derivative.
      */
-    virtual void operator() (AnyData &out, const AnyData &in);
+    virtual void operator() (AnyData &out, const AnyData &in) override;
 
-    virtual void notify(const Event &);
+    virtual void notify(const Event &) override;
 
     /**
      * Set the maximal residual reduction allowed without triggering

--- a/include/deal.II/algorithms/operator.h
+++ b/include/deal.II/algorithms/operator.h
@@ -73,7 +73,7 @@ namespace Algorithms
     /**
      * The virtual destructor.
      */
-    virtual ~OperatorBase() = default;
+    virtual ~OperatorBase() override = default;
 
     /**
      * The actual operation, which is implemented in a derived class.
@@ -121,7 +121,7 @@ namespace Algorithms
     /**
      * Empty virtual destructor.
      */
-    virtual ~OutputOperator() = default;
+    virtual ~OutputOperator() override = default;
 
     /**
      * Set the stream @p os to which data is written. If no stream is selected

--- a/include/deal.II/algorithms/theta_timestepping.h
+++ b/include/deal.II/algorithms/theta_timestepping.h
@@ -209,12 +209,12 @@ namespace Algorithms
      * instance, which contains the initial value when the operator is called.
      * It contains the final value when the operator returns.
      */
-    virtual void operator() (AnyData &out, const AnyData &in);
+    virtual void operator() (AnyData &out, const AnyData &in) override;
 
     /**
      * Register an event triggered by an outer iteration.
      */
-    virtual void notify(const Event &);
+    virtual void notify(const Event &) override;
 
     /**
      * Define an operator which will output the result in each step. Note that

--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -376,7 +376,7 @@ namespace internal
      * the constructor on a subrange given by two integers.
      */
     virtual void apply_to_subrange (const std::size_t begin,
-                                    const std::size_t end) const
+                                    const std::size_t end) const override
     {
       if (end == begin)
         return;
@@ -439,7 +439,7 @@ namespace internal
      * the constructor on a subrange given by two integers.
      */
     virtual void apply_to_subrange (const std::size_t begin,
-                                    const std::size_t end) const
+                                    const std::size_t end) const override
     {
       if (end == begin)
         return;
@@ -522,7 +522,7 @@ namespace internal
      * This sets elements on a subrange given by two integers.
      */
     virtual void apply_to_subrange (const std::size_t begin,
-                                    const std::size_t end) const
+                                    const std::size_t end) const override
     {
       // for classes with trivial assignment of zero can use memset. cast
       // element to (void*) to silence compiler warning for virtual
@@ -600,7 +600,7 @@ namespace internal
      * This initializes elements on a subrange given by two integers.
      */
     virtual void apply_to_subrange (const std::size_t begin,
-                                    const std::size_t end) const
+                                    const std::size_t end) const override
     {
       // for classes with trivial assignment of zero can use memset. cast
       // element to (void*) to silence compiler warning for virtual

--- a/include/deal.II/base/auto_derivative_function.h
+++ b/include/deal.II/base/auto_derivative_function.h
@@ -132,7 +132,7 @@ public:
   /**
    * Virtual destructor; absolutely necessary in this case.
    */
-  virtual ~AutoDerivativeFunction () = default;
+  virtual ~AutoDerivativeFunction () override = default;
 
   /**
    * Choose the difference formula. See the enum #DifferenceFormula for
@@ -158,7 +158,7 @@ public:
    * #DifferenceFormula.
    */
   virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                  const unsigned int  component = 0) const;
+                                  const unsigned int  component = 0) const override;
 
   /**
    * Return the gradient of all components of the function at the given point.
@@ -167,7 +167,7 @@ public:
    * #DifferenceFormula.
    */
   virtual void vector_gradient (const Point<dim>            &p,
-                                std::vector<Tensor<1,dim> > &gradients) const;
+                                std::vector<Tensor<1,dim> > &gradients) const override;
 
   /**
    * Set <tt>gradients</tt> to the gradients of the specified component of the
@@ -180,7 +180,7 @@ public:
    */
   virtual void gradient_list (const std::vector<Point<dim> > &points,
                               std::vector<Tensor<1,dim> >    &gradients,
-                              const unsigned int              component = 0) const;
+                              const unsigned int              component = 0) const override;
 
   /**
    * Set <tt>gradients</tt> to the gradients of the function at the
@@ -195,7 +195,7 @@ public:
    * #DifferenceFormula.
    */
   virtual void vector_gradient_list (const std::vector<Point<dim> > &points,
-                                     std::vector<std::vector<Tensor<1,dim> > > &gradients) const;
+                                     std::vector<std::vector<Tensor<1,dim> > > &gradients) const override;
 
   /**
    * Return a #DifferenceFormula of the order <tt>ord</tt> at minimum.

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2936,7 +2936,7 @@ protected:
    * read() function.
    */
   virtual const std::vector<dealii::DataOutBase::Patch<dim,spacedim> > &
-  get_patches () const;
+  get_patches () const override;
 
   /**
    * Abstract virtual function through which the names of data sets are
@@ -2944,7 +2944,7 @@ protected:
    *
    * Return the names of the variables as read the last time we read a file.
    */
-  virtual std::vector<std::string> get_dataset_names () const;
+  virtual std::vector<std::string> get_dataset_names () const override;
 
   /**
    * This functions returns information about how the individual components of
@@ -2966,7 +2966,7 @@ protected:
    */
   virtual
   std::vector<std::tuple<unsigned int, unsigned int, std::string> >
-  get_vector_data_ranges () const;
+  get_vector_data_ranges () const override;
 
 private:
   /**

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -62,7 +62,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~ExceptionBase () noexcept;
+  virtual ~ExceptionBase () noexcept override;
 
   /**
    * Copy operator. This operator is deleted since exception objects
@@ -85,7 +85,7 @@ public:
   /**
    * Override the standard function that returns the description of the error.
    */
-  virtual const char *what() const noexcept;
+  virtual const char *what() const noexcept override;
 
   /**
    * Get exception name.
@@ -193,7 +193,7 @@ private:
   public:                                                                 \
     Exception (const std::string &msg = defaulttext) : arg (msg) {}       \
     virtual ~Exception () noexcept {}                                     \
-    virtual void print_info (std::ostream &out) const {                   \
+    virtual void print_info (std::ostream &out) const override {          \
       out << "    " << arg << std::endl;                                  \
     }                                                                     \
   private:                                                                \
@@ -211,7 +211,7 @@ private:
   public:                                                                 \
     Exception1 (const type1 a1) : arg1 (a1) {}    /*NOLINT*/              \
     virtual ~Exception1 () noexcept {}                                    \
-    virtual void print_info (std::ostream &out) const {                   \
+    virtual void print_info (std::ostream &out) const override {          \
       out << "    " outsequence << std::endl;                             \
     }                                                                     \
   private:                                                                \
@@ -231,7 +231,7 @@ private:
     Exception2 (const type1 a1, const type2 a2) : /*NOLINT*/              \
       arg1 (a1), arg2(a2) {}                                              \
     virtual ~Exception2 () noexcept {}                                    \
-    virtual void print_info (std::ostream &out) const {                   \
+    virtual void print_info (std::ostream &out) const override {          \
       out << "    " outsequence << std::endl;                             \
     }                                                                     \
   private:                                                                \
@@ -252,7 +252,7 @@ private:
     Exception3 (const type1 a1, const type2 a2, const type3 a3) : /*NOLINT*/ \
       arg1 (a1), arg2(a2), arg3(a3) {}                                    \
     virtual ~Exception3 () noexcept {}                                    \
-    virtual void print_info (std::ostream &out) const {                   \
+    virtual void print_info (std::ostream &out) const override {          \
       out << "    " outsequence << std::endl;                             \
     }                                                                     \
   private:                                                                \
@@ -275,7 +275,7 @@ private:
                 const type3 a3, const type4 a4) : /*NOLINT*/              \
       arg1 (a1), arg2(a2), arg3(a3), arg4(a4) {}                          \
     virtual ~Exception4 () noexcept {}                                    \
-    virtual void print_info (std::ostream &out) const {                   \
+    virtual void print_info (std::ostream &out) const override {          \
       out << "    " outsequence << std::endl;                             \
     }                                                                     \
   private:                                                                \
@@ -299,7 +299,7 @@ private:
                 const type4 a4, const type5 a5) :              /*NOLINT*/ \
       arg1 (a1), arg2(a2), arg3(a3), arg4(a4), arg5(a5) {}                \
     virtual ~Exception5 () noexcept {}                                    \
-    virtual void print_info (std::ostream &out) const {                   \
+    virtual void print_info (std::ostream &out) const override {          \
       out << "    " outsequence << std::endl;                             \
     }                                                                     \
   private:                                                                \
@@ -922,7 +922,7 @@ namespace StandardExceptions
   public:
     ExcMPI (const int error_code);
 
-    virtual void print_info (std::ostream &out) const;
+    virtual void print_info (std::ostream &out) const override;
 
     const int error_code;
   };

--- a/include/deal.II/base/flow_function.h
+++ b/include/deal.II/base/flow_function.h
@@ -56,7 +56,7 @@ namespace Functions
     /**
      * Virtual destructor.
      */
-    virtual ~FlowFunction() = default;
+    virtual ~FlowFunction() override = default;
 
     /**
      * Store an adjustment for the pressure function, such that its mean value
@@ -70,14 +70,14 @@ namespace Functions
      * point.
      */
     virtual void vector_values (const std::vector<Point<dim> > &points,
-                                std::vector<std::vector<double> > &values) const = 0;
+                                std::vector<std::vector<double> > &values) const override = 0;
     /**
      * Gradients in a structure more suitable for vector valued functions. The
      * outer vector is indexed by solution component, the inner by quadrature
      * point.
      */
     virtual void vector_gradients (const std::vector<Point<dim> >            &points,
-                                   std::vector<std::vector<Tensor<1,dim> > > &gradients) const = 0;
+                                   std::vector<std::vector<Tensor<1,dim> > > &gradients) const override = 0;
     /**
      * Force terms in a structure more suitable for vector valued functions.
      * The outer vector is indexed by solution component, the inner by
@@ -89,17 +89,17 @@ namespace Functions
     virtual void vector_laplacians (const std::vector<Point<dim> > &points,
                                     std::vector<std::vector<double> >   &values) const = 0;
 
-    virtual void vector_value (const Point<dim> &points, Vector<double> &value) const;
-    virtual double value (const Point<dim> &points, const unsigned int component) const;
+    virtual void vector_value (const Point<dim> &points, Vector<double> &value) const override;
+    virtual double value (const Point<dim> &points, const unsigned int component) const override;
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> >   &values) const;
+                                    std::vector<Vector<double> >   &values) const override;
     virtual void vector_gradient_list (const std::vector<Point<dim> >            &points,
-                                       std::vector<std::vector<Tensor<1,dim> > > &gradients) const;
+                                       std::vector<std::vector<Tensor<1,dim> > > &gradients) const override;
     /**
      * The force term in the momentum equation.
      */
     virtual void vector_laplacian_list (const std::vector<Point<dim> > &points,
-                                        std::vector<Vector<double> >   &values) const;
+                                        std::vector<Vector<double> >   &values) const override;
 
     std::size_t memory_consumption () const;
 
@@ -146,14 +146,14 @@ namespace Functions
     PoisseuilleFlow<dim> (const double r,
                           const double Re);
 
-    virtual ~PoisseuilleFlow() = default;
+    virtual ~PoisseuilleFlow() override = default;
 
     virtual void vector_values (const std::vector<Point<dim> > &points,
-                                std::vector<std::vector<double> > &values) const;
+                                std::vector<std::vector<double> > &values) const override;
     virtual void vector_gradients (const std::vector<Point<dim> > &points,
-                                   std::vector<std::vector<Tensor<1,dim> > > &gradients) const;
+                                   std::vector<std::vector<Tensor<1,dim> > > &gradients) const override;
     virtual void vector_laplacians (const std::vector<Point<dim> > &points,
-                                    std::vector<std::vector<double> >   &values) const;
+                                    std::vector<std::vector<double> >   &values) const override;
 
   private:
     const double radius;
@@ -189,14 +189,14 @@ namespace Functions
      */
     void set_parameters (const double viscosity, const double reaction);
 
-    virtual ~StokesCosine() = default;
+    virtual ~StokesCosine() override = default;
 
     virtual void vector_values (const std::vector<Point<dim> > &points,
-                                std::vector<std::vector<double> > &values) const;
+                                std::vector<std::vector<double> > &values) const override;
     virtual void vector_gradients (const std::vector<Point<dim> > &points,
-                                   std::vector<std::vector<Tensor<1,dim> > > &gradients) const;
+                                   std::vector<std::vector<Tensor<1,dim> > > &gradients) const override;
     virtual void vector_laplacians (const std::vector<Point<dim> > &points,
-                                    std::vector<std::vector<double> >   &values) const;
+                                    std::vector<std::vector<double> >   &values) const override;
 
   private:
     /// The viscosity
@@ -230,11 +230,11 @@ namespace Functions
     StokesLSingularity();
 
     virtual void vector_values (const std::vector<Point<2> > &points,
-                                std::vector<std::vector<double> > &values) const;
+                                std::vector<std::vector<double> > &values) const override;
     virtual void vector_gradients (const std::vector<Point<2> > &points,
-                                   std::vector<std::vector<Tensor<1,2> > > &gradients) const;
+                                   std::vector<std::vector<Tensor<1,2> > > &gradients) const override;
     virtual void vector_laplacians (const std::vector<Point<2> > &points,
-                                    std::vector<std::vector<double> >   &values) const;
+                                    std::vector<std::vector<double> >   &values) const override;
   private:
     /// The auxiliary function Psi.
     double Psi(double phi) const;
@@ -279,14 +279,14 @@ namespace Functions
      */
     Kovasznay (const double Re, bool Stokes = false);
 
-    virtual ~Kovasznay() = default;
+    virtual ~Kovasznay() override = default;
 
     virtual void vector_values (const std::vector<Point<2> > &points,
-                                std::vector<std::vector<double> > &values) const;
+                                std::vector<std::vector<double> > &values) const override;
     virtual void vector_gradients (const std::vector<Point<2> > &points,
-                                   std::vector<std::vector<Tensor<1,2> > > &gradients) const;
+                                   std::vector<std::vector<Tensor<1,2> > > &gradients) const override;
     virtual void vector_laplacians (const std::vector<Point<2> > &points,
-                                    std::vector<std::vector<double> >   &values) const;
+                                    std::vector<std::vector<double> >   &values) const override;
 
     /// The value of lambda.
     double lambda () const;

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -182,7 +182,7 @@ public:
    * Nonetheless, since derived classes want to call the destructor of a base
    * class, this destructor is implemented (despite it being pure virtual).
    */
-  virtual ~Function () = 0;
+  virtual ~Function () override = 0;
 
   /**
    * Assignment operator. This is here only so that you can have objects of
@@ -397,30 +397,30 @@ namespace Functions
     ConstantFunction (const RangeNumberType *begin_ptr, const unsigned int n_components);
 
     virtual RangeNumberType value (const Point<dim>   &p,
-                                   const unsigned int  component = 0) const;
+                                   const unsigned int  component = 0) const override;
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<RangeNumberType>   &return_value) const;
+                               Vector<RangeNumberType>   &return_value) const override;
 
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<RangeNumberType>            &return_values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<RangeNumberType> >   &return_values) const;
+                                    std::vector<Vector<RangeNumberType> >   &return_values) const override;
 
     virtual Tensor<1,dim, RangeNumberType> gradient (const Point<dim> &p,
-                                                     const unsigned int component = 0) const;
+                                                     const unsigned int component = 0) const override;
 
     virtual void vector_gradient (const Point<dim>            &p,
-                                  std::vector<Tensor<1,dim, RangeNumberType> > &gradients) const;
+                                  std::vector<Tensor<1,dim, RangeNumberType> > &gradients) const override;
 
     virtual void gradient_list (const std::vector<Point<dim> > &points,
                                 std::vector<Tensor<1,dim, RangeNumberType> >    &gradients,
-                                const unsigned int              component = 0) const;
+                                const unsigned int              component = 0) const override;
 
     virtual void vector_gradient_list (const std::vector<Point<dim> >            &points,
-                                       std::vector<std::vector<Tensor<1,dim, RangeNumberType> > > &gradients) const;
+                                       std::vector<std::vector<Tensor<1,dim, RangeNumberType> > > &gradients) const override;
 
     std::size_t memory_consumption () const;
 
@@ -540,7 +540,7 @@ public:
    * Return the value of the function at the given point for all components.
    */
   virtual void vector_value (const Point<dim> &p,
-                             Vector<RangeNumberType>   &return_value) const;
+                             Vector<RangeNumberType>   &return_value) const override;
 
   /**
    * Set <tt>values</tt> to the point values of the function at the
@@ -549,7 +549,7 @@ public:
    * array.
    */
   virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                  std::vector<Vector<RangeNumberType> >   &values) const;
+                                  std::vector<Vector<RangeNumberType> >   &values) const override;
 
   /**
    * Return an estimate for the memory consumption, in bytes, of this object.
@@ -662,7 +662,7 @@ public:
    * the function given to the constructor produces for this point.
    */
   virtual RangeNumberType value (const Point<dim>   &p,
-                                 const unsigned int  component = 0) const;
+                                 const unsigned int  component = 0) const override;
 
 private:
   /**
@@ -731,7 +731,7 @@ public:
    * the function given to the constructor produces for this point.
    */
   virtual RangeNumberType value (const Point<dim>   &p,
-                                 const unsigned int  component = 0) const;
+                                 const unsigned int  component = 0) const override;
 
   /**
    * Return all components of a vector-valued function at a given point.
@@ -739,7 +739,7 @@ public:
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
    */
   virtual void vector_value (const Point<dim>   &p,
-                             Vector<RangeNumberType>     &values) const;
+                             Vector<RangeNumberType>     &values) const override;
 
 private:
   /**
@@ -818,13 +818,13 @@ public:
    * This destructor is defined as virtual so as to coincide with all other
    * aspects of class.
    */
-  virtual ~VectorFunctionFromTensorFunction() = default;
+  virtual ~VectorFunctionFromTensorFunction() override = default;
 
   /**
    * Return a single component of a vector-valued function at a given point.
    */
   virtual RangeNumberType value (const Point<dim> &p,
-                                 const unsigned int component = 0) const;
+                                 const unsigned int component = 0) const override;
 
   /**
    * Return all components of a vector-valued function at a given point.
@@ -832,7 +832,7 @@ public:
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
    */
   virtual void vector_value (const Point<dim> &p,
-                             Vector<RangeNumberType>   &values) const;
+                             Vector<RangeNumberType>   &values) const override;
 
   /**
    * Return all components of a vector-valued function at a list of points.
@@ -842,7 +842,7 @@ public:
    * function
    */
   virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                  std::vector<Vector<RangeNumberType> >   &value_list) const;
+                                  std::vector<Vector<RangeNumberType> >   &value_list) const override;
 
 private:
   /**

--- a/include/deal.II/base/function_bessel.h
+++ b/include/deal.II/base/function_bessel.h
@@ -38,15 +38,15 @@ namespace Functions
     Bessel1(const unsigned int order,
             const double wave_number,
             const Point<dim> center = Point<dim>());
-    virtual double value (const Point<dim> &points, const unsigned int component) const;
+    virtual double value (const Point<dim> &points, const unsigned int component) const override;
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
     virtual void gradient_list (const std::vector<Point<dim> > &points,
                                 std::vector<Tensor<1,dim> >    &gradients,
-                                const unsigned int              component = 0) const;
+                                const unsigned int              component = 0) const override;
   private:
     unsigned int order;
     double wave_number;

--- a/include/deal.II/base/function_cspline.h
+++ b/include/deal.II/base/function_cspline.h
@@ -80,19 +80,19 @@ namespace Functions
     /**
      * Virtual destructor.
      */
-    virtual ~CSpline();
+    virtual ~CSpline() override;
 
     virtual double value (const Point<dim> &point,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
 
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     virtual SymmetricTensor<2,dim> hessian (const Point<dim>   &p,
-                                            const unsigned int  component = 0) const;
+                                            const unsigned int  component = 0) const override;
 
     virtual double laplacian(const Point< dim > &p,
-                             const unsigned int component = 0) const;
+                             const unsigned int component = 0) const override;
 
     std::size_t memory_consumption () const;
 

--- a/include/deal.II/base/function_derivative.h
+++ b/include/deal.II/base/function_derivative.h
@@ -85,14 +85,14 @@ public:
   void set_h (const double h);
 
   virtual double value (const Point<dim> &p,
-                        const unsigned int component = 0) const;
+                        const unsigned int component = 0) const override;
 
   virtual void vector_value(const Point<dim> &p,
-                            Vector<double> &value) const;
+                            Vector<double> &value) const override;
 
   virtual void value_list (const std::vector<Point<dim> > &points,
                            std::vector<double>            &values,
-                           const unsigned int              component = 0) const;
+                           const unsigned int              component = 0) const override;
 
   /**
    * Return an estimate for the memory consumption, in bytes, of this object.

--- a/include/deal.II/base/function_lib.h
+++ b/include/deal.II/base/function_lib.h
@@ -53,24 +53,24 @@ namespace Functions
   {
   public:
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
     virtual void vector_value (const Point<dim>   &p,
-                               Vector<double>     &values) const;
+                               Vector<double>     &values) const override;
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
     virtual void vector_gradient (const Point<dim>   &p,
-                                  std::vector<Tensor<1,dim> >    &gradient) const;
+                                  std::vector<Tensor<1,dim> >    &gradient) const override;
     virtual void gradient_list (const std::vector<Point<dim> > &points,
                                 std::vector<Tensor<1,dim> >    &gradients,
-                                const unsigned int              component = 0) const;
+                                const unsigned int              component = 0) const override;
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
     virtual void laplacian_list (const std::vector<Point<dim> > &points,
                                  std::vector<double>            &values,
-                                 const unsigned int              component = 0) const;
+                                 const unsigned int              component = 0) const override;
   };
 
 
@@ -87,37 +87,37 @@ namespace Functions
   {
   public:
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> > &values) const;
+                                    std::vector<Vector<double> > &values) const override;
 
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int       component = 0) const;
+                                    const unsigned int       component = 0) const override;
 
     virtual void gradient_list (const std::vector<Point<dim> > &points,
                                 std::vector<Tensor<1,dim> >    &gradients,
-                                const unsigned int              component = 0) const;
+                                const unsigned int              component = 0) const override;
 
     virtual void vector_gradient_list (const std::vector<Point<dim> > &,
-                                       std::vector<std::vector<Tensor<1,dim> > > &) const;
+                                       std::vector<std::vector<Tensor<1,dim> > > &) const override;
 
     /**
      * Laplacian of the function at one point.
      */
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
 
     /**
      * Laplacian of the function at multiple points.
      */
     virtual void laplacian_list (const std::vector<Point<dim> > &points,
                                  std::vector<double>            &values,
-                                 const unsigned int              component = 0) const;
+                                 const unsigned int              component = 0) const override;
   };
 
 
@@ -151,40 +151,40 @@ namespace Functions
      * The value at a single point.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Values at multiple points.
      */
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     /**
      * Gradient at a single point.
      */
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     /**
      * Gradients at multiple points.
      */
     virtual void gradient_list (const std::vector<Point<dim> > &points,
                                 std::vector<Tensor<1,dim> >    &gradients,
-                                const unsigned int              component = 0) const;
+                                const unsigned int              component = 0) const override;
 
     /**
      * Laplacian at a single point.
      */
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
 
     /**
      * Laplacian at multiple points.
      */
     virtual void laplacian_list (const std::vector<Point<dim> > &points,
                                  std::vector<double>            &values,
-                                 const unsigned int              component = 0) const;
+                                 const unsigned int              component = 0) const override;
   private:
     const double offset;
   };
@@ -210,41 +210,41 @@ namespace Functions
     CosineFunction (const unsigned int n_components = 1);
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> > &values) const;
+                                    std::vector<Vector<double> > &values) const override;
 
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     virtual void gradient_list (const std::vector<Point<dim> > &points,
                                 std::vector<Tensor<1,dim> >    &gradients,
-                                const unsigned int              component = 0) const;
+                                const unsigned int              component = 0) const override;
 
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
 
     virtual void laplacian_list (const std::vector<Point<dim> > &points,
                                  std::vector<double>            &values,
-                                 const unsigned int              component = 0) const;
+                                 const unsigned int              component = 0) const override;
 
     /**
      * Second derivatives at a single point.
      */
     virtual SymmetricTensor<2,dim> hessian (const Point<dim>   &p,
-                                            const unsigned int  component = 0) const;
+                                            const unsigned int  component = 0) const override;
 
     /**
      * Second derivatives at multiple points.
      */
     virtual void hessian_list (const std::vector<Point<dim> > &points,
                                std::vector<SymmetricTensor<2,dim> >    &hessians,
-                               const unsigned int              component = 0) const;
+                               const unsigned int              component = 0) const override;
   };
 
 
@@ -270,28 +270,28 @@ namespace Functions
     CosineGradFunction ();
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component) const;
+                          const unsigned int  component) const override;
     virtual void vector_value (const Point<dim>   &p,
-                               Vector<double>     &values) const;
+                               Vector<double>     &values) const override;
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component) const;
+                             const unsigned int              component) const override;
 
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> > &values) const;
+                                    std::vector<Vector<double> > &values) const override;
 
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component) const;
+                                    const unsigned int  component) const override;
 
     virtual void gradient_list (const std::vector<Point<dim> > &points,
                                 std::vector<Tensor<1,dim> >    &gradients,
-                                const unsigned int              component) const;
+                                const unsigned int              component) const override;
 
     virtual void vector_gradient_list (const std::vector<Point<dim> >            &points,
-                                       std::vector<std::vector<Tensor<1,dim> > > &gradients) const;
+                                       std::vector<std::vector<Tensor<1,dim> > > &gradients) const override;
 
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component) const;
+                              const unsigned int  component) const override;
   };
 
 
@@ -310,40 +310,40 @@ namespace Functions
      * The value at a single point.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Values at multiple points.
      */
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     /**
      * Gradient at a single point.
      */
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     /**
      * Gradients at multiple points.
      */
     virtual void gradient_list (const std::vector<Point<dim> > &points,
                                 std::vector<Tensor<1,dim> >    &gradients,
-                                const unsigned int              component = 0) const;
+                                const unsigned int              component = 0) const override;
 
     /**
      * Laplacian at a single point.
      */
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
 
     /**
      * Laplacian at multiple points.
      */
     virtual void laplacian_list (const std::vector<Point<dim> > &points,
                                  std::vector<double>            &values,
-                                 const unsigned int              component = 0) const;
+                                 const unsigned int              component = 0) const override;
   };
 
 
@@ -363,31 +363,31 @@ namespace Functions
   {
   public:
     virtual double value (const Point<2>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void value_list (const std::vector<Point<2> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     virtual void vector_value_list (const std::vector<Point<2> > &points,
-                                    std::vector<Vector<double> > &values) const;
+                                    std::vector<Vector<double> > &values) const override;
 
     virtual Tensor<1,2> gradient (const Point<2>     &p,
-                                  const unsigned int  component = 0) const;
+                                  const unsigned int  component = 0) const override;
 
     virtual void gradient_list (const std::vector<Point<2> > &points,
                                 std::vector<Tensor<1,2> >    &gradients,
-                                const unsigned int            component = 0) const;
+                                const unsigned int            component = 0) const override;
 
     virtual void vector_gradient_list (const std::vector<Point<2> > &,
-                                       std::vector<std::vector<Tensor<1,2> > > &) const;
+                                       std::vector<std::vector<Tensor<1,2> > > &) const override;
 
     virtual double laplacian (const Point<2>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
 
     virtual void laplacian_list (const std::vector<Point<2> > &points,
                                  std::vector<double>          &values,
-                                 const unsigned int            component = 0) const;
+                                 const unsigned int            component = 0) const override;
   };
 
 
@@ -409,31 +409,31 @@ namespace Functions
      */
     LSingularityGradFunction ();
     virtual double value (const Point<2>   &p,
-                          const unsigned int  component) const;
+                          const unsigned int  component) const override;
 
     virtual void value_list (const std::vector<Point<2> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component) const;
+                             const unsigned int              component) const override;
 
     virtual void vector_value_list (const std::vector<Point<2> > &points,
-                                    std::vector<Vector<double> > &values) const;
+                                    std::vector<Vector<double> > &values) const override;
 
     virtual Tensor<1,2> gradient (const Point<2>     &p,
-                                  const unsigned int  component) const;
+                                  const unsigned int  component) const override;
 
     virtual void gradient_list (const std::vector<Point<2> > &points,
                                 std::vector<Tensor<1,2> >    &gradients,
-                                const unsigned int            component) const;
+                                const unsigned int            component) const override;
 
     virtual void vector_gradient_list (const std::vector<Point<2> > &,
-                                       std::vector<std::vector<Tensor<1,2> > > &) const;
+                                       std::vector<std::vector<Tensor<1,2> > > &) const override;
 
     virtual double laplacian (const Point<2>   &p,
-                              const unsigned int  component) const;
+                              const unsigned int  component) const override;
 
     virtual void laplacian_list (const std::vector<Point<2> > &points,
                                  std::vector<double>          &values,
-                                 const unsigned int            component) const;
+                                 const unsigned int            component) const override;
   };
 
 
@@ -449,31 +449,31 @@ namespace Functions
   {
   public:
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> > &values) const;
+                                    std::vector<Vector<double> > &values) const override;
 
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     virtual void gradient_list (const std::vector<Point<dim> > &points,
                                 std::vector<Tensor<1,dim> >    &gradients,
-                                const unsigned int            component = 0) const;
+                                const unsigned int            component = 0) const override;
 
     virtual void vector_gradient_list (const std::vector<Point<dim> > &,
-                                       std::vector<std::vector<Tensor<1,dim> > > &) const;
+                                       std::vector<std::vector<Tensor<1,dim> > > &) const override;
 
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
 
     virtual void laplacian_list (const std::vector<Point<dim> > &points,
                                  std::vector<double>          &values,
-                                 const unsigned int            component = 0) const;
+                                 const unsigned int            component = 0) const override;
   };
 
 
@@ -487,31 +487,31 @@ namespace Functions
   {
   public:
     virtual double value (const Point<2>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     virtual void value_list (const std::vector<Point<2> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     virtual void vector_value_list (const std::vector<Point<2> > &points,
-                                    std::vector<Vector<double> > &values) const;
+                                    std::vector<Vector<double> > &values) const override;
 
     virtual Tensor<1,2> gradient (const Point<2>   &p,
-                                  const unsigned int  component = 0) const;
+                                  const unsigned int  component = 0) const override;
 
     virtual void gradient_list (const std::vector<Point<2> > &points,
                                 std::vector<Tensor<1,2> >    &gradients,
-                                const unsigned int            component = 0) const;
+                                const unsigned int            component = 0) const override;
 
     virtual void vector_gradient_list (const std::vector<Point<2> > &,
-                                       std::vector<std::vector<Tensor<1,2> > > &) const;
+                                       std::vector<std::vector<Tensor<1,2> > > &) const override;
 
     virtual double laplacian (const Point<2>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
 
     virtual void laplacian_list (const std::vector<Point<2> > &points,
                                  std::vector<double>          &values,
-                                 const unsigned int            component = 0) const;
+                                 const unsigned int            component = 0) const override;
   };
 
 
@@ -546,40 +546,40 @@ namespace Functions
      * Function value at one point.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Function values at multiple points.
      */
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     /**
      * Gradient at one point.
      */
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     /**
      * Gradients at multiple points.
      */
     virtual void gradient_list (const std::vector<Point<dim> > &points,
                                 std::vector<Tensor<1,dim> >    &gradients,
-                                const unsigned int              component = 0) const;
+                                const unsigned int              component = 0) const override;
 
     /**
      * Laplacian of the function at one point.
      */
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
 
     /**
      * Laplacian of the function at multiple points.
      */
     virtual void laplacian_list (const std::vector<Point<dim> > &points,
                                  std::vector<double>            &values,
-                                 const unsigned int              component = 0) const;
+                                 const unsigned int              component = 0) const override;
 
     /**
      * Return an estimate for the memory consumption, in bytes, of this
@@ -647,20 +647,20 @@ namespace Functions
      * first component.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Return the gradient of the specified component of the function at the
      * given point.
      */
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     /**
      * Compute the Laplacian of a given component at point <tt>p</tt>.
      */
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
   private:
     /**
      * Stored Fourier coefficients.
@@ -699,20 +699,20 @@ namespace Functions
      * first component.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Return the gradient of the specified component of the function at the
      * given point.
      */
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     /**
      * Compute the Laplacian of a given component at point <tt>p</tt>.
      */
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
   private:
     /**
      * Stored Fourier coefficients.
@@ -748,20 +748,20 @@ namespace Functions
      * first component.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Return the gradient of the specified component of the function at the
      * given point.
      */
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     /**
      * Compute the Laplacian of a given component at point <tt>p</tt>.
      */
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
   private:
     /**
      * Stored Fourier coefficients and weights.
@@ -800,20 +800,20 @@ namespace Functions
      * first component.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Return the gradient of the specified component of the function at the
      * given point.
      */
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     /**
      * Compute the Laplacian of a given component at point <tt>p</tt>.
      */
     virtual double laplacian (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+                              const unsigned int  component = 0) const override;
 
   private:
     /**
@@ -911,20 +911,20 @@ namespace Functions
      * Function value at one point.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Function values at multiple points.
      */
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     /**
      * Function values at multiple points.
      */
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> >           &values) const;
+                                    std::vector<Vector<double> >           &values) const override;
   };
 
 
@@ -956,20 +956,20 @@ namespace Functions
      * Function value at one point.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Function values at multiple points.
      */
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     /**
      * Function values at multiple points.
      */
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> >           &values) const;
+                                    std::vector<Vector<double> >           &values) const override;
   };
 
 
@@ -1002,26 +1002,26 @@ namespace Functions
      * Function value at one point.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Function values at multiple points.
      */
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     /**
      * Function values at multiple points.
      */
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> >           &values) const;
+                                    std::vector<Vector<double> >           &values) const override;
 
     /**
      * Function gradient at one point.
      */
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
   };
 
 
@@ -1056,7 +1056,7 @@ namespace Functions
      * Function value at one point.
      */
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
 
     /**
      * Return all components of a vector-valued function at a given point.
@@ -1065,20 +1065,20 @@ namespace Functions
      * #n_components.
      */
     virtual void vector_value (const Point<dim>   &p,
-                               Vector<double>     &values) const;
+                               Vector<double>     &values) const override;
 
     /**
      * Function values at multiple points.
      */
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>            &values,
-                             const unsigned int              component = 0) const;
+                             const unsigned int              component = 0) const override;
 
     /**
      * Function gradient at one point.
      */
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
   private:
     /**
@@ -1154,7 +1154,7 @@ namespace Functions
     virtual
     double
     value (const Point<dim> &p,
-           const unsigned int component = 0) const;
+           const unsigned int component = 0) const override;
 
     /**
      * Compute the gradient of the function defined by bilinear interpolation
@@ -1170,7 +1170,7 @@ namespace Functions
     virtual
     Tensor<1, dim>
     gradient (const Point<dim>    &p,
-              const unsigned int component = 0) const;
+              const unsigned int component = 0) const override;
 
   protected:
     /**
@@ -1260,7 +1260,7 @@ namespace Functions
     virtual
     double
     value (const Point<dim> &p,
-           const unsigned int component = 0) const;
+           const unsigned int component = 0) const override;
 
   private:
     /**
@@ -1312,7 +1312,7 @@ namespace Functions
      * Function value at one point.
      */
     virtual double value (const Point<dim> &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
 
 
     /**
@@ -1320,13 +1320,13 @@ namespace Functions
      */
     virtual void value_list (const std::vector<Point<dim> > &points,
                              std::vector<double>      &values,
-                             const unsigned int       component = 0) const;
+                             const unsigned int       component = 0) const override;
 
     /**
      * Function gradient at one point.
      */
     virtual Tensor<1,dim> gradient (const Point<dim> &p,
-                                    const unsigned int component = 0) const;
+                                    const unsigned int component = 0) const override;
 
   private:
 

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -212,7 +212,7 @@ public:
    * Destructor. Explicitly delete the FunctionParser objects (there is one
    * for each component of the function).
    */
-  ~FunctionParser();
+  ~FunctionParser() override;
 
   /**
    * Type for the constant map. Used by the initialize() method.
@@ -291,7 +291,7 @@ public:
    * component.
    */
   virtual double value (const Point<dim>   &p,
-                        const unsigned int  component = 0) const;
+                        const unsigned int  component = 0) const override;
 
   /**
    * Return all components of a vector-valued function at the given point @p
@@ -300,7 +300,7 @@ public:
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
    */
   virtual void vector_value (const Point<dim>   &p,
-                             Vector<double>     &values) const;
+                             Vector<double>     &values) const override;
 
   /**
    * @addtogroup Exceptions

--- a/include/deal.II/base/function_spherical.h
+++ b/include/deal.II/base/function_spherical.h
@@ -65,7 +65,7 @@ namespace Functions
      * calls svalue() with it, and returns the result.
      */
     virtual double value (const Point<dim> &point,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
 
     /**
      * Return the gradient with respect to the Cartesian coordinates at point @p p.
@@ -75,7 +75,7 @@ namespace Functions
      * coordinates.
      */
     virtual Tensor<1,dim> gradient (const Point<dim>   &p,
-                                    const unsigned int  component = 0) const;
+                                    const unsigned int  component = 0) const override;
 
     /**
      * Return the Hessian with respect to the Cartesian coordinates at point @p p.
@@ -85,7 +85,7 @@ namespace Functions
      * Cartesian coordinates.
      */
     virtual SymmetricTensor<2,dim> hessian (const Point<dim> &p,
-                                            const unsigned int component=0) const;
+                                            const unsigned int component=0) const override;
 
     std::size_t memory_consumption () const;
 

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -138,7 +138,7 @@ public:
   /**
    * Destructor.
    */
-  ~LogStream();
+  ~LogStream() override;
 
 
   /**

--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -356,7 +356,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~ParameterAcceptor();
+  virtual ~ParameterAcceptor() override;
 
   /**
    * Call declare_all_parameters(), read the parameters from `filename` (only
@@ -590,13 +590,13 @@ public:
    * Overloads the ParameterAcceptor::declare_parameters function, by calling
    * @p SourceClass::declare_parameters with @p prm as an argument.
    */
-  virtual void declare_parameters(ParameterHandler &prm);
+  virtual void declare_parameters(ParameterHandler &prm) override;
 
   /**
    * Overloads the ParameterAcceptor::parse_parameters function, by calling
    * @p SourceClass::parse_parameters with @p prm as an argument.
    */
-  virtual void parse_parameters(ParameterHandler &prm);
+  virtual void parse_parameters(ParameterHandler &prm) override;
 };
 
 

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -863,7 +863,7 @@ public:
    * safer as we have virtual functions.  It actually does nothing
    * spectacular.
    */
-  virtual ~ParameterHandler () = default;
+  virtual ~ParameterHandler () override = default;
 
   /**
    * Parse each line from a stream until the stream returns the <tt>eof</tt>

--- a/include/deal.II/base/parsed_function.h
+++ b/include/deal.II/base/parsed_function.h
@@ -184,7 +184,7 @@ namespace Functions
      * p.
      */
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &values) const;
+                               Vector<double>   &values) const override;
 
     /**
      * Return the value of the function at the given point. Unless there is
@@ -193,7 +193,7 @@ namespace Functions
      * first component.
      */
     virtual double value (const Point< dim >     &p,
-                          const unsigned int  component = 0)    const;
+                          const unsigned int  component = 0)    const override;
 
     /**
      * Set the time to a specific value for time-dependent functions.
@@ -201,7 +201,7 @@ namespace Functions
      * We need to overwrite this to set the time also in the accessor
      * FunctionParser<dim>.
      */
-    virtual void set_time(const double newtime);
+    virtual void set_time(const double newtime) override;
 
   private:
     /**

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -165,7 +165,7 @@ namespace Utilities
        */
       virtual void reinit(const IndexSet &vector_space_vector_index_set,
                           const IndexSet &read_write_vector_index_set,
-                          const MPI_Comm &communicator);
+                          const MPI_Comm &communicator) override;
 
       /**
        * Set the locally owned indices. Used in the constructor.
@@ -356,7 +356,7 @@ namespace Utilities
       /**
        * Return the MPI communicator underlying the partitioner object.
        */
-      virtual const MPI_Comm &get_mpi_communicator() const;
+      virtual const MPI_Comm &get_mpi_communicator() const override;
 
       /**
        * Return whether ghost indices have been explicitly added as a @p

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -206,21 +206,21 @@ namespace Patterns
      * Return <tt>true</tt> if the string is an integer and its value is
      * within the specified range.
      */
-    virtual bool match (const std::string &test_string) const;
+    virtual bool match (const std::string &test_string) const override;
 
     /**
      * Return a description of the pattern that valid strings are expected to
      * match. If bounds were specified to the constructor, then include them
      * into this description.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * Create a new object if the start of description matches
@@ -298,21 +298,21 @@ namespace Patterns
      * Return <tt>true</tt> if the string is a number and its value is within
      * the specified range.
      */
-    virtual bool match (const std::string &test_string) const;
+    virtual bool match (const std::string &test_string) const override;
 
     /**
      * Return a description of the pattern that valid strings are expected to
      * match. If bounds were specified to the constructor, then include them
      * into this description.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * Creates a new object on the heap using @p new if the given
@@ -368,27 +368,27 @@ namespace Patterns
      * Return <tt>true</tt> if the string is an element of the description
      * list passed to the constructor.
      */
-    virtual bool match (const std::string &test_string) const;
+    virtual bool match (const std::string &test_string) const override;
 
     /**
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the list of valid strings passed to the
      * constructor.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * Determine an estimate for the memory consumption (in bytes) of this
      * object.
      */
-    std::size_t memory_consumption () const;
+    std::size_t memory_consumption () const override;
 
     /**
      * Create a new object if the start of description matches
@@ -461,20 +461,20 @@ namespace Patterns
      * Return <tt>true</tt> if the string is a comma-separated list of strings
      * each of which match the pattern given to the constructor.
      */
-    virtual bool match (const std::string &test_string) const;
+    virtual bool match (const std::string &test_string) const override;
 
     /**
      * Return a description of the pattern that valid strings are expected to
      * match.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * Create a new object if the start of description matches
@@ -487,7 +487,7 @@ namespace Patterns
      * Determine an estimate for the memory consumption (in bytes) of this
      * object.
      */
-    std::size_t memory_consumption () const;
+    std::size_t memory_consumption () const override;
 
     /**
      * @addtogroup Exceptions
@@ -578,20 +578,20 @@ namespace Patterns
      * Return <tt>true</tt> if the string is a comma-separated list of strings
      * each of which match the pattern given to the constructor.
      */
-    virtual bool match (const std::string &test_string) const;
+    virtual bool match (const std::string &test_string) const override;
 
     /**
      * Return a description of the pattern that valid strings are expected to
      * match.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * Create a new object if the start of description matches
@@ -604,7 +604,7 @@ namespace Patterns
      * Determine an estimate for the memory consumption (in bytes) of this
      * object.
      */
-    std::size_t memory_consumption () const;
+    std::size_t memory_consumption () const override;
 
     /**
      * Return a reference to the key pattern.
@@ -785,20 +785,20 @@ namespace Patterns
      * Return <tt>true</tt> if the string is a list of strings
      * each of which matches the patterns given to the constructor.
      */
-    virtual bool match (const std::string &test_string) const;
+    virtual bool match (const std::string &test_string) const override;
 
     /**
      * Return a description of the pattern that valid strings are expected to
      * match.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * Create a new object if the start of description matches
@@ -811,7 +811,7 @@ namespace Patterns
      * Determine an estimate for the memory consumption (in bytes) of this
      * object.
      */
-    std::size_t memory_consumption () const;
+    std::size_t memory_consumption () const override;
 
     /**
      * Return a reference to the i-th pattern in the tuple.
@@ -863,21 +863,21 @@ namespace Patterns
      * Return <tt>true</tt> if the string is an element of the description
      * list passed to the constructor.
      */
-    virtual bool match (const std::string &test_string) const;
+    virtual bool match (const std::string &test_string) const override;
 
     /**
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the list of valid strings passed to the
      * constructor.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * Create a new object if the start of description matches
@@ -890,7 +890,7 @@ namespace Patterns
      * Determine an estimate for the memory consumption (in bytes) of this
      * object.
      */
-    std::size_t memory_consumption () const;
+    std::size_t memory_consumption () const override;
 
     /**
      * @addtogroup Exceptions
@@ -934,14 +934,14 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * Create a new object if the start of description matches
@@ -973,20 +973,20 @@ namespace Patterns
      * Return <tt>true</tt> if the string matches its constraints, i.e.
      * always.
      */
-    virtual bool match (const std::string &test_string) const;
+    virtual bool match (const std::string &test_string) const override;
 
     /**
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the string <tt>"[Anything]"</tt>.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * Create a new object if the start of description matches
@@ -1046,20 +1046,20 @@ namespace Patterns
      * Return <tt>true</tt> if the string matches its constraints, i.e.
      * always.
      */
-    virtual bool match (const std::string &test_string) const;
+    virtual bool match (const std::string &test_string) const override;
 
     /**
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the string <tt>"[Filename]"</tt>.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * file type flag
@@ -1105,20 +1105,20 @@ namespace Patterns
      * Return <tt>true</tt> if the string matches its constraints, i.e.
      * always.
      */
-    virtual bool match (const std::string &test_string) const;
+    virtual bool match (const std::string &test_string) const override;
 
     /**
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the string <tt>"[Filename]"</tt>.
      */
-    virtual std::string description (const OutputStyle style=Machine) const;
+    virtual std::string description (const OutputStyle style=Machine) const override;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
      * heap. Ownership of that object is transferred to the caller of this
      * function.
      */
-    virtual std::unique_ptr<PatternBase> clone () const;
+    virtual std::unique_ptr<PatternBase> clone () const override;
 
     /**
      * Create a new object if the start of description matches

--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -165,7 +165,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~Quadrature () = default;
+  virtual ~Quadrature () override = default;
 
   /**
    * Assignment operator. Copies contents of #weights and #quadrature_points

--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -63,7 +63,7 @@ public:
   /**
    * Default destructor.
    */
-  ~CellDataStorage() = default;
+  ~CellDataStorage() override = default;
 
   /**
    * Initialize data on the @p cell to store @p number_of_data_points_per_cell of objects of type @p T .

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -454,7 +454,7 @@ public:
   /**
    * Destructor. Free allocated memory.
    */
-  ~TableBase () = default;
+  ~TableBase () override = default;
 
   /**
    * Assignment operator. Copy all elements of <tt>src</tt> into the matrix.

--- a/include/deal.II/base/tensor_function.h
+++ b/include/deal.II/base/tensor_function.h
@@ -75,7 +75,7 @@ public:
    * usually not used by their true type, but rather through pointers to this
    * base class.
    */
-  virtual ~TensorFunction () = default;
+  virtual ~TensorFunction () override = default;
 
   /**
    * Return the value of the function at the given point.
@@ -127,17 +127,17 @@ public:
   ConstantTensorFunction (const dealii::Tensor<rank, dim, Number> &value,
                           const Number initial_time = 0.0);
 
-  virtual ~ConstantTensorFunction () = default;
+  virtual ~ConstantTensorFunction () override = default;
 
-  virtual typename dealii::TensorFunction<rank, dim, Number>::value_type value (const Point<dim> &p) const;
+  virtual typename dealii::TensorFunction<rank, dim, Number>::value_type value (const Point<dim> &p) const override;
 
   virtual void value_list (const std::vector<Point<dim> > &points,
-                           std::vector<typename dealii::TensorFunction<rank, dim, Number>::value_type> &values) const;
+                           std::vector<typename dealii::TensorFunction<rank, dim, Number>::value_type> &values) const override;
 
-  virtual typename dealii::TensorFunction<rank, dim, Number>::gradient_type gradient (const Point<dim> &p) const;
+  virtual typename dealii::TensorFunction<rank, dim, Number>::gradient_type gradient (const Point<dim> &p) const override;
 
   virtual void gradient_list (const std::vector<Point<dim> > &points,
-                              std::vector<typename dealii::TensorFunction<rank, dim, Number>::gradient_type> &gradients) const;
+                              std::vector<typename dealii::TensorFunction<rank, dim, Number>::gradient_type> &gradients) const override;
 
 private:
   const dealii::Tensor<rank, dim, Number> _value;

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1364,7 +1364,7 @@ namespace Threads
         task_descriptor (task_descriptor)
       {}
 
-      virtual tbb::task *execute ()
+      virtual tbb::task *execute () override
       {
         // call the function object and put the return value into the
         // proper place

--- a/include/deal.II/base/time_stepping.h
+++ b/include/deal.II/base/time_stepping.h
@@ -128,7 +128,7 @@ namespace TimeStepping
     /**
      * Virtual destructor.
      */
-    virtual ~RungeKutta() = default;
+    virtual ~RungeKutta() override = default;
 
     /**
      * Purely virtual method used to initialize the Runge-Kutta method.
@@ -151,7 +151,7 @@ namespace TimeStepping
      std::vector<std::function<VectorType (const double, const double, const VectorType &)> > &J_inverse,
      double                                                                                   t,
      double                                                                                   delta_t,
-     VectorType                                                                               &y);
+     VectorType                                                                               &y) override;
 
     /**
      * Purely virtual function. This function is used to advance from time @p
@@ -220,7 +220,7 @@ namespace TimeStepping
     /**
      * Initialize the explicit Runge-Kutta method.
      */
-    void initialize(const runge_kutta_method method);
+    void initialize(const runge_kutta_method method) override;
 
     /**
      * This function is used to advance from time @p t to t+ @p delta_t. @p f
@@ -238,7 +238,7 @@ namespace TimeStepping
      const std::function<VectorType (const double, const double, const VectorType &)>  &id_minus_tau_J_inverse,
      double                                                                      t,
      double                                                                      delta_t,
-     VectorType                                                                  &y);
+     VectorType                                                                  &y) override;
 
     /**
      * This function is used to advance from time @p t to t+ @p delta_t. This
@@ -269,7 +269,7 @@ namespace TimeStepping
     /**
      * Return the status of the current object.
      */
-    const Status &get_status() const;
+    const Status &get_status() const override;
 
   private:
     /**
@@ -319,7 +319,7 @@ namespace TimeStepping
     /**
      * Initialize the implicit Runge-Kutta method.
      */
-    void initialize(const runge_kutta_method method);
+    void initialize(const runge_kutta_method method) override;
 
     /**
      * This function is used to advance from time @p t to t+ @p delta_t. @p f
@@ -337,7 +337,7 @@ namespace TimeStepping
      const std::function<VectorType (const double, const double, const VectorType &)> &id_minus_tau_J_inverse,
      double                                                                           t,
      double                                                                           delta_t,
-     VectorType                                                                       &y);
+     VectorType                                                                       &y) override;
 
     /**
      * Set the maximum number of iterations and the tolerance used by the
@@ -367,7 +367,7 @@ namespace TimeStepping
     /**
      * Return the status of the current object.
      */
-    const Status &get_status() const;
+    const Status &get_status() const override;
 
   private:
     /**
@@ -456,7 +456,7 @@ namespace TimeStepping
     /**
      * Destructor.
      */
-    ~EmbeddedExplicitRungeKutta()
+    ~EmbeddedExplicitRungeKutta() override
     {
       free_memory();
     }
@@ -469,7 +469,7 @@ namespace TimeStepping
     /**
      * Initialize the embedded explicit Runge-Kutta method.
      */
-    void initialize(const runge_kutta_method method);
+    void initialize(const runge_kutta_method method) override;
 
     /**
      * This function is used to advance from time @p t to t+ @p delta_t. @p f
@@ -487,7 +487,7 @@ namespace TimeStepping
      const std::function<VectorType (const double, const double, const VectorType &)> &id_minus_tau_J_inverse,
      double                                                                     t,
      double                                                                     delta_t,
-     VectorType &y);
+     VectorType &y) override;
 
     /**
      * This function is used to advance from time @p t to t+ @p delta_t. This
@@ -530,7 +530,7 @@ namespace TimeStepping
     /**
      * Return the status of the current object.
      */
-    const Status &get_status() const;
+    const Status &get_status() const override;
 
   private:
     /**

--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -351,7 +351,7 @@ namespace WorkStream
         /**
          * Create an item and return a pointer to it.
          */
-        virtual void *operator () (void *)
+        virtual void *operator () (void *) override
         {
           // find first unused item. we know that there must be one
           // because we have set the maximal number of tokens in flight
@@ -493,7 +493,7 @@ namespace WorkStream
         /**
          * Work on an item.
          */
-        void *operator () (void *item)
+        void *operator () (void *item) override
         {
           // first unpack the current item
           typedef
@@ -637,7 +637,7 @@ namespace WorkStream
         /**
          * Work on a single item.
          */
-        void *operator () (void *item)
+        void *operator () (void *item) override
         {
           // first unpack the current item
           typedef

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -241,7 +241,7 @@ namespace parallel
       /**
        * Destructor.
        */
-      virtual ~Triangulation () = default;
+      virtual ~Triangulation () override = default;
 
       /**
        * Coarsen and refine the mesh according to refinement and coarsening
@@ -251,7 +251,7 @@ namespace parallel
        * addition of calling dealii::GridTools::partition_triangulation() at
        * the end.
        */
-      virtual void execute_coarsening_and_refinement ();
+      virtual void execute_coarsening_and_refinement () override;
 
       /**
        * Create a triangulation.
@@ -261,7 +261,7 @@ namespace parallel
        */
       virtual void create_triangulation (const std::vector< Point< spacedim > > &vertices,
                                          const std::vector< CellData< dim > > &cells,
-                                         const SubCellData &subcelldata);
+                                         const SubCellData &subcelldata) override;
 
       /**
        * Copy @p other_tria to this triangulation.
@@ -273,7 +273,7 @@ namespace parallel
        * since it only stores those cells that it owns, one layer of ghost cells around
        * the ones it locally owns, and a number of artificial cells.
        */
-      virtual void copy_triangulation (const dealii::Triangulation<dim, spacedim> &other_tria);
+      virtual void copy_triangulation (const dealii::Triangulation<dim, spacedim> &other_tria) override;
 
       /**
        * Read the data of this object from a stream for the purpose of
@@ -318,7 +318,7 @@ namespace parallel
        * Override the function to update the number cache so we can fill data
        * like @p level_ghost_owners.
        */
-      virtual void update_number_cache ();
+      virtual void update_number_cache () override;
 
     private:
 

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -361,7 +361,7 @@ namespace parallel
       /**
        * Destructor.
        */
-      virtual ~Triangulation ();
+      virtual ~Triangulation () override;
 
       /**
        * Reset this triangulation into a virgin state by deleting all data.
@@ -369,7 +369,7 @@ namespace parallel
        * Note that this operation is only allowed if no subscriptions to this
        * object exist any more, such as DoFHandler objects using it.
        */
-      virtual void clear ();
+      virtual void clear () override;
 
       /**
        * Implementation of the same function as in the base class.
@@ -380,7 +380,7 @@ namespace parallel
        * parallel::distributed::Triangulation but only if the serial
        * Triangulation has never been refined.
        */
-      virtual void copy_triangulation (const dealii::Triangulation<dim, spacedim> &other_tria);
+      virtual void copy_triangulation (const dealii::Triangulation<dim, spacedim> &other_tria) override;
 
       /**
        * Create a triangulation as documented in the base class.
@@ -393,7 +393,7 @@ namespace parallel
        */
       virtual void create_triangulation (const std::vector<Point<spacedim> >    &vertices,
                                          const std::vector<CellData<dim> > &cells,
-                                         const SubCellData                 &subcelldata);
+                                         const SubCellData                 &subcelldata) override;
 
       /**
        * Coarsen and refine the mesh according to refinement and coarsening
@@ -424,7 +424,7 @@ namespace parallel
        * function is connected to the signal it will be used to balance the
        * calculated weights, otherwise the number of cells is balanced.
        */
-      virtual void execute_coarsening_and_refinement ();
+      virtual void execute_coarsening_and_refinement () override;
 
       /**
        * Override the implementation of prepare_coarsening_and_refinement from
@@ -432,7 +432,7 @@ namespace parallel
        * and the level difference over vertices over the periodic boundary
        * must be not more than 2:1.
        */
-      virtual bool prepare_coarsening_and_refinement ();
+      virtual bool prepare_coarsening_and_refinement () override;
 
       /**
        * Manually repartition the active cells between processors. Normally
@@ -548,12 +548,12 @@ namespace parallel
        * mesh, i.e., the union of locally owned cells on all processors.
        */
       virtual
-      bool has_hanging_nodes() const;
+      bool has_hanging_nodes() const override;
 
       /**
        * Return the local memory consumption in bytes.
        */
-      virtual std::size_t memory_consumption () const;
+      virtual std::size_t memory_consumption () const override;
 
       /**
        * Return the local memory consumption contained in the p4est data
@@ -799,7 +799,7 @@ namespace parallel
        */
       virtual void
       add_periodicity
-      (const std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator> > &);
+      (const std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator> > &) override;
 
 
     private:
@@ -808,7 +808,7 @@ namespace parallel
        * Override the function to update the number cache so we can fill data
        * like @p level_ghost_owners.
        */
-      virtual void update_number_cache ();
+      virtual void update_number_cache () override;
 
       /**
        * store the Settings.
@@ -970,7 +970,7 @@ namespace parallel
        * are adjacent to each vertex.
        */
       virtual std::map<unsigned int, std::set<dealii::types::subdomain_id> >
-      compute_vertices_with_ghost_neighbors () const;
+      compute_vertices_with_ghost_neighbors () const override;
 
       /**
        * This method returns a bit vector of length tria.n_vertices()
@@ -1022,7 +1022,7 @@ namespace parallel
       /**
        * Destructor.
        */
-      virtual ~Triangulation ();
+      virtual ~Triangulation () override;
 
       /**
        * Return a permutation vector for the order the coarse cells are
@@ -1116,21 +1116,21 @@ namespace parallel
        * Like above, this method, which is only implemented for dim = 2 or 3,
        * needs a stub because it is used in dof_handler_policy.cc
        */
-      std::map<unsigned int, std::set<dealii::types::subdomain_id> >
-      compute_vertices_with_ghost_neighbors () const;
+      virtual std::map<unsigned int, std::set<dealii::types::subdomain_id> >
+      compute_vertices_with_ghost_neighbors () const override;
 
       /**
        * Like above, this method, which is only implemented for dim = 2 or 3,
        * needs a stub because it is used in dof_handler_policy.cc
        */
-      std::map<unsigned int, std::set<dealii::types::subdomain_id> >
+      virtual std::map<unsigned int, std::set<dealii::types::subdomain_id> >
       compute_level_vertices_with_ghost_neighbors (const unsigned int level) const;
 
       /**
        * Like above, this method, which is only implemented for dim = 2 or 3,
        * needs a stub because it is used in dof_handler_policy.cc
        */
-      std::vector<bool>
+      virtual std::vector<bool>
       mark_locally_active_vertices_on_level(const unsigned int level) const;
 
     };

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -56,7 +56,7 @@ namespace parallel
     /**
      * Destructor.
      */
-    virtual ~Triangulation ();
+    virtual ~Triangulation () override;
 
     /**
      * Return MPI communicator used by this triangulation.
@@ -66,7 +66,7 @@ namespace parallel
     /**
      * Implementation of the same function as in the base class.
      */
-    virtual void copy_triangulation (const dealii::Triangulation<dim, spacedim> &old_tria);
+    virtual void copy_triangulation (const dealii::Triangulation<dim, spacedim> &old_tria) override;
 
     /**
      * Return the number of active cells owned by each of the MPI processes
@@ -103,12 +103,12 @@ namespace parallel
      * by each processor. This equals the overall number of active cells in
      * the triangulation.
      */
-    virtual types::global_dof_index n_global_active_cells () const;
+    virtual types::global_dof_index n_global_active_cells () const override;
 
     /**
      * Return the local memory consumption in bytes.
      */
-    virtual std::size_t memory_consumption () const;
+    virtual std::size_t memory_consumption () const override;
 
 
     /**
@@ -118,7 +118,7 @@ namespace parallel
      * the domain that are not very refined, but if other processors store
      * cells in more deeply refined parts of the domain.
      */
-    virtual unsigned int n_global_levels () const;
+    virtual unsigned int n_global_levels () const override;
 
     /**
      * Return the subdomain id of those cells that are owned by the current
@@ -126,7 +126,7 @@ namespace parallel
      * subdomain id are either owned by another processor or have children
      * that only exist on other processors.
      */
-    types::subdomain_id locally_owned_subdomain () const;
+    types::subdomain_id locally_owned_subdomain () const override;
 
     /**
      * Return a set of MPI ranks of the processors that have at least one

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -352,7 +352,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~DoFHandler ();
+  virtual ~DoFHandler () override;
 
   /**
    * Copy operator. DoFHandler objects are large and expensive.

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -124,23 +124,23 @@ namespace internal
         // documentation is inherited
         virtual
         NumberCache
-        distribute_dofs () const;
+        distribute_dofs () const override;
 
         // documentation is inherited
         virtual
         std::vector<NumberCache>
-        distribute_mg_dofs () const;
+        distribute_mg_dofs () const override;
 
         // documentation is inherited
         virtual
         NumberCache
-        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers) const;
+        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers) const override;
 
         // documentation is inherited
         virtual
         NumberCache
         renumber_mg_dofs (const unsigned int                          level,
-                          const std::vector<types::global_dof_index> &new_numbers) const;
+                          const std::vector<types::global_dof_index> &new_numbers) const override;
 
       protected:
         /**
@@ -176,14 +176,14 @@ namespace internal
          */
         virtual
         NumberCache
-        distribute_dofs () const;
+        distribute_dofs () const override;
 
         /**
          * This function is not yet implemented.
          */
         virtual
         std::vector<NumberCache>
-        distribute_mg_dofs () const;
+        distribute_mg_dofs () const override;
 
         /**
          * Renumber degrees of freedom as specified by the first argument.
@@ -196,13 +196,13 @@ namespace internal
          */
         virtual
         NumberCache
-        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers) const;
+        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers) const override;
 
         // documentation is inherited
         virtual
         NumberCache
         renumber_mg_dofs (const unsigned int                          level,
-                          const std::vector<types::global_dof_index> &new_numbers) const;
+                          const std::vector<types::global_dof_index> &new_numbers) const override;
 
       private:
         /**
@@ -230,23 +230,23 @@ namespace internal
         // documentation is inherited
         virtual
         NumberCache
-        distribute_dofs () const;
+        distribute_dofs () const override;
 
         // documentation is inherited
         virtual
         std::vector<NumberCache>
-        distribute_mg_dofs () const;
+        distribute_mg_dofs () const override;
 
         // documentation is inherited
         virtual
         NumberCache
-        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers) const;
+        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers) const override;
 
         // documentation is inherited
         virtual
         NumberCache
         renumber_mg_dofs (const unsigned int                          level,
-                          const std::vector<types::global_dof_index> &new_numbers) const;
+                          const std::vector<types::global_dof_index> &new_numbers) const override;
 
       private:
         /**

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -768,7 +768,7 @@ public:
    * Virtual destructor. Makes sure that pointers to this class are deleted
    * properly.
    */
-  virtual ~FiniteElement () = default;
+  virtual ~FiniteElement () override = default;
 
   /**
    * Creates information for creating a FESystem with this class as

--- a/include/deal.II/fe/fe_abf.h
+++ b/include/deal.II/fe/fe_abf.h
@@ -111,7 +111,7 @@ public:
    * returns <tt>FE_ABF<dim>(degree)</tt>, with @p dim and @p degree replaced
    * by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
@@ -121,19 +121,19 @@ public:
    * always @p true.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   // documentation inherited from the base class
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,dim> >
-  clone() const;
+  clone() const override;
 
 private:
   /**

--- a/include/deal.II/fe/fe_bdm.h
+++ b/include/deal.II/fe/fe_bdm.h
@@ -70,17 +70,17 @@ public:
    * returns <tt>FE_BDM<dim>(degree)</tt>, with @p dim and @p degree replaced
    * by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,dim> >
-  clone() const;
+  clone() const override;
 
   // documentation inherited from the base class
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
 private:
   /**

--- a/include/deal.II/fe/fe_bernstein.h
+++ b/include/deal.II/fe/fe_bernstein.h
@@ -79,7 +79,7 @@ public:
    */
   virtual void
   get_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                            FullMatrix<double>       &matrix) const;
+                            FullMatrix<double>       &matrix) const override;
 
   /**
    * FE_Bernstein is not interpolatory in the element interior, which prevents
@@ -90,7 +90,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_restriction_matrix (const unsigned int child,
-                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
    * FE_Bernstein is not interpolatory in the element interior, which prevents
@@ -101,7 +101,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_prolongation_matrix (const unsigned int child,
-                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face of
@@ -114,7 +114,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face of
@@ -128,13 +128,13 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
    * the new way, which has to be used to make elements "hp compatible".
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * If, on a vertex, several finite elements are active, the hp code first
@@ -153,7 +153,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -161,7 +161,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -169,7 +169,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -182,7 +182,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
 
 
   /**
@@ -190,11 +190,11 @@ public:
    * returns <tt>FE_Bernstein<dim>(degree)</tt>, with @p dim and @p degree
    * replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
 protected:
 

--- a/include/deal.II/fe/fe_dg_vector.h
+++ b/include/deal.II/fe/fe_dg_vector.h
@@ -65,11 +65,11 @@ public:
    * returns <tt>FE_RaviartThomas<dim>(degree)</tt>, with @p dim and @p degree
    * replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
@@ -78,9 +78,9 @@ public:
    * For this element, we always return @p true.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
 private:
   /**
@@ -152,7 +152,7 @@ public:
    * returns <tt>FE_DGNedelec<dim>(degree)</tt>, with @p dim and @p degree
    * replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 };
 
 
@@ -179,7 +179,7 @@ public:
    * returns <tt>FE_DGRaviartThomas<dim>(degree)</tt>, with @p dim and @p
    * degree replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 };
 
 
@@ -205,7 +205,7 @@ public:
    * returns <tt>FE_DGBDM<dim>(degree)</tt>, with @p dim and @p degree
    * replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 };
 
 

--- a/include/deal.II/fe/fe_dgp.h
+++ b/include/deal.II/fe/fe_dgp.h
@@ -319,7 +319,7 @@ public:
    * returns <tt>FE_DGP<dim>(degree)</tt>, with @p dim and @p degree replaced
    * by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   /**
    * @name Functions to support hp
@@ -346,7 +346,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -357,7 +357,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -368,7 +368,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
@@ -378,7 +378,7 @@ public:
    * of the element), as it has no hanging nodes (being a discontinuous
    * element).
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -391,7 +391,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * @}
@@ -410,7 +410,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -426,14 +426,14 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -443,7 +443,7 @@ public:
    * accessed through pointers to their base class, rather than the class
    * itself.
    */
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
 
   /**
@@ -451,11 +451,11 @@ public:
    * first entry is true, all other are false.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
 private:
 

--- a/include/deal.II/fe/fe_dgp_monomial.h
+++ b/include/deal.II/fe/fe_dgp_monomial.h
@@ -294,7 +294,7 @@ public:
    * returns <tt>FE_DGPMonomial<dim>(degree)</tt>, with <tt>dim</tt> and
    * <tt>p</tt> replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   /**
    * @name Functions to support hp
@@ -321,7 +321,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -332,7 +332,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -343,7 +343,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
@@ -353,7 +353,7 @@ public:
    * the degree of the element), as it has no hanging nodes (being a
    * discontinuous element).
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -366,7 +366,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * @}
@@ -383,7 +383,7 @@ public:
    */
   virtual void
   get_interpolation_matrix (const FiniteElement<dim> &source,
-                            FullMatrix<double>           &matrix) const;
+                            FullMatrix<double>           &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -398,7 +398,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -414,14 +414,14 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -431,11 +431,11 @@ public:
    * accessed through pointers to their base class, rather than the class
    * itself.
    */
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,dim> >
-  clone() const;
+  clone() const override;
 
 private:
 

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -279,16 +279,16 @@ public:
    * returns <tt>FE_DGPNonparametric<dim>(degree)</tt>, with @p dim and @p
    * degree replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
   // for documentation, see the FiniteElement base class
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   /**
    * This function is intended to return the value of a shape function at a
@@ -301,7 +301,7 @@ public:
    * type FiniteElement::ExcUnitShapeValuesDoNotExist.
    */
   virtual double shape_value (const unsigned int i,
-                              const Point<dim> &p) const;
+                              const Point<dim> &p) const override;
 
   /**
    * This function is intended to return the value of a shape function at a
@@ -315,7 +315,7 @@ public:
    */
   virtual double shape_value_component (const unsigned int i,
                                         const Point<dim> &p,
-                                        const unsigned int component) const;
+                                        const unsigned int component) const override;
 
   /**
    * This function is intended to return the gradient of a shape function at a
@@ -328,7 +328,7 @@ public:
    * type FiniteElement::ExcUnitShapeValuesDoNotExist.
    */
   virtual Tensor<1,dim> shape_grad (const unsigned int  i,
-                                    const Point<dim>   &p) const;
+                                    const Point<dim>   &p) const override;
 
   /**
    * This function is intended to return the gradient of a shape function at a
@@ -342,7 +342,7 @@ public:
    */
   virtual Tensor<1,dim> shape_grad_component (const unsigned int i,
                                               const Point<dim> &p,
-                                              const unsigned int component) const;
+                                              const unsigned int component) const override;
 
   /**
    * This function is intended to return the Hessian of a shape function at a
@@ -355,7 +355,7 @@ public:
    * exception of type FiniteElement::ExcUnitShapeValuesDoNotExist.
    */
   virtual Tensor<2,dim> shape_grad_grad (const unsigned int  i,
-                                         const Point<dim> &p) const;
+                                         const Point<dim> &p) const override;
 
   /**
    * This function is intended to return the Hessian of a shape function at a
@@ -369,7 +369,7 @@ public:
    */
   virtual Tensor<2,dim> shape_grad_grad_component (const unsigned int i,
                                                    const Point<dim> &p,
-                                                   const unsigned int component) const;
+                                                   const unsigned int component) const override;
 
   /**
    * Return the polynomial degree of this finite element, i.e. the value
@@ -390,7 +390,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -406,7 +406,7 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * @name Functions to support hp
@@ -433,7 +433,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -444,7 +444,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -455,7 +455,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
@@ -465,7 +465,7 @@ public:
    * of the degree of the element), as it has no hanging nodes (being a
    * discontinuous element).
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -478,7 +478,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * @}
@@ -489,7 +489,7 @@ public:
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -499,7 +499,7 @@ public:
    * accessed through pointers to their base class, rather than the class
    * itself.
    */
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
 protected:
 
@@ -512,7 +512,7 @@ protected:
   get_data (const UpdateFlags                                                    update_flags,
             const Mapping<dim,spacedim>                                         &mapping,
             const Quadrature<dim>                                               &quadrature,
-            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -523,7 +523,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                   const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -534,7 +534,7 @@ protected:
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -546,7 +546,7 @@ protected:
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                           const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
 private:
 

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -118,7 +118,7 @@ public:
    * returns <tt>FE_DGQ<dim>(degree)</tt>, with <tt>dim</tt> and
    * <tt>degree</tt> replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   /**
    * Return the matrix interpolating from the given finite element to the
@@ -131,7 +131,7 @@ public:
    */
   virtual void
   get_interpolation_matrix (const FiniteElement<dim, spacedim> &source,
-                            FullMatrix<double>           &matrix) const;
+                            FullMatrix<double>           &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -146,7 +146,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim, spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -162,7 +162,7 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim, spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * Projection from a fine grid space onto a coarse grid space. Overrides the
@@ -183,7 +183,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_restriction_matrix (const unsigned int child,
-                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
    * Embedding matrix between grids. Overrides the respective method in
@@ -208,7 +208,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_prolongation_matrix (const unsigned int child,
-                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
    * @name Functions to support hp
@@ -235,7 +235,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -246,7 +246,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -257,7 +257,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
@@ -267,7 +267,7 @@ public:
    * of the element), as it has no hanging nodes (being a discontinuous
    * element).
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -280,7 +280,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim, spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim, spacedim> &fe_other) const override;
 
   /**
    * @}
@@ -291,14 +291,14 @@ public:
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Return a list of constant modes of the element. For this element, it
    * simply returns one row with all entries set to true.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
   /**
    * Implementation of the corresponding function in the FiniteElement
@@ -310,7 +310,7 @@ public:
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -320,11 +320,11 @@ public:
    * accessed through pointers to their base class, rather than the class
    * itself.
    */
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
 protected:
   /**
@@ -416,7 +416,7 @@ public:
    * returns <tt>FE_DGQArbitraryNodes<dim>(degree)</tt>, with <tt>dim</tt> and
    * <tt>degree</tt> replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   /**
    * Implementation of the corresponding function in the FiniteElement
@@ -428,10 +428,10 @@ public:
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 };
 
 
@@ -462,7 +462,7 @@ public:
    * mode) is set to true and all other elements are set to false.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
   /**
    * Return a string that uniquely identifies a finite element. This class
@@ -470,11 +470,11 @@ public:
    * <tt>degree</tt> replaced by the values given by the template parameter
    * and the argument passed to the constructor, respectively.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 };
 
 
@@ -512,11 +512,11 @@ public:
    * <tt>degree</tt> replaced by the values given by the template parameter
    * and the argument passed to the constructor, respectively.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 };
 
 

--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -281,16 +281,16 @@ public:
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   /**
    * Return a string that identifies a finite element.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   /**
    * Access to a composing element. The index needs to be smaller than the
@@ -299,7 +299,7 @@ public:
    * element to be enriched, which could be FE_Nothing.
    */
   virtual const FiniteElement<dim,spacedim> &
-  base_element (const unsigned int index) const;
+  base_element (const unsigned int index) const override;
 
   /**
    * Return the value of the @p ith shape function at the point @p p. @p p is a
@@ -310,7 +310,7 @@ public:
    * real-space.
    */
   virtual double shape_value(const unsigned int      i,
-                             const Point< dim >     &p) const;
+                             const Point< dim >     &p) const override;
 
   /**
    * @name Transfer matrices
@@ -325,7 +325,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_restriction_matrix (const unsigned int child,
-                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
    * Embedding matrix between grids.
@@ -335,7 +335,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_prolongation_matrix (const unsigned int child,
-                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   //@}
 
@@ -350,7 +350,7 @@ public:
    * This function returns @p true if and only if all its base elements return @p true
    * for this function.
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -366,7 +366,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the
@@ -383,7 +383,7 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * If, on a vertex, several finite elements are active, the hp code first
@@ -402,7 +402,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -410,7 +410,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -418,7 +418,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -431,7 +431,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
   //@}
 
 
@@ -567,19 +567,19 @@ protected:
   get_data (const UpdateFlags      flags,
             const Mapping<dim,spacedim>    &mapping,
             const Quadrature<dim> &quadrature,
-            dealii::internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim > &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim > &output_data) const override;
 
   virtual std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase>
   get_face_data (const UpdateFlags      update_flags,
                  const Mapping<dim,spacedim>    &mapping,
                  const Quadrature<dim-1> &quadrature,
-                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim >        &output_data) const;
+                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData< dim, spacedim >        &output_data) const override;
 
   virtual std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase>
   get_subface_data (const UpdateFlags      update_flags,
                     const Mapping<dim,spacedim>    &mapping,
                     const Quadrature<dim-1> &quadrature,
-                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void fill_fe_values (const typename Triangulation<dim, spacedim>::cell_iterator &cell,
@@ -590,7 +590,7 @@ protected:
                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
                        dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data
-                      ) const;
+                      ) const override;
 
   virtual
   void
@@ -602,7 +602,7 @@ protected:
                         const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                         const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
                         dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data
-                      ) const;
+                      ) const override;
 
   virtual
   void
@@ -615,7 +615,7 @@ protected:
                           const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
                           dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data
-                         ) const;
+                         ) const override;
 
 private:
   /**

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -64,14 +64,14 @@ public:
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
   /**
    * Return a string that uniquely identifies a finite element. This class
    * returns <tt>FE_FaceQ<dim>(degree)</tt>, with <tt>dim</tt> and
    * <tt>degree</tt> replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   /**
    * Implementation of the corresponding function in the FiniteElement
@@ -83,7 +83,7 @@ public:
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -95,7 +95,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -108,14 +108,14 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * @name Functions to support hp
@@ -141,7 +141,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -151,7 +151,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -161,13 +161,13 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim, spacedim> &fe_other) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
    * the new way, which has to be used to make elements "hp compatible".
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -180,7 +180,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
   /**
    * @}
    */
@@ -190,7 +190,7 @@ public:
    * simply returns one row with all entries set to true.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
 private:
   /**
@@ -224,19 +224,19 @@ public:
 
   virtual
   std::unique_ptr<FiniteElement<1,spacedim>>
-                                          clone() const;
+                                          clone() const override;
 
   /**
    * Return a string that uniquely identifies a finite element. This class
    * returns <tt>FE_FaceQ<dim>(degree)</tt>, with <tt>dim</tt> and
    * <tt>degree</tt> replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   // for documentation, see the FiniteElement base class
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -248,7 +248,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<1,spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -261,20 +261,20 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<1,spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
    * the new way, which has to be used to make elements "hp compatible".
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * If, on a vertex, several finite elements are active, the hp code first
@@ -295,7 +295,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<1, spacedim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<1, spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -305,7 +305,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<1, spacedim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<1, spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -315,7 +315,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<1, spacedim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<1, spacedim> &fe_other) const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -328,14 +328,14 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<1,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<1,spacedim> &fe_other) const override;
 
   /**
    * Return a list of constant modes of the element. For this element, it
    * simply returns one row with all entries set to true.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
 protected:
   /*
@@ -349,7 +349,7 @@ protected:
   get_data (const UpdateFlags                                                  /*update_flags*/,
             const Mapping<1,spacedim>                                         &/*mapping*/,
             const Quadrature<1>                                               &/*quadrature*/,
-            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &/*output_data*/) const
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &/*output_data*/) const override
   {
     return std_cxx14::make_unique<typename FiniteElement<1, spacedim>::InternalDataBase>();
   }
@@ -358,7 +358,7 @@ protected:
   get_face_data(const UpdateFlags update_flags,
                 const Mapping<1,spacedim> &/*mapping*/,
                 const Quadrature<0> &quadrature,
-                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &/*output_data*/) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &/*output_data*/) const override
   {
     // generate a new data object and initialize some fields
     auto data = std_cxx14::make_unique<typename FiniteElement<1,spacedim>::InternalDataBase>();
@@ -381,7 +381,7 @@ protected:
   get_subface_data(const UpdateFlags                                                  update_flags,
                    const Mapping<1,spacedim>                                         &mapping,
                    const Quadrature<0>                                               &quadrature,
-                   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const
+                   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const override
   {
     return get_face_data(update_flags, mapping, quadrature, output_data);
   }
@@ -395,7 +395,7 @@ protected:
                   const typename Mapping<1,spacedim>::InternalDataBase              &mapping_internal,
                   const dealii::internal::FEValuesImplementation::MappingRelatedData<1, spacedim> &mapping_data,
                   const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const override;
 
   virtual
   void
@@ -406,7 +406,7 @@ protected:
                        const typename Mapping<1,spacedim>::InternalDataBase              &mapping_internal,
                        const dealii::internal::FEValuesImplementation::MappingRelatedData<1, spacedim> &mapping_data,
                        const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const override;
 
   virtual
   void
@@ -418,7 +418,7 @@ protected:
                           const typename Mapping<1,spacedim>::InternalDataBase              &mapping_internal,
                           const dealii::internal::FEValuesImplementation::MappingRelatedData<1, spacedim> &mapping_data,
                           const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, spacedim> &output_data) const override;
 
 private:
   /**
@@ -468,14 +468,14 @@ public:
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
   /**
    * Return a string that uniquely identifies a finite element. This class
    * returns <tt>FE_FaceP<dim>(degree)</tt> , with <tt>dim</tt> and
    * <tt>degree</tt> replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -487,7 +487,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -500,20 +500,20 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
    * the new way, which has to be used to make elements "hp compatible".
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -526,7 +526,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Return a list of constant modes of the element. For this element, the
@@ -535,7 +535,7 @@ public:
    * polynomials).
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
 private:
   /**
@@ -562,7 +562,7 @@ public:
   /**
    * Return the name of the element
    */
-  std::string get_name() const;
+  std::string get_name() const override;
 };
 
 

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -124,7 +124,7 @@ public:
    * returns <tt>FE_Nedelec<dim>(degree)</tt>, with @p dim and @p degree
    * replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
 
   /**
@@ -132,7 +132,7 @@ public:
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
@@ -142,14 +142,14 @@ public:
    * of the degree of the element), as it implements the complete set of
    * functions necessary for hp capability.
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return whether this element dominates the one, which is given as
    * argument.
    */
   virtual FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * If, on a vertex, several finite elements are active, the hp code first
@@ -167,21 +167,21 @@ public:
    * corresponding index of the other finite element.
    */
   virtual std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
    * of freedom on lines.
    */
   virtual std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
    * of freedom on lines.
    */
   virtual std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face of
@@ -196,7 +196,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim> &source,
-                                 FullMatrix<double> &matrix) const;
+                                 FullMatrix<double> &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the subface
@@ -212,7 +212,7 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim> &source,
                                     const unsigned int subface,
-                                    FullMatrix<double> &matrix) const;
+                                    FullMatrix<double> &matrix) const override;
   /**
    * Projection from a fine grid space onto a coarse grid space. If this
    * projection operator is associated with a matrix @p P, then the
@@ -229,7 +229,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_restriction_matrix (const unsigned int child,
-                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
    * Embedding matrix between grids.
@@ -253,25 +253,25 @@ public:
    */
   virtual const FullMatrix<double> &
   get_prolongation_matrix (const unsigned int child,
-                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   // documentation inherited from the base class
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
   /**
    * Return a list of constant modes of the element.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,dim> >
-  clone() const;
+  clone() const override;
 
 private:
   /**

--- a/include/deal.II/fe/fe_nedelec_sz.h
+++ b/include/deal.II/fe/fe_nedelec_sz.h
@@ -77,53 +77,53 @@ public:
 
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
-  virtual std::unique_ptr<FiniteElement<dim,dim> > clone() const;
+  virtual std::unique_ptr<FiniteElement<dim,dim> > clone() const override;
 
   /**
   * This element is vector-valued so this function will
   * throw an exception.
   */
   virtual double shape_value (const unsigned int i,
-                              const Point<dim>  &p) const;
+                              const Point<dim>  &p) const override;
 
   /**
   * Not implemented.
   */
   virtual double shape_value_component (const unsigned int i,
                                         const Point<dim>  &p,
-                                        const unsigned int component) const;
+                                        const unsigned int component) const override;
 
   /**
   * This element is vector-valued so this function will
   * throw an exception.
   */
   virtual Tensor<1,dim> shape_grad (const unsigned int i,
-                                    const Point<dim>  &p) const;
+                                    const Point<dim>  &p) const override;
 
   /**
   * Not implemented.
   */
   virtual Tensor<1,dim> shape_grad_component (const unsigned int i,
                                               const Point<dim>  &p,
-                                              const unsigned int component) const;
+                                              const unsigned int component) const override;
 
   /**
   * This element is vector-valued so this function will
   * throw an exception.
   */
   virtual Tensor<2,dim> shape_grad_grad (const unsigned int i,
-                                         const Point<dim>  &p) const;
+                                         const Point<dim>  &p) const override;
 
   /**
   * Not implemented.
   */
   virtual Tensor<2,dim> shape_grad_grad_component (const unsigned int i,
                                                    const Point<dim>  &p,
-                                                   const unsigned int component) const;
+                                                   const unsigned int component) const override;
 
   /**
    * Given <tt>flags</tt>, determines the values which must be computed only
@@ -151,7 +151,7 @@ protected:
   get_data (const UpdateFlags                                                             update_flags,
             const Mapping<dim,dim>                                                       &mapping,
             const Quadrature<dim>                                                        &quadrature,
-            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim> &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim> &output_data) const override;
 
   /**
   * Compute information about the shape functions on the cell denoted by the
@@ -166,7 +166,7 @@ protected:
                   const typename Mapping<dim,dim>::InternalDataBase                            &mapping_internal,
                   const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, dim> &mapping_data,
                   const typename FiniteElement<dim,dim>::InternalDataBase                      &fedata,
-                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim> &data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim> &data) const override;
 
   /**
   * Compute information about the shape functions on the cell and face denoted
@@ -181,7 +181,7 @@ protected:
                        const typename Mapping<dim,dim>::InternalDataBase                            &mapping_internal,
                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, dim> &mapping_data,
                        const typename FiniteElement<dim,dim>::InternalDataBase                      &fedata,
-                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim> &data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim> &data) const override;
 
   /**
   * Not implemented.
@@ -195,7 +195,7 @@ protected:
                           const typename Mapping<dim,dim>::InternalDataBase                            &mapping_internal,
                           const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, dim> &mapping_data,
                           const typename FiniteElement<dim,dim>::InternalDataBase                      &fedata,
-                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim> &data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim> &data) const override;
 
   /**
   * Derived Internal data which is used to store cell-independent data.

--- a/include/deal.II/fe/fe_p1nc.h
+++ b/include/deal.II/fe/fe_p1nc.h
@@ -261,18 +261,18 @@ public:
    */
   FE_P1NC();
 
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
-  virtual UpdateFlags requires_update_flags (const UpdateFlags flags) const;
+  virtual UpdateFlags requires_update_flags (const UpdateFlags flags) const override;
 
   virtual
   std::unique_ptr<FiniteElement<2,2>>
-                                   clone() const;
+                                   clone() const override;
 
   /**
    * Destructor.
    */
-  virtual ~FE_P1NC () = default;
+  virtual ~FE_P1NC () override = default;
 
 
 
@@ -302,21 +302,21 @@ private:
   get_data (const UpdateFlags update_flags,
             const Mapping<2,2> &,
             const Quadrature<2> &quadrature,
-            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const override;
 
   virtual
   std::unique_ptr<FiniteElement<2,2>::InternalDataBase>
   get_face_data (const UpdateFlags update_flags,
                  const Mapping<2,2> &,
                  const Quadrature<1> &quadrature,
-                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
+                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const override;
 
   virtual
   std::unique_ptr<FiniteElement<2,2>::InternalDataBase>
   get_subface_data (const UpdateFlags update_flags,
                     const Mapping<2,2> &,
                     const Quadrature<1> &quadrature,
-                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
+                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const override;
 
   /**
    * Compute the data on the current cell.
@@ -329,7 +329,7 @@ private:
                   const Mapping<2,2>::InternalDataBase              &mapping_internal,
                   const internal::FEValuesImplementation::MappingRelatedData<2,2> &mapping_data,
                   const FiniteElement<2,2>::InternalDataBase        &fe_internal,
-                  internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
+                  internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const override;
 
   /**
    * Compute the data on the face of the current cell.
@@ -342,7 +342,7 @@ private:
                        const Mapping<2,2>::InternalDataBase                      &mapping_internal,
                        const dealii::internal::FEValuesImplementation::MappingRelatedData<2,2> &mapping_data,
                        const InternalDataBase                                    &fe_internal,
-                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const override;
 
   /**
    * Compute the data on the subface of the current cell.
@@ -356,7 +356,7 @@ private:
                           const Mapping<2,2>::InternalDataBase                      &mapping_internal,
                           const dealii::internal::FEValuesImplementation::MappingRelatedData<2,2> &mapping_data,
                           const InternalDataBase                                    &fe_internal,
-                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2,2> &output_data) const override;
 
   /**
    * Create the constraints matrix for hanging edges.

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -86,7 +86,7 @@ public:
   // for documentation, see the FiniteElement base class
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   /**
    * Return the numbering of the underlying polynomial space compared to
@@ -107,7 +107,7 @@ public:
    * the semantics of this function.
    */
   virtual double shape_value (const unsigned int i,
-                              const Point<dim> &p) const;
+                              const Point<dim> &p) const override;
 
   /**
    * Return the value of the <tt>component</tt>th vector component of the
@@ -121,7 +121,7 @@ public:
    */
   virtual double shape_value_component (const unsigned int i,
                                         const Point<dim> &p,
-                                        const unsigned int component) const;
+                                        const unsigned int component) const override;
 
   /**
    * Return the gradient of the <tt>i</tt>th shape function at the point
@@ -129,7 +129,7 @@ public:
    * the semantics of this function.
    */
   virtual Tensor<1,dim> shape_grad (const unsigned int  i,
-                                    const Point<dim>   &p) const;
+                                    const Point<dim>   &p) const override;
 
   /**
    * Return the gradient of the <tt>component</tt>th vector component of the
@@ -143,7 +143,7 @@ public:
    */
   virtual Tensor<1,dim> shape_grad_component (const unsigned int i,
                                               const Point<dim> &p,
-                                              const unsigned int component) const;
+                                              const unsigned int component) const override;
 
   /**
    * Return the tensor of second derivatives of the <tt>i</tt>th shape
@@ -151,7 +151,7 @@ public:
    * class for more information about the semantics of this function.
    */
   virtual Tensor<2,dim> shape_grad_grad (const unsigned int  i,
-                                         const Point<dim> &p) const;
+                                         const Point<dim> &p) const override;
 
   /**
    * Return the second derivative of the <tt>component</tt>th vector component
@@ -165,7 +165,7 @@ public:
    */
   virtual Tensor<2,dim> shape_grad_grad_component (const unsigned int i,
                                                    const Point<dim> &p,
-                                                   const unsigned int component) const;
+                                                   const unsigned int component) const override;
 
   /**
    * Return the tensor of third derivatives of the <tt>i</tt>th shape function
@@ -173,7 +173,7 @@ public:
    * for more information about the semantics of this function.
    */
   virtual Tensor<3,dim> shape_3rd_derivative (const unsigned int  i,
-                                              const Point<dim>   &p) const;
+                                              const Point<dim>   &p) const override;
 
   /**
    * Return the third derivative of the <tt>component</tt>th vector component
@@ -187,7 +187,7 @@ public:
    */
   virtual Tensor<3,dim> shape_3rd_derivative_component (const unsigned int i,
                                                         const Point<dim>   &p,
-                                                        const unsigned int component) const;
+                                                        const unsigned int component) const override;
 
   /**
    * Return the tensor of fourth derivatives of the <tt>i</tt>th shape
@@ -195,7 +195,7 @@ public:
    * class for more information about the semantics of this function.
    */
   virtual Tensor<4,dim> shape_4th_derivative (const unsigned int  i,
-                                              const Point<dim>   &p) const;
+                                              const Point<dim>   &p) const override;
 
   /**
    * Return the fourth derivative of the <tt>component</tt>th vector component
@@ -209,7 +209,7 @@ public:
    */
   virtual Tensor<4,dim> shape_4th_derivative_component (const unsigned int i,
                                                         const Point<dim>   &p,
-                                                        const unsigned int component) const;
+                                                        const unsigned int component) const override;
 
 protected:
   /*
@@ -223,7 +223,7 @@ protected:
   get_data(const UpdateFlags                                                    update_flags,
            const Mapping<dim,spacedim>                                         &/*mapping*/,
            const Quadrature<dim>                                               &quadrature,
-           dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
+           dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override
   {
     // generate a new data object and
     // initialize some fields
@@ -334,7 +334,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                   const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -345,7 +345,7 @@ protected:
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -357,7 +357,7 @@ protected:
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                           const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   /**
    * Fields of cell-independent data.

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -72,7 +72,7 @@ public:
   // for documentation, see the FiniteElement base class
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
 protected:
   /*
@@ -86,7 +86,7 @@ protected:
   get_data (const UpdateFlags                                                    /*update_flags*/,
             const Mapping<dim,spacedim>                                         &/*mapping*/,
             const Quadrature<dim>                                               &/*quadrature*/,
-            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const override
   {
     return std_cxx14::make_unique<InternalData>();
   }
@@ -95,7 +95,7 @@ protected:
   get_face_data(const UpdateFlags                                                    update_flags,
                 const Mapping<dim,spacedim>                                         &/*mapping*/,
                 const Quadrature<dim-1>                                             &quadrature,
-                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+                dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const override
   {
     // generate a new data object and
     // initialize some fields
@@ -144,7 +144,7 @@ protected:
   get_subface_data(const UpdateFlags                                                    update_flags,
                    const Mapping<dim,spacedim>                                         &mapping,
                    const Quadrature<dim-1>                                             &quadrature,
-                   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const
+                   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override
   {
     return get_face_data(update_flags, mapping,
                          QProjector<dim - 1>::project_to_all_children(quadrature),
@@ -160,7 +160,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                   const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -171,7 +171,7 @@ protected:
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -183,7 +183,7 @@ protected:
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                           const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   /**
    * Fields of cell-independent data.

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -154,7 +154,7 @@ public:
   // for documentation, see the FiniteElement base class
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   /**
    * Compute the (scalar) value of shape function @p i at the given quadrature
@@ -163,12 +163,12 @@ public:
    * an exception.
    */
   virtual double shape_value (const unsigned int i,
-                              const Point<dim> &p) const;
+                              const Point<dim> &p) const override;
 
   // documentation inherited from the base class
   virtual double shape_value_component (const unsigned int i,
                                         const Point<dim> &p,
-                                        const unsigned int component) const;
+                                        const unsigned int component) const override;
 
   /**
    * Compute the gradient of (scalar) shape function @p i at the given
@@ -177,12 +177,12 @@ public:
    * throws an exception.
    */
   virtual Tensor<1,dim> shape_grad (const unsigned int  i,
-                                    const Point<dim>   &p) const;
+                                    const Point<dim>   &p) const override;
 
   // documentation inherited from the base class
   virtual Tensor<1,dim> shape_grad_component (const unsigned int i,
                                               const Point<dim> &p,
-                                              const unsigned int component) const;
+                                              const unsigned int component) const override;
 
   /**
    * Compute the Hessian of (scalar) shape function @p i at the given
@@ -191,12 +191,12 @@ public:
    * throws an exception.
    */
   virtual Tensor<2,dim> shape_grad_grad (const unsigned int  i,
-                                         const Point<dim> &p) const;
+                                         const Point<dim> &p) const override;
 
   // documentation inherited from the base class
   virtual Tensor<2,dim> shape_grad_grad_component (const unsigned int i,
                                                    const Point<dim> &p,
-                                                   const unsigned int component) const;
+                                                   const unsigned int component) const override;
 
 protected:
   /**
@@ -213,7 +213,7 @@ protected:
   get_data(const UpdateFlags                                                    update_flags,
            const Mapping<dim,spacedim>                                         &/*mapping*/,
            const Quadrature<dim>                                               &quadrature,
-           dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
+           dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const override
   {
     // generate a new data object and
     // initialize some fields
@@ -341,7 +341,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                   const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -352,7 +352,7 @@ protected:
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -364,7 +364,7 @@ protected:
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                           const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   /**
    * Fields of cell-independent data for FE_PolyTensor. Stores the values of

--- a/include/deal.II/fe/fe_q.h
+++ b/include/deal.II/fe/fe_q.h
@@ -576,11 +576,11 @@ public:
    * returns <tt>FE_Q<dim>(degree)</tt>, with @p dim and @p degree replaced by
    * appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
   /**
    * Implementation of the corresponding function in the FiniteElement
@@ -592,7 +592,7 @@ public:
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 };
 
 

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -58,7 +58,7 @@ public:
    */
   virtual void
   get_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                            FullMatrix<double>       &matrix) const;
+                            FullMatrix<double>       &matrix) const override;
 
 
   /**
@@ -72,7 +72,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -86,14 +86,14 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Projection from a fine grid space onto a coarse grid space. Overrides the
@@ -119,7 +119,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_restriction_matrix (const unsigned int child,
-                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
    * Embedding matrix between grids. Overrides the respective method in
@@ -149,7 +149,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_prolongation_matrix (const unsigned int child,
-                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
    * Given an index in the natural ordering of indices on a face, return the
@@ -194,14 +194,14 @@ public:
                                    const unsigned int face,
                                    const bool face_orientation = true,
                                    const bool face_flip        = false,
-                                   const bool face_rotation    = false) const;
+                                   const bool face_rotation    = false) const override;
 
   /**
    * Return a list of constant modes of the element. For this element, the
    * list consists of true arguments for all components.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
   /**
    * @name Functions to support hp
@@ -216,7 +216,7 @@ public:
    * of the element), as it implements the complete set of functions necessary
    * for hp capability.
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * If, on a vertex, several finite elements are active, the hp code first
@@ -235,7 +235,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -243,7 +243,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -251,7 +251,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -264,7 +264,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
   //@}
 
   /**

--- a/include/deal.II/fe/fe_q_bubbles.h
+++ b/include/deal.II/fe/fe_q_bubbles.h
@@ -102,13 +102,13 @@ public:
    * returns <tt>FE_Q_Bubbles<dim>(degree)</tt>, with @p dim and @p degree
    * replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   // documentation inherited from the base class
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
   /**
    * Return the matrix interpolating from the given finite element to the
@@ -121,15 +121,15 @@ public:
    */
   virtual void
   get_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                            FullMatrix<double>       &matrix) const;
+                            FullMatrix<double>       &matrix) const override;
 
   virtual const FullMatrix<double> &
   get_prolongation_matrix  (const unsigned int child,
-                            const RefinementCase<dim> &refinement_case) const;
+                            const RefinementCase<dim> &refinement_case) const override;
 
   virtual const FullMatrix<double> &
   get_restriction_matrix  (const unsigned int child,
-                           const RefinementCase<dim> &refinement_case) const;
+                           const RefinementCase<dim> &refinement_case) const override;
 
   /**
    * Check for non-zero values on a face.
@@ -140,11 +140,11 @@ public:
    * Implementation of the interface in FiniteElement
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
 private:
 

--- a/include/deal.II/fe/fe_q_dg0.h
+++ b/include/deal.II/fe/fe_q_dg0.h
@@ -256,13 +256,13 @@ public:
    * returns <tt>FE_Q_DG0<dim>(degree)</tt>, with @p dim and @p degree
    * replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   // documentation inherited from the base class
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
   /**
    * Return the matrix interpolating from the given finite element to the
@@ -275,7 +275,7 @@ public:
    */
   virtual void
   get_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                            FullMatrix<double>       &matrix) const;
+                            FullMatrix<double>       &matrix) const override;
 
 
   /**
@@ -283,7 +283,7 @@ public:
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Return a list of constant modes of the element. For this element, there
@@ -292,11 +292,11 @@ public:
    * the discontinuous part.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
 private:
 

--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -551,18 +551,18 @@ public:
    * returns <tt>FE_Q_Hierarchical<dim>(degree)</tt>, with @p dim and @p
    * degree replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,dim> >
-  clone() const;
+  clone() const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * @name Functions to support hp
@@ -577,21 +577,21 @@ public:
    * the degree of the element), as it implements the complete set of
    * functions necessary for hp capability.
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return the matrix interpolating from the given finite element to the
    * present one. Interpolation only between FE_Q_Hierarchical is supported.
    */
   virtual void get_interpolation_matrix(const FiniteElement< dim> &source,
-                                        FullMatrix< double > &matrix) const;
+                                        FullMatrix< double > &matrix) const override;
 
   /**
    * Embedding matrix between grids. Only isotropic refinement is supported.
    */
   virtual const
   FullMatrix<double> &get_prolongation_matrix  (const unsigned int child,
-                                                const RefinementCase<dim> &refinement_case = RefinementCase< dim >::isotropic_refinement) const;
+                                                const RefinementCase<dim> &refinement_case = RefinementCase< dim >::isotropic_refinement) const override;
 
   /**
    * If, on a vertex, several finite elements are active, the hp code first
@@ -610,21 +610,21 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * Same as above but for lines.
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * Same as above but for faces.
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   /*@}*/
 
@@ -639,7 +639,7 @@ public:
    * from a given element, then they must throw an exception of type
    * <tt>FiniteElement<dim>::ExcInterpolationNotImplemented</tt>.
    */
-  virtual void get_face_interpolation_matrix (const FiniteElement<dim> &source, FullMatrix<double> &matrix) const;
+  virtual void get_face_interpolation_matrix (const FiniteElement<dim> &source, FullMatrix<double> &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the subface
@@ -652,7 +652,7 @@ public:
    * from a given element, then they must throw an exception of type
    * <tt>ExcInterpolationNotImplemented</tt>.
    */
-  virtual void get_subface_interpolation_matrix (const FiniteElement<dim> &source, const unsigned int subface, FullMatrix<double> &matrix) const;
+  virtual void get_subface_interpolation_matrix (const FiniteElement<dim> &source, const unsigned int subface, FullMatrix<double> &matrix) const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -665,7 +665,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim> &fe_other) const override;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -675,7 +675,7 @@ public:
    * accessed through pointers to their base class, rather than the class
    * itself.
    */
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
   /**
    * For a finite element of degree @p sub_degree < @p degree, we return a
@@ -690,7 +690,7 @@ public:
    * false for the remaining ones.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
 private:
 

--- a/include/deal.II/fe/fe_q_iso_q1.h
+++ b/include/deal.II/fe/fe_q_iso_q1.h
@@ -123,11 +123,11 @@ public:
    * returns <tt>FE_Q_iso_q1<dim>(equivalent_degree)</tt>, with @p dim and @p
    * equivalent_degree replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
   /**
    * Implementation of the corresponding function in the FiniteElement
@@ -139,7 +139,7 @@ public:
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
   /**
    * @name Functions to support hp
@@ -157,7 +157,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
   //@}
 };
 

--- a/include/deal.II/fe/fe_rannacher_turek.h
+++ b/include/deal.II/fe/fe_rannacher_turek.h
@@ -64,17 +64,17 @@ public:
   FE_RannacherTurek(const unsigned int order = 0,
                     const unsigned int n_face_support_points = 2);
 
-  virtual std::string get_name() const;
+  virtual std::string get_name() const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,dim> >
-  clone() const;
+  clone() const override;
 
   // documentation inherited from the base class
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
 private:
   /**

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -115,12 +115,12 @@ public:
    * returns <tt>FE_RaviartThomas<dim>(degree)</tt>, with @p dim and @p degree
    * replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   // documentation inherited from the base class
   virtual
   std::unique_ptr<FiniteElement<dim,dim> >
-  clone() const;
+  clone() const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
@@ -130,22 +130,22 @@ public:
    * always @p true.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   // documentation inherited from the base class
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
   /**
    * Return a list of constant modes of the element. This method is currently
    * not correctly implemented because it returns ones for all components.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
 private:
   /**
@@ -255,37 +255,37 @@ public:
    * returns <tt>FE_RaviartThomasNodal<dim>(degree)</tt>, with @p dim and @p
    * degree replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   // documentation inherited from the base class
   virtual
   std::unique_ptr<FiniteElement<dim,dim> >
-  clone() const;
+  clone() const override;
 
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
   virtual void get_face_interpolation_matrix (const FiniteElement<dim> &source,
-                                              FullMatrix<double>       &matrix) const;
+                                              FullMatrix<double>       &matrix) const override;
 
   virtual void get_subface_interpolation_matrix (const FiniteElement<dim> &source,
                                                  const unsigned int        subface,
-                                                 FullMatrix<double>       &matrix) const;
-  virtual bool hp_constraints_are_implemented () const;
+                                                 FullMatrix<double>       &matrix) const override;
+  virtual bool hp_constraints_are_implemented () const override;
 
   virtual std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   virtual std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   virtual std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim> &fe_other) const override;
 
   virtual FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim> &fe_other) const override;
 
 private:
   /**
@@ -312,7 +312,7 @@ private:
    * always @p true.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
   /**
    * Initialize the FiniteElement<dim>::generalized_support_points and
    * FiniteElement<dim>::generalized_face_support_points fields. Called from

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -497,7 +497,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~FESystem () = default;
+  virtual ~FESystem () override = default;
 
   /**
    * Return a string that uniquely identifies a finite element. This element
@@ -507,15 +507,15 @@ public:
    * the multiplicities of the basis elements. If a multiplicity is equal to
    * one, then the superscript is omitted.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
   virtual
   UpdateFlags
-  requires_update_flags (const UpdateFlags update_flags) const;
+  requires_update_flags (const UpdateFlags update_flags) const override;
 
   // make variant with ComponentMask also available:
   using FiniteElement<dim,spacedim>::get_sub_fe;
@@ -526,7 +526,7 @@ public:
   virtual
   const FiniteElement<dim,spacedim> &
   get_sub_fe (const unsigned int first_component,
-              const unsigned int n_selected_components) const;
+              const unsigned int n_selected_components) const override;
 
   /**
    * Return the value of the @p ith shape function at the point @p p.  @p p is
@@ -541,7 +541,7 @@ public:
    * the shape of the cell in real space.
    */
   virtual double shape_value (const unsigned int i,
-                              const Point<dim> &p) const;
+                              const Point<dim> &p) const override;
 
   /**
    * Return the value of the @p componentth vector component of the @p ith
@@ -553,7 +553,7 @@ public:
    */
   virtual double shape_value_component (const unsigned int i,
                                         const Point<dim> &p,
-                                        const unsigned int component) const;
+                                        const unsigned int component) const override;
 
   /**
    * Return the gradient of the @p ith shape function at the point @p p. @p p
@@ -570,7 +570,7 @@ public:
    * the shape of the cell in real space.
    */
   virtual Tensor<1,dim> shape_grad (const unsigned int  i,
-                                    const Point<dim>   &p) const;
+                                    const Point<dim>   &p) const override;
 
   /**
    * Return the gradient of the @p componentth vector component of the @p ith
@@ -582,7 +582,7 @@ public:
    */
   virtual Tensor<1,dim> shape_grad_component (const unsigned int i,
                                               const Point<dim> &p,
-                                              const unsigned int component) const;
+                                              const unsigned int component) const override;
 
   /**
    * Return the tensor of second derivatives of the @p ith shape function at
@@ -599,7 +599,7 @@ public:
    * the shape of the cell in real space.
    */
   virtual Tensor<2,dim> shape_grad_grad (const unsigned int  i,
-                                         const Point<dim> &p) const;
+                                         const Point<dim> &p) const override;
 
   /**
    * Return the second derivatives of the @p componentth vector component of
@@ -613,7 +613,7 @@ public:
   Tensor<2,dim>
   shape_grad_grad_component (const unsigned int i,
                              const Point<dim> &p,
-                             const unsigned int component) const;
+                             const unsigned int component) const override;
 
   /**
    * Return the tensor of third derivatives of the @p ith shape function at
@@ -630,7 +630,7 @@ public:
    * the shape of the cell in real space.
    */
   virtual Tensor<3,dim> shape_3rd_derivative (const unsigned int  i,
-                                              const Point<dim>   &p) const;
+                                              const Point<dim>   &p) const override;
 
   /**
    * Return the third derivatives of the @p componentth vector component of
@@ -642,7 +642,7 @@ public:
    */
   virtual Tensor<3,dim> shape_3rd_derivative_component (const unsigned int i,
                                                         const Point<dim>   &p,
-                                                        const unsigned int component) const;
+                                                        const unsigned int component) const override;
 
   /**
    * Return the tensor of fourth derivatives of the @p ith shape function at
@@ -659,7 +659,7 @@ public:
    * the shape of the cell in real space.
    */
   virtual Tensor<4,dim> shape_4th_derivative (const unsigned int  i,
-                                              const Point<dim>   &p) const;
+                                              const Point<dim>   &p) const override;
 
   /**
    * Return the fourth derivatives of the @p componentth vector component of
@@ -671,7 +671,7 @@ public:
    */
   virtual Tensor<4,dim> shape_4th_derivative_component (const unsigned int i,
                                                         const Point<dim>   &p,
-                                                        const unsigned int component) const;
+                                                        const unsigned int component) const override;
 
   /**
    * Return the matrix interpolating from the given finite element to the
@@ -686,7 +686,7 @@ public:
    */
   virtual void
   get_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                            FullMatrix<double>           &matrix) const;
+                            FullMatrix<double>           &matrix) const override;
 
   /**
    * Access to a composing element. The index needs to be smaller than the
@@ -695,14 +695,14 @@ public:
    * the multiplicities are greater than one.
    */
   virtual const FiniteElement<dim,spacedim> &
-  base_element (const unsigned int index) const;
+  base_element (const unsigned int index) const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Projection from a fine grid space onto a coarse grid space. Overrides the
@@ -729,7 +729,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_restriction_matrix (const unsigned int child,
-                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                          const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
    * Embedding matrix between grids. Overrides the respective method in
@@ -760,7 +760,7 @@ public:
    */
   virtual const FullMatrix<double> &
   get_prolongation_matrix (const unsigned int child,
-                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
+                           const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
    * Given an index in the natural ordering of indices on a face, return the
@@ -805,21 +805,21 @@ public:
                                    const unsigned int face,
                                    const bool face_orientation = true,
                                    const bool face_flip        = false,
-                                   const bool face_rotation    = false) const;
+                                   const bool face_rotation    = false) const override;
 
   /**
    * Implementation of the respective function in the base class.
    */
   virtual
   Point<dim>
-  unit_support_point (const unsigned int index) const;
+  unit_support_point (const unsigned int index) const override;
 
   /**
    * Implementation of the respective function in the base class.
    */
   virtual
   Point<dim-1>
-  unit_face_support_point (const unsigned int index) const;
+  unit_face_support_point (const unsigned int index) const override;
 
   /**
    * Return a list of constant modes of the element. The returns table has as
@@ -829,7 +829,7 @@ public:
    * element. Concatenates the constant modes of each base element.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
   /**
    * @name Functions to support hp
@@ -843,7 +843,7 @@ public:
    * This function returns @p true if and only if all its base elements return
    * @p true for this function.
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -859,7 +859,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
 
   /**
@@ -877,7 +877,7 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * If, on a vertex, several finite elements are active, the hp code first
@@ -896,7 +896,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -904,7 +904,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -912,7 +912,7 @@ public:
    */
   virtual
   std::vector<std::pair<unsigned int, unsigned int> >
-  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const;
+  hp_quad_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -925,7 +925,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
   //@}
 
   /**
@@ -945,7 +945,7 @@ public:
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &dof_values) const;
+                                                          std::vector<double>                &dof_values) const override;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -955,7 +955,7 @@ public:
    * accessed through pointers to their base class, rather than the class
    * itself.
    */
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
 protected:
 
@@ -964,21 +964,21 @@ protected:
   get_data (const UpdateFlags                                                    update_flags,
             const Mapping<dim,spacedim>                                         &mapping,
             const Quadrature<dim>                                               &quadrature,
-            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+            dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase>
   get_face_data (const UpdateFlags                                                    update_flags,
                  const Mapping<dim,spacedim>                                         &mapping,
                  const Quadrature<dim-1>                                             &quadrature,
-                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                 dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   std::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase>
   get_subface_data (const UpdateFlags                                                    update_flags,
                     const Mapping<dim,spacedim>                                         &mapping,
                     const Quadrature<dim-1>                                             &quadrature,
-                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -989,7 +989,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                   const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                   const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -1000,7 +1000,7 @@ protected:
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                        const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                       dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   virtual
   void
@@ -1012,7 +1012,7 @@ protected:
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
                           const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const;
+                          dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &output_data) const override;
 
   /**
    * Do the work for the three <tt>fill_fe*_values</tt> functions.
@@ -1109,7 +1109,7 @@ private:
      * Destructor. Deletes all @p InternalDatas whose pointers are stored by
      * the @p base_fe_datas vector.
      */
-    ~InternalData();
+    ~InternalData() override;
 
     /**
      * Give write-access to the pointer to a @p InternalData of the @p

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -98,7 +98,7 @@ namespace FETools
     /**
      * Virtual destructor doing nothing but making the compiler happy.
      */
-    virtual ~FEFactoryBase() = default;
+    virtual ~FEFactoryBase() override = default;
   };
 
   /**
@@ -120,14 +120,14 @@ namespace FETools
      * Create a FiniteElement and return a pointer to it.
      */
     virtual std::unique_ptr<FiniteElement<FE::dimension,FE::space_dimension> >
-    get (const unsigned int degree) const;
+    get (const unsigned int degree) const override;
 
     /**
      * Create a FiniteElement from a quadrature formula (currently only
      * implemented for FE_Q) and return a pointer to it.
      */
     virtual std::unique_ptr<FiniteElement<FE::dimension,FE::space_dimension> >
-    get (const Quadrature<1> &quad) const;
+    get (const Quadrature<1> &quad) const override;
   };
 
   /**

--- a/include/deal.II/fe/fe_trace.h
+++ b/include/deal.II/fe/fe_trace.h
@@ -56,11 +56,11 @@ public:
    * returns <tt>FE_DGQ<dim>(degree)</tt>, with <tt>dim</tt> and
    * <tt>degree</tt> replaced by appropriate values.
    */
-  virtual std::string get_name () const;
+  virtual std::string get_name () const override;
 
   virtual
   std::unique_ptr<FiniteElement<dim,spacedim> >
-  clone() const;
+  clone() const override;
 
   /**
    * Implementation of the corresponding function in the FiniteElement
@@ -72,27 +72,27 @@ public:
   virtual
   void
   convert_generalized_support_point_values_to_dof_values (const std::vector<Vector<double> > &support_point_values,
-                                                          std::vector<double>                &nodal_values) const;
+                                                          std::vector<double>                &nodal_values) const override;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
    */
   virtual bool has_support_on_face (const unsigned int shape_index,
-                                    const unsigned int face_index) const;
+                                    const unsigned int face_index) const override;
 
   /**
    * Return a list of constant modes of the element. For this element, it
    * simply returns one row with all entries set to true.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
-  get_constant_modes () const;
+  get_constant_modes () const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
    * the new way, which has to be used to make elements "hp compatible".
    */
-  virtual bool hp_constraints_are_implemented () const;
+  virtual bool hp_constraints_are_implemented () const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -104,7 +104,7 @@ public:
    */
   virtual void
   get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
-                                 FullMatrix<double>       &matrix) const;
+                                 FullMatrix<double>       &matrix) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face
@@ -117,7 +117,7 @@ public:
   virtual void
   get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &source,
                                     const unsigned int        subface,
-                                    FullMatrix<double>       &matrix) const;
+                                    FullMatrix<double>       &matrix) const override;
 
   /**
    * Return whether this element dominates the one given as argument when they
@@ -130,7 +130,7 @@ public:
    */
   virtual
   FiniteElementDomination::Domination
-  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
+  compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const override;
 
 private:
   /**
@@ -161,7 +161,7 @@ public:
   /**
    * Return the name of the element
    */
-  std::string get_name() const;
+  std::string get_name() const override;
 };
 
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -1864,7 +1864,7 @@ public:
   /**
    * Destructor.
    */
-  ~FEValuesBase ();
+  ~FEValuesBase () override;
 
 
   /// @name ShapeAccess Access to shape function values. These fields are filled by the finite element.

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -81,7 +81,7 @@ namespace GridTools
     /**
      * Destructor.
      */
-    ~Cache();
+    ~Cache() override;
 
     /**
      * Make sure that the objects marked for update are recomputed during

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -348,7 +348,7 @@ public:
    * Destructor. Does nothing here, but needs to be declared virtual to make
    * class hierarchies derived from this class possible.
    */
-  virtual ~Manifold () = default;
+  virtual ~Manifold () override = default;
 
   /**
    * Return a copy of this manifold.

--- a/include/deal.II/grid/persistent_tria.h
+++ b/include/deal.II/grid/persistent_tria.h
@@ -133,7 +133,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~PersistentTriangulation () = default;
+  virtual ~PersistentTriangulation () override = default;
 
   /**
    * Overloaded version of the same function in the base class which stores
@@ -141,7 +141,7 @@ public:
    * triangulation and after that calls the respective function of the base
    * class.
    */
-  virtual void execute_coarsening_and_refinement ();
+  virtual void execute_coarsening_and_refinement () override;
 
   /**
    * Restore the grid according to the saved data. For this, the coarse grid
@@ -182,7 +182,7 @@ public:
    * The coarse grid must persist until the end of this object, since it will
    * be used upon reconstruction of the grid.
    */
-  virtual void copy_triangulation (const Triangulation<dim, spacedim> &tria);
+  virtual void copy_triangulation (const Triangulation<dim, spacedim> &tria) override;
 
   /**
    * Throw an error, since this function is not useful in the context of this
@@ -190,7 +190,7 @@ public:
    */
   virtual void create_triangulation (const std::vector<Point<spacedim> >    &vertices,
                                      const std::vector<CellData<dim> > &cells,
-                                     const SubCellData                 &subcelldata);
+                                     const SubCellData                 &subcelldata) override;
 
   /**
    * An overload of the respective function of the base class.
@@ -201,7 +201,7 @@ public:
   virtual void create_triangulation_compatibility (
     const std::vector<Point<spacedim> >    &vertices,
     const std::vector<CellData<dim> > &cells,
-    const SubCellData                 &subcelldata);
+    const SubCellData                 &subcelldata) override;
 
   /**
    * Write all refine and coarsen flags to the ostream @p out.
@@ -224,7 +224,7 @@ public:
    * Determine an estimate for the memory consumption (in bytes) of this
    * object.
    */
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
   /**
    * Exception.

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1613,7 +1613,7 @@ public:
      * automatically generated destructor would have a different one due to
      * member objects.
      */
-    virtual ~DistortedCellList () noexcept;
+    virtual ~DistortedCellList () noexcept override;
 
     /**
      * A list of those cells among the coarse mesh cells that are deformed or
@@ -1683,7 +1683,7 @@ public:
   /**
    * Delete the object and all levels of the hierarchy.
    */
-  virtual ~Triangulation ();
+  virtual ~Triangulation () override;
 
   /**
    * Reset this triangulation into a virgin state by deleting all data.

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -275,7 +275,7 @@ namespace hp
     /**
      * Destructor.
      */
-    virtual ~DoFHandler ();
+    virtual ~DoFHandler () override;
 
     /**
      * Copy operator. DoFHandler objects are large and expensive.

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -375,7 +375,7 @@ public:
   /**
    * Destructor.
    */
-  ~BlockMatrixBase ();
+  ~BlockMatrixBase () override;
 
   /**
    * Copy the matrix given as argument into the current object.

--- a/include/deal.II/lac/block_sparse_matrix.h
+++ b/include/deal.II/lac/block_sparse_matrix.h
@@ -106,7 +106,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~BlockSparseMatrix ();
+  virtual ~BlockSparseMatrix () override;
 
 
 

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -115,7 +115,7 @@ public:
   /**
    * Destructor.
    */
-  ~BlockSparsityPatternBase ();
+  ~BlockSparsityPatternBase () override;
 
   /**
    * Resize the matrix, by setting the number of block rows and columns. This

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -168,7 +168,7 @@ public:
   /**
    * Destructor. Clears memory
    */
-  ~BlockVector () = default;
+  ~BlockVector () override = default;
 
   /**
    * Call the compress() function on all the subblocks.

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -516,7 +516,7 @@ public:
    * Destructor. Free all memory, but do not release the memory of the
    * sparsity structure.
    */
-  virtual ~ChunkSparseMatrix ();
+  virtual ~ChunkSparseMatrix () override;
 
   /**
    * Copy operator. Since copying entire sparse matrices is a very expensive

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -334,7 +334,7 @@ public:
   /**
    * Destructor.
    */
-  ~ChunkSparsityPattern () = default;
+  ~ChunkSparsityPattern () override = default;
 
   /**
    * Copy operator. For this the same holds as for the copy constructor: it is

--- a/include/deal.II/lac/exceptions.h
+++ b/include/deal.II/lac/exceptions.h
@@ -56,7 +56,7 @@ namespace LACExceptions
   public:
     ExcPETScError (const int error_code);
 
-    virtual void print_info (std::ostream &out) const;
+    virtual void print_info (std::ostream &out) const override;
 
     const int error_code;
   };

--- a/include/deal.II/lac/matrix_out.h
+++ b/include/deal.II/lac/matrix_out.h
@@ -114,7 +114,7 @@ public:
   /**
    * Destructor. Declared in order to make it virtual.
    */
-  virtual ~MatrixOut () = default;
+  virtual ~MatrixOut () override = default;
 
   /**
    * Generate a list of patches from the given matrix and use the given string
@@ -163,13 +163,13 @@ private:
    * they shall write to a file.
    */
   virtual const std::vector<Patch> &
-  get_patches () const;
+  get_patches () const override;
 
   /**
    * Virtual function through which the names of data sets are obtained by the
    * output functions of the base class.
    */
-  virtual std::vector<std::string> get_dataset_names () const;
+  virtual std::vector<std::string> get_dataset_names () const override;
 
   /**
    * Get the value of the matrix at gridpoint <tt>(i,j)</tt>. Depending on the

--- a/include/deal.II/lac/petsc_full_matrix.h
+++ b/include/deal.II/lac/petsc_full_matrix.h
@@ -83,7 +83,7 @@ namespace PETScWrappers
      * matrix. Since this is a sequential matrix, it returns the MPI_COMM_SELF
      * communicator.
      */
-    virtual const MPI_Comm &get_mpi_communicator () const;
+    virtual const MPI_Comm &get_mpi_communicator () const override;
 
   private:
 

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -306,7 +306,7 @@ namespace PETScWrappers
     /**
      * Destructor. Made virtual so that one can use pointers to this class.
      */
-    virtual ~MatrixBase ();
+    virtual ~MatrixBase () override;
 
     /**
      * This operator assigns a scalar to a matrix. Since this does usually not

--- a/include/deal.II/lac/petsc_matrix_free.h
+++ b/include/deal.II/lac/petsc_matrix_free.h
@@ -177,7 +177,7 @@ namespace PETScWrappers
      * Return a reference to the MPI communicator object in use with this
      * matrix.
      */
-    const MPI_Comm &get_mpi_communicator () const;
+    const MPI_Comm &get_mpi_communicator () const override;
 
     /**
      * Matrix-vector multiplication: let <i>dst = M*src</i> with <i>M</i>

--- a/include/deal.II/lac/petsc_parallel_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_parallel_block_sparse_matrix.h
@@ -106,7 +106,7 @@ namespace PETScWrappers
       /**
        * Destructor.
        */
-      ~BlockSparseMatrix () = default;
+      ~BlockSparseMatrix () override = default;
 
       /**
        * Pseudo copy operator only copying empty objects. The sizes of the

--- a/include/deal.II/lac/petsc_parallel_block_vector.h
+++ b/include/deal.II/lac/petsc_parallel_block_vector.h
@@ -136,7 +136,7 @@ namespace PETScWrappers
       /**
        * Destructor. Clears memory
        */
-      ~BlockVector () = default;
+      ~BlockVector () override = default;
 
       /**
        * Copy operator: fill all components of the vector that are locally

--- a/include/deal.II/lac/petsc_parallel_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_parallel_sparse_matrix.h
@@ -151,7 +151,7 @@ namespace PETScWrappers
       /**
        * Destructor to free the PETSc object.
        */
-      ~SparseMatrix ();
+      ~SparseMatrix () override;
 
       /**
        * Create a sparse matrix of dimensions @p m times @p n, with an initial
@@ -352,7 +352,7 @@ namespace PETScWrappers
        * Return a reference to the MPI communicator object in use with this
        * matrix.
        */
-      virtual const MPI_Comm &get_mpi_communicator () const;
+      virtual const MPI_Comm &get_mpi_communicator () const override;
 
       /**
        * @addtogroup Exceptions

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -267,7 +267,7 @@ namespace PETScWrappers
        * Release all memory and return to a state just like after having
        * called the default constructor.
        */
-      void clear ();
+      virtual void clear () override;
 
       /**
        * Copy the given vector. Resize the present vector if necessary. Also
@@ -353,7 +353,7 @@ namespace PETScWrappers
        * Return a reference to the MPI communicator object in use with this
        * vector.
        */
-      const MPI_Comm &get_mpi_communicator () const;
+      const MPI_Comm &get_mpi_communicator () const override;
 
       /**
        * Print to a stream. @p precision denotes the desired precision with

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -310,7 +310,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
 
@@ -361,7 +361,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
 
@@ -411,7 +411,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
 
@@ -461,7 +461,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
 
@@ -528,7 +528,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
 
@@ -579,7 +579,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
   /**
@@ -628,7 +628,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
 
@@ -678,7 +678,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
 
@@ -734,7 +734,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
 
@@ -784,7 +784,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
 
@@ -835,7 +835,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
 
@@ -890,7 +890,7 @@ namespace PETScWrappers
      * Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
   };
 
   /**
@@ -952,7 +952,7 @@ namespace PETScWrappers
      */
     const AdditionalData additional_data;
 
-    virtual void set_solver_type (KSP &ksp) const;
+    virtual void set_solver_type (KSP &ksp) const override;
 
   private:
     /**

--- a/include/deal.II/lac/petsc_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_sparse_matrix.h
@@ -197,7 +197,7 @@ namespace PETScWrappers
      * matrix. Since this is a sequential matrix, it returns the MPI_COMM_SELF
      * communicator.
      */
-    virtual const MPI_Comm &get_mpi_communicator () const;
+    virtual const MPI_Comm &get_mpi_communicator () const override;
 
     /**
      * Return the number of rows of this matrix.

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -266,7 +266,7 @@ namespace PETScWrappers
     /**
      * Destructor
      */
-    virtual ~VectorBase ();
+    virtual ~VectorBase () override;
 
     /**
      * Release all memory and return to a state just like after having called

--- a/include/deal.II/lac/pointer_matrix.h
+++ b/include/deal.II/lac/pointer_matrix.h
@@ -68,7 +68,7 @@ public:
    * of any derived class is called whenever a pointer-to-base-class object is
    * destroyed.
    */
-  virtual ~PointerMatrixBase () = default;
+  virtual ~PointerMatrixBase () override = default;
 
   /**
    * Reset the object to its original state.
@@ -153,7 +153,7 @@ public:
                 const char *name);
 
   // Use doc from base class
-  virtual void clear();
+  virtual void clear() override;
 
   /**
    * Return whether the object is empty.
@@ -171,25 +171,25 @@ public:
    * Matrix-vector product.
    */
   virtual void vmult (VectorType       &dst,
-                      const VectorType &src) const;
+                      const VectorType &src) const override;
 
   /**
    * Transposed matrix-vector product.
    */
   virtual void Tvmult (VectorType       &dst,
-                       const VectorType &src) const;
+                       const VectorType &src) const override;
 
   /**
    * Matrix-vector product, adding to <tt>dst</tt>.
    */
   virtual void vmult_add (VectorType       &dst,
-                          const VectorType &src) const;
+                          const VectorType &src) const override;
 
   /**
    * Transposed matrix-vector product, adding to <tt>dst</tt>.
    */
   virtual void Tvmult_add (VectorType       &dst,
-                           const VectorType &src) const;
+                           const VectorType &src) const override;
 
 private:
   /**
@@ -260,7 +260,7 @@ public:
                    const char               *name);
 
   // Use doc from base class
-  virtual void clear();
+  virtual void clear() override;
 
   /**
    * Return whether the object is empty.
@@ -283,25 +283,25 @@ public:
    * Matrix-vector product.
    */
   virtual void vmult (VectorType       &dst,
-                      const VectorType &src) const;
+                      const VectorType &src) const override;
 
   /**
    * Transposed matrix-vector product.
    */
   virtual void Tvmult (VectorType       &dst,
-                       const VectorType &src) const;
+                       const VectorType &src) const override;
 
   /**
    * Matrix-vector product, adding to <tt>dst</tt>.
    */
   virtual void vmult_add (VectorType       &dst,
-                          const VectorType &src) const;
+                          const VectorType &src) const override;
 
   /**
    * Transposed matrix-vector product, adding to <tt>dst</tt>.
    */
   virtual void Tvmult_add (VectorType       &dst,
-                           const VectorType &src) const;
+                           const VectorType &src) const override;
 
 private:
   /**

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -1803,11 +1803,11 @@ namespace internal
                           internal::VectorImplementation::minimum_parallel_grain_size);
       }
 
-      ~VectorUpdatesRange() = default;
+      ~VectorUpdatesRange() override = default;
 
       virtual void
       apply_to_subrange (const std::size_t begin,
-                         const std::size_t end) const
+                         const std::size_t end) const override
       {
         updater.apply_to_subrange(begin, end);
       }

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -155,7 +155,7 @@ public:
   /**
    * Destructor.
    */
-  ~PreconditionBlock() = default;
+  ~PreconditionBlock() override = default;
 
   /**
    * Initialize matrix and block size.  We store the matrix and the block size

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -110,7 +110,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~PreconditionSelector();
+  virtual ~PreconditionSelector() override;
 
   /**
    * Takes the matrix that is needed for preconditionings that involves a

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -168,7 +168,7 @@ namespace LinearAlgebra
     /**
      * Destructor.
      */
-    ~ReadWriteVector () = default;
+    ~ReadWriteVector () override = default;
 
     /**
      * Set the global size of the vector to @p size. The stored elements have

--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -134,7 +134,7 @@ public:
   /**
    * Destructor
    */
-  ~ScaLAPACKMatrix() = default;
+  ~ScaLAPACKMatrix() override = default;
 
   /**
    * Initialize the rectangular matrix with @p n_rows and @p n_cols

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -173,7 +173,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~SolverBicgstab ();
+  virtual ~SolverBicgstab () override;
 
   /**
    * Solve primal problem only.

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -122,7 +122,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~SolverCG () = default;
+  virtual ~SolverCG () override = default;
 
   /**
    * Solve the linear system $Ax=b$ for x.

--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -99,9 +99,9 @@ public:
       : last_step (last_step), last_residual(last_residual)
     {}
 
-    virtual ~NoConvergence () noexcept = default;
+    virtual ~NoConvergence () noexcept override = default;
 
-    virtual void print_info (std::ostream &out) const
+    virtual void print_info (std::ostream &out) const override
     {
       out << "Iterative method reported convergence failure in step "
           << last_step << ". The residual in the last step was " << last_residual
@@ -155,7 +155,7 @@ public:
    * Virtual destructor is needed as there are virtual functions in this
    * class.
    */
-  virtual ~SolverControl() = default;
+  virtual ~SolverControl() override = default;
 
   /**
    * Interface to parameter file.
@@ -429,7 +429,7 @@ public:
    * Virtual destructor is needed as there are virtual functions in this
    * class.
    */
-  virtual ~ReductionControl() = default;
+  virtual ~ReductionControl() override = default;
 
   /**
    * Interface to parameter file.
@@ -447,7 +447,7 @@ public:
    * value</tt> upon the first iteration.
    */
   virtual State check (const unsigned int step,
-                       const double   check_value);
+                       const double   check_value) override;
 
   /**
    * Reduction factor.
@@ -513,7 +513,7 @@ public:
    * Virtual destructor is needed as there are virtual functions in this
    * class.
    */
-  virtual ~IterationNumberControl() = default;
+  virtual ~IterationNumberControl() override = default;
 
   /**
    * Decide about success or failure of an iteration. This function bases
@@ -521,7 +521,7 @@ public:
    * the check value reached exactly zero.
    */
   virtual State check (const unsigned int step,
-                       const double   check_value);
+                       const double   check_value) override;
 };
 
 
@@ -569,14 +569,14 @@ public:
    * Virtual destructor is needed as there are virtual functions in this
    * class.
    */
-  virtual ~ConsecutiveControl() = default;
+  virtual ~ConsecutiveControl() override = default;
 
   /**
    * Decide about success or failure of an iteration, see the class description
    * above.
    */
   virtual State check (const unsigned int step,
-                       const double   check_value);
+                       const double   check_value) override;
 
 protected:
   /**

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -94,7 +94,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~SolverMinRes () = default;
+  virtual ~SolverMinRes () override = default;
 
   /**
    * Solve the linear system $Ax=b$ for x.

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -102,7 +102,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~SolverRichardson () = default;
+  virtual ~SolverRichardson () override = default;
 
   /**
    * Solve the linear system $Ax=b$ for x.

--- a/include/deal.II/lac/solver_selector.h
+++ b/include/deal.II/lac/solver_selector.h
@@ -111,7 +111,7 @@ public:
   /**
    * Destructor
    */
-  ~SolverSelector();
+  ~SolverSelector() override;
 
   /**
    * Solver procedure. Calls the @p solve function of the @p solver whose @p

--- a/include/deal.II/lac/sparse_decomposition.h
+++ b/include/deal.II/lac/sparse_decomposition.h
@@ -128,13 +128,13 @@ public:
    * Destruction. Mark the destructor pure to ensure that this class isn't
    * used directly, but only its derived classes.
    */
-  virtual ~SparseLUDecomposition () = 0;
+  virtual ~SparseLUDecomposition () override = 0;
 
   /**
    * Deletes all member variables. Leaves the class in the state that it had
    * directly after calling the constructor
    */
-  virtual void clear();
+  virtual void clear() override;
 
   /**
    * Parameters for SparseDecomposition.

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -104,7 +104,7 @@ public:
   /**
    * Destructor.
    */
-  ~SparseDirectUMFPACK ();
+  ~SparseDirectUMFPACK () override;
 
   /**
    * @name Setting up a sparse factorization

--- a/include/deal.II/lac/sparse_ilu.h
+++ b/include/deal.II/lac/sparse_ilu.h
@@ -128,7 +128,7 @@ public:
    * Determine an estimate for the memory consumption (in bytes) of this
    * object.
    */
-  std::size_t memory_consumption () const;
+  std::size_t memory_consumption () const override;
 
   /**
    * @addtogroup Exceptions

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -589,7 +589,7 @@ public:
    * Destructor. Free all memory, but do not release the memory of the
    * sparsity structure.
    */
-  virtual ~SparseMatrix ();
+  virtual ~SparseMatrix () override;
 
   /**
    * Copy operator. Since copying entire sparse matrices is a very expensive

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -323,7 +323,7 @@ public:
   /**
    * Destructor. Free all memory.
    */
-  ~SparseMatrixEZ () = default;
+  ~SparseMatrixEZ () override = default;
 
   /**
    * Pseudo operator only copying empty objects.

--- a/include/deal.II/lac/sparse_mic.h
+++ b/include/deal.II/lac/sparse_mic.h
@@ -61,13 +61,13 @@ public:
   /**
    * Destructor.
    */
-  virtual ~SparseMIC();
+  virtual ~SparseMIC() override;
 
   /**
    * Deletes all member variables. Leaves the class in the state that it had
    * directly after calling the constructor
    */
-  virtual void clear();
+  virtual void clear() override;
 
   /**
    * Make the @p AdditionalData type in the base class accessible to this
@@ -125,7 +125,7 @@ public:
    * Determine an estimate for the memory consumption (in bytes) of this
    * object.
    */
-  std::size_t memory_consumption () const;
+  std::size_t memory_consumption () const override;
 
   /**
    * @addtogroup Exceptions

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -486,7 +486,7 @@ public:
   /**
    * Destructor.
    */
-  ~SparsityPattern () = default;
+  ~SparsityPattern () override = default;
 
   /**
    * Copy operator. For this the same holds as for the copy constructor: it is

--- a/include/deal.II/lac/swappable_vector.h
+++ b/include/deal.II/lac/swappable_vector.h
@@ -76,7 +76,7 @@ public:
    * Destructor. If this class still owns a file to which temporary data was
    * stored, then it is deleted.
    */
-  virtual ~SwappableVector ();
+  virtual ~SwappableVector () override;
 
   /**
    * Copy operator. Do mostly the same as the copy constructor does; if

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -109,7 +109,7 @@ namespace TrilinosWrappers
     /**
      * Destructor.
      */
-    ~BlockSparseMatrix ();
+    ~BlockSparseMatrix () override;
 
     /**
      * Pseudo copy operator only copying empty objects. The sizes of the block

--- a/include/deal.II/lac/trilinos_epetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_epetra_communication_pattern.h
@@ -55,14 +55,14 @@ namespace LinearAlgebra
       /**
        * Reinitialize the object.
        */
-      void reinit(const IndexSet &vector_space_vector_index_set,
-                  const IndexSet &read_write_vector_index_set,
-                  const MPI_Comm &communicator);
+      virtual void reinit(const IndexSet &vector_space_vector_index_set,
+                          const IndexSet &read_write_vector_index_set,
+                          const MPI_Comm &communicator) override;
 
       /**
        * Return the underlying MPI communicator.
        */
-      const MPI_Comm &get_mpi_communicator() const;
+      virtual const MPI_Comm &get_mpi_communicator() const override;
 
       /**
        * Return the underlying Epetra_Import object.

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -138,7 +138,7 @@ namespace TrilinosWrappers
       /**
        * Destructor. Clears memory
        */
-      ~BlockVector () = default;
+      ~BlockVector () override = default;
 
       /**
        * Copy operator: fill all components of the vector that are locally

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -104,7 +104,7 @@ namespace TrilinosWrappers
     /**
      * Destructor.
      */
-    ~PreconditionBase () = default;
+    ~PreconditionBase () override = default;
 
     /**
      * Destroys the preconditioner, leaving an object like just after having
@@ -1505,7 +1505,7 @@ namespace TrilinosWrappers
     /**
      * Destructor.
      */
-    ~PreconditionAMG();
+    ~PreconditionAMG() override;
 
 
     /**
@@ -1770,7 +1770,7 @@ namespace TrilinosWrappers
     /**
      * Destructor.
      */
-    ~PreconditionAMGMueLu();
+    ~PreconditionAMGMueLu() override;
 
     /**
      * Let Trilinos compute a multilevel hierarchy for the solution of a
@@ -1876,34 +1876,34 @@ namespace TrilinosWrappers
      * Apply the preconditioner, i.e., dst = src.
      */
     void vmult (MPI::Vector       &dst,
-                const MPI::Vector &src) const;
+                const MPI::Vector &src) const override;
 
     /**
      * Apply the transport conditioner, i.e., dst = src.
      */
     void Tvmult (MPI::Vector       &dst,
-                 const MPI::Vector &src) const;
+                 const MPI::Vector &src) const override;
 
     /**
      * Apply the preconditioner on deal.II data structures instead of the ones
      * provided in the Trilinos wrapper class, i.e., dst = src.
      */
     void vmult (dealii::Vector<double>       &dst,
-                const dealii::Vector<double> &src) const;
+                const dealii::Vector<double> &src) const override;
 
     /**
      * Apply the transpose preconditioner on deal.II data structures instead
      * of the ones provided in the Trilinos wrapper class, i.e. dst = src.
      */
     void Tvmult (dealii::Vector<double>       &dst,
-                 const dealii::Vector<double> &src) const;
+                 const dealii::Vector<double> &src) const override;
 
     /**
      * Apply the preconditioner on deal.II parallel data structures instead of
      * the ones provided in the Trilinos wrapper class, i.e., dst = src.
      */
     void vmult (LinearAlgebra::distributed::Vector<double>       &dst,
-                const dealii::LinearAlgebra::distributed::Vector<double> &src) const;
+                const dealii::LinearAlgebra::distributed::Vector<double> &src) const override;
 
     /**
      * Apply the transpose preconditioner on deal.II parallel data structures
@@ -1911,7 +1911,7 @@ namespace TrilinosWrappers
      * src.
      */
     void Tvmult (LinearAlgebra::distributed::Vector<double>       &dst,
-                 const dealii::LinearAlgebra::distributed::Vector<double> &src) const;
+                 const dealii::LinearAlgebra::distributed::Vector<double> &src) const override;
   };
 
 

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -583,7 +583,7 @@ namespace TrilinosWrappers
     /**
      * Destructor. Made virtual so that one can use pointers to this class.
      */
-    virtual ~SparseMatrix () = default;
+    virtual ~SparseMatrix () override = default;
 
     /**
      * This function initializes the Trilinos matrix with a deal.II sparsity
@@ -2206,7 +2206,7 @@ namespace TrilinosWrappers
         /**
          * Destructor
          */
-        virtual ~TrilinosPayload() = default;
+        virtual ~TrilinosPayload() override = default;
 
         /**
          * Return a payload configured for identity operations
@@ -2357,7 +2357,7 @@ namespace TrilinosWrappers
          * Epetra_Operator.
          */
         virtual bool
-        UseTranspose () const;
+        UseTranspose () const override;
 
         /**
          * Sets an internal flag so that all operations performed by the matrix,
@@ -2375,7 +2375,7 @@ namespace TrilinosWrappers
          * operations that may occur on different threads simultaneously.
          */
         virtual int
-        SetUseTranspose (bool UseTranspose);
+        SetUseTranspose (bool UseTranspose) override;
 
         /**
          * Apply the vmult operation on a vector @p X (of internally defined
@@ -2390,7 +2390,7 @@ namespace TrilinosWrappers
          */
         virtual int
         Apply(const VectorType &X,
-              VectorType       &Y) const;
+              VectorType       &Y) const override;
 
         /**
          * Apply the vmult inverse operation on a vector @p X (of internally
@@ -2411,7 +2411,7 @@ namespace TrilinosWrappers
          */
         virtual int
         ApplyInverse(const VectorType &Y,
-                     VectorType       &X) const;
+                     VectorType       &X) const override;
 //@}
 
         /**
@@ -2426,7 +2426,7 @@ namespace TrilinosWrappers
          * Epetra_Operator.
          */
         virtual const char *
-        Label () const;
+        Label () const override;
 
         /**
          * Return a reference to the underlying MPI communicator for
@@ -2436,7 +2436,7 @@ namespace TrilinosWrappers
          * Epetra_Operator.
          */
         virtual const Epetra_Comm &
-        Comm () const;
+        Comm () const override;
 
         /**
          * Return the partitioning of the domain space of this matrix, i.e., the
@@ -2446,7 +2446,7 @@ namespace TrilinosWrappers
          * Epetra_Operator.
          */
         virtual const Epetra_Map &
-        OperatorDomainMap () const;
+        OperatorDomainMap () const override;
 
         /**
          * Return the partitioning of the range space of this matrix, i.e., the
@@ -2457,7 +2457,7 @@ namespace TrilinosWrappers
          * Epetra_Operator.
          */
         virtual const Epetra_Map &
-        OperatorRangeMap () const;
+        OperatorRangeMap () const override;
 //@}
 
       private:
@@ -2499,7 +2499,7 @@ namespace TrilinosWrappers
          * Epetra_Operator.
          */
         virtual bool
-        HasNormInf () const;
+        HasNormInf () const override;
 
         /**
          * Return the infinity norm of this operator.
@@ -2509,7 +2509,7 @@ namespace TrilinosWrappers
          * Epetra_Operator.
          */
         virtual double
-        NormInf () const;
+        NormInf () const override;
       };
 
       /**

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -329,7 +329,7 @@ namespace TrilinosWrappers
     /**
      * Destructor. Made virtual so that one can use pointers to this class.
      */
-    virtual ~SparsityPattern () = default;
+    virtual ~SparsityPattern () override = default;
 
     /**
      * Initialize a sparsity pattern that is completely stored locally, having

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -506,7 +506,7 @@ namespace TrilinosWrappers
       /**
        * Destructor.
        */
-      ~Vector () = default;
+      ~Vector () override = default;
 
       /**
        * Release all memory and return to a state just like after having called

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -225,7 +225,7 @@ public:
    * Destructor, deallocates memory. Made virtual to allow for derived classes
    * to behave properly.
    */
-  virtual ~Vector () = default;
+  virtual ~Vector () override = default;
 
   /**
    * This function does nothing but exists for compatibility with the parallel

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -110,7 +110,7 @@ public:
    * destroying objects of derived type through pointers to this base
    * class.
    */
-  virtual ~VectorMemory () = default;
+  virtual ~VectorMemory () override = default;
 
   /**
    * Return a pointer to a new vector. The number of elements or their
@@ -256,7 +256,7 @@ public:
    *   same kind of service that <code>std::unique</code> provides
    *   for arbitrary memory allocated on the heap.
    */
-  virtual VectorType *alloc ();
+  virtual VectorType *alloc () override;
 
   /**
    * Return a vector and indicate that it is not going to be used any further
@@ -275,7 +275,7 @@ public:
    *   same kind of service that <code>std::unique</code> provides
    *   for arbitrary memory allocated on the heap.
    */
-  virtual void free (const VectorType *const v);
+  virtual void free (const VectorType *const v) override;
 };
 
 
@@ -329,7 +329,7 @@ public:
    * However, as discussed in the class documentation, this does not imply
    * that their memory is returned to the operating system.
    */
-  virtual ~GrowingVectorMemory();
+  virtual ~GrowingVectorMemory() override;
 
   /**
    * Return a pointer to a new vector. The number of elements or their
@@ -349,7 +349,7 @@ public:
    *   same kind of service that <code>std::unique</code> provides
    *   for arbitrary memory allocated on the heap.
    */
-  virtual VectorType *alloc ();
+  virtual VectorType *alloc () override;
 
   /**
    * Return a vector and indicate that it is not going to be used any further
@@ -368,7 +368,7 @@ public:
    *   same kind of service that <code>std::unique</code> provides
    *   for arbitrary memory allocated on the heap.
    */
-  virtual void free (const VectorType *const);
+  virtual void free (const VectorType *const) override;
 
   /**
    * Release all vectors that are not currently in use.

--- a/include/deal.II/lac/vector_view.h
+++ b/include/deal.II/lac/vector_view.h
@@ -162,7 +162,7 @@ public:
    * This destructor will only reset the internal sizes and the internal
    * pointers, but it will NOT clear the memory.
    */
-  ~VectorView();
+  ~VectorView() override;
 
   /**
    * The reinit function of this object has a behavior which is different from
@@ -205,7 +205,7 @@ public:
    * call this reinit function if you really know what you are doing.
    */
   virtual void reinit (const size_type N,
-                       const bool         omit_zeroing_entries=false);
+                       const bool         omit_zeroing_entries=false) override;
 
   /**
    * This reinit function is equivalent to constructing a new object with the
@@ -224,7 +224,7 @@ public:
    * This function is here to prevent memory corruption. It should never be
    * called, and will throw an exception if you try to do so.
    */
-  virtual void swap (Vector<Number> &v);
+  virtual void swap (Vector<Number> &v) override;
 };
 
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -454,7 +454,7 @@ public:
   /**
    * Destructor.
    */
-  ~MatrixFree() = default;
+  ~MatrixFree() override = default;
 
   /**
    * Extracts the information needed to perform loops over cells. The

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -203,7 +203,7 @@ namespace MatrixFreeOperators
     /**
      * Virtual destructor.
      */
-    virtual ~Base() = default;
+    virtual ~Base() override = default;
 
     /**
      * Release all memory and return to a state just like after having called
@@ -660,7 +660,7 @@ namespace MatrixFreeOperators
     /**
      * For preconditioning, we store a lumped mass matrix at the diagonal entries.
      */
-    virtual void compute_diagonal ();
+    virtual void compute_diagonal () override;
 
   private:
     /**
@@ -669,7 +669,7 @@ namespace MatrixFreeOperators
      * using initialize_dof_vector().
      */
     virtual void apply_add (VectorType       &dst,
-                            const VectorType &src) const;
+                            const VectorType &src) const override;
 
     /**
      * For this operator, there is just a cell contribution.

--- a/include/deal.II/meshworker/local_integrator.h
+++ b/include/deal.II/meshworker/local_integrator.h
@@ -66,7 +66,7 @@ namespace MeshWorker
     /**
      * The empty virtual destructor.
      */
-    virtual ~LocalIntegrator() = default;
+    virtual ~LocalIntegrator() override = default;
 
     /**
      * Virtual function for integrating on cells. Throws exception

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -199,7 +199,7 @@ namespace MeshWorker
     /**
      * Virtual, but empty destructor.
      */
-    virtual ~VectorDataBase() = default;
+    virtual ~VectorDataBase() override = default;
 
     /**
      * The only function added to VectorSelector is an abstract virtual
@@ -319,7 +319,7 @@ namespace MeshWorker
       const unsigned int component,
       const unsigned int n_comp,
       const unsigned int start,
-      const unsigned int size) const;
+      const unsigned int size) const override;
 
     virtual void mg_fill(
       std::vector<std::vector<std::vector<typename VectorType::value_type> > > &values,
@@ -331,7 +331,7 @@ namespace MeshWorker
       const unsigned int component,
       const unsigned int n_comp,
       const unsigned int start,
-      const unsigned int size) const;
+      const unsigned int size) const override;
 
     /**
      * The memory used by this object.

--- a/include/deal.II/multigrid/mg_base.h
+++ b/include/deal.II/multigrid/mg_base.h
@@ -50,7 +50,7 @@ public:
   /*
    * Virtual destructor.
    */
-  virtual ~MGMatrixBase() = default;
+  virtual ~MGMatrixBase() override = default;
 
   /**
    * Matrix-vector-multiplication on a certain level.
@@ -106,7 +106,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~MGCoarseGridBase () = default;
+  virtual ~MGCoarseGridBase () override = default;
 
   /**
    * Solution operator.
@@ -171,7 +171,7 @@ public:
   /**
    * Destructor. Does nothing here, but needs to be declared virtual anyway.
    */
-  virtual ~MGTransferBase() = default;
+  virtual ~MGTransferBase() override = default;
 
   /**
    * Prolongate a vector from level <tt>to_level-1</tt> to level
@@ -237,7 +237,7 @@ public:
   /**
    * Virtual destructor.
    */
-  virtual ~MGSmootherBase() = default;
+  virtual ~MGSmootherBase() override = default;
 
   /**
    * Release matrices.

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -63,7 +63,7 @@ public:
    */
   void operator() (const unsigned int level,
                    VectorType         &dst,
-                   const VectorType   &src) const;
+                   const VectorType   &src) const override;
 
 private:
   /**
@@ -202,7 +202,7 @@ public:
    */
   virtual void operator() (const unsigned int level,
                            VectorType         &dst,
-                           const VectorType   &src) const;
+                           const VectorType   &src) const override;
 
 private:
   /**
@@ -260,7 +260,7 @@ public:
 
   void operator() (const unsigned int level,
                    VectorType         &dst,
-                   const VectorType   &src) const;
+                   const VectorType   &src) const override;
 
 private:
   /**

--- a/include/deal.II/multigrid/mg_matrix.h
+++ b/include/deal.II/multigrid/mg_matrix.h
@@ -74,12 +74,12 @@ namespace mg
      */
     const LinearOperator<VectorType> &operator[] (unsigned int level) const;
 
-    virtual void vmult (const unsigned int level, VectorType &dst, const VectorType &src) const;
-    virtual void vmult_add (const unsigned int level, VectorType &dst, const VectorType &src) const;
-    virtual void Tvmult (const unsigned int level, VectorType &dst, const VectorType &src) const;
-    virtual void Tvmult_add (const unsigned int level, VectorType &dst, const VectorType &src) const;
-    virtual unsigned int get_minlevel() const;
-    virtual unsigned int get_maxlevel() const;
+    virtual void vmult (const unsigned int level, VectorType &dst, const VectorType &src) const override;
+    virtual void vmult_add (const unsigned int level, VectorType &dst, const VectorType &src) const override;
+    virtual void Tvmult (const unsigned int level, VectorType &dst, const VectorType &src) const override;
+    virtual void Tvmult_add (const unsigned int level, VectorType &dst, const VectorType &src) const override;
+    virtual unsigned int get_minlevel() const override;
+    virtual unsigned int get_maxlevel() const override;
 
     /**
      * Memory used by this object.

--- a/include/deal.II/multigrid/mg_smoother.h
+++ b/include/deal.II/multigrid/mg_smoother.h
@@ -216,14 +216,14 @@ namespace mg
     /**
      * Empty all vectors.
      */
-    void clear ();
+    void clear () override;
 
     /**
      * The actual smoothing method.
      */
     virtual void smooth (const unsigned int level,
                          VectorType         &u,
-                         const VectorType   &rhs) const;
+                         const VectorType   &rhs) const override;
 
     /**
      * The apply variant of smoothing, setting the vector u to zero before
@@ -242,7 +242,7 @@ namespace mg
      */
     virtual void apply (const unsigned int level,
                         VectorType         &u,
-                        const VectorType   &rhs) const;
+                        const VectorType   &rhs) const override;
 
     /**
      * Memory used by this object.
@@ -504,14 +504,14 @@ public:
   /**
    * Empty all vectors.
    */
-  void clear ();
+  void clear () override;
 
   /**
    * The actual smoothing method.
    */
   virtual void smooth (const unsigned int level,
                        VectorType         &u,
-                       const VectorType   &rhs) const;
+                       const VectorType   &rhs) const override;
 
   /**
    * The apply variant of smoothing, setting the vector u to zero before
@@ -530,7 +530,7 @@ public:
    */
   virtual void apply (const unsigned int level,
                       VectorType         &u,
-                      const VectorType   &rhs) const;
+                      const VectorType   &rhs) const override;
 
   /**
    * Object containing relaxation methods.

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -554,7 +554,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferPrebuilt () = default;
+  virtual ~MGTransferPrebuilt () override = default;
 
   /**
    * Initialize the constraints to be used in build_matrices().
@@ -594,7 +594,7 @@ public:
    */
   virtual void prolongate (const unsigned int to_level,
                            VectorType         &dst,
-                           const VectorType   &src) const;
+                           const VectorType   &src) const override;
 
   /**
    * Restrict a vector from level <tt>from_level</tt> to level
@@ -613,7 +613,7 @@ public:
    */
   virtual void restrict_and_add (const unsigned int from_level,
                                  VectorType         &dst,
-                                 const VectorType   &src) const;
+                                 const VectorType   &src) const override;
 
   /**
    * Finite element does not provide prolongation matrices.

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -200,7 +200,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferBlock ();
+  virtual ~MGTransferBlock () override;
 
   /**
    * Initialize additional #factors and #memory if the restriction of the
@@ -222,11 +222,11 @@ public:
 
   virtual void prolongate (const unsigned int    to_level,
                            BlockVector<number>       &dst,
-                           const BlockVector<number> &src) const;
+                           const BlockVector<number> &src) const override;
 
   virtual void restrict_and_add (const unsigned int    from_level,
                                  BlockVector<number>       &dst,
-                                 const BlockVector<number> &src) const;
+                                 const BlockVector<number> &src) const override;
 
   /**
    * Transfer from a vector on the global grid to a multilevel vector for the
@@ -327,7 +327,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferBlockSelect () = default;
+  virtual ~MGTransferBlockSelect () override = default;
 
   /**
    * Actually build the prolongation matrices for grouped blocks.
@@ -353,11 +353,11 @@ public:
 
   virtual void prolongate (const unsigned int    to_level,
                            Vector<number>       &dst,
-                           const Vector<number> &src) const;
+                           const Vector<number> &src) const override;
 
   virtual void restrict_and_add (const unsigned int    from_level,
                                  Vector<number>       &dst,
-                                 const Vector<number> &src) const;
+                                 const Vector<number> &src) const override;
 
   /**
    * Transfer a single block from a vector on the global grid to a multilevel

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -186,7 +186,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferSelect () = default;
+  virtual ~MGTransferSelect () override = default;
 
 //TODO: rewrite docs; make sure defaulted args are actually allowed
   /**
@@ -235,11 +235,11 @@ public:
 
   virtual void prolongate (const unsigned int    to_level,
                            Vector<number>       &dst,
-                           const Vector<number> &src) const;
+                           const Vector<number> &src) const override;
 
   virtual void restrict_and_add (const unsigned int    from_level,
                                  Vector<number>       &dst,
-                                 const Vector<number> &src) const;
+                                 const Vector<number> &src) const override;
 
   /**
    * Transfer from a vector on the global grid to a multilevel vector for the

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -70,7 +70,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferMatrixFree () = default;
+  virtual ~MGTransferMatrixFree () override = default;
 
   /**
    * Initialize the constraints to be used in build().
@@ -103,7 +103,7 @@ public:
    */
   virtual void prolongate (const unsigned int                           to_level,
                            LinearAlgebra::distributed::Vector<Number>       &dst,
-                           const LinearAlgebra::distributed::Vector<Number> &src) const;
+                           const LinearAlgebra::distributed::Vector<Number> &src) const override;
 
   /**
    * Restrict a vector from level <tt>from_level</tt> to level
@@ -125,7 +125,7 @@ public:
    */
   virtual void restrict_and_add (const unsigned int from_level,
                                  LinearAlgebra::distributed::Vector<Number>       &dst,
-                                 const LinearAlgebra::distributed::Vector<Number> &src) const;
+                                 const LinearAlgebra::distributed::Vector<Number> &src) const override;
 
   /**
    * Restrict fine-mesh field @p src to each multigrid level in @p mg_dof and
@@ -289,7 +289,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MGTransferBlockMatrixFree () = default;
+  virtual ~MGTransferBlockMatrixFree () override = default;
 
   /**
    * Initialize the constraints to be used in build().
@@ -332,7 +332,7 @@ public:
    */
   virtual void prolongate (const unsigned int                                    to_level,
                            LinearAlgebra::distributed::BlockVector<Number>       &dst,
-                           const LinearAlgebra::distributed::BlockVector<Number> &src) const;
+                           const LinearAlgebra::distributed::BlockVector<Number> &src) const override;
 
   /**
    * Restrict a vector from level <tt>from_level</tt> to level
@@ -354,7 +354,7 @@ public:
    */
   virtual void restrict_and_add (const unsigned int from_level,
                                  LinearAlgebra::distributed::BlockVector<Number>       &dst,
-                                 const LinearAlgebra::distributed::BlockVector<Number> &src) const;
+                                 const LinearAlgebra::distributed::BlockVector<Number> &src) const override;
 
   /**
    * Transfer from a block-vector on the global grid to block-vectors defined

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -590,7 +590,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~DataOut_DoFData ();
+  virtual ~DataOut_DoFData () override;
 
   /**
    * Designate a dof handler to be used to extract geometry data and the
@@ -884,14 +884,14 @@ protected:
    * they shall write to a file.
    */
   virtual
-  const std::vector<Patch> &get_patches () const;
+  const std::vector<Patch> &get_patches () const override;
 
   /**
    * Virtual function through which the names of data sets are obtained by the
    * output functions of the base class.
    */
   virtual
-  std::vector<std::string> get_dataset_names () const;
+  std::vector<std::string> get_dataset_names () const override;
 
   /**
    * Extracts the finite elements stored in the dof_data object, including a
@@ -906,7 +906,7 @@ protected:
    */
   virtual
   std::vector<std::tuple<unsigned int, unsigned int, std::string> >
-  get_vector_data_ranges () const;
+  get_vector_data_ranges () const override;
 
   /**
    * Make all template siblings friends. Needed for the merge_patches()

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -470,7 +470,7 @@ namespace internal
       virtual
       double
       get_cell_data_value (const unsigned int       cell_number,
-                           const ComponentExtractor extract_component) const;
+                           const ComponentExtractor extract_component) const override;
 
       /**
        * Given a FEValuesBase object, extract the values on the present cell
@@ -481,7 +481,7 @@ namespace internal
       get_function_values
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
        const ComponentExtractor                                                       extract_component,
-       std::vector<double>                                                           &patch_values) const;
+       std::vector<double>                                                           &patch_values) const override;
 
       /**
        * Given a FEValuesBase object, extract the values on the present cell
@@ -493,7 +493,7 @@ namespace internal
       get_function_values
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
        const ComponentExtractor                                                       extract_component,
-       std::vector<dealii::Vector<double> >                                          &patch_values_system) const;
+       std::vector<dealii::Vector<double> >                                          &patch_values_system) const override;
 
       /**
        * Given a FEValuesBase object, extract the gradients on the present
@@ -504,7 +504,7 @@ namespace internal
       get_function_gradients
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
        const ComponentExtractor                                                       extract_component,
-       std::vector<Tensor<1,DoFHandlerType::space_dimension> >                       &patch_gradients) const;
+       std::vector<Tensor<1,DoFHandlerType::space_dimension> >                       &patch_gradients) const override;
 
       /**
        * Given a FEValuesBase object, extract the gradients on the present
@@ -516,7 +516,7 @@ namespace internal
       get_function_gradients
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
        const ComponentExtractor                                                       extract_component,
-       std::vector<std::vector<Tensor<1,DoFHandlerType::space_dimension> > >         &patch_gradients_system) const;
+       std::vector<std::vector<Tensor<1,DoFHandlerType::space_dimension> > >         &patch_gradients_system) const override;
 
       /**
        * Given a FEValuesBase object, extract the second derivatives on the
@@ -527,7 +527,7 @@ namespace internal
       get_function_hessians
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
        const ComponentExtractor                                                       extract_component,
-       std::vector<Tensor<2,DoFHandlerType::space_dimension> >                       &patch_hessians) const;
+       std::vector<Tensor<2,DoFHandlerType::space_dimension> >                       &patch_hessians) const override;
 
       /**
        * Given a FEValuesBase object, extract the second derivatives on the
@@ -539,24 +539,24 @@ namespace internal
       get_function_hessians
       (const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe_patch_values,
        const ComponentExtractor                                                       extract_component,
-       std::vector<std::vector< Tensor<2,DoFHandlerType::space_dimension> > >        &patch_hessians_system) const;
+       std::vector<std::vector< Tensor<2,DoFHandlerType::space_dimension> > >        &patch_hessians_system) const override;
 
       /**
        * Return whether the data represented by (a derived class of) this object
        * represents a complex-valued (as opposed to real-valued) information.
        */
-      virtual bool is_complex_valued () const;
+      virtual bool is_complex_valued () const override;
 
       /**
        * Clear all references to the vectors.
        */
-      virtual void clear ();
+      virtual void clear () override;
 
       /**
        * Determine an estimate for the memory consumption (in bytes) of this
        * object.
        */
-      virtual std::size_t memory_consumption () const;
+      virtual std::size_t memory_consumption () const override;
 
     private:
       /**

--- a/include/deal.II/numerics/data_out_stack.h
+++ b/include/deal.II/numerics/data_out_stack.h
@@ -128,7 +128,7 @@ public:
   /**
    * Destructor. Only declared to make it @p virtual.
    */
-  virtual ~DataOutStack () = default;
+  virtual ~DataOutStack () override = default;
 
   /**
    * Start the next set of data for a specific parameter value. The argument
@@ -339,14 +339,14 @@ private:
    * data in the form of Patch structures (declared in the base class
    * DataOutBase) to the actual output function.
    */
-  virtual const std::vector< dealii::DataOutBase::Patch<dim+1,dim+1> > & get_patches () const;
+  virtual const std::vector< dealii::DataOutBase::Patch<dim+1,dim+1> > & get_patches () const override;
 
 
   /**
    * Virtual function through which the names of data sets are obtained by the
    * output functions of the base class.
    */
-  virtual std::vector<std::string> get_dataset_names () const;
+  virtual std::vector<std::string> get_dataset_names () const override;
 };
 
 

--- a/include/deal.II/numerics/data_postprocessor.h
+++ b/include/deal.II/numerics/data_postprocessor.h
@@ -430,7 +430,7 @@ public:
    * virtual to ensure that data postprocessors can be destroyed through
    * pointers to the base class.
    */
-  virtual ~DataPostprocessor () = default;
+  virtual ~DataPostprocessor () override = default;
 
   /**
    * This is the main function which actually performs the postprocessing. The
@@ -555,7 +555,7 @@ public:
    * quantities. Given the purpose of this class, this is a vector with a
    * single entry equal to the name given to the constructor.
    */
-  virtual std::vector<std::string> get_names () const;
+  virtual std::vector<std::string> get_names () const override;
 
   /**
    * This function returns information about how the individual components of
@@ -566,14 +566,14 @@ public:
    */
   virtual
   std::vector<DataComponentInterpretation::DataComponentInterpretation>
-  get_data_component_interpretation () const;
+  get_data_component_interpretation () const override;
 
   /**
    * Return, which data has to be provided to compute the derived quantities.
    * The flags returned here are the ones passed to the constructor of this
    * class.
    */
-  virtual UpdateFlags get_needed_update_flags () const;
+  virtual UpdateFlags get_needed_update_flags () const override;
 
 private:
   /**
@@ -790,7 +790,7 @@ public:
    * quantities. Given the purpose of this class, this is a vector with dim
    * entries all equal to the name given to the constructor.
    */
-  virtual std::vector<std::string> get_names () const;
+  virtual std::vector<std::string> get_names () const override;
 
   /**
    * This function returns information about how the individual components of
@@ -801,14 +801,14 @@ public:
    */
   virtual
   std::vector<DataComponentInterpretation::DataComponentInterpretation>
-  get_data_component_interpretation () const;
+  get_data_component_interpretation () const override;
 
   /**
    * Return which data has to be provided to compute the derived quantities.
    * The flags returned here are the ones passed to the constructor of this
    * class.
    */
-  virtual UpdateFlags get_needed_update_flags () const;
+  virtual UpdateFlags get_needed_update_flags () const override;
 
 private:
   /**
@@ -1029,7 +1029,7 @@ public:
    * quantities. Given the purpose of this class, this is a vector with dim
    * entries all equal to the name given to the constructor.
    */
-  virtual std::vector<std::string> get_names () const;
+  virtual std::vector<std::string> get_names () const override;
 
   /**
    * This function returns information about how the individual components of
@@ -1040,14 +1040,14 @@ public:
    */
   virtual
   std::vector<DataComponentInterpretation::DataComponentInterpretation>
-  get_data_component_interpretation () const;
+  get_data_component_interpretation () const override;
 
   /**
    * Return which data has to be provided to compute the derived quantities.
    * The flags returned here are the ones passed to the constructor of this
    * class.
    */
-  virtual UpdateFlags get_needed_update_flags () const;
+  virtual UpdateFlags get_needed_update_flags () const override;
 
 private:
   /**

--- a/include/deal.II/numerics/dof_output_operator.h
+++ b/include/deal.II/numerics/dof_output_operator.h
@@ -54,7 +54,7 @@ namespace Algorithms
     void initialize (const DoFHandler<dim, spacedim> &dof_handler);
 
     virtual OutputOperator<VectorType> &
-    operator << (const AnyData &vectors);
+    operator << (const AnyData &vectors) override;
 
   private:
     SmartPointer<const DoFHandler<dim, spacedim>,

--- a/include/deal.II/numerics/dof_output_operator.templates.h
+++ b/include/deal.II/numerics/dof_output_operator.templates.h
@@ -66,7 +66,7 @@ namespace Algorithms
     out.write (out_filename);
     out.clear ();
     return *this;
-  }
+  };
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -195,7 +195,7 @@ namespace Functions
      * information.
      */
     virtual void vector_value (const Point<dim> &p,
-                               Vector<typename VectorType::value_type>   &values) const;
+                               Vector<typename VectorType::value_type>   &values) const override;
 
     /**
      * Return the value of the function at the given point. Unless there is
@@ -215,7 +215,7 @@ namespace Functions
      * information.
      */
     virtual typename VectorType::value_type value (const Point< dim > &p,
-                                                   const unsigned int  component = 0)    const;
+                                                   const unsigned int  component = 0)    const override;
 
     /**
      * Set @p values to the point values of the specified component of the
@@ -234,7 +234,7 @@ namespace Functions
      */
     virtual void value_list (const std::vector<Point< dim > >     &points,
                              std::vector<typename VectorType::value_type > &values,
-                             const unsigned int  component = 0)    const;
+                             const unsigned int  component = 0)    const override;
 
 
     /**
@@ -253,7 +253,7 @@ namespace Functions
      * information.
      */
     virtual void vector_value_list (const std::vector<Point< dim > >     &points,
-                                    std::vector<Vector<typename VectorType::value_type> > &values) const;
+                                    std::vector<Vector<typename VectorType::value_type> > &values) const override;
 
     /**
      * Return the gradient of all components of the function at the given
@@ -272,7 +272,7 @@ namespace Functions
      */
     virtual void
     vector_gradient (const Point< dim > &p,
-                     std::vector< Tensor< 1, dim,typename VectorType::value_type > > &gradients) const;
+                     std::vector< Tensor< 1, dim,typename VectorType::value_type > > &gradients) const override;
 
     /**
      * Return the gradient of the specified component of the function at the
@@ -290,7 +290,7 @@ namespace Functions
      * information.
      */
     virtual Tensor<1,dim,typename VectorType::value_type> gradient(const Point< dim > &p,
-        const unsigned int component = 0)const;
+        const unsigned int component = 0)const override;
 
     /**
      * Return the gradient of all components of the function at all the given
@@ -308,7 +308,7 @@ namespace Functions
     virtual void
     vector_gradient_list (const std::vector< Point< dim > > &p,
                           std::vector<
-                          std::vector< Tensor< 1, dim,typename VectorType::value_type > > > &gradients) const;
+                          std::vector< Tensor< 1, dim,typename VectorType::value_type > > > &gradients) const override;
 
     /**
      * Return the gradient of the specified component of the function at all
@@ -326,7 +326,7 @@ namespace Functions
     virtual void
     gradient_list (const std::vector< Point< dim > > &p,
                    std::vector< Tensor< 1, dim,typename VectorType::value_type > > &gradients,
-                   const unsigned int component=0) const;
+                   const unsigned int component=0) const override;
 
 
     /**
@@ -342,7 +342,7 @@ namespace Functions
      */
     virtual typename VectorType::value_type
     laplacian (const Point<dim>   &p,
-               const unsigned int  component = 0) const;
+               const unsigned int  component = 0) const override;
 
     /**
      * Compute the Laplacian of all components at point <tt>p</tt> and store
@@ -358,7 +358,7 @@ namespace Functions
      */
     virtual void
     vector_laplacian (const Point<dim>   &p,
-                      Vector<typename VectorType::value_type>     &values) const;
+                      Vector<typename VectorType::value_type>     &values) const override;
 
     /**
      * Compute the Laplacian of one component at a set of points.
@@ -374,7 +374,7 @@ namespace Functions
     virtual void
     laplacian_list (const std::vector<Point<dim> > &points,
                     std::vector<typename VectorType::value_type>            &values,
-                    const unsigned int              component = 0) const;
+                    const unsigned int              component = 0) const override;
 
     /**
      * Compute the Laplacians of all components at a set of points.
@@ -389,7 +389,7 @@ namespace Functions
      */
     virtual void
     vector_laplacian_list (const std::vector<Point<dim> > &points,
-                           std::vector<Vector<typename VectorType::value_type> >   &values) const;
+                           std::vector<Vector<typename VectorType::value_type> >   &values) const override;
 
     /**
      * Given a set of points located in the domain (or, in the case of

--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -672,7 +672,7 @@ public:
   /**
    * Destructor. At present, this does nothing.
    */
-  virtual ~TimeStepBase () = default;
+  virtual ~TimeStepBase () override = default;
 
   /**
    * Reconstruct all the data that is needed for this time level to work. This
@@ -1326,7 +1326,7 @@ public:
    * Destructor. At present, this does not more than releasing the lock on the
    * coarse grid triangulation given to the constructor.
    */
-  virtual ~TimeStepBase_Tria ();
+  virtual ~TimeStepBase_Tria () override;
 
   /**
    * Reconstruct all the data that is needed for this time level to work. This
@@ -1348,7 +1348,7 @@ public:
    * likely is the case), preferably at the beginning so that your function
    * can take effect of the triangulation already existing.
    */
-  virtual void wake_up (const unsigned int wakeup_level);
+  virtual void wake_up (const unsigned int wakeup_level) override;
 
   /**
    * This is the opposite function to @p wake_up. It is used to delete data or
@@ -1363,7 +1363,7 @@ public:
    * this function from your overloaded version, preferably at the end so that
    * your function can use the triangulation as long as you need it.
    */
-  virtual void sleep (const unsigned int);
+  virtual void sleep (const unsigned int) override;
 
   /**
    * Do the refinement according to the flags passed to the constructor of
@@ -1411,7 +1411,7 @@ public:
    * amount memory used by the derived class, and add the result of this
    * function to your result.
    */
-  virtual std::size_t memory_consumption () const;
+  virtual std::size_t memory_consumption () const override;
 
   /**
    * Exception

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -82,7 +82,7 @@ namespace Particles
     /**
      * Destructor.
      */
-    ~ParticleHandler();
+    ~ParticleHandler() override;
 
     /**
      * Initialize the particle handler. This function does not clear the

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -169,12 +169,12 @@ LogStream::operator<< (std::ostream& (*p) (std::ostream &))
       return newline_written_;
     }
   private:
-    int_type overflow(int_type ch)
+    int_type overflow(int_type ch) override
     {
       newline_written_ = true;
       return ch;
     }
-    int sync()
+    int sync() override
     {
       flushed_ = true;
       return 0;

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2364,7 +2364,7 @@ public:
    * we have to have a conversion operator.
    */
   virtual
-  operator typename Triangulation<dim,spacedim>::cell_iterator () const;
+  operator typename Triangulation<dim,spacedim>::cell_iterator () const override;
 
   /**
    * Return the number of degrees of freedom the DoF handler object has to
@@ -2372,7 +2372,7 @@ public:
    */
   virtual
   types::global_dof_index
-  n_dofs_for_dof_handler () const;
+  n_dofs_for_dof_handler () const override;
 
 #include "fe_values.decl.2.inst"
 
@@ -2383,7 +2383,7 @@ public:
   virtual
   void
   get_interpolated_dof_values (const IndexSet &in,
-                               Vector<IndexSet::value_type> &out) const;
+                               Vector<IndexSet::value_type> &out) const override;
 
 private:
   /**
@@ -2429,7 +2429,7 @@ public:
    * from and to the same time.
    */
   virtual
-  operator typename Triangulation<dim,spacedim>::cell_iterator () const;
+  operator typename Triangulation<dim,spacedim>::cell_iterator () const override;
 
   /**
    * Implement the respective function of the base class. Since this is not
@@ -2437,7 +2437,7 @@ public:
    */
   virtual
   types::global_dof_index
-  n_dofs_for_dof_handler () const;
+  n_dofs_for_dof_handler () const override;
 
 #include "fe_values.decl.2.inst"
 
@@ -2448,7 +2448,7 @@ public:
   virtual
   void
   get_interpolated_dof_values (const IndexSet &in,
-                               Vector<IndexSet::value_type> &out) const;
+                               Vector<IndexSet::value_type> &out) const override;
 
 private:
   /**

--- a/source/fe/fe_values.decl.2.inst.in
+++ b/source/fe/fe_values.decl.2.inst.in
@@ -27,5 +27,5 @@ for (VEC : VECTOR_TYPES)
     virtual
     void
     get_interpolated_dof_values (const VEC      &in,
-                                 Vector<VEC::value_type> &out) const;
+                                 Vector<VEC::value_type> &out) const override;
 }

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -294,10 +294,10 @@ namespace TrilinosWrappers
                                   const double               &reduction,
                                   const Epetra_LinearProblem &linear_problem);
 
-        virtual ~TrilinosReductionControl() = default;
+        virtual ~TrilinosReductionControl() override = default;
 
         virtual bool
-        ResidualVectorRequired () const
+        ResidualVectorRequired () const override
         {
           return status_test_collection->ResidualVectorRequired();
         }
@@ -306,7 +306,7 @@ namespace TrilinosWrappers
         CheckStatus (int                 CurrentIter,
                      Epetra_MultiVector *CurrentResVector,
                      double              CurrentResNormEst,
-                     bool                SolutionUpdated)
+                     bool                SolutionUpdated) override
         {
           // Note: CurrentResNormEst is set to -1.0 if no estimate of the
           // residual value is available
@@ -324,14 +324,14 @@ namespace TrilinosWrappers
         }
 
         virtual AztecOO_StatusType
-        GetStatus () const
+        GetStatus () const override
         {
           return status_test_collection->GetStatus();
         }
 
         virtual std::ostream &
         Print (std::ostream &stream,
-               int           indent = 0) const
+               int           indent = 0) const override
         {
           return status_test_collection->Print(stream,indent);
         }

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -110,7 +110,7 @@ namespace internal
           is_blocked (is_blocked)
         {}
 
-        tbb::task *execute ()
+        tbb::task *execute () override
         {
           work();
 
@@ -143,7 +143,7 @@ namespace internal
           is_blocked (is_blocked_in)
         {}
 
-        tbb::task *execute ()
+        tbb::task *execute () override
         {
           tbb::empty_task *root = new( tbb::task::allocate_root() )tbb::empty_task;
           const unsigned int evens = task_info.partition_evens[partition];
@@ -267,7 +267,7 @@ namespace internal
           is_blocked (is_blocked_in)
         {}
 
-        tbb::task *execute ()
+        tbb::task *execute () override
         {
           const unsigned int n_chunks = (task_info.cell_partition_data[partition+1]-
                                          task_info.cell_partition_data[partition]+
@@ -302,7 +302,7 @@ namespace internal
         do_compress(do_compress)
       {}
 
-      tbb::task *execute ()
+      tbb::task *execute () override
       {
         if (do_compress == false)
           worker.vector_update_ghosts_finish();


### PR DESCRIPTION
This fixes a pet peeve of mine. Namely, this PR marks all `virtual` functions in derived classes as `override` and adds the flag `Wsuggest-override` for `gcc`.
This builds for me using `gcc-8`with all dependencies (apart from CUDA) enabled and forcing bundled packages. Only the bundled `boost`needed to be fixed as well, while using `boost-1.67` was just fine.
I didn't add any `virtual`specifiers but made sure to not remove any as well.