### PR TITLE
Avoid accessing uninitialized memory in TaskInfo

### DIFF
--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -774,7 +774,7 @@ namespace internal
           // create a tight map of categories for not taking exceeding amounts
           // of memory below. Sort the new categories by the numbers in the
           // old one.
-          tight_category_map.reserve(n_active_cells+n_ghost_cells);
+          tight_category_map.resize(n_active_cells+n_ghost_cells);
           std::set<unsigned int> used_categories;
           for (unsigned int i=0; i<n_active_cells+n_ghost_cells; ++i)
             used_categories.insert(cell_vectorization_categories[i]);


### PR DESCRIPTION
We only reserved space for the `std::vector<unsigned int>` tight_category_map. Later, we access all of these elements.  Hence, `resize()` seems to be the right thing to do here.

This fixes the tests `matrix_free/matrix_vector_hp` and ` matrix_free/no_index_initialize` in #6622.
