### PR TITLE
Contrib: Add a scripts to compile/download clang-format

### DIFF
--- a/contrib/utilities/compile_clang_format
+++ b/contrib/utilities/compile_clang_format
@@ -71,7 +71,16 @@ git reset --hard "${CLANG_COMMIT}"
 cd ../../
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DLLVM_BUILD_STATIC=true ..
+
+case "${OSTYPE}" in
+  darwin*)
+    cmake -DCMAKE_BUILD_TYPE=MinSizeRel ..
+    ;;
+  *)
+    cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DLLVM_BUILD_STATIC=true ..
+    ;;
+esac
+
 make -j4 clang-format
 cp bin/clang-format "${CLANG_PATH}"/bin
 cp ../{CODE_OWNERS,CREDITS,LICENSE}.TXT "${CLANG_PATH}"

--- a/contrib/utilities/compile_clang_format
+++ b/contrib/utilities/compile_clang_format
@@ -86,5 +86,5 @@ cp bin/clang-format "${CLANG_PATH}"/bin
 cp ../{CODE_OWNERS,CREDITS,LICENSE}.TXT "${CLANG_PATH}"
 rm -rf "${tmpdir}"
 
-echo "All done. clang-format succesfully installed into"
-echo "    ${CLANG_PATH}/clang-6/bin"
+echo "All done. clang-format successfully installed into"
+echo "    ${CLANG_PATH}/bin"

--- a/contrib/utilities/compile_clang_format
+++ b/contrib/utilities/compile_clang_format
@@ -1,0 +1,81 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2018 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+#
+# This script downloads, compiles and installs the clang-format binary. The
+# destination directory is
+#   [contrib/utilities]/programs/clang-<VERSION>/bin.
+#
+# Compiling clang-format and all necessary parts of LLVM/CLANG might
+# require a significant amount of resources. Alternatively, you can use
+# download_clang_format to install a statically-linked binary.
+#
+
+set -e
+set -u
+
+PRG="$(cd "$(dirname "$0")" && pwd)/programs"
+
+CLANG_PATH="${PRG}/clang-6"
+
+RELEASE_DATE="2018-04-06"
+RELEASE_BRANCH="release_60"
+LLVM_REPOSITORY="https://github.com/llvm-mirror/llvm"
+CLANG_REPOSITORY="https://github.com/llvm-mirror/clang"
+LLVM_COMMIT="1a0dddf879aadfcfea409b3c0a9aa3c9da306945"
+CLANG_COMMIT="d5f48a217f404c3462537527f4169bb45eed3904"
+
+if [ ! -d "${PRG}" ]
+then
+    echo "create folder ${PRG}"
+    mkdir "${PRG}"
+fi
+
+if [ -d "${CLANG_PATH}" ]
+then
+    echo "${CLANG_PATH}  exists. Exiting."
+    exit 1
+fi
+
+echo "Downloading and compiling clang-format-6."
+mkdir -p "${CLANG_PATH}/bin"
+
+tmpdir="${TMPDIR:-/tmp}/dealiiclang${RANDOM}${RANDOM}"
+mkdir -p "${tmpdir}"
+cd "${tmpdir}"
+
+git init
+git remote add origin "${LLVM_REPOSITORY}"
+git fetch --shallow-since="${RELEASE_DATE}" origin "${RELEASE_BRANCH}"
+git reset --hard "${LLVM_COMMIT}"
+
+git init tools/clang
+cd tools/clang
+git remote add origin "${CLANG_REPOSITORY}"
+git fetch --shallow-since="${RELEASE_DATE}" origin "${RELEASE_BRANCH}"
+git reset --hard "${CLANG_COMMIT}"
+
+cd ../../
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DLLVM_BUILD_STATIC=true ..
+make -j4 clang-format
+cp bin/clang-format "${CLANG_PATH}"/bin
+cp ../{CODE_OWNERS,CREDITS,LICENSE}.TXT "${CLANG_PATH}"
+rm -rf "${tmpdir}"
+
+echo "All done. clang-format succesfully installed into"
+echo "    ${CLANG_PATH}/clang-6/bin"

--- a/contrib/utilities/compile_clang_format
+++ b/contrib/utilities/compile_clang_format
@@ -57,15 +57,41 @@ tmpdir="${TMPDIR:-/tmp}/dealiiclang${RANDOM}${RANDOM}"
 mkdir -p "${tmpdir}"
 cd "${tmpdir}"
 
+GIT_VERSION=$(git version)
+GIT_MAJOR_VERSION=$(echo "${GIT_VERSION}" | sed 's/^[^0-9]*\([0-9]*\).*$/\1/g')
+GIT_MINOR_VERSION=$(echo "${GIT_VERSION}" | sed 's/^[^0-9]*[0-9]*\.\([0-9]*\).*$/\1/g')
+
+if [ "$GIT_MAJOR_VERSION" -ge 2 ] && [ "$GIT_MINOR_VERSION" -ge 11 ]; then
+  GIT_SHALLOW_SINCE_AVAILABLE=true
+else
+  GIT_SHALLOW_SINCE_AVAILABLE=false
+fi
+
 git init
 git remote add origin "${LLVM_REPOSITORY}"
