### PR TITLE
Glibc debug fixes 1

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2832,11 +2832,12 @@ namespace internal
       void
       update_cell_dof_indices_cache (const DoFCellAccessor<dealii::hp::DoFHandler<dim,spacedim>, level_dof_access> &accessor)
       {
-        // caches are only for cells with DoFs, i.e., for active ones
+        // caches are only for cells with DoFs, i.e., for active ones and not FE_Nothing
         if (accessor.has_children())
           return;
-
         const unsigned int dofs_per_cell = accessor.get_fe().dofs_per_cell;
+        if (dofs_per_cell == 0)
+          return;
 
         // make sure the cache is at least
         // as big as we need it when

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2269,7 +2269,7 @@ next_cell:
             const unsigned int local_pos_recv = vertices_recv_buffers[i][2*j];
             const types::global_vertex_index global_id_recv = vertices_recv_buffers[i][2*j+1];
             const std::string cellid_recv(&cellids_recv_buffers[i][max_cellid_size*j],
-                                          &cellids_recv_buffers[i][max_cellid_size*(j+1)]);
+                                          &cellids_recv_buffers[i][max_cellid_size*j] + max_cellid_size);
             bool found = false;
             typename std::set<active_cell_iterator>::iterator
             cell_set_it = missing_vert_cells.begin(),

--- a/tests/manifold/transfinite_manifold_07.cc
+++ b/tests/manifold/transfinite_manifold_07.cc
@@ -227,9 +227,7 @@ void concentric_disks(Triangulation<2>          &tria,
       cell_idx++;
     }
 
-  tria.create_triangulation(std::vector<Point<2>>(&vertices[0], &vertices[n_vert]),
-                            cells,
-                            SubCellData()); // no boundary information
+  tria.create_triangulation(vertices, cells, SubCellData()); // no boundary information
 
   double eps = 1e-5 * x[0];
   unsigned int label = 100;


### PR DESCRIPTION
I recently learned about GCC's debug mode (i.e., compiling with `-D_GLIBCXX_DEBUG`). I ran the whole test suite on my work station today with this flag on and a couple dozen tests failed, mostly from doing things like `&vector[size]` instead of `vector.data() + size`.

This PR includes fixes for the simple bugs. I will open an issue in a moment that lists the remaining failures: at least one (with the flux sparsity pattern) looks, to me, like a real set of bugs.