### PR TITLE
Separate 'inline' onto a line of its own.

### DIFF
--- a/include/deal.II/differentiation/ad/adolc_math.h
+++ b/include/deal.II/differentiation/ad/adolc_math.h
@@ -44,8 +44,10 @@ namespace std
    * Make a unary function with one name available under a different name
    */
 #define DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION_COPY(func_to, func_from) \
-  inline adouble func_to(const adouble &x) {return func_from(static_cast<const badouble &>(x));} \
-  inline adtl::adouble func_to(const adtl::adouble &x) {return adtl::func_from(x);}
+  inline \
+  adouble func_to(const adouble &x) {return func_from(static_cast<const badouble &>(x));} \
+  inline \
+  adtl::adouble func_to(const adtl::adouble &x) {return adtl::func_from(x);}
 
   /**
    * Expose a unary function
@@ -57,12 +59,18 @@ namespace std
    * Make a binary function with one name available under a different name
    */
 #define DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY(func_to,func_from) \
-  inline adouble func_to(const adouble &x, const adouble &y) {return func_from(static_cast<const badouble &>(x),static_cast<const badouble &>(y));} \
-  inline adouble func_to(const double &x,  const adouble &y) {return func_from(x,static_cast<const badouble &>(y));} \
-  inline adouble func_to(const adouble &x, const double  &y) {return func_from(static_cast<const badouble &>(x),y);} \
-  inline adtl::adouble func_to(const adtl::adouble &x, const adtl::adouble &y) {return adtl::func_from(x,y);} \
-  inline adtl::adouble func_to(const double &x, const adtl::adouble &y) {return adtl::func_from(x,y);} \
-  inline adtl::adouble func_to(const adtl::adouble &x, const double &y) {return adtl::func_from(x,y);}
+  inline \
+  adouble func_to(const adouble &x, const adouble &y) {return func_from(static_cast<const badouble &>(x),static_cast<const badouble &>(y));} \
+  inline \
+  adouble func_to(const double &x,  const adouble &y) {return func_from(x,static_cast<const badouble &>(y));} \
+  inline \
+  adouble func_to(const adouble &x, const double  &y) {return func_from(static_cast<const badouble &>(x),y);} \
+  inline \
+  adtl::adouble func_to(const adtl::adouble &x, const adtl::adouble &y) {return adtl::func_from(x,y);} \
+  inline \
+  adtl::adouble func_to(const double &x, const adtl::adouble &y) {return adtl::func_from(x,y);} \
+  inline \
+  adtl::adouble func_to(const adtl::adouble &x, const double &y) {return adtl::func_from(x,y);}
 
   /**
    * Expose a binary function
@@ -74,8 +82,10 @@ namespace std
    * Expose a binary function
    */
 #define DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_2(func) \
-  inline adouble func(const adouble &x, const adouble &y) {return func(static_cast<const badouble &>(x),static_cast<const badouble &>(y));} \
-  inline adtl::adouble func(const adtl::adouble &x, const adtl::adouble &y) {return adtl::func(x,y);}
+  inline \
+  adouble func(const adouble &x, const adouble &y) {return func(static_cast<const badouble &>(x),static_cast<const badouble &>(y));} \
+  inline \
+  adtl::adouble func(const adtl::adouble &x, const adtl::adouble &y) {return adtl::func(x,y);}
 
   // See
   // https://gitlab.com/adol-c/adol-c/blob/master/ADOL-C/include/adolc/adouble.h
@@ -93,11 +103,13 @@ namespace std
   DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(sqrt)
 #if defined(DEAL_II_ADOLC_WITH_ATRIG_ERF)
   DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(erf)
-  inline adouble erfc(const adouble &x)
+  inline
+  adouble erfc(const adouble &x)
   {
     return 1.0 - std::erf(x);
   } \
-  inline adtl::adouble erfc(const adtl::adouble &x)
+  inline
+  adtl::adouble erfc(const adtl::adouble &x)
   {
     return 1.0 - std::erf(x);
   }

--- a/include/deal.II/differentiation/ad/sacado_math.h
+++ b/include/deal.II/differentiation/ad/sacado_math.h
@@ -40,7 +40,8 @@ namespace std
              dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value &&
              dealii::Differentiation::AD::is_real_valued_ad_number<ADNumberType>::value
              >::type>
