### PR TITLE
Use appropriate latex packages for doxygen formulas.

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -134,7 +134,7 @@ GENERATE_LATEX         = NO
 # but set a few flags for when processing formulas embedded
 # in the documentation.
 PAPER_TYPE             = a4wide
-EXTRA_PACKAGES         = amsmath amsfonts
+EXTRA_PACKAGES         = amsmath amsfonts mathtools
 LATEX_BATCHMODE        = YES
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
The 'mathtools' package is necessary for the 'coloneqq' command that was first
used in step-60. See also #6432.