### PR TITLE
Make clear in the program that we omit significant parts of step-45.

### DIFF
--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -31,6 +31,10 @@
 //   object with periodicity constraints
 // - <code>StokesProblem<dim>::run()</code>: To supply a distributed triangulation with
 //   periodicity information.
+//
+// The rest of the program is identical to step-22, so let us skip this part
+// and only show these two functions in the following. (The full program can be
+// found in the "Plain program" section below, though.)
 
 
 // @cond SKIP
@@ -489,6 +493,9 @@ namespace Step45
                      mpi_communicator);
   }
 
+// The rest of the program is then again identical to step-22. We will omit
+// it here now, but as before, you can find these parts in the "Plain program"
+// section below.
 
 // @cond SKIP
   template <int dim>


### PR DESCRIPTION
I found it slightly confusing that significant parts of the step-45 program simply don't show
up in the generated documentation. Fix this by at least being clear about it in the commentary.

Fixes #6617.