### PR TITLE
Update the clang-format file to sort headers.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,5 +35,69 @@ IndentWidth:     2
 NamespaceIndentation: All
 Standard:        Cpp11
 
+IncludeBlocks: Regroup
+IncludeCategories:
+# config.h must always be first:
+  - Regex:    "deal.II/base/config.h"
+    Priority: -1
+# deal.II folders in sorted order:
+  - Regex:    "deal.II/algorithms/.*\\.h"
+    Priority: 110
+  - Regex:    "deal.II/base/.*\\.h"
+    Priority: 120
+  - Regex:    "deal.II/differentiation/.*\\.h"
+    Priority: 130
+  - Regex:    "deal.II/distributed/.*\\.h"
+    Priority: 140
+  - Regex:    "deal.II/dofs/.*\\.h"
+    Priority: 150
+  - Regex:    "deal.II/fe/.*\\.h"
+    Priority: 160
+  - Regex:    "deal.II/gmsh/.*\\.h"
+    Priority: 170
+  - Regex:    "deal.II/grid/.*\\.h"
+    Priority: 180
+  - Regex:    "deal.II/hp/.*\\.h"
+    Priority: 190
+  - Regex:    "deal.II/integrators/.*\\.h"
+    Priority: 200
+  - Regex:    "deal.II/lac/.*\\.h"
+    Priority: 210
+  - Regex:    "deal.II/matrix_free/.*\\.h"
+    Priority: 220
+  - Regex:    "deal.II/meshworker/.*\\.h"
+    Priority: 230
+  - Regex:    "deal.II/multigrid/.*\\.h"
+    Priority: 240
+  - Regex:    "deal.II/non_matching/.*\\.h"
+    Priority: 250
+  - Regex:    "deal.II/numerics/.*\\.h"
+    Priority: 260
+  - Regex:    "deal.II/opencascade/.*\\.h"
+    Priority: 270
+  - Regex:    "deal.II/optimization/.*\\.h"
+    Priority: 280
+  - Regex:    "deal.II/particles/.*\\.h"
+    Priority: 290
+  - Regex:    "deal.II/physics/.*\\.h"
+    Priority: 300
+  - Regex:    "deal.II/sundials/.*\\.h"
+    Priority: 121
+# put boost right after deal:
+  - Regex: "<boost.*>"
+    Priority: 500
+# try to group PETSc headers:
+  - Regex: "<petsc.*\\.h>"
+    Priority: 1000
+# try to catch all third party headers and put them after deal.II but before
+# standard headers:
+  - Regex: "<.*\\.(h|hpp|hxx)>"
+    Priority: 2000
+# match all standard headers. Things like '#include <armadillo>' should be
+# surrounded by #ifdef checks (which will not be merged by clang-format) so they
+# should not be caught here
+  - Regex: "<[a-z_]+>"
+    Priority: 100000
+
 TabWidth:        4
 UseTab:          Never


### PR DESCRIPTION
I was curious about what clang-format supports and I found this real gem of a feature: it can arrange and sort our include files! This commit works with all of the files I tried it with: it does not sort things in `#ifdef` guards but everything else is done correctly (IMO). An example: this transforms

```cpp

#include <deal.II/base/config.h>
#include <deal.II/base/exceptions.h>
#include <deal.II/base/quadrature_lib.h>
#include <deal.II/base/point.h>
#include <deal.II/dofs/function_map.h>
#include <deal.II/dofs/dof_handler.h>
#include <deal.II/hp/dof_handler.h>
#include <deal.II/hp/mapping_collection.h>

#include <map>
#include <vector>
#include <set>
#include <functional>
```

into
```cpp

#include <deal.II/base/config.h>

#include <deal.II/base/exceptions.h>
#include <deal.II/base/point.h>
#include <deal.II/base/quadrature_lib.h>

#include <deal.II/dofs/dof_handler.h>
#include <deal.II/dofs/function_map.h>

#include <deal.II/hp/dof_handler.h>
#include <deal.II/hp/mapping_collection.h>

#include <functional>
#include <map>
#include <set>
#include <vector>
```

I find unsorted `#include` files irritating so I am really excited about this feature.