### PR TITLE
Remove unnecessary PETSc include file

### DIFF
--- a/source/lac/exceptions.cc
+++ b/source/lac/exceptions.cc
@@ -18,9 +18,8 @@
 #include <deal.II/lac/exceptions.h>
 
 #ifdef DEAL_II_WITH_PETSC
-#include <petscconf.h>
-#include <petscsys.h>
-#include <petscerror.h>
+#  include <petscconf.h>
+#  include <petscsys.h>
 #endif // DEAL_II_WITH_PETSC
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
This is necessary for #6650. `clang-format` reorders the include files and it turns out that `petscerror.h` needs `petscsys.h`:

```
/mnt/data/darndt/Sources/petsc-3.9.1/include/petscerror.h:546:1: error: ‘PETSC_EXTERN’ does not name a type
 PETSC_EXTERN PetscErrorCode PetscError(MPI_Comm,int,const char*,const char*,PetscErrorCode,PetscErrorType,const char*,...);
 ^~~~~~~~~~~~
/mnt/data/darndt/Sources/petsc-3.9.1/include/petscerror.h:546:1: note: the macro ‘PETSC_EXTERN’ had not yet been defined
In file included from ../source/lac/exceptions.cc:23:
/mnt/data/darndt/Sources/petsc-3.9.1/include/petscsys.h:98: note: it was later defined here
 #define PETSC_EXTERN extern "C" PETSC_VISIBILITY_PUBLIC
```

In fact, `petscerror.h` is included in `petscsys.h` so we can just omit including it.