### PR TITLE
Update clang-format style file

### DIFF
--- a/examples/.clang-format
+++ b/examples/.clang-format
@@ -1,5 +1,6 @@
 #
-# The clang-format (Clang 6) style file used by deal.II.
+# The clang-format (Clang 6) style file used by deal.II for the examples.
+# In contrast to the general one, header files are not sorted.
 #
 
 AccessModifierOffset: -2
@@ -63,70 +64,6 @@ DerivePointerAlignment: false
 
 FixNamespaceComments: true
 
-IncludeBlocks: Regroup
-IncludeCategories:
-# config.h must always be first:
-  - Regex:    "deal.II/base/config.h"
-    Priority: -1
-# deal.II folders in sorted order:
-  - Regex:    "deal.II/algorithms/.*\\.h"
-    Priority: 110
-  - Regex:    "deal.II/base/.*\\.h"
-    Priority: 120
-  - Regex:    "deal.II/differentiation/.*\\.h"
-    Priority: 130
-  - Regex:    "deal.II/distributed/.*\\.h"
-    Priority: 140
-  - Regex:    "deal.II/dofs/.*\\.h"
-    Priority: 150
-  - Regex:    "deal.II/fe/.*\\.h"
-    Priority: 160
-  - Regex:    "deal.II/gmsh/.*\\.h"
-    Priority: 170
-  - Regex:    "deal.II/grid/.*\\.h"
-    Priority: 180
-  - Regex:    "deal.II/hp/.*\\.h"
-    Priority: 190
-  - Regex:    "deal.II/integrators/.*\\.h"
-    Priority: 200
-  - Regex:    "deal.II/lac/.*\\.h"
-    Priority: 210
-  - Regex:    "deal.II/matrix_free/.*\\.h"
-    Priority: 220
-  - Regex:    "deal.II/meshworker/.*\\.h"
-    Priority: 230
-  - Regex:    "deal.II/multigrid/.*\\.h"
-    Priority: 240
-  - Regex:    "deal.II/non_matching/.*\\.h"
-    Priority: 250
-  - Regex:    "deal.II/numerics/.*\\.h"
-    Priority: 260
-  - Regex:    "deal.II/opencascade/.*\\.h"
-    Priority: 270
-  - Regex:    "deal.II/optimization/.*\\.h"
-    Priority: 280
-  - Regex:    "deal.II/particles/.*\\.h"
-    Priority: 290
-  - Regex:    "deal.II/physics/.*\\.h"
-    Priority: 300
-  - Regex:    "deal.II/sundials/.*\\.h"
-    Priority: 310
-# put boost right after deal:
-  - Regex: "<boost.*>"
-    Priority: 500
-# try to group PETSc headers:
-  - Regex: "<petsc.*\\.h>"
-    Priority: 1000
-# try to catch all third party headers and put them after deal.II but before
-# standard headers:
-  - Regex: "<.*\\.(h|hpp|hxx)>"
-    Priority: 2000
-# match all standard headers. Things like '#include <armadillo>' should be
-# surrounded by #ifdef checks (which will not be merged by clang-format) so they
-# should not be caught here
-  - Regex: "<[a-z_]+>"
-    Priority: 100000
-
 IndentCaseLabels: true
 IndentPPDirectives: AfterHash
 IndentWidth: 2
@@ -146,7 +83,7 @@ PointerAlignment: Right
 ReflowComments: true
 CommentPragmas: '@(ref|p|copydoc) '
 
-SortIncludes: true
+SortIncludes: false
 SortUsingDeclarations: true
 
 SpaceAfterCStyleCast: false


### PR DESCRIPTION
This reflects the status of the `clang-format` options we agreed on in #6637. Since there are a lot of PRs based on #6637, I don't want to change anything there.
I am happy to keep this up-to-date.