### PR TITLE
Make sure program2doxygen does not change code blocks

### DIFF
--- a/doc/doxygen/scripts/program2doxygen
+++ b/doc/doxygen/scripts/program2doxygen
@@ -55,7 +55,7 @@ do {
         }
         $state = $code_fragment_mode;
         # Make sure we distinguish from the other code style
-        print " * <div class=inlineddealii>\n";
+        print " * <div class=CodeFragmentInTutorialComment>\n";
     }
     # We shall skip something...
     elsif (($state != $skip_mode) && m!^\s*//\s*\@cond SKIP!)

--- a/doc/doxygen/scripts/program2doxygen
+++ b/doc/doxygen/scripts/program2doxygen
@@ -26,11 +26,12 @@ if ($ARGV[0] =~ /step-\d+.cc/)
 }
 
 
-# have three states, in which the program can be:
-# comment-mode, program-mode and skip-mode
-$comment_mode = 0;
-$program_mode = 1;
-$skip_mode    = 2;
+# have four states, in which the program can be:
+# comment-mode, program-mode, skip-mode, and code-fragment-mode
+$comment_mode          = 0;
+$program_mode          = 1;
+$skip_mode             = 2;
+$code_fragment_mode    = 3;
 $state =  $comment_mode;
 
 print " * \n";
@@ -43,8 +44,19 @@ do {
 
     s/\t/        /g;
 
+    # We are entering code fragments
+    if (($state != $code_fragment_mode) && m!^\s*//\s*\@code!)
+    {
+        # Cleanly close @code segments in program mode:
+        if ($state == $program_mode)
+        {
+            print " * \@endcode\n";
+            print " * \n";
+        }
+        $state = $code_fragment_mode;
+    }
     # We shall skip something...
-    if (($state != $skip_mode) && m!^\s*//\s*\@cond SKIP!)
+    elsif (($state != $skip_mode) && m!^\s*//\s*\@cond SKIP!)
     {
         # Cleanly close @code segments in program mode:
         if ($state == $program_mode)
@@ -114,7 +126,22 @@ do {
             $state = $comment_mode;
         }
     }
-} while (<>);
+    elsif ($state == $code_fragment_mode)
+    {
+        # This is the end of a @code - @endcode block, so back to
+        # comment_mode:
+        if (m!^\s*//\s*\@endcode!)
+        {
+            $state = $comment_mode;
+        }
+        # in code fragment mode: only skip leading whitespace and
+        # comment // signs
+        s!\s*//\s(.*)\n!$1!;
+
+        # finally print this line
+        print " * $_\n";
+    }
+ } while (<>);
 
 if ($state == $program_mode) {
    print " * \@endcode\n";

--- a/doc/doxygen/scripts/program2doxygen
+++ b/doc/doxygen/scripts/program2doxygen
@@ -138,10 +138,10 @@ do {
         }
         # in code fragment mode: only skip leading whitespace and
         # comment // signs
-        s!\s*//\s(.*)\n!$1!;
+        s!^\s*//(.*)\n!$1!;
 
         # finally print this line
-        print " * $_\n";
+        print " *$_\n";
 
         if (m!^ *\s*\@endcode!)
         {

--- a/doc/doxygen/scripts/program2doxygen
+++ b/doc/doxygen/scripts/program2doxygen
@@ -54,6 +54,8 @@ do {
             print " * \n";
         }
         $state = $code_fragment_mode;
+        # Make sure we distinguish from the other code style
+        print " * <div class=inlineddealii>\n";
     }
     # We shall skip something...
     elsif (($state != $skip_mode) && m!^\s*//\s*\@cond SKIP!)
@@ -128,7 +130,7 @@ do {
     }
     elsif ($state == $code_fragment_mode)
     {
-        # This is the end of a @code - @endcode block, so back to
+        # If this is the end of a @code - @endcode block, go back to
         # comment_mode:
         if (m!^\s*//\s*\@endcode!)
         {
@@ -140,7 +142,12 @@ do {
 
         # finally print this line
         print " * $_\n";
-    }
+
+        if (m!^ *\s*\@endcode!)
+        {
+            print " * </div>\n";
+        }
+   }
  } while (<>);
 
 if ($state == $program_mode) {

--- a/doc/doxygen/stylesheet.css
+++ b/doc/doxygen/stylesheet.css
@@ -84,8 +84,8 @@ div.image img[src="fe_enriched_h-refinement.png"] {
 
 
 /*
- * environment for custom codes
+ * environment for code fragments in tutorial comments
  */
-.inlineddealii {
-    background-color: #FF33F0;
+.CodeFragmentInTutorialComment {
+    /* background-color: #FF33F0; */
 }

--- a/doc/doxygen/stylesheet.css
+++ b/doc/doxygen/stylesheet.css
@@ -81,3 +81,11 @@ div.image img[src="fe_enriched_h-refinement.png"] {
   margin-left: auto;
   margin-right: auto;
 }
+
+
+/*
+ * environment for custom codes
+ */
+.inlineddealii {
+    background-color: #FF33F0;
+}


### PR DESCRIPTION
Found when checking step-60. 

If a user has defined a code fragment block, like this one:
~~~
// @code 
// int main() {
//      test_function();
// }
// @endcode
~~~
our perl scripts strips all trailing white spaces from the tutorial programs. 

This fix makes sure that this does not happen inside step-xx.cc files.