### PR TITLE
Avoid using one-dimensional arrays in place of multi-dimensional ones

### DIFF
--- a/examples/doxygen/block_matrix_array.cc
+++ b/examples/doxygen/block_matrix_array.cc
@@ -30,32 +30,32 @@
 
 using namespace dealii;
 
-double Adata[] =
+double Adata[4][4] =
 {
-  4., .5, .1, 0.,
-  .5, 4., .5, .1,
-  .1, .5, 4., .5,
-  0., .1, .5, 4.
+  {4., .5, .1, 0.},
+  {.5, 4., .5, .1},
+  {.1, .5, 4., .5},
+  {0., .1, .5, 4.}
 };
 
-double B1data[] =
+double B1data[4][2] =
 {
-  .5, .1,
-  .4, .2,
-  .3, .3,
-  .2, .4
+  {.5, .1},
+  {.4, .2},
+  {.3, .3},
+  {.2, .4}
 };
 
-double B2data[] =
+double B2data[2][4] =
 {
-  .3, 0., -.3, 0.,
-  -.3, 0., .3, 0.
+  {.3, 0., -.3, 0.},
+  {-.3, 0., .3, 0.}
 };
 
-double Cdata[] =
+double Cdata[2][2] =
 {
-  8., 1.,
-  1., 8.
+  {8., 1.},
+  {1., 8.}
 };
 
 int main ()
@@ -65,10 +65,10 @@ int main ()
   FullMatrix<float> B2(2,4);
   FullMatrix<float> C(2,2);
 
-  A.fill(Adata);
-  B1.fill(B1data);
-  B2.fill(B2data);
-  C.fill(Cdata);
+  A.fill(&Adata[0][0]);
+  B1.fill(&B1data[0][0]);
+  B2.fill(&B2data[0][0]);
+  C.fill(&Cdata[0][0]);
 
   BlockMatrixArray<double> matrix(2, 2);
 

--- a/tests/lac/householder.cc
+++ b/tests/lac/householder.cc
@@ -22,11 +22,11 @@
 #include <deal.II/lac/vector.h>
 
 
-const double rect[] =
+const double rect[3][4] =
 {
-  4., 3., 2., 1.,
-  5., 8., 1., -2.,
-  11., 13., -4., -5
+  {4., 3., 2., 1.},
+  {5., 8., 1., -2.},
+  {11., 13., -4., -5}
 };
 
 
@@ -36,7 +36,7 @@ int main()
   deallog << std::setprecision(3);
   deallog.attach(logfile);
 
-  FullMatrix<double> A(4,3,rect);
+  FullMatrix<double> A(4,3,&rect[0][0]);
   Householder<double> H(A);
 
   Vector<double> u(4);

--- a/tests/lapack/full_matrix_01.cc
+++ b/tests/lapack/full_matrix_01.cc
@@ -30,19 +30,19 @@
  * lambda = 5     v = (0, 1,-1, 0)
  * lambda = 5     v = (0, 0, 1,-1)
  */
-const double symm[] =
+const double symm[4][4] =
 {
-  4., -1., -1., -1.,
-  -1., 4., -1., -1.,
-  -1., -1., 4., -1.,
-  -1., -1., -1., 4.
+  {4., -1., -1., -1.},
+  {-1., 4., -1., -1.},
+  {-1., -1., 4., -1.},
+  {-1., -1., -1., 4.}
 };
 
-const double rect[] =
+const double rect[3][4] =
 {
-  4., 3., 2., 1.,
-  5., 8., 1., -2.,
-  11., 13., -4., -5
+  {4., 3., 2., 1.},
+  {5., 8., 1., -2.},
+  {11., 13., -4., -5}
 };
 
 
@@ -100,14 +100,13 @@ int main()
   logfile.precision(3);
   deallog.attach(logfile);
 
-  test_rect(3,4,rect);
-  test_rect(4,3,rect);
-  test_rect(4,4,symm);
+  test_rect(3,4,&rect[0][0]);
+  test_rect(4,3,&rect[0][0]);
+  test_rect(4,4,&symm[0][0]);
 
   // Test symmetric system
-  FullMatrix<double> A(4,4,symm);
+  FullMatrix<double> A(4,4,&symm[0][0]);
   LAPACKFullMatrix<double> LA(4,4);
-  A.fill(symm);
   LA = A;
   LA.compute_eigenvalues();
   for (unsigned int i=0; i<A.m(); ++i)