-git fetch --shallow-since="${RELEASE_DATE}" origin "${RELEASE_BRANCH}"
+if [ "$GIT_SHALLOW_SINCE_AVAILABLE" = true ]; then
+  git fetch --shallow-since="${RELEASE_DATE}" origin "${RELEASE_BRANCH}"
+else
+  git fetch --depth=1 origin "${RELEASE_BRANCH}"
+  i=1;
+  while ! git cat-file -e ${LLVM_COMMIT} 2> /dev/null; do
+    git fetch --depth=$((i+=10)) origin "${RELEASE_BRANCH}";
+  done
+fi
 git reset --hard "${LLVM_COMMIT}"
 
 git init tools/clang
 cd tools/clang
 git remote add origin "${CLANG_REPOSITORY}"
-git fetch --shallow-since="${RELEASE_DATE}" origin "${RELEASE_BRANCH}"
+if [ "$GIT_SHALLOW_SINCE_AVAILABLE" = true ]; then
+  git fetch --shallow-since="${RELEASE_DATE}" origin "${RELEASE_BRANCH}"
+else
+  git fetch --depth=1 origin "${RELEASE_BRANCH}"
+  i=1;
+  while ! git cat-file -e ${CLANG_COMMIT} 2> /dev/null; do
+    git fetch --depth=$((i+=10)) origin "${RELEASE_BRANCH}";
+  done
+fi
 git reset --hard "${CLANG_COMMIT}"
 
 cd ../../

--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -74,5 +74,5 @@ else
 fi
 rm -r "${tmpdir}"
 
-echo "All done. clang-format succesfully installed into"
-echo "    ${CLANG_PATH}/clang-6/bin"
+echo "All done. clang-format successfully installed into"
+echo "    ${CLANG_PATH}/bin"

--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -1,0 +1,73 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2018 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+#
+# This script downloads and installs the clang-format binary. The
+# destination directory is
+#   [contrib/utilities]/programs/clang-<VERSION>/bin.
+#
+# This script only works on Linux (amd64) and macOS. For other
+# architectures it is necessary to compile the clang-format binary by hand.
+# This can be done with the compile_clang_format script.
+#
+
+PRG="$(cd "$(dirname "$0")" && pwd)/programs"
+CLANG_PATH="${PRG}/clang-6"
+
+URL="https://github.com/dealii/dealii/releases/download/v9.0.0"
+
+# Find out which kind of OS we are running and set the appropriate settings
+case "${OSTYPE}" in
+  linux*)
+    FILENAME="clang-format-6-linux.tar.gz"
+    CHECKSUM_CMD="sha256sum"
+    CHECKSUM="387b42b30db598d51bf26f020c5bef574cb6355210d2f5909691407a0fc81a26  $FILENAME"
+    ;;
+  *)
+    echo "unknown: ${OSTYPE}"
+    exit 1
+    ;;
+esac
+
+if [ ! -d "${PRG}" ]
+then
+    echo "create folder ${PRG}"
+    mkdir "${PRG}"
+fi
+
+if [ -d "${CLANG_PATH}" ]
+then
+    echo "${CLANG_PATH}  exists. Exiting."
+    exit 1
+fi
+
+echo "Downloading and installing clang-format-6."
+mkdir "${CLANG_PATH}"
+
+tmpdir="${TMPDIR:-/tmp}/dealiiclang${RANDOM}${RANDOM}"
+mkdir -p "${tmpdir}"
+cd "${tmpdir}"
+curl -s -L "${URL}/${FILENAME}" -O > /dev/null
+if echo "${CHECKSUM}" | "${CHECKSUM_CMD}" -c; then
+  tar xfz "${FILENAME}" -C "${PRG}" > /dev/null
+else
+  echo "*** The downloaded file has the wrong SHA256 checksum!"
+  exit 1
+fi
+rm -r "${tmpdir}"
+
+echo "All done. clang-format succesfully installed into"
+echo "    ${CLANG_PATH}/clang-6/bin"

--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -36,6 +36,11 @@ case "${OSTYPE}" in
     CHECKSUM_CMD="sha256sum"
     CHECKSUM="387b42b30db598d51bf26f020c5bef574cb6355210d2f5909691407a0fc81a26  $FILENAME"
     ;;
+  darwin*)
+    FILENAME="clang-format-6-darwin.tar.gz"
+    CHECKSUM_CMD="shasum"
+    CHECKSUM="8eaf852cc96947245de706f1059e764b7086a82e8bd769da2654936acb1d63e0  $FILENAME"
+    ;;
   *)
     echo "unknown: ${OSTYPE}"
     exit 1

--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -34,7 +34,7 @@ case "${OSTYPE}" in
   linux*)
     FILENAME="clang-format-6-linux.tar.gz"
     CHECKSUM_CMD="sha256sum"
-    CHECKSUM="387b42b30db598d51bf26f020c5bef574cb6355210d2f5909691407a0fc81a26  $FILENAME"
+    CHECKSUM="26c046456d0a8c109df74e890f46bbe4ad50b035a9febc13ec41c22dabd005a5  $FILENAME"
     ;;
   darwin*)
     FILENAME="clang-format-6-darwin.tar.gz"


### PR DESCRIPTION
This PR adds two scripts compile_clang_format and download_clang_format.

The first script checks out the LLVM/Clang repository and compiles clang-format
from sources. This requires a working compiler, cmake and git.

The second scripts downloads (and verifies) a static (64 bit) binary. This
should work on almost all linux distributions out of the box.

In reference to #6597