### PR TITLE
[9.0] take over #6587

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,11 @@
 /tests/* export-ignore
-/tests/quick_tests -export-ignore
 /tests/CMakeLists.txt -export-ignore
+/tests/quick_tests -export-ignore
 /tests/run_test.cmake -export-ignore
+/tests/tests.h -export-ignore
+.clang-format export-ignore
 .gitattributes export-ignore
+.gitignore export-ignore
 .travis.yml export-ignore
 /cmake/scripts/run_test.sh text eol=lf
 /tests/**/*output text eol=lf


### PR DESCRIPTION
In reference to #6587, #6586.

Let's fix this bug on the release branch as well, even though we won't tag a
new release. In case we do a 9.0.1 release we won't forget it...