### PR TITLE
Small doc fixes to the AD module

### DIFF
--- a/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
+++ b/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
@@ -209,7 +209,7 @@
  *   \quad .
  * @f]
  * As was previously mentioned, if each of the primitive operations $f_{n}$ is smooth and
- * differentiable, then the chain can be universally employed to compute the total derivative of $f$,
+ * differentiable, then the chain-rule can be universally employed to compute the total derivative of $f$,
  * namely $\dfrac{d f(x)}{d \mathbf{x}}$. What distinguishes the "forward" from the "reverse" mode
  * is how the chain-rule is evaluated, but ultimately both compute the total derivative
  * @f[
@@ -422,7 +422,7 @@
  *   use ADOL-C numbers.
  * - adolc_product_types.h: Defines some product and scalar types that allow the use of
  *   ADOL-C numbers in conjunction with the Tensor and SymmetricTensor classes.
- * - sacado_math.h: Extension of the sacado math operations that allow these numbers to be used
+ * - sacado_math.h: Extension of the Sacado math operations that allow these numbers to be used
  *   consistently throughout the library.
  * - sacado_number_types.h: Implementation of the internal classes that define how we
  *   use the supported Sacado numbers.


### PR DESCRIPTION
This patch fixes a couple of trivial typo's found in the documentation for the AD module.

@tamiko Could we please add this to the 9.0 branch as well?