### PR TITLE
Fix reference to FETools::hierarchic_to_lexicographic_numbering

### DIFF
--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -720,7 +720,7 @@ private:
    * degree of freedom in the hierarchic numbering would have.
    *
    * This function is analogous to the
-   * FETools::hierarchical_to_lexicographic_numbering() function. However, in
+   * FETools::hierarchic_to_lexicographic_numbering() function. However, in
    * contrast to the fe_q_hierarchical numbering defined above, the
    * lexicographic numbering originates from the tensor products of
    * consecutive numbered dofs (like for LagrangeEquidistant).


### PR DESCRIPTION
The correct name is [`FETools::hierarchic_to_lexicographic_numbering`](https://www.dealii.org/developer/doxygen/deal.II/namespaceFETools.html#a42118e6f1c76038d4ac41ebf140a4b62).