### PR TITLE
Only use progress bar in wget if available

### DIFF
--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -67,11 +67,15 @@ mkdir -p "${tmpdir}"
 cd "${tmpdir}"
 if [ -x "$(command -v wget)" ]; then
   echo "Using wget to download..."
-  wget -q --show-progress -L "${URL}/${FILENAME}" > /dev/null
+  # set progress option if available
+  wget --help | grep -q '\--show-progress' && \
+        _PROGRESS_OPT="--show-progress" || _PROGRESS_OPT=""
+
+  wget -q $_PROGRESS_OPT -L "${URL}/${FILENAME}" > /dev/null
 else
   if [ -x "$(command -v curl)" ]; then
     echo "Using curl to download..."
-    curl -s -L "${URL}/${FILENAME}" -O > /dev/null
+    curl --progress-bar -L "${URL}/${FILENAME}" -O > /dev/null
   else
     echo "Error: Neither wget nor curl is available..."
     exit 1


### PR DESCRIPTION
Older `wget` versions (prior to 1.16) don't support `--show-progress` (http://savannah.gnu.org/forum/forum.php?forum_id=8133). So we should check that the option really exists (https://stackoverflow.com/a/32491843).
On the other hand, there is a corresponding option for `curl`.