--- a/tests/lapack/full_matrix_03.cc
+++ b/tests/lapack/full_matrix_03.cc
@@ -30,19 +30,19 @@
  * lambda = 5     v = (0, 1,-1, 0)
  * lambda = 5     v = (0, 0, 1,-1)
  */
-const double symm[] =
+const double symm[4][4] =
 {
-  4., -1., -1., -1.,
-  -1., 4., -1., -1.,
-  -1., -1., 4., -1.,
-  -1., -1., -1., 4.
+  {4., -1., -1., -1.},
+  {-1., 4., -1., -1.},
+  {-1., -1., 4., -1.},
+  {-1., -1., -1., 4.}
 };
 
-const double rect[] =
+const double rect[3][4] =
 {
-  4., 3., 2., 1.,
-  5., 8., 1., -2.,
-  11., 13., -4., -5
+  {4., 3., 2., 1.},
+  {5., 8., 1., -2.},
+  {11., 13., -4., -5}
 };
 
 
@@ -116,14 +116,13 @@ int main()
   logfile.precision(3);
   deallog.attach(logfile);
 
-  test_rect(4,4,symm);
-  test_rect(4,3,rect);
-  test_rect(3,4,rect);
+  test_rect(4,4,&symm[0][0]);
+  test_rect(4,3,&rect[0][0]);
+  test_rect(3,4,&rect[0][0]);
 
   // Test symmetric system
-  FullMatrix<double> A(4,4,symm);
+  FullMatrix<double> A(4,4,&symm[0][0]);
   LAPACKFullMatrix<double> LA(4,4);
-  A.fill(symm);
   LA = A;
   LA.compute_eigenvalues();
   for (unsigned int i=0; i<A.m(); ++i)

--- a/tests/lapack/full_matrix_04.cc
+++ b/tests/lapack/full_matrix_04.cc
@@ -30,19 +30,19 @@
  * lambda = 5     v = (0, 1,-1, 0)
  * lambda = 5     v = (0, 0, 1,-1)
  */
-const double symm[] =
+const double symm[4][4] =
 {
-  4., -1., -1., -1.,
-  -1., 4., -1., -1.,
-  -1., -1., 4., -1.,
-  -1., -1., -1., 4.
+  {4., -1., -1., -1.},
+  {-1., 4., -1., -1.},
+  {-1., -1., 4., -1.},
+  {-1., -1., -1., 4.}
 };
 
-const double rect[] =
+const double rect[3][4] =
 {
-  4., 3., 2., 1.,
-  5., 8., 1., -2.,
-  11., 13., -4., -5
+  {4., 3., 2., 1.},
+  {5., 8., 1., -2.},
+  {11., 13., -4., -5}
 };
 
 
@@ -118,7 +118,7 @@ int main()
   logfile.precision(3);
   deallog.attach(logfile);
 
-  test_rect(4,4,symm);
-  test_rect(4,3,rect);
-  test_rect(3,4,rect);
+  test_rect(4,4,&symm[0][0]);
+  test_rect(4,3,&rect[0][0]);
+  test_rect(3,4,&rect[0][0]);
 }

--- a/tests/lapack/full_matrix_05.cc
+++ b/tests/lapack/full_matrix_05.cc
@@ -24,20 +24,20 @@
 #include <iostream>
 #include <vector>
 
-const double left[] =
+const double left[4][4] =
 {
-  4., -1., -1., -1.,
-  -1., 4., -1., -1.,
-  -1., -1., 4., -1.,
-  -1., -1., -1., 4.
+  {4., -1., -1., -1.},
+  {-1., 4., -1., -1.},
+  {-1., -1., 4., -1.},
+  {-1., -1., -1., 4.}
 };
 
-const double right[] =
+const double right[4][4] =
 {
-  4., -1., -1., -1.,
-  -1., 5., -1., -1.,
-  -1., -1., 6., -1.,
-  -1., -1., -1., 7.
+  {4., -1., -1., -1.},
+  {-1., 5., -1., -1.},
+  {-1., -1., 6., -1.},
+  {-1., -1., -1., 7.}
 };
 
 
@@ -49,8 +49,8 @@ int main()
   logfile.precision(1);
   deallog.attach(logfile);
 
-  FullMatrix<double> A(4,4,left),
-             B(4,4,right);
+  FullMatrix<double> A(4,4,&left[0][0]),
+             B(4,4,&right[0][0]);
   LAPACKFullMatrix<double> LA(4,4),
                    LB(4,4);
   for (unsigned int itype=1; itype<=3; ++itype)

