### PR TITLE
Avoid using std::make_pair and just use a brace-enclosed list.

### DIFF
--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3239,10 +3239,10 @@ namespace parallel
 #endif
 
       // add new pair with offset and pack_callback
-      cell_attached_data.pack_callbacks.push_back(
-        std::make_pair(cell_attached_data.cumulative_fixed_data_size + sizeof(CellStatus),
-                       pack_callback)
-      );
+      cell_attached_data.pack_callbacks.push_back({ cell_attached_data.cumulative_fixed_data_size
+                                                    + sizeof(CellStatus),
+                                                    pack_callback
+                                                  } );
 
       // increase counters
       ++cell_attached_data.n_attached_datas;


### PR DESCRIPTION
I saw this while looking through #6472. It is entirely unnecessary, but I always find
std::make_pair a bit clumsy -- we can write this more concisely in C++11 now with brace
enclosed lists.

@marcfehling -- FYI.