### PR TITLE
Add script that reindents recently changed files.

### DIFF
--- a/cmake/setup_custom_targets.cmake
+++ b/cmake/setup_custom_targets.cmake
@@ -100,6 +100,16 @@ IF(NOT DEAL_II_COMPONENT_PACKAGE)
 ENDIF()
 
 #
+# Provide an indentation target for indenting uncommitted changes and changes on
+# the current feature branch
+#
+ADD_CUSTOM_TARGET(indent-branch
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND ./contrib/utilities/indent-branch
+  COMMENT "Indenting recently changed files in the deal.II directories"
+  )
+
+#
 # Provide "indent" target for indenting all headers and source files
 #
 ADD_CUSTOM_TARGET(indent
@@ -145,7 +155,9 @@ FILE(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/print_info.cmake
 #    setup_tests    - set up testsuite subprojects
 #    prune_tests    - remove all testsuite subprojects
 #
-#    indent         - indent all headers and source file
+#    indent         - indent all headers and source files
+#    indent-branch  - indent all headers and source files that changed since the
+#                     last commit to master, including untracked ones
 ")
 
 #

--- a/contrib/utilities/indent-branch
+++ b/contrib/utilities/indent-branch
@@ -1,0 +1,55 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2018 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+#
+# This script does the same thing as contrib/utilities/indent but only reformats
+# files which have changed (or been added and not committed) since the last
+# merge commit to the master branch. It should be run as
+#
+#    make indent-branch
+#
+# from a build directory.
+#
+
+if [ ! -f contrib/utilities/indent_common.sh ]; then
+  echo "*** This script must be run from the top-level directory of deal.II."
+  exit 1
+fi
+
+source contrib/utilities/indent_common.sh
+
+#
+# Run sanity checks:
+#
+
+checks
+
+#
+# Process all source and header files:
+#
+
+process_changed "tests include source examples" ".*\.(cc|h|cu|cuh)" format_file
+process_changed "source" ".*\.inst.in" format_inst
+
+#
+# Fix permissions and convert to unix line ending if necessary:
+#
+
+process_changed "tests include source examples" \
+  ".*\.(cc|h|cu|cuh|inst.in|output.*|cmake)" fix_permissions
+
+process_changed "tests include source examples" \
+  ".*\.(cc|h|cu|cuh|inst.in|cmake)" dos_to_unix

--- a/contrib/utilities/indent-branch
+++ b/contrib/utilities/indent-branch
@@ -15,9 +15,10 @@
 ## ---------------------------------------------------------------------
 
 #
-# This script does the same thing as contrib/utilities/indent but only reformats
-# files which have changed (or been added and not committed) since the last
-# merge commit to the master branch. It should be run as
+# This script does the same thing as contrib/utilities/indent but only
+# reformats files which have changed (or have been added but neither
+# staged/commited) since the last merge commit to the master branch. It
+# should be run as
 #
 #    make indent-branch
 #

--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -177,3 +177,21 @@ process()
   esac
 }
 
+#
+# Variant of above function that only processes files that have changed
+# since the last merge commit to master. For this, we collect all files
+# that
+#  - are new
+#  - have changed since the last merge commit to master
+#
+
+process_changed()
+{
+  LAST_MERGE_COMMIT="$(git log --format="%H" --merges --max-count=1 master)"
+
+  ( git ls-files -z --others --exclude-standard -- ${1};
+    git diff -z --name-only $LAST_MERGE_COMMIT -- ${1} )|
+      sort -zu |
+      grep -zE "^${2}$" |
+      xargs --no-run-if-empty -0 -n 1 -P 10 -I {} bash -c "${3} {}"
+}

--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -189,9 +189,9 @@ process_changed()
 {
   LAST_MERGE_COMMIT="$(git log --format="%H" --merges --max-count=1 master)"
 
-  ( git ls-files -z --others --exclude-standard -- ${1};
-    git diff -z --name-only $LAST_MERGE_COMMIT -- ${1} )|
-      sort -zu |
-      grep -zE "^${2}$" |
-      xargs --no-run-if-empty -0 -n 1 -P 10 -I {} bash -c "${3} {}"
+  ( git ls-files --others --exclude-standard -- ${1};
+    git diff --name-only $LAST_MERGE_COMMIT -- ${1} )|
+      sort -u |
+      grep -E "^${2}$" |
+      xargs --no-run-if-empty -d '\n' -n 1 -P 10 -I {} bash -c "${3} {}"
 }


### PR DESCRIPTION
My laptop needs about 30s to run clang-format since the script currently reindents all files regardless of whether or not they have been modified. This PR adds a new target indent-branch that only reindents files that have been modified (or added) since the last commit to master. This takes less than a second to run (with a few files changed) on my laptop.