--- a/tests/lapack/full_matrix_06.cc
+++ b/tests/lapack/full_matrix_06.cc
@@ -25,20 +25,20 @@
 #include <iostream>
 #include <vector>
 
-const double left[] =
+const double left[4][4] =
 {
-  4., -1., -1., -1.,
-  -1., 4., -1., -1.,
-  -1., -1., 4., -1.,
-  -1., -1., -1., 4.
+  {4., -1., -1., -1.},
+  {-1., 4., -1., -1.},
+  {-1., -1., 4., -1.},
+  {-1., -1., -1., 4.}
 };
 
-const double right[] =
+const double right[4][4] =
 {
-  4., -1., -1., -1.,
-  -1., 5., -1., -1.,
-  -1., -1., 6., -1.,
-  -1., -1., -1., 7.
+  {4., -1., -1., -1.},
+  {-1., 5., -1., -1.},
+  {-1., -1., 6., -1.},
+  {-1., -1., -1., 7.}
 };
 
 
@@ -50,8 +50,8 @@ int main()
   logfile.precision(1);
   deallog.attach(logfile);
 
-  FullMatrix<double> A(4,4,left),
-             B(4,4,right);
+  FullMatrix<double> A(4,4,&left[0][0]),
+             B(4,4,&right[0][0]);
   LAPACKFullMatrix<double> LA(4,4),
                    LB(4,4);
   for (unsigned int itype=1; itype<=3; ++itype)

--- a/tests/lapack/full_matrix_07.cc
+++ b/tests/lapack/full_matrix_07.cc
@@ -25,13 +25,12 @@
 #include <iostream>
 #include <vector>
 
-const double left[] =
+const double left[4][4] =
 {
-
-  1.75, -0.433012701892219, 0.0, 0.0,
-  -0.433012701892219, 1.25, 0.0, 0.0,
-  0.0, 0.0, 3.5, -0.5,
-  0.0, 0.0, -0.5, 3.5
+  {1.75, -0.433012701892219, 0.0, 0.0},
+  {-0.433012701892219, 1.25, 0.0, 0.0},
+  {0.0, 0.0, 3.5, -0.5},
+  {0.0, 0.0, -0.5, 3.5}
 };
 
 
@@ -43,7 +42,7 @@ int main()
   logfile.precision(1);
   deallog.attach(logfile);
 
-  FullMatrix<double> A(4,4,left);
+  FullMatrix<double> A(4,4,&left[0][0]);
   LAPACKFullMatrix<double> LA(4,4);
   LA = A;
   FullMatrix<double> eigenvectors;

--- a/tests/quick_tests/lapack.cc
+++ b/tests/quick_tests/lapack.cc
@@ -33,19 +33,19 @@
  * lambda = 5     v = (0, 1,-1, 0)
  * lambda = 5     v = (0, 0, 1,-1)
  */
-const double symm[] =
+const double symm[4][4] =
 {
-  4., -1., -1., -1.,
-  -1., 4., -1., -1.,
-  -1., -1., 4., -1.,
-  -1., -1., -1., 4.
+  {4., -1., -1., -1.},
+  {-1., 4., -1., -1.},
+  {-1., -1., 4., -1.},
+  {-1., -1., -1., 4.}
 };
 
-const double rect[] =
+const double rect[3][4] =
 {
-  4., 3., 2., 1.,
-  5., 8., 1., -2.,
-  11., 13., -4., -5
+  {4., 3., 2., 1.},
+  {5., 8., 1., -2.},
+  {11., 13., -4., -5}
 };
 
 using namespace dealii;
@@ -104,14 +104,13 @@ int main()
   logfile.precision(3);
   deallog.attach(logfile);
 
-  test_rect(3,4,rect);
-  test_rect(4,3,rect);
-  test_rect(4,4,symm);
+  test_rect(3,4,&rect[0][0]);
+  test_rect(4,3,&rect[0][0]);
+  test_rect(4,4,&symm[0][0]);
 
   // Test symmetric system
-  FullMatrix<double> A(4,4,symm);
+  FullMatrix<double> A(4,4,&symm[0][0]);
   LAPACKFullMatrix<double> LA(4,4);
-  A.fill(symm);
   LA = A;
   LA.compute_eigenvalues();
   for (unsigned int i=0; i<A.m(); ++i)


### PR DESCRIPTION
There are some places where we write multi-dimensional arrays as one-dimensional arrays.
`clang-format` would not preserve the formatting. Therefore, this PRs rewrites the respective objects as multi-dimensional arrays. Of course, this doesn't change the representation in memory, but only the access (using `&array[0][0]` instead of `array`).