-  inline ADNumberType erf(ADNumberType x)
+  inline
+  ADNumberType erf(ADNumberType x)
   {
     // Reference:
     // Handbook of Mathematical Functions: with Formulas, Graphs, and Mathematical Tables
@@ -82,7 +83,8 @@ namespace std
   template<typename ADNumberType, typename = typename std::enable_if<
              dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value
              >::type>
-  inline ADNumberType erfc(const ADNumberType &x)
+  inline
+  ADNumberType erfc(const ADNumberType &x)
   {
     return 1.0 - std::erf(x);
   }

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -53,7 +53,8 @@ namespace DoFTools
   {
     namespace
     {
-      inline bool
+      inline
+      bool
       check_master_dof_list (const FullMatrix<double> &face_interpolation_matrix,
                              const std::vector<types::global_dof_index> &master_dof_list)
       {

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -1852,11 +1852,12 @@ next_cell:
    * is parallel to the unit vector in <direction>
    */
   template <int spacedim>
-  inline bool orthogonal_equality (const Point<spacedim>    &point1,
-                                   const Point<spacedim>    &point2,
-                                   const int                 direction,
-                                   const Tensor<1,spacedim> &offset,
-                                   const FullMatrix<double> &matrix)
+  inline
+  bool orthogonal_equality (const Point<spacedim>    &point1,
+                            const Point<spacedim>    &point2,
+                            const int                 direction,
+                            const Tensor<1,spacedim> &offset,
+                            const FullMatrix<double> &matrix)
   {
     Assert (0<=direction && direction<spacedim,
             ExcIndexRange (direction, 0, spacedim));
@@ -1967,7 +1968,8 @@ next_cell:
 
 
   template <typename FaceIterator>
-  inline bool
+  inline
+  bool
   orthogonal_equality (std::bitset<3>     &orientation,
                        const FaceIterator &face1,
                        const FaceIterator &face2,
@@ -2015,7 +2017,8 @@ next_cell:
 
 
   template <typename FaceIterator>
-  inline bool
+  inline
+  bool
   orthogonal_equality (const FaceIterator &face1,
                        const FaceIterator &face2,
                        const int          direction,

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2129,8 +2129,9 @@ namespace internal
        */
       struct QuadComparator
       {
-        inline bool operator () (const internal::TriangulationImplementation::TriaObject<2> &q1,
-                                 const internal::TriangulationImplementation::TriaObject<2> &q2) const
+        inline
+        bool operator () (const internal::TriangulationImplementation::TriaObject<2> &q1,
+                          const internal::TriangulationImplementation::TriaObject<2> &q2) const
         {
           // here is room to
           // optimize the repeated

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -34,34 +34,40 @@ DEAL_II_NAMESPACE_OPEN
 #ifdef DEAL_II_WITH_HDF5
 
 template<typename number>
-inline hid_t hdf5_type_id (const number *)
+inline
+hid_t hdf5_type_id (const number *)
 {
   Assert (false, dealii::ExcNotImplemented());
   //don't know what to put here; it does not matter
   return -1;
 }
 
-inline hid_t hdf5_type_id (const double *)
+inline
+hid_t hdf5_type_id (const double *)
 {
   return H5T_NATIVE_DOUBLE;
 }
 
-inline hid_t hdf5_type_id (const float *)
+inline
+hid_t hdf5_type_id (const float *)
 {
   return H5T_NATIVE_FLOAT;
 }
 
-inline hid_t hdf5_type_id (const int *)
+inline
+hid_t hdf5_type_id (const int *)
 {
   return H5T_NATIVE_INT;
 }
 
-inline hid_t hdf5_type_id (const unsigned int *)
+inline
+hid_t hdf5_type_id (const unsigned int *)
 {
   return H5T_NATIVE_UINT;
 }
 
-inline hid_t hdf5_type_id (const char *)
+inline
+hid_t hdf5_type_id (const char *)
 {
   return H5T_NATIVE_CHAR;
 }

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -316,7 +316,8 @@ namespace internal
     }
 
     // Transform the ghost indices to local index space for the vector
-    inline void
+    inline
+    void
     copy_indices_to_mpi_local_numbers(const Utilities::MPI::Partitioner &part,
                                       const std::vector<types::global_dof_index> &mine,
                                       const std::vector<types::global_dof_index> &remote,

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -47,7 +47,8 @@ DEAL_II_NAMESPACE_OPEN
 namespace
 {
   template <typename T>
-  inline T sqr (const T t)
+  inline
+  T sqr (const T t)
   {
     return t*t;
   }

--- a/tests/base/mpi_some_to_some_02.cc
+++ b/tests/base/mpi_some_to_some_02.cc
@@ -28,7 +28,8 @@
 
 using namespace Patterns::Tools;
 
-inline unsigned int random_index(const unsigned int &max_index)
+inline
+unsigned int random_index(const unsigned int &max_index)
 {
   return Testing::rand()*(max_index-1)/RAND_MAX;
 }

--- a/tests/fe/bdm_1.cc
+++ b/tests/fe/bdm_1.cc
@@ -30,7 +30,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 plot_shape_functions(const unsigned int degree)
 {
   FE_BDM<dim> fe_bdm(degree);

--- a/tests/fe/derivatives.cc
+++ b/tests/fe/derivatives.cc
@@ -31,7 +31,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 plot_derivatives(Mapping<dim> &mapping,
                  FiniteElement<dim> &finel,
                  const char *name)

--- a/tests/fe/derivatives_bernstein.cc
+++ b/tests/fe/derivatives_bernstein.cc
@@ -31,7 +31,8 @@
 //#include "../../include/fe_bernstein.h"
 
 template <int dim>
-inline void
+inline
+void
 plot_derivatives(Mapping<dim> &mapping,
                  FiniteElement<dim> &finel,
                  const char *name)

--- a/tests/fe/derivatives_face.cc
+++ b/tests/fe/derivatives_face.cc
@@ -31,7 +31,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 plot_derivatives(Mapping<dim> &mapping,
                  FiniteElement<dim> &finel,
                  const char *name)

--- a/tests/fe/fe_face_values_1d.cc
+++ b/tests/fe/fe_face_values_1d.cc
@@ -41,7 +41,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 plot_faces(Mapping<dim> &mapping,
            FiniteElement<dim> &fe,
            typename DoFHandler<dim>::cell_iterator &cell)
@@ -86,7 +87,8 @@ plot_faces(Mapping<dim> &mapping,
 
 
 template <int dim>
-inline void
+inline
+void
 plot_subfaces(Mapping<dim> &mapping,
               FiniteElement<dim> &fe,
               typename DoFHandler<dim>::cell_iterator &cell)

--- a/tests/fe/fe_prolongation_common.h
+++ b/tests/fe/fe_prolongation_common.h
@@ -62,7 +62,8 @@ void print_formatted (const FullMatrix<number> &A,
 
 
 template <int dim>
-inline void
+inline
+void
 check_prolongation (FiniteElement<dim> &fe, const char *name)
 {
   deallog << name << '<' << dim << '>' << " constraint " << std::endl;

--- a/tests/fe/fe_restriction_common.h
+++ b/tests/fe/fe_restriction_common.h
@@ -58,7 +58,8 @@ void print_formatted (const FullMatrix<number> &A,
 
 
 template <int dim>
-inline void
+inline
+void
 check_restriction (FiniteElement<dim> &fe, const char *name)
 {
   deallog << name << '<' << dim << '>' << " constraint " << std::endl;

--- a/tests/fe/fe_support_points_common.h
+++ b/tests/fe/fe_support_points_common.h
@@ -42,7 +42,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 check_support (const FiniteElement<dim> &finel, const char *name)
 {
   Triangulation<dim> tr;

--- a/tests/fe/nedelec.cc
+++ b/tests/fe/nedelec.cc
@@ -97,7 +97,8 @@ transform_grid (Triangulation<2> &tria,
 
 
 template <int dim>
-inline void
+inline
+void
 plot_shape_functions(const unsigned int degree)
 {
   FE_Nedelec<dim> element(degree);

--- a/tests/fe/nedelec_2.cc
+++ b/tests/fe/nedelec_2.cc
@@ -174,7 +174,8 @@ plot (const Triangulation<dim> &tr, const unsigned int p)
 
 
 template <int dim>
-inline void
+inline
+void
 check (const unsigned int p)
 {
   Triangulation<dim> tr;

--- a/tests/fe/nedelec_3.cc
+++ b/tests/fe/nedelec_3.cc
@@ -36,7 +36,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 check (const unsigned int p)
 {
   deallog << dim << "-D" << std::endl;

--- a/tests/fe/rt_1.cc
+++ b/tests/fe/rt_1.cc
@@ -30,7 +30,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 plot_shape_functions(const unsigned int degree)
 {
   std::ostringstream prefix;

--- a/tests/fe/rt_bubbles_1.cc
+++ b/tests/fe/rt_bubbles_1.cc
@@ -29,7 +29,8 @@
 
 
 template<int dim>
-inline void
+inline
+void
 plot_shape_functions(const unsigned int degree)
 {
   std::ostringstream prefix;

--- a/tests/fe/shapes.h
+++ b/tests/fe/shapes.h
@@ -27,7 +27,8 @@ char fname[50];
 // x (y) (z) value[0]+1 value[1]+1 ...
 ////////////////////////////////////////////////////////////////////////////
 template <int dim>
-inline void
+inline
+void
 plot_shape_functions(Mapping<dim> &mapping,
                      FiniteElement<dim> &finel,
                      const char *name)
@@ -99,7 +100,8 @@ plot_shape_functions(Mapping<dim> &mapping,
 
 
 template <int dim>
-inline void
+inline
+void
 plot_face_shape_functions(
   Mapping<dim> &mapping,
   FiniteElement<dim> &finel,

--- a/tests/fe/transfer.cc
+++ b/tests/fe/transfer.cc
@@ -37,7 +37,8 @@
     print_matrix(tr ## dim, l, fe, #el); }
 
 template <int dim>
-inline void
+inline
+void
 print_matrix(Triangulation<dim> &tr,
              unsigned int level,
              const FiniteElement<dim> &finel,

--- a/tests/hp/hp_constraints_neither_dominate_02.cc
+++ b/tests/hp/hp_constraints_neither_dominate_02.cc
@@ -78,7 +78,8 @@ using namespace dealii;
 template <int dim>
 struct less_than_key
 {
-  inline bool operator() (const std::pair<Point<dim>,Vector<double> > &pair1, const std::pair<Point<dim>,Vector<double> > &pair2)
+  inline
+  bool operator() (const std::pair<Point<dim>,Vector<double> > &pair1, const std::pair<Point<dim>,Vector<double> > &pair2)
   {
     const double precision = 1e-3;
     const Point<dim> &p1 = pair1.first;

--- a/tests/mappings/fe_face_values_1d_mapping_cartesian.cc
+++ b/tests/mappings/fe_face_values_1d_mapping_cartesian.cc
@@ -40,7 +40,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 plot_faces(Mapping<dim> &mapping,
            FiniteElement<dim> &fe,
            typename DoFHandler<dim>::cell_iterator &cell)
@@ -85,7 +86,8 @@ plot_faces(Mapping<dim> &mapping,
 
 
 template <int dim>
-inline void
+inline
+void
 plot_subfaces(Mapping<dim> &mapping,
               FiniteElement<dim> &fe,
               typename DoFHandler<dim>::cell_iterator &cell)

--- a/tests/mappings/fe_face_values_1d_mapping_q2.cc
+++ b/tests/mappings/fe_face_values_1d_mapping_q2.cc
@@ -40,7 +40,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 plot_faces(Mapping<dim> &mapping,
            FiniteElement<dim> &fe,
            typename DoFHandler<dim>::cell_iterator &cell)
@@ -85,7 +86,8 @@ plot_faces(Mapping<dim> &mapping,
 
 
 template <int dim>
-inline void
+inline
+void
 plot_subfaces(Mapping<dim> &mapping,
               FiniteElement<dim> &fe,
               typename DoFHandler<dim>::cell_iterator &cell)

--- a/tests/mappings/mapping.cc
+++ b/tests/mappings/mapping.cc
@@ -40,7 +40,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 plot_transformation(Mapping<dim> &mapping,
                     FiniteElement<dim> &fe,
                     typename DoFHandler<dim>::cell_iterator &cell,
@@ -80,7 +81,8 @@ plot_transformation(Mapping<dim> &mapping,
 
 
 template <int dim>
-inline void
+inline
+void
 plot_faces(Mapping<dim> &mapping,
            FiniteElement<dim> &fe,
            typename DoFHandler<dim>::cell_iterator &cell,
@@ -124,7 +126,8 @@ plot_faces(Mapping<dim> &mapping,
 
 
 template <int dim>
-inline void
+inline
+void
 plot_subfaces(Mapping<dim> &mapping,
               FiniteElement<dim> &fe,
               typename DoFHandler<dim>::cell_iterator &cell,
@@ -170,7 +173,8 @@ plot_subfaces(Mapping<dim> &mapping,
 
 
 template <>
-inline void
+inline
+void
 plot_faces(Mapping<1> &,
            FiniteElement<1> &,
            DoFHandler<1>::cell_iterator &,
@@ -180,7 +184,8 @@ plot_faces(Mapping<1> &,
 
 
 template <>
-inline void
+inline
+void
 plot_subfaces(Mapping<1> &,
               FiniteElement<1> &,
               DoFHandler<1>::cell_iterator &,
@@ -190,7 +195,8 @@ plot_subfaces(Mapping<1> &,
 
 
 template <int dim>
-inline void
+inline
+void
 compute_area(Mapping<dim> &mapping,
              FiniteElement<dim> &fe,
              typename DoFHandler<dim>::cell_iterator &cell)

--- a/tests/mappings/mapping_q1_eulerian.cc
+++ b/tests/mappings/mapping_q1_eulerian.cc
@@ -30,7 +30,8 @@
 
 
 template <int dim>
-inline void
+inline
+void
 show_values(FiniteElement<dim> &fe,
             const char *name)
 {

--- a/tests/multigrid/smoother_block.cc
+++ b/tests/multigrid/smoother_block.cc
@@ -83,7 +83,8 @@ ScalingMatrix<number>::ScalingMatrix(number factor)
 
 template <typename number>
 template <typename VectorType>
-inline void
+inline
+void
 ScalingMatrix<number>::vmult (VectorType &dst, const VectorType &src) const
 {
   dst.equ(factor, src);
@@ -91,7 +92,8 @@ ScalingMatrix<number>::vmult (VectorType &dst, const VectorType &src) const
 
 template <typename number>
 template <typename VectorType>
-inline void
+inline
+void
 ScalingMatrix<number>::Tvmult (VectorType &dst, const VectorType &src) const
 {
   dst.equ(factor, src);
@@ -99,7 +101,8 @@ ScalingMatrix<number>::Tvmult (VectorType &dst, const VectorType &src) const
 
 template <typename number>
 template <typename VectorType>
-inline void
+inline
+void
 ScalingMatrix<number>::vmult_add (VectorType &dst, const VectorType &src) const
 {
   dst.add(factor, src);
@@ -109,7 +112,8 @@ ScalingMatrix<number>::vmult_add (VectorType &dst, const VectorType &src) const
 
 template <typename number>
 template <typename VectorType>
-inline void
+inline
+void
 ScalingMatrix<number>::Tvmult_add (VectorType &dst, const VectorType &src) const
 {
   dst.add(factor, src);

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -238,8 +238,9 @@ T random_value(const T &min=static_cast<T>(0),
 // Construct a uniformly distributed random point, with each coordinate
 // between min and max
 template<int dim>
-inline Point<dim> random_point(const double &min=0.0,
-                               const double &max=1.0)
+inline
+Point<dim> random_point(const double &min=0.0,
+                        const double &max=1.0)
 {
   Assert(max >= min, ExcMessage("Make sure max>=min"));
   Point<dim> p;
@@ -385,7 +386,8 @@ Number filter_out_small_numbers (const Number number, const double tolerance)
  * Limit concurrency to a fixed (small) number of threads, independent
  * of the core count.
  */
-inline unsigned int testing_max_num_threads()
+inline
+unsigned int testing_max_num_threads()
 {
   return 3;
 }


### PR DESCRIPTION
This has been discussed in #6650 and #6660, but it is a change that we can
already do now, without having to wait for clang-format. In fact, if I
read it right, then clang-format cannot do this itself. But regardless of
whether it can or can not do this on its own, I think it is worth doing
it and with a patch such as this, we get it out of the way already now
without having to put it into the 'one monumental patch' that is about
to come anyway.