### PR TITLE
Avoid using std::bind1st in FE_Nedelec_SZ

### DIFF
--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -985,11 +985,11 @@ void FE_NedelecSZ<dim>::fill_edge_values(const typename Triangulation<dim,dim>::
             {
               std::transform (edge_sigma_values[m].begin(), edge_sigma_values[m].end(),
                               edge_sigma_values[m].begin(),
-                              std::bind1st (std::multiplies<double> (), static_cast<double>(edge_sign[m])));
+              [&](const double edge_sigma_value) {return edge_sign[m]*edge_sigma_value;});
 
               std::transform (edge_sigma_grads[m].begin(), edge_sigma_grads[m].end(),
                               edge_sigma_grads[m].begin(),
-                              std::bind1st (std::multiplies<double> (), static_cast<double>(edge_sign[m])));
+              [&](const double edge_sigma_grad) {return edge_sign[m]*edge_sigma_grad;});
             }
 
           // If we want to generate shape gradients then we need second derivatives of the 1d polynomials,
@@ -1131,10 +1131,10 @@ void FE_NedelecSZ<dim>::fill_edge_values(const typename Triangulation<dim,dim>::
             {
               std::transform (edge_sigma_values[m].begin(), edge_sigma_values[m].end(),
                               edge_sigma_values[m].begin(),
-                              std::bind1st (std::multiplies<double> (), static_cast<double>(edge_sign[m])));
+              [&](const double edge_sigma_value) {return edge_sign[m]*edge_sigma_value;});
               std::transform (edge_sigma_grads[m].begin(), edge_sigma_grads[m].end(),
                               edge_sigma_grads[m].begin(),
-                              std::bind1st (std::multiplies<double> (), static_cast<double>(edge_sign[m])));
+              [&](const double edge_sigma_grad) {return edge_sign[m]*edge_sigma_grad;});
             }
 
           // Now calculate the edge-based shape functions:


### PR DESCRIPTION
Currently, we can't build using recent `clang` compiler with `libc++` and `std=c++17`, see [`CDash`](https://cdash.kyomu.43-1.org/viewBuildError.php?buildid=1655), due to the removal of `std::bind1st` in `C++17`.

Unfortunately, I don't have any idea how to convince `astyle` to use a reasonable indentation.