### PR TITLE
Manage relations of p4est quadrants and dealii cells.

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -912,6 +912,40 @@ namespace parallel
       CellAttachedData cell_attached_data;
 
       /**
+       * This auxiliary data structure stores the relation between a p4est
+       * quadrant, a deal.II cell and its current CellStatus. For an extensive
+       * description of the latter, see the documentation for the member
+       * function register_data_attach.
+       */
+      typedef typename std::tuple<
+        typename dealii::internal::p4est::types<dim>::quadrant *,
+        CellStatus,
+        cell_iterator>
+        quadrant_cell_relation_t;
+
+      /**
+       * Vector of tuples, which each contain a p4est quadrant, a deal.II cell
+       * and their relation after refinement. To update its contents, use the
+       * compute_quadrant_cell_relations member function.
+       *
+       * The size of this vector is assumed to be equal to the number of locally
+       * owned quadrants in the parallel_forest object.
+       */
+      std::vector<quadrant_cell_relation_t> local_quadrant_cell_relations;
+
+      /**
+       * Go through all p4est trees and store the relations between locally
+       * owned quadrants and cells in the private member
+       * local_quadrant_cell_relations.
+       *
+       * The stored vector will be ordered by the occurrence of quadrants in
+       * the corresponding local sc_array of the parallel_forest. p4est requires
+       * this specific ordering for its transfer functions.
+       */
+      void
+      update_quadrant_cell_relations();
+
+      /**
        * Two arrays that store which p4est tree corresponds to which coarse
        * grid cell and vice versa. We need these arrays because p4est goes
        * with the original order of coarse cells when it sets up its forest,
@@ -996,7 +1030,7 @@ namespace parallel
        * them.
        */
       std::vector<unsigned int>
-      get_cell_weights();
+      get_cell_weights() const;
 
       /**
        * Override the implementation in parallel::Triangulation because


### PR DESCRIPTION
For a potential future parallelization of the comparison of the parallel forest with the deal.ii triangulation, we introduce a new functionality to reduce the occurrences of recursion algorithms to a minimum and replace those with classical loops whenever possible.

Instead of recursing through the whole tree, e.g. by packing or unpacking a SolutionTransfer object, we seek to store the relations between the p4est quadrants and the deal.ii cells once, and get back to those if we need them. For this idea, a new function <code>compute_cell_quadrant_relations</code> has been introduced in the <code>parallel::distributed::Triangulation</code> class to fulfil this task. It stores the relations in a new private member <code>local_quadrant_cell_relations</code>.

This function will be called whenever the deal.ii triangulation gets synced to the parallel forest in <code>copy_local_forest_to_triangulation</code>, i.e. in <code>execute_coarsening_and_refinement</code>, <code>repartition</code>, <code>save</code>, and <code>load</code>. During refinement, we need an additional call for the intermediate state in which the parallel forest is already refined, but the triangulation isn't yet. The stored relations are then available for the corresponding <code>pack_callback</code> and <code>unpack_callback</code> functions.

I adapted the functions <code>attach_mesh_data</code>, <code>notify_ready_to_unpack</code>, and <code>get_cell_weights</code> to make use of this functionality.

Other functions that can potentially benefit from it as well, but haven't been changed in this pull request, are:
- <code>build_lists</code>
- <code>set_vertices_recursively</code>
- <code>fill_vertices_recursively</code>
- <code>determine_level_subdomain_id_recursively</code>
- <code>match_tree_recursively</code>

Both functions related to vertices are called in <code>communicate_locally_moved_vertices</code>, and the last two are called in <code>copy_local_forest_to_triangulation</code>.

If I understood the purpose of these functions correctly, most of them are concerned with the exchange of ghost cells. Since the newly introduced <code>local_quadrant_cell_relations</code> member only stores local relations (i.e. local quadrants in p4est), I am not sure if this new functionality would work out of the box for these particular functions as well.

I will not continue working on this particular feature, and move on to the p4est transfer with variable data sizes, since the requirements are now fulfilled. Maybe someone else would be interested to continue on working on that functionality.

@bangerth, @tjhei -- FYI