### PR TITLE
Predefine the MPI and P4EST versions for doxygen.

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -182,11 +182,17 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_WITH_LAPACK=1 \
                          DEAL_II_WITH_METIS=1 \
                          DEAL_II_WITH_MPI=1 \
+                         DEAL_II_MPI_VERSION_MAJOR=3 \
+                         DEAL_II_MPI_VERSION_MINOR=0 \
                          DEAL_II_WITH_MUPARSER=1 \
                          DEAL_II_WITH_NANOFLANN=1 \
                          DEAL_II_WITH_NETCDF=1 \
                          DEAL_II_WITH_OPENCASCADE=1 \
                          DEAL_II_WITH_P4EST=1 \
+                         DEAL_II_P4EST_VERSION_MAJOR=2 \
+                         DEAL_II_P4EST_VERSION_MINOR=0 \
+                         DEAL_II_P4EST_VERSION_SUBMINOR=0 \
+                         DEAL_II_P4EST_VERSION_PATCH=0 \
                          DEAL_II_WITH_PETSC=1 \
                          DEAL_II_WITH_SCALAPACK=1 \
                          DEAL_II_WITH_SLEPC=1 \


### PR DESCRIPTION
This is necessary because doxygen complains when it evaluates the DEAL_II_P4EST_VERSION_GTE
and similar macros that reference version numbers.