### PR TITLE
Fix invalid access uncovered GLIBCXX_DEBUG in MatrixFree

### DIFF
--- a/doc/news/changes/minor/20180518DanielArndtMartinKronbichler
+++ b/doc/news/changes/minor/20180518DanielArndtMartinKronbichler
@@ -1,0 +1,5 @@
+Fixed: Two invalid off-by-one data accesses in the initialization of
+MatrixFree with face data enabled, that appeared in some rare cases on certain
+configurations of processors, have been fixed.
+(Daniel Arndt, Martin Kronbichler, 2018/05/18)
+

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3942,7 +3942,7 @@ FEEvaluationBase<dim,n_components_,Number,is_face>
                                          values_dofs[comp][ind_local][v]);
                 }
 
-              if (apply_constraints == true)
+              if (apply_constraints == true && comp+1<n_components)
                 {
                   if (is_face)
                     next_index_indicators = dof_info->row_starts[cells[v]*n_fe_components+first_selected_component+comp+2].second;

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1174,7 +1174,8 @@ void MatrixFree<dim,Number>::initialize_indices
 
       std::vector<bool> hard_vectorization_boundary(task_info.face_partition_data.size(),
                                                     false);
-      if (task_info.scheme == internal::MatrixFreeFunctions::TaskInfo::none)
+      if (task_info.scheme == internal::MatrixFreeFunctions::TaskInfo::none &&
+          task_info.partition_row_index[2] < task_info.face_partition_data.size())
         hard_vectorization_boundary[task_info.partition_row_index[2]] = true;
       else
         for (unsigned int i=0; i<hard_vectorization_boundary.size(); ++i)


### PR DESCRIPTION
Fixes #6627.

Relates to #6622.

At least for the tests I can verify, this should fix all problems in matrix-free. (I have not (yet) compiled Trilinos with `_GLIBCXX_DEBUG`.)