### PR TITLE
Fix failing test after applying clang-format

### DIFF
--- a/include/deal.II/base/vector_slice.h
+++ b/include/deal.II/base/vector_slice.h
@@ -187,8 +187,8 @@ VectorSlice<VectorType>::VectorSlice(VectorType   &v,
   :
   v(v), start(start), length(length)
 {
-  Assert((start+length<=v.size()),
-         ExcIndexRange(length, 0, v.size()-start+1));
+  Assert((start + length <= v.size()),
+         ExcIndexRange(length, 0, v.size() - start + 1));
 }
 
 

--- a/tests/base/slice_vector.debug.output
+++ b/tests/base/slice_vector.debug.output
@@ -1,4 +1,4 @@
 
 DEAL::	0	1	2	0	1	2	3
 DEAL::	2	0	1
-DEAL::ExcIndexRange(length, 0, v.size()-start+1)
+DEAL::ExcIndexRange(length, 0, v.size() - start + 1)

--- a/tests/petsc/exception_messages.cc
+++ b/tests/petsc/exception_messages.cc
@@ -22,7 +22,6 @@
 
 #include <petscconf.h>
 #include <petscsys.h>
-#include <petscerror.h>
 
 #include <vector>
 

--- a/tests/petsc_complex/assemble_01.cc
+++ b/tests/petsc_complex/assemble_01.cc
@@ -27,6 +27,8 @@
 
 #include "../tests.h"
 
+#include <numeric>
+
 
 int main (int argc,char **argv)
 {

--- a/tests/test_grids.h
+++ b/tests/test_grids.h
@@ -18,6 +18,8 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/grid_generator.h>
 
+using namespace dealii;
+
 /**
  * A set of test meshes for the deal.II test suite.
  *

--- a/tests/test_grids.h
+++ b/tests/test_grids.h
@@ -18,7 +18,7 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/grid_generator.h>
 
-using namespace dealii;
+#include "tests.h"
 
 /**
  * A set of test meshes for the deal.II test suite.


### PR DESCRIPTION
There were still some failing tests after applying `clang-format`:
- Again, there was the issue with including `petscerror.h`.
- Due to the new header file ordering,  `tests/test_grids.h` didn't assume `dealii::`.
- The formatting also changed the output for `base/slice_vector`. Luckily, this survived applying `astyle` again.