### PR TITLE
Use wget instead of curl.

### DIFF
--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -59,13 +59,25 @@ then
     exit 1
 fi
 
-echo "Downloading and installing clang-format-6."
+echo "Downloading and installing clang-format-6 from ${URL}/${FILENAME}"
 mkdir "${CLANG_PATH}"
 
 tmpdir="${TMPDIR:-/tmp}/dealiiclang${RANDOM}${RANDOM}"
 mkdir -p "${tmpdir}"
 cd "${tmpdir}"
-curl -s -L "${URL}/${FILENAME}" -O > /dev/null
+if [ -x "$(command -v wget)" ]; then
+  echo "Using wget to download..."
+  wget -q --show-progress -L "${URL}/${FILENAME}" > /dev/null
+else
+  if [ -x "$(command -v curl)" ]; then
+    echo "Using curl to download..."
+    curl -s -L "${URL}/${FILENAME}" -O > /dev/null
+  else
+    echo "Error: Neither wget nor curl is available..."
+    exit 1
+  fi
+fi
+
 if echo "${CHECKSUM}" | "${CHECKSUM_CMD}" -c; then
   tar xfz "${FILENAME}" -C "${PRG}" > /dev/null
 else


### PR DESCRIPTION
Also show a progress bar for the download, but be otherwise quiet. This is useful on slow connections.

I propose this patch because (i) I don't have `curl` installed on my system, but do have `wget`, (ii) `wget` is likely more widely available.