### PR TITLE
Fix a few more instances of 'freedoms'

### DIFF
--- a/examples/step-8/doc/intro.dox
+++ b/examples/step-8/doc/intro.dox
@@ -229,7 +229,7 @@ ${\mathbf u}_h$ and ${\mathbf v}_h$ into this formula:
 @f}
 We note that here and in the following, the indices $k,l$ run over spatial
 directions, i.e. $0\le k,l < d$, and that indices $i,j$ run over degrees
-of freedoms.
+of freedom.
 
 The local stiffness matrix on cell $K$ therefore has the following entries:
 @f[
@@ -352,4 +352,3 @@ this is required. In addition, in step-20, @ref step_21
 revisit some vector-valued problems and show a few techniques that may make it
 simpler to actually go through all the stuff shown above, with
 FiniteElement::system_to_component_index etc.
-

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -1749,7 +1749,7 @@ public:
    * element, independent of the cell we are presently on, but for hp DoF
    * handlers, this may change from cell to cell.
    *
-   * @note Since degrees of freedoms only exist on active cells for
+   * @note Since degrees of freedom only exist on active cells for
    * hp::DoFHandler (i.e., there is currently no implementation of multilevel
    * hp::DoFHandler objects), it does not make sense to query the finite
    * element on non-active cells since they do not have finite element spaces
@@ -1764,7 +1764,7 @@ public:
    * for this cell. This function is only useful if the DoF handler object
    * associated with the current cell is an hp::DoFHandler.
    *
-   * @note Since degrees of freedoms only exist on active cells for
+   * @note Since degrees of freedom only exist on active cells for
    * hp::DoFHandler (i.e., there is currently no implementation of multilevel
    * hp::DoFHandler objects), it does not make sense to query active FE
    * indices on non-active cells since they do not have finite element spaces
@@ -1788,7 +1788,7 @@ public:
    * if the DoF handler object associated with the current cell is an
    * hp::DoFHandler.
    *
-   * @note Since degrees of freedoms only exist on active cells for
+   * @note Since degrees of freedom only exist on active cells for
    * hp::DoFHandler (i.e., there is currently no implementation of multilevel
    * hp::DoFHandler objects), it does not make sense to assign active FE
    * indices to non-active cells since they do not have finite element spaces

--- a/include/deal.II/lac/constrained_linear_operator.h
+++ b/include/deal.II/lac/constrained_linear_operator.h
@@ -229,7 +229,7 @@ LinearOperator<Range, Domain> project_to_constrained_linear_operator(
  *   Id_c = project_to_constrained_linear_operator(constraint_matrix, linop);
  * @endcode
  * and <code>Id_c</code> is the projection to the subspace consisting of all
- * vector entries associated with constrained degrees of freedoms.
+ * vector entries associated with constrained degrees of freedom.
  *
  * This LinearOperator object is used together with
  * constrained_right_hand_side() to build up the following modified system of

--- a/include/deal.II/lac/sparse_vanka.h
+++ b/include/deal.II/lac/sparse_vanka.h
@@ -413,7 +413,7 @@ private:
  * will work on each block separately, i.e. the solutions of the local systems
  * corresponding to a degree of freedom of one block will only be used to
  * update the degrees of freedom belonging to the same block, but never to
- * update degrees of freedoms of other blocks. A block can be a consecutive
+ * update degrees of freedom of other blocks. A block can be a consecutive
  * list of indices, as in the first alternative below, or a nonconsecutive
  * list of indices. Of course, we assume that the intersection of each two
  * blocks is empty and that the union of all blocks equals the interval

--- a/tests/bits/joa_1.cc
+++ b/tests/bits/joa_1.cc
@@ -419,7 +419,7 @@ void LaplaceProblem<dim>::setup_system ()
 
 
   // After setting up all the degrees
-  // of freedoms, here are now the
+  // of freedom, here are now the
   // differences compared to step-5,
   // all of which are related to
   // constraints associated with the


### PR DESCRIPTION
Since 'degrees' is already plural 'freedom' should not be.

Follow up to #6643.