### PR TITLE
Bugfix: Reindent indent and fix find invocation

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -60,29 +60,46 @@ if [ "${CLANG_FORMAT_MAJOR_VERSION}" -ne 6 ] || [ "${CLANG_FORMAT_MINOR_VERSION}
   exit 1
 fi
 
+#
+# collect all header and source files and process them in batches of 50
+# files with up to 10 in parallel
+#
 
+find tests include source examples \
+  \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print0 |
+  xargs -0 -n 50 -P 10 clang-format -i
 
-# collect all header and source files and process them in batches of 50 files
-# with up to 10 in parallel
-find tests include source examples \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print0 | xargs -0 -n 50 -P 10 clang-format -i
-
+#
 # use the same process to set file permissions for all source files
-find tests include source examples \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print0 | xargs -0 -n 50 -P 10 chmod 644
+#
 
+find tests include source examples \
+  \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print0 |
+  xargs -0 -n 50 -P 10 chmod 644
+
+#
 # convert dos formatted files to unix file format by stripping out
 # carriage returns (15=0x0D):
+#
+
 dos_to_unix()
 {
-    f=$1
-    tr -d '\015' <"$f" >"$f.tmp"
-    diff -q "$f" "$f.tmp" >/dev/null || mv "$f.tmp" "$f"
-    rm -f "$f.tmp"
+  f=$1
+  tr -d '\015' <"$f" >"$f.tmp"
+  diff -q "$f" "$f.tmp" >/dev/null || mv "$f.tmp" "$f"
+  rm -f "$f.tmp"
 }
 export -f dos_to_unix
-find tests include source examples \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print0 | xargs -0 -n 1 -P 10 -I {} bash -c 'dos_to_unix "$@"' _ {}
 
+find tests include source examples \
+  \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print0 |
+  xargs -0 -n 1 -P 10 -I {} bash -c 'dos_to_unix "$@"' _ {}
+
+#
 # format .inst.in files. We need to replace \{ and \} because it confuses
 # clang-format
+#
+
 format_inst()
 {
     f=$1
@@ -100,4 +117,5 @@ format_inst()
 }
 export -f format_inst
 
-find source -name '*.inst.in' -exec bash -c 'format_inst "$@"' bash {} +
+find source -name '*.inst.in' -print0 |
+  xargs -0 -n 1 -P 10 -I {} bash -c 'format_inst "$@"' _ {}

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -96,19 +96,22 @@ find tests include source examples \
   xargs -0 -n 1 -P 10 -I {} bash -c 'dos_to_unix "$@"' _ {}
 
 #
-# format .inst.in files. We need to replace \{ and \} because it confuses
-# clang-format
+# format .inst.in files. We need to replace \{ and \} by a sentinel because
+# clang-format happily strips away the backslash. Further, there is a minor
+# caveat: clang-format automatically renames a comment after a closing
+# bracket for a namespace to "} // namespace FooBar". Thus use "namespace"
+# as keyword:
 #
 
 format_inst()
 {
     f=$1
     cp "$f" "$f.tmp"
-    sed -i.orig 's#\\{#{ //#g' "$f.tmp"
-    sed -i.orig 's#\\}#} //#g' "$f.tmp"
+    sed -i.orig 's#\\{#{ // namespace#g' "$f.tmp"
+    sed -i.orig 's#\\}#} // namespace#g' "$f.tmp"
     clang-format -i "$f.tmp"
-    sed -i.orig 's#{ //#\\{#g' "$f.tmp"
-    sed -i.orig 's#} //#\\}#g' "$f.tmp"
+    sed -i.orig 's#{ // namespace#\\{#g' "$f.tmp"
+    sed -i.orig 's#}[ ]*// namespace.*#\\}#g' "$f.tmp"
     if ! diff -q "$f" "$f.tmp" >/dev/null
     then
       cp "$f.tmp" "$f"

--- a/source/base/bounding_box.inst.in
+++ b/source/base/bounding_box.inst.in
@@ -15,7 +15,6 @@
 
 
 for (deal_II_dimension : SPACE_DIMENSIONS; number : REAL_SCALARS)
-{
-    template
-    class BoundingBox<deal_II_dimension,number>;
-}
+  {
+    template class BoundingBox<deal_II_dimension, number>;
+  }

--- a/source/base/data_out_base.inst.in
+++ b/source/base/data_out_base.inst.in
@@ -14,144 +14,172 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : OUTPUT_DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : OUTPUT_DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class DataOutInterface<deal_II_dimension, deal_II_space_dimension>;
     template class DataOutReader<deal_II_dimension, deal_II_space_dimension>;
 
     namespace DataOutBase
     \{
-    template struct Patch<deal_II_dimension, deal_II_space_dimension>;
+      template struct Patch<deal_II_dimension, deal_II_space_dimension>;
 
-    template
-    std::ostream &
-    operator << (std::ostream                           &out,
-                 const Patch<deal_II_dimension, deal_II_space_dimension> &patch);
+      template std::ostream &
+      operator<<(
+        std::ostream &                                           out,
+        const Patch<deal_II_dimension, deal_II_space_dimension> &patch);
 
-    template
-    std::istream &
-    operator >> (std::istream                     &in,
+      template std::istream &
+      operator>>(std::istream &                                     in,
                  Patch<deal_II_dimension, deal_II_space_dimension> &patch);
 
-    template
-    void
-    write_vtk (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-               const std::vector<std::string>          &data_names,
-               const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-               const VtkFlags                          &flags,
-               std::ostream                            &out);
+      template void
+      write_vtk(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &             vector_data_ranges,
+        const VtkFlags &flags,
+        std::ostream &  out);
 
-    template
-    void
-    write_vtu (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-               const std::vector<std::string>          &data_names,
-               const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-               const VtkFlags                          &flags,
-               std::ostream                            &out);
+      template void
+      write_vtu(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &             vector_data_ranges,
+        const VtkFlags &flags,
+        std::ostream &  out);
 
-    template
-    void
-    write_ucd (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-               const std::vector<std::string>          &data_names,
-               const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-               const UcdFlags                          &flags,
-               std::ostream                            &out);
+      template void
+      write_ucd(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &             vector_data_ranges,
+        const UcdFlags &flags,
+        std::ostream &  out);
 
-    template
-    void
-    write_dx (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-              const std::vector<std::string>          &data_names,
-              const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-              const DXFlags                          &flags,
-              std::ostream                            &out);
+      template void
+      write_dx(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &            vector_data_ranges,
+        const DXFlags &flags,
+        std::ostream & out);
 
-    template
-    void
-    write_gnuplot (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-                   const std::vector<std::string>          &data_names,
-                   const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-                   const GnuplotFlags                          &flags,
-                   std::ostream                            &out);
+      template void
+      write_gnuplot(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &                 vector_data_ranges,
+        const GnuplotFlags &flags,
+        std::ostream &      out);
 
-    template
-    void
-    write_povray (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-                  const std::vector<std::string>          &data_names,
-                  const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-                  const PovrayFlags                          &flags,
-                  std::ostream                            &out);
+      template void
+      write_povray(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &                vector_data_ranges,
+        const PovrayFlags &flags,
+        std::ostream &     out);
 
-    template
-    void
-    write_eps (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-               const std::vector<std::string>          &data_names,
-               const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-               const EpsFlags                          &flags,
-               std::ostream                            &out);
+      template void
+      write_eps(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &             vector_data_ranges,
+        const EpsFlags &flags,
+        std::ostream &  out);
 
-    template
-    void
-    write_gmv (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-               const std::vector<std::string>          &data_names,
-               const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-               const GmvFlags                          &flags,
-               std::ostream                            &out);
+      template void
+      write_gmv(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &             vector_data_ranges,
+        const GmvFlags &flags,
+        std::ostream &  out);
 
-    template
-    void
-    write_tecplot (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-                   const std::vector<std::string>          &data_names,
-                   const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-                   const TecplotFlags                          &flags,
-                   std::ostream                            &out);
+      template void
+      write_tecplot(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &                 vector_data_ranges,
+        const TecplotFlags &flags,
+        std::ostream &      out);
 
-    template
-    void
-    write_tecplot_binary (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-                          const std::vector<std::string>          &data_names,
-                          const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-                          const TecplotFlags                          &flags,
-                          std::ostream                            &out);
+      template void
+      write_tecplot_binary(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &                 vector_data_ranges,
+        const TecplotFlags &flags,
+        std::ostream &      out);
 
-#if deal_II_space_dimension >1
-    template
-    void
-    write_svg (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-               const std::vector<std::string>          &data_names,
-               const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-               const SvgFlags                          &flags,
-               std::ostream                            &out);
-#endif
-    template
-    void
-    write_deal_II_intermediate (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-                                const std::vector<std::string>          &data_names,
-                                const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
-                                const Deal_II_IntermediateFlags                          &flags,
-                                std::ostream                            &out);
+#  if deal_II_space_dimension > 1
+      template void
+      write_svg(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &             vector_data_ranges,
+        const SvgFlags &flags,
+        std::ostream &  out);
+#  endif
+      template void
+      write_deal_II_intermediate(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                             patches,
+        const std::vector<std::string> &data_names,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &                              vector_data_ranges,
+        const Deal_II_IntermediateFlags &flags,
+        std::ostream &                   out);
 
-    template
-    void
-    write_hdf5_parallel (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &patches,
-                         const DataOutFilter &data_filter,
-                         const std::string &filename,
-                         MPI_Comm comm);
+      template void
+      write_hdf5_parallel(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
+          &                  patches,
+        const DataOutFilter &data_filter,
+        const std::string &  filename,
+        MPI_Comm             comm);
 
-    template
-    void
-    write_filtered_data (const std::vector<Patch<deal_II_dimension,deal_II_space_dimension> > &,
-                         const std::vector<std::string>          &,
-                         const std::vector<std::tuple<unsigned int, unsigned int, std::string> > &,
-                         DataOutBase::DataOutFilter &);
+      template void
+      write_filtered_data(
+        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>> &,
+        const std::vector<std::string> &,
+        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+          &,
+        DataOutBase::DataOutFilter &);
 
     \}
 #endif
-}
+  }
 
-for (deal_II_dimension : OUTPUT_DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; flag_type : OUTPUT_FLAG_TYPES)
-{
-    template
-    void
-    DataOutInterface<deal_II_dimension, deal_II_space_dimension>::set_flags (const DataOutBase::flag_type &flags);
-}
+for (deal_II_dimension : OUTPUT_DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS;
+     flag_type : OUTPUT_FLAG_TYPES)
+  {
+    template void
+    DataOutInterface<deal_II_dimension, deal_II_space_dimension>::set_flags(
+      const DataOutBase::flag_type &flags);
+  }

--- a/source/base/function.inst.in
+++ b/source/base/function.inst.in
@@ -15,7 +15,7 @@
 
 
 for (S : REAL_SCALARS; dim : SPACE_DIMENSIONS)
-{
+  {
     template class Function<dim, S>;
     template class Functions::ZeroFunction<dim, S>;
     template class Functions::ConstantFunction<dim, S>;
@@ -23,10 +23,10 @@ for (S : REAL_SCALARS; dim : SPACE_DIMENSIONS)
     template class ScalarFunctionFromFunctionObject<dim, S>;
     template class VectorFunctionFromScalarFunctionObject<dim, S>;
     template class VectorFunctionFromTensorFunction<dim, S>;
-}
+  }
 
 for (S : COMPLEX_SCALARS; dim : SPACE_DIMENSIONS)
-{
+  {
     template class Function<dim, S>;
     template class Functions::ZeroFunction<dim, S>;
     template class Functions::ConstantFunction<dim, S>;
@@ -34,4 +34,4 @@ for (S : COMPLEX_SCALARS; dim : SPACE_DIMENSIONS)
     template class ScalarFunctionFromFunctionObject<dim, S>;
     template class VectorFunctionFromScalarFunctionObject<dim, S>;
     template class VectorFunctionFromTensorFunction<dim, S>;
-}
+  }

--- a/source/base/function_time.inst.in
+++ b/source/base/function_time.inst.in
@@ -14,11 +14,11 @@
 // ---------------------------------------------------------------------
 
 for (S : REAL_SCALARS)
-{
+  {
     template class FunctionTime<S>;
-}
+  }
 
 for (S : COMPLEX_SCALARS)
-{
+  {
     template class FunctionTime<S>;
-}
+  }

--- a/source/base/geometric_utilities.inst.in
+++ b/source/base/geometric_utilities.inst.in
@@ -15,7 +15,7 @@
 
 
 for (dim : SPACE_DIMENSIONS)
-{
-    template Point<dim> from_spherical<dim>(const std::array<double,dim> &);
-    template std::array<double,dim> to_spherical<dim>(const Point<dim> &);
-}
+  {
+    template Point<dim> from_spherical<dim>(const std::array<double, dim> &);
+    template std::array<double, dim> to_spherical<dim>(const Point<dim> &);
+  }

--- a/source/base/mpi.inst.in
+++ b/source/base/mpi.inst.in
@@ -15,42 +15,39 @@
 
 
 for (S : REAL_SCALARS)
-{
-    template
-    void sum<S> (const SparseMatrix<S> &, const MPI_Comm &, SparseMatrix<S> &);
-}
+  {
+    template void sum<S>(
+      const SparseMatrix<S> &, const MPI_Comm &, SparseMatrix<S> &);
+  }
 
 for (S : MPI_SCALARS)
-{
-    template
-    void sum<LAPACKFullMatrix<S> > (const LAPACKFullMatrix<S> &, const MPI_Comm &, LAPACKFullMatrix<S> &);
+  {
+    template void sum<LAPACKFullMatrix<S>>(
+      const LAPACKFullMatrix<S> &, const MPI_Comm &, LAPACKFullMatrix<S> &);
 
-    template
-    void sum<Vector<S> > (const Vector<S> &, const MPI_Comm &, Vector<S> &);
+    template void sum<Vector<S>>(
+      const Vector<S> &, const MPI_Comm &, Vector<S> &);
 
-    template
-    void sum<FullMatrix<S> > (const FullMatrix<S> &, const MPI_Comm &, FullMatrix<S> &);
+    template void sum<FullMatrix<S>>(
+      const FullMatrix<S> &, const MPI_Comm &, FullMatrix<S> &);
 
-    template
-    void sum<S> (const ArrayView<const S> &, const MPI_Comm &, const ArrayView<S> &);
+    template void sum<S>(
+      const ArrayView<const S> &, const MPI_Comm &, const ArrayView<S> &);
 
-    template
-    S sum<S> (const S &, const MPI_Comm &);
+    template S sum<S>(const S &, const MPI_Comm &);
 
-    template
-    void sum<std::vector<S> > (const std::vector<S> &, const MPI_Comm &, std::vector<S> &);
+    template void sum<std::vector<S>>(
+      const std::vector<S> &, const MPI_Comm &, std::vector<S> &);
 
-    template
-    S max<S> (const S &, const MPI_Comm &);
+    template S max<S>(const S &, const MPI_Comm &);
 
-    template
-    void max<std::vector<S> > (const std::vector<S> &, const MPI_Comm &, std::vector<S> &);
+    template void max<std::vector<S>>(
+      const std::vector<S> &, const MPI_Comm &, std::vector<S> &);
 
-    template
-    S min<S> (const S &, const MPI_Comm &);
+    template S min<S>(const S &, const MPI_Comm &);
 
-    template
-    void min<std::vector<S> > (const std::vector<S> &, const MPI_Comm &, std::vector<S> &);
+    template void min<std::vector<S>>(
+      const std::vector<S> &, const MPI_Comm &, std::vector<S> &);
 
     // The fixed-length array (i.e., things declared like T(&values)[N])
     // versions of the functions above live in the header file mpi.h since the
@@ -66,30 +63,27 @@ for (S : MPI_SCALARS)
     // inline it (so this instantiation is not necessary) but clang 3.8 does (so
     // this instantiation is necessary). Some versions of GCC (5.3 but not 4.8)
     // seem to inline it with the '-march=native' flag.
-    template
-    void Utilities::MPI::internal::all_reduce<S> (const MPI_Op    &,
-            const ArrayView<const S> &,
-            const MPI_Comm  &,
-            const ArrayView<S>    &);
-}
+    template void Utilities::MPI::internal::all_reduce<S>(
+      const MPI_Op &,
+      const ArrayView<const S> &,
+      const MPI_Comm &,
+      const ArrayView<S> &);
+  }
 
 
-for (S : REAL_SCALARS; rank: RANKS; dim : SPACE_DIMENSIONS)
-{
-    template
-    Tensor<rank,dim,S>
-    sum<rank,dim,S> (const Tensor<rank,dim,S> &, const MPI_Comm &);
-}
+for (S : REAL_SCALARS; rank : RANKS; dim : SPACE_DIMENSIONS)
+  {
+    template Tensor<rank, dim, S> sum<rank, dim, S>(
+      const Tensor<rank, dim, S> &, const MPI_Comm &);
+  }
 
 
 // Recall that SymmetricTensor only makes sense for rank 2 and 4
 for (S : REAL_SCALARS; dim : SPACE_DIMENSIONS)
-{
-    template
-    SymmetricTensor<2,dim,S>
-    sum<2,dim,S> (const SymmetricTensor<2,dim,S> &, const MPI_Comm &);
+  {
+    template SymmetricTensor<2, dim, S> sum<2, dim, S>(
+      const SymmetricTensor<2, dim, S> &, const MPI_Comm &);
 
-    template
-    SymmetricTensor<4,dim,S>
-    sum<4,dim,S> (const SymmetricTensor<4,dim,S> &, const MPI_Comm &);
-}
+    template SymmetricTensor<4, dim, S> sum<4, dim, S>(
+      const SymmetricTensor<4, dim, S> &, const MPI_Comm &);
+  }

--- a/source/base/partitioner.inst.in
+++ b/source/base/partitioner.inst.in
@@ -16,24 +16,31 @@
 
 
 for (SCALAR : MPI_SCALARS)
-{
+  {
 #ifdef DEAL_II_WITH_MPI
-    template void Utilities::MPI::Partitioner::export_to_ghosted_array_start<SCALAR>(const unsigned int ,
-            const ArrayView<const SCALAR> &,
-            const ArrayView<SCALAR> &,
-            const ArrayView<SCALAR> &,
-            std::vector<MPI_Request> &) const;
-    template void Utilities::MPI::Partitioner::export_to_ghosted_array_finish<SCALAR>(const ArrayView<SCALAR> &,
-            std::vector<MPI_Request> &) const;
-    template void Utilities::MPI::Partitioner::import_from_ghosted_array_start<SCALAR>(const VectorOperation::values ,
-            const unsigned int ,
-            const ArrayView<SCALAR> &,
-            const ArrayView<SCALAR> &,
-            std::vector<MPI_Request> &) const;
-    template void Utilities::MPI::Partitioner::import_from_ghosted_array_finish<SCALAR>(const VectorOperation::values ,
-            const ArrayView<const SCALAR> &,
-            const ArrayView<SCALAR> &,
-            const ArrayView<SCALAR> &,
-            std::vector<MPI_Request> &) const;
+    template void
+    Utilities::MPI::Partitioner::export_to_ghosted_array_start<SCALAR>(
+      const unsigned int,
+      const ArrayView<const SCALAR> &,
+      const ArrayView<SCALAR> &,
+      const ArrayView<SCALAR> &,
+      std::vector<MPI_Request> &) const;
+    template void
+    Utilities::MPI::Partitioner::export_to_ghosted_array_finish<SCALAR>(
+      const ArrayView<SCALAR> &, std::vector<MPI_Request> &) const;
+    template void
+    Utilities::MPI::Partitioner::import_from_ghosted_array_start<SCALAR>(
+      const VectorOperation::values,
+      const unsigned int,
+      const ArrayView<SCALAR> &,
+      const ArrayView<SCALAR> &,
+      std::vector<MPI_Request> &) const;
+    template void
+    Utilities::MPI::Partitioner::import_from_ghosted_array_finish<SCALAR>(
+      const VectorOperation::values,
+      const ArrayView<const SCALAR> &,
+      const ArrayView<SCALAR> &,
+      const ArrayView<SCALAR> &,
+      std::vector<MPI_Request> &) const;
 #endif
-}
+  }

--- a/source/base/polynomials_rannacher_turek.inst.in
+++ b/source/base/polynomials_rannacher_turek.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class PolynomialsRannacherTurek<deal_II_dimension>;
-}
-
+  }

--- a/source/base/symmetric_tensor.inst.in
+++ b/source/base/symmetric_tensor.inst.in
@@ -15,86 +15,73 @@
 
 
 for (deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
-{
-    template
-    class SymmetricTensor<2,deal_II_dimension,number>;
+  {
+    template class SymmetricTensor<2, deal_II_dimension, number>;
 
-    template
-    class SymmetricTensor<4,deal_II_dimension,number>;
+    template class SymmetricTensor<4, deal_II_dimension, number>;
 
-    template
-    std::array<number,deal_II_dimension>
-    eigenvalues (const SymmetricTensor<2,deal_II_dimension,number> &);
+    template std::array<number, deal_II_dimension> eigenvalues(
+      const SymmetricTensor<2, deal_II_dimension, number> &);
 
-    template
-    std::array<std::pair<number,Tensor<1,deal_II_dimension,number> >,std::integral_constant<int, deal_II_dimension>::value>
-    eigenvectors (const SymmetricTensor<2,deal_II_dimension,number> &,
-                  const SymmetricTensorEigenvectorMethod);
-}
+    template std::array<std::pair<number, Tensor<1, deal_II_dimension, number>>,
+                        std::integral_constant<int, deal_II_dimension>::value>
+    eigenvectors(const SymmetricTensor<2, deal_II_dimension, number> &,
+                 const SymmetricTensorEigenvectorMethod);
+  }
 
 for (deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_ADOLC_REAL_SCALARS)
-{
-    template
-    class SymmetricTensor<2,deal_II_dimension,number>;
+  {
+    template class SymmetricTensor<2, deal_II_dimension, number>;
 
-    template
-    class SymmetricTensor<4,deal_II_dimension,number>;
+    template class SymmetricTensor<4, deal_II_dimension, number>;
 
-    template
-    std::array<number,deal_II_dimension>
-    eigenvalues (const SymmetricTensor<2,deal_II_dimension,number> &);
+    template std::array<number, deal_II_dimension> eigenvalues(
+      const SymmetricTensor<2, deal_II_dimension, number> &);
 
-    template
-    std::array<std::pair<number,Tensor<1,deal_II_dimension,number> >,std::integral_constant<int, deal_II_dimension>::value>
-    eigenvectors (const SymmetricTensor<2,deal_II_dimension,number> &,
-                  const SymmetricTensorEigenvectorMethod);
-}
+    template std::array<std::pair<number, Tensor<1, deal_II_dimension, number>>,
+                        std::integral_constant<int, deal_II_dimension>::value>
+    eigenvectors(const SymmetricTensor<2, deal_II_dimension, number> &,
+                 const SymmetricTensorEigenvectorMethod);
+  }
 
-for (deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_TRILINOS_SACADO_REAL_SCALARS)
-{
-    template
-    class SymmetricTensor<2,deal_II_dimension,number>;
+for (deal_II_dimension : DIMENSIONS;
+     number : DIFFERENTIABLE_TRILINOS_SACADO_REAL_SCALARS)
+  {
+    template class SymmetricTensor<2, deal_II_dimension, number>;
 
-    template
-    class SymmetricTensor<4,deal_II_dimension,number>;
+    template class SymmetricTensor<4, deal_II_dimension, number>;
 
-    template
-    std::array<number,deal_II_dimension>
-    eigenvalues (const SymmetricTensor<2,deal_II_dimension,number> &);
+    template std::array<number, deal_II_dimension> eigenvalues(
+      const SymmetricTensor<2, deal_II_dimension, number> &);
 
-    template
-    std::array<std::pair<number,Tensor<1,deal_II_dimension,number> >,std::integral_constant<int, deal_II_dimension>::value>
-    eigenvectors (const SymmetricTensor<2,deal_II_dimension,number> &,
-                  const SymmetricTensorEigenvectorMethod);
-}
+    template std::array<std::pair<number, Tensor<1, deal_II_dimension, number>>,
+                        std::integral_constant<int, deal_II_dimension>::value>
+    eigenvectors(const SymmetricTensor<2, deal_II_dimension, number> &,
+                 const SymmetricTensorEigenvectorMethod);
+  }
 
 for (deal_II_dimension : DIMENSIONS; number : COMPLEX_SCALARS)
-{
-    template
-    class SymmetricTensor<2,deal_II_dimension,number>;
+  {
+    template class SymmetricTensor<2, deal_II_dimension, number>;
 
-    template
-    class SymmetricTensor<4,deal_II_dimension,number>;
-}
+    template class SymmetricTensor<4, deal_II_dimension, number>;
+  }
 
 
 for (number : REAL_SCALARS)
-{
-    template
-    SymmetricTensor<4,3,number>
-    invert (const SymmetricTensor<4,3,number> &t);
-}
+  {
+    template SymmetricTensor<4, 3, number> invert(
+      const SymmetricTensor<4, 3, number> &t);
+  }
 
 for (number : DIFFERENTIABLE_ADOLC_REAL_SCALARS)
-{
-    template
-    SymmetricTensor<4,3,number>
-    invert (const SymmetricTensor<4,3,number> &t);
-}
+  {
+    template SymmetricTensor<4, 3, number> invert(
+      const SymmetricTensor<4, 3, number> &t);
+  }
 
 for (number : DIFFERENTIABLE_TRILINOS_SACADO_REAL_SCALARS)
-{
-    template
-    SymmetricTensor<4,3,number>
-    invert (const SymmetricTensor<4,3,number> &t);
-}
+  {
+    template SymmetricTensor<4, 3, number> invert(
+      const SymmetricTensor<4, 3, number> &t);
+  }

--- a/source/base/tensor.inst.in
+++ b/source/base/tensor.inst.in
@@ -15,54 +15,49 @@
 
 
 for (rank : RANKS; deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
-{
-    template
-    class Tensor<rank,deal_II_dimension,number>;
-}
+  {
+    template class Tensor<rank, deal_II_dimension, number>;
+  }
 
 
 for (deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
-{
-    template
-    class Tensor<0,deal_II_dimension,number>;
-}
+  {
+    template class Tensor<0, deal_II_dimension, number>;
+  }
 
 
 for (rank : RANKS; deal_II_dimension : DIMENSIONS; number : COMPLEX_SCALARS)
-{
-    template
-    class Tensor<rank,deal_II_dimension,number>;
-}
+  {
+    template class Tensor<rank, deal_II_dimension, number>;
+  }
 
 
 for (deal_II_dimension : DIMENSIONS; number : COMPLEX_SCALARS)
-{
-    template
-    class Tensor<0,deal_II_dimension,number>;
-}
+  {
+    template class Tensor<0, deal_II_dimension, number>;
+  }
 
 
-for (rank : RANKS; deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_ADOLC_REAL_SCALARS)
-{
-    template
-    class Tensor<rank,deal_II_dimension,number>;
-}
+for (rank : RANKS; deal_II_dimension : DIMENSIONS;
+     number : DIFFERENTIABLE_ADOLC_REAL_SCALARS)
+  {
+    template class Tensor<rank, deal_II_dimension, number>;
+  }
 
 
 for (deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_ADOLC_REAL_SCALARS)
-{
-    template
-    class Tensor<0,deal_II_dimension,number>;
-}
+  {
+    template class Tensor<0, deal_II_dimension, number>;
+  }
 
-for (rank : RANKS; deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_TRILINOS_SACADO_REAL_SCALARS)
-{
-    template
-    class Tensor<rank,deal_II_dimension,number>;
-}
+for (rank : RANKS; deal_II_dimension : DIMENSIONS;
+     number : DIFFERENTIABLE_TRILINOS_SACADO_REAL_SCALARS)
+  {
+    template class Tensor<rank, deal_II_dimension, number>;
+  }
 
-for (deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_TRILINOS_SACADO_REAL_SCALARS)
-{
-    template
-    class Tensor<0,deal_II_dimension,number>;
-}
+for (deal_II_dimension : DIMENSIONS;
+     number : DIFFERENTIABLE_TRILINOS_SACADO_REAL_SCALARS)
+  {
+    template class Tensor<0, deal_II_dimension, number>;
+  }

--- a/source/base/tensor_function.inst.in
+++ b/source/base/tensor_function.inst.in
@@ -14,16 +14,16 @@
 // ---------------------------------------------------------------------
 
 
-for (S : REAL_SCALARS; rank: RANKS; dim : SPACE_DIMENSIONS)
-{
+for (S : REAL_SCALARS; rank : RANKS; dim : SPACE_DIMENSIONS)
+  {
     template class TensorFunction<rank, dim, S>;
     template class ConstantTensorFunction<rank, dim, S>;
     template class ZeroTensorFunction<rank, dim, S>;
-}
+  }
 
-for (S : COMPLEX_SCALARS; rank: RANKS; dim : SPACE_DIMENSIONS)
-{
+for (S : COMPLEX_SCALARS; rank : RANKS; dim : SPACE_DIMENSIONS)
+  {
     template class TensorFunction<rank, dim, S>;
     template class ConstantTensorFunction<rank, dim, S>;
     template class ZeroTensorFunction<rank, dim, S>;
-}
+  }

--- a/source/base/time_stepping.inst.in
+++ b/source/base/time_stepping.inst.in
@@ -15,25 +15,25 @@
 
 
 for (S : REAL_SCALARS; V : DEAL_II_VEC_TEMPLATES)
-{
-    template class RungeKutta<V<S> >;
-    template class ExplicitRungeKutta<V<S> >;
-    template class ImplicitRungeKutta<V<S> >;
-    template class EmbeddedExplicitRungeKutta<V<S> >;
-}
+  {
+    template class RungeKutta<V<S>>;
+    template class ExplicitRungeKutta<V<S>>;
+    template class ImplicitRungeKutta<V<S>>;
+    template class EmbeddedExplicitRungeKutta<V<S>>;
+  }
 
 for (S : REAL_SCALARS; V : DEAL_II_VEC_TEMPLATES)
-{
-    template class RungeKutta<LinearAlgebra::distributed::V<S> >;
-    template class ExplicitRungeKutta<LinearAlgebra::distributed::V<S> >;
-    template class ImplicitRungeKutta<LinearAlgebra::distributed::V<S> >;
-    template class EmbeddedExplicitRungeKutta<LinearAlgebra::distributed::V<S> >;
-}
+  {
+    template class RungeKutta<LinearAlgebra::distributed::V<S>>;
+    template class ExplicitRungeKutta<LinearAlgebra::distributed::V<S>>;
+    template class ImplicitRungeKutta<LinearAlgebra::distributed::V<S>>;
+    template class EmbeddedExplicitRungeKutta<LinearAlgebra::distributed::V<S>>;
+  }
 
 for (V : EXTERNAL_PARALLEL_VECTORS)
-{
+  {
     template class RungeKutta<V>;
     template class ExplicitRungeKutta<V>;
     template class ImplicitRungeKutta<V>;
     template class EmbeddedExplicitRungeKutta<V>;
-}
+  }

--- a/source/differentiation/ad/adolc_number_types.inst.in
+++ b/source/differentiation/ad/adolc_number_types.inst.in
@@ -14,38 +14,38 @@
 // ---------------------------------------------------------------------
 
 for (Number : DIFFERENTIABLE_ADOLC_REAL_SCALARS)
-{
+  {
     namespace Differentiation
     \{
-    namespace AD
-    \{
-    template struct ADNumberTraits<Number>;
+      namespace AD
+      \{
+        template struct ADNumberTraits<Number>;
+      \}
     \}
-    \}
-}
+  }
 
 
 for (Number : REAL_SCALARS)
-{
+  {
     namespace Differentiation
     \{
-    namespace AD
-    \{
-    template struct NumberTraits<Number,NumberTypes::adolc_taped>;
-    template struct NumberTraits<Number,NumberTypes::adolc_tapeless>;
+      namespace AD
+      \{
+        template struct NumberTraits<Number, NumberTypes::adolc_taped>;
+        template struct NumberTraits<Number, NumberTypes::adolc_tapeless>;
+      \}
     \}
-    \}
-}
+  }
 
 
 for (Number : COMPLEX_SCALARS)
-{
+  {
     namespace Differentiation
     \{
-    namespace AD
-    \{
-    template struct NumberTraits<Number,NumberTypes::adolc_taped>;
-    template struct NumberTraits<Number,NumberTypes::adolc_tapeless>;
+      namespace AD
+      \{
+        template struct NumberTraits<Number, NumberTypes::adolc_taped>;
+        template struct NumberTraits<Number, NumberTypes::adolc_tapeless>;
+      \}
     \}
-    \}
-}
+  }

--- a/source/distributed/grid_refinement.inst.in
+++ b/source/distributed/grid_refinement.inst.in
@@ -15,33 +15,34 @@
 
 
 
-
 for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace parallel
     \{
-    namespace distributed
-    \{
-    namespace GridRefinement
-    \{
-    template
-    void
-    refine_and_coarsen_fixed_number<deal_II_dimension,S,deal_II_dimension>
-    (parallel::distributed::Triangulation<deal_II_dimension> &,
-     const dealii::Vector<S> &,
-     const double,
-     const double,
-     const unsigned int);
+      namespace distributed
+      \{
+        namespace GridRefinement
+        \{
+          template void
+          refine_and_coarsen_fixed_number<deal_II_dimension,
+                                          S,
+                                          deal_II_dimension>(
+            parallel::distributed::Triangulation<deal_II_dimension> &,
+            const dealii::Vector<S> &,
+            const double,
+            const double,
+            const unsigned int);
 
-    template
-    void
-    refine_and_coarsen_fixed_fraction<deal_II_dimension,S,deal_II_dimension>
-    (parallel::distributed::Triangulation<deal_II_dimension> &,
-     const dealii::Vector<S> &,
-     const double,
-     const double);
-    \}
-    \}
+          template void
+          refine_and_coarsen_fixed_fraction<deal_II_dimension,
+                                            S,
+                                            deal_II_dimension>(
+            parallel::distributed::Triangulation<deal_II_dimension> &,
+            const dealii::Vector<S> &,
+            const double,
+            const double);
+        \}
+      \}
     \}
 
 
@@ -49,29 +50,31 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
 
     namespace parallel
     \{
-    namespace distributed
-    \{
-    namespace GridRefinement
-    \{
-    template
-    void
-    refine_and_coarsen_fixed_number<deal_II_dimension-1,S,deal_II_dimension>
-    (parallel::distributed::Triangulation<deal_II_dimension-1,deal_II_dimension> &,
-     const dealii::Vector<S> &,
-     const double,
-     const double,
-     const unsigned int);
+      namespace distributed
+      \{
+        namespace GridRefinement
+        \{
+          template void refine_and_coarsen_fixed_number<deal_II_dimension - 1,
+                                                        S,
+                                                        deal_II_dimension>(
+            parallel::distributed::Triangulation<deal_II_dimension - 1,
+                                                 deal_II_dimension> &,
+            const dealii::Vector<S> &,
+            const double,
+            const double,
+            const unsigned int);
 
-    template
-    void
-    refine_and_coarsen_fixed_fraction<deal_II_dimension-1,S,deal_II_dimension>
-    (parallel::distributed::Triangulation<deal_II_dimension-1,deal_II_dimension> &,
-     const dealii::Vector<S> &,
-     const double,
-     const double);
-    \}
-    \}
+          template void refine_and_coarsen_fixed_fraction<deal_II_dimension - 1,
+                                                          S,
+                                                          deal_II_dimension>(
+            parallel::distributed::Triangulation<deal_II_dimension - 1,
+                                                 deal_II_dimension> &,
+            const dealii::Vector<S> &,
+            const double,
+            const double);
+        \}
+      \}
     \}
 
 #endif
-}
+  }

--- a/source/distributed/p4est_wrappers.inst.in
+++ b/source/distributed/p4est_wrappers.inst.in
@@ -15,71 +15,69 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-#   ifdef DEAL_II_WITH_P4EST
+  {
+#ifdef DEAL_II_WITH_P4EST
 
     namespace internal
     \{
-    namespace p4est
-    \{
-#if     deal_II_dimension > 1
+      namespace p4est
+      \{
+#  if deal_II_dimension > 1
 
-    template
-    void
-    init_quadrant_children<deal_II_dimension>
-    (const types<deal_II_dimension>::quadrant & p4est_cell,
-     types<deal_II_dimension>::quadrant (&p4est_children)[GeometryInfo<deal_II_dimension>::max_children_per_cell]);
+        template void
+        init_quadrant_children<deal_II_dimension>(
+          const types<deal_II_dimension>::quadrant &p4est_cell,
+          types<deal_II_dimension>::quadrant (&p4est_children)
+            [GeometryInfo<deal_II_dimension>::max_children_per_cell]);
 
-    template
-    void
-    init_coarse_quadrant<deal_II_dimension>
-    (types<deal_II_dimension>::quadrant & quad);
+        template void
+        init_coarse_quadrant<deal_II_dimension>(
+          types<deal_II_dimension>::quadrant &quad);
 
-    template
-    bool
-    quadrant_is_equal<deal_II_dimension>
-    (const types<deal_II_dimension>::quadrant & q1,
-     const types<deal_II_dimension>::quadrant & q2);
+        template bool
+        quadrant_is_equal<deal_II_dimension>(
+          const types<deal_II_dimension>::quadrant &q1,
+          const types<deal_II_dimension>::quadrant &q2);
 
-    template
-    bool
-    quadrant_is_ancestor<deal_II_dimension>
-    (const types<deal_II_dimension>::quadrant & q1,
-     const types<deal_II_dimension>::quadrant & q2);
+        template bool
+        quadrant_is_ancestor<deal_II_dimension>(
+          const types<deal_II_dimension>::quadrant &q1,
+          const types<deal_II_dimension>::quadrant &q2);
 
-    template
-    bool
-    tree_exists_locally<deal_II_dimension>
-    (const types<deal_II_dimension>::forest *parallel_forest,
-     const types<deal_II_dimension>::topidx coarse_grid_cell);
+        template bool
+        tree_exists_locally<deal_II_dimension>(
+          const types<deal_II_dimension>::forest *parallel_forest,
+          const types<deal_II_dimension>::topidx  coarse_grid_cell);
 
-#      endif
+#  endif
+      \}
     \}
-    \}
-#   endif // DEAL_II_WITH_P4EST
-}
+#endif  // DEAL_II_WITH_P4EST
+  }
 
 
 for (deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
-{
-#   ifdef DEAL_II_WITH_P4EST
+  {
+#ifdef DEAL_II_WITH_P4EST
 
     namespace internal
     \{
-    namespace p4est
-    \{
-#if     deal_II_dimension > 1
-#if       deal_II_space_dimension >= deal_II_dimension
-    template
-    std::map<unsigned int, std::set<dealii::types::subdomain_id> >
-    compute_vertices_with_ghost_neighbors(const dealii::parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &tria,
-                                          typename dealii::internal::p4est::types<deal_II_dimension>::forest *parallel_forest,
-                                          typename dealii::internal::p4est::types<deal_II_dimension>::ghost *parallel_ghost);
+      namespace p4est
+      \{
+#  if deal_II_dimension > 1
+#    if deal_II_space_dimension >= deal_II_dimension
+        template std::map<unsigned int, std::set<dealii::types::subdomain_id>>
+        compute_vertices_with_ghost_neighbors(
+          const dealii::parallel::distributed::
+            Triangulation<deal_II_dimension, deal_II_space_dimension> &tria,
+          typename dealii::internal::p4est::types<deal_II_dimension>::forest
+            *parallel_forest,
+          typename dealii::internal::p4est::types<deal_II_dimension>::ghost
+            *parallel_ghost);
 
-#endif
-#endif
+#    endif
+#  endif
+      \}
     \}
-    \}
-#   endif // DEAL_II_WITH_P4EST
-}
-
+#endif  // DEAL_II_WITH_P4EST
+  }

--- a/source/distributed/shared_tria.inst.in
+++ b/source/distributed/shared_tria.inst.in
@@ -16,19 +16,18 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace parallel
     \{
-    namespace shared
-    \{
-    template class Triangulation<deal_II_dimension>;
-#       if deal_II_dimension < 3
-    template class Triangulation<deal_II_dimension, deal_II_dimension+1>;
-#       endif
-#       if deal_II_dimension < 2
-    template class Triangulation<deal_II_dimension, deal_II_dimension+2>;
-#       endif
+      namespace shared
+      \{
+        template class Triangulation<deal_II_dimension>;
+#if deal_II_dimension < 3
+        template class Triangulation<deal_II_dimension, deal_II_dimension + 1>;
+#endif
+#if deal_II_dimension < 2
+        template class Triangulation<deal_II_dimension, deal_II_dimension + 2>;
+#endif
+      \}
     \}
-    \}
-
-}
+  }

--- a/source/distributed/solution_transfer.inst.in
+++ b/source/distributed/solution_transfer.inst.in
@@ -16,33 +16,59 @@
 
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+  {
     namespace parallel
     \{
-    namespace distributed
-    \{
+      namespace distributed
+      \{
 #if deal_II_dimension <= deal_II_space_dimension
-    template class SolutionTransfer<deal_II_dimension,::dealii::Vector<double>, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
-    template class SolutionTransfer<deal_II_dimension,::dealii::LinearAlgebra::distributed::Vector<double>, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
-    template class SolutionTransfer<deal_II_dimension,::dealii::LinearAlgebra::distributed::Vector<float>, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
-    template class SolutionTransfer<deal_II_dimension,::dealii::LinearAlgebra::distributed::BlockVector<double>, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
-    template class SolutionTransfer<deal_II_dimension,::dealii::LinearAlgebra::distributed::BlockVector<float>, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          ::dealii::Vector<double>,
+          DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          ::dealii::LinearAlgebra::distributed::Vector<double>,
+          DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          ::dealii::LinearAlgebra::distributed::Vector<float>,
+          DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          ::dealii::LinearAlgebra::distributed::BlockVector<double>,
+          DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          ::dealii::LinearAlgebra::distributed::BlockVector<float>,
+          DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
 
 
-#ifdef DEAL_II_WITH_PETSC
-    template class SolutionTransfer<deal_II_dimension, PETScWrappers::MPI::Vector, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
+#  ifdef DEAL_II_WITH_PETSC
+        template class SolutionTransfer<
+          deal_II_dimension,
+          PETScWrappers::MPI::Vector,
+          DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
 
-    template class SolutionTransfer<deal_II_dimension, PETScWrappers::MPI::BlockVector, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          PETScWrappers::MPI::BlockVector,
+          DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+#  endif
+
+#  ifdef DEAL_II_WITH_TRILINOS
+        template class SolutionTransfer<
+          deal_II_dimension,
+          TrilinosWrappers::MPI::Vector,
+          DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+
+        template class SolutionTransfer<
+          deal_II_dimension,
+          TrilinosWrappers::MPI::BlockVector,
+          DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+#  endif
+
 #endif
-
-#ifdef DEAL_II_WITH_TRILINOS
-    template class SolutionTransfer<deal_II_dimension, TrilinosWrappers::MPI::Vector, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
-
-    template class SolutionTransfer<deal_II_dimension, TrilinosWrappers::MPI::BlockVector, DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
-#endif
-
-#endif
+      \}
     \}
-    \}
-
-}
+  }

--- a/source/distributed/tria.inst.in
+++ b/source/distributed/tria.inst.in
@@ -16,20 +16,18 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace parallel
     \{
-    namespace distributed
-    \{
-    template class Triangulation<deal_II_dimension>;
-#       if deal_II_dimension < 3
-    template class Triangulation<deal_II_dimension, deal_II_dimension+1>;
-#       endif
-#       if deal_II_dimension < 2
-    template class Triangulation<deal_II_dimension, deal_II_dimension+2>;
-#       endif
+      namespace distributed
+      \{
+        template class Triangulation<deal_II_dimension>;
+#if deal_II_dimension < 3
+        template class Triangulation<deal_II_dimension, deal_II_dimension + 1>;
+#endif
+#if deal_II_dimension < 2
+        template class Triangulation<deal_II_dimension, deal_II_dimension + 2>;
+#endif
+      \}
     \}
-    \}
-
-}
-
+  }

--- a/source/distributed/tria_base.inst.in
+++ b/source/distributed/tria_base.inst.in
@@ -16,16 +16,15 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace parallel
     \{
-    template class Triangulation<deal_II_dimension>;
-#       if deal_II_dimension < 3
-    template class Triangulation<deal_II_dimension, deal_II_dimension+1>;
-#       endif
-#       if deal_II_dimension < 2
-    template class Triangulation<deal_II_dimension, deal_II_dimension+2>;
-#       endif
+      template class Triangulation<deal_II_dimension>;
+#if deal_II_dimension < 3
+      template class Triangulation<deal_II_dimension, deal_II_dimension + 1>;
+#endif
+#if deal_II_dimension < 2
+      template class Triangulation<deal_II_dimension, deal_II_dimension + 2>;
+#endif
     \}
-
-}
+  }

--- a/source/dofs/block_info.inst.in
+++ b/source/dofs/block_info.inst.in
@@ -15,18 +15,21 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template void BlockInfo::initialize(const DoFHandler<deal_II_dimension,deal_II_dimension>&, bool, bool);
-    template void BlockInfo::initialize_local(const DoFHandler<deal_II_dimension,deal_II_dimension>&);
+  {
+    template void BlockInfo::initialize(
+      const DoFHandler<deal_II_dimension, deal_II_dimension> &, bool, bool);
+    template void BlockInfo::initialize_local(
+      const DoFHandler<deal_II_dimension, deal_II_dimension> &);
 
 #if deal_II_dimension < 3
-    template void BlockInfo::initialize(const DoFHandler<deal_II_dimension,deal_II_dimension+1>&, bool, bool);
-    template void BlockInfo::initialize_local(const DoFHandler<deal_II_dimension,deal_II_dimension+1>&);
+    template void BlockInfo::initialize(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &, bool, bool);
+    template void BlockInfo::initialize_local(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &);
 #endif
 
 #if deal_II_dimension == 3
-    template void BlockInfo::initialize(const DoFHandler<1,3>&, bool, bool);
-    template void BlockInfo::initialize_local(const DoFHandler<1,3>&);
+    template void BlockInfo::initialize(const DoFHandler<1, 3> &, bool, bool);
+    template void BlockInfo::initialize_local(const DoFHandler<1, 3> &);
 #endif
-}
-
+  }

--- a/source/dofs/dof_accessor.inst.in
+++ b/source/dofs/dof_accessor.inst.in
@@ -17,154 +17,174 @@
 
 // TODO: This could surely be made more systematic!
 for (deal_II_dimension : DIMENSIONS; lda : BOOL)
-{
-// explicit instantiations (for DoFHandler)
+  {
+    // explicit instantiations (for DoFHandler)
 
 
 #if deal_II_dimension == 2
     template class DoFAccessor<1, DoFHandler<2>, lda>;
 
-    template class TriaRawIterator   <DoFAccessor<1, DoFHandler<2>, lda> >;
-    template class TriaIterator      <DoFAccessor<1, DoFHandler<2>, lda> >;
-    template class TriaActiveIterator<DoFAccessor<1, DoFHandler<2>, lda> >;
+    template class TriaRawIterator<DoFAccessor<1, DoFHandler<2>, lda>>;
+    template class TriaIterator<DoFAccessor<1, DoFHandler<2>, lda>>;
+    template class TriaActiveIterator<DoFAccessor<1, DoFHandler<2>, lda>>;
 #endif
 
 #if deal_II_dimension == 3
     template class DoFAccessor<1, DoFHandler<3>, lda>;
     template class DoFAccessor<2, DoFHandler<3>, lda>;
 
-    template class TriaRawIterator   <DoFAccessor<1, DoFHandler<3>, lda> >;
-    template class TriaIterator      <DoFAccessor<1, DoFHandler<3>, lda> >;
-    template class TriaActiveIterator<DoFAccessor<1, DoFHandler<3>, lda> >;
-    template class TriaRawIterator   <DoFAccessor<2, DoFHandler<3>, lda> >;
-    template class TriaIterator      <DoFAccessor<2, DoFHandler<3>, lda> >;
-    template class TriaActiveIterator<DoFAccessor<2, DoFHandler<3>, lda> >;
+    template class TriaRawIterator<DoFAccessor<1, DoFHandler<3>, lda>>;
+    template class TriaIterator<DoFAccessor<1, DoFHandler<3>, lda>>;
+    template class TriaActiveIterator<DoFAccessor<1, DoFHandler<3>, lda>>;
+    template class TriaRawIterator<DoFAccessor<2, DoFHandler<3>, lda>>;
+    template class TriaIterator<DoFAccessor<2, DoFHandler<3>, lda>>;
+    template class TriaActiveIterator<DoFAccessor<2, DoFHandler<3>, lda>>;
 #endif
 
-    template class DoFAccessor<deal_II_dimension, DoFHandler<deal_II_dimension>, lda>;
+    template class DoFAccessor<deal_II_dimension,
+                               DoFHandler<deal_II_dimension>,
+                               lda>;
     template class DoFCellAccessor<DoFHandler<deal_II_dimension>, lda>;
 
-    template class TriaRawIterator   <DoFCellAccessor<DoFHandler<deal_II_dimension>, lda> >;
-    template class TriaIterator      <DoFCellAccessor<DoFHandler<deal_II_dimension>, lda> >;
-    template class TriaActiveIterator<DoFCellAccessor<DoFHandler<deal_II_dimension>, lda> >;
+    template class TriaRawIterator<
+      DoFCellAccessor<DoFHandler<deal_II_dimension>, lda>>;
+    template class TriaIterator<
+      DoFCellAccessor<DoFHandler<deal_II_dimension>, lda>>;
+    template class TriaActiveIterator<
+      DoFCellAccessor<DoFHandler<deal_II_dimension>, lda>>;
 
 
-// --------------------------------------------------------------------------
-// explicit instantiations (for hp::DoFHandler)
+    // --------------------------------------------------------------------------
+    // explicit instantiations (for hp::DoFHandler)
 
 
 #if deal_II_dimension == 2
     template class DoFAccessor<1, hp::DoFHandler<2>, lda>;
-    template class TriaRawIterator   <DoFAccessor<1, hp::DoFHandler<2>, lda> >;
-    template class TriaIterator      <DoFAccessor<1, hp::DoFHandler<2>, lda> >;
-    template class TriaActiveIterator<DoFAccessor<1, hp::DoFHandler<2>, lda> >;
+    template class TriaRawIterator<DoFAccessor<1, hp::DoFHandler<2>, lda>>;
+    template class TriaIterator<DoFAccessor<1, hp::DoFHandler<2>, lda>>;
+    template class TriaActiveIterator<DoFAccessor<1, hp::DoFHandler<2>, lda>>;
 #endif
 
 
 #if deal_II_dimension == 3
     template class DoFAccessor<1, hp::DoFHandler<3>, lda>;
-    template class TriaRawIterator   <DoFAccessor<1, hp::DoFHandler<3>, lda> >;
-    template class TriaIterator      <DoFAccessor<1, hp::DoFHandler<3>, lda> >;
-    template class TriaActiveIterator<DoFAccessor<1, hp::DoFHandler<3>, lda> >;
+    template class TriaRawIterator<DoFAccessor<1, hp::DoFHandler<3>, lda>>;
+    template class TriaIterator<DoFAccessor<1, hp::DoFHandler<3>, lda>>;
+    template class TriaActiveIterator<DoFAccessor<1, hp::DoFHandler<3>, lda>>;
 
     template class DoFAccessor<2, hp::DoFHandler<3>, lda>;
-    template class TriaRawIterator   <DoFAccessor<2, hp::DoFHandler<3>, lda> >;
-    template class TriaIterator      <DoFAccessor<2, hp::DoFHandler<3>, lda> >;
-    template class TriaActiveIterator<DoFAccessor<2, hp::DoFHandler<3>, lda> >;
+    template class TriaRawIterator<DoFAccessor<2, hp::DoFHandler<3>, lda>>;
+    template class TriaIterator<DoFAccessor<2, hp::DoFHandler<3>, lda>>;
+    template class TriaActiveIterator<DoFAccessor<2, hp::DoFHandler<3>, lda>>;
 #endif
 
-    template class DoFAccessor<deal_II_dimension, hp::DoFHandler<deal_II_dimension>, lda>;
+    template class DoFAccessor<deal_II_dimension,
+                               hp::DoFHandler<deal_II_dimension>,
+                               lda>;
     template class DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda>;
 
-    template class TriaRawIterator   <DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda> >;
-    template class TriaIterator      <DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda> >;
-    template class TriaActiveIterator<DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda> >;
+    template class TriaRawIterator<
+      DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda>>;
+    template class TriaIterator<
+      DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda>>;
+    template class TriaActiveIterator<
+      DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda>>;
 
 
 
-// // --------------------------------------------------------------------------
-// // explicit instantiations (for DoFHandler)
+    // //
+    // --------------------------------------------------------------------------
+    // // explicit instantiations (for DoFHandler)
 
 #if deal_II_dimension == 1
-    template class DoFAccessor<1, DoFHandler<1,2>, lda>;
+    template class DoFAccessor<1, DoFHandler<1, 2>, lda>;
 #endif
 
 #if deal_II_dimension == 2
-    template class DoFAccessor<1, DoFHandler<2,3>, lda>;
-    template class DoFAccessor<2, DoFHandler<2,3>, lda>;
+    template class DoFAccessor<1, DoFHandler<2, 3>, lda>;
+    template class DoFAccessor<2, DoFHandler<2, 3>, lda>;
 
-    template class TriaRawIterator   <DoFAccessor<1, DoFHandler<2,3>, lda> >;
-    template class TriaIterator      <DoFAccessor<1, DoFHandler<2,3>, lda> >;
-    template class TriaActiveIterator<DoFAccessor<1, DoFHandler<2,3>, lda> >;
+    template class TriaRawIterator<DoFAccessor<1, DoFHandler<2, 3>, lda>>;
+    template class TriaIterator<DoFAccessor<1, DoFHandler<2, 3>, lda>>;
+    template class TriaActiveIterator<DoFAccessor<1, DoFHandler<2, 3>, lda>>;
 #endif
 
 
 #if deal_II_dimension != 3
-    template class DoFCellAccessor<DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda>;
+    template class DoFCellAccessor<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      lda>;
 
-    template class
-    TriaRawIterator   <DoFCellAccessor<DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda> >;
-    template class
-    TriaIterator      <DoFCellAccessor<DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda> >;
-    template class
-    TriaActiveIterator<DoFCellAccessor<DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda> >;
+    template class TriaRawIterator<
+      DoFCellAccessor<DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+                      lda>>;
+    template class TriaIterator<
+      DoFCellAccessor<DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+                      lda>>;
+    template class TriaActiveIterator<
+      DoFCellAccessor<DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+                      lda>>;
 #endif
 
 
 #if deal_II_dimension == 3
-    template class DoFCellAccessor<DoFHandler<1,3>, lda>;
+    template class DoFCellAccessor<DoFHandler<1, 3>, lda>;
 
-    template class
-    TriaRawIterator   <DoFCellAccessor<DoFHandler<1,3>, lda> >;
-    template class
-    TriaIterator      <DoFCellAccessor<DoFHandler<1,3>, lda> >;
-    template class
-    TriaActiveIterator<DoFCellAccessor<DoFHandler<1,3>, lda> >;
+    template class TriaRawIterator<DoFCellAccessor<DoFHandler<1, 3>, lda>>;
+    template class TriaIterator<DoFCellAccessor<DoFHandler<1, 3>, lda>>;
+    template class TriaActiveIterator<DoFCellAccessor<DoFHandler<1, 3>, lda>>;
 #endif
 
 
-// --------------------------------------------------------------------------
-// explicit instantiations (for hp::DoFHandler)
+    // --------------------------------------------------------------------------
+    // explicit instantiations (for hp::DoFHandler)
 
 #if deal_II_dimension == 1
-    template class DoFAccessor<1, hp::DoFHandler<1,2>, lda>;
-    template class DoFAccessor<1, hp::DoFHandler<1,3>, lda>;
+    template class DoFAccessor<1, hp::DoFHandler<1, 2>, lda>;
+    template class DoFAccessor<1, hp::DoFHandler<1, 3>, lda>;
 #endif
 
 #if deal_II_dimension == 2
-    template class DoFAccessor<1, hp::DoFHandler<2,3>, lda>;
-    template class DoFAccessor<2, hp::DoFHandler<2,3>, lda>;
+    template class DoFAccessor<1, hp::DoFHandler<2, 3>, lda>;
+    template class DoFAccessor<2, hp::DoFHandler<2, 3>, lda>;
 
-    template class TriaRawIterator   <DoFAccessor<1, hp::DoFHandler<2,3>, lda> >;
-    template class TriaIterator      <DoFAccessor<1, hp::DoFHandler<2,3>, lda> >;
-    template class TriaActiveIterator<DoFAccessor<1, hp::DoFHandler<2,3>, lda> >;
+    template class TriaRawIterator<DoFAccessor<1, hp::DoFHandler<2, 3>, lda>>;
+    template class TriaIterator<DoFAccessor<1, hp::DoFHandler<2, 3>, lda>>;
+    template class TriaActiveIterator<
+      DoFAccessor<1, hp::DoFHandler<2, 3>, lda>>;
 #endif
 
 #if deal_II_dimension != 3
-    template class DoFCellAccessor<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda>;
+    template class DoFCellAccessor<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      lda>;
 
-    template class
-    TriaRawIterator   <DoFCellAccessor<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda> >;
-    template class
-    TriaIterator      <DoFCellAccessor<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda> >;
-    template class
-    TriaActiveIterator<DoFCellAccessor<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda> >;
+    template class TriaRawIterator<
+      DoFCellAccessor<hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+                      lda>>;
+    template class TriaIterator<
+      DoFCellAccessor<hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+                      lda>>;
+    template class TriaActiveIterator<
+      DoFCellAccessor<hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+                      lda>>;
 #endif
 
 
 #if deal_II_dimension == 3
-    template class DoFCellAccessor<hp::DoFHandler<1,3>, lda>;
+    template class DoFCellAccessor<hp::DoFHandler<1, 3>, lda>;
 
-    template class
-    TriaRawIterator   <DoFCellAccessor<hp::DoFHandler<1,3>, lda> >;
-    template class
-    TriaIterator      <DoFCellAccessor<hp::DoFHandler<1,3>, lda> >;
-    template class
-    TriaActiveIterator<DoFCellAccessor<hp::DoFHandler<1,3>, lda> >;
+    template class TriaRawIterator<DoFCellAccessor<hp::DoFHandler<1, 3>, lda>>;
+    template class TriaIterator<DoFCellAccessor<hp::DoFHandler<1, 3>, lda>>;
+    template class TriaActiveIterator<
+      DoFCellAccessor<hp::DoFHandler<1, 3>, lda>>;
 #endif
-}
+  }
 
-for (deal_II_struct_dimension : DIMENSIONS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
-{
-    template class DoFInvalidAccessor<deal_II_struct_dimension,deal_II_dimension,deal_II_space_dimension>;
-}
+for (deal_II_struct_dimension : DIMENSIONS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : DIMENSIONS)
+  {
+    template class DoFInvalidAccessor<deal_II_struct_dimension,
+                                      deal_II_dimension,
+                                      deal_II_space_dimension>;
+  }

--- a/source/dofs/dof_accessor_get.inst.in
+++ b/source/dofs/dof_accessor_get.inst.in
@@ -16,62 +16,56 @@
 
 
 for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; lda : BOOL)
-{
-    template
-    void
-    DoFCellAccessor<DoFHandler<deal_II_dimension>, lda>::get_interpolated_dof_values
-    (const VEC&, Vector<VEC::value_type>&,
-     const unsigned int fe_index) const;
+  {
+    template void DoFCellAccessor<DoFHandler<deal_II_dimension>, lda>::
+      get_interpolated_dof_values(
+        const VEC &, Vector<VEC::value_type> &, const unsigned int fe_index)
+        const;
 
 #if deal_II_dimension != 3
 
-    template
-    void
-    DoFCellAccessor<DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda>::get_interpolated_dof_values
-    (const VEC&, Vector<VEC::value_type>&,
-     const unsigned int fe_index) const;
+    template void DoFCellAccessor<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      lda>::get_interpolated_dof_values(const VEC &,
+                                        Vector<VEC::value_type> &,
+                                        const unsigned int fe_index) const;
 
 #endif
 
 #if deal_II_dimension == 3
 
-    template
-    void
-    DoFCellAccessor<DoFHandler<1,3>, lda>::get_interpolated_dof_values
-    (const VEC&, Vector<VEC::value_type>&,
-     const unsigned int fe_index) const;
+    template void
+    DoFCellAccessor<DoFHandler<1, 3>, lda>::get_interpolated_dof_values(
+      const VEC &, Vector<VEC::value_type> &, const unsigned int fe_index)
+      const;
 
 #endif
-
-}
+  }
 
 
 for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; lda : BOOL)
-{
-    template
-    void
-    DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda>::get_interpolated_dof_values
-    (const VEC&, Vector<VEC::value_type>&,
-     const unsigned int fe_index) const;
+  {
+    template void DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda>::
+      get_interpolated_dof_values(
+        const VEC &, Vector<VEC::value_type> &, const unsigned int fe_index)
+        const;
 
 #if deal_II_dimension != 3
 
-    template
-    void
-    DoFCellAccessor<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda>::get_interpolated_dof_values
-    (const VEC&, Vector<VEC::value_type>&,
-     const unsigned int fe_index) const;
+    template void DoFCellAccessor<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      lda>::get_interpolated_dof_values(const VEC &,
+                                        Vector<VEC::value_type> &,
+                                        const unsigned int fe_index) const;
 
 #endif
 
 #if deal_II_dimension == 3
 
-    template
-    void
-    DoFCellAccessor<hp::DoFHandler<1,3>, lda>::get_interpolated_dof_values
-    (const VEC&, Vector<VEC::value_type>&,
-     const unsigned int fe_index) const;
+    template void
+    DoFCellAccessor<hp::DoFHandler<1, 3>, lda>::get_interpolated_dof_values(
+      const VEC &, Vector<VEC::value_type> &, const unsigned int fe_index)
+      const;
 
 #endif
-}
-
+  }

--- a/source/dofs/dof_accessor_set.inst.in
+++ b/source/dofs/dof_accessor_set.inst.in
@@ -16,62 +16,56 @@
 
 
 for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; lda : BOOL)
-{
-    template
-    void
-    DoFCellAccessor<DoFHandler<deal_II_dimension>, lda>::set_dof_values_by_interpolation
-    (const Vector<VEC::value_type>&, VEC&,
-     const unsigned int fe_index) const;
+  {
+    template void DoFCellAccessor<DoFHandler<deal_II_dimension>, lda>::
+      set_dof_values_by_interpolation(
+        const Vector<VEC::value_type> &, VEC &, const unsigned int fe_index)
+        const;
 
 #if deal_II_dimension != 3
 
-    template
-    void
-    DoFCellAccessor<DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda>::set_dof_values_by_interpolation
-    (const Vector<VEC::value_type>&, VEC&,
-     const unsigned int fe_index) const;
+    template void DoFCellAccessor<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      lda>::set_dof_values_by_interpolation(const Vector<VEC::value_type> &,
+                                            VEC &,
+                                            const unsigned int fe_index) const;
 
 #endif
 
 #if deal_II_dimension == 3
 
-    template
-    void
-    DoFCellAccessor<DoFHandler<1,3>, lda>::set_dof_values_by_interpolation
-    (const Vector<VEC::value_type>&, VEC&,
-     const unsigned int fe_index) const;
+    template void
+    DoFCellAccessor<DoFHandler<1, 3>, lda>::set_dof_values_by_interpolation(
+      const Vector<VEC::value_type> &, VEC &, const unsigned int fe_index)
+      const;
 
 #endif
-
-}
+  }
 
 
 for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; lda : BOOL)
-{
-    template
-    void
-    DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda>::set_dof_values_by_interpolation
-    (const Vector<VEC::value_type>&, VEC&,
-     const unsigned int fe_index) const;
+  {
+    template void DoFCellAccessor<hp::DoFHandler<deal_II_dimension>, lda>::
+      set_dof_values_by_interpolation(
+        const Vector<VEC::value_type> &, VEC &, const unsigned int fe_index)
+        const;
 
 #if deal_II_dimension != 3
 
-    template
-    void
-    DoFCellAccessor<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, lda>::set_dof_values_by_interpolation
-    (const Vector<VEC::value_type>&, VEC&,
-     const unsigned int fe_index) const;
+    template void DoFCellAccessor<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      lda>::set_dof_values_by_interpolation(const Vector<VEC::value_type> &,
+                                            VEC &,
+                                            const unsigned int fe_index) const;
 
 #endif
 
 #if deal_II_dimension == 3
 
-    template
-    void
-    DoFCellAccessor<hp::DoFHandler<1,3>, lda>::set_dof_values_by_interpolation
-    (const Vector<VEC::value_type>&, VEC&,
-     const unsigned int fe_index) const;
+    template void
+    DoFCellAccessor<hp::DoFHandler<1, 3>, lda>::set_dof_values_by_interpolation(
+      const Vector<VEC::value_type> &, VEC &, const unsigned int fe_index)
+      const;
 
 #endif
-}
-
+  }

--- a/source/dofs/dof_handler.inst.in
+++ b/source/dofs/dof_handler.inst.in
@@ -15,17 +15,23 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace internal
     \{
-    template const types::global_dof_index * dummy<deal_II_dimension,deal_II_dimension> ();
-    template std::string policy_to_string(const dealii::internal::DoFHandlerImplementation::Policy::
-                                          PolicyBase<deal_II_dimension,deal_II_dimension> &);
+      template const types::global_dof_index *
+      dummy<deal_II_dimension, deal_II_dimension>();
+      template std::string
+      policy_to_string(
+        const dealii::internal::DoFHandlerImplementation::Policy::
+          PolicyBase<deal_II_dimension, deal_II_dimension> &);
 
 #if deal_II_dimension < 3
-    template const types::global_dof_index * dummy<deal_II_dimension,deal_II_dimension+1> ();
-    template std::string policy_to_string(const dealii::internal::DoFHandlerImplementation::Policy::
-                                          PolicyBase<deal_II_dimension,deal_II_dimension+1> &);
+      template const types::global_dof_index *
+      dummy<deal_II_dimension, deal_II_dimension + 1>();
+      template std::string
+      policy_to_string(
+        const dealii::internal::DoFHandlerImplementation::Policy::
+          PolicyBase<deal_II_dimension, deal_II_dimension + 1> &);
 #endif
     \}
 
@@ -33,131 +39,117 @@ for (deal_II_dimension : DIMENSIONS)
     template class DoFHandler<deal_II_dimension>;
 
 #if deal_II_dimension < 3
-    template class DoFHandler<deal_II_dimension,deal_II_dimension+1>;
+    template class DoFHandler<deal_II_dimension, deal_II_dimension + 1>;
 #endif
 
 #if deal_II_dimension == 3
-    template class DoFHandler<1,deal_II_dimension>;
+    template class DoFHandler<1, deal_II_dimension>;
 
-    template
-    types::global_dof_index
-    DoFHandler<1,3>::
-    get_dof_index<1> (const unsigned int       obj_level,
-                      const unsigned int       obj_index,
-                      const unsigned int       fe_index,
-                      const unsigned int       local_index) const;
+    template types::global_dof_index DoFHandler<1, 3>::get_dof_index<1>(
+      const unsigned int obj_level,
+      const unsigned int obj_index,
+      const unsigned int fe_index,
+      const unsigned int local_index) const;
 #endif
 
-    template
-    types::global_dof_index
-    DoFHandler<deal_II_dimension,deal_II_dimension>::
-    get_dof_index<1> (const unsigned int       obj_level,
-                      const unsigned int       obj_index,
-                      const unsigned int       fe_index,
-                      const unsigned int       local_index) const;
+    template types::global_dof_index
+    DoFHandler<deal_II_dimension, deal_II_dimension>::get_dof_index<1>(
+      const unsigned int obj_level,
+      const unsigned int obj_index,
+      const unsigned int fe_index,
+      const unsigned int local_index) const;
 
 #if deal_II_dimension < 3
-    template
-    types::global_dof_index
-    DoFHandler<deal_II_dimension,deal_II_dimension+1>::
-    get_dof_index<1> (const unsigned int       obj_level,
-                      const unsigned int       obj_index,
-                      const unsigned int       fe_index,
-                      const unsigned int       local_index) const;
+    template types::global_dof_index
+    DoFHandler<deal_II_dimension, deal_II_dimension + 1>::get_dof_index<1>(
+      const unsigned int obj_level,
+      const unsigned int obj_index,
+      const unsigned int fe_index,
+      const unsigned int local_index) const;
 #endif
 
 #if deal_II_dimension >= 2
-    template
-    types::global_dof_index
-    DoFHandler<deal_II_dimension,deal_II_dimension>::
-    get_dof_index<2> (const unsigned int       obj_level,
-                      const unsigned int       obj_index,
-                      const unsigned int       fe_index,
-                      const unsigned int       local_index) const;
+    template types::global_dof_index
+    DoFHandler<deal_II_dimension, deal_II_dimension>::get_dof_index<2>(
+      const unsigned int obj_level,
+      const unsigned int obj_index,
+      const unsigned int fe_index,
+      const unsigned int local_index) const;
+
+#  if deal_II_dimension < 3
+    template types::global_dof_index
+    DoFHandler<deal_II_dimension, deal_II_dimension + 1>::get_dof_index<2>(
+      const unsigned int obj_level,
+      const unsigned int obj_index,
+      const unsigned int fe_index,
+      const unsigned int local_index) const;
+#  endif
+
+#  if deal_II_dimension >= 3
+    template types::global_dof_index
+    DoFHandler<deal_II_dimension, deal_II_dimension>::get_dof_index<3>(
+      const unsigned int obj_level,
+      const unsigned int obj_index,
+      const unsigned int fe_index,
+      const unsigned int local_index) const;
+#  endif
+#endif
+
+    template void
+    DoFHandler<deal_II_dimension, deal_II_dimension>::set_dof_index<1>(
+      const unsigned int            obj_level,
+      const unsigned int            obj_index,
+      const unsigned int            fe_index,
+      const unsigned int            local_index,
+      const types::global_dof_index global_index) const;
 
 #if deal_II_dimension < 3
-    template
-    types::global_dof_index
-    DoFHandler<deal_II_dimension,deal_II_dimension+1>::
-    get_dof_index<2> (const unsigned int       obj_level,
-                      const unsigned int       obj_index,
-                      const unsigned int       fe_index,
-                      const unsigned int       local_index) const;
-#endif
-
-#if deal_II_dimension >= 3
-    template
-    types::global_dof_index
-    DoFHandler<deal_II_dimension,deal_II_dimension>::
-    get_dof_index<3> (const unsigned int       obj_level,
-                      const unsigned int       obj_index,
-                      const unsigned int       fe_index,
-                      const unsigned int       local_index) const;
-#endif
-#endif
-
-    template
-    void
-    DoFHandler<deal_II_dimension,deal_II_dimension>::
-    set_dof_index<1> (const unsigned int       obj_level,
-                      const unsigned int            obj_index,
-                      const unsigned int            fe_index,
-                      const unsigned int            local_index,
-                      const types::global_dof_index global_index) const;
-
-#if deal_II_dimension < 3
-    template
-    void
-    DoFHandler<deal_II_dimension,deal_II_dimension+1>::
-    set_dof_index<1> (const unsigned int       obj_level,
-                      const unsigned int            obj_index,
-                      const unsigned int            fe_index,
-                      const unsigned int            local_index,
-                      const types::global_dof_index global_index) const;
+    template void
+    DoFHandler<deal_II_dimension, deal_II_dimension + 1>::set_dof_index<1>(
+      const unsigned int            obj_level,
+      const unsigned int            obj_index,
+      const unsigned int            fe_index,
+      const unsigned int            local_index,
+      const types::global_dof_index global_index) const;
 #endif
 
 #if deal_II_dimension < 2
-    template
-    void
-    DoFHandler<deal_II_dimension,deal_II_dimension+2>::
-    set_dof_index<1> (const unsigned int       obj_level,
-                      const unsigned int            obj_index,
-                      const unsigned int            fe_index,
-                      const unsigned int            local_index,
-                      const types::global_dof_index global_index) const;
+    template void
+    DoFHandler<deal_II_dimension, deal_II_dimension + 2>::set_dof_index<1>(
+      const unsigned int            obj_level,
+      const unsigned int            obj_index,
+      const unsigned int            fe_index,
+      const unsigned int            local_index,
+      const types::global_dof_index global_index) const;
 #endif
 
 #if deal_II_dimension >= 2
-    template
-    void
-    DoFHandler<deal_II_dimension,deal_II_dimension>::
-    set_dof_index<2> (const unsigned int       obj_level,
-                      const unsigned int            obj_index,
-                      const unsigned int            fe_index,
-                      const unsigned int            local_index,
-                      const types::global_dof_index global_index) const;
+    template void
+    DoFHandler<deal_II_dimension, deal_II_dimension>::set_dof_index<2>(
+      const unsigned int            obj_level,
+      const unsigned int            obj_index,
+      const unsigned int            fe_index,
+      const unsigned int            local_index,
+      const types::global_dof_index global_index) const;
 
-#if deal_II_dimension < 3
-    template
-    void
-    DoFHandler<deal_II_dimension,deal_II_dimension+1>::
-    set_dof_index<2> (const unsigned int       obj_level,
-                      const unsigned int            obj_index,
-                      const unsigned int            fe_index,
-                      const unsigned int            local_index,
-                      const types::global_dof_index global_index) const;
-#endif
+#  if deal_II_dimension < 3
+    template void
+    DoFHandler<deal_II_dimension, deal_II_dimension + 1>::set_dof_index<2>(
+      const unsigned int            obj_level,
+      const unsigned int            obj_index,
+      const unsigned int            fe_index,
+      const unsigned int            local_index,
+      const types::global_dof_index global_index) const;
+#  endif
 
-#if deal_II_dimension >= 3
-    template
-    void
-    DoFHandler<deal_II_dimension,deal_II_dimension>::
-    set_dof_index<3> (const unsigned int       obj_level,
-                      const unsigned int            obj_index,
-                      const unsigned int            fe_index,
-                      const unsigned int            local_index,
-                      const types::global_dof_index global_index) const;
+#  if deal_II_dimension >= 3
+    template void
+    DoFHandler<deal_II_dimension, deal_II_dimension>::set_dof_index<3>(
+      const unsigned int            obj_level,
+      const unsigned int            obj_index,
+      const unsigned int            fe_index,
+      const unsigned int            local_index,
+      const types::global_dof_index global_index) const;
+#  endif
 #endif
-#endif
-}
-
+  }

--- a/source/dofs/dof_handler_policy.inst.in
+++ b/source/dofs/dof_handler_policy.inst.in
@@ -14,27 +14,33 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace internal
     \{
-    namespace DoFHandlerImplementation
-    \{
-    namespace Policy
-    \{
-    template class PolicyBase<deal_II_dimension,deal_II_space_dimension>;
+      namespace DoFHandlerImplementation
+      \{
+        namespace Policy
+        \{
+          template class PolicyBase<deal_II_dimension, deal_II_space_dimension>;
 
-    template class Sequential<dealii::DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
-    template class Sequential<dealii::hp::DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
+          template class Sequential<
+            dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+          template class Sequential<
+            dealii::hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
 
-    template class ParallelShared<dealii::DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
-    template class ParallelShared<dealii::hp::DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
+          template class ParallelShared<
+            dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+          template class ParallelShared<
+            dealii::hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
 
-    template class ParallelDistributed<dealii::DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
-    template class ParallelDistributed<dealii::hp::DoFHandler<deal_II_dimension,deal_II_space_dimension> >;
-    \}
-    \}
+          template class ParallelDistributed<
+            dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+          template class ParallelDistributed<
+            dealii::hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        \}
+      \}
     \}
 #endif
-}
+  }

--- a/source/dofs/dof_objects.inst.in
+++ b/source/dofs/dof_objects.inst.in
@@ -16,69 +16,58 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class DoFObjects<deal_II_dimension>;
-}
+  }
 
 
 for (deal_II_dimension, structdim : DIMENSIONS)
-{
-    template
-    types::global_dof_index
-    DoFObjects<structdim>::
-    get_dof_index (const dealii::DoFHandler<deal_II_dimension> &dof_handler,
-                   const unsigned int       obj_index,
-                   const unsigned int       fe_index,
-                   const unsigned int       local_index) const;
+  {
+    template types::global_dof_index DoFObjects<structdim>::get_dof_index(
+      const dealii::DoFHandler<deal_II_dimension> &dof_handler,
+      const unsigned int                           obj_index,
+      const unsigned int                           fe_index,
+      const unsigned int                           local_index) const;
 
-    template
-    void
-    DoFObjects<structdim>::
-    set_dof_index (const dealii::DoFHandler<deal_II_dimension> &dof_handler,
-                   const unsigned int       obj_index,
-                   const unsigned int       fe_index,
-                   const unsigned int       local_index,
-                   const types::global_dof_index       global_index);
+    template void DoFObjects<structdim>::set_dof_index(
+      const dealii::DoFHandler<deal_II_dimension> &dof_handler,
+      const unsigned int                           obj_index,
+      const unsigned int                           fe_index,
+      const unsigned int                           local_index,
+      const types::global_dof_index                global_index);
 
 #if (deal_II_dimension < 3) && (structdim < 3)
 
-    template
-    types::global_dof_index
-    DoFObjects<structdim>::
-    get_dof_index (const dealii::DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_handler,
-                   const unsigned int       obj_index,
-                   const unsigned int       fe_index,
-                   const unsigned int       local_index) const;
+    template types::global_dof_index DoFObjects<structdim>::get_dof_index(
+      const dealii::DoFHandler<deal_II_dimension, deal_II_dimension + 1>
+        &                dof_handler,
+      const unsigned int obj_index,
+      const unsigned int fe_index,
+      const unsigned int local_index) const;
 
-    template
-    void
-    DoFObjects<structdim>::
-    set_dof_index (const dealii::DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_handler,
-                   const unsigned int       obj_index,
-                   const unsigned int       fe_index,
-                   const unsigned int       local_index,
-                   const types::global_dof_index global_index);
+    template void DoFObjects<structdim>::set_dof_index(
+      const dealii::DoFHandler<deal_II_dimension, deal_II_dimension + 1>
+        &                           dof_handler,
+      const unsigned int            obj_index,
+      const unsigned int            fe_index,
+      const unsigned int            local_index,
+      const types::global_dof_index global_index);
 #endif
 
 
 #if (deal_II_dimension == 3) && (structdim < 3)
 
-    template
-    types::global_dof_index
-    DoFObjects<structdim>::
-    get_dof_index (const dealii::DoFHandler<1,3> &dof_handler,
-                   const unsigned int       obj_index,
-                   const unsigned int       fe_index,
-                   const unsigned int       local_index) const;
+    template types::global_dof_index DoFObjects<structdim>::get_dof_index(
+      const dealii::DoFHandler<1, 3> &dof_handler,
+      const unsigned int              obj_index,
+      const unsigned int              fe_index,
+      const unsigned int              local_index) const;
 
-    template
-    void
-    DoFObjects<structdim>::
-    set_dof_index (const dealii::DoFHandler<1,3> &dof_handler,
-                   const unsigned int       obj_index,
-                   const unsigned int       fe_index,
-                   const unsigned int       local_index,
-                   const types::global_dof_index       global_index);
+    template void DoFObjects<structdim>::set_dof_index(
+      const dealii::DoFHandler<1, 3> &dof_handler,
+      const unsigned int              obj_index,
+      const unsigned int              fe_index,
+      const unsigned int              local_index,
+      const types::global_dof_index   global_index);
 #endif
-}
-
+  }

--- a/source/dofs/dof_renumbering.inst.in
+++ b/source/dofs/dof_renumbering.inst.in
@@ -14,316 +14,324 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace DoFRenumbering
     \{
-    namespace boost
-    \{
-//TODO[WB]: also implement the following boost for hp DoFHandlers etc.
+      namespace boost
+      \{
+        // TODO[WB]: also implement the following boost for hp DoFHandlers etc.
+      \}
+
+
+      // non-boost functions:
+      template void
+      Cuthill_McKee<DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const bool,
+        const bool,
+        const std::vector<types::global_dof_index> &);
+
+      template void
+      compute_Cuthill_McKee<
+        DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        std::vector<types::global_dof_index> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const bool,
+        const bool,
+        const std::vector<types::global_dof_index> &);
+
+      template void
+      component_wise<DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const std::vector<unsigned int> &);
+
+      template void
+      component_wise<
+        hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const std::vector<unsigned int> &);
+
+      template void
+      block_wise<deal_II_dimension, deal_II_space_dimension>(
+        DoFHandler<deal_II_dimension, deal_II_space_dimension> &);
+
+      template void
+      subdomain_wise<DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        DoFHandler<deal_II_dimension, deal_II_space_dimension> &);
+
+      template void
+      compute_subdomain_wise(
+        std::vector<types::global_dof_index> &new_dof_indices,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension>
+          &dof_handler);
+
     \}
-
-
-// non-boost functions:
-    template
-    void Cuthill_McKee<DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const bool,
-     const bool,
-     const std::vector<types::global_dof_index>&);
-
-    template
-    void
-    compute_Cuthill_McKee<DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (std::vector<types::global_dof_index>&,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const bool,
-     const bool,
-     const std::vector<types::global_dof_index>&);
-
-    template
-    void component_wise<DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const std::vector<unsigned int>&);
-
-    template
-    void component_wise<hp::DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const std::vector<unsigned int>&);
-
-    template
-    void block_wise<deal_II_dimension,deal_II_space_dimension>
-    (DoFHandler<deal_II_dimension,deal_II_space_dimension>&);
-
-    template
-    void subdomain_wise<DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (DoFHandler<deal_II_dimension,deal_II_space_dimension> &);
-
-    template
-    void
-    compute_subdomain_wise (std::vector<types::global_dof_index> &new_dof_indices,
-                            const DoFHandler<deal_II_dimension,deal_II_space_dimension> &dof_handler);
-
-    \}  // namespace DoFRenumbering
 #endif
-}
+  }
 
-//TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension, deal_II_space_dimension>
+// TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension,
+// deal_II_space_dimension>
 // where applicable and move to codimension cases above also when applicable
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension == deal_II_space_dimension
     namespace DoFRenumbering
     \{
-    namespace boost
-    \{
-//TODO[WB]: also implement the following boost for hp DoFHandlers etc.
-    template
-    void
-    Cuthill_McKee (DoFHandler<deal_II_dimension> &, bool, bool);
+      namespace boost
+      \{
+        // TODO[WB]: also implement the following boost for hp DoFHandlers etc.
+        template void
+        Cuthill_McKee(DoFHandler<deal_II_dimension> &, bool, bool);
 
-    template
-    void
-    compute_Cuthill_McKee (std::vector<dealii::types::global_dof_index> &,
-                           const DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        compute_Cuthill_McKee(std::vector<dealii::types::global_dof_index> &,
+                              const DoFHandler<deal_II_dimension> &,
+                              bool,
+                              bool);
 
-    template
-    void
-    king_ordering (DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        king_ordering(DoFHandler<deal_II_dimension> &, bool, bool);
 
-    template
-    void
-    compute_king_ordering (std::vector<dealii::types::global_dof_index> &,
-                           const DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        compute_king_ordering(std::vector<dealii::types::global_dof_index> &,
+                              const DoFHandler<deal_II_dimension> &,
+                              bool,
+                              bool);
 
-    template
-    void
-    minimum_degree (DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        minimum_degree(DoFHandler<deal_II_dimension> &, bool, bool);
 
-    template
-    void
-    compute_minimum_degree (std::vector<dealii::types::global_dof_index> &,
-                            const DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        compute_minimum_degree(std::vector<dealii::types::global_dof_index> &,
+                               const DoFHandler<deal_II_dimension> &,
+                               bool,
+                               bool);
 
 
-    template
-    void
-    Cuthill_McKee (hp::DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        Cuthill_McKee(hp::DoFHandler<deal_II_dimension> &, bool, bool);
 
-    template
-    void
-    compute_Cuthill_McKee (std::vector<dealii::types::global_dof_index> &,
-                           const hp::DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        compute_Cuthill_McKee(std::vector<dealii::types::global_dof_index> &,
+                              const hp::DoFHandler<deal_II_dimension> &,
+                              bool,
+                              bool);
 
-    template
-    void
-    king_ordering (hp::DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        king_ordering(hp::DoFHandler<deal_II_dimension> &, bool, bool);
 
-    template
-    void
-    compute_king_ordering (std::vector<dealii::types::global_dof_index> &,
-                           const hp::DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        compute_king_ordering(std::vector<dealii::types::global_dof_index> &,
+                              const hp::DoFHandler<deal_II_dimension> &,
+                              bool,
+                              bool);
 
-    template
-    void
-    minimum_degree (hp::DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        minimum_degree(hp::DoFHandler<deal_II_dimension> &, bool, bool);
 
-    template
-    void
-    compute_minimum_degree (std::vector<dealii::types::global_dof_index> &,
-                            const hp::DoFHandler<deal_II_dimension> &, bool, bool);
+        template void
+        compute_minimum_degree(std::vector<dealii::types::global_dof_index> &,
+                               const hp::DoFHandler<deal_II_dimension> &,
+                               bool,
+                               bool);
+      \}
+
+
+      // non-boost functions:
+
+      template void
+      Cuthill_McKee<hp::DoFHandler<deal_II_dimension>>(
+        hp::DoFHandler<deal_II_dimension> &,
+        const bool,
+        const bool,
+        const std::vector<types::global_dof_index> &);
+
+      template void
+      compute_Cuthill_McKee<hp::DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const bool,
+        const bool,
+        const std::vector<types::global_dof_index> &);
+
+      template void
+      component_wise(DoFHandler<deal_II_dimension> &,
+                     unsigned int,
+                     const std::vector<unsigned int> &);
+
+      template void
+      block_wise<deal_II_dimension>(hp::DoFHandler<deal_II_dimension> &);
+
+      template void
+      block_wise<deal_II_dimension>(DoFHandler<deal_II_dimension> &,
+                                    unsigned int);
+
+      template void
+      hierarchical<deal_II_dimension>(DoFHandler<deal_II_dimension> &);
+
+      template void
+      cell_wise<DoFHandler<deal_II_dimension>>(
+        DoFHandler<deal_II_dimension> &,
+        const std::vector<DoFHandler<deal_II_dimension>::active_cell_iterator>
+          &);
+
+      template void
+      compute_cell_wise<DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        std::vector<types::global_dof_index> &,
+        const DoFHandler<deal_II_dimension> &,
+        const std::vector<DoFHandler<deal_II_dimension>::active_cell_iterator>
+          &);
+
+      template void
+      cell_wise<DoFHandler<deal_II_dimension>>(
+        DoFHandler<deal_II_dimension> &,
+        unsigned int,
+        const std::vector<DoFHandler<deal_II_dimension>::level_cell_iterator>
+          &);
+
+      template void
+      compute_cell_wise<DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        std::vector<types::global_dof_index> &,
+        const DoFHandler<deal_II_dimension> &,
+        unsigned int,
+        const std::vector<DoFHandler<deal_II_dimension>::level_cell_iterator>
+          &);
+
+      template void
+      compute_downstream<DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        std::vector<types::global_dof_index> &,
+        const DoFHandler<deal_II_dimension> &,
+        const Tensor<1, DoFHandler<deal_II_dimension>::space_dimension> &,
+        const bool);
+
+      template void
+      clockwise_dg<DoFHandler<deal_II_dimension>>(
+        DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        bool);
+
+      template void
+      compute_clockwise_dg<DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        const DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        const bool);
+
+      // Renumbering for hp::DoFHandler
+
+      template void
+      cell_wise<hp::DoFHandler<deal_II_dimension>>(
+        hp::DoFHandler<deal_II_dimension> &,
+        const std::vector<
+          hp::DoFHandler<deal_II_dimension>::active_cell_iterator> &);
+
+      template void
+      compute_cell_wise<hp::DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        std::vector<types::global_dof_index> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const std::vector<
+          hp::DoFHandler<deal_II_dimension>::active_cell_iterator> &);
+
+      template void
+      compute_downstream<hp::DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        std::vector<types::global_dof_index> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const Tensor<1, hp::DoFHandler<deal_II_dimension>::space_dimension> &,
+        const bool);
+
+      template void
+      clockwise_dg<hp::DoFHandler<deal_II_dimension>>(
+        hp::DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        bool);
+
+      template void
+      compute_clockwise_dg<hp::DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        const bool);
+
+      template void
+      downstream(
+        DoFHandler<deal_II_dimension> &,
+        const Tensor<1, DoFHandler<deal_II_dimension>::space_dimension> &,
+        const bool);
+
+      // MG
+
+      template void
+      downstream(
+        DoFHandler<deal_II_dimension> &,
+        const unsigned int,
+        const Tensor<1, DoFHandler<deal_II_dimension>::space_dimension> &,
+        const bool);
+
+      template void
+      clockwise_dg(DoFHandler<deal_II_dimension> &,
+                   const unsigned int,
+                   const Point<deal_II_dimension> &,
+                   bool);
+
+      // Generic numbering schemes
+
+      template void
+      random<DoFHandler<deal_II_dimension>>(DoFHandler<deal_II_dimension> &);
+
+      template void
+      compute_random<DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        const DoFHandler<deal_II_dimension> &);
+
+      template void
+      sort_selected_dofs_back<DoFHandler<deal_II_dimension>>(
+        DoFHandler<deal_II_dimension> &,
+        const std::vector<bool> &);
+
+      template void
+      compute_sort_selected_dofs_back<DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        const DoFHandler<deal_II_dimension> &,
+        const std::vector<bool> &);
+
+      template void
+      random<hp::DoFHandler<deal_II_dimension>>(
+        hp::DoFHandler<deal_II_dimension> &);
+
+      template void
+      compute_random<hp::DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        const hp::DoFHandler<deal_II_dimension> &);
+
+      template void
+      sort_selected_dofs_back<hp::DoFHandler<deal_II_dimension>>(
+        hp::DoFHandler<deal_II_dimension> &,
+        const std::vector<bool> &);
+
+      template void
+      compute_sort_selected_dofs_back<hp::DoFHandler<deal_II_dimension>>(
+        std::vector<types::global_dof_index> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const std::vector<bool> &);
+
+
+      template void
+      subdomain_wise<hp::DoFHandler<deal_II_dimension>>(
+        hp::DoFHandler<deal_II_dimension> &);
+
+      template void
+      Cuthill_McKee<DoFHandler<deal_II_dimension>>(
+        DoFHandler<deal_II_dimension> &,
+        const unsigned int,
+        const bool,
+        const std::vector<types::global_dof_index> &);
     \}
-
-
-// non-boost functions:
-
-    template
-    void Cuthill_McKee<hp::DoFHandler<deal_II_dimension> >
-    (hp::DoFHandler<deal_II_dimension>&,
-     const bool,
-     const bool,
-     const std::vector<types::global_dof_index>&);
-
-    template
-    void
-    compute_Cuthill_McKee<hp::DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&,
-     const hp::DoFHandler<deal_II_dimension>&,
-     const bool,
-     const bool,
-     const std::vector<types::global_dof_index>&);
-
-    template
-    void component_wise
-    (DoFHandler<deal_II_dimension>&,
-     unsigned int,
-     const std::vector<unsigned int>&);
-
-    template
-    void block_wise<deal_II_dimension>
-    (hp::DoFHandler<deal_II_dimension>&);
-
-    template
-    void block_wise<deal_II_dimension>
-    (DoFHandler<deal_II_dimension>&,
-     unsigned int);
-
-    template
-    void hierarchical<deal_II_dimension>
-    (DoFHandler<deal_II_dimension>&);
-
-    template void
-    cell_wise<DoFHandler<deal_II_dimension> >
-    (DoFHandler<deal_II_dimension>&,
-     const std::vector<DoFHandler<deal_II_dimension>::active_cell_iterator>&);
-
-    template void
-    compute_cell_wise<DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&, std::vector<types::global_dof_index>&,
-     const DoFHandler<deal_II_dimension>&,
-     const std::vector<DoFHandler<deal_II_dimension>::active_cell_iterator>&);
-
-    template void
-    cell_wise<DoFHandler<deal_II_dimension> >
-    (DoFHandler<deal_II_dimension>&, unsigned int,
-     const std::vector<DoFHandler<deal_II_dimension>::level_cell_iterator>&);
-
-    template void
-    compute_cell_wise<DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&, std::vector<types::global_dof_index>&,
-     const DoFHandler<deal_II_dimension>&, unsigned int,
-     const std::vector<DoFHandler<deal_II_dimension>::level_cell_iterator>&);
-
-    template void
-    compute_downstream<DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&,std::vector<types::global_dof_index>&,
-     const DoFHandler<deal_II_dimension>&, const Tensor<1,DoFHandler<deal_II_dimension>::space_dimension>&,
-     const bool);
-
-    template
-    void
-    clockwise_dg<DoFHandler<deal_II_dimension> >
-    (DoFHandler<deal_II_dimension>&, const Point<deal_II_dimension>&, bool);
-
-    template
-    void
-    compute_clockwise_dg<DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&, const DoFHandler<deal_II_dimension>&,
-     const Point<deal_II_dimension>&, const bool);
-
-// Renumbering for hp::DoFHandler
-
-    template void
-    cell_wise<hp::DoFHandler<deal_II_dimension> >
-    (hp::DoFHandler<deal_II_dimension>&,
-     const std::vector<hp::DoFHandler<deal_II_dimension>::active_cell_iterator>&);
-
-    template void
-    compute_cell_wise<hp::DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&, std::vector<types::global_dof_index>&,
-     const hp::DoFHandler<deal_II_dimension>&,
-     const std::vector<hp::DoFHandler<deal_II_dimension>::active_cell_iterator>&);
-
-    template void
-    compute_downstream<hp::DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&,std::vector<types::global_dof_index>&,
-     const hp::DoFHandler<deal_II_dimension>&,
-     const Tensor<1,hp::DoFHandler<deal_II_dimension>::space_dimension>&,
-     const bool);
-
-    template
-    void
-    clockwise_dg<hp::DoFHandler<deal_II_dimension> >
-    (hp::DoFHandler<deal_II_dimension>&,
-     const Point<deal_II_dimension>&, bool);
-
-    template
-    void
-    compute_clockwise_dg<hp::DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&,
-     const hp::DoFHandler<deal_II_dimension>&,
-     const Point<deal_II_dimension>&,
-     const bool);
-
-    template
-    void downstream
-    (DoFHandler<deal_II_dimension>&,
-     const Tensor<1,DoFHandler<deal_II_dimension>::space_dimension>&,
-     const bool);
-
-// MG
-
-    template
-    void downstream
-    (DoFHandler<deal_II_dimension>&,
-     const unsigned int,
-     const Tensor<1,DoFHandler<deal_II_dimension>::space_dimension>&,
-     const bool);
-
-    template
-    void clockwise_dg
-    (DoFHandler<deal_II_dimension>&,
-     const unsigned int,
-     const Point<deal_II_dimension>&, bool);
-
-// Generic numbering schemes
-
-    template
-    void random<DoFHandler<deal_II_dimension> >
-    (DoFHandler<deal_II_dimension> &);
-
-    template
-    void
-    compute_random<DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&,
-     const DoFHandler<deal_II_dimension> &);
-
-    template
-    void sort_selected_dofs_back<DoFHandler<deal_II_dimension> >
-    (DoFHandler<deal_II_dimension> &,
-     const std::vector<bool> &);
-
-    template
-    void
-    compute_sort_selected_dofs_back<DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&,
-     const DoFHandler<deal_II_dimension> &,
-     const std::vector<bool> &);
-
-    template
-    void random<hp::DoFHandler<deal_II_dimension> >
-    (hp::DoFHandler<deal_II_dimension> &);
-
-    template
-    void
-    compute_random<hp::DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&,
-     const hp::DoFHandler<deal_II_dimension> &);
-
-    template
-    void sort_selected_dofs_back<hp::DoFHandler<deal_II_dimension> >
-    (hp::DoFHandler<deal_II_dimension> &,
-     const std::vector<bool> &);
-
-    template
-    void
-    compute_sort_selected_dofs_back<hp::DoFHandler<deal_II_dimension> >
-    (std::vector<types::global_dof_index>&,
-     const hp::DoFHandler<deal_II_dimension> &,
-     const std::vector<bool> &);
-
-
-    template
-    void subdomain_wise<hp::DoFHandler<deal_II_dimension> >
-    (hp::DoFHandler<deal_II_dimension> &);
-
-    template
-    void Cuthill_McKee<DoFHandler<deal_II_dimension> >
-    (DoFHandler<deal_II_dimension>&,
-     const unsigned int,
-     const bool,
-     const std::vector<types::global_dof_index>&);
-    \}  // namespace DoFRenumbering
 #endif
-}
+  }

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -14,816 +14,716 @@
 // ---------------------------------------------------------------------
 
 
-for (DoFHandler : DOFHANDLER_TEMPLATES; deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
-{
-
+for (DoFHandler : DOFHANDLER_TEMPLATES;
+     deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void
-    DoFTools::extract_locally_relevant_dofs<DoFHandler<deal_II_dimension,deal_II_space_dimension > >
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension > & dof_handler,
-     IndexSet & dof_set);
+    template void DoFTools::extract_locally_relevant_dofs<
+      DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof_handler,
+      IndexSet &                                                    dof_set);
 
-    template
-    void
-    DoFTools::extract_locally_relevant_level_dofs<DoFHandler<deal_II_dimension,deal_II_space_dimension > >
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension > & dof_handler,
-     const unsigned int level,
-     IndexSet & dof_set);
+    template void DoFTools::extract_locally_relevant_level_dofs<
+      DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof_handler,
+      const unsigned int                                            level,
+      IndexSet &                                                    dof_set);
 
-    template
-    void
-    DoFTools::extract_locally_owned_dofs<DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension> & dof_handler,
-     IndexSet & dof_set);
+    template void DoFTools::extract_locally_owned_dofs<
+      DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof_handler,
+      IndexSet &                                                    dof_set);
 
-    template
-    void
-    DoFTools::extract_locally_active_dofs<DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension> & dof_handler,
-     IndexSet & dof_set);
+    template void DoFTools::extract_locally_active_dofs<
+      DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof_handler,
+      IndexSet &                                                    dof_set);
 #endif
-}
+  }
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template
-    std::vector<unsigned int>
-    DoFTools::make_vertex_patches (SparsityPattern&, const DoFHandler<deal_II_dimension>&,
-                                   unsigned int, bool, bool, bool, bool, bool);
+  {
+    template std::vector<unsigned int> DoFTools::make_vertex_patches(
+      SparsityPattern &,
+      const DoFHandler<deal_II_dimension> &,
+      unsigned int,
+      bool,
+      bool,
+      bool,
+      bool,
+      bool);
 
-    template
-    std::vector<unsigned int>
-    DoFTools::make_vertex_patches (SparsityPattern&, const DoFHandler<deal_II_dimension>&,
-                                   unsigned int, const BlockMask&, bool, bool, bool, bool);
+    template std::vector<unsigned int> DoFTools::make_vertex_patches(
+      SparsityPattern &,
+      const DoFHandler<deal_II_dimension> &,
+      unsigned int,
+      const BlockMask &,
+      bool,
+      bool,
+      bool,
+      bool);
 
-    template
-    void DoFTools::make_single_patch (SparsityPattern&, const DoFHandler<deal_II_dimension>&,
-                                      unsigned int, bool);
+    template void DoFTools::make_single_patch(
+      SparsityPattern &,
+      const DoFHandler<deal_II_dimension> &,
+      unsigned int,
+      bool);
 
-    template
-    void DoFTools::make_child_patches(SparsityPattern&, const DoFHandler<deal_II_dimension>&,
-                                      unsigned int, bool, bool);
+    template void DoFTools::make_child_patches(
+      SparsityPattern &,
+      const DoFHandler<deal_II_dimension> &,
+      unsigned int,
+      bool,
+      bool);
 
-// TODO: can cleanup a bit more to fit into the scheme used above
+    // TODO: can cleanup a bit more to fit into the scheme used above
 
-    template
-    void
-    DoFTools::distribute_cell_to_dof_vector<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &dof_handler,
-     const Vector<float> &cell_data,
-     Vector<double>      &dof_data,
-     const unsigned int   component);
-    template
-    void
-    DoFTools::distribute_cell_to_dof_vector<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &dof_handler,
-     const Vector<double> &cell_data,
-     Vector<double>       &dof_data,
-     const unsigned int    component);
+    template void
+    DoFTools::distribute_cell_to_dof_vector<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &dof_handler,
+      const Vector<float> &                cell_data,
+      Vector<double> &                     dof_data,
+      const unsigned int                   component);
+    template void
+    DoFTools::distribute_cell_to_dof_vector<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &dof_handler,
+      const Vector<double> &               cell_data,
+      Vector<double> &                     dof_data,
+      const unsigned int                   component);
 
-    template
-    void
-    DoFTools::distribute_cell_to_dof_vector<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &dof_handler,
-     const Vector<float> &cell_data,
-     Vector<double>      &dof_data,
-     const unsigned int   component);
-    template
-    void
-    DoFTools::distribute_cell_to_dof_vector<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &dof_handler,
-     const Vector<double> &cell_data,
-     Vector<double>       &dof_data,
-     const unsigned int    component);
-
+    template void
+    DoFTools::distribute_cell_to_dof_vector<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &dof_handler,
+      const Vector<float> &                    cell_data,
+      Vector<double> &                         dof_data,
+      const unsigned int                       component);
+    template void
+    DoFTools::distribute_cell_to_dof_vector<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &dof_handler,
+      const Vector<double> &                   cell_data,
+      Vector<double> &                         dof_data,
+      const unsigned int                       component);
 
 
-    template void DoFTools::extract_level_dofs<DoFHandler<deal_II_dimension> >
-    (const unsigned int level,
-     const DoFHandler<deal_II_dimension>&,
-     const ComponentMask &,
-     std::vector<bool>&);
 
-    template void DoFTools::extract_level_dofs<DoFHandler<deal_II_dimension> >
-    (const unsigned int level,
-     const DoFHandler<deal_II_dimension>&,
-     const BlockMask &,
-     std::vector<bool>&);
+    template void DoFTools::extract_level_dofs<DoFHandler<deal_II_dimension>>(
+      const unsigned int level,
+      const DoFHandler<deal_II_dimension> &,
+      const ComponentMask &,
+      std::vector<bool> &);
+
+    template void DoFTools::extract_level_dofs<DoFHandler<deal_II_dimension>>(
+      const unsigned int level,
+      const DoFHandler<deal_II_dimension> &,
+      const BlockMask &,
+      std::vector<bool> &);
 
 #if deal_II_dimension > 1
-    template void DoFTools::extract_level_dofs<DoFHandler<1, deal_II_dimension> >
-    (const unsigned int level,
-     const DoFHandler<1, deal_II_dimension>&,
-     const BlockMask &,
-     std::vector<bool>&);
+    template void
+    DoFTools::extract_level_dofs<DoFHandler<1, deal_II_dimension>>(
+      const unsigned int level,
+      const DoFHandler<1, deal_II_dimension> &,
+      const BlockMask &,
+      std::vector<bool> &);
 #endif
 
 #if deal_II_dimension > 2
-    template void DoFTools::extract_level_dofs<DoFHandler<2, deal_II_dimension> >
-    (const unsigned int level,
-     const DoFHandler<2, deal_II_dimension>&,
-     const BlockMask &,
-     std::vector<bool>&);
+    template void
+    DoFTools::extract_level_dofs<DoFHandler<2, deal_II_dimension>>(
+      const unsigned int level,
+      const DoFHandler<2, deal_II_dimension> &,
+      const BlockMask &,
+      std::vector<bool> &);
 #endif
 
-    template
-    void
-    DoFTools::extract_boundary_dofs<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &,
-     const ComponentMask                  &,
-     std::vector<bool>                        &,
-     const std::set<types::boundary_id> &);
+    template void
+    DoFTools::extract_boundary_dofs<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &,
+      const ComponentMask &,
+      std::vector<bool> &,
+      const std::set<types::boundary_id> &);
 
-    template
-    void
-    DoFTools::extract_boundary_dofs<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &,
-     const ComponentMask                  &,
-     std::vector<bool>                        &,
-     const std::set<types::boundary_id> &);
+    template void
+    DoFTools::extract_boundary_dofs<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &,
+      const ComponentMask &,
+      std::vector<bool> &,
+      const std::set<types::boundary_id> &);
 
-    template
-    void
-    DoFTools::extract_boundary_dofs<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &,
-     const ComponentMask                  &,
-     IndexSet                        &,
-     const std::set<types::boundary_id> &);
+    template void
+    DoFTools::extract_boundary_dofs<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &,
+      const ComponentMask &,
+      IndexSet &,
+      const std::set<types::boundary_id> &);
 
-    template
-    void
-    DoFTools::extract_boundary_dofs<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &,
-     const ComponentMask                  &,
-     IndexSet                        &,
-     const std::set<types::boundary_id> &);
+    template void
+    DoFTools::extract_boundary_dofs<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &,
+      const ComponentMask &,
+      IndexSet &,
+      const std::set<types::boundary_id> &);
 
-    template
-    void
-    DoFTools::extract_dofs_with_support_on_boundary<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &,
-     const ComponentMask                  &,
-     std::vector<bool>                        &,
-     const std::set<types::boundary_id> &);
-    template
-    void
-    DoFTools::extract_dofs_with_support_on_boundary<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &,
-     const ComponentMask                  &,
-     std::vector<bool>                        &,
-     const std::set<types::boundary_id> &);
+    template void DoFTools::extract_dofs_with_support_on_boundary<
+      DoFHandler<deal_II_dimension>>(const DoFHandler<deal_II_dimension> &,
+                                     const ComponentMask &,
+                                     std::vector<bool> &,
+                                     const std::set<types::boundary_id> &);
+    template void DoFTools::extract_dofs_with_support_on_boundary<
+      hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &,
+      const ComponentMask &,
+      std::vector<bool> &,
+      const std::set<types::boundary_id> &);
 
-    template
-    IndexSet
-    DoFTools::extract_dofs_with_support_contained_within<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &,
-     const std::function< bool(const typename DoFHandler<deal_II_dimension>::active_cell_iterator &)> &,
-     const ConstraintMatrix&);
+    template IndexSet DoFTools::extract_dofs_with_support_contained_within<
+      DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &,
+      const std::function<bool(
+        const typename DoFHandler<deal_II_dimension>::active_cell_iterator &)>
+        &,
+      const ConstraintMatrix &);
 
-    template
-    void
-    DoFTools::extract_hanging_node_dofs
-    (const DoFHandler<deal_II_dimension> &dof_handler,
-     std::vector<bool>     &selected_dofs);
+    template void DoFTools::extract_hanging_node_dofs(
+      const DoFHandler<deal_II_dimension> &dof_handler,
+      std::vector<bool> &                  selected_dofs);
 
-    template
-    void
-    DoFTools::extract_subdomain_dofs<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &dof_handler,
-     const types::subdomain_id  subdomain_id,
-     std::vector<bool>     &selected_dofs);
-    template
-    void
-    DoFTools::extract_subdomain_dofs<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &dof_handler,
-     const types::subdomain_id subdomain_id,
-     std::vector<bool>     &selected_dofs);
+    template void
+    DoFTools::extract_subdomain_dofs<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &dof_handler,
+      const types::subdomain_id            subdomain_id,
+      std::vector<bool> &                  selected_dofs);
+    template void
+    DoFTools::extract_subdomain_dofs<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &dof_handler,
+      const types::subdomain_id                subdomain_id,
+      std::vector<bool> &                      selected_dofs);
 
-    template
-    void
-    DoFTools::extract_constant_modes<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &dof_handler,
-     const ComponentMask &selected_components,
-     std::vector<std::vector<bool> > &constant_modes);
+    template void
+    DoFTools::extract_constant_modes<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &dof_handler,
+      const ComponentMask &                selected_components,
+      std::vector<std::vector<bool>> &     constant_modes);
 
-    template
-    void
-    DoFTools::extract_constant_modes<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &dof_handler,
-     const ComponentMask &selected_components,
-     std::vector<std::vector<bool> > &constant_modes);
+    template void
+    DoFTools::extract_constant_modes<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &dof_handler,
+      const ComponentMask &                    selected_components,
+      std::vector<std::vector<bool>> &         constant_modes);
 
-    template
-    void
-    DoFTools::get_active_fe_indices<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &dof_handler,
-     std::vector<unsigned int> &active_fe_indices);
+    template void
+    DoFTools::get_active_fe_indices<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &dof_handler,
+      std::vector<unsigned int> &          active_fe_indices);
 
-    template
-    void
-    DoFTools::get_active_fe_indices<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &dof_handler,
-     std::vector<unsigned int> &active_fe_indices);
+    template void
+    DoFTools::get_active_fe_indices<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &dof_handler,
+      std::vector<unsigned int> &              active_fe_indices);
 
-    template
-    void
-    DoFTools::get_subdomain_association<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &dof_handler,
-     std::vector<types::subdomain_id>           &subdomain_association);
-    template
-    void
-    DoFTools::get_subdomain_association<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &dof_handler,
-     std::vector<types::subdomain_id>           &subdomain_association);
+    template void
+    DoFTools::get_subdomain_association<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &dof_handler,
+      std::vector<types::subdomain_id> &   subdomain_association);
+    template void
+    DoFTools::get_subdomain_association<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &dof_handler,
+      std::vector<types::subdomain_id> &       subdomain_association);
 
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_owned_dofs_per_subdomain<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &dof_handler);
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_owned_dofs_per_subdomain<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &dof_handler);
+    template std::vector<IndexSet>
+    DoFTools::locally_owned_dofs_per_subdomain<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &dof_handler);
+    template std::vector<IndexSet> DoFTools::locally_owned_dofs_per_subdomain<
+      hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &dof_handler);
 
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_relevant_dofs_per_subdomain<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &dof_handler);
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_relevant_dofs_per_subdomain<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &dof_handler);
+    template std::vector<IndexSet> DoFTools::
+      locally_relevant_dofs_per_subdomain<DoFHandler<deal_II_dimension>>(
+        const DoFHandler<deal_II_dimension> &dof_handler);
+    template std::vector<IndexSet> DoFTools::
+      locally_relevant_dofs_per_subdomain<hp::DoFHandler<deal_II_dimension>>(
+        const hp::DoFHandler<deal_II_dimension> &dof_handler);
 
-    template
-    unsigned int
-    DoFTools::count_dofs_with_subdomain_association<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &,
-     const types::subdomain_id);
-    template
-    IndexSet
-    DoFTools::dof_indices_with_subdomain_association<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &,
-     const types::subdomain_id);
-    template
-    void
-    DoFTools::count_dofs_with_subdomain_association<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &,
-     const types::subdomain_id,
-     std::vector<unsigned int> &);
+    template unsigned int DoFTools::count_dofs_with_subdomain_association<
+      DoFHandler<deal_II_dimension>>(const DoFHandler<deal_II_dimension> &,
+                                     const types::subdomain_id);
+    template IndexSet DoFTools::dof_indices_with_subdomain_association<
+      DoFHandler<deal_II_dimension>>(const DoFHandler<deal_II_dimension> &,
+                                     const types::subdomain_id);
+    template void DoFTools::count_dofs_with_subdomain_association<
+      DoFHandler<deal_II_dimension>>(const DoFHandler<deal_II_dimension> &,
+                                     const types::subdomain_id,
+                                     std::vector<unsigned int> &);
 
-    template
-    unsigned int
-    DoFTools::count_dofs_with_subdomain_association<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &,
-     const types::subdomain_id);
-    template
-    IndexSet
-    DoFTools::dof_indices_with_subdomain_association<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &,
-     const types::subdomain_id);
-    template
-    void
-    DoFTools::count_dofs_with_subdomain_association<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &,
-     const types::subdomain_id,
-     std::vector<unsigned int> &);
+    template unsigned int DoFTools::count_dofs_with_subdomain_association<
+      hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &, const types::subdomain_id);
+    template IndexSet DoFTools::dof_indices_with_subdomain_association<
+      hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &, const types::subdomain_id);
+    template void DoFTools::count_dofs_with_subdomain_association<
+      hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &,
+      const types::subdomain_id,
+      std::vector<unsigned int> &);
 
 #if deal_II_dimension < 3
 
-    template
-    void
-    DoFTools::extract_boundary_dofs<DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     const ComponentMask                  &,
-     std::vector<bool>                        &,
-     const std::set<types::boundary_id> &);
+    template void DoFTools::extract_boundary_dofs<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const ComponentMask &,
+      std::vector<bool> &,
+      const std::set<types::boundary_id> &);
 
-    template
-    void
-    DoFTools::extract_boundary_dofs<DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     const ComponentMask                  &,
-     IndexSet                        &,
-     const std::set<types::boundary_id> &);
+    template void DoFTools::extract_boundary_dofs<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const ComponentMask &,
+      IndexSet &,
+      const std::set<types::boundary_id> &);
 
-    template
-    unsigned int
-    DoFTools::count_dofs_with_subdomain_association<DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     const types::subdomain_id);
+    template unsigned int DoFTools::count_dofs_with_subdomain_association<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const types::subdomain_id);
 
-    template
-    IndexSet
-    DoFTools::dof_indices_with_subdomain_association<DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     const types::subdomain_id);
-    template
-    void
-    DoFTools::count_dofs_with_subdomain_association<DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     const types::subdomain_id,
-     std::vector<unsigned int> &);
+    template IndexSet DoFTools::dof_indices_with_subdomain_association<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const types::subdomain_id);
+    template void DoFTools::count_dofs_with_subdomain_association<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const types::subdomain_id,
+      std::vector<unsigned int> &);
 
-    template
-    unsigned int
-    DoFTools::count_dofs_with_subdomain_association<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     const types::subdomain_id);
+    template unsigned int DoFTools::count_dofs_with_subdomain_association<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const types::subdomain_id);
 
-    template
-    IndexSet
-    DoFTools::dof_indices_with_subdomain_association<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     const types::subdomain_id);
+    template IndexSet DoFTools::dof_indices_with_subdomain_association<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const types::subdomain_id);
 
-    template
-    void
-    DoFTools::get_subdomain_association<DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_handler,
-     std::vector<types::subdomain_id>           &subdomain_association);
-    template
-    void
-    DoFTools::get_subdomain_association<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_handler,
-     std::vector<types::subdomain_id>           &subdomain_association);
+    template void DoFTools::get_subdomain_association<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof_handler,
+      std::vector<types::subdomain_id> &subdomain_association);
+    template void DoFTools::get_subdomain_association<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>
+        &                               dof_handler,
+      std::vector<types::subdomain_id> &subdomain_association);
 
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_owned_dofs_per_subdomain<DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_handler);
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_owned_dofs_per_subdomain<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_handler);
+    template std::vector<IndexSet> DoFTools::locally_owned_dofs_per_subdomain<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof_handler);
+    template std::vector<IndexSet> DoFTools::locally_owned_dofs_per_subdomain<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>
+        &dof_handler);
 
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_relevant_dofs_per_subdomain<DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_handler);
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_relevant_dofs_per_subdomain<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_handler);
+    template std::vector<IndexSet>
+    DoFTools::locally_relevant_dofs_per_subdomain<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof_handler);
+    template std::vector<IndexSet>
+    DoFTools::locally_relevant_dofs_per_subdomain<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>
+        &dof_handler);
 
-    template
-    void
-    DoFTools::count_dofs_with_subdomain_association<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     const types::subdomain_id,
-     std::vector<unsigned int> &);
+    template void DoFTools::count_dofs_with_subdomain_association<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const types::subdomain_id,
+      std::vector<unsigned int> &);
 #endif
 
 #if deal_II_dimension == 3
-    template
-    void
-    DoFTools::extract_boundary_dofs<DoFHandler<1,3> >
-    (const DoFHandler<1,3> &,
-     const ComponentMask                  &,
-     std::vector<bool>                        &,
-     const std::set<types::boundary_id> &);
+    template void DoFTools::extract_boundary_dofs<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &,
+      const ComponentMask &,
+      std::vector<bool> &,
+      const std::set<types::boundary_id> &);
 
-    template
-    void
-    DoFTools::extract_boundary_dofs<DoFHandler<1,3> >
-    (const DoFHandler<1,3> &,
-     const ComponentMask                  &,
-     IndexSet                        &,
-     const std::set<types::boundary_id> &);
+    template void DoFTools::extract_boundary_dofs<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &,
+      const ComponentMask &,
+      IndexSet &,
+      const std::set<types::boundary_id> &);
 
-    template
-    void
-    DoFTools::get_subdomain_association<DoFHandler<1,3> >
-    (const DoFHandler<1,3> &dof_handler,
-     std::vector<types::subdomain_id>           &subdomain_association);
-    template
-    void
-    DoFTools::get_subdomain_association<hp::DoFHandler<1,3> >
-    (const hp::DoFHandler<1,3> &dof_handler,
-     std::vector<types::subdomain_id>           &subdomain_association);
+    template void DoFTools::get_subdomain_association<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &          dof_handler,
+      std::vector<types::subdomain_id> &subdomain_association);
+    template void DoFTools::get_subdomain_association<hp::DoFHandler<1, 3>>(
+      const hp::DoFHandler<1, 3> &      dof_handler,
+      std::vector<types::subdomain_id> &subdomain_association);
 
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_owned_dofs_per_subdomain<DoFHandler<1,3> >
-    (const DoFHandler<1,3>     &dof_handler);
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_owned_dofs_per_subdomain<hp::DoFHandler<1,3> >
-    (const hp::DoFHandler<1,3> &dof_handler);
+    template std::vector<IndexSet>
+    DoFTools::locally_owned_dofs_per_subdomain<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &dof_handler);
+    template std::vector<IndexSet>
+    DoFTools::locally_owned_dofs_per_subdomain<hp::DoFHandler<1, 3>>(
+      const hp::DoFHandler<1, 3> &dof_handler);
 
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_relevant_dofs_per_subdomain<DoFHandler<1,3> >
-    (const DoFHandler<1,3>     &dof_handler);
-    template
-    std::vector<IndexSet>
-    DoFTools::locally_relevant_dofs_per_subdomain<hp::DoFHandler<1,3> >
-    (const hp::DoFHandler<1,3> &dof_handler);
+    template std::vector<IndexSet>
+    DoFTools::locally_relevant_dofs_per_subdomain<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &dof_handler);
+    template std::vector<IndexSet>
+    DoFTools::locally_relevant_dofs_per_subdomain<hp::DoFHandler<1, 3>>(
+      const hp::DoFHandler<1, 3> &dof_handler);
 
-    template
-    unsigned int
-    DoFTools::count_dofs_with_subdomain_association<DoFHandler<1,3> >
-    (const DoFHandler<1,3> &,
-     const types::subdomain_id);
-    template
-    IndexSet
-    DoFTools::dof_indices_with_subdomain_association<DoFHandler<1,3> >
-    (const DoFHandler<1,3> &,
-     const types::subdomain_id);
-    template
-    void
-    DoFTools::count_dofs_with_subdomain_association<DoFHandler<1,3> >
-    (const DoFHandler<1,3> &,
-     const types::subdomain_id,
-     std::vector<unsigned int> &);
+    template unsigned int
+    DoFTools::count_dofs_with_subdomain_association<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &, const types::subdomain_id);
+    template IndexSet
+    DoFTools::dof_indices_with_subdomain_association<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &, const types::subdomain_id);
+    template void
+    DoFTools::count_dofs_with_subdomain_association<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &,
+      const types::subdomain_id,
+      std::vector<unsigned int> &);
 
-    template
-    unsigned int
-    DoFTools::count_dofs_with_subdomain_association<hp::DoFHandler<1,3> >
-    (const hp::DoFHandler<1,3> &,
-     const types::subdomain_id);
-    template
-    IndexSet
-    DoFTools::dof_indices_with_subdomain_association<hp::DoFHandler<1,3> >
-    (const hp::DoFHandler<1,3> &,
-     const types::subdomain_id);
-    template
-    void
-    DoFTools::count_dofs_with_subdomain_association<hp::DoFHandler<1,3> >
-    (const hp::DoFHandler<1,3> &,
-     const types::subdomain_id,
-     std::vector<unsigned int> &);
+    template unsigned int
+    DoFTools::count_dofs_with_subdomain_association<hp::DoFHandler<1, 3>>(
+      const hp::DoFHandler<1, 3> &, const types::subdomain_id);
+    template IndexSet
+    DoFTools::dof_indices_with_subdomain_association<hp::DoFHandler<1, 3>>(
+      const hp::DoFHandler<1, 3> &, const types::subdomain_id);
+    template void
+    DoFTools::count_dofs_with_subdomain_association<hp::DoFHandler<1, 3>>(
+      const hp::DoFHandler<1, 3> &,
+      const types::subdomain_id,
+      std::vector<unsigned int> &);
 #endif
 
 
 
-    template
-    void
-    DoFTools::count_dofs_per_component<DoFHandler<deal_II_dimension> > (
-        const DoFHandler<deal_II_dimension>&,
-        std::vector<types::global_dof_index>&, bool, std::vector<unsigned int>);
+    template void
+    DoFTools::count_dofs_per_component<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &,
+      std::vector<types::global_dof_index> &,
+      bool,
+      std::vector<unsigned int>);
 
-    template
-    void
-    DoFTools::count_dofs_per_component<hp::DoFHandler<deal_II_dimension> > (
-        const hp::DoFHandler<deal_II_dimension>&,
-        std::vector<types::global_dof_index>&, bool, std::vector<unsigned int>);
+    template void
+    DoFTools::count_dofs_per_component<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &,
+      std::vector<types::global_dof_index> &,
+      bool,
+      std::vector<unsigned int>);
 
 
 #if deal_II_dimension < 3
-    template
-    void
-    DoFTools::count_dofs_per_component<DoFHandler<deal_II_dimension, deal_II_dimension+1> > (
-        const DoFHandler<deal_II_dimension, deal_II_dimension+1>&,
-        std::vector<types::global_dof_index>&, bool, std::vector<unsigned int>);
+    template void DoFTools::count_dofs_per_component<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::vector<types::global_dof_index> &,
+      bool,
+      std::vector<unsigned int>);
 
-    template
-    void
-    DoFTools::count_dofs_per_component<hp::DoFHandler<deal_II_dimension, deal_II_dimension+1> > (
-        const hp::DoFHandler<deal_II_dimension, deal_II_dimension+1>&,
-        std::vector<types::global_dof_index>&, bool, std::vector<unsigned int>);
+    template void DoFTools::count_dofs_per_component<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::vector<types::global_dof_index> &,
+      bool,
+      std::vector<unsigned int>);
 
-    template
-    void
-    DoFTools::extract_level_dofs<DoFHandler<deal_II_dimension, deal_II_dimension+1> >
-    (const unsigned int level,
-     const DoFHandler<deal_II_dimension, deal_II_dimension+1>&,
-     const ComponentMask&,
-     std::vector<bool>&);
+    template void DoFTools::extract_level_dofs<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const unsigned int level,
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const ComponentMask &,
+      std::vector<bool> &);
 
 #endif
 
 
 #if deal_II_dimension == 3
-    template
-    void
-    DoFTools::count_dofs_per_component<DoFHandler<1,3> > (
-        const DoFHandler<1,3>&,
-        std::vector<types::global_dof_index>&, bool, std::vector<unsigned int>);
+    template void DoFTools::count_dofs_per_component<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &,
+      std::vector<types::global_dof_index> &,
+      bool,
+      std::vector<unsigned int>);
 
-    template
-    void
-    DoFTools::count_dofs_per_component<hp::DoFHandler<1,3> > (
-        const hp::DoFHandler<1,3>&,
-        std::vector<types::global_dof_index>&, bool, std::vector<unsigned int>);
+    template void DoFTools::count_dofs_per_component<hp::DoFHandler<1, 3>>(
+      const hp::DoFHandler<1, 3> &,
+      std::vector<types::global_dof_index> &,
+      bool,
+      std::vector<unsigned int>);
 
-    template
-    void
-    DoFTools::extract_level_dofs<DoFHandler<1, 3> >
-    (const unsigned int level,
-     const DoFHandler<1,3>&,
-     const ComponentMask &,
-     std::vector<bool>&);
+    template void DoFTools::extract_level_dofs<DoFHandler<1, 3>>(
+      const unsigned int level,
+      const DoFHandler<1, 3> &,
+      const ComponentMask &,
+      std::vector<bool> &);
 
 #endif
 
 
-    template
-    void
-    DoFTools::count_dofs_per_block<DoFHandler<deal_II_dimension> > (
-        const DoFHandler<deal_II_dimension>&,
-        std::vector<types::global_dof_index>&,
-        const std::vector<unsigned int> &);
+    template void DoFTools::count_dofs_per_block<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &,
+      std::vector<types::global_dof_index> &,
+      const std::vector<unsigned int> &);
 
-    template
-    void
-    DoFTools::count_dofs_per_block<hp::DoFHandler<deal_II_dimension> > (
-        const hp::DoFHandler<deal_II_dimension>&,
-        std::vector<types::global_dof_index>&,
-        const std::vector<unsigned int> &);
+    template void
+    DoFTools::count_dofs_per_block<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &,
+      std::vector<types::global_dof_index> &,
+      const std::vector<unsigned int> &);
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &,
-     const std::set<types::boundary_id> &,
-     std::vector<types::global_dof_index> &);
+    template void
+    DoFTools::map_dof_to_boundary_indices<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &,
+      const std::set<types::boundary_id> &,
+      std::vector<types::global_dof_index> &);
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<DoFHandler<deal_II_dimension> >
-    (const DoFHandler<deal_II_dimension> &,
-     std::vector<types::global_dof_index> &);
+    template void
+    DoFTools::map_dof_to_boundary_indices<DoFHandler<deal_II_dimension>>(
+      const DoFHandler<deal_II_dimension> &,
+      std::vector<types::global_dof_index> &);
 
 
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &,
-     const std::set<types::boundary_id> &,
-     std::vector<types::global_dof_index> &);
+    template void
+    DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &,
+      const std::set<types::boundary_id> &,
+      std::vector<types::global_dof_index> &);
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<deal_II_dimension> >
-    (const hp::DoFHandler<deal_II_dimension> &,
-     std::vector<types::global_dof_index> &);
+    template void
+    DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<deal_II_dimension>>(
+      const hp::DoFHandler<deal_II_dimension> &,
+      std::vector<types::global_dof_index> &);
 
 
 
-    template
-    void
-    DoFTools::map_dofs_to_support_points<deal_II_dimension>
-    (const Mapping<deal_II_dimension,deal_II_dimension>&,
-     const DoFHandler<deal_II_dimension>&,
-     std::vector<Point<deal_II_dimension> >&);
+    template void DoFTools::map_dofs_to_support_points<deal_II_dimension>(
+      const Mapping<deal_II_dimension, deal_II_dimension> &,
+      const DoFHandler<deal_II_dimension> &,
+      std::vector<Point<deal_II_dimension>> &);
 
 
-    template
-    void
-    DoFTools::map_dofs_to_support_points<deal_II_dimension>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_dimension>&,
-     const hp::DoFHandler<deal_II_dimension>&,
-     std::vector<Point<deal_II_dimension> >&);
+    template void DoFTools::map_dofs_to_support_points<deal_II_dimension>(
+      const hp::MappingCollection<deal_II_dimension, deal_II_dimension> &,
+      const hp::DoFHandler<deal_II_dimension> &,
+      std::vector<Point<deal_II_dimension>> &);
 
 
-    template
-    void
-    DoFTools::map_dofs_to_support_points<deal_II_dimension>
-    (const Mapping<deal_II_dimension,deal_II_dimension>&,
-     const DoFHandler<deal_II_dimension>&,
-     std::map<types::global_dof_index, Point<deal_II_dimension> >&);
+    template void DoFTools::map_dofs_to_support_points<deal_II_dimension>(
+      const Mapping<deal_II_dimension, deal_II_dimension> &,
+      const DoFHandler<deal_II_dimension> &,
+      std::map<types::global_dof_index, Point<deal_II_dimension>> &);
 
 
-    template
-    void
-    DoFTools::map_dofs_to_support_points<deal_II_dimension>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_dimension>&,
-     const hp::DoFHandler<deal_II_dimension>&,
-     std::map<types::global_dof_index, Point<deal_II_dimension> >&);
+    template void DoFTools::map_dofs_to_support_points<deal_II_dimension>(
+      const hp::MappingCollection<deal_II_dimension, deal_II_dimension> &,
+      const hp::DoFHandler<deal_II_dimension> &,
+      std::map<types::global_dof_index, Point<deal_II_dimension>> &);
 
 #if deal_II_dimension < 3
 
-    template
-    void
-    DoFTools::map_dofs_to_support_points<deal_II_dimension,deal_II_dimension+1>
-    (const Mapping<deal_II_dimension,deal_II_dimension+1>&,
-     const DoFHandler<deal_II_dimension, deal_II_dimension+1>&,
-     std::vector<Point<deal_II_dimension+1> >&);
+    template void DoFTools::map_dofs_to_support_points<deal_II_dimension,
+                                                       deal_II_dimension + 1>(
+      const Mapping<deal_II_dimension, deal_II_dimension + 1> &,
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::vector<Point<deal_II_dimension + 1>> &);
 
-    template
-    void
-    DoFTools::map_dofs_to_support_points<deal_II_dimension,deal_II_dimension+1>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_dimension+1>&,
-     const hp::DoFHandler<deal_II_dimension, deal_II_dimension+1>&,
-     std::vector<Point<deal_II_dimension+1> >&);
+    template void DoFTools::map_dofs_to_support_points<deal_II_dimension,
+                                                       deal_II_dimension + 1>(
+      const hp::MappingCollection<deal_II_dimension, deal_II_dimension + 1> &,
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::vector<Point<deal_II_dimension + 1>> &);
 
-    template
-    void
-    DoFTools::map_dofs_to_support_points<deal_II_dimension,deal_II_dimension+1>
-    (const Mapping<deal_II_dimension,deal_II_dimension+1>&,
-     const DoFHandler<deal_II_dimension, deal_II_dimension+1>&,
-     std::map<types::global_dof_index, Point<deal_II_dimension+1> >&);
+    template void DoFTools::map_dofs_to_support_points<deal_II_dimension,
+                                                       deal_II_dimension + 1>(
+      const Mapping<deal_II_dimension, deal_II_dimension + 1> &,
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::map<types::global_dof_index, Point<deal_II_dimension + 1>> &);
 
-    template
-    void
-    DoFTools::map_dofs_to_support_points<deal_II_dimension,deal_II_dimension+1>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_dimension+1>&,
-     const hp::DoFHandler<deal_II_dimension, deal_II_dimension+1>&,
-     std::map<types::global_dof_index, Point<deal_II_dimension+1> >&);
+    template void DoFTools::map_dofs_to_support_points<deal_II_dimension,
+                                                       deal_II_dimension + 1>(
+      const hp::MappingCollection<deal_II_dimension, deal_II_dimension + 1> &,
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::map<types::global_dof_index, Point<deal_II_dimension + 1>> &);
 
 
-    template
-    void
-    DoFTools::count_dofs_per_block<DoFHandler<deal_II_dimension,deal_II_dimension+1> > (
-        const DoFHandler<deal_II_dimension,deal_II_dimension+1>&,
-        std::vector<types::global_dof_index>&,
-        const std::vector<unsigned int> &);
+    template void DoFTools::count_dofs_per_block<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::vector<types::global_dof_index> &,
+      const std::vector<unsigned int> &);
 
-    template
-    void
-    DoFTools::count_dofs_per_block<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> > (
-        const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>&,
-        std::vector<types::global_dof_index>&,
-        const std::vector<unsigned int> &);
+    template void DoFTools::count_dofs_per_block<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::vector<types::global_dof_index> &,
+      const std::vector<unsigned int> &);
 
 #endif
 
 
 #if deal_II_dimension == 3
 
-    template
-    void
-    DoFTools::map_dofs_to_support_points<1,3>
-    (const Mapping<1,3>&,
-     const DoFHandler<1,3>&,
-     std::vector<Point<3> >&);
+    template void DoFTools::map_dofs_to_support_points<1, 3>(
+      const Mapping<1, 3> &, const DoFHandler<1, 3> &, std::vector<Point<3>> &);
 
-    template
-    void
-    DoFTools::count_dofs_per_block<DoFHandler<1,3> > (
-        const DoFHandler<1,3>&,
-        std::vector<types::global_dof_index>&,
-        const std::vector<unsigned int> &);
+    template void DoFTools::count_dofs_per_block<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &,
+      std::vector<types::global_dof_index> &,
+      const std::vector<unsigned int> &);
 
-    template
-    void
-    DoFTools::count_dofs_per_block<hp::DoFHandler<1,3> > (
-        const hp::DoFHandler<1,3>&,
-        std::vector<types::global_dof_index>&,
-        const std::vector<unsigned int> &);
+    template void DoFTools::count_dofs_per_block<hp::DoFHandler<1, 3>>(
+      const hp::DoFHandler<1, 3> &,
+      std::vector<types::global_dof_index> &,
+      const std::vector<unsigned int> &);
 
 #endif
 
-    template
-    void
-    DoFTools::write_gnuplot_dof_support_point_info(std::ostream &,
-            const std::map<types::global_dof_index, Point<deal_II_dimension> > &);
+    template void DoFTools::write_gnuplot_dof_support_point_info(
+      std::ostream &,
+      const std::map<types::global_dof_index, Point<deal_II_dimension>> &);
 
 
-    template
-    void
-    DoFTools::convert_couplings_to_blocks (
-        const DoFHandler<deal_II_dimension>&, const Table<2, Coupling>&,
-        std::vector<Table<2,Coupling> >&);
+    template void DoFTools::convert_couplings_to_blocks(
+      const DoFHandler<deal_II_dimension> &,
+      const Table<2, Coupling> &,
+      std::vector<Table<2, Coupling>> &);
 
-    template
-    void
-    DoFTools::convert_couplings_to_blocks (
-        const hp::DoFHandler<deal_II_dimension>&, const Table<2, Coupling>&,
-        std::vector<Table<2,Coupling> >&);
+    template void DoFTools::convert_couplings_to_blocks(
+      const hp::DoFHandler<deal_II_dimension> &,
+      const Table<2, Coupling> &,
+      std::vector<Table<2, Coupling>> &);
 
 
 #if deal_II_dimension < 3
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     const std::set<types::boundary_id> &,
-     std::vector<types::global_dof_index> &);
+    template void DoFTools::map_dof_to_boundary_indices<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const std::set<types::boundary_id> &,
+      std::vector<types::global_dof_index> &);
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     std::vector<types::global_dof_index> &);
+    template void DoFTools::map_dof_to_boundary_indices<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::vector<types::global_dof_index> &);
 
 
-    template
-    void
-    DoFTools::extract_hanging_node_dofs
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_handler,
-     std::vector<bool>     &selected_dofs);
+    template void DoFTools::extract_hanging_node_dofs(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof_handler,
+      std::vector<bool> &selected_dofs);
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     const std::set<types::boundary_id> &,
-     std::vector<types::global_dof_index> &);
+    template void DoFTools::map_dof_to_boundary_indices<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      const std::set<types::boundary_id> &,
+      std::vector<types::global_dof_index> &);
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> >
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &,
-     std::vector<types::global_dof_index> &);
+    template void DoFTools::map_dof_to_boundary_indices<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::vector<types::global_dof_index> &);
 
 #endif
 
 #if deal_II_dimension == 3
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<DoFHandler<1,3> >
-    (const DoFHandler<1,3> &,
-     const std::set<types::boundary_id> &,
-     std::vector<types::global_dof_index> &);
+    template void DoFTools::map_dof_to_boundary_indices<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &,
+      const std::set<types::boundary_id> &,
+      std::vector<types::global_dof_index> &);
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<DoFHandler<1,3> >
-    (const DoFHandler<1,3> &,
-     std::vector<types::global_dof_index> &);
+    template void DoFTools::map_dof_to_boundary_indices<DoFHandler<1, 3>>(
+      const DoFHandler<1, 3> &, std::vector<types::global_dof_index> &);
 
 
-    template
-    void
-    DoFTools::extract_hanging_node_dofs
-    (const DoFHandler<1,3> &dof_handler,
-     std::vector<bool>     &selected_dofs);
+    template void DoFTools::extract_hanging_node_dofs(
+      const DoFHandler<1, 3> &dof_handler, std::vector<bool> &selected_dofs);
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<1,3> >
-    (const hp::DoFHandler<1,3> &,
-     const std::set<unsigned int> &,
-     std::vector<types::global_dof_index> &);
+    template void DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<1, 3>>(
+      const hp::DoFHandler<1, 3> &,
+      const std::set<unsigned int> &,
+      std::vector<types::global_dof_index> &);
 
-    template
-    void
-    DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<1,3> >
-    (const hp::DoFHandler<1,3> &,
-     std::vector<types::global_dof_index> &);
+    template void DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<1, 3>>(
+      const hp::DoFHandler<1, 3> &, std::vector<types::global_dof_index> &);
 
 #endif
-
-
-}
+  }
 
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace DoFTools
     \{
-    template
-    unsigned int
-    count_dofs_on_patch<DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (const std::vector<DoFHandler<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator> &patch);
+      template unsigned int
+      count_dofs_on_patch<
+        DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        const std::vector<
+          DoFHandler<deal_II_dimension,
+                     deal_II_space_dimension>::active_cell_iterator> &patch);
 
-    template
-    std::vector<types::global_dof_index>
-    get_dofs_on_patch<DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (const std::vector<DoFHandler<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator> &patch);
+      template std::vector<types::global_dof_index>
+      get_dofs_on_patch<DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        const std::vector<
+          DoFHandler<deal_II_dimension,
+                     deal_II_space_dimension>::active_cell_iterator> &patch);
 
-    template
-    unsigned int
-    count_dofs_on_patch<hp::DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (const std::vector<hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator> &patch);
+      template unsigned int
+      count_dofs_on_patch<
+        hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        const std::vector<
+          hp::DoFHandler<deal_II_dimension,
+                         deal_II_space_dimension>::active_cell_iterator>
+          &patch);
 
-    template
-    std::vector<types::global_dof_index>
-    get_dofs_on_patch<hp::DoFHandler<deal_II_dimension,deal_II_space_dimension> >
-    (const std::vector<hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator> &patch);
+      template std::vector<types::global_dof_index>
+      get_dofs_on_patch<
+        hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        const std::vector<
+          hp::DoFHandler<deal_II_dimension,
+                         deal_II_space_dimension>::active_cell_iterator>
+          &patch);
 
-    template
-    void
-    extract_dofs<deal_II_dimension,deal_II_space_dimension>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const ComponentMask &,
-     std::vector<bool>&);
+      template void
+      extract_dofs<deal_II_dimension, deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ComponentMask &,
+        std::vector<bool> &);
 
-    template
-    void
-    extract_dofs<deal_II_dimension,deal_II_space_dimension>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const BlockMask &,
-     std::vector<bool>&);
+      template void
+      extract_dofs<deal_II_dimension, deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const BlockMask &,
+        std::vector<bool> &);
 
-    template
-    void
-    extract_dofs<deal_II_dimension,deal_II_space_dimension>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const ComponentMask &,
-     std::vector<bool>&);
+      template void
+      extract_dofs<deal_II_dimension, deal_II_space_dimension>(
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ComponentMask &,
+        std::vector<bool> &);
 
-    template
-    void
-    extract_dofs<deal_II_dimension,deal_II_space_dimension>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const BlockMask &,
-     std::vector<bool>&);
+      template void
+      extract_dofs<deal_II_dimension, deal_II_space_dimension>(
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const BlockMask &,
+        std::vector<bool> &);
 
-    template
-    void
-    make_cell_patches<deal_II_dimension,deal_II_space_dimension>
-    (SparsityPattern&,
-     const DoFHandler<deal_II_dimension, deal_II_space_dimension>&,
-     const unsigned int, const std::vector<bool>&,
-     const types::global_dof_index);
+      template void
+      make_cell_patches<deal_II_dimension, deal_II_space_dimension>(
+        SparsityPattern &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const unsigned int,
+        const std::vector<bool> &,
+        const types::global_dof_index);
 
     \}
 #endif
-}
+  }

--- a/source/dofs/dof_tools_constraints.inst.in
+++ b/source/dofs/dof_tools_constraints.inst.in
@@ -15,105 +15,94 @@
 
 // co-dim instantiations not for hp-DoFHandler
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension < deal_II_space_dimension
-    template
-    void
-    DoFTools::make_hanging_node_constraints (
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension>	 &,
-        ConstraintMatrix &);
+    template void DoFTools::make_hanging_node_constraints(
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+      ConstraintMatrix &);
 #endif
-}
+  }
 
 for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
-{
-    template
-    void
-    DoFTools::make_hanging_node_constraints (
-        const DH<deal_II_dimension, deal_II_dimension>	 &,
-        ConstraintMatrix &);
+  {
+    template void DoFTools::make_hanging_node_constraints(
+      const DH<deal_II_dimension, deal_II_dimension> &, ConstraintMatrix &);
 
 #if deal_II_dimension != 1
-    template
-    void
-    DoFTools::make_periodicity_constraints (const DH<deal_II_dimension>::face_iterator &,
-                                            const DH<deal_II_dimension>::face_iterator &,
-                                            dealii::ConstraintMatrix &,
-                                            const ComponentMask &,
-                                            bool, bool, bool,
-                                            const FullMatrix<double> &,
-                                            const std::vector<unsigned int> &);
+    template void DoFTools::make_periodicity_constraints(
+      const DH<deal_II_dimension>::face_iterator &,
+      const DH<deal_II_dimension>::face_iterator &,
+      dealii::ConstraintMatrix &,
+      const ComponentMask &,
+      bool,
+      bool,
+      bool,
+      const FullMatrix<double> &,
+      const std::vector<unsigned int> &);
 
-    template
-    void
-    DoFTools::make_periodicity_constraints<DH<deal_II_dimension> >
-    (const std::vector<GridTools::PeriodicFacePair<DH<deal_II_dimension>::cell_iterator> > &,
-     dealii::ConstraintMatrix &,
-     const ComponentMask &,
-     const std::vector<unsigned int> &);
+    template void DoFTools::make_periodicity_constraints<DH<deal_II_dimension>>(
+      const std::vector<
+        GridTools::PeriodicFacePair<DH<deal_II_dimension>::cell_iterator>> &,
+      dealii::ConstraintMatrix &,
+      const ComponentMask &,
+      const std::vector<unsigned int> &);
 
 
-    template
-    void
-    DoFTools::make_periodicity_constraints(const DH<deal_II_dimension> &,
-                                           const types::boundary_id,
-                                           const types::boundary_id,
-                                           const int,
-                                           dealii::ConstraintMatrix &,
-                                           const ComponentMask &);
+    template void DoFTools::make_periodicity_constraints(
+      const DH<deal_II_dimension> &,
+      const types::boundary_id,
+      const types::boundary_id,
+      const int,
+      dealii::ConstraintMatrix &,
+      const ComponentMask &);
 
-    template
-    void
-    DoFTools::make_periodicity_constraints(const DH<deal_II_dimension> &,
-                                           const types::boundary_id,
-                                           const int,
-                                           dealii::ConstraintMatrix &,
-                                           const ComponentMask &);
+    template void DoFTools::make_periodicity_constraints(
+      const DH<deal_II_dimension> &,
+      const types::boundary_id,
+      const int,
+      dealii::ConstraintMatrix &,
+      const ComponentMask &);
 #endif
-}
+  }
 
-for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void
-    DoFTools::make_zero_boundary_constraints
-    (const DH<deal_II_dimension, deal_II_space_dimension> &,
-     ConstraintMatrix                                     &,
-     const ComponentMask                                  &);
+    template void DoFTools::make_zero_boundary_constraints(
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      ConstraintMatrix &,
+      const ComponentMask &);
 
-    template
-    void
-    DoFTools::make_zero_boundary_constraints
-    (const DH<deal_II_dimension, deal_II_space_dimension> &,
-     const types::boundary_id,
-     ConstraintMatrix                                     &,
-     const ComponentMask                                  &);
+    template void DoFTools::make_zero_boundary_constraints(
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const types::boundary_id,
+      ConstraintMatrix &,
+      const ComponentMask &);
 #endif
-}
+  }
 
 // intergrid transfer is not yet implemented for hp::DoFHandler
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void
-    DoFTools::compute_intergrid_constraints
-    (const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-     const unsigned int,
-     const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-     const unsigned int,
-     const InterGridMap<DoFHandler<deal_II_dimension, deal_II_space_dimension> > &,
-     ConstraintMatrix &);
+    template void DoFTools::compute_intergrid_constraints(
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+      const unsigned int,
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+      const unsigned int,
+      const InterGridMap<DoFHandler<deal_II_dimension, deal_II_space_dimension>>
+        &,
+      ConstraintMatrix &);
 
-    template
-    void
-    DoFTools::compute_intergrid_transfer_representation<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-     const unsigned int,
-     const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-     const unsigned int,
-     const InterGridMap<DoFHandler<deal_II_dimension, deal_II_space_dimension> > &,
-     std::vector<std::map<types::global_dof_index, float> > &);
+    template void
+    DoFTools::compute_intergrid_transfer_representation<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+      const unsigned int,
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+      const unsigned int,
+      const InterGridMap<DoFHandler<deal_II_dimension, deal_II_space_dimension>>
+        &,
+      std::vector<std::map<types::global_dof_index, float>> &);
 #endif
-}
+  }

--- a/source/dofs/dof_tools_sparsity.inst.in
+++ b/source/dofs/dof_tools_sparsity.inst.in
@@ -13,288 +13,324 @@
 //
 // ---------------------------------------------------------------------
 
-for (scalar: REAL_SCALARS; SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
-{
-    template void
-    DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension>,SP,scalar>
-    (const DoFHandler<deal_II_dimension>& dof,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,scalar>*> &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
+for (scalar : REAL_SCALARS; SP : SPARSITY_PATTERNS;
+     deal_II_dimension : DIMENSIONS)
+  {
+    template void DoFTools::
+      make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension>, SP, scalar>(
+        const DoFHandler<deal_II_dimension> &dof,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_dimension, scalar> *>
+          &                                         boundary_ids,
+        const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+        SP &                                        sparsity);
 
     template void
-    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,SP,scalar>
-    (const hp::DoFHandler<deal_II_dimension>& dof,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,scalar>*> &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
+    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,
+                                             SP,
+                                             scalar>(
+      const hp::DoFHandler<deal_II_dimension> &                    dof,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_dimension, scalar> *> &boundary_ids,
+      const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+      SP &                                        sparsity);
 
 #if deal_II_dimension < 3
-    template void
-    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP,scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
-     const std::map<types::boundary_id, const Function<deal_II_dimension+1,scalar>*>  &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
+    template void DoFTools::make_boundary_sparsity_pattern<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP,
+      scalar>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_dimension + 1, scalar> *>
+        &                                         boundary_ids,
+      const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+      SP &                                        sparsity);
 
-    template void
-    DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP,scalar>
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
-     const std::map<types::boundary_id, const Function<deal_II_dimension+1,scalar>*> &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
+    template void DoFTools::make_boundary_sparsity_pattern<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP,
+      scalar>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_dimension + 1, scalar> *>
+        &                                         boundary_ids,
+      const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+      SP &                                        sparsity);
 
-    //template void
-    //DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP,scalar>
+    // template void
+    // DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP,scalar>
     //(const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
-    // const std::map<types::boundary_id, const Function<deal_II_dimension+1,scalar>*> &boundary_ids,
-    // const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-    // SP    &sparsity);
+    // const std::map<types::boundary_id, const
+    // Function<deal_II_dimension+1,scalar>*> &boundary_ids, const
+    // std::vector<types::global_dof_index>  &dof_to_boundary_mapping, SP
+    // &sparsity);
 
 #endif
 
 #if deal_II_dimension == 1
-    template void
-    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+2>,SP,scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+2>& dof,
-     const std::map<types::boundary_id, const Function<deal_II_dimension+2,scalar>*>  &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
+    template void DoFTools::make_boundary_sparsity_pattern<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 2>,
+      SP,
+      scalar>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 2> &dof,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_dimension + 2, scalar> *>
+        &                                         boundary_ids,
+      const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+      SP &                                        sparsity);
 
-    template void
-    DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+2>,SP,scalar>
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+2>& dof,
-     const std::map<types::boundary_id, const Function<deal_II_dimension+2,scalar>*> &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
+    template void DoFTools::make_boundary_sparsity_pattern<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 2>,
+      SP,
+      scalar>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 2> &dof,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_dimension + 2, scalar> *>
+        &                                         boundary_ids,
+      const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+      SP &                                        sparsity);
 #endif
+  }
 
-}
+for (scalar : COMPLEX_SCALARS; SP : SPARSITY_PATTERNS;
+     deal_II_dimension : DIMENSIONS)
+  {
+    template void DoFTools::
+      make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension>, SP, scalar>(
+        const DoFHandler<deal_II_dimension> &dof,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_dimension, scalar> *>
+          &                                         boundary_ids,
+        const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+        SP &                                        sparsity);
 
-for (scalar: COMPLEX_SCALARS; SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
-{
     template void
-    DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension>,SP,scalar>
-    (const DoFHandler<deal_II_dimension>& dof,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,scalar>*> &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
-
-    template void
-    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,SP,scalar>
-    (const hp::DoFHandler<deal_II_dimension>& dof,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,scalar>*> &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
+    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,
+                                             SP,
+                                             scalar>(
+      const hp::DoFHandler<deal_II_dimension> &                    dof,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_dimension, scalar> *> &boundary_ids,
+      const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+      SP &                                        sparsity);
 
 #if deal_II_dimension < 3
-    template void
-    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP,scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
-     const std::map<types::boundary_id, const Function<deal_II_dimension+1,scalar>*>  &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
+    template void DoFTools::make_boundary_sparsity_pattern<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP,
+      scalar>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_dimension + 1, scalar> *>
+        &                                         boundary_ids,
+      const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+      SP &                                        sparsity);
 
-    template void
-    DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP,scalar>
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
-     const std::map<types::boundary_id, const Function<deal_II_dimension+1,scalar>*> &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
+    template void DoFTools::make_boundary_sparsity_pattern<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP,
+      scalar>(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_dimension + 1, scalar> *>
+        &                                         boundary_ids,
+      const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+      SP &                                        sparsity);
 
-    //template void
-    //DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP,scalar>
+    // template void
+    // DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP,scalar>
     //(const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
-    // const std::map<types::boundary_id, const Function<deal_II_dimension+1,scalar>*> &boundary_ids,
-    // const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-    // SP    &sparsity);
+    // const std::map<types::boundary_id, const
+    // Function<deal_II_dimension+1,scalar>*> &boundary_ids, const
+    // std::vector<types::global_dof_index>  &dof_to_boundary_mapping, SP
+    // &sparsity);
 
 #endif
-
-}
+  }
 
 for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
-{
-    template void
-    DoFTools::make_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension>, SP>
-    (const DoFHandler<deal_II_dimension,deal_II_dimension> &dof,
-     SP    &sparsity,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
+  {
+    template void DoFTools::make_sparsity_pattern<
+      DoFHandler<deal_II_dimension, deal_II_dimension>,
+      SP>(const DoFHandler<deal_II_dimension, deal_II_dimension> &dof,
+          SP &                                                    sparsity,
+          const ConstraintMatrix &,
+          const bool,
+          const types::subdomain_id);
+
+    template void DoFTools::make_sparsity_pattern<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension>,
+      SP>(const hp::DoFHandler<deal_II_dimension, deal_II_dimension> &dof,
+          SP &                                                        sparsity,
+          const ConstraintMatrix &,
+          const bool,
+          const types::subdomain_id);
+
+    template void DoFTools::make_sparsity_pattern<
+      DoFHandler<deal_II_dimension, deal_II_dimension>,
+      SP>(const DoFHandler<deal_II_dimension, deal_II_dimension> &,
+          const Table<2, Coupling> &,
+          SP &,
+          const ConstraintMatrix &,
+          const bool,
+          const types::subdomain_id);
+
+    template void DoFTools::make_sparsity_pattern<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension>,
+      SP>(const hp::DoFHandler<deal_II_dimension, deal_II_dimension> &,
+          const Table<2, Coupling> &,
+          SP &,
+          const ConstraintMatrix &,
+          const bool,
+          const types::subdomain_id);
+
+    template void DoFTools::make_sparsity_pattern<
+      DoFHandler<deal_II_dimension, deal_II_dimension>,
+      SP>(const DoFHandler<deal_II_dimension, deal_II_dimension> &dof_row,
+          const DoFHandler<deal_II_dimension, deal_II_dimension> &dof_col,
+          SP &                                                    sparsity);
+
+    template void DoFTools::make_sparsity_pattern<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension>,
+      SP>(const hp::DoFHandler<deal_II_dimension, deal_II_dimension> &dof_row,
+          const hp::DoFHandler<deal_II_dimension, deal_II_dimension> &dof_col,
+          SP &                                                        sparsity);
 
     template void
-    DoFTools::make_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension>, SP>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension> &dof,
-     SP    &sparsity,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
+    DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension>, SP>(
+      const DoFHandler<deal_II_dimension> &dof,
+      const std::vector<types::global_dof_index> &,
+      SP &);
 
     template void
-    DoFTools::make_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension>, SP>
-    (const DoFHandler<deal_II_dimension,deal_II_dimension>&,
-     const Table<2,Coupling>&,
-     SP &,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
+    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,
+                                             SP>(
+      const hp::DoFHandler<deal_II_dimension> &dof,
+      const std::vector<types::global_dof_index> &,
+      SP &);
 
     template void
-    DoFTools::make_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension>, SP>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension>&,
-     const Table<2,Coupling>&,
-     SP &,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
+    DoFTools::make_flux_sparsity_pattern<DoFHandler<deal_II_dimension>, SP>(
+      const DoFHandler<deal_II_dimension> &dof, SP &sparsity);
 
     template void
-    DoFTools::make_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension>, SP>
-    (const DoFHandler<deal_II_dimension,deal_II_dimension> &dof_row,
-     const DoFHandler<deal_II_dimension,deal_II_dimension> &dof_col,
-     SP    &sparsity);
+    DoFTools::make_flux_sparsity_pattern<hp::DoFHandler<deal_II_dimension>, SP>(
+      const hp::DoFHandler<deal_II_dimension> &dof, SP &sparsity);
 
     template void
-    DoFTools::make_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension>, SP>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension> &dof_row,
-     const hp::DoFHandler<deal_II_dimension,deal_II_dimension> &dof_col,
-     SP    &sparsity);
+    DoFTools::make_flux_sparsity_pattern<DoFHandler<deal_II_dimension>, SP>(
+      const DoFHandler<deal_II_dimension> &dof,
+      SP &                                 sparsity,
+      const Table<2, Coupling> &,
+      const Table<2, Coupling> &,
+      const types::subdomain_id);
 
     template void
-    DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension>,SP>
-    (const DoFHandler<deal_II_dimension>& dof,
-     const std::vector<types::global_dof_index>  &,
-     SP    &);
+    DoFTools::make_flux_sparsity_pattern<DoFHandler<deal_II_dimension>, SP>(
+      const DoFHandler<deal_II_dimension> &dof,
+      SP &                                 sparsity,
+      const ConstraintMatrix &             constraints,
+      const bool,
+      const Table<2, Coupling> &,
+      const Table<2, Coupling> &,
+      const types::subdomain_id);
 
     template void
-    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,SP>
-    (const hp::DoFHandler<deal_II_dimension>& dof,
-     const std::vector<types::global_dof_index>  &,
-     SP    &);
+    DoFTools::make_flux_sparsity_pattern<DoFHandler<deal_II_dimension>, SP>(
+      const DoFHandler<deal_II_dimension> &dof,
+      SP &                                 sparsity,
+      const ConstraintMatrix &             constraints,
+      const bool,
+      const types::subdomain_id);
 
     template void
-    DoFTools::make_flux_sparsity_pattern<DoFHandler<deal_II_dimension>,SP>
-    (const DoFHandler<deal_II_dimension> &dof,
-     SP    &sparsity);
-
-    template void
-    DoFTools::make_flux_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,SP>
-    (const hp::DoFHandler<deal_II_dimension> &dof,
-     SP    &sparsity);
-
-    template void
-    DoFTools::make_flux_sparsity_pattern<DoFHandler<deal_II_dimension>,SP>
-    (const DoFHandler<deal_II_dimension> &dof,
-     SP    &sparsity,
-     const Table<2,Coupling>&,
-     const Table<2,Coupling>&,
-     const types::subdomain_id);
-
-    template void
-    DoFTools::make_flux_sparsity_pattern<DoFHandler<deal_II_dimension>,SP>
-    (const DoFHandler<deal_II_dimension> &dof,
-     SP    &sparsity,
-     const ConstraintMatrix &constraints,
-     const bool,
-     const Table<2,Coupling>&,
-     const Table<2,Coupling>&,
-     const types::subdomain_id);
-
-    template void
-    DoFTools::make_flux_sparsity_pattern<DoFHandler<deal_II_dimension>,SP>
-    (const DoFHandler<deal_II_dimension> &dof,
-     SP    &sparsity,
-     const ConstraintMatrix &constraints,
-     const bool,
-     const types::subdomain_id);
-
-    template void
-    DoFTools::make_flux_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,SP>
-    (const hp::DoFHandler<deal_II_dimension> &dof,
-     SP    &sparsity,
-     const ConstraintMatrix &constraints,
-     const bool,
-     const types::subdomain_id);
+    DoFTools::make_flux_sparsity_pattern<hp::DoFHandler<deal_II_dimension>, SP>(
+      const hp::DoFHandler<deal_II_dimension> &dof,
+      SP &                                     sparsity,
+      const ConstraintMatrix &                 constraints,
+      const bool,
+      const types::subdomain_id);
 
 #if deal_II_dimension > 1
 
     template void
-    DoFTools::make_flux_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,SP>
-    (const hp::DoFHandler<deal_II_dimension> &dof,
-     SP    &sparsity,
-     const Table<2,Coupling>&,
-     const Table<2,Coupling>&,
-     const types::subdomain_id);
+    DoFTools::make_flux_sparsity_pattern<hp::DoFHandler<deal_II_dimension>, SP>(
+      const hp::DoFHandler<deal_II_dimension> &dof,
+      SP &                                     sparsity,
+      const Table<2, Coupling> &,
+      const Table<2, Coupling> &,
+      const types::subdomain_id);
 
     template void
-    DoFTools::make_flux_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,SP>
-    (const hp::DoFHandler<deal_II_dimension> &dof,
-     SP    &sparsity,
-     const ConstraintMatrix &constraints,
-     const bool,
-     const Table<2,Coupling>&,
-     const Table<2,Coupling>&,
-     const types::subdomain_id);
+    DoFTools::make_flux_sparsity_pattern<hp::DoFHandler<deal_II_dimension>, SP>(
+      const hp::DoFHandler<deal_II_dimension> &dof,
+      SP &                                     sparsity,
+      const ConstraintMatrix &                 constraints,
+      const bool,
+      const Table<2, Coupling> &,
+      const Table<2, Coupling> &,
+      const types::subdomain_id);
 
 #endif
 
 #if deal_II_dimension < 3
 
-    template void
-    DoFTools::make_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+1>, SP>
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof,
-     SP    &sparsity,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
+    template void DoFTools::make_sparsity_pattern<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP>(const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof,
+          SP &                                                        sparsity,
+          const ConstraintMatrix &,
+          const bool,
+          const types::subdomain_id);
 
-    template void
-    DoFTools::make_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, SP>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof,
-     SP    &sparsity,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
+    template void DoFTools::make_sparsity_pattern<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP>(const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof,
+          SP &sparsity,
+          const ConstraintMatrix &,
+          const bool,
+          const types::subdomain_id);
 
-    template void
-    DoFTools::make_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+1>, SP>
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1>&,
-     const Table<2,Coupling>&,
-     SP &,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
+    template void DoFTools::make_sparsity_pattern<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP>(const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+          const Table<2, Coupling> &,
+          SP &,
+          const ConstraintMatrix &,
+          const bool,
+          const types::subdomain_id);
 
-    template void
-    DoFTools::make_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, SP>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>&,
-     const Table<2,Coupling>&,
-     SP &,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
+    template void DoFTools::make_sparsity_pattern<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP>(const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+          const Table<2, Coupling> &,
+          SP &,
+          const ConstraintMatrix &,
+          const bool,
+          const types::subdomain_id);
 
-    template void
-    DoFTools::make_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+1>, SP>
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_row,
-     const DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_col,
-     SP    &sparsity);
+    template void DoFTools::make_sparsity_pattern<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP>(const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof_row,
+          const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof_col,
+          SP &                                                        sparsity);
 
-    template void
-    DoFTools::make_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, SP>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_row,
-     const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1> &dof_col,
-     SP    &sparsity);
+    template void DoFTools::make_sparsity_pattern<
+      hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof_row,
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof_col,
+      SP &                                                            sparsity);
 
-    template void
-    DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP>
-    (const DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
-     const std::vector<types::global_dof_index>  &,
-     SP    &);
+    template void DoFTools::make_boundary_sparsity_pattern<
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>,
+      SP>(const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof,
+          const std::vector<types::global_dof_index> &,
+          SP &);
 
-    //template void
-    //DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP>
+    // template void
+    // DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP>
     //(const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
     // const std::vector<types::global_dof_index>  &,
     // SP    &);
@@ -304,80 +340,71 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
 
 #if deal_II_dimension == 3
 
-    template void
-    DoFTools::make_sparsity_pattern<DoFHandler<1,3>, SP>
-    (const DoFHandler<1,3> &dof,
-     SP    &sparsity,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
+    template void DoFTools::make_sparsity_pattern<DoFHandler<1, 3>, SP>(
+      const DoFHandler<1, 3> &dof,
+      SP &                    sparsity,
+      const ConstraintMatrix &,
+      const bool,
+      const types::subdomain_id);
+
+    template void DoFTools::make_sparsity_pattern<hp::DoFHandler<1, 3>, SP>(
+      const hp::DoFHandler<1, 3> &dof,
+      SP &                        sparsity,
+      const ConstraintMatrix &,
+      const bool,
+      const types::subdomain_id);
+
+    template void DoFTools::make_sparsity_pattern<DoFHandler<1, 3>, SP>(
+      const DoFHandler<1, 3> &,
+      const Table<2, Coupling> &,
+      SP &,
+      const ConstraintMatrix &,
+      const bool,
+      const types::subdomain_id);
+
+    template void DoFTools::make_sparsity_pattern<hp::DoFHandler<1, 3>, SP>(
+      const hp::DoFHandler<1, 3> &,
+      const Table<2, Coupling> &,
+      SP &,
+      const ConstraintMatrix &,
+      const bool,
+      const types::subdomain_id);
+
+    template void DoFTools::make_sparsity_pattern<DoFHandler<1, 3>, SP>(
+      const DoFHandler<1, 3> &dof_row,
+      const DoFHandler<1, 3> &dof_col,
+      SP &                    sparsity);
+
+    template void DoFTools::make_sparsity_pattern<hp::DoFHandler<1, 3>, SP>(
+      const hp::DoFHandler<1, 3> &dof_row,
+      const hp::DoFHandler<1, 3> &dof_col,
+      SP &                        sparsity);
 
     template void
-    DoFTools::make_sparsity_pattern<hp::DoFHandler<1,3>, SP>
-    (const hp::DoFHandler<1,3> &dof,
-     SP    &sparsity,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
+    DoFTools::make_boundary_sparsity_pattern<DoFHandler<1, 3>, SP>(
+      const DoFHandler<1, 3> &dof,
+      const std::vector<types::global_dof_index> &,
+      SP &);
 
     template void
-    DoFTools::make_sparsity_pattern<DoFHandler<1,3>, SP>
-    (const DoFHandler<1,3>&,
-     const Table<2,Coupling>&,
-     SP &,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
-
-    template void
-    DoFTools::make_sparsity_pattern<hp::DoFHandler<1,3>, SP>
-    (const hp::DoFHandler<1,3>&,
-     const Table<2,Coupling>&,
-     SP &,
-     const ConstraintMatrix &,
-     const bool,
-     const types::subdomain_id);
-
-    template void
-    DoFTools::make_sparsity_pattern<DoFHandler<1,3>, SP>
-    (const DoFHandler<1,3> &dof_row,
-     const DoFHandler<1,3> &dof_col,
-     SP    &sparsity);
-
-    template void
-    DoFTools::make_sparsity_pattern<hp::DoFHandler<1,3>, SP>
-    (const hp::DoFHandler<1,3> &dof_row,
-     const hp::DoFHandler<1,3> &dof_col,
-     SP    &sparsity);
-
-    template void
-    DoFTools::make_boundary_sparsity_pattern<DoFHandler<1,3>,SP>
-    (const DoFHandler<1,3>& dof,
-     const std::vector<types::global_dof_index>  &,
-     SP    &);
-
-    template void
-    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<1,3>,SP>
-    (const hp::DoFHandler<1,3>& dof,
-     const std::vector<types::global_dof_index>  &,
-     SP    &);
+    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<1, 3>, SP>(
+      const hp::DoFHandler<1, 3> &dof,
+      const std::vector<types::global_dof_index> &,
+      SP &);
 
 #endif
-
-}
+  }
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template
-    Table<2,DoFTools::Coupling>
-    DoFTools::dof_couplings_from_component_couplings
-    (const FiniteElement<deal_II_dimension> &fe,
-     const Table<2,DoFTools::Coupling> &component_couplings);
+  {
+    template Table<2, DoFTools::Coupling>
+    DoFTools::dof_couplings_from_component_couplings(
+      const FiniteElement<deal_II_dimension> &fe,
+      const Table<2, DoFTools::Coupling> &    component_couplings);
 
-    template
-    std::vector<Table<2,DoFTools::Coupling> >
-    DoFTools::dof_couplings_from_component_couplings
-    (const hp::FECollection<deal_II_dimension> &fe,
-     const Table<2,DoFTools::Coupling> &component_couplings);
-}
+    template std::vector<Table<2, DoFTools::Coupling>>
+    DoFTools::dof_couplings_from_component_couplings(
+      const hp::FECollection<deal_II_dimension> &fe,
+      const Table<2, DoFTools::Coupling> &       component_couplings);
+  }

--- a/source/fe/fe.inst.in
+++ b/source/fe/fe.inst.in
@@ -15,10 +15,9 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class FiniteElement<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
+  }

--- a/source/fe/fe_abf.inst.in
+++ b/source/fe/fe_abf.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_ABF<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_bdm.inst.in
+++ b/source/fe/fe_bdm.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_BDM<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_bernstein.inst.in
+++ b/source/fe/fe_bernstein.inst.in
@@ -15,9 +15,9 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class FE_Bernstein<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
+  }

--- a/source/fe/fe_dg_vector.inst.in
+++ b/source/fe/fe_dg_vector.inst.in
@@ -16,14 +16,17 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template class FE_DGVector<PolynomialsABF<deal_II_dimension>, deal_II_dimension>;
-    template class FE_DGVector<PolynomialsBDM<deal_II_dimension>, deal_II_dimension>;
-    template class FE_DGVector<PolynomialsNedelec<deal_II_dimension>, deal_II_dimension>;
-    template class FE_DGVector<PolynomialsRaviartThomas<deal_II_dimension>, deal_II_dimension>;
+  {
+    template class FE_DGVector<PolynomialsABF<deal_II_dimension>,
+                               deal_II_dimension>;
+    template class FE_DGVector<PolynomialsBDM<deal_II_dimension>,
+                               deal_II_dimension>;
+    template class FE_DGVector<PolynomialsNedelec<deal_II_dimension>,
+                               deal_II_dimension>;
+    template class FE_DGVector<PolynomialsRaviartThomas<deal_II_dimension>,
+                               deal_II_dimension>;
 
     template class FE_DGNedelec<deal_II_dimension>;
     template class FE_DGRaviartThomas<deal_II_dimension>;
     template class FE_DGBDM<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_dgp.inst.in
+++ b/source/fe/fe_dgp.inst.in
@@ -15,11 +15,9 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class FE_DGP<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
-
+  }

--- a/source/fe/fe_dgp_monomial.inst.in
+++ b/source/fe/fe_dgp_monomial.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_DGPMonomial<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_dgp_nonparametric.inst.in
+++ b/source/fe/fe_dgp_nonparametric.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_DGPNonparametric<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_dgq.inst.in
+++ b/source/fe/fe_dgq.inst.in
@@ -15,12 +15,13 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class FE_DGQ<deal_II_dimension, deal_II_space_dimension>;
-    template class FE_DGQArbitraryNodes<deal_II_dimension, deal_II_space_dimension>;
+    template class FE_DGQArbitraryNodes<deal_II_dimension,
+                                        deal_II_space_dimension>;
     template class FE_DGQLegendre<deal_II_dimension, deal_II_space_dimension>;
     template class FE_DGQHermite<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
+  }

--- a/source/fe/fe_enriched.inst.in
+++ b/source/fe/fe_enriched.inst.in
@@ -14,10 +14,9 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class FE_Enriched<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
+  }

--- a/source/fe/fe_face.inst.in
+++ b/source/fe/fe_face.inst.in
@@ -16,13 +16,14 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension > 1
-    template class FE_PolyFace<TensorProductPolynomials<deal_II_dimension-1> >;
-    template class FE_PolyFace<PolynomialSpace<deal_II_dimension-1>, deal_II_dimension>;
-    //template class FE_PolyFace<PolynomialsP<deal_II_dimension>, deal_II_dimension>;
+    template class FE_PolyFace<TensorProductPolynomials<deal_II_dimension - 1>>;
+    template class FE_PolyFace<PolynomialSpace<deal_II_dimension - 1>,
+                               deal_II_dimension>;
+    // template class FE_PolyFace<PolynomialsP<deal_II_dimension>,
+    // deal_II_dimension>;
 #endif
-    template class FE_FaceQ<deal_II_dimension,deal_II_dimension>;
-    template class FE_FaceP<deal_II_dimension,deal_II_dimension>;
-}
-
+    template class FE_FaceQ<deal_II_dimension, deal_II_dimension>;
+    template class FE_FaceP<deal_II_dimension, deal_II_dimension>;
+  }

--- a/source/fe/fe_nedelec.inst.in
+++ b/source/fe/fe_nedelec.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_Nedelec<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_nedelec_sz.inst.in
+++ b/source/fe/fe_nedelec_sz.inst.in
@@ -16,9 +16,8 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension != 1
     template class FE_NedelecSZ<deal_II_dimension>;
 #endif
-}
-
+  }

--- a/source/fe/fe_nothing.inst.in
+++ b/source/fe/fe_nothing.inst.in
@@ -16,9 +16,8 @@
 
 
 for (deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template class FE_Nothing<deal_II_dimension,deal_II_space_dimension>;
+    template class FE_Nothing<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
+  }

--- a/source/fe/fe_poly.inst.in
+++ b/source/fe/fe_poly.inst.in
@@ -15,16 +15,31 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template class FE_Poly<TensorProductPolynomials<deal_II_dimension>, deal_II_dimension, deal_II_space_dimension>;
-    template class FE_Poly<TensorProductPolynomialsConst<deal_II_dimension>, deal_II_dimension, deal_II_space_dimension>;
-    template class FE_Poly<TensorProductPolynomialsBubbles<deal_II_dimension>, deal_II_dimension, deal_II_space_dimension>;
-    template class FE_Poly<TensorProductPolynomials<deal_II_dimension,Polynomials::PiecewisePolynomial<double> >, deal_II_dimension, deal_II_space_dimension>;
-    template class FE_Poly<PolynomialSpace<deal_II_dimension>, deal_II_dimension, deal_II_space_dimension>;
-    template class FE_Poly<PolynomialsP<deal_II_dimension>, deal_II_dimension, deal_II_space_dimension>;
-    template class FE_Poly<PolynomialsRannacherTurek<deal_II_dimension>, deal_II_dimension, deal_II_space_dimension>;
+    template class FE_Poly<TensorProductPolynomials<deal_II_dimension>,
+                           deal_II_dimension,
+                           deal_II_space_dimension>;
+    template class FE_Poly<TensorProductPolynomialsConst<deal_II_dimension>,
+                           deal_II_dimension,
+                           deal_II_space_dimension>;
+    template class FE_Poly<TensorProductPolynomialsBubbles<deal_II_dimension>,
+                           deal_II_dimension,
+                           deal_II_space_dimension>;
+    template class FE_Poly<
+      TensorProductPolynomials<deal_II_dimension,
+                               Polynomials::PiecewisePolynomial<double>>,
+      deal_II_dimension,
+      deal_II_space_dimension>;
+    template class FE_Poly<PolynomialSpace<deal_II_dimension>,
+                           deal_II_dimension,
+                           deal_II_space_dimension>;
+    template class FE_Poly<PolynomialsP<deal_II_dimension>,
+                           deal_II_dimension,
+                           deal_II_space_dimension>;
+    template class FE_Poly<PolynomialsRannacherTurek<deal_II_dimension>,
+                           deal_II_dimension,
+                           deal_II_space_dimension>;
 #endif
-}
-
+  }

--- a/source/fe/fe_poly_tensor.inst.in
+++ b/source/fe/fe_poly_tensor.inst.in
@@ -16,11 +16,15 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template class FE_PolyTensor<PolynomialsRaviartThomas<deal_II_dimension>,deal_II_dimension>;
-    template class FE_PolyTensor<PolynomialsRT_Bubbles<deal_II_dimension>,deal_II_dimension>;
-    template class FE_PolyTensor<PolynomialsABF<deal_II_dimension>,deal_II_dimension>;
-    template class FE_PolyTensor<PolynomialsBDM<deal_II_dimension>,deal_II_dimension>;
-    template class FE_PolyTensor<PolynomialsNedelec<deal_II_dimension>, deal_II_dimension>;
-}
-
+  {
+    template class FE_PolyTensor<PolynomialsRaviartThomas<deal_II_dimension>,
+                                 deal_II_dimension>;
+    template class FE_PolyTensor<PolynomialsRT_Bubbles<deal_II_dimension>,
+                                 deal_II_dimension>;
+    template class FE_PolyTensor<PolynomialsABF<deal_II_dimension>,
+                                 deal_II_dimension>;
+    template class FE_PolyTensor<PolynomialsBDM<deal_II_dimension>,
+                                 deal_II_dimension>;
+    template class FE_PolyTensor<PolynomialsNedelec<deal_II_dimension>,
+                                 deal_II_dimension>;
+  }

--- a/source/fe/fe_q.inst.in
+++ b/source/fe/fe_q.inst.in
@@ -15,11 +15,9 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class FE_Q<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
-
+  }

--- a/source/fe/fe_q_base.inst.in
+++ b/source/fe/fe_q_base.inst.in
@@ -15,14 +15,22 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template class FE_Q_Base<TensorProductPolynomials<deal_II_dimension>, deal_II_dimension, deal_II_space_dimension>;
-    template class FE_Q_Base<TensorProductPolynomialsConst<deal_II_dimension>, deal_II_dimension, deal_II_space_dimension>;
-    template class FE_Q_Base<TensorProductPolynomialsBubbles<deal_II_dimension>, deal_II_dimension, deal_II_space_dimension>;
-    template class FE_Q_Base<TensorProductPolynomials<deal_II_dimension,Polynomials::PiecewisePolynomial<double> >, deal_II_dimension, deal_II_space_dimension>;
+    template class FE_Q_Base<TensorProductPolynomials<deal_II_dimension>,
+                             deal_II_dimension,
+                             deal_II_space_dimension>;
+    template class FE_Q_Base<TensorProductPolynomialsConst<deal_II_dimension>,
+                             deal_II_dimension,
+                             deal_II_space_dimension>;
+    template class FE_Q_Base<TensorProductPolynomialsBubbles<deal_II_dimension>,
+                             deal_II_dimension,
+                             deal_II_space_dimension>;
+    template class FE_Q_Base<
+      TensorProductPolynomials<deal_II_dimension,
+                               Polynomials::PiecewisePolynomial<double>>,
+      deal_II_dimension,
+      deal_II_space_dimension>;
 #endif
-}
-
-
+  }

--- a/source/fe/fe_q_bubbles.inst.in
+++ b/source/fe/fe_q_bubbles.inst.in
@@ -15,9 +15,9 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class FE_Q_Bubbles<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
+  }

--- a/source/fe/fe_q_dg0.inst.in
+++ b/source/fe/fe_q_dg0.inst.in
@@ -15,11 +15,9 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class FE_Q_DG0<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
-
+  }

--- a/source/fe/fe_q_hierarchical.inst.in
+++ b/source/fe/fe_q_hierarchical.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_Q_Hierarchical<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_q_iso_q1.inst.in
+++ b/source/fe/fe_q_iso_q1.inst.in
@@ -15,11 +15,9 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class FE_Q_iso_Q1<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
-
+  }

--- a/source/fe/fe_rannacher_turek.inst.in
+++ b/source/fe/fe_rannacher_turek.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_RannacherTurek<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_raviart_thomas.inst.in
+++ b/source/fe/fe_raviart_thomas.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_RaviartThomas<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_raviart_thomas_nodal.inst.in
+++ b/source/fe/fe_raviart_thomas_nodal.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_RaviartThomasNodal<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_rt_bubbles.inst.in
+++ b/source/fe/fe_rt_bubbles.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_RT_Bubbles<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/fe_system.inst.in
+++ b/source/fe/fe_system.inst.in
@@ -14,11 +14,9 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class FESystem<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
-
+  }

--- a/source/fe/fe_tools.inst.in
+++ b/source/fe/fe_tools.inst.in
@@ -14,282 +14,307 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
     namespace FETools
     \{
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace Compositing
-    \{
-    template
-    FiniteElementData<deal_II_dimension>
-    multiply_dof_numbers (const std::vector<const FiniteElement<deal_II_dimension,deal_II_space_dimension>*> &fes,
-                          const std::vector<unsigned int>                       &multiplicities,
-                          bool);
+      namespace Compositing
+      \{
+        template FiniteElementData<deal_II_dimension>
+        multiply_dof_numbers(
+          const std::vector<
+            const FiniteElement<deal_II_dimension, deal_II_space_dimension> *>
+            &                              fes,
+          const std::vector<unsigned int> &multiplicities,
+          bool);
 
-    template
-    FiniteElementData<deal_II_dimension>
-    multiply_dof_numbers (const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe1,
-                          const unsigned int            N1,
-                          const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe2,
-                          const unsigned int            N2,
-                          const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe3,
-                          const unsigned int            N3,
-                          const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe4,
-                          const unsigned int            N4,
-                          const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe5,
-                          const unsigned int            N5);
+        template FiniteElementData<deal_II_dimension>
+        multiply_dof_numbers(
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe1,
+          const unsigned int                                               N1,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe2,
+          const unsigned int                                               N2,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe3,
+          const unsigned int                                               N3,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe4,
+          const unsigned int                                               N4,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe5,
+          const unsigned int                                               N5);
 
-    template
-    std::vector<bool>
-    compute_restriction_is_additive_flags (const std::vector<const FiniteElement<deal_II_dimension,deal_II_space_dimension>*> &fes,
-                                           const std::vector<unsigned int>              &multiplicities);
+        template std::vector<bool>
+        compute_restriction_is_additive_flags(
+          const std::vector<
+            const FiniteElement<deal_II_dimension, deal_II_space_dimension> *>
+            &                              fes,
+          const std::vector<unsigned int> &multiplicities);
 
-    template
-    std::vector<bool>
-    compute_restriction_is_additive_flags (const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe1,
-                                           const unsigned int        N1,
-                                           const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe2,
-                                           const unsigned int        N2,
-                                           const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe3,
-                                           const unsigned int        N3,
-                                           const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe4,
-                                           const unsigned int        N4,
-                                           const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe5,
-                                           const unsigned int        N5);
+        template std::vector<bool>
+        compute_restriction_is_additive_flags(
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe1,
+          const unsigned int                                               N1,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe2,
+          const unsigned int                                               N2,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe3,
+          const unsigned int                                               N3,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe4,
+          const unsigned int                                               N4,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe5,
+          const unsigned int                                               N5);
 
-    template
-    std::vector<ComponentMask>
-    compute_nonzero_components (const std::vector<const FiniteElement<deal_II_dimension,deal_II_space_dimension>*> &fes,
-                                const std::vector<unsigned int>              &multiplicities,
-                                const bool do_tensor_product);
+        template std::vector<ComponentMask>
+        compute_nonzero_components(
+          const std::vector<
+            const FiniteElement<deal_II_dimension, deal_II_space_dimension> *>
+            &                              fes,
+          const std::vector<unsigned int> &multiplicities,
+          const bool                       do_tensor_product);
 
-    template
-    std::vector<ComponentMask>
-    compute_nonzero_components (const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe1,
-                                const unsigned int        N1,
-                                const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe2,
-                                const unsigned int        N2,
-                                const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe3,
-                                const unsigned int        N3,
-                                const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe4,
-                                const unsigned int        N4,
-                                const FiniteElement<deal_II_dimension,deal_II_space_dimension> *fe5,
-                                const unsigned int        N5,
-                                const bool);
+        template std::vector<ComponentMask>
+        compute_nonzero_components(
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe1,
+          const unsigned int                                               N1,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe2,
+          const unsigned int                                               N2,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe3,
+          const unsigned int                                               N3,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe4,
+          const unsigned int                                               N4,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> *fe5,
+          const unsigned int                                               N5,
+          const bool);
 
-    template
-    void
-    build_cell_tables(std::vector< std::pair< std::pair< unsigned int, unsigned int >, unsigned int > > &system_to_base_table,
-                      std::vector< std::pair< unsigned int, unsigned int > >  &system_to_component_table,
-                      std::vector< std::pair< std::pair< unsigned int, unsigned int >, unsigned int > > &component_to_base_table,
-                      const FiniteElement<deal_II_dimension,deal_II_space_dimension> &fe,
-                      const bool do_tensor_product);
+        template void
+        build_cell_tables(
+          std::vector<std::pair<std::pair<unsigned int, unsigned int>,
+                                unsigned int>> &system_to_base_table,
+          std::vector<std::pair<unsigned int, unsigned int>>
+            &                                   system_to_component_table,
+          std::vector<std::pair<std::pair<unsigned int, unsigned int>,
+                                unsigned int>> &component_to_base_table,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> &fe,
+          const bool do_tensor_product);
 
-    template
-    void
-    build_face_tables(std::vector< std::pair< std::pair< unsigned int, unsigned int >, unsigned int > > &face_system_to_base_table,
-                      std::vector< std::pair< unsigned int, unsigned int > >                            &face_system_to_component_table,
-                      const FiniteElement<deal_II_dimension,deal_II_space_dimension> &fe,
-                      const bool do_tensor_product);
+        template void
+        build_face_tables(
+          std::vector<std::pair<std::pair<unsigned int, unsigned int>,
+                                unsigned int>> &face_system_to_base_table,
+          std::vector<std::pair<unsigned int, unsigned int>>
+            &face_system_to_component_table,
+          const FiniteElement<deal_II_dimension, deal_II_space_dimension> &fe,
+          const bool do_tensor_product);
 
-    \}
+      \}
 
-    template
-    void compute_block_renumbering (
-        const FiniteElement<deal_II_dimension,deal_II_space_dimension> &,
-        std::vector<types::global_dof_index> &, std::vector<types::global_dof_index> &, bool);
+      template void
+      compute_block_renumbering(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
+        std::vector<types::global_dof_index> &,
+        std::vector<types::global_dof_index> &,
+        bool);
 
-    template
-    void compute_projection_matrices<deal_II_dimension, double, deal_II_space_dimension>
-    (const FiniteElement<deal_II_dimension,deal_II_space_dimension> &,
-     std::vector<std::vector<FullMatrix<double> > > &, bool);
+      template void
+      compute_projection_matrices<deal_II_dimension,
+                                  double,
+                                  deal_II_space_dimension>(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
+        std::vector<std::vector<FullMatrix<double>>> &,
+        bool);
 
-    template
-    void compute_embedding_matrices<deal_II_dimension, double, deal_II_space_dimension>
-    (const FiniteElement<deal_II_dimension,deal_II_space_dimension> &,
-     std::vector<std::vector<FullMatrix<double> > > &, const bool, const double);
+      template void
+      compute_embedding_matrices<deal_II_dimension,
+                                 double,
+                                 deal_II_space_dimension>(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
+        std::vector<std::vector<FullMatrix<double>>> &,
+        const bool,
+        const double);
 #endif
     \}
-}
+  }
 
 
 
-//TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension, deal_II_space_dimension>
+// TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension,
+// deal_II_space_dimension>
 // where applicable and move to codimension cases above also when applicable
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
     namespace FETools
     \{
 
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void get_interpolation_matrix<deal_II_dimension,double,deal_II_space_dimension>
-    (const FiniteElement<deal_II_dimension,deal_II_space_dimension> &,
-     const FiniteElement<deal_II_dimension,deal_II_space_dimension> &,
-     FullMatrix<double> &);
+      template void
+      get_interpolation_matrix<deal_II_dimension,
+                               double,
+                               deal_II_space_dimension>(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
+        FullMatrix<double> &);
 
-    template std::unique_ptr<FiniteElement<deal_II_dimension,deal_II_space_dimension> >
-    get_fe_by_name<deal_II_dimension,deal_II_space_dimension> (const std::string &);
+      template std::unique_ptr<
+        FiniteElement<deal_II_dimension, deal_II_space_dimension>>
+      get_fe_by_name<deal_II_dimension, deal_II_space_dimension>(
+        const std::string &);
 
-    template
-    void
-    compute_interpolation_to_quadrature_points_matrix
-    (const FiniteElement<deal_II_dimension,deal_II_space_dimension> &,
-     const Quadrature<deal_II_dimension> &,
-     FullMatrix<double> &);
+      template void
+      compute_interpolation_to_quadrature_points_matrix(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension> &,
+        FullMatrix<double> &);
 
-    template
-    void
-    compute_projection_from_quadrature_points_matrix
-    (const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
-     const Quadrature<deal_II_dimension> &,
-     const Quadrature<deal_II_dimension> &,
-     FullMatrix<double> &);
+      template void
+      compute_projection_from_quadrature_points_matrix(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension> &,
+        const Quadrature<deal_II_dimension> &,
+        FullMatrix<double> &);
 #endif
 
 #if deal_II_dimension == deal_II_space_dimension
 
-    template class FEFactoryBase<deal_II_dimension>;
+      template class FEFactoryBase<deal_II_dimension>;
 
-    template FiniteElement<deal_II_dimension> *
-    get_fe_from_name<deal_II_dimension> (const std::string &);
+      template FiniteElement<deal_II_dimension> *
+      get_fe_from_name<deal_II_dimension>(const std::string &);
 
-    template
-    FullMatrix<double>
-    compute_node_matrix(const FiniteElement<deal_II_dimension> &);
+      template FullMatrix<double>
+      compute_node_matrix(const FiniteElement<deal_II_dimension> &);
 
-    template
-    void compute_component_wise(
+      template void
+      compute_component_wise(const FiniteElement<deal_II_dimension> &,
+                             std::vector<unsigned int> &,
+                             std::vector<std::vector<unsigned int>> &);
+
+      template void
+      get_back_interpolation_matrix<deal_II_dimension>(
         const FiniteElement<deal_II_dimension> &,
-        std::vector<unsigned int> &, std::vector<std::vector<unsigned int> > &);
+        const FiniteElement<deal_II_dimension> &,
+        FullMatrix<double> &);
+      template void
+      get_interpolation_difference_matrix<deal_II_dimension>(
+        const FiniteElement<deal_II_dimension> &,
+        const FiniteElement<deal_II_dimension> &,
+        FullMatrix<double> &);
+      template void
+      get_interpolation_matrix<deal_II_dimension>(
+        const FiniteElement<deal_II_dimension> &,
+        const FiniteElement<deal_II_dimension> &,
+        FullMatrix<float> &);
+      template void
+      get_back_interpolation_matrix<deal_II_dimension>(
+        const FiniteElement<deal_II_dimension> &,
+        const FiniteElement<deal_II_dimension> &,
+        FullMatrix<float> &);
+      template void
+      get_interpolation_difference_matrix<deal_II_dimension>(
+        const FiniteElement<deal_II_dimension> &,
+        const FiniteElement<deal_II_dimension> &,
+        FullMatrix<float> &);
 
-    template
-    void get_back_interpolation_matrix<deal_II_dimension>
-    (const FiniteElement<deal_II_dimension> &,
-     const FiniteElement<deal_II_dimension> &,
-     FullMatrix<double> &);
-    template
-    void get_interpolation_difference_matrix<deal_II_dimension>
-    (const FiniteElement<deal_II_dimension> &,
-     const FiniteElement<deal_II_dimension> &,
-     FullMatrix<double> &);
-    template
-    void get_interpolation_matrix<deal_II_dimension>
-    (const FiniteElement<deal_II_dimension> &,
-     const FiniteElement<deal_II_dimension> &,
-     FullMatrix<float> &);
-    template
-    void get_back_interpolation_matrix<deal_II_dimension>
-    (const FiniteElement<deal_II_dimension> &,
-     const FiniteElement<deal_II_dimension> &,
-     FullMatrix<float> &);
-    template
-    void get_interpolation_difference_matrix<deal_II_dimension>
-    (const FiniteElement<deal_II_dimension> &,
-     const FiniteElement<deal_II_dimension> &,
-     FullMatrix<float> &);
+      template void
+      get_projection_matrix<deal_II_dimension>(
+        const FiniteElement<deal_II_dimension> &,
+        const FiniteElement<deal_II_dimension> &,
+        FullMatrix<double> &);
 
-    template
-    void get_projection_matrix<deal_II_dimension>
-    (const FiniteElement<deal_II_dimension> &,
-     const FiniteElement<deal_II_dimension> &,
-     FullMatrix<double> &);
+      template void
+      compute_face_embedding_matrices<deal_II_dimension, double>(
+        const FiniteElement<deal_II_dimension> &,
+        FullMatrix<double> (
+            &)[GeometryInfo<deal_II_dimension>::max_children_per_face],
+        unsigned int,
+        unsigned int,
+        const double);
 
-    template
-    void compute_face_embedding_matrices<deal_II_dimension,double>
-    (const FiniteElement<deal_II_dimension> &, FullMatrix<double> ( &)[GeometryInfo<deal_II_dimension>::max_children_per_face],
-     unsigned int, unsigned int, const double);
-
-    template
-    void
-    compute_projection_from_quadrature_points(
+      template void
+      compute_projection_from_quadrature_points(
         const FullMatrix<double> &,
-        const std::vector< Tensor<1, deal_II_dimension > > &,
-        std::vector< Tensor<1, deal_II_dimension > > &);
+        const std::vector<Tensor<1, deal_II_dimension>> &,
+        std::vector<Tensor<1, deal_II_dimension>> &);
 
-    template
-    void
-    compute_projection_from_quadrature_points(
+      template void
+      compute_projection_from_quadrature_points(
         const FullMatrix<double> &,
-        const std::vector<SymmetricTensor<2, deal_II_dimension> > &,
-        std::vector<SymmetricTensor<2, deal_II_dimension> > &);
+        const std::vector<SymmetricTensor<2, deal_II_dimension>> &,
+        std::vector<SymmetricTensor<2, deal_II_dimension>> &);
 
-#if deal_II_dimension != 1
-    template
-    void
-    compute_projection_from_face_quadrature_points_matrix (const FiniteElement<deal_II_dimension> &,
-            const Quadrature<deal_II_dimension-1>    &,
-            const Quadrature<deal_II_dimension-1>    &,
-            const DoFHandler<deal_II_dimension>::active_cell_iterator &,
-            unsigned int,
-            FullMatrix<double> &);
-#endif
+#  if deal_II_dimension != 1
+      template void
+      compute_projection_from_face_quadrature_points_matrix(
+        const FiniteElement<deal_II_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const DoFHandler<deal_II_dimension>::active_cell_iterator &,
+        unsigned int,
+        FullMatrix<double> &);
+#  endif
 
-    template
-    void
-    hierarchic_to_lexicographic_numbering<deal_II_dimension>
-    (unsigned int,
-     std::vector<unsigned int> &);
+      template void
+      hierarchic_to_lexicographic_numbering<deal_II_dimension>(
+        unsigned int,
+        std::vector<unsigned int> &);
 
-    template
-    void
-    hierarchic_to_lexicographic_numbering<deal_II_dimension>
-    (const FiniteElementData<deal_II_dimension> &,
-     std::vector<unsigned int> &);
+      template void
+      hierarchic_to_lexicographic_numbering<deal_II_dimension>(
+        const FiniteElementData<deal_II_dimension> &,
+        std::vector<unsigned int> &);
 
-    template
-    void
-    lexicographic_to_hierarchic_numbering<deal_II_dimension>
-    (const FiniteElementData<deal_II_dimension> &,
-     std::vector<unsigned int> &);
+      template void
+      lexicographic_to_hierarchic_numbering<deal_II_dimension>(
+        const FiniteElementData<deal_II_dimension> &,
+        std::vector<unsigned int> &);
 
-    template
-    std::vector<unsigned int>
-    hierarchic_to_lexicographic_numbering<deal_II_dimension>
-    (const FiniteElementData<deal_II_dimension> &);
+      template std::vector<unsigned int>
+      hierarchic_to_lexicographic_numbering<deal_II_dimension>(
+        const FiniteElementData<deal_II_dimension> &);
 
-    template
-    std::vector<unsigned int>
-    lexicographic_to_hierarchic_numbering<deal_II_dimension>
-    (const FiniteElementData<deal_II_dimension> &);
+      template std::vector<unsigned int>
+      lexicographic_to_hierarchic_numbering<deal_II_dimension>(
+        const FiniteElementData<deal_II_dimension> &);
 
 #endif
     \}
-}
+  }
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; number : REAL_SCALARS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     number : REAL_SCALARS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace FETools
     \{
 
-    template
-    void
-    convert_generalized_support_point_values_to_dof_values<deal_II_dimension, deal_II_space_dimension, number> (
+      template void
+      convert_generalized_support_point_values_to_dof_values<
+        deal_II_dimension,
+        deal_II_space_dimension,
+        number>(
         const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
-        const std::vector<Vector<number> > &,
-        std::vector<number>                &);
+        const std::vector<Vector<number>> &,
+        std::vector<number> &);
 
     \}
 #endif
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; number : COMPLEX_SCALARS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     number : COMPLEX_SCALARS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace FETools
     \{
 
-    template
-    void
-    convert_generalized_support_point_values_to_dof_values<deal_II_dimension, deal_II_space_dimension, number> (
+      template void
+      convert_generalized_support_point_values_to_dof_values<
+        deal_II_dimension,
+        deal_II_space_dimension,
+        number>(
         const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
-        const std::vector<Vector<number> > &,
-        std::vector<number>                &);
+        const std::vector<Vector<number>> &,
+        std::vector<number> &);
 
     \}
 #endif
-}
+  }

--- a/source/fe/fe_tools_extrapolate.inst.in
+++ b/source/fe/fe_tools_extrapolate.inst.in
@@ -15,21 +15,24 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; VEC : VECTOR_TYPES)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     VEC : VECTOR_TYPES)
+  {
     namespace FETools
     \{
 #if deal_II_dimension == deal_II_space_dimension
-    template
-    void extrapolate<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &, const VEC &,
-     const DoFHandler<deal_II_dimension> &, VEC &);
+      template void
+      extrapolate<deal_II_dimension>(const DoFHandler<deal_II_dimension> &,
+                                     const VEC &,
+                                     const DoFHandler<deal_II_dimension> &,
+                                     VEC &);
 
-    template
-    void extrapolate<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &, const VEC &,
-     const DoFHandler<deal_II_dimension> &, const ConstraintMatrix &,
-     VEC &);
+      template void
+      extrapolate<deal_II_dimension>(const DoFHandler<deal_II_dimension> &,
+                                     const VEC &,
+                                     const DoFHandler<deal_II_dimension> &,
+                                     const ConstraintMatrix &,
+                                     VEC &);
 #endif
     \}
-}
+  }

--- a/source/fe/fe_tools_interpolate.inst.in
+++ b/source/fe/fe_tools_interpolate.inst.in
@@ -15,93 +15,113 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; Vector : VECTOR_TYPES)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     Vector : VECTOR_TYPES)
+  {
     namespace FETools
     \{
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void interpolate<deal_II_dimension,deal_II_space_dimension>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension> &, const Vector &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension> &, Vector &);
+      template void
+      interpolate<deal_II_dimension, deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Vector &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        Vector &);
 
-    template
-    void interpolate<deal_II_dimension,deal_II_space_dimension>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension> &, const Vector &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension> &, const ConstraintMatrix &,
-     Vector &);
+      template void
+      interpolate<deal_II_dimension, deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Vector &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ConstraintMatrix &,
+        Vector &);
 #endif
     \}
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
     namespace FETools
     \{
 #if deal_II_dimension == deal_II_space_dimension
-    template
-    void interpolate<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension> &, const Vector<double> &,
-     const hp::DoFHandler<deal_II_dimension> &, Vector<double> &);
+      template void
+      interpolate<deal_II_dimension>(const hp::DoFHandler<deal_II_dimension> &,
+                                     const Vector<double> &,
+                                     const hp::DoFHandler<deal_II_dimension> &,
+                                     Vector<double> &);
 
-    template
-    void interpolate<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension> &, const Vector<double> &,
-     const hp::DoFHandler<deal_II_dimension> &, const ConstraintMatrix &,
-     Vector<double> &);
+      template void
+      interpolate<deal_II_dimension>(const hp::DoFHandler<deal_II_dimension> &,
+                                     const Vector<double> &,
+                                     const hp::DoFHandler<deal_II_dimension> &,
+                                     const ConstraintMatrix &,
+                                     Vector<double> &);
 
-    template
-    void interpolate<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension> &, const Vector<float> &,
-     const hp::DoFHandler<deal_II_dimension> &, Vector<float> &);
+      template void
+      interpolate<deal_II_dimension>(const hp::DoFHandler<deal_II_dimension> &,
+                                     const Vector<float> &,
+                                     const hp::DoFHandler<deal_II_dimension> &,
+                                     Vector<float> &);
 
-    template
-    void interpolate<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension> &, const Vector<float> &,
-     const hp::DoFHandler<deal_II_dimension> &, const ConstraintMatrix &,
-     Vector<float> &);
+      template void
+      interpolate<deal_II_dimension>(const hp::DoFHandler<deal_II_dimension> &,
+                                     const Vector<float> &,
+                                     const hp::DoFHandler<deal_II_dimension> &,
+                                     const ConstraintMatrix &,
+                                     Vector<float> &);
 #endif
     \}
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; VEC : VECTOR_TYPES)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     VEC : VECTOR_TYPES)
+  {
     namespace FETools
     \{
 #if deal_II_dimension == deal_II_space_dimension
-    template
-    void back_interpolate<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &, const VEC &,
-     const FiniteElement<deal_II_dimension> &, VEC &);
+      template void
+      back_interpolate<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const FiniteElement<deal_II_dimension> &,
+        VEC &);
 
-    template
-    void back_interpolate<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension> &, const VEC &,
-     const FiniteElement<deal_II_dimension> &, VEC &);
+      template void
+      back_interpolate<deal_II_dimension>(
+        const hp::DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const FiniteElement<deal_II_dimension> &,
+        VEC &);
 
-    template
-    void back_interpolate<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &, const ConstraintMatrix &,
-     const VEC &,
-     const DoFHandler<deal_II_dimension> &, const ConstraintMatrix &,
-     VEC &);
+      template void
+      back_interpolate<deal_II_dimension>(const DoFHandler<deal_II_dimension> &,
+                                          const ConstraintMatrix &,
+                                          const VEC &,
+                                          const DoFHandler<deal_II_dimension> &,
+                                          const ConstraintMatrix &,
+                                          VEC &);
 
-    template
-    void interpolation_difference<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &, const VEC &,
-     const FiniteElement<deal_II_dimension> &, VEC &);
+      template void
+      interpolation_difference<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const FiniteElement<deal_II_dimension> &,
+        VEC &);
 
-    template
-    void interpolation_difference<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &, const ConstraintMatrix &,
-     const VEC &,
-     const DoFHandler<deal_II_dimension> &, const ConstraintMatrix &,
-     VEC &);
+      template void
+      interpolation_difference<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const ConstraintMatrix &,
+        const VEC &,
+        const DoFHandler<deal_II_dimension> &,
+        const ConstraintMatrix &,
+        VEC &);
 
-    template
-    void project_dg<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &, const VEC &,
-     const DoFHandler<deal_II_dimension> &, VEC &);
+      template void
+      project_dg<deal_II_dimension>(const DoFHandler<deal_II_dimension> &,
+                                    const VEC &,
+                                    const DoFHandler<deal_II_dimension> &,
+                                    VEC &);
 #endif
     \}
-}
+  }

--- a/source/fe/fe_trace.inst.in
+++ b/source/fe/fe_trace.inst.in
@@ -14,6 +14,6 @@
 // ---------------------------------------------------------------------
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class FE_TraceQ<deal_II_dimension>;
-}
+  }

--- a/source/fe/fe_values.decl.1.inst.in
+++ b/source/fe/fe_values.decl.1.inst.in
@@ -19,13 +19,11 @@
 // and derived classes
 
 for (VEC : VECTOR_TYPES)
-{
+  {
     /// Call
     /// @p get_interpolated_dof_values
     /// of the iterator with the
     /// given arguments.
-    virtual
-    void
-    get_interpolated_dof_values (const VEC &in,
-                                 Vector<VEC::value_type> &out) const = 0;
-}
+    virtual void get_interpolated_dof_values(
+      const VEC &in, Vector<VEC::value_type> &out) const = 0;
+  }

--- a/source/fe/fe_values.decl.2.inst.in
+++ b/source/fe/fe_values.decl.2.inst.in
@@ -19,13 +19,11 @@
 // and derived classes
 
 for (VEC : VECTOR_TYPES)
-{
+  {
     /// Call
     /// @p get_interpolated_dof_values
     /// of the iterator with the
     /// given arguments.
-    virtual
-    void
-    get_interpolated_dof_values (const VEC      &in,
-                                 Vector<VEC::value_type> &out) const override;
-}
+    virtual void get_interpolated_dof_values(
+      const VEC &in, Vector<VEC::value_type> &out) const override;
+  }

--- a/source/fe/fe_values.impl.1.inst.in
+++ b/source/fe/fe_values.impl.1.inst.in
@@ -15,14 +15,13 @@
 
 
 for (VEC : VECTOR_TYPES)
-{
+  {
     template <int dim, int spacedim>
     template <typename CI>
     void
-    FEValuesBase<dim,spacedim>::CellIterator<CI>::
-    get_interpolated_dof_values (const VEC      &in,
-                                 Vector<VEC::value_type> &out) const
-    {   //
-        cell->get_interpolated_dof_values (in, out);
+    FEValuesBase<dim, spacedim>::CellIterator<CI>::get_interpolated_dof_values(
+      const VEC &in, Vector<VEC::value_type> &out) const
+    { //
+      cell->get_interpolated_dof_values(in, out);
     \}
-}
+  }

--- a/source/fe/fe_values.impl.2.inst.in
+++ b/source/fe/fe_values.impl.2.inst.in
@@ -15,13 +15,12 @@
 
 
 for (VEC : VECTOR_TYPES)
-{
+  {
     template <int dim, int spacedim>
     void
-    FEValuesBase<dim,spacedim>::TriaCellIterator::
-    get_interpolated_dof_values (const VEC &,
-                                 Vector<VEC::value_type> &) const
-    {   //
-        Assert (false, ExcMessage (message_string));
+    FEValuesBase<dim, spacedim>::TriaCellIterator::get_interpolated_dof_values(
+      const VEC &, Vector<VEC::value_type> &) const
+    { //
+      Assert(false, ExcMessage(message_string));
     \}
-}
+  }

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -14,498 +14,766 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template class FEValuesBase<deal_II_dimension,deal_II_space_dimension>;
-    template class FEValues<deal_II_dimension,deal_II_space_dimension>;
-    template class FEValuesBase<deal_II_dimension,deal_II_space_dimension>::
-    CellIterator<DoFHandler<deal_II_dimension,deal_II_space_dimension>::cell_iterator>;
+    template class FEValuesBase<deal_II_dimension, deal_II_space_dimension>;
+    template class FEValues<deal_II_dimension, deal_II_space_dimension>;
+    template class FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      CellIterator<
+        DoFHandler<deal_II_dimension, deal_II_space_dimension>::cell_iterator>;
 
-    template class FEFaceValuesBase<deal_II_dimension,deal_II_space_dimension>;
-    template class FEFaceValues<deal_II_dimension,deal_II_space_dimension>;
-    template class FESubfaceValues<deal_II_dimension,deal_II_space_dimension>;
+    template class FEFaceValuesBase<deal_II_dimension, deal_II_space_dimension>;
+    template class FEFaceValues<deal_II_dimension, deal_II_space_dimension>;
+    template class FESubfaceValues<deal_II_dimension, deal_II_space_dimension>;
 
 
     namespace FEValuesViews
     \{
-    template class Scalar<deal_II_dimension, deal_II_space_dimension>;
-    template class Vector<deal_II_dimension, deal_II_space_dimension>;
-    template class SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>;
-    template class Tensor<2, deal_II_dimension, deal_II_space_dimension>;
+      template class Scalar<deal_II_dimension, deal_II_space_dimension>;
+      template class Vector<deal_II_dimension, deal_II_space_dimension>;
+      template class SymmetricTensor<2,
+                                     deal_II_dimension,
+                                     deal_II_space_dimension>;
+      template class Tensor<2, deal_II_dimension, deal_II_space_dimension>;
     \}
 
     namespace internal
     \{
-    namespace FEValuesImplementation
-    \{
-    template class MappingRelatedData<deal_II_dimension, deal_II_space_dimension>;
-    template class FiniteElementRelatedData<deal_II_dimension, deal_II_space_dimension>;
+      namespace FEValuesImplementation
+      \{
+        template class MappingRelatedData<deal_II_dimension,
+                                          deal_II_space_dimension>;
+        template class FiniteElementRelatedData<deal_II_dimension,
+                                                deal_II_space_dimension>;
+      \}
     \}
-    \}
 #endif
-}
+  }
 
 
-for (dof_handler : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; lda : BOOL)
-{
+for (dof_handler : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS;
+     lda : BOOL)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template void FEValues<deal_II_dimension,deal_II_space_dimension>::reinit(
-        const TriaIterator<DoFCellAccessor<dof_handler<deal_II_dimension,deal_II_space_dimension>, lda> >&);
-    template void FEFaceValues<deal_II_dimension,deal_II_space_dimension>::reinit(
-        const TriaIterator<DoFCellAccessor<dof_handler<deal_II_dimension,deal_II_space_dimension>, lda> >&, unsigned int);
-    template void FESubfaceValues<deal_II_dimension,deal_II_space_dimension>::reinit(
-        const TriaIterator<DoFCellAccessor<dof_handler<deal_II_dimension,deal_II_space_dimension>, lda> >&, unsigned int, unsigned int);
+    template void FEValues<deal_II_dimension, deal_II_space_dimension>::reinit(
+      const TriaIterator<
+        DoFCellAccessor<dof_handler<deal_II_dimension, deal_II_space_dimension>,
+                        lda>> &);
+    template void
+    FEFaceValues<deal_II_dimension, deal_II_space_dimension>::reinit(
+      const TriaIterator<
+        DoFCellAccessor<dof_handler<deal_II_dimension, deal_II_space_dimension>,
+                        lda>> &,
+      unsigned int);
+    template void
+    FESubfaceValues<deal_II_dimension, deal_II_space_dimension>::reinit(
+      const TriaIterator<
+        DoFCellAccessor<dof_handler<deal_II_dimension, deal_II_space_dimension>,
+                        lda>> &,
+      unsigned int,
+      unsigned int);
 #endif
-}
+  }
 
 
 
-for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_values<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,value_type>::type>&) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_gradients<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_hessians<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<2,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_laplacians<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,double>::type> &) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_third_derivatives<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<3,deal_II_space_dimension> >::type>&) const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<ProductType<dealii::VEC::value_type, value_type>::type> &)
+        const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<2, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<ProductType<dealii::VEC::value_type, double>::type> &)
+        const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<3, deal_II_space_dimension>>::type> &)
+        const;
 
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_values<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type >&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_gradients<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<2,deal_II_space_dimension> >::type >&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_symmetric_gradients<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::SymmetricTensor<2,deal_II_space_dimension> >::type >&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_curls<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,curl_type>::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_divergences<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,divergence_type>::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_hessians<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<3,deal_II_space_dimension> >::type >&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_laplacians<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type >&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_third_derivatives<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<4,deal_II_space_dimension> >::type >&) const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<2, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_symmetric_gradients<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<ProductType<
+          dealii::VEC::value_type,
+          dealii::SymmetricTensor<2, deal_II_space_dimension>>::type> &) const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_curls<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<ProductType<dealii::VEC::value_type, curl_type>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_divergences<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<ProductType<dealii::VEC::value_type, divergence_type>::type>
+          &) const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<3, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<4, deal_II_space_dimension>>::type> &)
+        const;
 
-    template
-    void FEValuesViews::SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>
-    ::get_function_values<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::SymmetricTensor<2,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>
-    ::get_function_divergences<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
+    template void FEValuesViews::SymmetricTensor<2,
+                                                 deal_II_dimension,
+                                                 deal_II_space_dimension>::
+      get_function_values<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<ProductType<
+          dealii::VEC::value_type,
+          dealii::SymmetricTensor<2, deal_II_space_dimension>>::type> &) const;
+    template void FEValuesViews::
+      SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>::
+        get_function_divergences<dealii::VEC>(
+          const dealii::VEC &,
+          std::vector<
+            ProductType<dealii::VEC::value_type,
+                        dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+          const;
 
-    template
-    void FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>
-    ::get_function_values<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<2,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>
-    ::get_function_divergences<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>
-    ::get_function_gradients<dealii::VEC>
-    (const dealii::VEC&, std::vector<ProductType<dealii::VEC::value_type,dealii::Tensor<3,deal_II_space_dimension> >::type>&) const;
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<2, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_divergences<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<dealii::VEC>(
+        const dealii::VEC &,
+        std::vector<
+          ProductType<dealii::VEC::value_type,
+                      dealii::Tensor<3, deal_II_space_dimension>>::type> &)
+        const;
 #endif
-}
+  }
 
 
-for (VEC : GENERAL_CONTAINER_TYPES;
-        Number : ALL_SCALAR_TYPES;
-        deal_II_dimension : DIMENSIONS;
-        deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : GENERAL_CONTAINER_TYPES; Number : ALL_SCALAR_TYPES;
+     deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_values_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::value_type>&) const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::value_type> &) const;
 
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_gradients_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::gradient_type>&) const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::gradient_type> &) const;
 
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_hessians_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::hessian_type>&) const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::hessian_type> &) const;
 
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_laplacians_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::value_type>&) const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::value_type> &) const;
 
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_third_derivatives_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::third_derivative_type>&) const;
-
-
-
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_values_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::value_type>&) const;
-
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_gradients_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::gradient_type>&) const;
-
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_symmetric_gradients_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::symmetric_gradient_type>&) const;
-
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_divergences_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::divergence_type>&) const;
-
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_curls_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::curl_type>&) const;
-
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_hessians_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::hessian_type>&) const;
-
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_laplacians_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::value_type>&) const;
-
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
-    ::get_function_third_derivatives_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::third_derivative_type>&) const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::third_derivative_type> &)
+        const;
 
 
 
-    template
-    void FEValuesViews::SymmetricTensor<2,deal_II_dimension, deal_II_space_dimension>
-    ::get_function_values_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::value_type>&) const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::value_type> &) const;
 
-    template
-    void FEValuesViews::SymmetricTensor<2,deal_II_dimension, deal_II_space_dimension>
-    ::get_function_divergences_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::divergence_type>&) const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::gradient_type> &) const;
+
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_symmetric_gradients_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::symmetric_gradient_type> &)
+        const;
+
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_divergences_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::divergence_type> &) const;
+
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_curls_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::curl_type> &) const;
+
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::hessian_type> &) const;
+
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::value_type> &) const;
+
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::third_derivative_type> &)
+        const;
 
 
 
-    template
-    void FEValuesViews::Tensor<2,deal_II_dimension, deal_II_space_dimension>
-    ::get_function_values_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::value_type>&) const;
+    template void FEValuesViews::
+      SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>::
+        get_function_values_from_local_dof_values<VEC<Number>>(
+          const VEC<Number> &,
+          std::vector<typename OutputType<Number>::value_type> &) const;
 
-    template
-    void FEValuesViews::Tensor<2,deal_II_dimension, deal_II_space_dimension>
-    ::get_function_divergences_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::divergence_type>&) const;
+    template void FEValuesViews::
+      SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>::
+        get_function_divergences_from_local_dof_values<VEC<Number>>(
+          const VEC<Number> &,
+          std::vector<typename OutputType<Number>::divergence_type> &) const;
 
-    template
-    void FEValuesViews::Tensor<2,deal_II_dimension, deal_II_space_dimension>
-    ::get_function_gradients_from_local_dof_values<VEC<Number>>
-            (const VEC<Number>&, std::vector<typename OutputType<Number>::gradient_type>&) const;
+
+
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_values_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::value_type> &) const;
+
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_divergences_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::divergence_type> &) const;
+
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &,
+        std::vector<typename OutputType<Number>::gradient_type> &) const;
 #endif
-}
+  }
 
 
-for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-    (const VEC&, std::vector<VEC::value_type>&) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<VEC::value_type>&) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<VEC>(const VEC &, std::vector<VEC::value_type> &)
+        const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<VEC::value_type> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-    (const VEC&, std::vector<Vector<VEC::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<VEC>(const VEC &,
+                               std::vector<Vector<VEC::value_type>> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<Vector<VEC::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<Vector<VEC::value_type>> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<VEC::value_type> > >, bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        VectorSlice<std::vector<std::vector<VEC::value_type>>>,
+        bool) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<VEC>
-    (const VEC&, std::vector<dealii::Tensor<1,deal_II_space_dimension,VEC::value_type> > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<1,deal_II_space_dimension,VEC::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<VEC>(
+        const VEC &,
+        std::vector<dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>
+          &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>
+          &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<VEC>
-    (const VEC&, std::vector<std::vector<dealii::Tensor<1,deal_II_space_dimension,VEC::value_type> > > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_space_dimension,VEC::value_type> > > >, bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<VEC>(
+        const VEC &,
+        std::vector<std::vector<
+          dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>> &)
+        const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        VectorSlice<std::vector<std::vector<
+          dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>>>,
+        bool) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<VEC>
-    (const VEC&, std::vector<dealii::Tensor<2,deal_II_space_dimension,VEC::value_type> > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<2,deal_II_space_dimension,VEC::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<VEC>(
+        const VEC &,
+        std::vector<dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>
+          &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>
+          &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<VEC>
-    (const VEC&, std::vector<std::vector<dealii::Tensor<2,deal_II_space_dimension,VEC::value_type> > > &, bool) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_space_dimension,VEC::value_type> > > >, bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<VEC>(
+        const VEC &,
+        std::vector<std::vector<
+          dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>> &,
+        bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        VectorSlice<std::vector<std::vector<
+          dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>>>,
+        bool) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-    (const VEC&, std::vector<VEC::value_type>&) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<VEC::value_type>&) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<VEC>(const VEC &, std::vector<VEC::value_type> &)
+        const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<VEC::value_type> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-    (const VEC&, std::vector<Vector<VEC::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<VEC>(
+        const VEC &, std::vector<Vector<VEC::value_type>> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<Vector<VEC::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<Vector<VEC::value_type>> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<std::vector<VEC::value_type> > &, bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<std::vector<VEC::value_type>> &,
+        bool) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<VEC>
-    (const VEC&, std::vector<dealii::Tensor<3,deal_II_space_dimension,VEC::value_type> > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<3,deal_II_space_dimension,VEC::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<VEC>(
+        const VEC &,
+        std::vector<dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>
+          &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>
+          &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<VEC>
-    (const VEC&, std::vector<std::vector<dealii::Tensor<3,deal_II_space_dimension,VEC::value_type> > > &, bool) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<VEC>
-    (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<3,deal_II_space_dimension,VEC::value_type> > > >, bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<VEC>(
+        const VEC &,
+        std::vector<std::vector<
+          dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>> &,
+        bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<VEC>(
+        const VEC &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        VectorSlice<std::vector<std::vector<
+          dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>>>,
+        bool) const;
 
 #endif
-}
+  }
 
 
 // instantiations for VEC=IndexSet
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void FEValuesViews::Scalar<deal_II_dimension,deal_II_space_dimension>::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,double>::type> &) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,double>::type>&) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_space_dimension> >::type>&) const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<ProductType<IndexSet::value_type, double>::type> &) const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<2, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<ProductType<IndexSet::value_type, double>::type> &) const;
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<3, deal_II_space_dimension>>::type> &)
+        const;
 
-    template
-    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_symmetric_gradients<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_curls<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,curl_type>::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_divergences<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,divergence_type>::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<4,deal_II_space_dimension> >::type>&) const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<2, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_symmetric_gradients<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<ProductType<
+          IndexSet::value_type,
+          dealii::SymmetricTensor<2, deal_II_space_dimension>>::type> &) const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_curls<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<ProductType<IndexSet::value_type, curl_type>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_divergences<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<ProductType<IndexSet::value_type, divergence_type>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<3, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<4, deal_II_space_dimension>>::type> &)
+        const;
 
-    template
-    void FEValuesViews::SymmetricTensor<2,deal_II_dimension,deal_II_space_dimension>::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::SymmetricTensor<2,deal_II_dimension,deal_II_space_dimension>::get_function_divergences<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
+    template void FEValuesViews::SymmetricTensor<2,
+                                                 deal_II_dimension,
+                                                 deal_II_space_dimension>::
+      get_function_values<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<ProductType<
+          IndexSet::value_type,
+          dealii::SymmetricTensor<2, deal_II_space_dimension>>::type> &) const;
+    template void FEValuesViews::
+      SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>::
+        get_function_divergences<dealii::IndexSet>(
+          const dealii::IndexSet &,
+          std::vector<
+            ProductType<IndexSet::value_type,
+                        dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+          const;
 
-    template
-    void FEValuesViews::Tensor<2,deal_II_dimension,deal_II_space_dimension>::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Tensor<2,deal_II_dimension,deal_II_space_dimension>::get_function_divergences<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
-    template
-    void FEValuesViews::Tensor<2,deal_II_dimension,deal_II_space_dimension>::get_function_gradients<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_space_dimension> >::type>&) const;
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<2, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_divergences<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+        const;
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<dealii::IndexSet>(
+        const dealii::IndexSet &,
+        std::vector<
+          ProductType<IndexSet::value_type,
+                      dealii::Tensor<3, deal_II_space_dimension>>::type> &)
+        const;
 #endif
-}
+  }
 
 
 
 // Instantiations of functions in FEValuesBase and IndexSet=IndexSet
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<IndexSet>
-    (const IndexSet&, std::vector<IndexSet::value_type>&) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<IndexSet::value_type>&) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<IndexSet>(const IndexSet &,
+                                    std::vector<IndexSet::value_type> &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<IndexSet::value_type> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<IndexSet>
-    (const IndexSet&, std::vector<Vector<IndexSet::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<IndexSet>(
+        const IndexSet &, std::vector<Vector<IndexSet::value_type>> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<Vector<IndexSet::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<Vector<IndexSet::value_type>> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<IndexSet::value_type> > >, bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        VectorSlice<std::vector<std::vector<IndexSet::value_type>>>,
+        bool) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<IndexSet>
-    (const IndexSet&, std::vector<dealii::Tensor<1,deal_II_space_dimension,IndexSet::value_type> > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<1,deal_II_space_dimension,IndexSet::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<IndexSet>(
+        const IndexSet &,
+        std::vector<
+          dealii::Tensor<1, deal_II_space_dimension, IndexSet::value_type>> &)
+        const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<
+          dealii::Tensor<1, deal_II_space_dimension, IndexSet::value_type>> &)
+        const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<IndexSet>
-    (const IndexSet&, std::vector<std::vector<dealii::Tensor<1,deal_II_space_dimension,IndexSet::value_type> > > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_space_dimension,IndexSet::value_type> > > >, bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<IndexSet>(
+        const IndexSet &,
+        std::vector<std::vector<
+          dealii::Tensor<1, deal_II_space_dimension, IndexSet::value_type>>> &)
+        const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        VectorSlice<std::vector<std::vector<
+          dealii::Tensor<1, deal_II_space_dimension, IndexSet::value_type>>>>,
+        bool) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<IndexSet>
-    (const IndexSet&, std::vector<dealii::Tensor<2,deal_II_space_dimension,IndexSet::value_type> > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<2,deal_II_space_dimension,IndexSet::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<IndexSet>(
+        const IndexSet &,
+        std::vector<
+          dealii::Tensor<2, deal_II_space_dimension, IndexSet::value_type>> &)
+        const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<
+          dealii::Tensor<2, deal_II_space_dimension, IndexSet::value_type>> &)
+        const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<IndexSet>
-    (const IndexSet&, std::vector<std::vector<dealii::Tensor<2,deal_II_space_dimension,IndexSet::value_type> > > &, bool) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_space_dimension,IndexSet::value_type> > > >, bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<IndexSet>(
+        const IndexSet &,
+        std::vector<std::vector<
+          dealii::Tensor<2, deal_II_space_dimension, IndexSet::value_type>>> &,
+        bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        VectorSlice<std::vector<std::vector<
+          dealii::Tensor<2, deal_II_space_dimension, IndexSet::value_type>>>>,
+        bool) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<IndexSet>
-    (const IndexSet&, std::vector<IndexSet::value_type>&) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<IndexSet::value_type>&) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<IndexSet>(
+        const IndexSet &, std::vector<IndexSet::value_type> &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<IndexSet::value_type> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<IndexSet>
-    (const IndexSet&, std::vector<Vector<IndexSet::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<IndexSet>(
+        const IndexSet &, std::vector<Vector<IndexSet::value_type>> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<Vector<IndexSet::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<Vector<IndexSet::value_type>> &) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<std::vector<IndexSet::value_type> > &, bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_laplacians<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<std::vector<IndexSet::value_type>> &,
+        bool) const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<IndexSet>
-    (const IndexSet&, std::vector<dealii::Tensor<3,deal_II_space_dimension,IndexSet::value_type> > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<3,deal_II_space_dimension,IndexSet::value_type> > &) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<IndexSet>(
+        const IndexSet &,
+        std::vector<
+          dealii::Tensor<3, deal_II_space_dimension, IndexSet::value_type>> &)
+        const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        std::vector<
+          dealii::Tensor<3, deal_II_space_dimension, IndexSet::value_type>> &)
+        const;
 
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<IndexSet>
-    (const IndexSet&, std::vector<std::vector<dealii::Tensor<3,deal_II_space_dimension,IndexSet::value_type> > > &, bool) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<3,deal_II_space_dimension,IndexSet::value_type> > > >, bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<IndexSet>(
+        const IndexSet &,
+        std::vector<std::vector<
+          dealii::Tensor<3, deal_II_space_dimension, IndexSet::value_type>>> &,
+        bool) const;
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_third_derivatives<IndexSet>(
+        const IndexSet &,
+        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        VectorSlice<std::vector<std::vector<
+          dealii::Tensor<3, deal_II_space_dimension, IndexSet::value_type>>>>,
+        bool) const;
 #endif
-}
+  }

--- a/source/fe/mapping.inst.in
+++ b/source/fe/mapping.inst.in
@@ -15,11 +15,9 @@
 
 
 
-
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class Mapping<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
+  }

--- a/source/fe/mapping_c1.inst.in
+++ b/source/fe/mapping_c1.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class MappingC1<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/mapping_cartesian.inst.in
+++ b/source/fe/mapping_cartesian.inst.in
@@ -16,7 +16,6 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class MappingCartesian<deal_II_dimension>;
-}
-
+  }

--- a/source/fe/mapping_fe_field.inst.in
+++ b/source/fe/mapping_fe_field.inst.in
@@ -15,12 +15,14 @@
 
 
 
-
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; VEC : REAL_VECTOR_TYPES)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     VEC : REAL_VECTOR_TYPES)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template class MappingFEField<deal_II_dimension, deal_II_space_dimension,  VEC,
-                                  dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension> >;
+    template class MappingFEField<
+      deal_II_dimension,
+      deal_II_space_dimension,
+      VEC,
+      dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
 #endif
-}
-
+  }

--- a/source/fe/mapping_manifold.inst.in
+++ b/source/fe/mapping_manifold.inst.in
@@ -14,10 +14,9 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class MappingManifold<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
+  }

--- a/source/fe/mapping_q.inst.in
+++ b/source/fe/mapping_q.inst.in
@@ -15,11 +15,9 @@
 
 
 
-
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class MappingQ<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
+  }

--- a/source/fe/mapping_q1.inst.in
+++ b/source/fe/mapping_q1.inst.in
@@ -14,11 +14,10 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class MappingQ1<deal_II_dimension, deal_II_space_dimension>;
     template struct StaticMappingQ1<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
+  }

--- a/source/fe/mapping_q1_eulerian.inst.in
+++ b/source/fe/mapping_q1_eulerian.inst.in
@@ -14,11 +14,12 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; VEC : REAL_VECTOR_TYPES)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     VEC : REAL_VECTOR_TYPES)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template class MappingQ1Eulerian<deal_II_dimension, VEC, deal_II_space_dimension>;
+    template class MappingQ1Eulerian<deal_II_dimension,
+                                     VEC,
+                                     deal_II_space_dimension>;
 #endif
-}
-
-
+  }

--- a/source/fe/mapping_q_eulerian.inst.in
+++ b/source/fe/mapping_q_eulerian.inst.in
@@ -14,11 +14,12 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; VEC : REAL_VECTOR_TYPES)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     VEC : REAL_VECTOR_TYPES)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template class MappingQEulerian<deal_II_dimension, VEC, deal_II_space_dimension>;
+    template class MappingQEulerian<deal_II_dimension,
+                                    VEC,
+                                    deal_II_space_dimension>;
 #endif
-}
-
-
+  }

--- a/source/fe/mapping_q_generic.inst.in
+++ b/source/fe/mapping_q_generic.inst.in
@@ -14,10 +14,9 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class MappingQGeneric<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
+  }

--- a/source/gmsh/utilities.inst.in
+++ b/source/gmsh/utilities.inst.in
@@ -14,14 +14,13 @@
 // ---------------------------------------------------------------------
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension > 1
 
-  template
-  void
-  create_triangulation_from_boundary_curve(const TopoDS_Edge &boundary,
-                                           Triangulation<2,deal_II_dimension> &tria,
-                                           const AdditionalParameters &prm);
+    template void create_triangulation_from_boundary_curve(
+      const TopoDS_Edge &                  boundary,
+      Triangulation<2, deal_II_dimension> &tria,
+      const AdditionalParameters &         prm);
 
 #endif
-}
+  }

--- a/source/grid/cell_id.inst.in
+++ b/source/grid/cell_id.inst.in
@@ -15,14 +15,18 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template Triangulation<deal_II_dimension,deal_II_space_dimension>::cell_iterator CellId::to_cell(const Triangulation<deal_II_dimension,deal_II_space_dimension> &tria) const;
+    template Triangulation<deal_II_dimension,
+                           deal_II_space_dimension>::cell_iterator
+    CellId::to_cell(
+      const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria)
+      const;
 #endif
-}
+  }
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template CellId::binary_type CellId::to_binary<deal_II_dimension>() const;
-}
+  }

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -14,182 +14,205 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
     namespace GridGenerator
     \{
 #if deal_II_dimension <= deal_II_space_dimension
-    template void
-    hyper_rectangle<deal_II_dimension, deal_II_space_dimension> (
+      template void
+      hyper_rectangle<deal_II_dimension, deal_II_space_dimension>(
         Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-        const Point<deal_II_dimension>&, const Point<deal_II_dimension>&,
+        const Point<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
         const bool);
 
-    template void
-    hyper_cube<deal_II_dimension, deal_II_space_dimension> (
-        Triangulation<deal_II_dimension, deal_II_space_dimension> &, const double, const double, const bool);
-
-    template void
-    subdivided_hyper_cube<deal_II_dimension, deal_II_space_dimension> (
+      template void
+      hyper_cube<deal_II_dimension, deal_II_space_dimension>(
         Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-        const unsigned int, const double, const double);
+        const double,
+        const double,
+        const bool);
+
+      template void
+      subdivided_hyper_cube<deal_II_dimension, deal_II_space_dimension>(
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const unsigned int,
+        const double,
+        const double);
 
 
-    template void
-    subdivided_hyper_rectangle<deal_II_dimension, deal_II_space_dimension>
-    (Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-     const std::vector<unsigned int>&,
-     const Point<deal_II_dimension>&,
-     const Point<deal_II_dimension>&,
-     const bool);
+      template void
+      subdivided_hyper_rectangle<deal_II_dimension, deal_II_space_dimension>(
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const std::vector<unsigned int> &,
+        const Point<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        const bool);
 
-    template void
-    subdivided_parallelepiped<deal_II_dimension, deal_II_space_dimension>
-    (Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-     const Point<deal_II_space_dimension> &,
-     const std::array<Tensor<1,deal_II_space_dimension>,deal_II_dimension> &,
-     const std::vector<unsigned int> &,
-     const bool colorize);
+      template void
+      subdivided_parallelepiped<deal_II_dimension, deal_II_space_dimension>(
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const Point<deal_II_space_dimension> &,
+        const std::array<Tensor<1, deal_II_space_dimension>, deal_II_dimension>
+          &,
+        const std::vector<unsigned int> &,
+        const bool colorize);
 
-    template void
-    hyper_cross<deal_II_dimension, deal_II_space_dimension>
-    (Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-     const std::vector<unsigned int> &, const bool);
+      template void
+      hyper_cross<deal_II_dimension, deal_II_space_dimension>(
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const std::vector<unsigned int> &,
+        const bool);
 
-    template void
-    cheese<deal_II_dimension, deal_II_space_dimension>
-    (Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-     const std::vector<unsigned int> &);
+      template void
+      cheese<deal_II_dimension, deal_II_space_dimension>(
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const std::vector<unsigned int> &);
 
-    template
-    void
-    merge_triangulations
-    (const Triangulation<deal_II_dimension,deal_II_space_dimension> &triangulation_1,
-     const Triangulation<deal_II_dimension,deal_II_space_dimension> &triangulation_2,
-     Triangulation<deal_II_dimension,deal_II_space_dimension>       &result);
+      template void
+      merge_triangulations(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &triangulation_1,
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &triangulation_2,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &result);
 
-    template
-    void
-    create_union_triangulation
-    (const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation_1,
-     const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation_2,
-     Triangulation<deal_II_dimension, deal_II_space_dimension>       &result);
+      template void
+      create_union_triangulation(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &triangulation_1,
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &triangulation_2,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &result);
 
-    template
-    void
-    create_triangulation_with_removed_cells (const Triangulation<deal_II_dimension, deal_II_space_dimension> &input_triangulation,
-            const std::set<Triangulation<deal_II_dimension, deal_II_space_dimension>::active_cell_iterator> &cells_to_remove,
-            Triangulation<deal_II_dimension, deal_II_space_dimension>       &result);
+      template void
+      create_triangulation_with_removed_cells(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &input_triangulation,
+        const std::set<
+          Triangulation<deal_II_dimension,
+                        deal_II_space_dimension>::active_cell_iterator>
+          &cells_to_remove,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &result);
 
 #endif
     \}
-}
+  }
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; Container : TRIANGULATION_AND_DOFHANDLER_TEMPLATES)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     Container : TRIANGULATION_AND_DOFHANDLER_TEMPLATES)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace GridGenerator \{
+    namespace GridGenerator
+    \{
 
-#if deal_II_dimension != 1
-    template
-#ifndef _MSC_VER
-    std::map<Container<deal_II_dimension-1,deal_II_space_dimension>::cell_iterator,
-             Container<deal_II_dimension,deal_II_space_dimension>::face_iterator>
-#else
-    ExtractBoundaryMesh<Container,deal_II_dimension,deal_II_space_dimension>::return_type
-#endif
-    extract_boundary_mesh (const Container<deal_II_dimension, deal_II_space_dimension> &mesh,
-                           Container<deal_II_dimension-1,deal_II_space_dimension>  &boundary_mesh,
-                           const std::set<types::boundary_id> &boundary_ids);
-#endif
+#  if deal_II_dimension != 1
+      template
+#    ifndef _MSC_VER
+        std::map<
+          Container<deal_II_dimension - 1,
+                    deal_II_space_dimension>::cell_iterator,
+          Container<deal_II_dimension, deal_II_space_dimension>::face_iterator>
+#    else
+        ExtractBoundaryMesh<Container,
+                            deal_II_dimension,
+                            deal_II_space_dimension>::return_type
+#    endif
+        extract_boundary_mesh(
+          const Container<deal_II_dimension, deal_II_space_dimension> &mesh,
+          Container<deal_II_dimension - 1, deal_II_space_dimension>
+            &                                 boundary_mesh,
+          const std::set<types::boundary_id> &boundary_ids);
+#  endif
     \}
 #endif
-
-}
+  }
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    namespace GridGenerator \{
+  {
+    namespace GridGenerator
+    \{
 
-    template
-    void
-    subdivided_hyper_rectangle(
-        Triangulation<deal_II_dimension>              &,
-        const std::vector<std::vector<double> > &,
-        const Point<deal_II_dimension>                &,
-        const Point<deal_II_dimension>                &,
-        const bool                       );
+      template void
+      subdivided_hyper_rectangle(Triangulation<deal_II_dimension> &,
+                                 const std::vector<std::vector<double>> &,
+                                 const Point<deal_II_dimension> &,
+                                 const Point<deal_II_dimension> &,
+                                 const bool);
 
-    template
-    void
-    general_cell (Triangulation<deal_II_dimension> &,
-                  const std::vector<Point<deal_II_dimension> > &,
-                  const bool);
+      template void
+      general_cell(Triangulation<deal_II_dimension> &,
+                   const std::vector<Point<deal_II_dimension>> &,
+                   const bool);
 
-    template void
-    simplex<deal_II_dimension> (
+      template void
+      simplex<deal_II_dimension>(
         Triangulation<deal_II_dimension, deal_II_dimension> &,
-        const std::vector<Point<deal_II_dimension> >&);
+        const std::vector<Point<deal_II_dimension>> &);
 
-    template void
-    parallelepiped<deal_II_dimension> (
-        Triangulation<deal_II_dimension>&,
-        const Point<deal_II_dimension> (&) [deal_II_dimension],
+      template void
+      parallelepiped<deal_II_dimension>(
+        Triangulation<deal_II_dimension> &,
+        const Point<deal_II_dimension> (&)[deal_II_dimension],
         const bool);
 
-    template void
-    subdivided_parallelepiped<deal_II_dimension> (
-        Triangulation<deal_II_dimension>&,
+      template void
+      subdivided_parallelepiped<deal_II_dimension>(
+        Triangulation<deal_II_dimension> &,
         const unsigned int,
-        const Point<deal_II_dimension> (&) [deal_II_dimension],
+        const Point<deal_II_dimension> (&)[deal_II_dimension],
         const bool);
 
 #ifndef _MSC_VER
-    template void
-    subdivided_parallelepiped<deal_II_dimension> (
-        Triangulation<deal_II_dimension>&,
-        const unsigned int (&) [deal_II_dimension],
-        const Point<deal_II_dimension> (&) [deal_II_dimension],
+      template void
+      subdivided_parallelepiped<deal_II_dimension>(
+        Triangulation<deal_II_dimension> &,
+        const unsigned int (&)[deal_II_dimension],
+        const Point<deal_II_dimension> (&)[deal_II_dimension],
         const bool);
 #else
-    template void
-    subdivided_parallelepiped<deal_II_dimension> (
-        Triangulation<deal_II_dimension>&,
-        const unsigned int*,
-        const Point<deal_II_dimension> (&) [deal_II_dimension],
+      template void
+      subdivided_parallelepiped<deal_II_dimension>(
+        Triangulation<deal_II_dimension> &,
+        const unsigned int *,
+        const Point<deal_II_dimension> (&)[deal_II_dimension],
         const bool);
 #endif
 
 
     \}
-}
+  }
 
 
 
 for (deal_II_space_dimension : DIMENSIONS)
-{
-    namespace GridGenerator \{
+  {
+    namespace GridGenerator
+    \{
 
 #if deal_II_space_dimension >= 2
-    template void
-    hyper_sphere<deal_II_space_dimension> (
-        Triangulation<deal_II_space_dimension-1, deal_II_space_dimension> &, const Point<deal_II_space_dimension> &, double);
+      template void hyper_sphere<deal_II_space_dimension>(
+        Triangulation<deal_II_space_dimension - 1, deal_II_space_dimension> &,
+        const Point<deal_II_space_dimension> &,
+        double);
 #endif
 
     \}
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS; deal_II_space_dimension_2 : SPACE_DIMENSIONS)
-{
-    namespace GridGenerator \{
-#if (deal_II_dimension <= deal_II_space_dimension) && (deal_II_dimension <= deal_II_space_dimension_2)
-    template
-    void
-    flatten_triangulation<>(const Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-                            Triangulation<deal_II_dimension,deal_II_space_dimension_2>&);
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     deal_II_space_dimension_2 : SPACE_DIMENSIONS)
+  {
+    namespace GridGenerator
+    \{
+#if (deal_II_dimension <= deal_II_space_dimension) && \
+  (deal_II_dimension <= deal_II_space_dimension_2)
+      template void
+      flatten_triangulation<>(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        Triangulation<deal_II_dimension, deal_II_space_dimension_2> &);
 #endif
     \}
-}
-
+  }

--- a/source/grid/grid_in.inst.in
+++ b/source/grid/grid_in.inst.in
@@ -15,9 +15,8 @@
 
 
 for (deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class GridIn<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
-
+  }

--- a/source/grid/grid_out.inst.in
+++ b/source/grid/grid_out.inst.in
@@ -16,93 +16,90 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension > 1
-    template void GridOut::write_dx
-    (const Triangulation<deal_II_dimension>&,
-     std::ostream&) const;
-    template void GridOut::write_mathgl
-    (const Triangulation<deal_II_dimension>&,
-     std::ostream&) const;
+    template void GridOut::write_dx(const Triangulation<deal_II_dimension> &,
+                                    std::ostream &) const;
+    template void GridOut::write_mathgl(
+      const Triangulation<deal_II_dimension> &, std::ostream &) const;
 #endif
 
-    template void GridOut::write_msh
-    (const Triangulation<deal_II_dimension>&,
-     std::ostream&) const;
+    template void GridOut::write_msh(const Triangulation<deal_II_dimension> &,
+                                     std::ostream &) const;
 
 #if deal_II_dimension != 2
-    template void GridOut::write_xfig
-    (const Triangulation<deal_II_dimension>&,
-     std::ostream&,
-     const Mapping<deal_II_dimension,deal_II_dimension>*) const;
+    template void GridOut::write_xfig(
+      const Triangulation<deal_II_dimension> &,
+      std::ostream &,
+      const Mapping<deal_II_dimension, deal_II_dimension> *) const;
 #endif
 
-    template void GridOut::write_gnuplot
-    (const Triangulation<deal_II_dimension>&,
-     std::ostream&,
-     const Mapping<deal_II_dimension,deal_II_dimension>*) const;
-    template void GridOut::write_ucd<deal_II_dimension>
-    (const Triangulation<deal_II_dimension> &,
-     std::ostream &) const;
-    template void GridOut::write_eps<deal_II_dimension>
-    (const Triangulation<deal_II_dimension> &,
-     std::ostream &,
-     const Mapping<deal_II_dimension,deal_II_dimension> *) const;
-    template void GridOut::write_vtk
-    (const Triangulation<deal_II_dimension>&,
-     std::ostream&) const;
-    template void GridOut::write_vtu
-    (const Triangulation<deal_II_dimension>&,
-     std::ostream&) const;
-    template void GridOut::write_mesh_per_processor_as_vtu
-    (const Triangulation<deal_II_dimension>&,
-     const std::string&,
-     const bool,
-     const bool) const;
+    template void GridOut::write_gnuplot(
+      const Triangulation<deal_II_dimension> &,
+      std::ostream &,
+      const Mapping<deal_II_dimension, deal_II_dimension> *) const;
+    template void GridOut::write_ucd<deal_II_dimension>(
+      const Triangulation<deal_II_dimension> &, std::ostream &) const;
+    template void GridOut::write_eps<deal_II_dimension>(
+      const Triangulation<deal_II_dimension> &,
+      std::ostream &,
+      const Mapping<deal_II_dimension, deal_II_dimension> *) const;
+    template void GridOut::write_vtk(const Triangulation<deal_II_dimension> &,
+                                     std::ostream &) const;
+    template void GridOut::write_vtu(const Triangulation<deal_II_dimension> &,
+                                     std::ostream &) const;
+    template void GridOut::write_mesh_per_processor_as_vtu(
+      const Triangulation<deal_II_dimension> &,
+      const std::string &,
+      const bool,
+      const bool) const;
 
-    template void GridOut::write<deal_II_dimension>
-    (const Triangulation<deal_II_dimension> &,
-     std::ostream &, const OutputFormat,
-     const Mapping<deal_II_dimension,deal_II_dimension> *) const;
-    template void GridOut::write<deal_II_dimension>
-    (const Triangulation<deal_II_dimension> &,
-     std::ostream &, const Mapping<deal_II_dimension,deal_II_dimension> *) const;
-}
+    template void GridOut::write<deal_II_dimension>(
+      const Triangulation<deal_II_dimension> &,
+      std::ostream &,
+      const OutputFormat,
+      const Mapping<deal_II_dimension, deal_II_dimension> *) const;
+    template void GridOut::write<deal_II_dimension>(
+      const Triangulation<deal_II_dimension> &,
+      std::ostream &,
+      const Mapping<deal_II_dimension, deal_II_dimension> *) const;
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension < deal_II_space_dimension
-    template void GridOut::write_msh
-    (const Triangulation<deal_II_dimension, deal_II_space_dimension>&,
-     std::ostream&) const;
-    template void GridOut::write_ucd
-    (const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-     std::ostream &) const;
-    template void GridOut::write_gnuplot
-    (const Triangulation<deal_II_dimension,deal_II_space_dimension>&,
-     std::ostream&,
-     const Mapping<deal_II_dimension,deal_II_space_dimension>*) const;
-    template void GridOut::write_vtk
-    (const Triangulation<deal_II_dimension,deal_II_space_dimension>&,
-     std::ostream&) const;
-    template void GridOut::write_vtu
-    (const Triangulation<deal_II_dimension,deal_II_space_dimension>&,
-     std::ostream&) const;
-    template void GridOut::write_mesh_per_processor_as_vtu
-    (const Triangulation<deal_II_dimension,deal_II_space_dimension>&,
-     const std::string&,
-     const bool,
-     const bool) const;
+    template void GridOut::write_msh(
+      const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+      std::ostream &) const;
+    template void GridOut::write_ucd(
+      const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+      std::ostream &) const;
+    template void GridOut::write_gnuplot(
+      const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+      std::ostream &,
+      const Mapping<deal_II_dimension, deal_II_space_dimension> *) const;
+    template void GridOut::write_vtk(
+      const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+      std::ostream &) const;
+    template void GridOut::write_vtu(
+      const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+      std::ostream &) const;
+    template void GridOut::write_mesh_per_processor_as_vtu(
+      const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+      const std::string &,
+      const bool,
+      const bool) const;
 
 
-    template void GridOut::write<deal_II_dimension,deal_II_space_dimension>
-    (const Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-     std::ostream &, const OutputFormat,
-     const Mapping<deal_II_dimension,deal_II_space_dimension> *) const;
-    template void GridOut::write<deal_II_dimension,deal_II_space_dimension>
-    (const Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-     std::ostream &, const Mapping<deal_II_dimension,deal_II_space_dimension> *) const;
+    template void GridOut::write<deal_II_dimension, deal_II_space_dimension>(
+      const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+      std::ostream &,
+      const OutputFormat,
+      const Mapping<deal_II_dimension, deal_II_space_dimension> *) const;
+    template void GridOut::write<deal_II_dimension, deal_II_space_dimension>(
+      const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+      std::ostream &,
+      const Mapping<deal_II_dimension, deal_II_space_dimension> *) const;
 
 #endif
-}
-
+  }

--- a/source/grid/grid_refinement.inst.in
+++ b/source/grid/grid_refinement.inst.in
@@ -15,111 +15,90 @@
 
 
 
-
 for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
-{
-    template
-    void
-    GridRefinement::
-    refine<deal_II_dimension,S,deal_II_dimension>
-    (Triangulation<deal_II_dimension> &,
-     const dealii::Vector<S> &,
-     const double,
-     const unsigned int);
+  {
+    template void
+    GridRefinement::refine<deal_II_dimension, S, deal_II_dimension>(
+      Triangulation<deal_II_dimension> &,
+      const dealii::Vector<S> &,
+      const double,
+      const unsigned int);
 
-    template
-    void
-    GridRefinement::
-    coarsen<deal_II_dimension,S,deal_II_dimension>
-    (Triangulation<deal_II_dimension> &,
-     const dealii::Vector<S> &,
-     const double);
+    template void
+    GridRefinement::coarsen<deal_II_dimension, S, deal_II_dimension>(
+      Triangulation<deal_II_dimension> &,
+      const dealii::Vector<S> &,
+      const double);
 
-    template
-    void
-    GridRefinement::
-    refine_and_coarsen_fixed_number<deal_II_dimension,S,deal_II_dimension>
-    (Triangulation<deal_II_dimension> &,
-     const dealii::Vector<S> &,
-     const double,
-     const double,
-     const unsigned int);
+    template void GridRefinement::
+      refine_and_coarsen_fixed_number<deal_II_dimension, S, deal_II_dimension>(
+        Triangulation<deal_II_dimension> &,
+        const dealii::Vector<S> &,
+        const double,
+        const double,
+        const unsigned int);
 
-    template
-    void
-    GridRefinement::
-    refine_and_coarsen_fixed_fraction<deal_II_dimension,S,deal_II_dimension>
-    (Triangulation<deal_II_dimension> &,
-     const dealii::Vector<S> &,
-     const double,
-     const double,
-     const unsigned int);
+    template void
+    GridRefinement::refine_and_coarsen_fixed_fraction<deal_II_dimension,
+                                                      S,
+                                                      deal_II_dimension>(
+      Triangulation<deal_II_dimension> &,
+      const dealii::Vector<S> &,
+      const double,
+      const double,
+      const unsigned int);
 
-    template
-    void
-    GridRefinement::
-    refine_and_coarsen_optimize<deal_II_dimension,S,deal_II_dimension>
-    (Triangulation<deal_II_dimension> &,
-     const dealii::Vector<S> &,
-     const unsigned int);
+    template void GridRefinement::
+      refine_and_coarsen_optimize<deal_II_dimension, S, deal_II_dimension>(
+        Triangulation<deal_II_dimension> &,
+        const dealii::Vector<S> &,
+        const unsigned int);
 
 #if deal_II_dimension < 3
-    template
-    void
-    GridRefinement::
-    refine<deal_II_dimension,S,deal_II_dimension+1>
-    (Triangulation<deal_II_dimension,deal_II_dimension+1> &,
-     const dealii::Vector<S> &,
-     const double,
-     const unsigned int);
+    template void
+      GridRefinement::refine<deal_II_dimension, S, deal_II_dimension + 1>(
+        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+        const dealii::Vector<S> &,
+        const double,
+        const unsigned int);
 
-    template
-    void
-    GridRefinement::
-    coarsen<deal_II_dimension,S,deal_II_dimension+1>
-    (Triangulation<deal_II_dimension,deal_II_dimension+1> &,
-     const dealii::Vector<S> &,
-     const double);
+    template void
+      GridRefinement::coarsen<deal_II_dimension, S, deal_II_dimension + 1>(
+        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+        const dealii::Vector<S> &,
+        const double);
 
-    template
-    void
-    GridRefinement::
-    refine_and_coarsen_fixed_number<deal_II_dimension,S,deal_II_dimension+1>
-    (Triangulation<deal_II_dimension,deal_II_dimension+1> &,
-     const dealii::Vector<S> &,
-     const double,
-     const double,
-     const unsigned int);
+    template void
+      GridRefinement::refine_and_coarsen_fixed_number<deal_II_dimension,
+                                                      S,
+                                                      deal_II_dimension + 1>(
+        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+        const dealii::Vector<S> &,
+        const double,
+        const double,
+        const unsigned int);
 
-    template
-    void
-    GridRefinement::
-    refine_and_coarsen_fixed_fraction<deal_II_dimension,S,deal_II_dimension+1>
-    (Triangulation<deal_II_dimension,deal_II_dimension+1> &,
-     const dealii::Vector<S> &,
-     const double,
-     const double,
-     const unsigned int);
+    template void
+      GridRefinement::refine_and_coarsen_fixed_fraction<deal_II_dimension,
+                                                        S,
+                                                        deal_II_dimension + 1>(
+        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+        const dealii::Vector<S> &,
+        const double,
+        const double,
+        const unsigned int);
 
-    template
-    void
-    GridRefinement::
-    refine_and_coarsen_optimize<deal_II_dimension,S,deal_II_dimension+1>
-    (Triangulation<deal_II_dimension,deal_II_dimension+1> &,
-     const dealii::Vector<S> &,
-     const unsigned int);
+    template void GridRefinement::
+      refine_and_coarsen_optimize<deal_II_dimension, S, deal_II_dimension + 1>(
+        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+        const dealii::Vector<S> &,
+        const unsigned int);
 #endif
-}
+  }
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template
-    std::pair<double, double>
-    GridRefinement::
-    adjust_refine_and_coarsen_number_fraction <deal_II_dimension>
-    (const unsigned int,
-     const unsigned int,
-     const double,
-     const double);
-}
-
+  {
+    template std::pair<double, double> GridRefinement::
+      adjust_refine_and_coarsen_number_fraction<deal_II_dimension>(
+        const unsigned int, const unsigned int, const double, const double);
+  }

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -13,347 +13,399 @@
 //
 // ---------------------------------------------------------------------
 
-for (X : TRIANGULATIONS; deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
-
+for (X : TRIANGULATIONS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace GridTools \{
-    template
-    std::pair<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type, Point<deal_II_dimension> >
-    find_active_cell_around_point (const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-                                   const X &,
-                                   const Point<deal_II_space_dimension> &,
-                                   const std::vector<std::set<typename dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type> > &,
-                                   const std::vector<std::vector<Tensor<1,deal_II_space_dimension> > > &,
-                                   const dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type &,
-                                   const std::vector<bool> &);
+    namespace GridTools
+    \{
+      template std::pair<
+        dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                             deal_II_space_dimension,
+                                             X>::type,
+        Point<deal_II_dimension>>
+      find_active_cell_around_point(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const X &,
+        const Point<deal_II_space_dimension> &,
+        const std::vector<std::set<
+          typename dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                                        deal_II_space_dimension,
+                                                        X>::type>> &,
+        const std::vector<std::vector<Tensor<1, deal_II_space_dimension>>> &,
+        const dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                                   deal_II_space_dimension,
+                                                   X>::type &,
+        const std::vector<bool> &);
 
-    template
-    std::vector < BoundingBox< deal_II_space_dimension > >
-    compute_mesh_predicate_bounding_box< X >
-    (const X &,
-     const std::function<bool (const dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type&)> &,
-     const unsigned int,
-     const bool,
-     const unsigned int);
+      template std::vector<BoundingBox<deal_II_space_dimension>>
+      compute_mesh_predicate_bounding_box<X>(
+        const X &,
+        const std::function<bool(
+          const dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                                     deal_II_space_dimension,
+                                                     X>::type &)> &,
+        const unsigned int,
+        const bool,
+        const unsigned int);
     \}
 
 #endif
-}
+  }
 
 
-// now also instantiate a few additional functions for parallel::distributed::Triangulation
-for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
-
+// now also instantiate a few additional functions for
+// parallel::distributed::Triangulation
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace GridTools \{
+    namespace GridTools
+    \{
 
-    template
-    unsigned int
-    find_closest_vertex_of_cell<deal_II_dimension,deal_II_space_dimension>
-    (const typename Triangulation<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator &,
-     const Point<deal_II_space_dimension> &);
+      template unsigned int
+      find_closest_vertex_of_cell<deal_II_dimension, deal_II_space_dimension>(
+        const typename Triangulation<
+          deal_II_dimension,
+          deal_II_space_dimension>::active_cell_iterator &,
+        const Point<deal_II_space_dimension> &);
 
-    template
-    std::map<unsigned int,types::global_vertex_index>
-    compute_local_to_global_vertex_index_map(const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &triangulation);
+      template std::map<unsigned int, types::global_vertex_index>
+      compute_local_to_global_vertex_index_map(
+        const parallel::distributed::Triangulation<deal_II_dimension,
+                                                   deal_II_space_dimension>
+          &triangulation);
 
-    template
-    std::map<unsigned int, Point<deal_II_space_dimension> >
-    extract_used_vertices(const Triangulation<deal_II_dimension,deal_II_space_dimension>&mesh,
-                          const Mapping<deal_II_dimension,deal_II_space_dimension> &mapping);
+      template std::map<unsigned int, Point<deal_II_space_dimension>>
+      extract_used_vertices(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &mesh,
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &mapping);
 
-    template
-    std::pair<typename Triangulation<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator,
-              Point<deal_II_dimension> >
-    find_active_cell_around_point(const Cache<deal_II_dimension,deal_II_space_dimension>&,
-                                  const Point<deal_II_space_dimension> &,
-                                  const typename Triangulation<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator &,
-                                  const std::vector<bool>  &);
+      template std::pair<
+        typename Triangulation<deal_II_dimension,
+                               deal_II_space_dimension>::active_cell_iterator,
+        Point<deal_II_dimension>>
+      find_active_cell_around_point(
+        const Cache<deal_II_dimension, deal_II_space_dimension> &,
+        const Point<deal_II_space_dimension> &,
+        const typename Triangulation<
+          deal_II_dimension,
+          deal_II_space_dimension>::active_cell_iterator &,
+        const std::vector<bool> &);
 
-    template
-    std::tuple< std::vector< typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator >,
-                std::vector< std::vector< Point< deal_II_dimension > > >, std::vector< std::vector< unsigned int > > >
-    compute_point_locations(const Cache< deal_II_dimension, deal_II_space_dimension > &,
-                            const std::vector< Point< deal_II_space_dimension > > &,
-                            const typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator &);
+      template std::tuple<std::vector<typename Triangulation<
+                            deal_II_dimension,
+                            deal_II_space_dimension>::active_cell_iterator>,
+                          std::vector<std::vector<Point<deal_II_dimension>>>,
+                          std::vector<std::vector<unsigned int>>>
+      compute_point_locations(
+        const Cache<deal_II_dimension, deal_II_space_dimension> &,
+        const std::vector<Point<deal_II_space_dimension>> &,
+        const typename Triangulation<
+          deal_II_dimension,
+          deal_II_space_dimension>::active_cell_iterator &);
 
-    template
-    std::tuple<
-        std::vector< typename Triangulation< deal_II_dimension, deal_II_space_dimension>::active_cell_iterator >,
-        std::vector< std::vector< Point<deal_II_dimension> > >,
-        std::vector< std::vector< unsigned int > >,
-        std::vector< std::vector< Point<deal_II_space_dimension> > >,
-        std::vector< std::vector< unsigned int > >
-        >
-    distributed_compute_point_locations
-    (const Cache< deal_II_dimension, deal_II_space_dimension >                  &,
-     const std::vector< Point< deal_II_space_dimension > >                      &,
-     const std::vector< std::vector< BoundingBox< deal_II_space_dimension > > > &);
+      template std::tuple<
+        std::vector<typename Triangulation<
+          deal_II_dimension,
+          deal_II_space_dimension>::active_cell_iterator>,
+        std::vector<std::vector<Point<deal_II_dimension>>>,
+        std::vector<std::vector<unsigned int>>,
+        std::vector<std::vector<Point<deal_II_space_dimension>>>,
+        std::vector<std::vector<unsigned int>>>
+      distributed_compute_point_locations(
+        const Cache<deal_II_dimension, deal_II_space_dimension> &,
+        const std::vector<Point<deal_II_space_dimension>> &,
+        const std::vector<std::vector<BoundingBox<deal_II_space_dimension>>> &);
     \}
 
 #endif
-}
+  }
 
 
 
 for (deal_II_space_dimension : SPACE_DIMENSIONS)
-{
-
-    dealii::internal::ActiveCellIterator<deal_II_space_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_space_dimension, deal_II_space_dimension> >::type
-    find_active_cell_around_point (const parallel::distributed::Triangulation<deal_II_space_dimension> &,
-                                   const Point<deal_II_space_dimension> &p);
-
-
-    std::pair<dealii::internal::ActiveCellIterator<deal_II_space_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_space_dimension, deal_II_space_dimension> >::type, Point<deal_II_space_dimension> >
-    find_active_cell_around_point (const Mapping<deal_II_space_dimension> &,
-                                   const parallel::distributed::Triangulation<deal_II_space_dimension> &,
-                                   const Point<deal_II_space_dimension> &);
-
-    template unsigned int
-    GridTools::find_closest_vertex(const std::map<unsigned int,Point<deal_II_space_dimension> >& vertices,
-                                   const Point<deal_II_space_dimension>& p);
-
-    template std::vector< std::vector< BoundingBox<deal_II_space_dimension> > >
-    GridTools::exchange_local_bounding_boxes(const std::vector< BoundingBox<deal_II_space_dimension> >&,
-            MPI_Comm);
-
-    template
-    std::tuple< std::vector< std::vector< unsigned int > >,
-                std::map< unsigned int, unsigned int>,
-                std::map< unsigned int, std::vector< unsigned int > > >
-    GridTools::guess_point_owner (const std::vector< std::vector< BoundingBox<deal_II_space_dimension> > > &,
-                                  const std::vector<Point<deal_II_space_dimension> >      &);
-
-}
+  {
+    dealii::internal::ActiveCellIterator<
+      deal_II_space_dimension,
+      deal_II_space_dimension,
+      parallel::distributed::Triangulation<deal_II_space_dimension,
+                                           deal_II_space_dimension>>::type
+    find_active_cell_around_point(
+      const parallel::distributed::Triangulation<deal_II_space_dimension> &,
+      const Point<deal_II_space_dimension> &p);
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+    std::pair<
+      dealii::internal::ActiveCellIterator<
+        deal_II_space_dimension,
+        deal_II_space_dimension,
+        parallel::distributed::Triangulation<deal_II_space_dimension,
+                                             deal_II_space_dimension>>::type,
+      Point<deal_II_space_dimension>>
+    find_active_cell_around_point(
+      const Mapping<deal_II_space_dimension> &,
+      const parallel::distributed::Triangulation<deal_II_space_dimension> &,
+      const Point<deal_II_space_dimension> &);
+
+    template unsigned int GridTools::find_closest_vertex(
+      const std::map<unsigned int, Point<deal_II_space_dimension>> &vertices,
+      const Point<deal_II_space_dimension> &                        p);
+
+    template std::vector<std::vector<BoundingBox<deal_II_space_dimension>>>
+    GridTools::exchange_local_bounding_boxes(
+      const std::vector<BoundingBox<deal_II_space_dimension>> &, MPI_Comm);
+
+    template std::tuple<std::vector<std::vector<unsigned int>>,
+                        std::map<unsigned int, unsigned int>,
+                        std::map<unsigned int, std::vector<unsigned int>>>
+    GridTools::guess_point_owner(
+      const std::vector<std::vector<BoundingBox<deal_II_space_dimension>>> &,
+      const std::vector<Point<deal_II_space_dimension>> &);
+  }
+
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace GridTools \{
+    namespace GridTools
+    \{
 
-    template
-    double
-    diameter
-    (const Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+      template double
+      diameter(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
-    template
-    double
-    volume
-    (const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-     const Mapping<deal_II_dimension, deal_II_space_dimension> &);
+      template double
+      volume(const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+             const Mapping<deal_II_dimension, deal_II_space_dimension> &);
 
-    template
-    BoundingBox<deal_II_space_dimension>
-    compute_bounding_box
-    (const Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+      template BoundingBox<deal_II_space_dimension>
+      compute_bounding_box(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
-    template
-    void delete_unused_vertices (std::vector<Point<deal_II_space_dimension> > &,
-                                 std::vector<CellData<deal_II_dimension> > &,
-                                 SubCellData &);
+      template void
+      delete_unused_vertices(std::vector<Point<deal_II_space_dimension>> &,
+                             std::vector<CellData<deal_II_dimension>> &,
+                             SubCellData &);
 
-    template
-    void delete_duplicated_vertices (std::vector<Point<deal_II_space_dimension> > &,
-                                     std::vector<CellData<deal_II_dimension> > &,
-                                     SubCellData &,
-                                     std::vector<unsigned int> &,
-                                     double);
+      template void
+      delete_duplicated_vertices(std::vector<Point<deal_II_space_dimension>> &,
+                                 std::vector<CellData<deal_II_dimension>> &,
+                                 SubCellData &,
+                                 std::vector<unsigned int> &,
+                                 double);
 
-    template
-    void shift<deal_II_dimension> (const Tensor<1,deal_II_space_dimension> &,
-                                   Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+      template void
+      shift<deal_II_dimension>(
+        const Tensor<1, deal_II_space_dimension> &,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
-    template
-    void scale<deal_II_dimension> (const double,
-                                   Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+      template void
+      scale<deal_II_dimension>(
+        const double,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
-#if deal_II_space_dimension==3
-    template
-    void
-    rotate<deal_II_dimension> (const double,
-                               const unsigned int,
-                               Triangulation<deal_II_dimension, deal_II_space_dimension> &);
-#endif
+#  if deal_II_space_dimension == 3
+      template void
+      rotate<deal_II_dimension>(
+        const double,
+        const unsigned int,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+#  endif
 
-    template
-    void distort_random<deal_II_dimension> (const double,
-                                            Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-                                            const bool);
+      template void
+      distort_random<deal_II_dimension>(
+        const double,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const bool);
 
-    template
-    void get_face_connectivity_of_cells
-    (const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation,
-     DynamicSparsityPattern   &cell_connectivity);
+      template void
+      get_face_connectivity_of_cells(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &                     triangulation,
+        DynamicSparsityPattern &cell_connectivity);
 
-    template
-    void get_vertex_connectivity_of_cells
-    (const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation,
-     DynamicSparsityPattern            &cell_connectivity);
+      template void
+      get_vertex_connectivity_of_cells(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &                     triangulation,
+        DynamicSparsityPattern &cell_connectivity);
 
-    template
-    void get_vertex_connectivity_of_cells_on_level
-    (const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation,
-     const unsigned int                                              level,
-     DynamicSparsityPattern                                          &cell_connectivity);
+      template void
+      get_vertex_connectivity_of_cells_on_level(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &                     triangulation,
+        const unsigned int      level,
+        DynamicSparsityPattern &cell_connectivity);
 
-    template
-    void partition_triangulation (const unsigned int,
-                                  Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-                                  const SparsityTools::Partitioner);
+      template void
+      partition_triangulation(
+        const unsigned int,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const SparsityTools::Partitioner);
 
-    template
-    void partition_triangulation (const unsigned int,
-                                  const std::vector<unsigned int> &,
-                                  Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-                                  const SparsityTools::Partitioner);
+      template void
+      partition_triangulation(
+        const unsigned int,
+        const std::vector<unsigned int> &,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const SparsityTools::Partitioner);
 
-    template
-    void partition_triangulation (const unsigned int,
-                                  const SparsityPattern &,
-                                  Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-                                  const SparsityTools::Partitioner);
+      template void
+      partition_triangulation(
+        const unsigned int,
+        const SparsityPattern &,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const SparsityTools::Partitioner);
 
-    template
-    void partition_triangulation (const unsigned int,
-                                  const std::vector<unsigned int> &,
-                                  const SparsityPattern &,
-                                  Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-                                  const SparsityTools::Partitioner);
+      template void
+      partition_triangulation(
+        const unsigned int,
+        const std::vector<unsigned int> &,
+        const SparsityPattern &,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const SparsityTools::Partitioner);
 
-    template
-    void partition_triangulation_zorder (const unsigned int,
-                                         Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+      template void
+      partition_triangulation_zorder(
+        const unsigned int,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
-    template
-    void partition_multigrid_levels (Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+      template void
+      partition_multigrid_levels(
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
-    template
-    void get_subdomain_association (const Triangulation<deal_II_dimension, deal_II_space_dimension>  &,
-                                    std::vector<types::subdomain_id> &);
+      template void
+      get_subdomain_association(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        std::vector<types::subdomain_id> &);
 
-    template
-    unsigned int count_cells_with_subdomain_association(
+      template unsigned int
+      count_cells_with_subdomain_association(
         const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
         const types::subdomain_id);
 
-    template
-    std::vector<bool>
-    get_locally_owned_vertices (const Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+      template std::vector<bool>
+      get_locally_owned_vertices(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
-    template
-    double
-    minimal_cell_diameter (const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation,
-                           const Mapping<deal_II_dimension, deal_II_space_dimension> &);
+      template double
+      minimal_cell_diameter(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &triangulation,
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &);
 
-    template
-    double
-    maximal_cell_diameter (const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation,
-                           const Mapping<deal_II_dimension, deal_II_space_dimension> &);
+      template double
+      maximal_cell_diameter(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &triangulation,
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &);
 
-    template
-    std::map<unsigned int,Point<deal_II_space_dimension> >
-    get_all_vertices_at_boundary (const Triangulation<deal_II_dimension,deal_II_space_dimension> &tria);
+      template std::map<unsigned int, Point<deal_II_space_dimension>>
+      get_all_vertices_at_boundary(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria);
 
-    template
-    std::vector<std::set<Triangulation<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator> >
-    vertex_to_cell_map(const Triangulation<deal_II_dimension,deal_II_space_dimension> &triangulation);
+      template std::vector<
+        std::set<Triangulation<deal_II_dimension,
+                               deal_II_space_dimension>::active_cell_iterator>>
+      vertex_to_cell_map(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &triangulation);
 
-    template
-    std::vector<std::vector<Tensor<1,deal_II_space_dimension> > >
-    vertex_to_cell_centers_directions(const Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh,
-                                      const std::vector<std::set<typename Triangulation<deal_II_dimension,
-                                      deal_II_space_dimension>::active_cell_iterator> > &vertex_to_cells);
+      template std::vector<std::vector<Tensor<1, deal_II_space_dimension>>>
+      vertex_to_cell_centers_directions(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &mesh,
+        const std::vector<std::set<typename Triangulation<
+          deal_II_dimension,
+          deal_II_space_dimension>::active_cell_iterator>> &vertex_to_cells);
 
-#if deal_II_dimension == deal_II_space_dimension
-#  if deal_II_dimension > 1
-    template
-    void
-    laplace_transform (const std::map<unsigned int,Point<deal_II_dimension> > &new_points,
-                       Triangulation<deal_II_dimension> &triangulation,
-                       const Function<deal_II_dimension> *coefficient,
-                       const bool);
+#  if deal_II_dimension == deal_II_space_dimension
+#    if deal_II_dimension > 1
+      template void
+      laplace_transform(
+        const std::map<unsigned int, Point<deal_II_dimension>> &new_points,
+        Triangulation<deal_II_dimension> &                      triangulation,
+        const Function<deal_II_dimension> *                     coefficient,
+        const bool);
+
+#    endif
+
+      template Triangulation<deal_II_dimension,
+                             deal_II_space_dimension>::DistortedCellList
+      fix_up_distorted_child_cells(
+        const Triangulation<deal_II_dimension,
+                            deal_II_space_dimension>::DistortedCellList
+          &distorted_cells,
+        Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &triangulation);
 
 #  endif
 
-    template
-    Triangulation<deal_II_dimension,deal_II_space_dimension>::DistortedCellList
-    fix_up_distorted_child_cells
-    (const Triangulation<deal_II_dimension,deal_II_space_dimension>::DistortedCellList &distorted_cells,
-     Triangulation<deal_II_dimension,deal_II_space_dimension> &triangulation);
-
-#endif
-
     \}
 #endif
+  }
 
-
-
-}
-
-for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_space_dimension >= deal_II_dimension
-    namespace GridTools \{
-    template void copy_boundary_to_manifold_id<deal_II_dimension, deal_II_space_dimension>
-    (Triangulation<deal_II_dimension, deal_II_space_dimension> &, const bool);
+    namespace GridTools
+    \{
+      template void
+      copy_boundary_to_manifold_id<deal_II_dimension, deal_II_space_dimension>(
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const bool);
 
-    template void copy_material_to_manifold_id<deal_II_dimension, deal_II_space_dimension>
-    (Triangulation<deal_II_dimension, deal_II_space_dimension> &, const bool);
+      template void
+      copy_material_to_manifold_id<deal_II_dimension, deal_II_space_dimension>(
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const bool);
 
-    template void map_boundary_to_manifold_ids<deal_II_dimension, deal_II_space_dimension>
-    (const std::vector<types::boundary_id> &,
-     const std::vector<types::manifold_id> &,
-    Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-    const std::vector<types::boundary_id> &);
-    
-    template
-    void regularize_corner_cells
-    (Triangulation<deal_II_dimension,deal_II_space_dimension> &, double);
+      template void
+      map_boundary_to_manifold_ids<deal_II_dimension, deal_II_space_dimension>(
+        const std::vector<types::boundary_id> &,
+        const std::vector<types::manifold_id> &,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const std::vector<types::boundary_id> &);
+
+      template void
+      regularize_corner_cells(
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        double);
     \}
 #endif
-}
+  }
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template
-    std::pair<unsigned int, double>
-    GridTools::
-    get_longest_direction<deal_II_dimension,deal_II_dimension>
-    (Triangulation<deal_II_dimension>::active_cell_iterator);
+  {
+    template std::pair<unsigned int, double>
+      GridTools::get_longest_direction<deal_II_dimension, deal_II_dimension>(
+        Triangulation<deal_II_dimension>::active_cell_iterator);
 
-    template
-    void
-    GridTools::
-    remove_hanging_nodes<deal_II_dimension,deal_II_dimension>
-    (Triangulation<deal_II_dimension> &tria, bool, unsigned int);
+    template void
+    GridTools::remove_hanging_nodes<deal_II_dimension, deal_II_dimension>(
+      Triangulation<deal_II_dimension> & tria, bool, unsigned int);
 
-    template
-    void
-    GridTools::
-    remove_anisotropy<deal_II_dimension,deal_II_dimension>
-    (Triangulation<deal_II_dimension> &, double, unsigned int);
+    template void
+    GridTools::remove_anisotropy<deal_II_dimension, deal_II_dimension>(
+      Triangulation<deal_II_dimension> &, double, unsigned int);
 
 #if deal_II_dimension < 3
-    template
-    std::pair<unsigned int, double>
-    GridTools::
-    get_longest_direction<deal_II_dimension,deal_II_dimension+1>
-    (Triangulation<deal_II_dimension,deal_II_dimension+1>::active_cell_iterator);
+    template std::pair<unsigned int, double>
+      GridTools::get_longest_direction<deal_II_dimension,
+                                       deal_II_dimension + 1>(
+        Triangulation<deal_II_dimension,
+                      deal_II_dimension + 1>::active_cell_iterator);
 
-    template
-    void
-    GridTools::
-    remove_hanging_nodes<deal_II_dimension,deal_II_dimension+1>
-    (Triangulation<deal_II_dimension,deal_II_dimension+1> &tria, bool, unsigned int);
+    template void
+      GridTools::remove_hanging_nodes<deal_II_dimension, deal_II_dimension + 1>(
+        Triangulation<deal_II_dimension, deal_II_dimension + 1> & tria,
+        bool,
+        unsigned int);
 
-    template
-    void
-    GridTools::
-    remove_anisotropy<deal_II_dimension,deal_II_dimension+1>
-    (Triangulation<deal_II_dimension,deal_II_dimension+1> &, double, unsigned int);
+    template void
+      GridTools::remove_anisotropy<deal_II_dimension, deal_II_dimension + 1>(
+        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+        double,
+        unsigned int);
 #endif
-}
+  }

--- a/source/grid/grid_tools_cache.inst.in
+++ b/source/grid/grid_tools_cache.inst.in
@@ -16,8 +16,8 @@
 
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class Cache<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
+  }

--- a/source/grid/grid_tools_dof_handlers.inst.in
+++ b/source/grid/grid_tools_dof_handlers.inst.in
@@ -1,242 +1,312 @@
 
-for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
-
+for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace GridTools \{
+    namespace GridTools
+    \{
 
-    template
-    unsigned int
-    find_closest_vertex (const X &,
-                         const Point<deal_II_space_dimension> &,
-                         const std::vector<bool> &);
+      template unsigned int
+      find_closest_vertex(const X &,
+                          const Point<deal_II_space_dimension> &,
+                          const std::vector<bool> &);
 
-    template
-    unsigned int
-    find_closest_vertex (const Mapping<deal_II_dimension, deal_II_space_dimension>&,
-                         const X &,
-                         const Point<deal_II_space_dimension> &,
-                         const std::vector<bool> &);
+      template unsigned int
+      find_closest_vertex(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const X &,
+        const Point<deal_II_space_dimension> &,
+        const std::vector<bool> &);
 
-    template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type>
-    find_cells_adjacent_to_vertex(const X &,
-                                  const unsigned int);
+      template std::vector<
+        dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                             deal_II_space_dimension,
+                                             X>::type>
+      find_cells_adjacent_to_vertex(const X &, const unsigned int);
 
-    template
-    dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type
-    find_active_cell_around_point (const X &,
-                                   const Point<deal_II_space_dimension> &,
-                                   const std::vector<bool> &);
+      template dealii::internal::
+        ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type
+        find_active_cell_around_point(const X &,
+                                      const Point<deal_II_space_dimension> &,
+                                      const std::vector<bool> &);
 
-    template
-    std::pair<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type, Point<deal_II_dimension> >
-    find_active_cell_around_point (const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-                                   const X &,
-                                   const Point<deal_II_space_dimension> &,
-                                   const std::vector<bool> &);
+      template std::pair<
+        dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                             deal_II_space_dimension,
+                                             X>::type,
+        Point<deal_II_dimension>>
+      find_active_cell_around_point(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const X &,
+        const Point<deal_II_space_dimension> &,
+        const std::vector<bool> &);
 
-    template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type>
-    compute_active_cell_halo_layer (const X &,
-                                    const std::function<bool (const dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type&)> &);
+      template std::vector<
+        dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                             deal_II_space_dimension,
+                                             X>::type>
+      compute_active_cell_halo_layer(
+        const X &,
+        const std::function<bool(
+          const dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                                     deal_II_space_dimension,
+                                                     X>::type &)> &);
 
-    template
-    std::vector<X::cell_iterator>
-    compute_cell_halo_layer_on_level (const X &,
-                                      const std::function<bool (const X::cell_iterator&)> &,
-                                      const unsigned int);
+      template std::vector<X::cell_iterator>
+      compute_cell_halo_layer_on_level(
+        const X &,
+        const std::function<bool(const X::cell_iterator &)> &,
+        const unsigned int);
 
-    template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type>
-    compute_ghost_cell_halo_layer (const X &);
-
-
-    template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type>
-    compute_active_cell_layer_within_distance (const X &,
-            const std::function<bool (const dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type&)> &,
-            const double);
-
-
-    template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type>
-    compute_ghost_cell_layer_within_distance (const X &, const double);
-
-
-    template
-    std::pair< Point<X::space_dimension>, Point<X::space_dimension> >
-    compute_bounding_box (const X &,
-                          const std::function<bool (const dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type&)> &);
+      template std::vector<
+        dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                             deal_II_space_dimension,
+                                             X>::type>
+      compute_ghost_cell_halo_layer(const X &);
 
 
-    template
-    std::list<std::pair<X::cell_iterator, X::cell_iterator> >
-    get_finest_common_cells (const X &mesh_1,
-                             const X &mesh_2);
+      template std::vector<
+        dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                             deal_II_space_dimension,
+                                             X>::type>
+      compute_active_cell_layer_within_distance(
+        const X &,
+        const std::function<bool(
+          const dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                                     deal_II_space_dimension,
+                                                     X>::type &)> &,
+        const double);
 
 
-    template
-    bool
-    have_same_coarse_mesh (const X &mesh_1,
-                           const X &mesh_2);
+      template std::vector<
+        dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                             deal_II_space_dimension,
+                                             X>::type>
+      compute_ghost_cell_layer_within_distance(const X &, const double);
+
+
+      template std::pair<Point<X::space_dimension>, Point<X::space_dimension>>
+      compute_bounding_box(
+        const X &,
+        const std::function<bool(
+          const dealii::internal::ActiveCellIterator<deal_II_dimension,
+                                                     deal_II_space_dimension,
+                                                     X>::type &)> &);
+
+
+      template std::list<std::pair<X::cell_iterator, X::cell_iterator>>
+      get_finest_common_cells(const X &mesh_1, const X &mesh_2);
+
+
+      template bool
+      have_same_coarse_mesh(const X &mesh_1, const X &mesh_2);
     \}
 
 #endif
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace GridTools \{
+    namespace GridTools
+    \{
 
-        template
-        std::pair<hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>::active_cell_iterator,
-                  Point<deal_II_dimension> >
-        find_active_cell_around_point
-        (const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension> &,
-         const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-         const Point<deal_II_space_dimension> &);
-
-                       \}
-#endif
-}
-
-
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; Container : TRIANGULATION_AND_DOFHANDLER_TEMPLATES)
-{
-#if deal_II_dimension <= deal_II_space_dimension
-    namespace GridTools \{
-
-    template
-    std::vector<Container<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator>
-    get_patch_around_cell<Container<deal_II_dimension,deal_II_space_dimension> >
-    (const Container<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator &cell);
-
-    template
-    std::vector< Container<deal_II_dimension,deal_II_space_dimension>::cell_iterator>
-    get_cells_at_coarsest_common_level <Container<deal_II_dimension,deal_II_space_dimension> > (
-        const std::vector< Container<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator> & patch_cells);
-
-    template
-    void build_triangulation_from_patch <Container<deal_II_dimension,deal_II_space_dimension> > (
-        const std::vector<Container<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator>  &patch,
-        Triangulation<Container<deal_II_dimension,deal_II_space_dimension>::dimension,Container<deal_II_dimension,deal_II_space_dimension>::space_dimension> &local_triangulation,
-        std::map<Triangulation<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator,
-        Container<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator > &patch_to_global_tria_map);
+      template std::pair<
+        hp::DoFHandler<deal_II_dimension,
+                       deal_II_space_dimension>::active_cell_iterator,
+        Point<deal_II_dimension>>
+      find_active_cell_around_point(
+        const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
+          &,
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Point<deal_II_space_dimension> &);
 
     \}
 #endif
-}
+  }
 
 
-
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; Container : DOFHANDLER_TEMPLATES)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     Container : TRIANGULATION_AND_DOFHANDLER_TEMPLATES)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace GridTools \{
+    namespace GridTools
+    \{
 
-    template
-    std::map< types::global_dof_index,std::vector<Container<deal_II_dimension,deal_II_space_dimension>::active_cell_iterator> >
-    get_dof_to_support_patch_map<Container<deal_II_dimension,deal_II_space_dimension> >
-    (Container<deal_II_dimension,deal_II_space_dimension> &dof_handler);
+      template std::vector<
+        Container<deal_II_dimension,
+                  deal_II_space_dimension>::active_cell_iterator>
+      get_patch_around_cell<
+        Container<deal_II_dimension, deal_II_space_dimension>>(
+        const Container<deal_II_dimension,
+                        deal_II_space_dimension>::active_cell_iterator &cell);
+
+      template std::vector<
+        Container<deal_II_dimension, deal_II_space_dimension>::cell_iterator>
+      get_cells_at_coarsest_common_level<
+        Container<deal_II_dimension, deal_II_space_dimension>>(
+        const std::vector<
+          Container<deal_II_dimension,
+                    deal_II_space_dimension>::active_cell_iterator>
+          &patch_cells);
+
+      template void
+      build_triangulation_from_patch<
+        Container<deal_II_dimension, deal_II_space_dimension>>(
+        const std::vector<
+          Container<deal_II_dimension,
+                    deal_II_space_dimension>::active_cell_iterator> &patch,
+        Triangulation<
+          Container<deal_II_dimension, deal_II_space_dimension>::dimension,
+          Container<deal_II_dimension,
+                    deal_II_space_dimension>::space_dimension>
+          &local_triangulation,
+        std::map<Triangulation<deal_II_dimension,
+                               deal_II_space_dimension>::active_cell_iterator,
+                 Container<deal_II_dimension,
+                           deal_II_space_dimension>::active_cell_iterator>
+          &patch_to_global_tria_map);
 
     \}
 #endif
-}
+  }
 
 
 
-// instantiate the following functions only for the "sequential" containers. this
-// is a misnomer here, however: the point is simply that we only instantiate
-// these functions for certain *iterator* types, and the iterator types are
-// the same for sequential and parallel containers; consequently, we get duplicate
-// instantiation errors if we instantiate for *all* container types, rather than
-// only the sequential ones
-for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     Container : DOFHANDLER_TEMPLATES)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace GridTools \{
+    namespace GridTools
+    \{
 
-    template
-    bool orthogonal_equality<X::active_face_iterator> (std::bitset<3> &,
-            const X::active_face_iterator&,
-            const X::active_face_iterator&,
-            const int,
-            const Tensor<1,deal_II_space_dimension> &,
-            const FullMatrix<double> &);
-
-    template
-    bool orthogonal_equality<X::face_iterator> (std::bitset<3> &,
-            const X::face_iterator&,
-            const X::face_iterator&,
-            const int,
-            const Tensor<1,deal_II_space_dimension> &,
-            const FullMatrix<double> &);
-
-    template
-    bool orthogonal_equality<X::active_face_iterator> (const X::active_face_iterator&,
-            const X::active_face_iterator&,
-            const int,
-            const Tensor<1,deal_II_space_dimension> &,
-            const FullMatrix<double> &);
-
-    template
-    bool orthogonal_equality<X::face_iterator> (const X::face_iterator&,
-            const X::face_iterator&,
-            const int,
-            const Tensor<1,deal_II_space_dimension> &,
-            const FullMatrix<double> &);
-
-    template
-    void collect_periodic_faces<X> (const X &,
-                                    const types::boundary_id,
-                                    const types::boundary_id,
-                                    const int,
-                                    std::vector<PeriodicFacePair<X::cell_iterator> > &,
-                                    const Tensor<1,X::space_dimension> &,
-                                    const FullMatrix<double> &);
-
-    template
-    void collect_periodic_faces<X> (const X &,
-                                    const types::boundary_id,
-                                    const int,
-                                    std::vector<PeriodicFacePair<X::cell_iterator> > &,
-                                    const Tensor<1,X::space_dimension> &,
-                                    const FullMatrix<double> &);
+      template std::map<
+        types::global_dof_index,
+        std::vector<Container<deal_II_dimension,
+                              deal_II_space_dimension>::active_cell_iterator>>
+      get_dof_to_support_patch_map<
+        Container<deal_II_dimension, deal_II_space_dimension>>(
+        Container<deal_II_dimension, deal_II_space_dimension> &dof_handler);
 
     \}
 #endif
-}
+  }
 
-// TODO the text above the last instantiation block implies that this should not be necessary... is it?
-for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+
+
+// instantiate the following functions only for the "sequential" containers.
+// this is a misnomer here, however: the point is simply that we only
+// instantiate these functions for certain *iterator* types, and the iterator
+// types are the same for sequential and parallel containers; consequently, we
+// get duplicate instantiation errors if we instantiate for *all* container
+// types, rather than only the sequential ones
+for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLERS;
+     deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-#if deal_II_dimension >= 2
+    namespace GridTools
+    \{
 
-    namespace GridTools \{
-    template
-    void
-    collect_periodic_faces<parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >
-    (const parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-     const types::boundary_id,
-     const types::boundary_id,
-     const int,
-     std::vector<PeriodicFacePair<parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>::cell_iterator> > &,
-     const Tensor<1,parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>::space_dimension> &,
-     const FullMatrix<double> &);
+      template bool orthogonal_equality<X::active_face_iterator>(
+        std::bitset<3> &,
+        const X::active_face_iterator &,
+        const X::active_face_iterator &,
+        const int,
+        const Tensor<1, deal_II_space_dimension> &,
+        const FullMatrix<double> &);
 
-    template
-    void
-    collect_periodic_faces<parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >
-    (const parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-     const types::boundary_id,
-     const int,
-     std::vector<PeriodicFacePair<parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>::cell_iterator> > &,
-     const Tensor<1,parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>::space_dimension> &,
-     const FullMatrix<double> &);
+      template bool orthogonal_equality<X::face_iterator>(
+        std::bitset<3> &,
+        const X::face_iterator &,
+        const X::face_iterator &,
+        const int,
+        const Tensor<1, deal_II_space_dimension> &,
+        const FullMatrix<double> &);
+
+      template bool
+      orthogonal_equality<X::active_face_iterator>(
+        const X::active_face_iterator &,
+        const X::active_face_iterator &,
+        const int,
+        const Tensor<1, deal_II_space_dimension> &,
+        const FullMatrix<double> &);
+
+      template bool
+      orthogonal_equality<X::face_iterator>(
+        const X::face_iterator &,
+        const X::face_iterator &,
+        const int,
+        const Tensor<1, deal_II_space_dimension> &,
+        const FullMatrix<double> &);
+
+      template void
+      collect_periodic_faces<X>(
+        const X &,
+        const types::boundary_id,
+        const types::boundary_id,
+        const int,
+        std::vector<PeriodicFacePair<X::cell_iterator>> &,
+        const Tensor<1, X::space_dimension> &,
+        const FullMatrix<double> &);
+
+      template void
+      collect_periodic_faces<X>(
+        const X &,
+        const types::boundary_id,
+        const int,
+        std::vector<PeriodicFacePair<X::cell_iterator>> &,
+        const Tensor<1, X::space_dimension> &,
+        const FullMatrix<double> &);
+
     \}
 #endif
+  }
+
+// TODO the text above the last instantiation block implies that this should not
+// be necessary... is it?
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+#  if deal_II_dimension >= 2
+
+    namespace GridTools
+    \{
+      template void
+      collect_periodic_faces<
+        parallel::distributed::Triangulation<deal_II_dimension,
+                                             deal_II_space_dimension>>(
+        const parallel::distributed::Triangulation<deal_II_dimension,
+                                                   deal_II_space_dimension> &,
+        const types::boundary_id,
+        const types::boundary_id,
+        const int,
+        std::vector<PeriodicFacePair<parallel::distributed::Triangulation<
+          deal_II_dimension,
+          deal_II_space_dimension>::cell_iterator>> &,
+        const Tensor<1,
+                     parallel::distributed::Triangulation<
+                       deal_II_dimension,
+                       deal_II_space_dimension>::space_dimension> &,
+        const FullMatrix<double> &);
+
+      template void
+      collect_periodic_faces<
+        parallel::distributed::Triangulation<deal_II_dimension,
+                                             deal_II_space_dimension>>(
+        const parallel::distributed::Triangulation<deal_II_dimension,
+                                                   deal_II_space_dimension> &,
+        const types::boundary_id,
+        const int,
+        std::vector<PeriodicFacePair<parallel::distributed::Triangulation<
+          deal_II_dimension,
+          deal_II_space_dimension>::cell_iterator>> &,
+        const Tensor<1,
+                     parallel::distributed::Triangulation<
+                       deal_II_dimension,
+                       deal_II_space_dimension>::space_dimension> &,
+        const FullMatrix<double> &);
+    \}
+#  endif
 #endif
-}
+  }

--- a/source/grid/intergrid_map.inst.in
+++ b/source/grid/intergrid_map.inst.in
@@ -15,9 +15,10 @@
 
 
 
-for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class InterGridMap<X>;
 #endif
-}
+  }

--- a/source/grid/manifold.inst.in
+++ b/source/grid/manifold.inst.in
@@ -15,17 +15,20 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class Manifold<deal_II_dimension, deal_II_space_dimension>;
     template class FlatManifold<deal_II_dimension, deal_II_space_dimension>;
 #endif
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; deal_II_chart_dimension :  DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     deal_II_chart_dimension : DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template class ChartManifold<deal_II_dimension, deal_II_space_dimension, deal_II_chart_dimension>;
+    template class ChartManifold<deal_II_dimension,
+                                 deal_II_space_dimension,
+                                 deal_II_chart_dimension>;
 #endif
-}
+  }

--- a/source/grid/manifold_lib.inst.in
+++ b/source/grid/manifold_lib.inst.in
@@ -13,24 +13,30 @@
 //
 // ---------------------------------------------------------------------
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class PolarManifold<deal_II_dimension, deal_II_space_dimension>;
-    template class SphericalManifold<deal_II_dimension, deal_II_space_dimension>;
-    template class TransfiniteInterpolationManifold<deal_II_dimension, deal_II_space_dimension>;
-    template class CylindricalManifold<deal_II_dimension, deal_II_space_dimension>;
+    template class SphericalManifold<deal_II_dimension,
+                                     deal_II_space_dimension>;
+    template class TransfiniteInterpolationManifold<deal_II_dimension,
+                                                    deal_II_space_dimension>;
+    template class CylindricalManifold<deal_II_dimension,
+                                       deal_II_space_dimension>;
 #endif
 #if deal_II_dimension == deal_II_space_dimension
     template class TorusManifold<deal_II_dimension>;
 #endif
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; deal_II_chart_dimension :  DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     deal_II_chart_dimension : DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-#if deal_II_chart_dimension <= deal_II_space_dimension
-    template class FunctionManifold<deal_II_dimension, deal_II_space_dimension, deal_II_chart_dimension>;
+#  if deal_II_chart_dimension <= deal_II_space_dimension
+    template class FunctionManifold<deal_II_dimension,
+                                    deal_II_space_dimension,
+                                    deal_II_chart_dimension>;
+#  endif
 #endif
-#endif
-}
+  }

--- a/source/grid/tria.inst.in
+++ b/source/grid/tria.inst.in
@@ -15,12 +15,12 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     template class Triangulation<deal_II_dimension, deal_II_space_dimension>;
 #endif
 #if deal_II_dimension == deal_II_space_dimension
     template struct CellData<deal_II_dimension>;
 #endif
-}
+  }

--- a/source/grid/tria_accessor.inst.in
+++ b/source/grid/tria_accessor.inst.in
@@ -16,78 +16,96 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template class TriaAccessorBase<1,deal_II_dimension>;
+  {
+    template class TriaAccessorBase<1, deal_II_dimension>;
 #if deal_II_dimension >= 2
-    template class TriaAccessorBase<2,deal_II_dimension>;
+    template class TriaAccessorBase<2, deal_II_dimension>;
 #endif
 #if deal_II_dimension >= 3
-    template class TriaAccessorBase<3,deal_II_dimension>;
+    template class TriaAccessorBase<3, deal_II_dimension>;
 #endif
 
-    template class TriaAccessor<1,deal_II_dimension,deal_II_dimension>;
+    template class TriaAccessor<1, deal_II_dimension, deal_II_dimension>;
 #if deal_II_dimension >= 2
-    template class TriaAccessor<2,deal_II_dimension,deal_II_dimension>;
+    template class TriaAccessor<2, deal_II_dimension, deal_II_dimension>;
 #endif
 #if deal_II_dimension >= 3
-    template class TriaAccessor<3,deal_II_dimension,deal_II_dimension>;
+    template class TriaAccessor<3, deal_II_dimension, deal_II_dimension>;
 #endif
 
 
     template class CellAccessor<deal_II_dimension>;
-    template class TriaRawIterator<TriaAccessor<1, deal_II_dimension, deal_II_dimension> >;
-    template class TriaRawIterator<CellAccessor<deal_II_dimension> >;
-    template class TriaIterator<TriaAccessor<1, deal_II_dimension, deal_II_dimension> >;
-    template class TriaIterator<CellAccessor<deal_II_dimension> >;
-    template class TriaActiveIterator<TriaAccessor<1, deal_II_dimension, deal_II_dimension> >;
-    template class TriaActiveIterator<CellAccessor<deal_II_dimension> >;
+    template class TriaRawIterator<
+      TriaAccessor<1, deal_II_dimension, deal_II_dimension>>;
+    template class TriaRawIterator<CellAccessor<deal_II_dimension>>;
+    template class TriaIterator<
+      TriaAccessor<1, deal_II_dimension, deal_II_dimension>>;
+    template class TriaIterator<CellAccessor<deal_II_dimension>>;
+    template class TriaActiveIterator<
+      TriaAccessor<1, deal_II_dimension, deal_II_dimension>>;
+    template class TriaActiveIterator<CellAccessor<deal_II_dimension>>;
 
 
 #if deal_II_dimension >= 2
-    template class TriaRawIterator<TriaAccessor<2, deal_II_dimension, deal_II_dimension> >;
-    template class TriaIterator<TriaAccessor<2, deal_II_dimension, deal_II_dimension> >;
-    template class TriaActiveIterator<TriaAccessor<2, deal_II_dimension, deal_II_dimension> >;
+    template class TriaRawIterator<
+      TriaAccessor<2, deal_II_dimension, deal_II_dimension>>;
+    template class TriaIterator<
+      TriaAccessor<2, deal_II_dimension, deal_II_dimension>>;
+    template class TriaActiveIterator<
+      TriaAccessor<2, deal_II_dimension, deal_II_dimension>>;
 #endif
 
 #if deal_II_dimension >= 3
-    template class TriaRawIterator<TriaAccessor<3, deal_II_dimension, deal_II_dimension> >;
-    template class TriaIterator<TriaAccessor<3, deal_II_dimension, deal_II_dimension> >;
-    template class TriaActiveIterator<TriaAccessor<3, deal_II_dimension, deal_II_dimension> >;
+    template class TriaRawIterator<
+      TriaAccessor<3, deal_II_dimension, deal_II_dimension>>;
+    template class TriaIterator<
+      TriaAccessor<3, deal_II_dimension, deal_II_dimension>>;
+    template class TriaActiveIterator<
+      TriaAccessor<3, deal_II_dimension, deal_II_dimension>>;
     template class CellAccessor<1, 3>;
 #endif
 
 #if deal_II_dimension == 1
-    template class TriaAccessorBase<1,deal_II_dimension,2>;
-    template class TriaAccessorBase<1,deal_II_dimension,3>;
+    template class TriaAccessorBase<1, deal_II_dimension, 2>;
+    template class TriaAccessorBase<1, deal_II_dimension, 3>;
 
-    template class TriaAccessor<1,deal_II_dimension,2>;
-    template class TriaAccessor<1,deal_II_dimension,3>;
+    template class TriaAccessor<1, deal_II_dimension, 2>;
+    template class TriaAccessor<1, deal_II_dimension, 3>;
 
 
 #endif
 #if deal_II_dimension == 2
-    template class TriaAccessorBase<1,deal_II_dimension,3>;
-    template class TriaAccessorBase<2,deal_II_dimension,3>;
+    template class TriaAccessorBase<1, deal_II_dimension, 3>;
+    template class TriaAccessorBase<2, deal_II_dimension, 3>;
 
-    template class TriaAccessor<1,deal_II_dimension,3>;
-    template class TriaAccessor<2,deal_II_dimension,3>;
+    template class TriaAccessor<1, deal_II_dimension, 3>;
+    template class TriaAccessor<2, deal_II_dimension, 3>;
 #endif
 
 #if deal_II_dimension != 3
-    template class CellAccessor<deal_II_dimension, deal_II_dimension+1>;
-    template class TriaRawIterator<TriaAccessor<1, deal_II_dimension, deal_II_dimension+1> >;
-    template class TriaRawIterator<CellAccessor<deal_II_dimension, deal_II_dimension+1> >;
-    template class TriaIterator<TriaAccessor<1, deal_II_dimension, deal_II_dimension+1> >;
-    template class TriaIterator<CellAccessor<deal_II_dimension, deal_II_dimension+1> >;
-    template class TriaActiveIterator<TriaAccessor<1, deal_II_dimension, deal_II_dimension+1> >;
-    template class TriaActiveIterator<CellAccessor<deal_II_dimension, deal_II_dimension+1> >;
+    template class CellAccessor<deal_II_dimension, deal_II_dimension + 1>;
+    template class TriaRawIterator<
+      TriaAccessor<1, deal_II_dimension, deal_II_dimension + 1>>;
+    template class TriaRawIterator<
+      CellAccessor<deal_II_dimension, deal_II_dimension + 1>>;
+    template class TriaIterator<
+      TriaAccessor<1, deal_II_dimension, deal_II_dimension + 1>>;
+    template class TriaIterator<
+      CellAccessor<deal_II_dimension, deal_II_dimension + 1>>;
+    template class TriaActiveIterator<
+      TriaAccessor<1, deal_II_dimension, deal_II_dimension + 1>>;
+    template class TriaActiveIterator<
+      CellAccessor<deal_II_dimension, deal_II_dimension + 1>>;
 
 
-#if deal_II_dimension == 2
-    template class TriaRawIterator<TriaAccessor<2, deal_II_dimension, deal_II_dimension+1> >;
-    template class TriaIterator<TriaAccessor<2, deal_II_dimension, deal_II_dimension+1> >;
-    template class TriaActiveIterator<TriaAccessor<2, deal_II_dimension, deal_II_dimension+1> >;
+#  if deal_II_dimension == 2
+    template class TriaRawIterator<
+      TriaAccessor<2, deal_II_dimension, deal_II_dimension + 1>>;
+    template class TriaIterator<
+      TriaAccessor<2, deal_II_dimension, deal_II_dimension + 1>>;
+    template class TriaActiveIterator<
+      TriaAccessor<2, deal_II_dimension, deal_II_dimension + 1>>;
+#  endif
+
 #endif
-
-#endif
-}
+  }

--- a/source/grid/tria_objects.inst.in
+++ b/source/grid/tria_objects.inst.in
@@ -15,9 +15,10 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension >= 3
     template dealii::Triangulation<deal_II_dimension>::raw_hex_iterator
-    TriaObjects<TriaObject<3> >::next_free_hex(const dealii::Triangulation<deal_II_dimension> &, const unsigned int);
+    TriaObjects<TriaObject<3>>::next_free_hex(
+      const dealii::Triangulation<deal_II_dimension> &, const unsigned int);
 #endif
-}
+  }

--- a/source/hp/dof_handler.inst.in
+++ b/source/hp/dof_handler.inst.in
@@ -15,75 +15,112 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace hp
     \{
-    template class DoFHandler<deal_II_dimension>;
+      template class DoFHandler<deal_II_dimension>;
 
 #if deal_II_dimension != 3
-    template class DoFHandler<deal_II_dimension, deal_II_dimension+1>;
+      template class DoFHandler<deal_II_dimension, deal_II_dimension + 1>;
 
-    template
-    types::global_dof_index
-    DoFHandler<deal_II_dimension, deal_II_dimension+1>::get_dof_index<1> (const unsigned int, const unsigned int, const unsigned int, const unsigned int) const;
+      template types::global_dof_index
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>::get_dof_index<1>(
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const unsigned int) const;
 
-    template
-    void
-    DoFHandler<deal_II_dimension, deal_II_dimension+1>::set_dof_index<1> (const unsigned int, const unsigned int, const unsigned int, const unsigned int, const types::global_dof_index) const;
+      template void
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>::set_dof_index<1>(
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const types::global_dof_index) const;
 
-#if deal_II_dimension >= 2
-    template
-    types::global_dof_index
-    DoFHandler<deal_II_dimension, deal_II_dimension+1>::get_dof_index<2> (const unsigned int, const unsigned int, const unsigned int, const unsigned int) const;
+#  if deal_II_dimension >= 2
+      template types::global_dof_index
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>::get_dof_index<2>(
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const unsigned int) const;
 
-    template
-    void
-    DoFHandler<deal_II_dimension, deal_II_dimension+1>::set_dof_index<2> (const unsigned int, const unsigned int, const unsigned int, const unsigned int, const types::global_dof_index) const;
-#endif
+      template void
+      DoFHandler<deal_II_dimension, deal_II_dimension + 1>::set_dof_index<2>(
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const types::global_dof_index) const;
+#  endif
 #endif
 
 #if deal_II_dimension == 3
-    template class DoFHandler<1, 3>;
+      template class DoFHandler<1, 3>;
 
-    template
-    types::global_dof_index
-    DoFHandler<1,3>::get_dof_index<1> (const unsigned int, const unsigned int, const unsigned int, const unsigned int) const;
+      template types::global_dof_index
+      DoFHandler<1, 3>::get_dof_index<1>(const unsigned int,
+                                         const unsigned int,
+                                         const unsigned int,
+                                         const unsigned int) const;
 
-    template
-    void
-    DoFHandler<1,3>::set_dof_index<1> (const unsigned int, const unsigned int, const unsigned int, const unsigned int, const types::global_dof_index) const;
+      template void
+      DoFHandler<1, 3>::set_dof_index<1>(const unsigned int,
+                                         const unsigned int,
+                                         const unsigned int,
+                                         const unsigned int,
+                                         const types::global_dof_index) const;
 #endif
 
-    template
-    types::global_dof_index
-    DoFHandler<deal_II_dimension>::get_dof_index<1> (const unsigned int, const unsigned int, const unsigned int, const unsigned int) const;
+      template types::global_dof_index
+      DoFHandler<deal_II_dimension>::get_dof_index<1>(const unsigned int,
+                                                      const unsigned int,
+                                                      const unsigned int,
+                                                      const unsigned int) const;
 
 #if deal_II_dimension >= 2
-    template
-    types::global_dof_index
-    DoFHandler<deal_II_dimension>::get_dof_index<2> (const unsigned int, const unsigned int, const unsigned int, const unsigned int) const;
+      template types::global_dof_index
+      DoFHandler<deal_II_dimension>::get_dof_index<2>(const unsigned int,
+                                                      const unsigned int,
+                                                      const unsigned int,
+                                                      const unsigned int) const;
 
-#if deal_II_dimension >= 3
-    template
-    types::global_dof_index
-    DoFHandler<deal_II_dimension>::get_dof_index<3> (const unsigned int, const unsigned int, const unsigned int, const unsigned int) const;
-#endif
+#  if deal_II_dimension >= 3
+      template types::global_dof_index
+      DoFHandler<deal_II_dimension>::get_dof_index<3>(const unsigned int,
+                                                      const unsigned int,
+                                                      const unsigned int,
+                                                      const unsigned int) const;
+#  endif
 #endif
 
-    template
-    void
-    DoFHandler<deal_II_dimension>::set_dof_index<1> (const unsigned int, const unsigned int, const unsigned int, const unsigned int, const types::global_dof_index) const;
+      template void
+      DoFHandler<deal_II_dimension>::set_dof_index<1>(
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const types::global_dof_index) const;
 
 #if deal_II_dimension >= 2
-    template
-    void
-    DoFHandler<deal_II_dimension>::set_dof_index<2> (const unsigned int, const unsigned int, const unsigned int, const unsigned int, const types::global_dof_index) const;
+      template void
+      DoFHandler<deal_II_dimension>::set_dof_index<2>(
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const types::global_dof_index) const;
 
-#if deal_II_dimension >= 3
-    template
-    void
-    DoFHandler<deal_II_dimension>::set_dof_index<3> (const unsigned int, const unsigned int, const unsigned int, const unsigned int, const types::global_dof_index) const;
-#endif
+#  if deal_II_dimension >= 3
+      template void
+      DoFHandler<deal_II_dimension>::set_dof_index<3>(
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const unsigned int,
+        const types::global_dof_index) const;
+#  endif
 #endif
     \}
-}
+  }

--- a/source/hp/fe_collection.inst.in
+++ b/source/hp/fe_collection.inst.in
@@ -15,16 +15,16 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace hp
     \{
-    template class FECollection<deal_II_dimension>;
+      template class FECollection<deal_II_dimension>;
 
 #if deal_II_dimension != 3
-    template class FECollection<deal_II_dimension, deal_II_dimension+1>;
+      template class FECollection<deal_II_dimension, deal_II_dimension + 1>;
 #endif
 #if deal_II_dimension == 3
-    template class FECollection<1,3>;
+      template class FECollection<1, 3>;
 #endif
     \}
-}
+  }

--- a/source/hp/fe_values.inst.in
+++ b/source/hp/fe_values.inst.in
@@ -15,25 +15,28 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace internal
     \{
-    namespace hp
-    \{
-    template class FEValuesBase<deal_II_dimension,deal_II_dimension,
-                                dealii::FEValues<deal_II_dimension> >;
-    template class FEValuesBase<deal_II_dimension,deal_II_dimension-1,
-                                dealii::FEFaceValues<deal_II_dimension> >;
-    template class FEValuesBase<deal_II_dimension,deal_II_dimension-1,
-                                dealii::FESubfaceValues<deal_II_dimension> >;
-    \}
+      namespace hp
+      \{
+        template class FEValuesBase<deal_II_dimension,
+                                    deal_II_dimension,
+                                    dealii::FEValues<deal_II_dimension>>;
+        template class FEValuesBase<deal_II_dimension,
+                                    deal_II_dimension - 1,
+                                    dealii::FEFaceValues<deal_II_dimension>>;
+        template class FEValuesBase<deal_II_dimension,
+                                    deal_II_dimension - 1,
+                                    dealii::FESubfaceValues<deal_II_dimension>>;
+      \}
     \}
 
     namespace hp
     \{
-    template class FEValues<deal_II_dimension>;
-    template class FEFaceValues<deal_II_dimension, deal_II_dimension>;
-    template class FESubfaceValues<deal_II_dimension, deal_II_dimension>;
+      template class FEValues<deal_II_dimension>;
+      template class FEFaceValues<deal_II_dimension, deal_II_dimension>;
+      template class FESubfaceValues<deal_II_dimension, deal_II_dimension>;
     \}
 
 
@@ -42,22 +45,28 @@ for (deal_II_dimension : DIMENSIONS)
 
     namespace internal
     \{
-    namespace hp
-    \{
-    template class FEValuesBase<deal_II_dimension,deal_II_dimension,
-                                dealii::FEValues<deal_II_dimension,deal_II_dimension+1> >;
-    template class FEValuesBase<deal_II_dimension,deal_II_dimension-1,
-                                dealii::FEFaceValues<deal_II_dimension,deal_II_dimension+1> >;
-    template class FEValuesBase<deal_II_dimension,deal_II_dimension-1,
-                                dealii::FESubfaceValues<deal_II_dimension,deal_II_dimension+1> >;
-    \}
+      namespace hp
+      \{
+        template class FEValuesBase<
+          deal_II_dimension,
+          deal_II_dimension,
+          dealii::FEValues<deal_II_dimension, deal_II_dimension + 1>>;
+        template class FEValuesBase<
+          deal_II_dimension,
+          deal_II_dimension - 1,
+          dealii::FEFaceValues<deal_II_dimension, deal_II_dimension + 1>>;
+        template class FEValuesBase<
+          deal_II_dimension,
+          deal_II_dimension - 1,
+          dealii::FESubfaceValues<deal_II_dimension, deal_II_dimension + 1>>;
+      \}
     \}
 
     namespace hp
     \{
-    template class FEValues<deal_II_dimension, deal_II_dimension+1>;
-    template class FEFaceValues<deal_II_dimension, deal_II_dimension+1>;
-    template class FESubfaceValues<deal_II_dimension, deal_II_dimension+1>;
+      template class FEValues<deal_II_dimension, deal_II_dimension + 1>;
+      template class FEFaceValues<deal_II_dimension, deal_II_dimension + 1>;
+      template class FESubfaceValues<deal_II_dimension, deal_II_dimension + 1>;
     \}
 #endif
 
@@ -65,38 +74,58 @@ for (deal_II_dimension : DIMENSIONS)
 
     namespace internal
     \{
-    namespace hp
-    \{
-    template class FEValuesBase<1,1,
-                                dealii::FEValues<1,3> >;
-    template class FEValuesBase<1,1-1,
-                                dealii::FEFaceValues<1,3> >;
-    template class FEValuesBase<1,1-1,
-                                dealii::FESubfaceValues<1,3> >;
-    \}
+      namespace hp
+      \{
+        template class FEValuesBase<1, 1, dealii::FEValues<1, 3>>;
+        template class FEValuesBase<1, 1 - 1, dealii::FEFaceValues<1, 3>>;
+        template class FEValuesBase<1, 1 - 1, dealii::FESubfaceValues<1, 3>>;
+      \}
     \}
 
     namespace hp
     \{
-    template class FEValues<1, 3>;
-    template class FEFaceValues<1, 3>;
-    template class FESubfaceValues<1, 3>;
+      template class FEValues<1, 3>;
+      template class FEFaceValues<1, 3>;
+      template class FESubfaceValues<1, 3>;
     \}
 #endif
-}
+  }
 
-for (dof_handler : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; lda : BOOL)
-{
+for (dof_handler : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS;
+     lda : BOOL)
+  {
     namespace hp
     \{
 #if deal_II_dimension <= deal_II_space_dimension
 
-    template void FEValues<deal_II_dimension,deal_II_space_dimension>::reinit(
-        TriaIterator<DoFCellAccessor<dealii::dof_handler<deal_II_dimension,deal_II_space_dimension>, lda> >, unsigned int, unsigned int, unsigned int);
-    template void FEFaceValues<deal_II_dimension,deal_II_space_dimension>::reinit(
-        TriaIterator<DoFCellAccessor<dealii::dof_handler<deal_II_dimension,deal_II_space_dimension>, lda> >, unsigned int, unsigned int, unsigned int, unsigned int);
-    template void FESubfaceValues<deal_II_dimension,deal_II_space_dimension>::reinit(
-        TriaIterator<DoFCellAccessor<dealii::dof_handler<deal_II_dimension,deal_II_space_dimension>, lda> >, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int);
+      template void
+      FEValues<deal_II_dimension, deal_II_space_dimension>::reinit(
+        TriaIterator<DoFCellAccessor<
+          dealii::dof_handler<deal_II_dimension, deal_II_space_dimension>,
+          lda>>,
+        unsigned int,
+        unsigned int,
+        unsigned int);
+      template void
+      FEFaceValues<deal_II_dimension, deal_II_space_dimension>::reinit(
+        TriaIterator<DoFCellAccessor<
+          dealii::dof_handler<deal_II_dimension, deal_II_space_dimension>,
+          lda>>,
+        unsigned int,
+        unsigned int,
+        unsigned int,
+        unsigned int);
+      template void
+      FESubfaceValues<deal_II_dimension, deal_II_space_dimension>::reinit(
+        TriaIterator<DoFCellAccessor<
+          dealii::dof_handler<deal_II_dimension, deal_II_space_dimension>,
+          lda>>,
+        unsigned int,
+        unsigned int,
+        unsigned int,
+        unsigned int,
+        unsigned int);
 #endif
     \}
-}
+  }

--- a/source/hp/mapping_collection.inst.in
+++ b/source/hp/mapping_collection.inst.in
@@ -15,20 +15,21 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace hp
     \{
-    template class MappingCollection<deal_II_dimension>;
-    template struct StaticMappingQ1<deal_II_dimension>;
+      template class MappingCollection<deal_II_dimension>;
+      template struct StaticMappingQ1<deal_II_dimension>;
 
 #if deal_II_dimension != 3
-    template class MappingCollection<deal_II_dimension,deal_II_dimension+1>;
-    template struct StaticMappingQ1<deal_II_dimension,deal_II_dimension+1>;
+      template class MappingCollection<deal_II_dimension,
+                                       deal_II_dimension + 1>;
+      template struct StaticMappingQ1<deal_II_dimension, deal_II_dimension + 1>;
 #endif
 
 #if deal_II_dimension == 3
-    template class MappingCollection<1,3>;
-    template struct StaticMappingQ1<1,3>;
+      template class MappingCollection<1, 3>;
+      template struct StaticMappingQ1<1, 3>;
 #endif
     \}
-}
+  }

--- a/source/lac/block_sparse_matrix.inst.in
+++ b/source/lac/block_sparse_matrix.inst.in
@@ -14,6 +14,6 @@
 // ---------------------------------------------------------------------
 
 for (S : REAL_SCALARS)
-{
+  {
     template class BlockSparseMatrix<S>;
-}
+  }

--- a/source/lac/block_vector.inst.in
+++ b/source/lac/block_vector.inst.in
@@ -16,25 +16,25 @@
 
 
 for (S : REAL_AND_COMPLEX_SCALARS)
-{
+  {
     template class BlockVector<S>;
-}
+  }
 
 for (S1, S2 : REAL_SCALARS)
-{
-    template void BlockVector<S1>::reinit<S2>(const BlockVector<S2>&,
-            const bool);
-}
+  {
+    template void BlockVector<S1>::reinit<S2>(const BlockVector<S2> &,
+                                              const bool);
+  }
 
 for (S1, S2 : COMPLEX_SCALARS)
-{
-    template void BlockVector<S1>::reinit<S2>(const BlockVector<S2>&,
-            const bool);
-}
+  {
+    template void BlockVector<S1>::reinit<S2>(const BlockVector<S2> &,
+                                              const bool);
+  }
 
 
 for (S1 : COMPLEX_SCALARS; S2 : REAL_SCALARS)
-{
-    template void BlockVector<S1>::reinit<S2>(const BlockVector<S2>&,
-            const bool);
-}
+  {
+    template void BlockVector<S1>::reinit<S2>(const BlockVector<S2> &,
+                                              const bool);
+  }

--- a/source/lac/chunk_sparse_matrix.inst.in
+++ b/source/lac/chunk_sparse_matrix.inst.in
@@ -18,107 +18,78 @@
 // real instantiations
 
 for (S : REAL_SCALARS)
-{
+  {
     template class ChunkSparseMatrix<S>;
-}
+  }
 
 
 
 for (S1, S2 : REAL_SCALARS)
-{
-    template ChunkSparseMatrix<S1> &
-    ChunkSparseMatrix<S1>::copy_from<S2> (const ChunkSparseMatrix<S2> &);
+  {
+    template ChunkSparseMatrix<S1> &ChunkSparseMatrix<S1>::copy_from<S2>(
+      const ChunkSparseMatrix<S2> &);
 
-    template
-    void ChunkSparseMatrix<S1>::copy_from<S2> (const FullMatrix<S2> &);
+    template void ChunkSparseMatrix<S1>::copy_from<S2>(const FullMatrix<S2> &);
 
-    template void ChunkSparseMatrix<S1>::add<S2> (const S1,
-            const ChunkSparseMatrix<S2> &);
-}
+    template void ChunkSparseMatrix<S1>::add<S2>(const S1,
+                                                 const ChunkSparseMatrix<S2> &);
+  }
 
 
 for (S1, S2 : REAL_SCALARS)
-{
-    template S2
-    ChunkSparseMatrix<S1>::
-    matrix_norm_square<S2> (const Vector<S2> &) const;
+  {
+    template S2 ChunkSparseMatrix<S1>::matrix_norm_square<S2>(
+      const Vector<S2> &) const;
 
-    template S2
-    ChunkSparseMatrix<S1>::
-    matrix_scalar_product<S2> (const Vector<S2> &,
-                               const Vector<S2> &) const;
+    template S2 ChunkSparseMatrix<S1>::matrix_scalar_product<S2>(
+      const Vector<S2> &, const Vector<S2> &) const;
 
-    template S2 ChunkSparseMatrix<S1>::
-    residual<S2> (Vector<S2> &,
-                  const Vector<S2> &,
-                  const Vector<S2> &) const;
+    template S2 ChunkSparseMatrix<S1>::residual<S2>(
+      Vector<S2> &, const Vector<S2> &, const Vector<S2> &) const;
 
-    template void ChunkSparseMatrix<S1>::
-    precondition_SSOR<S2> (Vector<S2> &,
-                           const Vector<S2> &,
-                           const S1) const;
+    template void ChunkSparseMatrix<S1>::precondition_SSOR<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
 
-    template void ChunkSparseMatrix<S1>::
-    precondition_SOR<S2> (Vector<S2> &,
-                          const Vector<S2> &,
-                          const S1) const;
+    template void ChunkSparseMatrix<S1>::precondition_SOR<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
 
-    template void ChunkSparseMatrix<S1>::
-    precondition_TSOR<S2> (Vector<S2> &,
-                           const Vector<S2> &,
-                           const S1) const;
+    template void ChunkSparseMatrix<S1>::precondition_TSOR<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
 
-    template void ChunkSparseMatrix<S1>::
-    precondition_Jacobi<S2> (Vector<S2> &,
-                             const Vector<S2> &,
-                             const S1) const;
+    template void ChunkSparseMatrix<S1>::precondition_Jacobi<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
 
-    template void ChunkSparseMatrix<S1>::
-    SOR<S2> (Vector<S2> &,
-             const S1) const;
-    template void ChunkSparseMatrix<S1>::
-    TSOR<S2> (Vector<S2> &,
-              const S1) const;
-    template void ChunkSparseMatrix<S1>::
-    SSOR<S2> (Vector<S2> &,
-              const S1) const;
-    template void ChunkSparseMatrix<S1>::
-    PSOR<S2> (Vector<S2> &,
-              const std::vector<types::global_dof_index>&,
-              const std::vector<types::global_dof_index>&,
-              const S1) const;
-    template void ChunkSparseMatrix<S1>::
-    TPSOR<S2> (Vector<S2> &,
-               const std::vector<types::global_dof_index>&,
-               const std::vector<types::global_dof_index>&,
-               const S1) const;
-    template void ChunkSparseMatrix<S1>::
-    SOR_step<S2> (Vector<S2> &,
-                  const Vector<S2> &,
-                  const S1) const;
-    template void ChunkSparseMatrix<S1>::
-    TSOR_step<S2> (Vector<S2> &,
-                   const Vector<S2> &,
-                   const S1) const;
-    template void ChunkSparseMatrix<S1>::
-    SSOR_step<S2> (Vector<S2> &,
-                   const Vector<S2> &,
-                   const S1) const;
-}
+    template void ChunkSparseMatrix<S1>::SOR<S2>(Vector<S2> &, const S1) const;
+    template void ChunkSparseMatrix<S1>::TSOR<S2>(Vector<S2> &, const S1) const;
+    template void ChunkSparseMatrix<S1>::SSOR<S2>(Vector<S2> &, const S1) const;
+    template void ChunkSparseMatrix<S1>::PSOR<S2>(
+      Vector<S2> &,
+      const std::vector<types::global_dof_index> &,
+      const std::vector<types::global_dof_index> &,
+      const S1) const;
+    template void ChunkSparseMatrix<S1>::TPSOR<S2>(
+      Vector<S2> &,
+      const std::vector<types::global_dof_index> &,
+      const std::vector<types::global_dof_index> &,
+      const S1) const;
+    template void ChunkSparseMatrix<S1>::SOR_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+    template void ChunkSparseMatrix<S1>::TSOR_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+    template void ChunkSparseMatrix<S1>::SSOR_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+  }
 
 
-for (S1, S2, S3 : REAL_SCALARS;
-        V1, V2     : DEAL_II_VEC_TEMPLATES)
-{
-    template void ChunkSparseMatrix<S1>::
-    vmult (V1<S2> &, const V2<S3> &) const;
-    template void ChunkSparseMatrix<S1>::
-    Tvmult (V1<S2> &, const V2<S3> &) const;
-    template void ChunkSparseMatrix<S1>::
-    vmult_add (V1<S2> &, const V2<S3> &) const;
-    template void ChunkSparseMatrix<S1>::
-    Tvmult_add (V1<S2> &, const V2<S3> &) const;
-}
+for (S1, S2, S3 : REAL_SCALARS; V1, V2 : DEAL_II_VEC_TEMPLATES)
+  {
+    template void ChunkSparseMatrix<S1>::vmult(V1<S2> &, const V2<S3> &) const;
+    template void ChunkSparseMatrix<S1>::Tvmult(V1<S2> &, const V2<S3> &) const;
+    template void ChunkSparseMatrix<S1>::vmult_add(V1<S2> &, const V2<S3> &)
+      const;
+    template void ChunkSparseMatrix<S1>::Tvmult_add(V1<S2> &, const V2<S3> &)
+      const;
+  }
 
 
 

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -13,102 +13,111 @@
 //
 // ---------------------------------------------------------------------
 
-for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
-{
-    template void ConstraintMatrix::condense<T<S> >(const T<S> &, T<S> &) const;
-    template void ConstraintMatrix::condense<T<S> >(T<S> &vec) const;
-    template void ConstraintMatrix::distribute_local_to_global<T<S> > (
-        const Vector<S>&, const std::vector<types::global_dof_index> &, T<S> &, const FullMatrix<S>&) const;
-    template void ConstraintMatrix::distribute_local_to_global<T<S> > (
-        const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, T<S> &, const FullMatrix<S>&, bool) const;
-    template void ConstraintMatrix::set_zero<T<S> >(T<S> &) const;
-}
+for (S : REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
+  {
+    template void ConstraintMatrix::condense<T<S>>(const T<S> &, T<S> &) const;
+    template void ConstraintMatrix::condense<T<S>>(T<S> & vec) const;
+    template void ConstraintMatrix::distribute_local_to_global<T<S>>(
+      const Vector<S> &,
+      const std::vector<types::global_dof_index> &,
+      T<S> &,
+      const FullMatrix<S> &) const;
+    template void ConstraintMatrix::distribute_local_to_global<T<S>>(
+      const Vector<S> &,
+      const std::vector<types::global_dof_index> &,
+      const std::vector<types::global_dof_index> &,
+      T<S> &,
+      const FullMatrix<S> &,
+      bool) const;
+    template void ConstraintMatrix::set_zero<T<S>>(T<S> &) const;
+  }
 
 
-for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
-{
-    template void ConstraintMatrix::condense<LinearAlgebra::distributed::T<S> >(const LinearAlgebra::distributed::T<S> &, LinearAlgebra::distributed::T<S> &) const;
-    template void ConstraintMatrix::condense<LinearAlgebra::distributed::T<S> >(LinearAlgebra::distributed::T<S> &vec) const;
+for (S : REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
+  {
+    template void ConstraintMatrix::condense<LinearAlgebra::distributed::T<S>>(
+      const LinearAlgebra::distributed::T<S> &,
+      LinearAlgebra::distributed::T<S> &) const;
+    template void ConstraintMatrix::condense<LinearAlgebra::distributed::T<S>>(
+      LinearAlgebra::distributed::T<S> & vec) const;
 
-    template
-    void
-    ConstraintMatrix::distribute_local_to_global<LinearAlgebra::distributed::T<S> >
-    (const Vector<S>&,
-     const std::vector<types::global_dof_index> &,
-     LinearAlgebra::distributed::T<S> &,
-     const FullMatrix<S>&) const;
+    template void ConstraintMatrix::distribute_local_to_global<
+      LinearAlgebra::distributed::T<S>>(
+      const Vector<S> &,
+      const std::vector<types::global_dof_index> &,
+      LinearAlgebra::distributed::T<S> &,
+      const FullMatrix<S> &) const;
 
-    template
-    void
-    ConstraintMatrix::distribute_local_to_global<LinearAlgebra::distributed::T<S> >
-    (const Vector<S>&,
-     const std::vector<types::global_dof_index> &,
-     const std::vector<types::global_dof_index> &,
-     LinearAlgebra::distributed::T<S> &,
-     const FullMatrix<S>&,
-     bool) const;
+    template void ConstraintMatrix::distribute_local_to_global<
+      LinearAlgebra::distributed::T<S>>(
+      const Vector<S> &,
+      const std::vector<types::global_dof_index> &,
+      const std::vector<types::global_dof_index> &,
+      LinearAlgebra::distributed::T<S> &,
+      const FullMatrix<S> &,
+      bool) const;
 
-    template
-    void
-    ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> > >
-    (const FullMatrix<S> &,
-     const std::vector< size_type > &,
-     DiagonalMatrix<LinearAlgebra::distributed::T<S> > &) const;
+    template void ConstraintMatrix::distribute_local_to_global<
+      DiagonalMatrix<LinearAlgebra::distributed::T<S>>>(
+      const FullMatrix<S> &,
+      const std::vector<size_type> &,
+      DiagonalMatrix<LinearAlgebra::distributed::T<S>> &) const;
 
-    template
-    void
-    ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> >, LinearAlgebra::distributed::T<S> >
-    (const FullMatrix<S> &,
-     const Vector<S>&,
-     const std::vector< size_type > &,
-     DiagonalMatrix<LinearAlgebra::distributed::T<S> > &,
-     LinearAlgebra::distributed::T<S>&,
-     bool,
-     std::integral_constant<bool, false>) const;
+    template void ConstraintMatrix::distribute_local_to_global<
+      DiagonalMatrix<LinearAlgebra::distributed::T<S>>,
+      LinearAlgebra::distributed::T<S>>(
+      const FullMatrix<S> &,
+      const Vector<S> &,
+      const std::vector<size_type> &,
+      DiagonalMatrix<LinearAlgebra::distributed::T<S>> &,
+      LinearAlgebra::distributed::T<S> &,
+      bool,
+      std::integral_constant<bool, false>) const;
 
-    template
-    void
-    ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> >, T<S> >
-    (const FullMatrix<S> &,
-     const Vector<S>&,
-     const std::vector< size_type > &,
-     DiagonalMatrix<LinearAlgebra::distributed::T<S> > &,
-     T<S>&,
-     bool,
-     std::integral_constant<bool, false>) const;
+    template void ConstraintMatrix::distribute_local_to_global<
+      DiagonalMatrix<LinearAlgebra::distributed::T<S>>,
+      T<S>>(const FullMatrix<S> &,
+            const Vector<S> &,
+            const std::vector<size_type> &,
+            DiagonalMatrix<LinearAlgebra::distributed::T<S>> &,
+            T<S> &,
+            bool,
+            std::integral_constant<bool, false>) const;
 
-    template
-    void
-    ConstraintMatrix::set_zero<LinearAlgebra::distributed::T<S> >(LinearAlgebra::distributed::T<S> &) const;
-}
+    template void ConstraintMatrix::set_zero<LinearAlgebra::distributed::T<S>>(
+      LinearAlgebra::distributed::T<S> &) const;
+  }
 
 
-for (V: EXTERNAL_PARALLEL_VECTORS)
-{
-    template void ConstraintMatrix::set_zero<V >(V&) const;
-}
+for (V : EXTERNAL_PARALLEL_VECTORS)
+  {
+    template void ConstraintMatrix::set_zero<V>(V &) const;
+  }
 
 
 for (S : REAL_SCALARS)
-{
-    template void ConstraintMatrix::condense<S>(SparseMatrix<S>&) const;
-    template void ConstraintMatrix::condense<S>(BlockSparseMatrix<S>&) const;
-}
+  {
+    template void ConstraintMatrix::condense<S>(SparseMatrix<S> &) const;
+    template void ConstraintMatrix::condense<S>(BlockSparseMatrix<S> &) const;
+  }
 
 
 for (S1 : REAL_SCALARS; S2 : REAL_SCALARS)
-{
-    template void ConstraintMatrix::condense<S1,Vector<S2> >(SparseMatrix<S1>&, Vector<S2>&) const;
-    template void ConstraintMatrix::condense<S1,BlockVector<S2> >(BlockSparseMatrix<S1>&, BlockVector<S2>&) const;
-}
+  {
+    template void ConstraintMatrix::condense<S1, Vector<S2>>(
+      SparseMatrix<S1> &, Vector<S2> &) const;
+    template void ConstraintMatrix::condense<S1, BlockVector<S2>>(
+      BlockSparseMatrix<S1> &, BlockVector<S2> &) const;
+  }
 
 for (S1 : COMPLEX_SCALARS)
-{
-    template void ConstraintMatrix::condense<S1,Vector<S1> >(SparseMatrix<S1>&, Vector<S1>&) const;
-}
+  {
+    template void ConstraintMatrix::condense<S1, Vector<S1>>(
+      SparseMatrix<S1> &, Vector<S1> &) const;
+  }
 
 
 for (Vec : VECTOR_TYPES)
-{
+  {
     template void ConstraintMatrix::distribute<Vec>(Vec &) const;
-}
+  }

--- a/source/lac/full_matrix.inst.in
+++ b/source/lac/full_matrix.inst.in
@@ -16,227 +16,218 @@
 
 
 for (S : REAL_AND_COMPLEX_SCALARS)
-{
+  {
     template class FullMatrix<S>;
 
     template void FullMatrix<S>::print(
-        LogStream&, const unsigned int, const unsigned int) const;
+      LogStream &, const unsigned int, const unsigned int) const;
     template void FullMatrix<S>::print(
-        std::ostream&, const unsigned int, const unsigned int) const;
+      std::ostream &, const unsigned int, const unsigned int) const;
 
-    template void FullMatrix<S>::copy_from<1>(
-        const Tensor<2,1>&, const unsigned int, const unsigned int, unsigned int, const unsigned int, const size_type, const size_type);
+    template void FullMatrix<S>::copy_from<1>(const Tensor<2, 1> &,
+                                              const unsigned int,
+                                              const unsigned int,
+                                              unsigned int,
+                                              const unsigned int,
+                                              const size_type,
+                                              const size_type);
 
-    template void FullMatrix<S>::copy_from<2>(
-        const Tensor<2,2>&, const unsigned int, const unsigned int, unsigned int, const unsigned int, const size_type, const size_type);
+    template void FullMatrix<S>::copy_from<2>(const Tensor<2, 2> &,
+                                              const unsigned int,
+                                              const unsigned int,
+                                              unsigned int,
+                                              const unsigned int,
+                                              const size_type,
+                                              const size_type);
 
-    template void FullMatrix<S>::copy_from<3>(
-        const Tensor<2,3>&, const unsigned int, const unsigned int, unsigned int, const unsigned int, const size_type, const size_type);
-}
+    template void FullMatrix<S>::copy_from<3>(const Tensor<2, 3> &,
+                                              const unsigned int,
+                                              const unsigned int,
+                                              unsigned int,
+                                              const unsigned int,
+                                              const size_type,
+                                              const size_type);
+  }
 
 
 for (S : REAL_SCALARS)
-{
-    template void FullMatrix<S>::copy_to<1>(
-        Tensor<2,1>&, const size_type, const size_type, const size_type, const size_type, const unsigned int, const unsigned int) const;
+  {
+    template void FullMatrix<S>::copy_to<1>(Tensor<2, 1> &,
+                                            const size_type,
+                                            const size_type,
+                                            const size_type,
+                                            const size_type,
+                                            const unsigned int,
+                                            const unsigned int) const;
 
-    template void FullMatrix<S>::copy_to<2>(
-        Tensor<2,2>&, const size_type, const size_type, const size_type, const size_type, const unsigned int, const unsigned int) const;
+    template void FullMatrix<S>::copy_to<2>(Tensor<2, 2> &,
+                                            const size_type,
+                                            const size_type,
+                                            const size_type,
+                                            const size_type,
+                                            const unsigned int,
+                                            const unsigned int) const;
 
-    template void FullMatrix<S>::copy_to<3>(
-        Tensor<2,3>&, const size_type, const size_type, const size_type, const size_type, const unsigned int, const unsigned int) const;
-}
+    template void FullMatrix<S>::copy_to<3>(Tensor<2, 3> &,
+                                            const size_type,
+                                            const size_type,
+                                            const size_type,
+                                            const size_type,
+                                            const unsigned int,
+                                            const unsigned int) const;
+  }
 
 
 for (S1, S2 : REAL_SCALARS)
-{
-    template
-    FullMatrix<S1>& FullMatrix<S1>::operator = (const LAPACKFullMatrix<S2>&);
+  {
+    template FullMatrix<S1> &FullMatrix<S1>::operator=(
+      const LAPACKFullMatrix<S2> &);
 
-    template
-    void FullMatrix<S1>::fill<S2> (
-        const FullMatrix<S2>&, size_type, size_type, size_type, size_type);
-    template
-    void FullMatrix<S1>::add<S2> (const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::add<S2> (const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::add<S2> (const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::add<S2> (
-        const FullMatrix<S2>&, S1, size_type, size_type, size_type, size_type);
-    template
-    void FullMatrix<S1>::Tadd<S2> (const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::Tadd<S2> (
-        const FullMatrix<S2>&, S1, size_type, size_type, size_type, size_type);
-    template
-    void FullMatrix<S1>::equ<S2> (const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::equ<S2> (const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::equ<S2> (const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::mmult<S2> (FullMatrix<S2>&, const FullMatrix<S2>&, const bool) const;
-    template
-    void FullMatrix<S1>::Tmmult<S2> (FullMatrix<S2>&, const FullMatrix<S2>&, const bool) const;
-    template
-    void FullMatrix<S1>::mTmult<S2> (FullMatrix<S2>&, const FullMatrix<S2>&, const bool) const;
-    template
-    void FullMatrix<S1>::TmTmult<S2> (FullMatrix<S2>&, const FullMatrix<S2>&, const bool) const;
-    template
-    void FullMatrix<S1>::invert<S2> (const FullMatrix<S2>&);
+    template void FullMatrix<S1>::fill<S2>(
+      const FullMatrix<S2> &, size_type, size_type, size_type, size_type);
+    template void FullMatrix<S1>::add<S2>(const S1, const FullMatrix<S2> &);
+    template void FullMatrix<S1>::add<S2>(
+      const S1, const FullMatrix<S2> &, const S1, const FullMatrix<S2> &);
+    template void FullMatrix<S1>::add<S2>(const S1,
+                                          const FullMatrix<S2> &,
+                                          const S1,
+                                          const FullMatrix<S2> &,
+                                          const S1,
+                                          const FullMatrix<S2> &);
+    template void FullMatrix<S1>::add<S2>(
+      const FullMatrix<S2> &, S1, size_type, size_type, size_type, size_type);
+    template void FullMatrix<S1>::Tadd<S2>(const S1, const FullMatrix<S2> &);
+    template void FullMatrix<S1>::Tadd<S2>(
+      const FullMatrix<S2> &, S1, size_type, size_type, size_type, size_type);
+    template void FullMatrix<S1>::equ<S2>(const S1, const FullMatrix<S2> &);
+    template void FullMatrix<S1>::equ<S2>(
+      const S1, const FullMatrix<S2> &, const S1, const FullMatrix<S2> &);
+    template void FullMatrix<S1>::equ<S2>(const S1,
+                                          const FullMatrix<S2> &,
+                                          const S1,
+                                          const FullMatrix<S2> &,
+                                          const S1,
+                                          const FullMatrix<S2> &);
+    template void FullMatrix<S1>::mmult<S2>(
+      FullMatrix<S2> &, const FullMatrix<S2> &, const bool) const;
+    template void FullMatrix<S1>::Tmmult<S2>(
+      FullMatrix<S2> &, const FullMatrix<S2> &, const bool) const;
+    template void FullMatrix<S1>::mTmult<S2>(
+      FullMatrix<S2> &, const FullMatrix<S2> &, const bool) const;
+    template void FullMatrix<S1>::TmTmult<S2>(
+      FullMatrix<S2> &, const FullMatrix<S2> &, const bool) const;
+    template void FullMatrix<S1>::invert<S2>(const FullMatrix<S2> &);
 
-    template
-    void FullMatrix<S1>::left_invert<S2> (const FullMatrix<S2> &);
-    template
-    void FullMatrix<S1>::right_invert<S2> (const FullMatrix<S2> &);
+    template void FullMatrix<S1>::left_invert<S2>(const FullMatrix<S2> &);
+    template void FullMatrix<S1>::right_invert<S2>(const FullMatrix<S2> &);
 
-    template
-    void FullMatrix<S1>::fill_permutation<S2> (
-        const FullMatrix<S2>&,
-        const std::vector<size_type>&,
-        const std::vector<size_type>&);
+    template void FullMatrix<S1>::fill_permutation<S2>(
+      const FullMatrix<S2> &,
+      const std::vector<size_type> &,
+      const std::vector<size_type> &);
 
-    template
-    void FullMatrix<S1>::cholesky<S2> (const FullMatrix<S2>&);
+    template void FullMatrix<S1>::cholesky<S2>(const FullMatrix<S2> &);
 
-    template
-    void FullMatrix<S1>::outer_product<S2> (const Vector<S2>&,
-                                            const Vector<S2>&);
-}
+    template void FullMatrix<S1>::outer_product<S2>(const Vector<S2> &,
+                                                    const Vector<S2> &);
+  }
 
 
 // real matrices can be multiplied by real or complex vectors
 for (S1 : REAL_SCALARS; S2 : REAL_AND_COMPLEX_SCALARS)
-{
-    template
-    void FullMatrix<S1>::vmult<S2>(
-        Vector<S2>&, const Vector<S2>&, bool) const;
-    template
-    void FullMatrix<S1>::Tvmult<S2>(
-        Vector<S2>&, const Vector<S2>&, bool) const;
-    template
-    S2 FullMatrix<S1>::matrix_norm_square<S2> (
-        const Vector<S2> &) const;
-    template
-    S2 FullMatrix<S1>::matrix_scalar_product<S2>(
-        const Vector<S2>&, const Vector<S2>&) const;
-    template
-    void FullMatrix<S1>::forward<S2>(
-        Vector<S2>&, const Vector<S2>&) const;
-    template
-    void FullMatrix<S1>::backward<S2>(
-        Vector<S2>&, const Vector<S2>&) const;
+  {
+    template void FullMatrix<S1>::vmult<S2>(
+      Vector<S2> &, const Vector<S2> &, bool) const;
+    template void FullMatrix<S1>::Tvmult<S2>(
+      Vector<S2> &, const Vector<S2> &, bool) const;
+    template S2 FullMatrix<S1>::matrix_norm_square<S2>(const Vector<S2> &)
+      const;
+    template S2 FullMatrix<S1>::matrix_scalar_product<S2>(
+      const Vector<S2> &, const Vector<S2> &) const;
+    template void FullMatrix<S1>::forward<S2>(Vector<S2> &, const Vector<S2> &)
+      const;
+    template void FullMatrix<S1>::backward<S2>(Vector<S2> &, const Vector<S2> &)
+      const;
 
-    template
-    void FullMatrix<S1>::precondition_Jacobi<S2> (
-        Vector<S2> &, const Vector<S2> &, const S1) const;
-}
+    template void FullMatrix<S1>::precondition_Jacobi<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+  }
 
 
 // complex matrices can be multiplied only by complex vectors
 for (S1 : COMPLEX_SCALARS; S2 : COMPLEX_SCALARS)
-{
-    template
-    void FullMatrix<S1>::vmult<S2>(
-        Vector<S2>&, const Vector<S2>&, bool) const;
-    template
-    void FullMatrix<S1>::Tvmult<S2>(
-        Vector<S2>&, const Vector<S2>&, bool) const;
-    template
-    S2 FullMatrix<S1>::matrix_norm_square<S2> (
-        const Vector<S2> &) const;
-    template
-    S2 FullMatrix<S1>::matrix_scalar_product<S2>(
-        const Vector<S2>&, const Vector<S2>&) const;
-    template
-    void FullMatrix<S1>::forward<S2>(
-        Vector<S2>&, const Vector<S2>&) const;
-    template
-    void FullMatrix<S1>::backward<S2>(
-        Vector<S2>&, const Vector<S2>&) const;
+  {
+    template void FullMatrix<S1>::vmult<S2>(
+      Vector<S2> &, const Vector<S2> &, bool) const;
+    template void FullMatrix<S1>::Tvmult<S2>(
+      Vector<S2> &, const Vector<S2> &, bool) const;
+    template S2 FullMatrix<S1>::matrix_norm_square<S2>(const Vector<S2> &)
+      const;
+    template S2 FullMatrix<S1>::matrix_scalar_product<S2>(
+      const Vector<S2> &, const Vector<S2> &) const;
+    template void FullMatrix<S1>::forward<S2>(Vector<S2> &, const Vector<S2> &)
+      const;
+    template void FullMatrix<S1>::backward<S2>(Vector<S2> &, const Vector<S2> &)
+      const;
 
-    template
-    void FullMatrix<S1>::precondition_Jacobi<S2> (
-        Vector<S2> &, const Vector<S2> &, const S1) const;
-}
+    template void FullMatrix<S1>::precondition_Jacobi<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+  }
 
 
 
 for (S1, S2, S3 : REAL_SCALARS)
-{
-    template
-    S1
-    FullMatrix<S1>::residual<S2,S3>(Vector<S2>&,
-                                    const Vector<S2>&,
-                                    const Vector<S3>&) const;
-}
+  {
+    template S1 FullMatrix<S1>::residual<S2, S3>(
+      Vector<S2> &, const Vector<S2> &, const Vector<S3> &) const;
+  }
 
 
 
 for (S1, S2 : COMPLEX_SCALARS)
-{
-    template
-    void FullMatrix<S1>::fill<S2> (
-        const FullMatrix<S2>&, size_type, size_type, size_type, size_type);
-    template
-    void FullMatrix<S1>::add<S2> (const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::add<S2> (const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::add<S2> (const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::add<S2> (
-        const FullMatrix<S2>&, S1, size_type, size_type, size_type, size_type);
-    template
-    void FullMatrix<S1>::Tadd<S2> (const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::Tadd<S2> (
-        const FullMatrix<S2>&, S1, size_type, size_type,
-        size_type, size_type);
-    template
-    void FullMatrix<S1>::equ<S2> (const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::equ<S2> (const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::equ<S2> (const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&,
-                                  const S1, const FullMatrix<S2>&);
-    template
-    void FullMatrix<S1>::mmult<S2> (FullMatrix<S2>&, const FullMatrix<S2>&, const bool) const;
-    template
-    void FullMatrix<S1>::Tmmult<S2> (FullMatrix<S2>&, const FullMatrix<S2>&, const bool) const;
-    template
-    void FullMatrix<S1>::invert<S2> (const FullMatrix<S2>&);
+  {
+    template void FullMatrix<S1>::fill<S2>(
+      const FullMatrix<S2> &, size_type, size_type, size_type, size_type);
+    template void FullMatrix<S1>::add<S2>(const S1, const FullMatrix<S2> &);
+    template void FullMatrix<S1>::add<S2>(
+      const S1, const FullMatrix<S2> &, const S1, const FullMatrix<S2> &);
+    template void FullMatrix<S1>::add<S2>(const S1,
+                                          const FullMatrix<S2> &,
+                                          const S1,
+                                          const FullMatrix<S2> &,
+                                          const S1,
+                                          const FullMatrix<S2> &);
+    template void FullMatrix<S1>::add<S2>(
+      const FullMatrix<S2> &, S1, size_type, size_type, size_type, size_type);
+    template void FullMatrix<S1>::Tadd<S2>(const S1, const FullMatrix<S2> &);
+    template void FullMatrix<S1>::Tadd<S2>(
+      const FullMatrix<S2> &, S1, size_type, size_type, size_type, size_type);
+    template void FullMatrix<S1>::equ<S2>(const S1, const FullMatrix<S2> &);
+    template void FullMatrix<S1>::equ<S2>(
+      const S1, const FullMatrix<S2> &, const S1, const FullMatrix<S2> &);
+    template void FullMatrix<S1>::equ<S2>(const S1,
+                                          const FullMatrix<S2> &,
+                                          const S1,
+                                          const FullMatrix<S2> &,
+                                          const S1,
+                                          const FullMatrix<S2> &);
+    template void FullMatrix<S1>::mmult<S2>(
+      FullMatrix<S2> &, const FullMatrix<S2> &, const bool) const;
+    template void FullMatrix<S1>::Tmmult<S2>(
+      FullMatrix<S2> &, const FullMatrix<S2> &, const bool) const;
+    template void FullMatrix<S1>::invert<S2>(const FullMatrix<S2> &);
 
-    template
-    void FullMatrix<S1>::left_invert<S2> (const FullMatrix<S2> &);
-    template
-    void FullMatrix<S1>::right_invert<S2> (const FullMatrix<S2> &);
+    template void FullMatrix<S1>::left_invert<S2>(const FullMatrix<S2> &);
+    template void FullMatrix<S1>::right_invert<S2>(const FullMatrix<S2> &);
 
-    template
-    void FullMatrix<S1>::fill_permutation<S2> (
-        const FullMatrix<S2>&,
-        const std::vector<size_type>&,
-        const std::vector<size_type>&);
-}
+    template void FullMatrix<S1>::fill_permutation<S2>(
+      const FullMatrix<S2> &,
+      const std::vector<size_type> &,
+      const std::vector<size_type> &);
+  }
 
 for (S1, S2, S3 : COMPLEX_SCALARS)
-{
-    template
-    S1
-    FullMatrix<S1>::residual<S2,S3>(Vector<S2>&,
-                                    const Vector<S2>&,
-                                    const Vector<S3>&) const;
-}
+  {
+    template S1 FullMatrix<S1>::residual<S2, S3>(
+      Vector<S2> &, const Vector<S2> &, const Vector<S3> &) const;
+  }

--- a/source/lac/la_parallel_block_vector.inst.in
+++ b/source/lac/la_parallel_block_vector.inst.in
@@ -16,60 +16,74 @@
 
 
 for (SCALAR : REAL_AND_COMPLEX_SCALARS)
-{
+  {
     namespace LinearAlgebra
     \{
-    namespace distributed
-    \{
-    template class BlockVector<SCALAR>;
-    template
-    void
-    BlockVector<SCALAR>::multivector_inner_product(FullMatrix<SCALAR> &, const BlockVector<SCALAR> &V, const bool) const;
-    template
-    void
-    BlockVector<SCALAR>::multivector_inner_product(LAPACKFullMatrix<SCALAR> &, const BlockVector<SCALAR> &V, const bool) const;
-    template
-    SCALAR
-    BlockVector<SCALAR>::multivector_inner_product_with_metric(const FullMatrix<SCALAR> &, const BlockVector<SCALAR> &V, const bool) const;
-    template
-    SCALAR
-    BlockVector<SCALAR>::multivector_inner_product_with_metric(const LAPACKFullMatrix<SCALAR> &, const BlockVector<SCALAR> &V, const bool) const;
-    template
-    void
-    BlockVector<SCALAR>::mmult(BlockVector<SCALAR> &V,const FullMatrix<SCALAR> &, const SCALAR, const SCALAR) const;
-    template
-    void
-    BlockVector<SCALAR>::mmult(BlockVector<SCALAR> &V,const LAPACKFullMatrix<SCALAR> &, const SCALAR, const SCALAR) const;
+      namespace distributed
+      \{
+        template class BlockVector<SCALAR>;
+        template void
+        BlockVector<SCALAR>::multivector_inner_product(
+          FullMatrix<SCALAR> &,
+          const BlockVector<SCALAR> &V,
+          const bool) const;
+        template void
+        BlockVector<SCALAR>::multivector_inner_product(
+          LAPACKFullMatrix<SCALAR> &,
+          const BlockVector<SCALAR> &V,
+          const bool) const;
+        template SCALAR
+        BlockVector<SCALAR>::multivector_inner_product_with_metric(
+          const FullMatrix<SCALAR> &,
+          const BlockVector<SCALAR> &V,
+          const bool) const;
+        template SCALAR
+        BlockVector<SCALAR>::multivector_inner_product_with_metric(
+          const LAPACKFullMatrix<SCALAR> &,
+          const BlockVector<SCALAR> &V,
+          const bool) const;
+        template void
+        BlockVector<SCALAR>::mmult(BlockVector<SCALAR> &V,
+                                   const FullMatrix<SCALAR> &,
+                                   const SCALAR,
+                                   const SCALAR) const;
+        template void
+        BlockVector<SCALAR>::mmult(BlockVector<SCALAR> &V,
+                                   const LAPACKFullMatrix<SCALAR> &,
+                                   const SCALAR,
+                                   const SCALAR) const;
+      \}
     \}
-    \}
-}
+  }
 
 for (S1 : REAL_AND_COMPLEX_SCALARS; S2 : REAL_SCALARS)
-{
+  {
     namespace LinearAlgebra
     \{
-    namespace distributed
-    \{
-    template void BlockVector<S1>::reinit<S2> (const BlockVector<S2>&,
-            const bool);
-    template void BlockVector<S1>::add<S2> (const std::vector<size_type> &,
-                                            const ::dealii::Vector<S2>&);
+      namespace distributed
+      \{
+        template void
+        BlockVector<S1>::reinit<S2>(const BlockVector<S2> &, const bool);
+        template void
+        BlockVector<S1>::add<S2>(const std::vector<size_type> &,
+                                 const ::dealii::Vector<S2> &);
+      \}
     \}
-    \}
-}
+  }
 
 
 
 for (S1, S2 : COMPLEX_SCALARS)
-{
+  {
     namespace LinearAlgebra
     \{
-    namespace distributed
-    \{
-    template void BlockVector<S1>::reinit<S2> (const BlockVector<S2>&,
-            const bool);
-    template void BlockVector<S1>::add<S2> (const std::vector<size_type> &,
-                                            const ::dealii::Vector<S2>&);
+      namespace distributed
+      \{
+        template void
+        BlockVector<S1>::reinit<S2>(const BlockVector<S2> &, const bool);
+        template void
+        BlockVector<S1>::add<S2>(const std::vector<size_type> &,
+                                 const ::dealii::Vector<S2> &);
+      \}
     \}
-    \}
-}
+  }

--- a/source/lac/la_parallel_vector.inst.in
+++ b/source/lac/la_parallel_vector.inst.in
@@ -16,42 +16,45 @@
 
 
 for (SCALAR : REAL_AND_COMPLEX_SCALARS)
-{
+  {
     namespace LinearAlgebra
     \{
-    namespace distributed
-    \{
-    template class Vector<SCALAR>;
+      namespace distributed
+      \{
+        template class Vector<SCALAR>;
+      \}
     \}
-    \}
-}
+  }
 
 for (S1 : REAL_AND_COMPLEX_SCALARS; S2 : REAL_SCALARS)
-{
+  {
     namespace LinearAlgebra
     \{
-    namespace distributed
-    \{
-    template void Vector<S1>::reinit<S2> (const Vector<S2>&,
-                                          const bool);
-    template S1 Vector<S1>::inner_product_local<S2> (const Vector<S2>&) const;
-    template void Vector<S1>::copy_locally_owned_data_from<S2> (const Vector<S2>&);
+      namespace distributed
+      \{
+        template void
+        Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
+        template S1
+        Vector<S1>::inner_product_local<S2>(const Vector<S2> &) const;
+        template void
+        Vector<S1>::copy_locally_owned_data_from<S2>(const Vector<S2> &);
+      \}
     \}
-    \}
-}
+  }
 
 
 for (S1, S2 : COMPLEX_SCALARS)
-{
+  {
     namespace LinearAlgebra
     \{
-    namespace distributed
-    \{
-    template void Vector<S1>::reinit<S2> (const Vector<S2>&,
-                                          const bool);
-    template S1 Vector<S1>::inner_product_local<S2> (const Vector<S2>&) const;
-    template void Vector<S1>::copy_locally_owned_data_from<S2> (const Vector<S2>&);
+      namespace distributed
+      \{
+        template void
+        Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
+        template S1
+        Vector<S1>::inner_product_local<S2>(const Vector<S2> &) const;
+        template void
+        Vector<S1>::copy_locally_owned_data_from<S2>(const Vector<S2> &);
+      \}
     \}
-    \}
-}
-
+  }

--- a/source/lac/la_vector.inst.in
+++ b/source/lac/la_vector.inst.in
@@ -16,14 +16,13 @@
 
 
 for (SCALAR : REAL_SCALARS)
-{
+  {
     template class Vector<SCALAR>;
-}
+  }
 
 
 
 for (SCALAR : COMPLEX_SCALARS)
-{
+  {
     template class Vector<SCALAR>;
-}
-
+  }

--- a/source/lac/lapack_full_matrix.inst.in
+++ b/source/lac/lapack_full_matrix.inst.in
@@ -16,16 +16,16 @@
 
 
 for (S : REAL_AND_COMPLEX_SCALARS)
-{
+  {
     template class LAPACKFullMatrix<S>;
     template class PreconditionLU<S>;
-}
+  }
 
 for (S1 : REAL_AND_COMPLEX_SCALARS; S2 : REAL_SCALARS)
-{
-    template LAPACKFullMatrix<S1> &
-    LAPACKFullMatrix<S1>::operator = (const FullMatrix<S2> &M);
+  {
+    template LAPACKFullMatrix<S1> &LAPACKFullMatrix<S1>::operator=(
+      const FullMatrix<S2> &M);
 
-    template LAPACKFullMatrix<S1> &
-    LAPACKFullMatrix<S1>::operator = (const SparseMatrix<S2> &M);
-}
+    template LAPACKFullMatrix<S1> &LAPACKFullMatrix<S1>::operator=(
+      const SparseMatrix<S2> &M);
+  }

--- a/source/lac/precondition_block.inst.in
+++ b/source/lac/precondition_block.inst.in
@@ -16,74 +16,57 @@
 
 
 for (S : REAL_SCALARS)
-{
+  {
     template class PreconditionBlockBase<S>;
-}
+  }
 
 
 for (S1, S2 : REAL_SCALARS)
-{
+  {
     template class PreconditionBlock<SparseMatrix<S1>, S2>;
     template class PreconditionBlockJacobi<SparseMatrix<S1>, S2>;
     template class PreconditionBlockSOR<SparseMatrix<S1>, S2>;
     template class PreconditionBlockSSOR<SparseMatrix<S1>, S2>;
-}
+  }
 
 
 for (S1, S2, S3 : REAL_SCALARS)
-{
-// ------------ PreconditionBlockJacobi -----------------
-    template
-    void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::vmult<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::Tvmult<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::vmult_add<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::Tvmult_add<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::step<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::Tstep<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
+  {
+    // ------------ PreconditionBlockJacobi -----------------
+    template void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::vmult<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::Tvmult<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::vmult_add<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::Tvmult_add<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::step<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockJacobi<SparseMatrix<S1>, S2>::Tstep<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
 
-// ------------ PreconditionBlockSOR -----------------
-    template
-    void PreconditionBlockSOR<SparseMatrix<S1>, S2>::vmult<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockSOR<SparseMatrix<S1>, S2>::Tvmult<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockSOR<SparseMatrix<S1>, S2>::vmult_add<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockSOR<SparseMatrix<S1>, S2>::Tvmult_add<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockSOR<SparseMatrix<S1>, S2>::step<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockSOR<SparseMatrix<S1>, S2>::Tstep<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
+    // ------------ PreconditionBlockSOR -----------------
+    template void PreconditionBlockSOR<SparseMatrix<S1>, S2>::vmult<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockSOR<SparseMatrix<S1>, S2>::Tvmult<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockSOR<SparseMatrix<S1>, S2>::vmult_add<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockSOR<SparseMatrix<S1>, S2>::Tvmult_add<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockSOR<SparseMatrix<S1>, S2>::step<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockSOR<SparseMatrix<S1>, S2>::Tstep<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
 
-// ------------ PreconditionBlockSSOR -----------------
-    template
-    void PreconditionBlockSSOR<SparseMatrix<S1>, S2>::vmult<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockSSOR<SparseMatrix<S1>, S2>::Tvmult<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockSSOR<SparseMatrix<S1>, S2>::step<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-    template
-    void PreconditionBlockSSOR<SparseMatrix<S1>, S2>::Tstep<S3>
-    (Vector<S3> &, const Vector<S3> &) const;
-}
-
+    // ------------ PreconditionBlockSSOR -----------------
+    template void PreconditionBlockSSOR<SparseMatrix<S1>, S2>::vmult<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockSSOR<SparseMatrix<S1>, S2>::Tvmult<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockSSOR<SparseMatrix<S1>, S2>::step<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+    template void PreconditionBlockSSOR<SparseMatrix<S1>, S2>::Tstep<S3>(
+      Vector<S3> &, const Vector<S3> &) const;
+  }

--- a/source/lac/read_write_vector.inst.in
+++ b/source/lac/read_write_vector.inst.in
@@ -16,37 +16,36 @@
 
 
 for (SCALAR : REAL_SCALARS)
-{
+  {
     namespace LinearAlgebra
     \{
-    template class ReadWriteVector<SCALAR>;
+      template class ReadWriteVector<SCALAR>;
     \}
-}
+  }
 
 for (S1, S2 : REAL_SCALARS)
-{
+  {
     namespace LinearAlgebra
     \{
-    template void ReadWriteVector<S1>::reinit<S2> (const ReadWriteVector<S2>&,
-            const bool);
+      template void
+      ReadWriteVector<S1>::reinit<S2>(const ReadWriteVector<S2> &, const bool);
     \}
-}
+  }
 
 
 for (SCALAR : COMPLEX_SCALARS)
-{
+  {
     namespace LinearAlgebra
     \{
-    template class ReadWriteVector<SCALAR>;
+      template class ReadWriteVector<SCALAR>;
     \}
-}
+  }
 
 for (S1, S2 : COMPLEX_SCALARS)
-{
+  {
     namespace LinearAlgebra
     \{
-    template void ReadWriteVector<S1>::reinit<S2> (const ReadWriteVector<S2>&,
-            const bool);
+      template void
+      ReadWriteVector<S1>::reinit<S2>(const ReadWriteVector<S2> &, const bool);
     \}
-}
-
+  }

--- a/source/lac/relaxation_block.inst.in
+++ b/source/lac/relaxation_block.inst.in
@@ -16,21 +16,28 @@
 
 
 for (S1, S2, S3 : REAL_SCALARS)
-{
-    template class RelaxationBlock<SparseMatrix<S1>, S2, Vector<S3> >;
-    template class RelaxationBlockJacobi<SparseMatrix<S1>, S2, Vector<S3> >;
-    template class RelaxationBlockSOR<SparseMatrix<S1>, S2, Vector<S3> >;
-    template class RelaxationBlockSSOR<SparseMatrix<S1>, S2, Vector<S3> >;
-}
+  {
+    template class RelaxationBlock<SparseMatrix<S1>, S2, Vector<S3>>;
+    template class RelaxationBlockJacobi<SparseMatrix<S1>, S2, Vector<S3>>;
+    template class RelaxationBlockSOR<SparseMatrix<S1>, S2, Vector<S3>>;
+    template class RelaxationBlockSSOR<SparseMatrix<S1>, S2, Vector<S3>>;
+  }
 
 
 for (S1 : REAL_SCALARS)
-{
+  {
 #ifdef DEAL_II_WITH_TRILINOS
-    template class RelaxationBlock<TrilinosWrappers::SparseMatrix, S1, TrilinosWrappers::MPI::Vector>;
-    template class RelaxationBlockJacobi<TrilinosWrappers::SparseMatrix, S1, TrilinosWrappers::MPI::Vector>;
-    template class RelaxationBlockSOR<TrilinosWrappers::SparseMatrix, S1, TrilinosWrappers::MPI::Vector>;
-    template class RelaxationBlockSSOR<TrilinosWrappers::SparseMatrix, S1, TrilinosWrappers::MPI::Vector>;
+    template class RelaxationBlock<TrilinosWrappers::SparseMatrix,
+                                   S1,
+                                   TrilinosWrappers::MPI::Vector>;
+    template class RelaxationBlockJacobi<TrilinosWrappers::SparseMatrix,
+                                         S1,
+                                         TrilinosWrappers::MPI::Vector>;
+    template class RelaxationBlockSOR<TrilinosWrappers::SparseMatrix,
+                                      S1,
+                                      TrilinosWrappers::MPI::Vector>;
+    template class RelaxationBlockSSOR<TrilinosWrappers::SparseMatrix,
+                                       S1,
+                                       TrilinosWrappers::MPI::Vector>;
 #endif
-}
-
+  }

--- a/source/lac/scalapack.inst.in
+++ b/source/lac/scalapack.inst.in
@@ -15,22 +15,21 @@
 
 
 for (Number : REAL_SCALARS)
-{
+  {
     template class ScaLAPACKMatrix<Number>;
 
-    template
-    void ScaLAPACKMatrix<Number>::scale_columns<Vector<Number>> (const Vector<Number>&);
+    template void ScaLAPACKMatrix<Number>::scale_columns<Vector<Number>>(
+      const Vector<Number> &);
 
-    template
-    void ScaLAPACKMatrix<Number>::scale_rows<Vector<Number>> (const Vector<Number>&);
-}
+    template void ScaLAPACKMatrix<Number>::scale_rows<Vector<Number>>(
+      const Vector<Number> &);
+  }
 
-for (VEC : GENERAL_CONTAINER_TYPES;
-        Number : REAL_SCALARS)
-{
-    template
-    void ScaLAPACKMatrix<Number>::scale_columns<VEC<Number>> (const VEC<Number>&);
+for (VEC : GENERAL_CONTAINER_TYPES; Number : REAL_SCALARS)
+  {
+    template void ScaLAPACKMatrix<Number>::scale_columns<VEC<Number>>(
+      const VEC<Number> &);
 
-    template
-    void ScaLAPACKMatrix<Number>::scale_rows<VEC<Number>> (const VEC<Number>&);
-}
+    template void ScaLAPACKMatrix<Number>::scale_rows<VEC<Number>>(
+      const VEC<Number> &);
+  }

--- a/source/lac/solver.inst.in
+++ b/source/lac/solver.inst.in
@@ -16,6 +16,6 @@
 
 
 for (S : VECTOR_TYPES)
-{
+  {
     template class Solver<S>;
-}
+  }

--- a/source/lac/sparse_matrix.inst.in
+++ b/source/lac/sparse_matrix.inst.in
@@ -18,290 +18,226 @@
 // real instantiations
 
 for (S : REAL_SCALARS)
-{
+  {
     template class SparseMatrix<S>;
-}
+  }
 
 
 
 for (S1, S2 : REAL_SCALARS)
-{
-    template SparseMatrix<S1> &
-    SparseMatrix<S1>::copy_from<S2> (const SparseMatrix<S2> &);
+  {
+    template SparseMatrix<S1> &SparseMatrix<S1>::copy_from<S2>(
+      const SparseMatrix<S2> &);
 
-    template
-    void SparseMatrix<S1>::copy_from<S2> (const FullMatrix<S2> &);
+    template void SparseMatrix<S1>::copy_from<S2>(const FullMatrix<S2> &);
 
-    template void SparseMatrix<S1>::add<S2> (const S1,
-            const SparseMatrix<S2> &);
+    template void SparseMatrix<S1>::add<S2>(const S1, const SparseMatrix<S2> &);
 
-    template void SparseMatrix<S1>::add<S2> (const size_type,
-            const size_type,
-            const size_type *,
-            const S2 *,
-            const bool,
-            const bool);
+    template void SparseMatrix<S1>::add<S2>(const size_type,
+                                            const size_type,
+                                            const size_type *,
+                                            const S2 *,
+                                            const bool,
+                                            const bool);
 
-    template void SparseMatrix<S1>::set<S2> (const size_type,
-            const size_type,
-            const size_type *,
-            const S2 *,
-            const bool);
-}
+    template void SparseMatrix<S1>::set<S2>(const size_type,
+                                            const size_type,
+                                            const size_type *,
+                                            const S2 *,
+                                            const bool);
+  }
 
 
 for (S1, S2 : REAL_SCALARS)
-{
-    template S2
-    SparseMatrix<S1>::
-    matrix_norm_square<S2> (const Vector<S2> &) const;
+  {
+    template S2 SparseMatrix<S1>::matrix_norm_square<S2>(const Vector<S2> &)
+      const;
 
-    template S2
-    SparseMatrix<S1>::
-    matrix_scalar_product<S2> (const Vector<S2> &,
-                               const Vector<S2> &) const;
+    template S2 SparseMatrix<S1>::matrix_scalar_product<S2>(
+      const Vector<S2> &, const Vector<S2> &) const;
 
-    template S2 SparseMatrix<S1>::
-    residual<S2> (Vector<S2> &,
-                  const Vector<S2> &,
-                  const Vector<S2> &) const;
+    template S2 SparseMatrix<S1>::residual<S2>(
+      Vector<S2> &, const Vector<S2> &, const Vector<S2> &) const;
 
-    template void SparseMatrix<S1>::
-    precondition_SSOR<S2> (Vector<S2> &,
-                           const Vector<S2> &,
-                           const S1,
-                           const std::vector<std::size_t>&) const;
+    template void SparseMatrix<S1>::precondition_SSOR<S2>(
+      Vector<S2> &,
+      const Vector<S2> &,
+      const S1,
+      const std::vector<std::size_t> &) const;
 
-    template void SparseMatrix<S1>::
-    precondition_SOR<S2> (Vector<S2> &,
-                          const Vector<S2> &,
-                          const S1) const;
+    template void SparseMatrix<S1>::precondition_SOR<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
 
-    template void SparseMatrix<S1>::
-    precondition_TSOR<S2> (Vector<S2> &,
-                           const Vector<S2> &,
-                           const S1) const;
+    template void SparseMatrix<S1>::precondition_TSOR<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
 
-    template void SparseMatrix<S1>::
-    precondition_Jacobi<S2> (Vector<S2> &,
-                             const Vector<S2> &,
-                             const S1) const;
+    template void SparseMatrix<S1>::precondition_Jacobi<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
 
-    template void SparseMatrix<S1>::
-    SOR<S2> (Vector<S2> &,
-             const S1) const;
-    template void SparseMatrix<S1>::
-    TSOR<S2> (Vector<S2> &,
-              const S1) const;
-    template void SparseMatrix<S1>::
-    SSOR<S2> (Vector<S2> &,
-              const S1) const;
-    template void SparseMatrix<S1>::
-    PSOR<S2> (Vector<S2> &,
-              const std::vector<size_type>&,
-              const std::vector<size_type>&,
-              const S1) const;
-    template void SparseMatrix<S1>::
-    TPSOR<S2> (Vector<S2> &,
-               const std::vector<size_type>&,
-               const std::vector<size_type>&,
-               const S1) const;
-    template void SparseMatrix<S1>::
-    Jacobi_step<S2> (Vector<S2> &,
-                     const Vector<S2> &,
-                     const S1) const;
-    template void SparseMatrix<S1>::
-    SOR_step<S2> (Vector<S2> &,
-                  const Vector<S2> &,
-                  const S1) const;
-    template void SparseMatrix<S1>::
-    TSOR_step<S2> (Vector<S2> &,
-                   const Vector<S2> &,
-                   const S1) const;
-    template void SparseMatrix<S1>::
-    SSOR_step<S2> (Vector<S2> &,
-                   const Vector<S2> &,
-                   const S1) const;
-}
+    template void SparseMatrix<S1>::SOR<S2>(Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::TSOR<S2>(Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::SSOR<S2>(Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::PSOR<S2>(Vector<S2> &,
+                                             const std::vector<size_type> &,
+                                             const std::vector<size_type> &,
+                                             const S1) const;
+    template void SparseMatrix<S1>::TPSOR<S2>(Vector<S2> &,
+                                              const std::vector<size_type> &,
+                                              const std::vector<size_type> &,
+                                              const S1) const;
+    template void SparseMatrix<S1>::Jacobi_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::SOR_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::TSOR_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::SSOR_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+  }
 
-for (S1, S2, S3 : REAL_SCALARS;
-        V1, V2     : DEAL_II_VEC_TEMPLATES)
-{
-    template void SparseMatrix<S1>::
-    vmult (V1<S2> &, const V2<S3> &) const;
-    template void SparseMatrix<S1>::
-    Tvmult (V1<S2> &, const V2<S3> &) const;
-    template void SparseMatrix<S1>::
-    vmult_add (V1<S2> &, const V2<S3> &) const;
-    template void SparseMatrix<S1>::
-    Tvmult_add (V1<S2> &, const V2<S3> &) const;
-}
+for (S1, S2, S3 : REAL_SCALARS; V1, V2 : DEAL_II_VEC_TEMPLATES)
+  {
+    template void SparseMatrix<S1>::vmult(V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::Tvmult(V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::vmult_add(V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::Tvmult_add(V1<S2> &, const V2<S3> &) const;
+  }
 
 for (S1 : REAL_SCALARS; S2, S3 : COMPLEX_SCALARS;
-        V1, V2     : DEAL_II_VEC_TEMPLATES)
-{
-    template void SparseMatrix<S1>::
-    vmult (V1<S2> &, const V2<S3> &) const;
-    template void SparseMatrix<S1>::
-    Tvmult (V1<S2> &, const V2<S3> &) const;
-    template void SparseMatrix<S1>::
-    vmult_add (V1<S2> &, const V2<S3> &) const;
-    template void SparseMatrix<S1>::
-    Tvmult_add (V1<S2> &, const V2<S3> &) const;
-}
+     V1, V2 : DEAL_II_VEC_TEMPLATES)
+  {
+    template void SparseMatrix<S1>::vmult(V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::Tvmult(V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::vmult_add(V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::Tvmult_add(V1<S2> &, const V2<S3> &) const;
+  }
 
 for (S1 : REAL_SCALARS)
-{
-    template void SparseMatrix<S1>::
-    vmult (LinearAlgebra::distributed::Vector<S1> &, const LinearAlgebra::distributed::Vector<S1> &) const;
-    template void SparseMatrix<S1>::
-    Tvmult (LinearAlgebra::distributed::Vector<S1> &, const LinearAlgebra::distributed::Vector<S1> &) const;
-    template void SparseMatrix<S1>::
-    vmult_add (LinearAlgebra::distributed::Vector<S1> &, const LinearAlgebra::distributed::Vector<S1> &) const;
-    template void SparseMatrix<S1>::
-    Tvmult_add (LinearAlgebra::distributed::Vector<S1> &, const LinearAlgebra::distributed::Vector<S1> &) const;
-}
+  {
+    template void SparseMatrix<S1>::vmult(
+      LinearAlgebra::distributed::Vector<S1> &,
+      const LinearAlgebra::distributed::Vector<S1> &) const;
+    template void SparseMatrix<S1>::Tvmult(
+      LinearAlgebra::distributed::Vector<S1> &,
+      const LinearAlgebra::distributed::Vector<S1> &) const;
+    template void SparseMatrix<S1>::vmult_add(
+      LinearAlgebra::distributed::Vector<S1> &,
+      const LinearAlgebra::distributed::Vector<S1> &) const;
+    template void SparseMatrix<S1>::Tvmult_add(
+      LinearAlgebra::distributed::Vector<S1> &,
+      const LinearAlgebra::distributed::Vector<S1> &) const;
+  }
 
-for (S1, S2, S3: REAL_SCALARS)
-{
-    template void SparseMatrix<S1>::
-    mmult (SparseMatrix<S2> &, const SparseMatrix<S3> &, const Vector<S1>&,
-           const bool) const;
-    template void SparseMatrix<S1>::
-    Tmmult (SparseMatrix<S2> &, const SparseMatrix<S3> &, const Vector<S1>&,
-            const bool) const;
-}
+for (S1, S2, S3 : REAL_SCALARS)
+  {
+    template void SparseMatrix<S1>::mmult(SparseMatrix<S2> &,
+                                          const SparseMatrix<S3> &,
+                                          const Vector<S1> &,
+                                          const bool) const;
+    template void SparseMatrix<S1>::Tmmult(SparseMatrix<S2> &,
+                                           const SparseMatrix<S3> &,
+                                           const Vector<S1> &,
+                                           const bool) const;
+  }
 
 
 
 // complex instantiations
 
 for (S : COMPLEX_SCALARS)
-{
+  {
     template class SparseMatrix<S>;
-}
+  }
 
 
 
 for (S1, S2 : COMPLEX_SCALARS)
-{
-    template SparseMatrix<S1> &
-    SparseMatrix<S1>::copy_from<S2> (const SparseMatrix<S2> &);
+  {
+    template SparseMatrix<S1> &SparseMatrix<S1>::copy_from<S2>(
+      const SparseMatrix<S2> &);
 
-    template
-    void SparseMatrix<S1>::copy_from<S2> (const FullMatrix<S2> &);
+    template void SparseMatrix<S1>::copy_from<S2>(const FullMatrix<S2> &);
 
-    template void SparseMatrix<S1>::add<S2> (const S1,
-            const SparseMatrix<S2> &);
+    template void SparseMatrix<S1>::add<S2>(const S1, const SparseMatrix<S2> &);
 
-    template void SparseMatrix<S1>::add<S2> (const size_type,
-            const size_type,
-            const size_type *,
-            const S2 *,
-            const bool,
-            const bool);
+    template void SparseMatrix<S1>::add<S2>(const size_type,
+                                            const size_type,
+                                            const size_type *,
+                                            const S2 *,
+                                            const bool,
+                                            const bool);
 
-    template void SparseMatrix<S1>::set<S2> (const size_type,
-            const size_type,
-            const size_type *,
-            const S2 *,
-            const bool);
-}
+    template void SparseMatrix<S1>::set<S2>(const size_type,
+                                            const size_type,
+                                            const size_type *,
+                                            const S2 *,
+                                            const bool);
+  }
 
 
 for (S1, S2 : COMPLEX_SCALARS)
-{
-    template S2
-    SparseMatrix<S1>::
-    matrix_norm_square<S2> (const Vector<S2> &) const;
+  {
+    template S2 SparseMatrix<S1>::matrix_norm_square<S2>(const Vector<S2> &)
+      const;
 
-    template S2
-    SparseMatrix<S1>::
-    matrix_scalar_product<S2> (const Vector<S2> &,
-                               const Vector<S2> &) const;
+    template S2 SparseMatrix<S1>::matrix_scalar_product<S2>(
+      const Vector<S2> &, const Vector<S2> &) const;
 
-    template S2 SparseMatrix<S1>::
-    residual<S2> (Vector<S2> &,
-                  const Vector<S2> &,
-                  const Vector<S2> &) const;
+    template S2 SparseMatrix<S1>::residual<S2>(
+      Vector<S2> &, const Vector<S2> &, const Vector<S2> &) const;
 
-    template void SparseMatrix<S1>::
-    precondition_SSOR<S2> (Vector<S2> &,
-                           const Vector<S2> &,
-                           const S1,
-                           const std::vector<std::size_t>&) const;
+    template void SparseMatrix<S1>::precondition_SSOR<S2>(
+      Vector<S2> &,
+      const Vector<S2> &,
+      const S1,
+      const std::vector<std::size_t> &) const;
 
-    template void SparseMatrix<S1>::
-    precondition_SOR<S2> (Vector<S2> &,
-                          const Vector<S2> &,
-                          const S1) const;
+    template void SparseMatrix<S1>::precondition_SOR<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
 
-    template void SparseMatrix<S1>::
-    precondition_TSOR<S2> (Vector<S2> &,
-                           const Vector<S2> &,
-                           const S1) const;
+    template void SparseMatrix<S1>::precondition_TSOR<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
 
-    template void SparseMatrix<S1>::
-    precondition_Jacobi<S2> (Vector<S2> &,
-                             const Vector<S2> &,
-                             const S1) const;
+    template void SparseMatrix<S1>::precondition_Jacobi<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
 
-    template void SparseMatrix<S1>::
-    SOR<S2> (Vector<S2> &,
-             const S1) const;
-    template void SparseMatrix<S1>::
-    TSOR<S2> (Vector<S2> &,
-              const S1) const;
-    template void SparseMatrix<S1>::
-    SSOR<S2> (Vector<S2> &,
-              const S1) const;
-    template void SparseMatrix<S1>::
-    PSOR<S2> (Vector<S2> &,
-              const std::vector<size_type>&,
-              const std::vector<size_type>&,
-              const S1) const;
-    template void SparseMatrix<S1>::
-    TPSOR<S2> (Vector<S2> &,
-               const std::vector<size_type>&,
-               const std::vector<size_type>&,
-               const S1) const;
-    template void SparseMatrix<S1>::
-    Jacobi_step<S2> (Vector<S2> &,
-                     const Vector<S2> &,
-                     const S1) const;
-    template void SparseMatrix<S1>::
-    SOR_step<S2> (Vector<S2> &,
-                  const Vector<S2> &,
-                  const S1) const;
-    template void SparseMatrix<S1>::
-    TSOR_step<S2> (Vector<S2> &,
-                   const Vector<S2> &,
-                   const S1) const;
-    template void SparseMatrix<S1>::
-    SSOR_step<S2> (Vector<S2> &,
-                   const Vector<S2> &,
-                   const S1) const;
-}
+    template void SparseMatrix<S1>::SOR<S2>(Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::TSOR<S2>(Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::SSOR<S2>(Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::PSOR<S2>(Vector<S2> &,
+                                             const std::vector<size_type> &,
+                                             const std::vector<size_type> &,
+                                             const S1) const;
+    template void SparseMatrix<S1>::TPSOR<S2>(Vector<S2> &,
+                                              const std::vector<size_type> &,
+                                              const std::vector<size_type> &,
+                                              const S1) const;
+    template void SparseMatrix<S1>::Jacobi_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::SOR_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::TSOR_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+    template void SparseMatrix<S1>::SSOR_step<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+  }
 
-for (S1, S2, S3 : COMPLEX_SCALARS;
-        V1, V2     : DEAL_II_VEC_TEMPLATES)
-{
-    template void SparseMatrix<S1>::
-    vmult (V1<S2> &, const V2<S3> &) const;
-    template void SparseMatrix<S1>::
-    Tvmult (V1<S2> &, const V2<S3> &) const;
-    template void SparseMatrix<S1>::
-    vmult_add (V1<S2> &, const V2<S3> &) const;
-    template void SparseMatrix<S1>::
-    Tvmult_add (V1<S2> &, const V2<S3> &) const;
-}
+for (S1, S2, S3 : COMPLEX_SCALARS; V1, V2 : DEAL_II_VEC_TEMPLATES)
+  {
+    template void SparseMatrix<S1>::vmult(V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::Tvmult(V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::vmult_add(V1<S2> &, const V2<S3> &) const;
+    template void SparseMatrix<S1>::Tvmult_add(V1<S2> &, const V2<S3> &) const;
+  }
 
-for (S1, S2, S3: COMPLEX_SCALARS)
-{
-    template void SparseMatrix<S1>::
-    mmult (SparseMatrix<S2> &, const SparseMatrix<S3> &, const Vector<S1>&,
-           const bool) const;
-    template void SparseMatrix<S1>::
-    Tmmult (SparseMatrix<S2> &, const SparseMatrix<S3> &, const Vector<S1>&,
-            const bool) const;
-}
+for (S1, S2, S3 : COMPLEX_SCALARS)
+  {
+    template void SparseMatrix<S1>::mmult(SparseMatrix<S2> &,
+                                          const SparseMatrix<S3> &,
+                                          const Vector<S1> &,
+                                          const bool) const;
+    template void SparseMatrix<S1>::Tmmult(SparseMatrix<S2> &,
+                                           const SparseMatrix<S3> &,
+                                           const Vector<S1> &,
+                                           const bool) const;
+  }

--- a/source/lac/sparse_matrix_ez.inst.in
+++ b/source/lac/sparse_matrix_ez.inst.in
@@ -16,42 +16,31 @@
 
 
 for (S : REAL_SCALARS)
-{
+  {
     template class SparseMatrixEZ<S>;
-}
+  }
 
 
 for (S1, S2 : REAL_SCALARS)
-{
-    template
-    void SparseMatrixEZ<S1>::vmult<S2> (Vector<S2> &,
-                                        const Vector<S2> &) const;
-    template
-    void SparseMatrixEZ<S1>::Tvmult<S2> (Vector<S2> &,
-                                         const Vector<S2> &) const;
-    template
-    void SparseMatrixEZ<S1>::vmult_add<S2> (Vector<S2> &,
-                                            const Vector<S2> &) const;
-    template
-    void SparseMatrixEZ<S1>::Tvmult_add<S2> (Vector<S2> &,
-            const Vector<S2> &) const;
+  {
+    template void SparseMatrixEZ<S1>::vmult<S2>(Vector<S2> &,
+                                                const Vector<S2> &) const;
+    template void SparseMatrixEZ<S1>::Tvmult<S2>(Vector<S2> &,
+                                                 const Vector<S2> &) const;
+    template void SparseMatrixEZ<S1>::vmult_add<S2>(Vector<S2> &,
+                                                    const Vector<S2> &) const;
+    template void SparseMatrixEZ<S1>::Tvmult_add<S2>(Vector<S2> &,
+                                                     const Vector<S2> &) const;
 
-    template
-    void SparseMatrixEZ<S1>::precondition_SSOR<S2> (Vector<S2> &,
-            const Vector<S2> &,
-            const S1,
-            const std::vector<std::size_t>&) const;
-    template
-    void SparseMatrixEZ<S1>::precondition_SOR<S2> (Vector<S2> &,
-            const Vector<S2> &,
-            const S1) const;
-    template
-    void SparseMatrixEZ<S1>::precondition_TSOR<S2> (Vector<S2> &,
-            const Vector<S2> &,
-            const S1) const;
-    template
-    void SparseMatrixEZ<S1>::precondition_Jacobi<S2> (Vector<S2> &,
-            const Vector<S2> &,
-            const S1) const;
-}
-
+    template void SparseMatrixEZ<S1>::precondition_SSOR<S2>(
+      Vector<S2> &,
+      const Vector<S2> &,
+      const S1,
+      const std::vector<std::size_t> &) const;
+    template void SparseMatrixEZ<S1>::precondition_SOR<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+    template void SparseMatrixEZ<S1>::precondition_TSOR<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+    template void SparseMatrixEZ<S1>::precondition_Jacobi<S2>(
+      Vector<S2> &, const Vector<S2> &, const S1) const;
+  }

--- a/source/lac/trilinos_sparse_matrix.inst.in
+++ b/source/lac/trilinos_sparse_matrix.inst.in
@@ -16,34 +16,34 @@
 
 
 for (S : REAL_SCALARS)
-{
+  {
     namespace TrilinosWrappers
     \{
-    template void
-    SparseMatrix::reinit (const dealii::SparseMatrix<S> &,
-                          const double,
-                          const bool,
-                          const dealii::SparsityPattern *);
-    template void
-    SparseMatrix::reinit (const Epetra_Map &,
-                          const dealii::SparseMatrix<S> &,
-                          const double,
-                          const bool,
-                          const dealii::SparsityPattern *);
-    template void
-    SparseMatrix::reinit (const Epetra_Map &,
-                          const Epetra_Map &,
-                          const dealii::SparseMatrix<S> &,
-                          const double,
-                          const bool,
-                          const dealii::SparsityPattern *);
-    template void
-    SparseMatrix::reinit (const IndexSet &,
-                          const IndexSet &,
-                          const dealii::SparseMatrix<S> &,
-                          const MPI_Comm &,
-                          const double,
-                          const bool,
-                          const dealii::SparsityPattern *);
+      template void
+      SparseMatrix::reinit(const dealii::SparseMatrix<S> &,
+                           const double,
+                           const bool,
+                           const dealii::SparsityPattern *);
+      template void
+      SparseMatrix::reinit(const Epetra_Map &,
+                           const dealii::SparseMatrix<S> &,
+                           const double,
+                           const bool,
+                           const dealii::SparsityPattern *);
+      template void
+      SparseMatrix::reinit(const Epetra_Map &,
+                           const Epetra_Map &,
+                           const dealii::SparseMatrix<S> &,
+                           const double,
+                           const bool,
+                           const dealii::SparsityPattern *);
+      template void
+      SparseMatrix::reinit(const IndexSet &,
+                           const IndexSet &,
+                           const dealii::SparseMatrix<S> &,
+                           const MPI_Comm &,
+                           const double,
+                           const bool,
+                           const dealii::SparsityPattern *);
     \}
-}
+  }

--- a/source/lac/trilinos_vector.inst.in
+++ b/source/lac/trilinos_vector.inst.in
@@ -16,8 +16,6 @@
 
 
 for (SCALAR : REAL_SCALARS)
-{
-    template
-    Vector &
-    Vector::operator = (const ::dealii::Vector<SCALAR> &v);
-}
+  {
+    template Vector &Vector::operator=(const ::dealii::Vector<SCALAR> &v);
+  }

--- a/source/lac/vector.inst.in
+++ b/source/lac/vector.inst.in
@@ -16,38 +16,26 @@
 
 
 for (SCALAR : REAL_AND_COMPLEX_SCALARS)
-{
+  {
     template class Vector<SCALAR>;
-}
+  }
 
 for (S1, S2 : REAL_SCALARS)
-{
-    template
-    bool
-    Vector<S1>::operator==<S2>(const Vector<S2>&) const;
-    template
-    S1
-    Vector<S1>::operator*<S2>(const Vector<S2>&) const;
-    template
-    void Vector<S1>::reinit<S2>(const Vector<S2>&, const bool);
-}
+  {
+    template bool Vector<S1>::operator==<S2>(const Vector<S2> &) const;
+    template S1 Vector<S1>::operator*<S2>(const Vector<S2> &) const;
+    template void Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
+  }
 
 for (S1, S2 : COMPLEX_SCALARS)
-{
-    template
-    bool
-    Vector<S1>::operator==<S2>(const Vector<S2>&) const;
-    template
-    S1
-    Vector<S1>::operator*<S2>(const Vector<S2>&) const;
-    template
-    void Vector<S1>::reinit<S2>(const Vector<S2>&, const bool);
-}
+  {
+    template bool Vector<S1>::operator==<S2>(const Vector<S2> &) const;
+    template S1 Vector<S1>::operator*<S2>(const Vector<S2> &) const;
+    template void Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
+  }
 
-for (S1: COMPLEX_SCALARS; S2: REAL_SCALARS)
-{
-    template
-    Vector<S1>& Vector<S1>::operator=<S2> (const Vector<S2> &);
-    template
-    void Vector<S1>::reinit<S2>(const Vector<S2>&, const bool);
-}
+for (S1 : COMPLEX_SCALARS; S2 : REAL_SCALARS)
+  {
+    template Vector<S1> &Vector<S1>::operator=<S2>(const Vector<S2> &);
+    template void Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
+  }

--- a/source/lac/vector_memory.inst.in
+++ b/source/lac/vector_memory.inst.in
@@ -16,7 +16,7 @@
 
 
 for (VECTOR : VECTOR_TYPES)
-{
+  {
     template class VectorMemory<VECTOR>;
     template class GrowingVectorMemory<VECTOR>;
-}
+  }

--- a/source/lac/vector_memory_release.inst.in
+++ b/source/lac/vector_memory_release.inst.in
@@ -16,6 +16,6 @@
 
 
 for (VECTOR : VECTOR_TYPES)
-{
+  {
     dealii::GrowingVectorMemory<dealii::VECTOR>::release_unused_memory();
-}
+  }

--- a/source/lac/vector_view.inst.in
+++ b/source/lac/vector_view.inst.in
@@ -16,11 +16,11 @@
 
 
 for (SCALAR : REAL_SCALARS)
-{
+  {
     template class VectorView<SCALAR>;
-}
+  }
 
 for (SCALAR : COMPLEX_SCALARS)
-{
+  {
     template class VectorView<SCALAR>;
-}
+  }

--- a/source/matrix_free/cuda_matrix_free.inst.in
+++ b/source/matrix_free/cuda_matrix_free.inst.in
@@ -15,7 +15,7 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template class MatrixFree<deal_II_dimension,double>;
-    template class MatrixFree<deal_II_dimension,float>;
-}
+  {
+    template class MatrixFree<deal_II_dimension, double>;
+    template class MatrixFree<deal_II_dimension, float>;
+  }

--- a/source/matrix_free/evaluation_selector.inst.in
+++ b/source/matrix_free/evaluation_selector.inst.in
@@ -14,22 +14,36 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; components : SPACE_DIMENSIONS; scalar_type : REAL_SCALARS)
-{
-    template
-    void
-    SelectEvaluator<deal_II_dimension, -1, 0, components, VectorizedArray<scalar_type> >::integrate
-    (const internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<scalar_type> > &shape_info,
-     VectorizedArray<scalar_type> *, VectorizedArray<scalar_type> *,
-     VectorizedArray<scalar_type> *, VectorizedArray<scalar_type> *,
-     const bool, const bool);
+for (deal_II_dimension : DIMENSIONS; components : SPACE_DIMENSIONS;
+     scalar_type : REAL_SCALARS)
+  {
+    template void SelectEvaluator<deal_II_dimension,
+                                  -1,
+                                  0,
+                                  components,
+                                  VectorizedArray<scalar_type>>::
+      integrate(const internal::MatrixFreeFunctions::ShapeInfo<
+                  VectorizedArray<scalar_type>> &shape_info,
+                VectorizedArray<scalar_type> *,
+                VectorizedArray<scalar_type> *,
+                VectorizedArray<scalar_type> *,
+                VectorizedArray<scalar_type> *,
+                const bool,
+                const bool);
 
-    template
-    void
-    SelectEvaluator<deal_II_dimension, -1, 0, components, VectorizedArray<scalar_type> >::evaluate
-    (const internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<scalar_type> > &shape_info,
-     VectorizedArray<scalar_type> *, VectorizedArray<scalar_type> *,
-     VectorizedArray<scalar_type> *,
-     VectorizedArray<scalar_type> *,
-     VectorizedArray<scalar_type> *, const bool, const bool, const bool);
-}
+    template void SelectEvaluator<deal_II_dimension,
+                                  -1,
+                                  0,
+                                  components,
+                                  VectorizedArray<scalar_type>>::
+      evaluate(const internal::MatrixFreeFunctions::ShapeInfo<
+                 VectorizedArray<scalar_type>> &shape_info,
+               VectorizedArray<scalar_type> *,
+               VectorizedArray<scalar_type> *,
+               VectorizedArray<scalar_type> *,
+               VectorizedArray<scalar_type> *,
+               VectorizedArray<scalar_type> *,
+               const bool,
+               const bool,
+               const bool);
+  }

--- a/source/matrix_free/mapping_info.inst.in
+++ b/source/matrix_free/mapping_info.inst.in
@@ -15,25 +15,39 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template struct internal::MatrixFreeFunctions::MappingInfo<deal_II_dimension,double>;
-    template struct internal::MatrixFreeFunctions::MappingInfo<deal_II_dimension,float>;
+  {
+    template struct internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double>;
+    template struct internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float>;
 
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<deal_II_dimension,deal_II_dimension,double>;
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<deal_II_dimension,deal_II_dimension,float>;
+    template struct internal::MatrixFreeFunctions::
+      MappingInfoStorage<deal_II_dimension, deal_II_dimension, double>;
+    template struct internal::MatrixFreeFunctions::
+      MappingInfoStorage<deal_II_dimension, deal_II_dimension, float>;
 #if deal_II_dimension > 1
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<deal_II_dimension-1,deal_II_dimension,double>;
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<deal_II_dimension-1,deal_II_dimension,float>;
+    template struct internal::MatrixFreeFunctions::
+      MappingInfoStorage<deal_II_dimension - 1, deal_II_dimension, double>;
+    template struct internal::MatrixFreeFunctions::
+      MappingInfoStorage<deal_II_dimension - 1, deal_II_dimension, float>;
 #endif
 
-    template void internal::MatrixFreeFunctions::MappingInfo<deal_II_dimension,double>::
-    print_memory_consumption<std::ostream> (std::ostream &, const TaskInfo&) const;
-    template void internal::MatrixFreeFunctions::MappingInfo<deal_II_dimension,double>::
-    print_memory_consumption<ConditionalOStream> (ConditionalOStream &,const TaskInfo&) const;
+    template void internal::MatrixFreeFunctions::MappingInfo<
+      deal_II_dimension,
+      double>::print_memory_consumption<std::ostream>(std::ostream &,
+                                                      const TaskInfo &) const;
+    template void
+    internal::MatrixFreeFunctions::MappingInfo<deal_II_dimension, double>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
+                                                   const TaskInfo &) const;
 
-    template void internal::MatrixFreeFunctions::MappingInfo<deal_II_dimension,float>::
-    print_memory_consumption<std::ostream> (std::ostream &, const TaskInfo&) const;
-    template void internal::MatrixFreeFunctions::MappingInfo<deal_II_dimension,float>::
-    print_memory_consumption<ConditionalOStream> (ConditionalOStream &, const TaskInfo&) const;
-
-}
+    template void internal::MatrixFreeFunctions::MappingInfo<
+      deal_II_dimension,
+      float>::print_memory_consumption<std::ostream>(std::ostream &,
+                                                     const TaskInfo &) const;
+    template void internal::MatrixFreeFunctions::MappingInfo<
+      deal_II_dimension,
+      float>::print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
+                                                           const TaskInfo &)
+      const;
+  }

--- a/source/matrix_free/matrix_free.inst.in
+++ b/source/matrix_free/matrix_free.inst.in
@@ -15,58 +15,58 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template class MatrixFree<deal_II_dimension,double>;
-    template class MatrixFree<deal_II_dimension,float>;
+  {
+    template class MatrixFree<deal_II_dimension, double>;
+    template class MatrixFree<deal_II_dimension, float>;
 
-    template void MatrixFree<deal_II_dimension,double>::
-    print_memory_consumption<std::ostream> (std::ostream &) const;
-    template void MatrixFree<deal_II_dimension,double>::
-    print_memory_consumption<ConditionalOStream> (ConditionalOStream &) const;
+    template void
+    MatrixFree<deal_II_dimension,
+               double>::print_memory_consumption<std::ostream>(std::ostream &)
+      const;
+    template void MatrixFree<deal_II_dimension, double>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
 
-    template void MatrixFree<deal_II_dimension,float>::
-    print_memory_consumption<std::ostream> (std::ostream &) const;
-    template void MatrixFree<deal_II_dimension,float>::
-    print_memory_consumption<ConditionalOStream> (ConditionalOStream &) const;
+    template void
+    MatrixFree<deal_II_dimension,
+               float>::print_memory_consumption<std::ostream>(std::ostream &)
+      const;
+    template void MatrixFree<deal_II_dimension, float>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
 
 #ifndef DEAL_II_MSVC
-    template
-    void
-    internal::MatrixFreeFunctions::ShapeInfo<double>::
-    reinit<deal_II_dimension>(const Quadrature<1> &,
-                              const FiniteElement<deal_II_dimension,deal_II_dimension> &,
-                              const unsigned int);
+    template void
+    internal::MatrixFreeFunctions::ShapeInfo<double>::reinit<deal_II_dimension>(
+      const Quadrature<1> &,
+      const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+      const unsigned int);
 
-    template
-    void
-    internal::MatrixFreeFunctions::ShapeInfo<float>::
-    reinit<deal_II_dimension>(const Quadrature<1> &,
-                              const FiniteElement<deal_II_dimension,deal_II_dimension> &,
-                              const unsigned int);
+    template void
+    internal::MatrixFreeFunctions::ShapeInfo<float>::reinit<deal_II_dimension>(
+      const Quadrature<1> &,
+      const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+      const unsigned int);
 
-    template
-    void
-    internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<double> >::
-    reinit<deal_II_dimension>(const Quadrature<1> &,
-                              const FiniteElement<deal_II_dimension,deal_II_dimension> &,
-                              const unsigned int);
+    template void internal::MatrixFreeFunctions::
+      ShapeInfo<VectorizedArray<double>>::reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
 
-    template
-    void
-    internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<float > >::
-    reinit<deal_II_dimension>(const Quadrature<1> &,
-                              const FiniteElement<deal_II_dimension,deal_II_dimension> &,
-                              const unsigned int);
+    template void internal::MatrixFreeFunctions::
+      ShapeInfo<VectorizedArray<float>>::reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
 #endif
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template bool MatrixFree<deal_II_dimension, double>::
-    is_supported(const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+    template bool MatrixFree<deal_II_dimension, double>::is_supported(
+      const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
 
-    template bool MatrixFree<deal_II_dimension, float>::
-    is_supported(const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+    template bool MatrixFree<deal_II_dimension, float>::is_supported(
+      const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
 #endif
-}
+  }

--- a/source/meshworker/mesh_worker_info.inst.in
+++ b/source/meshworker/mesh_worker_info.inst.in
@@ -14,27 +14,39 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
     namespace MeshWorker
     \{
 #if deal_II_dimension <= deal_II_space_dimension
-    template class IntegrationInfo<deal_II_dimension, deal_II_space_dimension>;
-    template class IntegrationInfoBox<deal_II_dimension, deal_II_space_dimension>;
+      template class IntegrationInfo<deal_II_dimension,
+                                     deal_II_space_dimension>;
+      template class IntegrationInfoBox<deal_II_dimension,
+                                        deal_II_space_dimension>;
 
-    template class DoFInfo<deal_II_dimension, deal_II_space_dimension,float>;
-    template class DoFInfoBox<deal_II_dimension,
-                              DoFInfo<deal_II_dimension, deal_II_space_dimension,float> >;
+      template class DoFInfo<deal_II_dimension, deal_II_space_dimension, float>;
+      template class DoFInfoBox<
+        deal_II_dimension,
+        DoFInfo<deal_II_dimension, deal_II_space_dimension, float>>;
 
-    template void IntegrationInfo<deal_II_dimension, deal_II_space_dimension>::fill_local_data(
-        const DoFInfo<deal_II_dimension, deal_II_space_dimension, float>&, bool);
+      template void
+      IntegrationInfo<deal_II_dimension, deal_II_space_dimension>::
+        fill_local_data(
+          const DoFInfo<deal_II_dimension, deal_II_space_dimension, float> &,
+          bool);
 
-    template class DoFInfo<deal_II_dimension, deal_II_space_dimension,double>;
-    template class DoFInfoBox<deal_II_dimension,
-                              DoFInfo<deal_II_dimension, deal_II_space_dimension,double> >;
+      template class DoFInfo<deal_II_dimension,
+                             deal_II_space_dimension,
+                             double>;
+      template class DoFInfoBox<
+        deal_II_dimension,
+        DoFInfo<deal_II_dimension, deal_II_space_dimension, double>>;
 
-    template void IntegrationInfo<deal_II_dimension, deal_II_space_dimension>::fill_local_data(
-        const DoFInfo<deal_II_dimension, deal_II_space_dimension, double>&, bool);
+      template void
+      IntegrationInfo<deal_II_dimension, deal_II_space_dimension>::
+        fill_local_data(
+          const DoFInfo<deal_II_dimension, deal_II_space_dimension, double> &,
+          bool);
 #endif
     \}
-}
+  }

--- a/source/meshworker/mesh_worker_vector_selector.inst.in
+++ b/source/meshworker/mesh_worker_vector_selector.inst.in
@@ -15,25 +15,34 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
     namespace MeshWorker
     \{
 #if deal_II_dimension <= deal_II_space_dimension
-    template class VectorDataBase<deal_II_dimension, deal_II_space_dimension>;
+      template class VectorDataBase<deal_II_dimension, deal_II_space_dimension>;
 #endif
     \}
-}
+  }
 
-for (VECTOR : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VECTOR : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
     namespace MeshWorker
     \{
 #if deal_II_dimension <= deal_II_space_dimension
-    template class VectorData<VECTOR, deal_II_dimension, deal_II_space_dimension>;
-    template class VectorData<const VECTOR, deal_II_dimension, deal_II_space_dimension>;
-    template class MGVectorData<VECTOR, deal_II_dimension, deal_II_space_dimension>;
-    template class MGVectorData<const VECTOR, deal_II_dimension, deal_II_space_dimension>;
+      template class VectorData<VECTOR,
+                                deal_II_dimension,
+                                deal_II_space_dimension>;
+      template class VectorData<const VECTOR,
+                                deal_II_dimension,
+                                deal_II_space_dimension>;
+      template class MGVectorData<VECTOR,
+                                  deal_II_dimension,
+                                  deal_II_space_dimension>;
+      template class MGVectorData<const VECTOR,
+                                  deal_II_dimension,
+                                  deal_II_space_dimension>;
 #endif
     \}
-}
+  }

--- a/source/multigrid/mg_base.inst.in
+++ b/source/multigrid/mg_base.inst.in
@@ -15,9 +15,9 @@
 
 
 for (VEC : VECTOR_TYPES)
-{
-    template class MGTransferBase< VEC >;
-    template class MGMatrixBase< VEC >;
-    template class MGSmootherBase< VEC >;
-    template class MGCoarseGridBase< VEC >;
-}
+  {
+    template class MGTransferBase<VEC>;
+    template class MGMatrixBase<VEC>;
+    template class MGSmootherBase<VEC>;
+    template class MGCoarseGridBase<VEC>;
+  }

--- a/source/multigrid/mg_level_global_transfer.inst.in
+++ b/source/multigrid/mg_level_global_transfer.inst.in
@@ -16,81 +16,109 @@
 
 
 for (V1 : VECTORS_WITH_MATRIX)
-{
-    template class MGLevelGlobalTransfer< V1 >;
-}
+  {
+    template class MGLevelGlobalTransfer<V1>;
+  }
 
 for (deal_II_dimension : DIMENSIONS; V1 : VECTORS_WITH_MATRIX)
-{
-    template
-    void MGLevelGlobalTransfer< V1 >::fill_and_communicate_copy_indices<deal_II_dimension,deal_II_dimension>(
-        const DoFHandler<deal_II_dimension,deal_II_dimension> &mg_dof);
-}
+  {
+    template void MGLevelGlobalTransfer<V1>::
+      fill_and_communicate_copy_indices<deal_II_dimension, deal_II_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_dimension> &mg_dof);
+  }
 
-for (deal_II_dimension : DIMENSIONS; V1,V2 : DEAL_II_VEC_TEMPLATES; S1, S2 : REAL_SCALARS)
-{
-    template void
-    MGLevelGlobalTransfer<V1<S1> >::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&, MGLevelObject<V1<S1> >&, const V2<S2>&) const;
-    template void
-    MGLevelGlobalTransfer<V1<S1> >::copy_from_mg (const DoFHandler<deal_II_dimension>&, V2<S2>&,
-            const MGLevelObject<V1<S1> >&) const;
-    template void
-    MGLevelGlobalTransfer<V1<S1> >::copy_from_mg_add (const DoFHandler<deal_II_dimension>&, V2<S2>&,
-            const MGLevelObject<V1<S1> >&) const;
-}
+for (deal_II_dimension : DIMENSIONS; V1, V2 : DEAL_II_VEC_TEMPLATES;
+     S1, S2 : REAL_SCALARS)
+  {
+    template void MGLevelGlobalTransfer<V1<S1>>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<V1<S1>> &,
+      const V2<S2> &) const;
+    template void MGLevelGlobalTransfer<V1<S1>>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      V2<S2> &,
+      const MGLevelObject<V1<S1>> &) const;
+    template void MGLevelGlobalTransfer<V1<S1>>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      V2<S2> &,
+      const MGLevelObject<V1<S1>> &) const;
+  }
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template
-    void MGLevelGlobalTransfer< LinearAlgebra::distributed::Vector<float> >::fill_and_communicate_copy_indices<deal_II_dimension,deal_II_dimension>(
-        const DoFHandler<deal_II_dimension,deal_II_dimension> &mg_dof);
-    template
-    void MGLevelGlobalTransfer< LinearAlgebra::distributed::Vector<float> >::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&, MGLevelObject<LinearAlgebra::distributed::Vector<float>>&, const LinearAlgebra::distributed::Vector<float>&, const bool) const;
-    template
-    void MGLevelGlobalTransfer< LinearAlgebra::distributed::Vector<double> >::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&, MGLevelObject<LinearAlgebra::distributed::Vector<double>>&, const LinearAlgebra::distributed::Vector<double>&, const bool) const;
-
-}
+  {
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<float>>::
+      fill_and_communicate_copy_indices<deal_II_dimension, deal_II_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_dimension> &mg_dof);
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<float>>::
+      copy_to_mg(const DoFHandler<deal_II_dimension> &,
+                 MGLevelObject<LinearAlgebra::distributed::Vector<float>> &,
+                 const LinearAlgebra::distributed::Vector<float> &,
+                 const bool) const;
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<double>>::
+      copy_to_mg(const DoFHandler<deal_II_dimension> &,
+                 MGLevelObject<LinearAlgebra::distributed::Vector<double>> &,
+                 const LinearAlgebra::distributed::Vector<double> &,
+                 const bool) const;
+  }
 
 for (deal_II_dimension : DIMENSIONS; S1, S2 : REAL_SCALARS)
-{
+  {
     template void
-    MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<S1> >::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&, MGLevelObject<LinearAlgebra::distributed::Vector<S1> >&, const LinearAlgebra::distributed::Vector<S2>&) const;
+    MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<S1>>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<LinearAlgebra::distributed::Vector<S1>> &,
+      const LinearAlgebra::distributed::Vector<S2> &) const;
     template void
-    MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<S1> >::copy_from_mg (const DoFHandler<deal_II_dimension>&, LinearAlgebra::distributed::Vector<S2>&,
-            const MGLevelObject<LinearAlgebra::distributed::Vector<S1> >&) const;
+    MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<S1>>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      LinearAlgebra::distributed::Vector<S2> &,
+      const MGLevelObject<LinearAlgebra::distributed::Vector<S1>> &) const;
     template void
-    MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<S1> >::copy_from_mg_add (const DoFHandler<deal_II_dimension>&, LinearAlgebra::distributed::Vector<S2>&,
-            const MGLevelObject<LinearAlgebra::distributed::Vector<S1> >&) const;
-}
+    MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<S1>>::
+      copy_from_mg_add(
+        const DoFHandler<deal_II_dimension> &,
+        LinearAlgebra::distributed::Vector<S2> &,
+        const MGLevelObject<LinearAlgebra::distributed::Vector<S1>> &) const;
+  }
 
-for(deal_II_dimension : DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS)
+  {
 #ifdef DEAL_II_WITH_TRILINOS
 
     template void
-    MGLevelGlobalTransfer<TrilinosWrappers::MPI::Vector>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&, MGLevelObject<TrilinosWrappers::MPI::Vector>&, const TrilinosWrappers::MPI::Vector&) const;
+    MGLevelGlobalTransfer<TrilinosWrappers::MPI::Vector>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<TrilinosWrappers::MPI::Vector> &,
+      const TrilinosWrappers::MPI::Vector &) const;
     template void
-    MGLevelGlobalTransfer<TrilinosWrappers::MPI::Vector>::copy_from_mg (const DoFHandler<deal_II_dimension>&, TrilinosWrappers::MPI::Vector&,
-            const MGLevelObject<TrilinosWrappers::MPI::Vector>&) const;
+    MGLevelGlobalTransfer<TrilinosWrappers::MPI::Vector>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      TrilinosWrappers::MPI::Vector &,
+      const MGLevelObject<TrilinosWrappers::MPI::Vector> &) const;
     template void
-    MGLevelGlobalTransfer<TrilinosWrappers::MPI::Vector>::copy_from_mg_add (const DoFHandler<deal_II_dimension>&, TrilinosWrappers::MPI::Vector&,
-            const MGLevelObject<TrilinosWrappers::MPI::Vector>&) const;
+    MGLevelGlobalTransfer<TrilinosWrappers::MPI::Vector>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      TrilinosWrappers::MPI::Vector &,
+      const MGLevelObject<TrilinosWrappers::MPI::Vector> &) const;
 #endif
 
 #ifdef DEAL_II_WITH_PETSC
+    template void MGLevelGlobalTransfer<PETScWrappers::MPI::Vector>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<PETScWrappers::MPI::Vector> &,
+      const PETScWrappers::MPI::Vector &) const;
     template void
-    MGLevelGlobalTransfer<PETScWrappers::MPI::Vector>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&, MGLevelObject<PETScWrappers::MPI::Vector>&, const PETScWrappers::MPI::Vector&) const;
+    MGLevelGlobalTransfer<PETScWrappers::MPI::Vector>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      PETScWrappers::MPI::Vector &,
+      const MGLevelObject<PETScWrappers::MPI::Vector> &) const;
     template void
-    MGLevelGlobalTransfer<PETScWrappers::MPI::Vector>::copy_from_mg (const DoFHandler<deal_II_dimension>&, PETScWrappers::MPI::Vector&,
-            const MGLevelObject<PETScWrappers::MPI::Vector>&) const;
-    template void
-    MGLevelGlobalTransfer<PETScWrappers::MPI::Vector>::copy_from_mg_add (const DoFHandler<deal_II_dimension>&, PETScWrappers::MPI::Vector&,
-            const MGLevelObject<PETScWrappers::MPI::Vector>&) const;
+    MGLevelGlobalTransfer<PETScWrappers::MPI::Vector>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      PETScWrappers::MPI::Vector &,
+      const MGLevelObject<PETScWrappers::MPI::Vector> &) const;
 #endif
-}
+  }

--- a/source/multigrid/mg_tools.inst.in
+++ b/source/multigrid/mg_tools.inst.in
@@ -16,140 +16,150 @@
 
 
 for (PATTERN : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS;
-        deal_II_space_dimension: SPACE_DIMENSIONS)
-{
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
     namespace MGTools
     \{
 
 #if deal_II_dimension <= deal_II_space_dimension
-    template void
-    make_sparsity_pattern<DoFHandler<deal_II_dimension, deal_II_space_dimension>, PATTERN> (
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        PATTERN &,
-        const unsigned int);
+      template void
+      make_sparsity_pattern<
+        DoFHandler<deal_II_dimension, deal_II_space_dimension>,
+        PATTERN>(const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+                 PATTERN &,
+                 const unsigned int);
 
-    template void
-    make_interface_sparsity_pattern<DoFHandler<deal_II_dimension, deal_II_space_dimension>, PATTERN> (
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const MGConstrainedDoFs &,
-        PATTERN &,
-        const unsigned int);
+      template void
+      make_interface_sparsity_pattern<
+        DoFHandler<deal_II_dimension, deal_II_space_dimension>,
+        PATTERN>(const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+                 const MGConstrainedDoFs &,
+                 PATTERN &,
+                 const unsigned int);
 #endif
 
 #if deal_II_dimension == deal_II_space_dimension
-    template void
-    make_flux_sparsity_pattern<deal_II_dimension> (
+      template void
+      make_flux_sparsity_pattern<deal_II_dimension>(
         const DoFHandler<deal_II_dimension> &,
         PATTERN &,
         const unsigned int);
 
-    template void
-    make_flux_sparsity_pattern_edge<deal_II_dimension> (
+      template void
+      make_flux_sparsity_pattern_edge<deal_II_dimension>(
         const DoFHandler<deal_II_dimension> &,
         PATTERN &,
         const unsigned int);
 
-#if deal_II_dimension > 1
+#  if deal_II_dimension > 1
 
-    template void
-    make_flux_sparsity_pattern<deal_II_dimension> (
+      template void
+      make_flux_sparsity_pattern<deal_II_dimension>(
         const DoFHandler<deal_II_dimension> &,
         PATTERN &,
         const unsigned int,
-        const Table<2,DoFTools::Coupling>&,
-        const Table<2,DoFTools::Coupling>&);
+        const Table<2, DoFTools::Coupling> &,
+        const Table<2, DoFTools::Coupling> &);
 
-    template void
-    make_flux_sparsity_pattern_edge<deal_II_dimension> (
+      template void
+      make_flux_sparsity_pattern_edge<deal_II_dimension>(
         const DoFHandler<deal_II_dimension> &,
         PATTERN &,
         const unsigned int,
-        const Table<2,DoFTools::Coupling>&);
-#endif
+        const Table<2, DoFTools::Coupling> &);
+#  endif
 #endif
     \}
-}
+  }
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace MGTools
     \{
 
 #if deal_II_dimension > 1
-    template void
-    compute_row_length_vector(
-        const DoFHandler<deal_II_dimension>&, unsigned int,
-        std::vector<unsigned int>&, const DoFTools::Coupling);
-    template void
-    compute_row_length_vector(
-        const DoFHandler<deal_II_dimension>&, unsigned int,
-        std::vector<unsigned int>&,
-        const Table<2,DoFTools::Coupling>&, const Table<2,DoFTools::Coupling>&);
+      template void
+      compute_row_length_vector(const DoFHandler<deal_II_dimension> &,
+                                unsigned int,
+                                std::vector<unsigned int> &,
+                                const DoFTools::Coupling);
+      template void
+      compute_row_length_vector(const DoFHandler<deal_II_dimension> &,
+                                unsigned int,
+                                std::vector<unsigned int> &,
+                                const Table<2, DoFTools::Coupling> &,
+                                const Table<2, DoFTools::Coupling> &);
 #endif
 
-    template void count_dofs_per_component (
-        const DoFHandler<deal_II_dimension>&, std::vector<std::vector<types::global_dof_index> >&,
-        bool, std::vector<unsigned int>);
-    template void count_dofs_per_block (
-        const DoFHandler<deal_II_dimension>&, std::vector<std::vector<types::global_dof_index> >&,
+      template void
+      count_dofs_per_component(
+        const DoFHandler<deal_II_dimension> &,
+        std::vector<std::vector<types::global_dof_index>> &,
+        bool,
         std::vector<unsigned int>);
+      template void
+      count_dofs_per_block(const DoFHandler<deal_II_dimension> &,
+                           std::vector<std::vector<types::global_dof_index>> &,
+                           std::vector<unsigned int>);
 
 #if deal_II_dimension > 1
-    template void make_boundary_list(
-        const DoFHandler<deal_II_dimension>&,
-        const FunctionMap<deal_II_dimension>::type&,
-        std::vector<std::set<types::global_dof_index> >&,
-        const ComponentMask &);
+      template void
+      make_boundary_list(const DoFHandler<deal_II_dimension> &,
+                         const FunctionMap<deal_II_dimension>::type &,
+                         std::vector<std::set<types::global_dof_index>> &,
+                         const ComponentMask &);
 #endif
 
-    template void make_boundary_list(
-        const DoFHandler<deal_II_dimension>&,
-        const FunctionMap<deal_II_dimension>::type&,
-        std::vector<IndexSet>&,
-        const ComponentMask &);
+      template void
+      make_boundary_list(const DoFHandler<deal_II_dimension> &,
+                         const FunctionMap<deal_II_dimension>::type &,
+                         std::vector<IndexSet> &,
+                         const ComponentMask &);
 
-    template void  make_boundary_list(
-        const DoFHandler<deal_II_dimension> &,
-        const std::set<types::boundary_id> &,
-        std::vector<IndexSet> &,
-        const ComponentMask &);
+      template void
+      make_boundary_list(const DoFHandler<deal_II_dimension> &,
+                         const std::set<types::boundary_id> &,
+                         std::vector<IndexSet> &,
+                         const ComponentMask &);
 
 
-    template
-    void
-    extract_inner_interface_dofs (const DoFHandler<deal_II_dimension> &mg_dof_handler,
-                                  std::vector<IndexSet>  &interface_dofs);
+      template void
+      extract_inner_interface_dofs(
+        const DoFHandler<deal_II_dimension> &mg_dof_handler,
+        std::vector<IndexSet> &              interface_dofs);
 
-    template
-    void
-    extract_non_interface_dofs (const DoFHandler<deal_II_dimension> & mg_dof_handler,
-                                std::vector<std::set<types::global_dof_index> > &non_interface_dofs);
+      template void
+      extract_non_interface_dofs(
+        const DoFHandler<deal_II_dimension> &           mg_dof_handler,
+        std::vector<std::set<types::global_dof_index>> &non_interface_dofs);
 
 
 #if deal_II_dimension < 3
-    template void count_dofs_per_block (
-        const DoFHandler<deal_II_dimension,deal_II_dimension+1>&,
-        std::vector<std::vector<types::global_dof_index> >&, std::vector<unsigned int>);
+      template void
+      count_dofs_per_block(
+        const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+        std::vector<std::vector<types::global_dof_index>> &,
+        std::vector<unsigned int>);
 #endif
 
 #if deal_II_dimension == 3
-    template void count_dofs_per_block (
-        const DoFHandler<1,3>&,
-        std::vector<std::vector<types::global_dof_index> >&, std::vector<unsigned int>);
+      template void
+      count_dofs_per_block(const DoFHandler<1, 3> &,
+                           std::vector<std::vector<types::global_dof_index>> &,
+                           std::vector<unsigned int>);
 #endif
     \}
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS;
-        deal_II_space_dimension: SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
     namespace MGTools
     \{
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    unsigned int
-    max_level_for_coarse_mesh (const Triangulation<deal_II_dimension, deal_II_space_dimension> & tria);
+      template unsigned int
+      max_level_for_coarse_mesh(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria);
 #endif
     \}
-}
+  }

--- a/source/multigrid/mg_transfer_block.inst.in
+++ b/source/multigrid/mg_transfer_block.inst.in
@@ -16,119 +16,102 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template
-    void MGTransferBlock<float>::build_matrices<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>&, const DoFHandler<deal_II_dimension>&,
-     const std::vector<bool>&);
+  {
+    template void MGTransferBlock<float>::build_matrices<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &,
+      const DoFHandler<deal_II_dimension> &,
+      const std::vector<bool> &);
 
-    template
-    void MGTransferBlock<double>::build_matrices<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>&, const DoFHandler<deal_II_dimension>&,
-     const std::vector<bool>&);
-
-    template
-    void MGTransferBlockSelect<float>::build_matrices<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>&, const DoFHandler<deal_II_dimension>&,
-     const unsigned int);
-
-    template
-    void MGTransferBlockSelect<double>::build_matrices<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>&, const DoFHandler<deal_II_dimension>&,
-     const unsigned int);
+    template void MGTransferBlock<double>::build_matrices<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &,
+      const DoFHandler<deal_II_dimension> &,
+      const std::vector<bool> &);
 
     template void
-    MGTransferBlock<float>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&,
-        MGLevelObject<BlockVector<float> >&,
-        const BlockVector<double>&) const;
-    template void
-    MGTransferBlock<float>::copy_from_mg (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<BlockVector<float> >&) const;
-    template void
-    MGTransferBlock<float>::copy_from_mg_add (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<BlockVector<float> >&) const;
+    MGTransferBlockSelect<float>::build_matrices<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &,
+      const DoFHandler<deal_II_dimension> &,
+      const unsigned int);
 
     template void
-    MGTransferBlock<double>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&,
-        MGLevelObject<BlockVector<double> >&,
-        const BlockVector<double>&) const;
-    template void
-    MGTransferBlock<double>::copy_from_mg (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<BlockVector<double> >&) const;
-    template void
-    MGTransferBlock<double>::copy_from_mg_add (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<BlockVector<double> >&) const;
+    MGTransferBlockSelect<double>::build_matrices<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &,
+      const DoFHandler<deal_II_dimension> &,
+      const unsigned int);
 
-    template void
-    MGTransferBlockSelect<float>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&,
-        MGLevelObject<Vector<float> >&,
-        const Vector<double>&) const;
-    template void
-    MGTransferBlockSelect<float>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&,
-        MGLevelObject<Vector<float> >&,
-        const BlockVector<double>&) const;
-    template void
-    MGTransferBlockSelect<float>::copy_from_mg (
-        const DoFHandler<deal_II_dimension>&,
-        Vector<double>&,
-        const MGLevelObject<Vector<float> >&) const;
-    template void
-    MGTransferBlockSelect<float>::copy_from_mg (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<Vector<float> >&) const;
-    template void
-    MGTransferBlockSelect<float>::copy_from_mg_add (
-        const DoFHandler<deal_II_dimension>&,
-        Vector<double>&,
-        const MGLevelObject<Vector<float> >&) const;
-    template void
-    MGTransferBlockSelect<float>::copy_from_mg_add (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<Vector<float> >&) const;
+    template void MGTransferBlock<float>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<BlockVector<float>> &,
+      const BlockVector<double> &) const;
+    template void MGTransferBlock<float>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<BlockVector<float>> &) const;
+    template void MGTransferBlock<float>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<BlockVector<float>> &) const;
 
-    template void
-    MGTransferBlockSelect<double>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&,
-        MGLevelObject<Vector<double> >&,
-        const Vector<double>&) const;
-    template void
-    MGTransferBlockSelect<double>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&,
-        MGLevelObject<Vector<double> >&,
-        const BlockVector<double>&) const;
-    template void
-    MGTransferBlockSelect<double>::copy_from_mg (
-        const DoFHandler<deal_II_dimension>&,
-        Vector<double>&,
-        const MGLevelObject<Vector<double> >&) const;
-    template void
-    MGTransferBlockSelect<double>::copy_from_mg (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<Vector<double> >&) const;
-    template void
-    MGTransferBlockSelect<double>::copy_from_mg_add (
-        const DoFHandler<deal_II_dimension>&,
-        Vector<double>&,
-        const MGLevelObject<Vector<double> >&) const;
-    template void
-    MGTransferBlockSelect<double>::copy_from_mg_add (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<Vector<double> >&) const;
-}
+    template void MGTransferBlock<double>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<BlockVector<double>> &,
+      const BlockVector<double> &) const;
+    template void MGTransferBlock<double>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<BlockVector<double>> &) const;
+    template void MGTransferBlock<double>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<BlockVector<double>> &) const;
 
+    template void MGTransferBlockSelect<float>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<Vector<float>> &,
+      const Vector<double> &) const;
+    template void MGTransferBlockSelect<float>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<Vector<float>> &,
+      const BlockVector<double> &) const;
+    template void MGTransferBlockSelect<float>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      Vector<double> &,
+      const MGLevelObject<Vector<float>> &) const;
+    template void MGTransferBlockSelect<float>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<Vector<float>> &) const;
+    template void MGTransferBlockSelect<float>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      Vector<double> &,
+      const MGLevelObject<Vector<float>> &) const;
+    template void MGTransferBlockSelect<float>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<Vector<float>> &) const;
+
+    template void MGTransferBlockSelect<double>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<Vector<double>> &,
+      const Vector<double> &) const;
+    template void MGTransferBlockSelect<double>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<Vector<double>> &,
+      const BlockVector<double> &) const;
+    template void MGTransferBlockSelect<double>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      Vector<double> &,
+      const MGLevelObject<Vector<double>> &) const;
+    template void MGTransferBlockSelect<double>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<Vector<double>> &) const;
+    template void MGTransferBlockSelect<double>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      Vector<double> &,
+      const MGLevelObject<Vector<double>> &) const;
+    template void MGTransferBlockSelect<double>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<Vector<double>> &) const;
+  }

--- a/source/multigrid/mg_transfer_component.inst.in
+++ b/source/multigrid/mg_transfer_component.inst.in
@@ -16,85 +16,72 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    template
-    void MGTransferSelect<float>::build_matrices<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &d,
-     const DoFHandler<deal_II_dimension> &,
-     unsigned int, unsigned int,
-     const std::vector<unsigned int>&,
-     const std::vector<unsigned int>&,
-     const std::vector<std::set<types::global_dof_index> >&);
+  {
+    template void MGTransferSelect<float>::build_matrices<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &d,
+      const DoFHandler<deal_II_dimension> &,
+      unsigned int,
+      unsigned int,
+      const std::vector<unsigned int> &,
+      const std::vector<unsigned int> &,
+      const std::vector<std::set<types::global_dof_index>> &);
 
-    template
-    void MGTransferSelect<double>::build_matrices<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &d,
-     const DoFHandler<deal_II_dimension> &,
-     unsigned int, unsigned int,
-     const std::vector<unsigned int>&,
-     const std::vector<unsigned int>&,
-     const std::vector<std::set<types::global_dof_index> >&);
+    template void MGTransferSelect<double>::build_matrices<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &d,
+      const DoFHandler<deal_II_dimension> &,
+      unsigned int,
+      unsigned int,
+      const std::vector<unsigned int> &,
+      const std::vector<unsigned int> &,
+      const std::vector<std::set<types::global_dof_index>> &);
 
-    template void
-    MGTransferSelect<float>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&,
-        MGLevelObject<Vector<float> >&,
-        const Vector<double>&) const;
-    template void
-    MGTransferSelect<float>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&,
-        MGLevelObject<Vector<float> >&,
-        const BlockVector<double>&) const;
-    template void
-    MGTransferSelect<float>::copy_from_mg (
-        const DoFHandler<deal_II_dimension>&,
-        Vector<double>&,
-        const MGLevelObject<Vector<float> >&) const;
-    template void
-    MGTransferSelect<float>::copy_from_mg (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<Vector<float> >&) const;
-    template void
-    MGTransferSelect<float>::copy_from_mg_add (
-        const DoFHandler<deal_II_dimension>&,
-        Vector<double>&,
-        const MGLevelObject<Vector<float> >&) const;
-    template void
-    MGTransferSelect<float>::copy_from_mg_add (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<Vector<float> >&) const;
+    template void MGTransferSelect<float>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<Vector<float>> &,
+      const Vector<double> &) const;
+    template void MGTransferSelect<float>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<Vector<float>> &,
+      const BlockVector<double> &) const;
+    template void MGTransferSelect<float>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      Vector<double> &,
+      const MGLevelObject<Vector<float>> &) const;
+    template void MGTransferSelect<float>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<Vector<float>> &) const;
+    template void MGTransferSelect<float>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      Vector<double> &,
+      const MGLevelObject<Vector<float>> &) const;
+    template void MGTransferSelect<float>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<Vector<float>> &) const;
 
-    template void
-    MGTransferSelect<double>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&,
-        MGLevelObject<Vector<double> >&,
-        const Vector<double>&) const;
-    template void
-    MGTransferSelect<double>::copy_to_mg (
-        const DoFHandler<deal_II_dimension>&,
-        MGLevelObject<Vector<double> >&,
-        const BlockVector<double>&) const;
-    template void
-    MGTransferSelect<double>::copy_from_mg (
-        const DoFHandler<deal_II_dimension>&,
-        Vector<double>&,
-        const MGLevelObject<Vector<double> >&) const;
-    template void
-    MGTransferSelect<double>::copy_from_mg (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<Vector<double> >&) const;
-    template void
-    MGTransferSelect<double>::copy_from_mg_add (
-        const DoFHandler<deal_II_dimension>&,
-        Vector<double>&,
-        const MGLevelObject<Vector<double> >&) const;
-    template void
-    MGTransferSelect<double>::copy_from_mg_add (
-        const DoFHandler<deal_II_dimension>&,
-        BlockVector<double>&,
-        const MGLevelObject<Vector<double> >&) const;
-}
-
+    template void MGTransferSelect<double>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<Vector<double>> &,
+      const Vector<double> &) const;
+    template void MGTransferSelect<double>::copy_to_mg(
+      const DoFHandler<deal_II_dimension> &,
+      MGLevelObject<Vector<double>> &,
+      const BlockVector<double> &) const;
+    template void MGTransferSelect<double>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      Vector<double> &,
+      const MGLevelObject<Vector<double>> &) const;
+    template void MGTransferSelect<double>::copy_from_mg(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<Vector<double>> &) const;
+    template void MGTransferSelect<double>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      Vector<double> &,
+      const MGLevelObject<Vector<double>> &) const;
+    template void MGTransferSelect<double>::copy_from_mg_add(
+      const DoFHandler<deal_II_dimension> &,
+      BlockVector<double> &,
+      const MGLevelObject<Vector<double>> &) const;
+  }

--- a/source/multigrid/mg_transfer_internal.inst.in
+++ b/source/multigrid/mg_transfer_internal.inst.in
@@ -15,76 +15,78 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS;
-        deal_II_space_dimension: SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
     namespace internal
     \{
-    namespace MGTransfer
-    \{
+      namespace MGTransfer
+      \{
 
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void fill_copy_indices<deal_II_dimension, deal_II_space_dimension>(
-        const dealii::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-        const MGConstrainedDoFs*,
-        std::vector<std::vector<std::pair<types::global_dof_index, types::global_dof_index> > > &,
-        std::vector<std::vector<std::pair<types::global_dof_index, types::global_dof_index> > > &,
-        std::vector<std::vector<std::pair<types::global_dof_index, types::global_dof_index> > > &,
-        const bool);
+        template void
+        fill_copy_indices<deal_II_dimension, deal_II_space_dimension>(
+          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
+            &,
+          const MGConstrainedDoFs *,
+          std::vector<std::vector<
+            std::pair<types::global_dof_index, types::global_dof_index>>> &,
+          std::vector<std::vector<
+            std::pair<types::global_dof_index, types::global_dof_index>>> &,
+          std::vector<std::vector<
+            std::pair<types::global_dof_index, types::global_dof_index>>> &,
+          const bool);
 #endif
+      \}
     \}
-    \}
-}
+  }
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace internal
     \{
-    namespace MGTransfer
-    \{
+      namespace MGTransfer
+      \{
 
-    template
-    unsigned int
-    compute_shift_within_children<deal_II_dimension>(const unsigned int,
-            const unsigned int,
-            const unsigned int);
+        template unsigned int
+        compute_shift_within_children<deal_II_dimension>(const unsigned int,
+                                                         const unsigned int,
+                                                         const unsigned int);
+      \}
     \}
-    \}
-}
+  }
 
 for (S : REAL_SCALARS)
-{
+  {
     namespace internal
     \{
-    namespace MGTransfer
-    \{
+      namespace MGTransfer
+      \{
 
-    template
-    struct ElementInfo<S>;
+        template struct ElementInfo<S>;
+      \}
     \}
-    \}
-}
+  }
 
 for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS)
-{
+  {
     namespace internal
     \{
-    namespace MGTransfer
-    \{
+      namespace MGTransfer
+      \{
 
-    template
-    void setup_transfer<deal_II_dimension>(const dealii::DoFHandler<deal_II_dimension>&,
-                                           const MGConstrainedDoFs*,
-                                           ElementInfo<S>&,
-                                           std::vector<std::vector<unsigned int> >&,
-                                           std::vector<std::vector<std::pair<unsigned int,unsigned int> > >&,
-                                           std::vector<unsigned int>&,
-                                           std::vector<std::vector<std::vector<unsigned short> > >&,
-                                           std::vector<std::vector<S> >&,
-                                           std::vector<std::vector<std::pair<unsigned int, unsigned int> > >&,
-                                           MGLevelObject<LinearAlgebra::distributed::Vector<S> >&);
+        template void
+        setup_transfer<deal_II_dimension>(
+          const dealii::DoFHandler<deal_II_dimension> &,
+          const MGConstrainedDoFs *,
+          ElementInfo<S> &,
+          std::vector<std::vector<unsigned int>> &,
+          std::vector<std::vector<std::pair<unsigned int, unsigned int>>> &,
+          std::vector<unsigned int> &,
+          std::vector<std::vector<std::vector<unsigned short>>> &,
+          std::vector<std::vector<S>> &,
+          std::vector<std::vector<std::pair<unsigned int, unsigned int>>> &,
+          MGLevelObject<LinearAlgebra::distributed::Vector<S>> &);
+      \}
     \}
-    \}
-}
+  }

--- a/source/multigrid/mg_transfer_matrix_free.inst.in
+++ b/source/multigrid/mg_transfer_matrix_free.inst.in
@@ -16,7 +16,7 @@
 
 
 for (deal_II_dimension : DIMENSIONS; S1 : REAL_SCALARS)
-{
-    template class MGTransferMatrixFree< deal_II_dimension, S1 >;
-    template class MGTransferBlockMatrixFree< deal_II_dimension, S1 >;
-}
+  {
+    template class MGTransferMatrixFree<deal_II_dimension, S1>;
+    template class MGTransferBlockMatrixFree<deal_II_dimension, S1>;
+  }

--- a/source/multigrid/mg_transfer_prebuilt.inst.in
+++ b/source/multigrid/mg_transfer_prebuilt.inst.in
@@ -16,13 +16,12 @@
 
 
 for (V1 : VECTORS_WITH_MATRIX)
-{
-    template class MGTransferPrebuilt< V1 >;
-}
+  {
+    template class MGTransferPrebuilt<V1>;
+  }
 
 for (deal_II_dimension : DIMENSIONS; V1 : VECTORS_WITH_MATRIX)
-{
-    template
-    void MGTransferPrebuilt< V1 >::build_matrices<deal_II_dimension>(
-        const DoFHandler<deal_II_dimension> &mg_dof);
-}
+  {
+    template void MGTransferPrebuilt<V1>::build_matrices<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &mg_dof);
+  }

--- a/source/multigrid/multigrid.inst.in
+++ b/source/multigrid/multigrid.inst.in
@@ -15,6 +15,6 @@
 
 
 for (VEC : VECTOR_TYPES)
-{
-    template class Multigrid< VEC >;
-}
+  {
+    template class Multigrid<VEC>;
+  }

--- a/source/non_matching/coupling.inst.in
+++ b/source/non_matching/coupling.inst.in
@@ -14,59 +14,59 @@
 // ---------------------------------------------------------------------
 
 
-for (dim0 : DIMENSIONS; dim1 :DIMENSIONS; spacedim :  SPACE_DIMENSIONS;
-        Sparsity : SPARSITY_PATTERNS)
-{
+for (dim0 : DIMENSIONS; dim1 : DIMENSIONS; spacedim : SPACE_DIMENSIONS;
+     Sparsity : SPARSITY_PATTERNS)
+  {
 #if dim1 <= dim0 && dim0 <= spacedim
-    template
-    void create_coupling_sparsity_pattern(const DoFHandler<dim0, spacedim> &space_dh,
-            const DoFHandler<dim1, spacedim> &immersed_dh,
-            const Quadrature<dim1>           &quad,
-            Sparsity                         &sparsity,
-            const ConstraintMatrix           &constraints,
-            const ComponentMask              &space_comps,
-            const ComponentMask              &immersed_comps,
-            const Mapping<dim0, spacedim>    &space_mapping,
-            const Mapping<dim1, spacedim>    &immersed_mapping);
+    template void create_coupling_sparsity_pattern(
+      const DoFHandler<dim0, spacedim> &space_dh,
+      const DoFHandler<dim1, spacedim> &immersed_dh,
+      const Quadrature<dim1> &          quad,
+      Sparsity &                        sparsity,
+      const ConstraintMatrix &          constraints,
+      const ComponentMask &             space_comps,
+      const ComponentMask &             immersed_comps,
+      const Mapping<dim0, spacedim> &   space_mapping,
+      const Mapping<dim1, spacedim> &   immersed_mapping);
 
-    template
-    void create_coupling_sparsity_pattern(const GridTools::Cache<dim0,spacedim> &cache,
-            const DoFHandler<dim0, spacedim> &space_dh,
-            const DoFHandler<dim1, spacedim> &immersed_dh,
-            const Quadrature<dim1>           &quad,
-            Sparsity                         &sparsity,
-            const ConstraintMatrix           &constraints,
-            const ComponentMask              &space_comps,
-            const ComponentMask              &immersed_comps,
-            const Mapping<dim1, spacedim>    &immersed_mapping);
+    template void create_coupling_sparsity_pattern(
+      const GridTools::Cache<dim0, spacedim> &cache,
+      const DoFHandler<dim0, spacedim> &      space_dh,
+      const DoFHandler<dim1, spacedim> &      immersed_dh,
+      const Quadrature<dim1> &                quad,
+      Sparsity &                              sparsity,
+      const ConstraintMatrix &                constraints,
+      const ComponentMask &                   space_comps,
+      const ComponentMask &                   immersed_comps,
+      const Mapping<dim1, spacedim> &         immersed_mapping);
 #endif
-}
+  }
 
 
-for (dim0 : DIMENSIONS; dim1 :DIMENSIONS; spacedim : SPACE_DIMENSIONS;
-        Matrix : SPARSE_MATRICES)
-{
+for (dim0 : DIMENSIONS; dim1 : DIMENSIONS; spacedim : SPACE_DIMENSIONS;
+     Matrix : SPARSE_MATRICES)
+  {
 #if dim1 <= dim0 && dim0 <= spacedim
-    template
-    void create_coupling_mass_matrix(const DoFHandler<dim0, spacedim> &space_dh,
-                                     const DoFHandler<dim1, spacedim> &immersed_dh,
-                                     const Quadrature<dim1>           &quad,
-                                     Matrix                           &matrix,
-                                     const ConstraintMatrix           &constraints,
-                                     const ComponentMask              &space_comps,
-                                     const ComponentMask              &immersed_comps,
-                                     const Mapping<dim0, spacedim>    &space_mapping,
-                                     const Mapping<dim1, spacedim>    &immersed_mapping);
+    template void create_coupling_mass_matrix(
+      const DoFHandler<dim0, spacedim> &space_dh,
+      const DoFHandler<dim1, spacedim> &immersed_dh,
+      const Quadrature<dim1> &          quad,
+      Matrix &                          matrix,
+      const ConstraintMatrix &          constraints,
+      const ComponentMask &             space_comps,
+      const ComponentMask &             immersed_comps,
+      const Mapping<dim0, spacedim> &   space_mapping,
+      const Mapping<dim1, spacedim> &   immersed_mapping);
 
-    template
-    void create_coupling_mass_matrix(const GridTools::Cache<dim0,spacedim> &cache,
-                                     const DoFHandler<dim0, spacedim> &space_dh,
-                                     const DoFHandler<dim1, spacedim> &immersed_dh,
-                                     const Quadrature<dim1>           &quad,
-                                     Matrix                           &matrix,
-                                     const ConstraintMatrix           &constraints,
-                                     const ComponentMask              &space_comps,
-                                     const ComponentMask              &immersed_comps,
-                                     const Mapping<dim1, spacedim>    &immersed_mapping);
+    template void create_coupling_mass_matrix(
+      const GridTools::Cache<dim0, spacedim> &cache,
+      const DoFHandler<dim0, spacedim> &      space_dh,
+      const DoFHandler<dim1, spacedim> &      immersed_dh,
+      const Quadrature<dim1> &                quad,
+      Matrix &                                matrix,
+      const ConstraintMatrix &                constraints,
+      const ComponentMask &                   space_comps,
+      const ComponentMask &                   immersed_comps,
+      const Mapping<dim1, spacedim> &         immersed_mapping);
 #endif
-}
+  }

--- a/source/numerics/data_out.inst.in
+++ b/source/numerics/data_out.inst.in
@@ -16,25 +16,29 @@
 
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
-{
-    namespace internal \{
-    namespace DataOutImplementation \{
+  {
+    namespace internal
+    \{
+      namespace DataOutImplementation
+      \{
 #if deal_II_dimension <= deal_II_space_dimension
-    template struct ParallelData<deal_II_dimension,deal_II_space_dimension>;
+        template struct ParallelData<deal_II_dimension,
+                                     deal_II_space_dimension>;
 #endif
+      \}
     \}
-    \}
-}
+  }
 
 
 for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
-{
-    template class DataOut<deal_II_dimension, DH<deal_II_dimension> >;
+  {
+    template class DataOut<deal_II_dimension, DH<deal_II_dimension>>;
 #if deal_II_dimension < 3
-    template class DataOut<deal_II_dimension, DH<deal_II_dimension,deal_II_dimension+1> >;
+    template class DataOut<deal_II_dimension,
+                           DH<deal_II_dimension, deal_II_dimension + 1>>;
 #endif
 
 #if deal_II_dimension == 3
-    template class DataOut<1, DH<1,3> >;
+    template class DataOut<1, DH<1, 3>>;
 #endif
-}
+  }

--- a/source/numerics/data_out_dof_data.inst.in
+++ b/source/numerics/data_out_dof_data.inst.in
@@ -14,165 +14,213 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
-{
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension,deal_II_dimension>::
-    add_data_vector_internal<VEC> (const DH<deal_II_dimension,deal_II_dimension> *,
-                                   const VEC                       &,
-                                   const std::vector<std::string> &,
-                                   const DataVectorType,
-                                   const std::vector<DataComponentInterpretation::DataComponentInterpretation> &,
-                                   const bool);
+for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
+     deal_II_dimension : DIMENSIONS)
+  {
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension,
+                                  deal_II_dimension>::
+      add_data_vector_internal<VEC>(
+        const DH<deal_II_dimension, deal_II_dimension> *,
+        const VEC &,
+        const std::vector<std::string> &,
+        const DataVectorType,
+        const std::vector<
+          DataComponentInterpretation::DataComponentInterpretation> &,
+        const bool);
 
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension,deal_II_dimension>::
-    add_data_vector<VEC> (const DH<deal_II_dimension,deal_II_dimension> &,
-                          const VEC                 &,
-                          const DataPostprocessor<DH<deal_II_dimension,deal_II_dimension>::space_dimension> &);
-
-
-
-// stuff needed for face data
-
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension-1,deal_II_dimension>::
-    add_data_vector_internal<VEC> (const DH<deal_II_dimension,deal_II_dimension> *,
-                                   const VEC                       &,
-                                   const std::vector<std::string> &,
-                                   const DataVectorType,
-                                   const std::vector<DataComponentInterpretation::DataComponentInterpretation> &,
-                                   const bool);
-
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension-1,deal_II_dimension>::
-    add_data_vector<VEC> (const DH<deal_II_dimension,deal_II_dimension> &,
-                          const VEC                 &,
-                          const DataPostprocessor<DH<deal_II_dimension,deal_II_dimension>::space_dimension> &);
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension,
+                                  deal_II_dimension>::
+      add_data_vector<VEC>(
+        const DH<deal_II_dimension, deal_II_dimension> &,
+        const VEC &,
+        const DataPostprocessor<
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
 
 
 
-// things for DataOutRotation
+    // stuff needed for face data
+
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension - 1,
+                                  deal_II_dimension>::
+      add_data_vector_internal<VEC>(
+        const DH<deal_II_dimension, deal_II_dimension> *,
+        const VEC &,
+        const std::vector<std::string> &,
+        const DataVectorType,
+        const std::vector<
+          DataComponentInterpretation::DataComponentInterpretation> &,
+        const bool);
+
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension - 1,
+                                  deal_II_dimension>::
+      add_data_vector<VEC>(
+        const DH<deal_II_dimension, deal_II_dimension> &,
+        const VEC &,
+        const DataPostprocessor<
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
+
+
+
+    // things for DataOutRotation
 
 #if deal_II_dimension < 3
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension+1,deal_II_dimension+1>::
-    add_data_vector_internal<VEC> (const DH<deal_II_dimension,deal_II_dimension> *,
-                                   const VEC                       &,
-                                   const std::vector<std::string> &,
-                                   const DataVectorType,
-                                   const std::vector<DataComponentInterpretation::DataComponentInterpretation> &,
-                                   const bool);
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension + 1,
+                                  deal_II_dimension + 1>::
+      add_data_vector_internal<VEC>(
+        const DH<deal_II_dimension, deal_II_dimension> *,
+        const VEC &,
+        const std::vector<std::string> &,
+        const DataVectorType,
+        const std::vector<
+          DataComponentInterpretation::DataComponentInterpretation> &,
+        const bool);
 
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension+1,deal_II_dimension+1>::
-    add_data_vector<VEC> (const DH<deal_II_dimension,deal_II_dimension> &,
-                          const VEC                 &,
-                          const DataPostprocessor<DH<deal_II_dimension,deal_II_dimension>::space_dimension> &);
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension + 1,
+                                  deal_II_dimension + 1>::
+      add_data_vector<VEC>(
+        const DH<deal_II_dimension, deal_II_dimension> &,
+        const VEC &,
+        const DataPostprocessor<
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
 #endif
-}
+  }
 
 
 
 for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
-{
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension,deal_II_dimension>::
-    add_data_vector_internal<IndexSet> (const DH<deal_II_dimension,deal_II_dimension> *,
-                                        const IndexSet                       &,
-                                        const std::vector<std::string> &,
-                                        const DataVectorType,
-                                        const std::vector<DataComponentInterpretation::DataComponentInterpretation> &,
-                                        const bool);
+  {
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension,
+                                  deal_II_dimension>::
+      add_data_vector_internal<IndexSet>(
+        const DH<deal_II_dimension, deal_II_dimension> *,
+        const IndexSet &,
+        const std::vector<std::string> &,
+        const DataVectorType,
+        const std::vector<
+          DataComponentInterpretation::DataComponentInterpretation> &,
+        const bool);
 
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension,deal_II_dimension>::
-    add_data_vector<IndexSet> (const DH<deal_II_dimension, deal_II_dimension> &,
-                               const IndexSet                 &,
-                               const DataPostprocessor<DH<deal_II_dimension,deal_II_dimension>::space_dimension> &);
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension,
+                                  deal_II_dimension>::
+      add_data_vector<IndexSet>(
+        const DH<deal_II_dimension, deal_II_dimension> &,
+        const IndexSet &,
+        const DataPostprocessor<
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
 
 
 
-// stuff needed for face data
+    // stuff needed for face data
 
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension-1,deal_II_dimension>::
-    add_data_vector_internal<IndexSet> (const DH<deal_II_dimension,deal_II_dimension> *,
-                                        const IndexSet                       &,
-                                        const std::vector<std::string> &,
-                                        const DataVectorType,
-                                        const std::vector<DataComponentInterpretation::DataComponentInterpretation> &,
-                                        const bool);
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension - 1,
+                                  deal_II_dimension>::
+      add_data_vector_internal<IndexSet>(
+        const DH<deal_II_dimension, deal_II_dimension> *,
+        const IndexSet &,
+        const std::vector<std::string> &,
+        const DataVectorType,
+        const std::vector<
+          DataComponentInterpretation::DataComponentInterpretation> &,
+        const bool);
 
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension-1,deal_II_dimension>::
-    add_data_vector<IndexSet> (const DH<deal_II_dimension, deal_II_dimension> &,
-                               const IndexSet                 &,
-                               const DataPostprocessor<DH<deal_II_dimension,deal_II_dimension>::space_dimension> &);
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension - 1,
+                                  deal_II_dimension>::
+      add_data_vector<IndexSet>(
+        const DH<deal_II_dimension, deal_II_dimension> &,
+        const IndexSet &,
+        const DataPostprocessor<
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
 
-// things for DataOutRotation
+    // things for DataOutRotation
 
 #if deal_II_dimension < 3
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension+1,deal_II_dimension+1>::
-    add_data_vector_internal<IndexSet> (const DH<deal_II_dimension,deal_II_dimension> *,
-                                        const IndexSet                       &,
-                                        const std::vector<std::string> &,
-                                        const DataVectorType,
-                                        const std::vector<DataComponentInterpretation::DataComponentInterpretation> &,
-                                        const bool);
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension + 1,
+                                  deal_II_dimension + 1>::
+      add_data_vector_internal<IndexSet>(
+        const DH<deal_II_dimension, deal_II_dimension> *,
+        const IndexSet &,
+        const std::vector<std::string> &,
+        const DataVectorType,
+        const std::vector<
+          DataComponentInterpretation::DataComponentInterpretation> &,
+        const bool);
 
-    template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension>,deal_II_dimension+1,deal_II_dimension+1>::
-    add_data_vector<IndexSet> (const DH<deal_II_dimension, deal_II_dimension> &,
-                               const IndexSet                 &,
-                               const DataPostprocessor<DH<deal_II_dimension,deal_II_dimension>::space_dimension> &);
+    template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
+                                  deal_II_dimension + 1,
+                                  deal_II_dimension + 1>::
+      add_data_vector<IndexSet>(
+        const DH<deal_II_dimension, deal_II_dimension> &,
+        const IndexSet &,
+        const DataPostprocessor<
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
 #endif
-}
+  }
 
 
 
 for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
-{
-    template class DataOut_DoFData<DH<deal_II_dimension>,deal_II_dimension>;
+  {
+    template class DataOut_DoFData<DH<deal_II_dimension>, deal_II_dimension>;
 
 #if deal_II_dimension < 3
-    template class DataOut_DoFData<DH<deal_II_dimension>,deal_II_dimension+1>;
-    template class DataOut_DoFData<DH<deal_II_dimension>,deal_II_dimension,deal_II_dimension+1>;
+    template class DataOut_DoFData<DH<deal_II_dimension>,
+                                   deal_II_dimension + 1>;
+    template class DataOut_DoFData<DH<deal_II_dimension>,
+                                   deal_II_dimension,
+                                   deal_II_dimension + 1>;
 #endif
 
 #if deal_II_dimension >= 2
-    template class DataOut_DoFData<DH<deal_II_dimension>,deal_II_dimension-1,deal_II_dimension>;
+    template class DataOut_DoFData<DH<deal_II_dimension>,
+                                   deal_II_dimension - 1,
+                                   deal_II_dimension>;
 #endif
 
 #if deal_II_dimension == 3
-    template class DataOut_DoFData<DH<1>,1,3>;
+    template class DataOut_DoFData<DH<1>, 1, 3>;
 #endif
-
-}
+  }
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
-    namespace internal \{
-    namespace DataOutImplementation \{
-    template struct ParallelDataBase<deal_II_dimension,deal_II_dimension>;
+  {
+    namespace internal
+    \{
+      namespace DataOutImplementation
+      \{
+        template struct ParallelDataBase<deal_II_dimension, deal_II_dimension>;
+      \}
     \}
-    \}
-}
+  }
 
 
 for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
-{
-    namespace internal \{
-    namespace DataOutImplementation \{
-    template
-    void
-    ParallelDataBase<deal_II_dimension,deal_II_dimension>::
-    reinit_all_fe_values<dealii::DH<deal_II_dimension,deal_II_dimension> >
-    (std::vector<std::shared_ptr<DataEntryBase<dealii::DH<deal_II_dimension,deal_II_dimension> > > > &dof_data,
-     const dealii::Triangulation<deal_II_dimension,deal_II_dimension>::cell_iterator &cell,
-     const unsigned int face);
+  {
+    namespace internal
+    \{
+      namespace DataOutImplementation
+      \{
+        template void
+        ParallelDataBase<deal_II_dimension, deal_II_dimension>::
+          reinit_all_fe_values<
+            dealii::DH<deal_II_dimension, deal_II_dimension>>(
+            std::vector<std::shared_ptr<
+              DataEntryBase<dealii::DH<deal_II_dimension, deal_II_dimension>>>>
+              &dof_data,
+            const dealii::Triangulation<deal_II_dimension,
+                                        deal_II_dimension>::cell_iterator &cell,
+            const unsigned int face);
+      \}
     \}
-    \}
-}
+  }

--- a/source/numerics/data_out_dof_data_codim.inst.in
+++ b/source/numerics/data_out_dof_data_codim.inst.in
@@ -14,93 +14,126 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
-{
+for (VEC : REAL_VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
+     deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : DIMENSIONS)
+  {
 #if deal_II_dimension < deal_II_space_dimension
     template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_space_dimension>,deal_II_dimension,deal_II_space_dimension>::
-    add_data_vector_internal<VEC> (const DH<deal_II_dimension,deal_II_space_dimension> *,
-                                   const VEC                       &,
-                                   const std::vector<std::string> &,
-                                   const DataVectorType,
-                                   const std::vector<DataComponentInterpretation::DataComponentInterpretation> &,
-                                   const bool);
+    DataOut_DoFData<DH<deal_II_dimension, deal_II_space_dimension>,
+                    deal_II_dimension,
+                    deal_II_space_dimension>::
+      add_data_vector_internal<VEC>(
+        const DH<deal_II_dimension, deal_II_space_dimension> *,
+        const VEC &,
+        const std::vector<std::string> &,
+        const DataVectorType,
+        const std::vector<
+          DataComponentInterpretation::DataComponentInterpretation> &,
+        const bool);
 
     template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_space_dimension>,deal_II_dimension,deal_II_space_dimension>::
-    add_data_vector<VEC> (const VEC                 &,
-                          const DataPostprocessor<DH<deal_II_dimension,deal_II_space_dimension>::space_dimension> &);
+    DataOut_DoFData<DH<deal_II_dimension, deal_II_space_dimension>,
+                    deal_II_dimension,
+                    deal_II_space_dimension>::
+      add_data_vector<VEC>(
+        const VEC &,
+        const DataPostprocessor<
+          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension> &);
 
     template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_space_dimension>,deal_II_dimension,deal_II_space_dimension>::
-    add_data_vector<VEC> (const DH<deal_II_dimension,deal_II_space_dimension> &,
-                          const VEC                 &,
-                          const DataPostprocessor<DH<deal_II_dimension,deal_II_space_dimension>::space_dimension> &);
+    DataOut_DoFData<DH<deal_II_dimension, deal_II_space_dimension>,
+                    deal_II_dimension,
+                    deal_II_space_dimension>::
+      add_data_vector<VEC>(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const DataPostprocessor<
+          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension> &);
 #endif
-}
+  }
 
 
 
-for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
-{
+for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : DIMENSIONS)
+  {
 #if deal_II_dimension < deal_II_space_dimension
     template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_space_dimension>,deal_II_dimension,deal_II_space_dimension>::
-    add_data_vector_internal<IndexSet>
-    (const DH<deal_II_dimension,deal_II_space_dimension> *,
-     const IndexSet                 &,
-     const std::vector<std::string> &,
-     const DataVectorType,
-     const std::vector<DataComponentInterpretation::DataComponentInterpretation> &,
-     const bool);
+    DataOut_DoFData<DH<deal_II_dimension, deal_II_space_dimension>,
+                    deal_II_dimension,
+                    deal_II_space_dimension>::
+      add_data_vector_internal<IndexSet>(
+        const DH<deal_II_dimension, deal_II_space_dimension> *,
+        const IndexSet &,
+        const std::vector<std::string> &,
+        const DataVectorType,
+        const std::vector<
+          DataComponentInterpretation::DataComponentInterpretation> &,
+        const bool);
 
     template void
-    DataOut_DoFData<DH<deal_II_dimension,deal_II_space_dimension>,deal_II_dimension,deal_II_space_dimension>::
-    add_data_vector<IndexSet> (const IndexSet                 &,
-                               const DataPostprocessor<DH<deal_II_dimension,deal_II_space_dimension>::space_dimension> &);
+    DataOut_DoFData<DH<deal_II_dimension, deal_II_space_dimension>,
+                    deal_II_dimension,
+                    deal_II_space_dimension>::
+      add_data_vector<IndexSet>(
+        const IndexSet &,
+        const DataPostprocessor<
+          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension> &);
 #endif
-}
+  }
 
 
 
 for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension < 3
-    template class DataOut_DoFData<DH<deal_II_dimension,deal_II_dimension+1>,deal_II_dimension,deal_II_dimension+1>;
+    template class DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension + 1>,
+                                   deal_II_dimension,
+                                   deal_II_dimension + 1>;
 #endif
 
 #if deal_II_dimension == 3
-    template class DataOut_DoFData<DH<1,3>,1,3>;
+    template class DataOut_DoFData<DH<1, 3>, 1, 3>;
 #endif
-
-}
+  }
 
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
-{
-    namespace internal \{
-    namespace DataOutImplementation \{
+  {
+    namespace internal
+    \{
+      namespace DataOutImplementation
+      \{
 #if deal_II_dimension < deal_II_space_dimension
-    template struct ParallelDataBase<deal_II_dimension,deal_II_space_dimension>;
+        template struct ParallelDataBase<deal_II_dimension,
+                                         deal_II_space_dimension>;
 #endif
+      \}
     \}
-    \}
-}
+  }
 
 
-for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
-{
-    namespace internal \{
-    namespace DataOutImplementation \{
+for (DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : DIMENSIONS)
+  {
+    namespace internal
+    \{
+      namespace DataOutImplementation
+      \{
 #if deal_II_dimension < deal_II_space_dimension
-    template
-    void
-    ParallelDataBase<deal_II_dimension,deal_II_space_dimension>::
-    reinit_all_fe_values<dealii::DH<deal_II_dimension,deal_II_space_dimension> >
-    (std::vector<std::shared_ptr<DataEntryBase<dealii::DH<deal_II_dimension,deal_II_space_dimension> > > > &dof_data,
-     const dealii::Triangulation<deal_II_dimension,deal_II_space_dimension>::cell_iterator &cell,
-     const unsigned int face);
+        template void
+        ParallelDataBase<deal_II_dimension, deal_II_space_dimension>::
+          reinit_all_fe_values<
+            dealii::DH<deal_II_dimension, deal_II_space_dimension>>(
+            std::vector<std::shared_ptr<DataEntryBase<
+              dealii::DH<deal_II_dimension, deal_II_space_dimension>>>>
+              &dof_data,
+            const dealii::Triangulation<deal_II_dimension,
+                                        deal_II_space_dimension>::cell_iterator
+              &                cell,
+            const unsigned int face);
 #endif
+      \}
     \}
-    \}
-}
+  }

--- a/source/numerics/data_out_faces.inst.in
+++ b/source/numerics/data_out_faces.inst.in
@@ -15,10 +15,12 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     // don't instantiate anything for the 1d
-#if deal_II_dimension >=2
-    template class DataOutFaces<deal_II_dimension, DoFHandler<deal_II_dimension> >;
-    template class DataOutFaces<deal_II_dimension, hp::DoFHandler<deal_II_dimension> >;
+#if deal_II_dimension >= 2
+    template class DataOutFaces<deal_II_dimension,
+                                DoFHandler<deal_II_dimension>>;
+    template class DataOutFaces<deal_II_dimension,
+                                hp::DoFHandler<deal_II_dimension>>;
 #endif
-}
+  }

--- a/source/numerics/data_out_rotation.inst.in
+++ b/source/numerics/data_out_rotation.inst.in
@@ -15,8 +15,9 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension < 3
-    template class DataOutRotation<deal_II_dimension, DoFHandler<deal_II_dimension> >;
+    template class DataOutRotation<deal_II_dimension,
+                                   DoFHandler<deal_II_dimension>>;
 #endif
-}
+  }

--- a/source/numerics/data_out_stack.inst.in
+++ b/source/numerics/data_out_stack.inst.in
@@ -15,39 +15,55 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension < 3
-    template class DataOutStack<deal_II_dimension,deal_II_dimension,DoFHandler<deal_II_dimension> >;
+    template class DataOutStack<deal_II_dimension,
+                                deal_II_dimension,
+                                DoFHandler<deal_II_dimension>>;
 
-    template void DataOutStack<deal_II_dimension,deal_II_dimension,DoFHandler<deal_II_dimension> >::
-    add_data_vector<double> (const Vector<double> &,
-                             const std::string    &);
-    template void DataOutStack<deal_II_dimension,deal_II_dimension,DoFHandler<deal_II_dimension> >::
-    add_data_vector<float> (const Vector<float>  &,
-                            const std::string    &);
+    template void DataOutStack<deal_II_dimension,
+                               deal_II_dimension,
+                               DoFHandler<deal_II_dimension>>::
+      add_data_vector<double>(const Vector<double> &, const std::string &);
+    template void DataOutStack<deal_II_dimension,
+                               deal_II_dimension,
+                               DoFHandler<deal_II_dimension>>::
+      add_data_vector<float>(const Vector<float> &, const std::string &);
 
-    template void DataOutStack<deal_II_dimension,deal_II_dimension,DoFHandler<deal_II_dimension> >::
-    add_data_vector<double> (const Vector<double> &,
-                             const std::vector<std::string>    &);
-    template void DataOutStack<deal_II_dimension,deal_II_dimension,DoFHandler<deal_II_dimension> >::
-    add_data_vector<float> (const Vector<float>  &,
-                            const std::vector<std::string>    &);
+    template void DataOutStack<deal_II_dimension,
+                               deal_II_dimension,
+                               DoFHandler<deal_II_dimension>>::
+      add_data_vector<double>(const Vector<double> &,
+                              const std::vector<std::string> &);
+    template void DataOutStack<deal_II_dimension,
+                               deal_II_dimension,
+                               DoFHandler<deal_II_dimension>>::
+      add_data_vector<float>(const Vector<float> &,
+                             const std::vector<std::string> &);
 
 
-    template class DataOutStack<deal_II_dimension,deal_II_dimension,hp::DoFHandler<deal_II_dimension> >;
+    template class DataOutStack<deal_II_dimension,
+                                deal_II_dimension,
+                                hp::DoFHandler<deal_II_dimension>>;
 
-    template void DataOutStack<deal_II_dimension,deal_II_dimension,hp::DoFHandler<deal_II_dimension> >::
-    add_data_vector<double> (const Vector<double> &,
-                             const std::string    &);
-    template void DataOutStack<deal_II_dimension,deal_II_dimension,hp::DoFHandler<deal_II_dimension> >::
-    add_data_vector<float> (const Vector<float>  &,
-                            const std::string    &);
+    template void DataOutStack<deal_II_dimension,
+                               deal_II_dimension,
+                               hp::DoFHandler<deal_II_dimension>>::
+      add_data_vector<double>(const Vector<double> &, const std::string &);
+    template void DataOutStack<deal_II_dimension,
+                               deal_II_dimension,
+                               hp::DoFHandler<deal_II_dimension>>::
+      add_data_vector<float>(const Vector<float> &, const std::string &);
 
-    template void DataOutStack<deal_II_dimension,deal_II_dimension,hp::DoFHandler<deal_II_dimension> >::
-    add_data_vector<double> (const Vector<double> &,
-                             const std::vector<std::string>    &);
-    template void DataOutStack<deal_II_dimension,deal_II_dimension,hp::DoFHandler<deal_II_dimension> >::
-    add_data_vector<float> (const Vector<float>  &,
-                            const std::vector<std::string>    &);
+    template void DataOutStack<deal_II_dimension,
+                               deal_II_dimension,
+                               hp::DoFHandler<deal_II_dimension>>::
+      add_data_vector<double>(const Vector<double> &,
+                              const std::vector<std::string> &);
+    template void DataOutStack<deal_II_dimension,
+                               deal_II_dimension,
+                               hp::DoFHandler<deal_II_dimension>>::
+      add_data_vector<float>(const Vector<float> &,
+                             const std::vector<std::string> &);
 #endif
-}
+  }

--- a/source/numerics/data_postprocessor.inst.in
+++ b/source/numerics/data_postprocessor.inst.in
@@ -15,9 +15,9 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class DataPostprocessor<deal_II_dimension>;
     template class DataPostprocessorScalar<deal_II_dimension>;
     template class DataPostprocessorVector<deal_II_dimension>;
     template class DataPostprocessorTensor<deal_II_dimension>;
-}
+  }

--- a/source/numerics/derivative_approximation.inst.in
+++ b/source/numerics/derivative_approximation.inst.in
@@ -14,120 +14,108 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS ; VEC : REAL_VECTOR_TYPES ; DH : DOFHANDLER_TEMPLATES)
-{
+for (deal_II_dimension : DIMENSIONS; VEC : REAL_VECTOR_TYPES;
+     DH : DOFHANDLER_TEMPLATES)
+  {
     namespace DerivativeApproximation
     \{
-    template
-    void
-    approximate_gradient<deal_II_dimension>
-    (const Mapping<deal_II_dimension> &mapping,
-     const DH<deal_II_dimension> &dof_handler,
-     const VEC             &solution,
-     Vector<float>         &derivative_norm,
-     const unsigned int     component);
+      template void
+      approximate_gradient<deal_II_dimension>(
+        const Mapping<deal_II_dimension> &mapping,
+        const DH<deal_II_dimension> &     dof_handler,
+        const VEC &                       solution,
+        Vector<float> &                   derivative_norm,
+        const unsigned int                component);
 
-    template
-    void
-    approximate_gradient<deal_II_dimension>
-    (const DH<deal_II_dimension> &dof_handler,
-     const VEC             &solution,
-     Vector<float>         &derivative_norm,
-     const unsigned int     component);
+      template void
+      approximate_gradient<deal_II_dimension>(
+        const DH<deal_II_dimension> &dof_handler,
+        const VEC &                  solution,
+        Vector<float> &              derivative_norm,
+        const unsigned int           component);
 
-    template
-    void
-    approximate_second_derivative<deal_II_dimension>
-    (const Mapping<deal_II_dimension> &mapping,
-     const DH<deal_II_dimension> &dof_handler,
-     const VEC             &solution,
-     Vector<float>         &derivative_norm,
-     const unsigned int     component);
+      template void
+      approximate_second_derivative<deal_II_dimension>(
+        const Mapping<deal_II_dimension> &mapping,
+        const DH<deal_II_dimension> &     dof_handler,
+        const VEC &                       solution,
+        Vector<float> &                   derivative_norm,
+        const unsigned int                component);
 
-    template
-    void
-    approximate_second_derivative<deal_II_dimension>
-    (const DH<deal_II_dimension> &dof_handler,
-     const VEC             &solution,
-     Vector<float>         &derivative_norm,
-     const unsigned int     component);
+      template void
+      approximate_second_derivative<deal_II_dimension>(
+        const DH<deal_II_dimension> &dof_handler,
+        const VEC &                  solution,
+        Vector<float> &              derivative_norm,
+        const unsigned int           component);
 
-    template
-    void
-    approximate_derivative_tensor < DH <deal_II_dimension>, VEC, 1 >
-    (const Mapping<deal_II_dimension> &mapping,
-     const DH <deal_II_dimension> &dof_handler,
-     const VEC &solution,
-     const DH <deal_II_dimension>::active_cell_iterator &cell,
-     Tensor<1,deal_II_dimension> &derivative,
-     const unsigned int     component);
+      template void
+      approximate_derivative_tensor<DH<deal_II_dimension>, VEC, 1>(
+        const Mapping<deal_II_dimension> &                 mapping,
+        const DH<deal_II_dimension> &                      dof_handler,
+        const VEC &                                        solution,
+        const DH<deal_II_dimension>::active_cell_iterator &cell,
+        Tensor<1, deal_II_dimension> &                     derivative,
+        const unsigned int                                 component);
 
-    template
-    void
-    approximate_derivative_tensor < DH <deal_II_dimension>, VEC, 2 >
-    (const Mapping <deal_II_dimension> &mapping,
-     const DH <deal_II_dimension> &dof_handler,
-     const VEC &solution,
-     const DH <deal_II_dimension>::active_cell_iterator &cell,
-     Tensor<2,deal_II_dimension> &derivative,
-     const unsigned int     component);
+      template void
+      approximate_derivative_tensor<DH<deal_II_dimension>, VEC, 2>(
+        const Mapping<deal_II_dimension> &                 mapping,
+        const DH<deal_II_dimension> &                      dof_handler,
+        const VEC &                                        solution,
+        const DH<deal_II_dimension>::active_cell_iterator &cell,
+        Tensor<2, deal_II_dimension> &                     derivative,
+        const unsigned int                                 component);
 
-    template
-    void
-    approximate_derivative_tensor < DH <deal_II_dimension>, VEC, 3 >
-    (const Mapping <deal_II_dimension> &mapping,
-     const DH <deal_II_dimension> &dof_handler,
-     const VEC &solution,
-     const DH <deal_II_dimension>::active_cell_iterator &cell,
-     Tensor<3,deal_II_dimension> &derivative,
-     const unsigned int     component);
+      template void
+      approximate_derivative_tensor<DH<deal_II_dimension>, VEC, 3>(
+        const Mapping<deal_II_dimension> &                 mapping,
+        const DH<deal_II_dimension> &                      dof_handler,
+        const VEC &                                        solution,
+        const DH<deal_II_dimension>::active_cell_iterator &cell,
+        Tensor<3, deal_II_dimension> &                     derivative,
+        const unsigned int                                 component);
 
 
-    template
-    void
-    approximate_derivative_tensor < DH <deal_II_dimension>, VEC, 1 >
-    (const DH <deal_II_dimension> &dof_handler,
-     const VEC &solution,
-     const DH <deal_II_dimension>::active_cell_iterator &cell,
-     Tensor<1,deal_II_dimension> &derivative,
-     const unsigned int     component);
+      template void
+      approximate_derivative_tensor<DH<deal_II_dimension>, VEC, 1>(
+        const DH<deal_II_dimension> &                      dof_handler,
+        const VEC &                                        solution,
+        const DH<deal_II_dimension>::active_cell_iterator &cell,
+        Tensor<1, deal_II_dimension> &                     derivative,
+        const unsigned int                                 component);
 
-    template
-    void
-    approximate_derivative_tensor < DH <deal_II_dimension>, VEC, 2 >
-    (const DH <deal_II_dimension> &dof_handler,
-     const VEC &solution,
-     const DH <deal_II_dimension>::active_cell_iterator &cell,
-     Tensor<2,deal_II_dimension> &derivative,
-     const unsigned int     component);
+      template void
+      approximate_derivative_tensor<DH<deal_II_dimension>, VEC, 2>(
+        const DH<deal_II_dimension> &                      dof_handler,
+        const VEC &                                        solution,
+        const DH<deal_II_dimension>::active_cell_iterator &cell,
+        Tensor<2, deal_II_dimension> &                     derivative,
+        const unsigned int                                 component);
 
-    template
-    void
-    approximate_derivative_tensor < DH <deal_II_dimension>, VEC, 3 >
-    (const DH <deal_II_dimension> &dof_handler,
-     const VEC &solution,
-     const DH <deal_II_dimension>::active_cell_iterator &cell,
-     Tensor<3,deal_II_dimension> &derivative,
-     const unsigned int     component);
+      template void
+      approximate_derivative_tensor<DH<deal_II_dimension>, VEC, 3>(
+        const DH<deal_II_dimension> &                      dof_handler,
+        const VEC &                                        solution,
+        const DH<deal_II_dimension>::active_cell_iterator &cell,
+        Tensor<3, deal_II_dimension> &                     derivative,
+        const unsigned int                                 component);
 
     \}
-}
+  }
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace DerivativeApproximation
     \{
-    template
-    double
-    derivative_norm(const Tensor<1,deal_II_dimension> &derivative);
+      template double
+      derivative_norm(const Tensor<1, deal_II_dimension> &derivative);
 
-    template
-    double
-    derivative_norm(const Tensor<2,deal_II_dimension> &derivative);
+      template double
+      derivative_norm(const Tensor<2, deal_II_dimension> &derivative);
 
-    template
-    double
-    derivative_norm(const Tensor<3,deal_II_dimension> &derivative);
+      template double
+      derivative_norm(const Tensor<3, deal_II_dimension> &derivative);
     \}
-}
+  }

--- a/source/numerics/dof_output_operator.inst.in
+++ b/source/numerics/dof_output_operator.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
-{
+for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
+  {
     template class DoFOutputOperator<VEC, deal_II_dimension, deal_II_dimension>;
-}
+  }

--- a/source/numerics/error_estimator.inst.in
+++ b/source/numerics/error_estimator.inst.in
@@ -14,144 +14,151 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension != 1 && deal_II_dimension <= deal_II_space_dimension
-    template class KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>;
+    template class KellyErrorEstimator<deal_II_dimension,
+                                       deal_II_space_dimension>;
 #endif
-}
+  }
 
-for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; DH : DOFHANDLER_TEMPLATES )
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS;
+     DH : DOFHANDLER_TEMPLATES)
+  {
 #if deal_II_dimension != 1 && deal_II_dimension <= deal_II_space_dimension
 
-    template
-    void
+    template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (const Mapping<deal_II_dimension, deal_II_space_dimension>      &,
-            const DH<deal_II_dimension,deal_II_space_dimension>   &,
-            const Quadrature<deal_II_dimension-1> &,
-            const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-            const VEC       &,
-            Vector<float>           &,
-            const ComponentMask &,
-            const Function<deal_II_space_dimension>     *,
-            const unsigned int,
-            const types::subdomain_id,
-            const types::material_id,
-            const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
-
-    template
-    void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (
-        const DH<deal_II_dimension,deal_II_space_dimension>   &,
-        const Quadrature<deal_II_dimension-1> &,
-        const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-        const VEC       &,
-        Vector<float>           &,
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const VEC &,
+        Vector<float> &,
         const ComponentMask &,
-        const Function<deal_II_space_dimension>     *,
+        const Function<deal_II_space_dimension> *,
         const unsigned int,
         const types::subdomain_id,
         const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
+        const KellyErrorEstimator<deal_II_dimension,
+                                  deal_II_space_dimension>::Strategy);
 
-    template
-    void
+    template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (const Mapping<deal_II_dimension, deal_II_space_dimension>      &,
-            const DH<deal_II_dimension,deal_II_space_dimension>   &,
-            const Quadrature<deal_II_dimension-1> &,
-            const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-            const std::vector<const VEC *>       &,
-            std::vector<Vector<float> *>         &,
-            const ComponentMask &,
-            const Function<deal_II_space_dimension>     *,
-            const unsigned int,
-            const types::subdomain_id,
-            const types::material_id,
-            const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
-
-    template
-    void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (
-        const DH<deal_II_dimension,deal_II_space_dimension>   &,
-        const Quadrature<deal_II_dimension-1> &,
-        const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-        const std::vector<const VEC *>       &,
-        std::vector<Vector<float> *>         &,
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const VEC &,
+        Vector<float> &,
         const ComponentMask &,
-        const Function<deal_II_space_dimension>     *,
+        const Function<deal_II_space_dimension> *,
         const unsigned int,
         const types::subdomain_id,
         const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
+        const KellyErrorEstimator<deal_II_dimension,
+                                  deal_II_space_dimension>::Strategy);
 
-    template
-    void
+    template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (const Mapping<deal_II_dimension, deal_II_space_dimension>      &,
-            const DH<deal_II_dimension,deal_II_space_dimension>   &,
-            const hp::QCollection<deal_II_dimension-1> &,
-            const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-            const VEC       &,
-            Vector<float>           &,
-            const ComponentMask &,
-            const Function<deal_II_space_dimension>     *,
-            const unsigned int,
-            const types::subdomain_id,
-            const types::material_id,
-            const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
-
-    template
-    void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (
-        const DH<deal_II_dimension,deal_II_space_dimension>   &,
-        const hp::QCollection<deal_II_dimension-1> &,
-        const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-        const VEC       &,
-        Vector<float>           &,
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const std::vector<const VEC *> &,
+        std::vector<Vector<float> *> &,
         const ComponentMask &,
-        const Function<deal_II_space_dimension>     *,
+        const Function<deal_II_space_dimension> *,
         const unsigned int,
         const types::subdomain_id,
         const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
+        const KellyErrorEstimator<deal_II_dimension,
+                                  deal_II_space_dimension>::Strategy);
 
-    template
-    void
+    template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (const Mapping<deal_II_dimension, deal_II_space_dimension>      &,
-            const DH<deal_II_dimension,deal_II_space_dimension>   &,
-            const hp::QCollection<deal_II_dimension-1> &,
-            const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-            const std::vector<const VEC *>       &,
-            std::vector<Vector<float> *>         &,
-            const ComponentMask &,
-            const Function<deal_II_space_dimension>     *,
-            const unsigned int,
-            const types::subdomain_id,
-            const types::material_id,
-            const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
-
-    template
-    void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (
-        const DH<deal_II_dimension,deal_II_space_dimension>   &,
-        const hp::QCollection<deal_II_dimension-1> &,
-        const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-        const std::vector<const VEC *>       &,
-        std::vector<Vector<float> *>         &,
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const std::vector<const VEC *> &,
+        std::vector<Vector<float> *> &,
         const ComponentMask &,
-        const Function<deal_II_space_dimension>     *,
+        const Function<deal_II_space_dimension> *,
         const unsigned int,
         const types::subdomain_id,
         const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
+        const KellyErrorEstimator<deal_II_dimension,
+                                  deal_II_space_dimension>::Strategy);
+
+    template void
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const VEC &,
+        Vector<float> &,
+        const ComponentMask &,
+        const Function<deal_II_space_dimension> *,
+        const unsigned int,
+        const types::subdomain_id,
+        const types::material_id,
+        const KellyErrorEstimator<deal_II_dimension,
+                                  deal_II_space_dimension>::Strategy);
+
+    template void
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const VEC &,
+        Vector<float> &,
+        const ComponentMask &,
+        const Function<deal_II_space_dimension> *,
+        const unsigned int,
+        const types::subdomain_id,
+        const types::material_id,
+        const KellyErrorEstimator<deal_II_dimension,
+                                  deal_II_space_dimension>::Strategy);
+
+    template void
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const std::vector<const VEC *> &,
+        std::vector<Vector<float> *> &,
+        const ComponentMask &,
+        const Function<deal_II_space_dimension> *,
+        const unsigned int,
+        const types::subdomain_id,
+        const types::material_id,
+        const KellyErrorEstimator<deal_II_dimension,
+                                  deal_II_space_dimension>::Strategy);
+
+    template void
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const std::vector<const VEC *> &,
+        std::vector<Vector<float> *> &,
+        const ComponentMask &,
+        const Function<deal_II_space_dimension> *,
+        const unsigned int,
+        const types::subdomain_id,
+        const types::material_id,
+        const KellyErrorEstimator<deal_II_dimension,
+                                  deal_II_space_dimension>::Strategy);
 
 #endif
-}
+  }

--- a/source/numerics/error_estimator_1d.inst.in
+++ b/source/numerics/error_estimator_1d.inst.in
@@ -14,137 +14,135 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; DH : DOFHANDLER_TEMPLATES )
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS;
+     DH : DOFHANDLER_TEMPLATES)
+  {
 #if deal_II_dimension == 1 && deal_II_dimension <= deal_II_space_dimension
 
-    template
-    void
+    template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (const Mapping<deal_II_dimension, deal_II_space_dimension>      &,
-            const DH<deal_II_dimension,deal_II_space_dimension>   &,
-            const Quadrature<deal_II_dimension-1> &,
-            const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-            const VEC       &,
-            Vector<float>           &,
-            const ComponentMask &,
-            const Function<deal_II_space_dimension>     *,
-            const unsigned int,
-            const types::subdomain_id,
-            const types::material_id,
-            const Strategy);
-
-    template
-    void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (
-        const DH<deal_II_dimension,deal_II_space_dimension>   &,
-        const Quadrature<deal_II_dimension-1> &,
-        const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-        const VEC       &,
-        Vector<float>           &,
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const VEC &,
+        Vector<float> &,
         const ComponentMask &,
-        const Function<deal_II_space_dimension>     *,
+        const Function<deal_II_space_dimension> *,
         const unsigned int,
         const types::subdomain_id,
         const types::material_id,
         const Strategy);
 
-    template
-    void
+    template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (const Mapping<deal_II_dimension, deal_II_space_dimension>      &,
-            const DH<deal_II_dimension,deal_II_space_dimension>   &,
-            const Quadrature<deal_II_dimension-1> &,
-            const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-            const std::vector<const VEC *>       &,
-            std::vector<Vector<float> *>         &,
-            const ComponentMask &,
-            const Function<deal_II_space_dimension>     *,
-            const unsigned int,
-            const types::subdomain_id,
-            const types::material_id,
-            const Strategy);
-
-    template
-    void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (
-        const DH<deal_II_dimension,deal_II_space_dimension>   &,
-        const Quadrature<deal_II_dimension-1> &,
-        const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-        const std::vector<const VEC *>       &,
-        std::vector<Vector<float> *>         &,
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const VEC &,
+        Vector<float> &,
         const ComponentMask &,
-        const Function<deal_II_space_dimension>     *,
+        const Function<deal_II_space_dimension> *,
         const unsigned int,
         const types::subdomain_id,
         const types::material_id,
         const Strategy);
 
-    template
-    void
+    template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (const Mapping<deal_II_dimension, deal_II_space_dimension>      &,
-            const DH<deal_II_dimension,deal_II_space_dimension>   &,
-            const hp::QCollection<deal_II_dimension-1> &,
-            const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-            const VEC       &,
-            Vector<float>           &,
-            const ComponentMask &,
-            const Function<deal_II_space_dimension>     *,
-            const unsigned int,
-            const types::subdomain_id,
-            const types::material_id,
-            const Strategy);
-
-    template
-    void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (
-        const DH<deal_II_dimension,deal_II_space_dimension>   &,
-        const hp::QCollection<deal_II_dimension-1> &,
-        const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-        const VEC       &,
-        Vector<float>           &,
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const std::vector<const VEC *> &,
+        std::vector<Vector<float> *> &,
         const ComponentMask &,
-        const Function<deal_II_space_dimension>     *,
+        const Function<deal_II_space_dimension> *,
         const unsigned int,
         const types::subdomain_id,
         const types::material_id,
         const Strategy);
 
-    template
-    void
+    template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (const Mapping<deal_II_dimension, deal_II_space_dimension>      &,
-            const DH<deal_II_dimension,deal_II_space_dimension>   &,
-            const hp::QCollection<deal_II_dimension-1> &,
-            const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-            const std::vector<const VEC *>       &,
-            std::vector<Vector<float> *>         &,
-            const ComponentMask &,
-            const Function<deal_II_space_dimension>     *,
-            const unsigned int,
-            const types::subdomain_id,
-            const types::material_id,
-            const Strategy);
-
-    template
-    void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-    estimate<VEC,DH<deal_II_dimension,deal_II_space_dimension> > (
-        const DH<deal_II_dimension,deal_II_space_dimension>   &,
-        const hp::QCollection<deal_II_dimension-1> &,
-        const FunctionMap<deal_II_space_dimension,VEC::value_type>::type &,
-        const std::vector<const VEC *>       &,
-        std::vector<Vector<float> *>         &,
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const std::vector<const VEC *> &,
+        std::vector<Vector<float> *> &,
         const ComponentMask &,
-        const Function<deal_II_space_dimension>     *,
+        const Function<deal_II_space_dimension> *,
+        const unsigned int,
+        const types::subdomain_id,
+        const types::material_id,
+        const Strategy);
+
+    template void
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const VEC &,
+        Vector<float> &,
+        const ComponentMask &,
+        const Function<deal_II_space_dimension> *,
+        const unsigned int,
+        const types::subdomain_id,
+        const types::material_id,
+        const Strategy);
+
+    template void
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const VEC &,
+        Vector<float> &,
+        const ComponentMask &,
+        const Function<deal_II_space_dimension> *,
+        const unsigned int,
+        const types::subdomain_id,
+        const types::material_id,
+        const Strategy);
+
+    template void
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const std::vector<const VEC *> &,
+        std::vector<Vector<float> *> &,
+        const ComponentMask &,
+        const Function<deal_II_space_dimension> *,
+        const unsigned int,
+        const types::subdomain_id,
+        const types::material_id,
+        const Strategy);
+
+    template void
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
+      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
+        const std::vector<const VEC *> &,
+        std::vector<Vector<float> *> &,
+        const ComponentMask &,
+        const Function<deal_II_space_dimension> *,
         const unsigned int,
         const types::subdomain_id,
         const types::material_id,
         const Strategy);
 
 #endif
-}
+  }

--- a/source/numerics/fe_field_function.inst.in
+++ b/source/numerics/fe_field_function.inst.in
@@ -15,8 +15,8 @@
 
 
 
-for (VECTOR : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
-{
+for (VECTOR : VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
+  {
     template class FEFieldFunction<deal_II_dimension,
                                    DoFHandler<deal_II_dimension>,
                                    VECTOR>;
@@ -24,4 +24,4 @@ for (VECTOR : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
     template class FEFieldFunction<deal_II_dimension,
                                    hp::DoFHandler<deal_II_dimension>,
                                    VECTOR>;
-}
+  }

--- a/source/numerics/matrix_creator.inst.in
+++ b/source/numerics/matrix_creator.inst.in
@@ -15,269 +15,290 @@
 
 
 
-// MatrixCreator::create_mass_matrix for the matrix only --> only real-valued scalars
-for (scalar: REAL_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+// MatrixCreator::create_mass_matrix for the matrix only --> only real-valued
+// scalars
+for (scalar : REAL_SCALARS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     // non-hp version of create_mass_matrix
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
+    template void MatrixCreator::
+      create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &   mapping,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+        const Quadrature<deal_II_dimension> &                         q,
+        SparseMatrix<scalar> &                                        matrix,
+        const Function<deal_II_space_dimension, scalar> *const coefficient,
+        const ConstraintMatrix &                               constraints);
+    template void MatrixCreator::
+      create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+        const Quadrature<deal_II_dimension> &                         q,
+        SparseMatrix<scalar> &                                        matrix,
+        const Function<deal_II_space_dimension, scalar> *const coefficient,
+        const ConstraintMatrix &                               constraints);
 
     // hp versions of functions
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
+    template void MatrixCreator::
+      create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
+        const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
+          &mapping,
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+        const hp::QCollection<deal_II_dimension> &                        q,
+        SparseMatrix<scalar> &                                 matrix,
+        const Function<deal_II_space_dimension, scalar> *const coefficient,
+        const ConstraintMatrix &                               constraints);
 
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<scalar>     &matrix,
-     const Function<deal_II_space_dimension,scalar> * const coefficient,
-     const ConstraintMatrix   &constraints);
+    template void MatrixCreator::
+      create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+        const hp::QCollection<deal_II_dimension> &                        q,
+        SparseMatrix<scalar> &                                 matrix,
+        const Function<deal_II_space_dimension, scalar> *const coefficient,
+        const ConstraintMatrix &                               constraints);
 #endif
-}
+  }
 
 
-// MatrixCreator::create_mass_matrix for matrix + rhs --> real- and complex-valued scalars
-for (scalar: REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+// MatrixCreator::create_mass_matrix for matrix + rhs --> real- and
+// complex-valued scalars
+for (scalar : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     // non-hp version of create_mass_matrix
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<numbers::NumberTraits<scalar>::real_type>     &matrix,
-     const Function<deal_II_space_dimension,scalar>      &rhs,
-     Vector<scalar>           &rhs_vector,
-     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<numbers::NumberTraits<scalar>::real_type>     &matrix,
-     const Function<deal_II_space_dimension,scalar>      &rhs,
-     Vector<scalar>           &rhs_vector,
-     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const coefficient,
-     const ConstraintMatrix   &constraints);
+    template void MatrixCreator::
+      create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &   mapping,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+        const Quadrature<deal_II_dimension> &                         q,
+        SparseMatrix<numbers::NumberTraits<scalar>::real_type> &      matrix,
+        const Function<deal_II_space_dimension, scalar> &             rhs,
+        Vector<scalar> &rhs_vector,
+        const Function<deal_II_space_dimension,
+                       numbers::NumberTraits<scalar>::real_type>
+          *const                coefficient,
+        const ConstraintMatrix &constraints);
+    template void MatrixCreator::
+      create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+        const Quadrature<deal_II_dimension> &                         q,
+        SparseMatrix<numbers::NumberTraits<scalar>::real_type> &      matrix,
+        const Function<deal_II_space_dimension, scalar> &             rhs,
+        Vector<scalar> &rhs_vector,
+        const Function<deal_II_space_dimension,
+                       numbers::NumberTraits<scalar>::real_type>
+          *const                coefficient,
+        const ConstraintMatrix &constraints);
 
     // hp version
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<numbers::NumberTraits<scalar>::real_type>     &matrix,
-     const Function<deal_II_space_dimension,scalar>      &rhs,
-     Vector<scalar>           &rhs_vector,
-     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const coefficient,
-     const ConstraintMatrix   &constraints);
+    template void MatrixCreator::
+      create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
+        const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
+          &mapping,
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+        const hp::QCollection<deal_II_dimension> &                        q,
+        SparseMatrix<numbers::NumberTraits<scalar>::real_type> &matrix,
+        const Function<deal_II_space_dimension, scalar> &       rhs,
+        Vector<scalar> &                                        rhs_vector,
+        const Function<deal_II_space_dimension,
+                       numbers::NumberTraits<scalar>::real_type>
+          *const                coefficient,
+        const ConstraintMatrix &constraints);
 
-    template
-    void MatrixCreator::create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<numbers::NumberTraits<scalar>::real_type>     &matrix,
-     const Function<deal_II_space_dimension,scalar>      &rhs,
-     Vector<scalar>           &rhs_vector,
-     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const coefficient,
-     const ConstraintMatrix   &constraints);
+    template void MatrixCreator::
+      create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+        const hp::QCollection<deal_II_dimension> &                        q,
+        SparseMatrix<numbers::NumberTraits<scalar>::real_type> &matrix,
+        const Function<deal_II_space_dimension, scalar> &       rhs,
+        Vector<scalar> &                                        rhs_vector,
+        const Function<deal_II_space_dimension,
+                       numbers::NumberTraits<scalar>::real_type>
+          *const                coefficient,
+        const ConstraintMatrix &constraints);
 #endif
-}
+  }
 
 
-for (scalar: REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (scalar : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template
-    void MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>     &dof,
-     const Quadrature<deal_II_dimension-1>   &q,
-     SparseMatrix<numbers::NumberTraits<scalar>::real_type>      &matrix,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*> &rhs,
-     Vector<scalar>            &rhs_vector,
-     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const a,
-     std::vector<unsigned int>);
+    template void
+    MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,
+                                               deal_II_space_dimension,
+                                               scalar>(
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &     dof,
+      const Quadrature<deal_II_dimension - 1> &                          q,
+      SparseMatrix<numbers::NumberTraits<scalar>::real_type> &           matrix,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, scalar> *> &rhs,
+      Vector<scalar> &                      rhs_vector,
+      std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+      const Function<deal_II_space_dimension,
+                     numbers::NumberTraits<scalar>::real_type> *const a,
+      std::vector<unsigned int>);
 
-    template
-    void MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,deal_II_space_dimension, scalar>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension> &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>     &dof,
-     const Quadrature<deal_II_dimension-1>   &q,
-     SparseMatrix<numbers::NumberTraits<scalar>::real_type>      &matrix,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*> &rhs,
-     Vector<scalar>            &rhs_vector,
-     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const a,
-     std::vector<unsigned int>);
+    template void
+    MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,
+                                               deal_II_space_dimension,
+                                               scalar>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &     dof,
+      const Quadrature<deal_II_dimension - 1> &                          q,
+      SparseMatrix<numbers::NumberTraits<scalar>::real_type> &           matrix,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, scalar> *> &rhs,
+      Vector<scalar> &                      rhs_vector,
+      std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+      const Function<deal_II_space_dimension,
+                     numbers::NumberTraits<scalar>::real_type> *const a,
+      std::vector<unsigned int>);
 
-    template
-    void
-    MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>&,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const hp::QCollection<deal_II_dimension-1>&,
-     SparseMatrix<numbers::NumberTraits<scalar>::real_type>&,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*>&,
-     Vector<scalar>&,
-     std::vector<types::global_dof_index>&,
-     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const,
-     std::vector<unsigned int>);
+    template void
+    MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,
+                                               deal_II_space_dimension,
+                                               scalar>(
+      const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::QCollection<deal_II_dimension - 1> &,
+      SparseMatrix<numbers::NumberTraits<scalar>::real_type> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, scalar> *> &,
+      Vector<scalar> &,
+      std::vector<types::global_dof_index> &,
+      const Function<deal_II_space_dimension,
+                     numbers::NumberTraits<scalar>::real_type> *const,
+      std::vector<unsigned int>);
 
-    template
-    void MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,deal_II_space_dimension,scalar>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const hp::QCollection<deal_II_dimension-1>&,
-     SparseMatrix<numbers::NumberTraits<scalar>::real_type>&,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,scalar>*>&,
-     Vector<scalar>&,
-     std::vector<types::global_dof_index>&,
-     const Function<deal_II_space_dimension,numbers::NumberTraits<scalar>::real_type> * const,
-     std::vector<unsigned int>);
+    template void
+    MatrixCreator::create_boundary_mass_matrix<deal_II_dimension,
+                                               deal_II_space_dimension,
+                                               scalar>(
+      const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::QCollection<deal_II_dimension - 1> &,
+      SparseMatrix<numbers::NumberTraits<scalar>::real_type> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, scalar> *> &,
+      Vector<scalar> &,
+      std::vector<types::global_dof_index> &,
+      const Function<deal_II_space_dimension,
+                     numbers::NumberTraits<scalar>::real_type> *const,
+      std::vector<unsigned int>);
 #endif
-}
+  }
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension == deal_II_space_dimension
 
-// non-hp versions of create_laplace_matrix
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_dimension> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension>
-    (const Mapping<deal_II_dimension>       &mapping,
-     const DoFHandler<deal_II_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_dimension> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension>
-    (const Mapping<deal_II_dimension>       &mapping,
-     const DoFHandler<deal_II_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_dimension>      &rhs,
-     Vector<double>           &rhs_vector,
-     const Function<deal_II_dimension> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_dimension>      &rhs,
-     Vector<double>           &rhs_vector,
-     const Function<deal_II_dimension> * const coefficient,
-     const ConstraintMatrix   &constraints);
+    // non-hp versions of create_laplace_matrix
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &    dof,
+      const Quadrature<deal_II_dimension> &    q,
+      SparseMatrix<double> &                   matrix,
+      const Function<deal_II_dimension> *const coefficient,
+      const ConstraintMatrix &                 constraints);
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension>(
+      const Mapping<deal_II_dimension> &       mapping,
+      const DoFHandler<deal_II_dimension> &    dof,
+      const Quadrature<deal_II_dimension> &    q,
+      SparseMatrix<double> &                   matrix,
+      const Function<deal_II_dimension> *const coefficient,
+      const ConstraintMatrix &                 constraints);
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension>(
+      const Mapping<deal_II_dimension> &       mapping,
+      const DoFHandler<deal_II_dimension> &    dof,
+      const Quadrature<deal_II_dimension> &    q,
+      SparseMatrix<double> &                   matrix,
+      const Function<deal_II_dimension> &      rhs,
+      Vector<double> &                         rhs_vector,
+      const Function<deal_II_dimension> *const coefficient,
+      const ConstraintMatrix &                 constraints);
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &    dof,
+      const Quadrature<deal_II_dimension> &    q,
+      SparseMatrix<double> &                   matrix,
+      const Function<deal_II_dimension> &      rhs,
+      Vector<double> &                         rhs_vector,
+      const Function<deal_II_dimension> *const coefficient,
+      const ConstraintMatrix &                 constraints);
 
-// hp versions of create_laplace_matrix
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_dimension> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension>
-    (const hp::MappingCollection<deal_II_dimension>       &mapping,
-     const hp::DoFHandler<deal_II_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_dimension> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension>
-    (const hp::MappingCollection<deal_II_dimension>       &mapping,
-     const hp::DoFHandler<deal_II_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_dimension>      &rhs,
-     Vector<double>           &rhs_vector,
-     const Function<deal_II_dimension> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension>    &dof,
-     const hp::QCollection<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_dimension>      &rhs,
-     Vector<double>           &rhs_vector,
-     const Function<deal_II_dimension> * const coefficient,
-     const ConstraintMatrix   &constraints);
+    // hp versions of create_laplace_matrix
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension>(
+      const hp::DoFHandler<deal_II_dimension> & dof,
+      const hp::QCollection<deal_II_dimension> &q,
+      SparseMatrix<double> &                    matrix,
+      const Function<deal_II_dimension> *const  coefficient,
+      const ConstraintMatrix &                  constraints);
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension>(
+      const hp::MappingCollection<deal_II_dimension> &mapping,
+      const hp::DoFHandler<deal_II_dimension> &       dof,
+      const hp::QCollection<deal_II_dimension> &      q,
+      SparseMatrix<double> &                          matrix,
+      const Function<deal_II_dimension> *const        coefficient,
+      const ConstraintMatrix &                        constraints);
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension>(
+      const hp::MappingCollection<deal_II_dimension> &mapping,
+      const hp::DoFHandler<deal_II_dimension> &       dof,
+      const hp::QCollection<deal_II_dimension> &      q,
+      SparseMatrix<double> &                          matrix,
+      const Function<deal_II_dimension> &             rhs,
+      Vector<double> &                                rhs_vector,
+      const Function<deal_II_dimension> *const        coefficient,
+      const ConstraintMatrix &                        constraints);
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension>(
+      const hp::DoFHandler<deal_II_dimension> & dof,
+      const hp::QCollection<deal_II_dimension> &q,
+      SparseMatrix<double> &                    matrix,
+      const Function<deal_II_dimension> &       rhs,
+      Vector<double> &                          rhs_vector,
+      const Function<deal_II_dimension> *const  coefficient,
+      const ConstraintMatrix &                  constraints);
 
 #endif
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension < deal_II_space_dimension
     // non-hp version of create_laplace_matrix
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension,deal_II_space_dimension>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_space_dimension,double> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension,deal_II_space_dimension>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_space_dimension,double> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension,deal_II_space_dimension>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>       &mapping,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_space_dimension,double>      &rhs,
-     Vector<double>           &rhs_vector,
-     const Function<deal_II_space_dimension,double> * const coefficient,
-     const ConstraintMatrix   &constraints);
-    template
-    void MatrixCreator::create_laplace_matrix<deal_II_dimension,deal_II_space_dimension>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>    &dof,
-     const Quadrature<deal_II_dimension>    &q,
-     SparseMatrix<double>     &matrix,
-     const Function<deal_II_space_dimension,double>      &rhs,
-     Vector<double>           &rhs_vector,
-     const Function<deal_II_space_dimension,double> * const coefficient,
-     const ConstraintMatrix   &constraints);
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension,
+                                                       deal_II_space_dimension>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &   mapping,
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+      const Quadrature<deal_II_dimension> &                         q,
+      SparseMatrix<double> &                                        matrix,
+      const Function<deal_II_space_dimension, double> *const        coefficient,
+      const ConstraintMatrix &constraints);
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension,
+                                                       deal_II_space_dimension>(
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+      const Quadrature<deal_II_dimension> &                         q,
+      SparseMatrix<double> &                                        matrix,
+      const Function<deal_II_space_dimension, double> *const        coefficient,
+      const ConstraintMatrix &constraints);
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension,
+                                                       deal_II_space_dimension>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &   mapping,
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+      const Quadrature<deal_II_dimension> &                         q,
+      SparseMatrix<double> &                                        matrix,
+      const Function<deal_II_space_dimension, double> &             rhs,
+      Vector<double> &                                              rhs_vector,
+      const Function<deal_II_space_dimension, double> *const        coefficient,
+      const ConstraintMatrix &constraints);
+    template void MatrixCreator::create_laplace_matrix<deal_II_dimension,
+                                                       deal_II_space_dimension>(
+      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &dof,
+      const Quadrature<deal_II_dimension> &                         q,
+      SparseMatrix<double> &                                        matrix,
+      const Function<deal_II_space_dimension, double> &             rhs,
+      Vector<double> &                                              rhs_vector,
+      const Function<deal_II_space_dimension, double> *const        coefficient,
+      const ConstraintMatrix &constraints);
 #endif
-}
-
+  }

--- a/source/numerics/matrix_tools.inst.in
+++ b/source/numerics/matrix_tools.inst.in
@@ -13,42 +13,36 @@
 //
 // ---------------------------------------------------------------------
 
-for (number: REAL_SCALARS)
-{
-    template
-    void MatrixTools::local_apply_boundary_values
-    (const std::map<types::global_dof_index,number> &boundary_values,
-     const std::vector<types::global_dof_index> &local_dof_indices,
-     FullMatrix<number> &local_matrix,
-     Vector<number>     &local_rhs,
-     const bool          eliminate_columns);
+for (number : REAL_SCALARS)
+  {
+    template void MatrixTools::local_apply_boundary_values(
+      const std::map<types::global_dof_index, number> &boundary_values,
+      const std::vector<types::global_dof_index> &     local_dof_indices,
+      FullMatrix<number> &                             local_matrix,
+      Vector<number> &                                 local_rhs,
+      const bool                                       eliminate_columns);
 
-    template
-    void MatrixTools::apply_boundary_values
-    (const std::map<types::global_dof_index,number> &boundary_values,
-     SparseMatrix<number>  &matrix,
-     Vector<number>   &solution,
-     Vector<number>   &right_hand_side,
-     const bool        eliminate_columns);
+    template void MatrixTools::apply_boundary_values(
+      const std::map<types::global_dof_index, number> &boundary_values,
+      SparseMatrix<number> &                           matrix,
+      Vector<number> &                                 solution,
+      Vector<number> &                                 right_hand_side,
+      const bool                                       eliminate_columns);
 
-    template
-    void MatrixTools::apply_boundary_values
-    (const std::map<types::global_dof_index,number> &boundary_values,
-     BlockSparseMatrix<number>  &matrix,
-     BlockVector<number>   &solution,
-     BlockVector<number>   &right_hand_side,
-     const bool        eliminate_columns);
+    template void MatrixTools::apply_boundary_values(
+      const std::map<types::global_dof_index, number> &boundary_values,
+      BlockSparseMatrix<number> &                      matrix,
+      BlockVector<number> &                            solution,
+      BlockVector<number> &                            right_hand_side,
+      const bool                                       eliminate_columns);
+  }
 
-}
-
-for (number: COMPLEX_SCALARS)
-{
-    template
-    void MatrixTools::apply_boundary_values
-    (const std::map<types::global_dof_index,number> &boundary_values,
-     SparseMatrix<number>  &matrix,
-     Vector<number>   &solution,
-     Vector<number>   &right_hand_side,
-     const bool        eliminate_columns);
-}
-
+for (number : COMPLEX_SCALARS)
+  {
+    template void MatrixTools::apply_boundary_values(
+      const std::map<types::global_dof_index, number> &boundary_values,
+      SparseMatrix<number> &                           matrix,
+      Vector<number> &                                 solution,
+      Vector<number> &                                 right_hand_side,
+      const bool                                       eliminate_columns);
+  }

--- a/source/numerics/point_value_history.inst.in
+++ b/source/numerics/point_value_history.inst.in
@@ -16,44 +16,39 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class PointValueHistory<deal_II_dimension>;
-}
+  }
 
 
-for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
-{
-    template
-    void PointValueHistory<deal_II_dimension>::evaluate_field
-    (const std::string &,
-     const VEC &);
-}
+for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
+  {
+    template void PointValueHistory<deal_II_dimension>::evaluate_field(
+      const std::string &, const VEC &);
+  }
 
 
-for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
-{
-    template
-    void PointValueHistory<deal_II_dimension>::evaluate_field_at_requested_location
-    (const std::string &,
-     const VEC &);
-}
+for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
+  {
+    template void
+    PointValueHistory<deal_II_dimension>::evaluate_field_at_requested_location(
+      const std::string &, const VEC &);
+  }
 
-for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
-{
-    template
-    void PointValueHistory<deal_II_dimension>::evaluate_field
-    (const std::vector <std::string> &,
-     const VEC &,
-     const DataPostprocessor<deal_II_dimension> &,
-     const Quadrature<deal_II_dimension> &);
-}
+for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
+  {
+    template void PointValueHistory<deal_II_dimension>::evaluate_field(
+      const std::vector<std::string> &,
+      const VEC &,
+      const DataPostprocessor<deal_II_dimension> &,
+      const Quadrature<deal_II_dimension> &);
+  }
 
-for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS)
-{
-    template
-    void PointValueHistory<deal_II_dimension>::evaluate_field
-    (const std::string &,
-     const VEC &,
-     const DataPostprocessor<deal_II_dimension> &,
-     const Quadrature<deal_II_dimension> &);
-}
+for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
+  {
+    template void PointValueHistory<deal_II_dimension>::evaluate_field(
+      const std::string &,
+      const VEC &,
+      const DataPostprocessor<deal_II_dimension> &,
+      const Quadrature<deal_II_dimension> &);
+  }

--- a/source/numerics/solution_transfer.inst.in
+++ b/source/numerics/solution_transfer.inst.in
@@ -14,13 +14,17 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    template class SolutionTransfer<deal_II_dimension, VEC, DoFHandler<deal_II_dimension, deal_II_space_dimension> >;
-    template class SolutionTransfer<deal_II_dimension, VEC, hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> >;
+    template class SolutionTransfer<
+      deal_II_dimension,
+      VEC,
+      DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+    template class SolutionTransfer<
+      deal_II_dimension,
+      VEC,
+      hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
 #endif
-}
-
-
-
+  }

--- a/source/numerics/time_dependent.inst.in
+++ b/source/numerics/time_dependent.inst.in
@@ -15,12 +15,12 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class TimeStepBase_Tria<deal_II_dimension>;
     namespace TimeStepBase_Tria_Flags
     \{
-    template struct Flags<deal_II_dimension>;
-    template struct RefinementFlags<deal_II_dimension>;
-    template struct RefinementData<deal_II_dimension>;
+      template struct Flags<deal_II_dimension>;
+      template struct RefinementFlags<deal_II_dimension>;
+      template struct RefinementData<deal_II_dimension>;
     \}
-}
+  }

--- a/source/numerics/vector_tools_boundary.inst.in
+++ b/source/numerics/vector_tools_boundary.inst.in
@@ -14,209 +14,231 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; DH : DOFHANDLER_TEMPLATES; number : REAL_AND_COMPLEX_SCALARS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     DH : DOFHANDLER_TEMPLATES;
+     number : REAL_AND_COMPLEX_SCALARS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace VectorTools \{
-    template
-    void interpolate_boundary_values
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>    &,
-     const DH<deal_II_dimension,deal_II_space_dimension> &,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,number>*> &,
-     std::map<types::global_dof_index,number>       &,
-     const ComponentMask    &);
+    namespace VectorTools
+    \{
+      template void
+      interpolate_boundary_values(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_space_dimension, number> *> &,
+        std::map<types::global_dof_index, number> &,
+        const ComponentMask &);
 
-    template
-    void interpolate_boundary_values
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>    &,
-     const DH<deal_II_dimension,deal_II_space_dimension> &,
-     const types::boundary_id,
-     const Function<deal_II_space_dimension,number>   &,
-     std::map<types::global_dof_index,number>       &,
-     const ComponentMask    &);
-
-    template
-    void interpolate_boundary_values (
-        const DH<deal_II_dimension,deal_II_space_dimension> &,
+      template void
+      interpolate_boundary_values(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
         const types::boundary_id,
-        const Function<deal_II_space_dimension,number>   &,
-        std::map<types::global_dof_index,number>       &,
-        const ComponentMask    &);
+        const Function<deal_II_space_dimension, number> &,
+        std::map<types::global_dof_index, number> &,
+        const ComponentMask &);
 
-    template
-    void interpolate_boundary_values
-    (const DH<deal_II_dimension,deal_II_space_dimension> &,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,number>*> &,
-     std::map<types::global_dof_index,number>       &,
-     const ComponentMask    &);
-    \}
-#endif
-}
-
-
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; number : REAL_AND_COMPLEX_SCALARS)
-{
-#if deal_II_dimension <= deal_II_space_dimension
-    namespace VectorTools \{
-    template
-    void interpolate_boundary_values
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>    &,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension> &,
-     const std::map<types::boundary_id, const Function<deal_II_space_dimension,number>*> &,
-     std::map<types::global_dof_index,number>       &,
-     const ComponentMask    &);
-    \}
-#endif
-}
-
-
-
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; DH : DOFHANDLER_TEMPLATES)
-{
-#if deal_II_dimension <= deal_II_space_dimension
-    namespace VectorTools \{
-
-    template
-    void interpolate_boundary_values (
-        const Mapping<deal_II_dimension,deal_II_space_dimension>    &,
-        const DH<deal_II_dimension,deal_II_space_dimension> &,
-        const std::map<types::boundary_id, const Function<deal_II_space_dimension,double>*> &,
-        ConstraintMatrix                    &,
-        const ComponentMask    &);
-
-    template
-    void interpolate_boundary_values
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>    &,
-     const DH<deal_II_dimension,deal_II_space_dimension> &,
-     const types::boundary_id,
-     const Function<deal_II_space_dimension>   &,
-     ConstraintMatrix                    &,
-     const ComponentMask             &);
-
-    template
-    void interpolate_boundary_values (
-        const DH<deal_II_dimension,deal_II_space_dimension> &,
+      template void
+      interpolate_boundary_values(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
         const types::boundary_id,
-        const Function<deal_II_space_dimension>   &,
-        ConstraintMatrix                    &,
-        const ComponentMask    &);
+        const Function<deal_II_space_dimension, number> &,
+        std::map<types::global_dof_index, number> &,
+        const ComponentMask &);
 
-    template
-    void interpolate_boundary_values (
-        const DH<deal_II_dimension,deal_II_space_dimension> &,
-        const std::map<types::boundary_id, const Function<deal_II_space_dimension,double>*> &,
-        ConstraintMatrix                    &,
-        const ComponentMask    &);
+      template void
+      interpolate_boundary_values(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_space_dimension, number> *> &,
+        std::map<types::global_dof_index, number> &,
+        const ComponentMask &);
     \}
 #endif
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS; number : REAL_AND_COMPLEX_SCALARS)
-{
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     number : REAL_AND_COMPLEX_SCALARS)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+    namespace VectorTools
+    \{
+      template void
+      interpolate_boundary_values(
+        const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
+          &,
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_space_dimension, number> *> &,
+        std::map<types::global_dof_index, number> &,
+        const ComponentMask &);
+    \}
+#endif
+  }
+
+
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     DH : DOFHANDLER_TEMPLATES)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+    namespace VectorTools
+    \{
+
+      template void
+      interpolate_boundary_values(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_space_dimension, double> *> &,
+        ConstraintMatrix &,
+        const ComponentMask &);
+
+      template void
+      interpolate_boundary_values(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const types::boundary_id,
+        const Function<deal_II_space_dimension> &,
+        ConstraintMatrix &,
+        const ComponentMask &);
+
+      template void
+      interpolate_boundary_values(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const types::boundary_id,
+        const Function<deal_II_space_dimension> &,
+        ConstraintMatrix &,
+        const ComponentMask &);
+
+      template void
+      interpolate_boundary_values(
+        const DH<deal_II_dimension, deal_II_space_dimension> &,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_space_dimension, double> *> &,
+        ConstraintMatrix &,
+        const ComponentMask &);
+    \}
+#endif
+  }
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     number : REAL_AND_COMPLEX_SCALARS)
+  {
 #if deal_II_dimension == deal_II_space_dimension
-    namespace VectorTools \{
+    namespace VectorTools
+    \{
 
-    template
-    void project_boundary_values<deal_II_dimension>
-    (const Mapping<deal_II_dimension>     &,
-     const DoFHandler<deal_II_dimension>  &,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,number>*> &,
-     const Quadrature<deal_II_dimension-1>&,
-     std::map<types::global_dof_index,number>&,
-     std::vector<unsigned int>);
+      template void
+      project_boundary_values<deal_II_dimension>(
+        const Mapping<deal_II_dimension> &,
+        const DoFHandler<deal_II_dimension> &,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_dimension, number> *> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        std::map<types::global_dof_index, number> &,
+        std::vector<unsigned int>);
 
-    template
-    void project_boundary_values<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>  &,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,number>*> &,
-     const Quadrature<deal_II_dimension-1>&,
-     std::map<types::global_dof_index,number>&,
-     std::vector<unsigned int>);
+      template void
+      project_boundary_values<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_dimension, number> *> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        std::map<types::global_dof_index, number> &,
+        std::vector<unsigned int>);
 
-    template
-    void project_boundary_values<deal_II_dimension,deal_II_space_dimension>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension> &,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,number>*> &,
-     const hp::QCollection<deal_II_dimension-1> &,
-     std::map<types::global_dof_index,number> &,
-     std::vector<unsigned int>);
+      template void
+      project_boundary_values<deal_II_dimension, deal_II_space_dimension>(
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_dimension, number> *> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        std::map<types::global_dof_index, number> &,
+        std::vector<unsigned int>);
 
     \}
 #endif
-}
+  }
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
-    namespace VectorTools \{
+  {
+    namespace VectorTools
+    \{
 #if deal_II_dimension == deal_II_space_dimension
 
 
-    template
-    void project_boundary_values<deal_II_dimension>
-    (const Mapping<deal_II_dimension>     &,
-     const DoFHandler<deal_II_dimension>  &,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,double>*> &,
-     const Quadrature<deal_II_dimension-1>&,
-     ConstraintMatrix&, std::vector<unsigned int>);
+      template void
+      project_boundary_values<deal_II_dimension>(
+        const Mapping<deal_II_dimension> &,
+        const DoFHandler<deal_II_dimension> &,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_dimension, double> *> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        ConstraintMatrix &,
+        std::vector<unsigned int>);
 
-    template
-    void project_boundary_values<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>  &,
-     const std::map<types::boundary_id, const Function<deal_II_dimension,double>*> &,
-     const Quadrature<deal_II_dimension-1>&,
-     ConstraintMatrix&,
-     std::vector<unsigned int>);
+      template void
+      project_boundary_values<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const std::map<types::boundary_id,
+                       const Function<deal_II_dimension, double> *> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        ConstraintMatrix &,
+        std::vector<unsigned int>);
 
-#if deal_II_dimension != 1
-    template
-    void project_boundary_values_curl_conforming<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>&,
-     const unsigned int,
-     const Function<deal_II_dimension>&,
-     const types::boundary_id,
-     ConstraintMatrix&,
-     const Mapping<deal_II_dimension>&);
-    template
-    void project_boundary_values_curl_conforming<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension>&,
-     const unsigned int,
-     const Function<deal_II_dimension>&,
-     const types::boundary_id,
-     ConstraintMatrix&,
-     const hp::MappingCollection<deal_II_dimension>&);
-    template
-    void project_boundary_values_curl_conforming_l2<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>&,
-     const unsigned int,
-     const Function<deal_II_dimension>&,
-     const types::boundary_id,
-     ConstraintMatrix&,
-     const Mapping<deal_II_dimension>&);
-    template
-    void project_boundary_values_curl_conforming_l2<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension>&,
-     const unsigned int,
-     const Function<deal_II_dimension>&,
-     const types::boundary_id,
-     ConstraintMatrix&,
-     const hp::MappingCollection<deal_II_dimension>&);
-    template
-    void project_boundary_values_div_conforming<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension>&,
-     const unsigned int,
-     const Function<deal_II_dimension>&,
-     const types::boundary_id,
-     ConstraintMatrix&,
-     const Mapping<deal_II_dimension>&);
-    template
-    void project_boundary_values_div_conforming<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension>&,
-     const unsigned int,
-     const Function<deal_II_dimension>&,
-     const types::boundary_id,
-     ConstraintMatrix&,
-     const hp::MappingCollection<deal_II_dimension>&);
-#endif
+#  if deal_II_dimension != 1
+      template void
+      project_boundary_values_curl_conforming<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const unsigned int,
+        const Function<deal_II_dimension> &,
+        const types::boundary_id,
+        ConstraintMatrix &,
+        const Mapping<deal_II_dimension> &);
+      template void
+      project_boundary_values_curl_conforming<deal_II_dimension>(
+        const hp::DoFHandler<deal_II_dimension> &,
+        const unsigned int,
+        const Function<deal_II_dimension> &,
+        const types::boundary_id,
+        ConstraintMatrix &,
+        const hp::MappingCollection<deal_II_dimension> &);
+      template void
+      project_boundary_values_curl_conforming_l2<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const unsigned int,
+        const Function<deal_II_dimension> &,
+        const types::boundary_id,
+        ConstraintMatrix &,
+        const Mapping<deal_II_dimension> &);
+      template void
+      project_boundary_values_curl_conforming_l2<deal_II_dimension>(
+        const hp::DoFHandler<deal_II_dimension> &,
+        const unsigned int,
+        const Function<deal_II_dimension> &,
+        const types::boundary_id,
+        ConstraintMatrix &,
+        const hp::MappingCollection<deal_II_dimension> &);
+      template void
+      project_boundary_values_div_conforming<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const unsigned int,
+        const Function<deal_II_dimension> &,
+        const types::boundary_id,
+        ConstraintMatrix &,
+        const Mapping<deal_II_dimension> &);
+      template void
+      project_boundary_values_div_conforming<deal_II_dimension>(
+        const hp::DoFHandler<deal_II_dimension> &,
+        const unsigned int,
+        const Function<deal_II_dimension> &,
+        const types::boundary_id,
+        ConstraintMatrix &,
+        const hp::MappingCollection<deal_II_dimension> &);
+#  endif
 #endif
     \}
-}
+  }

--- a/source/numerics/vector_tools_constraints.inst.in
+++ b/source/numerics/vector_tools_constraints.inst.in
@@ -14,81 +14,83 @@
 // ---------------------------------------------------------------------
 
 
-//TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension, deal_II_space_dimension>
+// TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension,
+// deal_II_space_dimension>
 // where applicable and move to codimension cases above also when applicable
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
-    namespace VectorTools \{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+    namespace VectorTools
+    \{
 
 #if deal_II_dimension == deal_II_space_dimension
-#if deal_II_dimension != 1
-    template
-    void
-    compute_nonzero_normal_flux_constraints (const DoFHandler<deal_II_dimension> &dof_handler,
-            const unsigned int     first_vector_component,
-            const std::set<types::boundary_id> &boundary_ids,
-            FunctionMap<deal_II_dimension>::type &function_map,
-            ConstraintMatrix      &constraints,
-            const Mapping<deal_II_dimension>    &mapping);
+#  if deal_II_dimension != 1
+      template void
+      compute_nonzero_normal_flux_constraints(
+        const DoFHandler<deal_II_dimension> & dof_handler,
+        const unsigned int                    first_vector_component,
+        const std::set<types::boundary_id> &  boundary_ids,
+        FunctionMap<deal_II_dimension>::type &function_map,
+        ConstraintMatrix &                    constraints,
+        const Mapping<deal_II_dimension> &    mapping);
 
-    template
-    void
-    compute_nonzero_normal_flux_constraints (const hp::DoFHandler<deal_II_dimension> &dof_handler,
-            const unsigned int     first_vector_component,
-            const std::set<types::boundary_id> &boundary_ids,
-            FunctionMap<deal_II_dimension>::type &function_map,
-            ConstraintMatrix      &constraints,
-            const Mapping<deal_II_dimension>    &mapping);
+      template void
+      compute_nonzero_normal_flux_constraints(
+        const hp::DoFHandler<deal_II_dimension> &dof_handler,
+        const unsigned int                       first_vector_component,
+        const std::set<types::boundary_id> &     boundary_ids,
+        FunctionMap<deal_II_dimension>::type &   function_map,
+        ConstraintMatrix &                       constraints,
+        const Mapping<deal_II_dimension> &       mapping);
 
-    template
-    void
-    compute_nonzero_tangential_flux_constraints (const DoFHandler<deal_II_dimension> &dof_handler,
-            const unsigned int     first_vector_component,
-            const std::set<types::boundary_id> &boundary_ids,
-            FunctionMap<deal_II_dimension>::type &function_map,
-            ConstraintMatrix      &constraints,
-            const Mapping<deal_II_dimension>    &mapping);
-    template
-    void
-    compute_nonzero_tangential_flux_constraints (const hp::DoFHandler<deal_II_dimension> &dof_handler,
-            const unsigned int     first_vector_component,
-            const std::set<types::boundary_id> &boundary_ids,
-            FunctionMap<deal_II_dimension>::type &function_map,
-            ConstraintMatrix      &constraints,
-            const Mapping<deal_II_dimension>    &mapping);
+      template void
+      compute_nonzero_tangential_flux_constraints(
+        const DoFHandler<deal_II_dimension> & dof_handler,
+        const unsigned int                    first_vector_component,
+        const std::set<types::boundary_id> &  boundary_ids,
+        FunctionMap<deal_II_dimension>::type &function_map,
+        ConstraintMatrix &                    constraints,
+        const Mapping<deal_II_dimension> &    mapping);
+      template void
+      compute_nonzero_tangential_flux_constraints(
+        const hp::DoFHandler<deal_II_dimension> &dof_handler,
+        const unsigned int                       first_vector_component,
+        const std::set<types::boundary_id> &     boundary_ids,
+        FunctionMap<deal_II_dimension>::type &   function_map,
+        ConstraintMatrix &                       constraints,
+        const Mapping<deal_II_dimension> &       mapping);
 
-    template
-    void
-    compute_no_normal_flux_constraints (const DoFHandler<deal_II_dimension> &dof_handler,
-                                        const unsigned int     first_vector_component,
-                                        const std::set<types::boundary_id> &boundary_ids,
-                                        ConstraintMatrix      &constraints,
-                                        const Mapping<deal_II_dimension>    &mapping);
+      template void
+      compute_no_normal_flux_constraints(
+        const DoFHandler<deal_II_dimension> &dof_handler,
+        const unsigned int                   first_vector_component,
+        const std::set<types::boundary_id> & boundary_ids,
+        ConstraintMatrix &                   constraints,
+        const Mapping<deal_II_dimension> &   mapping);
 
-    template
-    void
-    compute_no_normal_flux_constraints (const hp::DoFHandler<deal_II_dimension> &dof_handler,
-                                        const unsigned int     first_vector_component,
-                                        const std::set<types::boundary_id> &boundary_ids,
-                                        ConstraintMatrix      &constraints,
-                                        const Mapping<deal_II_dimension>    &mapping);
+      template void
+      compute_no_normal_flux_constraints(
+        const hp::DoFHandler<deal_II_dimension> &dof_handler,
+        const unsigned int                       first_vector_component,
+        const std::set<types::boundary_id> &     boundary_ids,
+        ConstraintMatrix &                       constraints,
+        const Mapping<deal_II_dimension> &       mapping);
 
-    template
-    void
-    compute_normal_flux_constraints (const DoFHandler<deal_II_dimension> &dof_handler,
-                                     const unsigned int     first_vector_component,
-                                     const std::set<types::boundary_id> &boundary_ids,
-                                     ConstraintMatrix      &constraints,
-                                     const Mapping<deal_II_dimension>    &mapping);
+      template void
+      compute_normal_flux_constraints(
+        const DoFHandler<deal_II_dimension> &dof_handler,
+        const unsigned int                   first_vector_component,
+        const std::set<types::boundary_id> & boundary_ids,
+        ConstraintMatrix &                   constraints,
+        const Mapping<deal_II_dimension> &   mapping);
 
-    template
-    void
-    compute_normal_flux_constraints (const hp::DoFHandler<deal_II_dimension> &dof_handler,
-                                     const unsigned int     first_vector_component,
-                                     const std::set<types::boundary_id> &boundary_ids,
-                                     ConstraintMatrix      &constraints,
-                                     const Mapping<deal_II_dimension>    &mapping);
-#endif
+      template void
+      compute_normal_flux_constraints(
+        const hp::DoFHandler<deal_II_dimension> &dof_handler,
+        const unsigned int                       first_vector_component,
+        const std::set<types::boundary_id> &     boundary_ids,
+        ConstraintMatrix &                       constraints,
+        const Mapping<deal_II_dimension> &       mapping);
+#  endif
 #endif
     \}
-}
+  }

--- a/source/numerics/vector_tools_integrate_difference.inst.in
+++ b/source/numerics/vector_tools_integrate_difference.inst.in
@@ -14,124 +14,157 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace VectorTools \{
+    namespace VectorTools
+    \{
 
-    template
-    void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension>
-    (const Mapping<deal_II_dimension, deal_II_space_dimension>&,
-     const DoFHandler<deal_II_dimension, deal_II_space_dimension>&,
-     const VEC&,
-     const Function<deal_II_space_dimension>&,
-     Vector<float>&,
-     const Quadrature<deal_II_dimension>&,
-     const NormType&,
-     const Function<deal_II_space_dimension>*,
-     const double);
+      template void
+      integrate_difference<deal_II_dimension,
+                           VEC,
+                           Vector<float>,
+                           deal_II_space_dimension>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const Function<deal_II_space_dimension> &,
+        Vector<float> &,
+        const Quadrature<deal_II_dimension> &,
+        const NormType &,
+        const Function<deal_II_space_dimension> *,
+        const double);
 
-    template
-    void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension>
-    (const DoFHandler<deal_II_dimension, deal_II_space_dimension>&,
-     const VEC&,
-     const Function<deal_II_space_dimension>&,
-     Vector<float>&,
-     const Quadrature<deal_II_dimension>&,
-     const NormType&,
-     const Function<deal_II_space_dimension>*,
-     const double);
+      template void
+      integrate_difference<deal_II_dimension,
+                           VEC,
+                           Vector<float>,
+                           deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const Function<deal_II_space_dimension> &,
+        Vector<float> &,
+        const Quadrature<deal_II_dimension> &,
+        const NormType &,
+        const Function<deal_II_space_dimension> *,
+        const double);
 
-    template
-    void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension >
-    (const Mapping<deal_II_dimension, deal_II_space_dimension>&,
-     const DoFHandler<deal_II_dimension, deal_II_space_dimension>&,
-     const VEC&,
-     const Function<deal_II_space_dimension>&,
-     Vector<double>&,
-     const Quadrature<deal_II_dimension>&,
-     const NormType&,
-     const Function<deal_II_space_dimension>*,
-     const double);
+      template void
+      integrate_difference<deal_II_dimension,
+                           VEC,
+                           Vector<double>,
+                           deal_II_space_dimension>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const Function<deal_II_space_dimension> &,
+        Vector<double> &,
+        const Quadrature<deal_II_dimension> &,
+        const NormType &,
+        const Function<deal_II_space_dimension> *,
+        const double);
 
-    template
-    void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension >
-    (const DoFHandler<deal_II_dimension, deal_II_space_dimension>&,
-     const VEC&,
-     const Function<deal_II_space_dimension>&,
-     Vector<double>&,
-     const Quadrature<deal_II_dimension>&,
-     const NormType&,
-     const Function<deal_II_space_dimension>*,
-     const double);
+      template void
+      integrate_difference<deal_II_dimension,
+                           VEC,
+                           Vector<double>,
+                           deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const Function<deal_II_space_dimension> &,
+        Vector<double> &,
+        const Quadrature<deal_II_dimension> &,
+        const NormType &,
+        const Function<deal_II_space_dimension> *,
+        const double);
 
-    template
-    void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>&,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const VEC&,
-     const Function<deal_II_space_dimension>&,
-     Vector<double>&,
-     const hp::QCollection<deal_II_dimension>&,
-     const NormType&,
-     const Function<deal_II_space_dimension>*,
-     const double);
+      template void
+      integrate_difference<deal_II_dimension,
+                           VEC,
+                           Vector<double>,
+                           deal_II_space_dimension>(
+        const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
+          &,
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const Function<deal_II_space_dimension> &,
+        Vector<double> &,
+        const hp::QCollection<deal_II_dimension> &,
+        const NormType &,
+        const Function<deal_II_space_dimension> *,
+        const double);
 
-    template
-    void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const VEC&,
-     const Function<deal_II_space_dimension>&,
-     Vector<double>&,
-     const hp::QCollection<deal_II_dimension>&,
-     const NormType&,
-     const Function<deal_II_space_dimension>*,
-     const double);
+      template void
+      integrate_difference<deal_II_dimension,
+                           VEC,
+                           Vector<double>,
+                           deal_II_space_dimension>(
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const Function<deal_II_space_dimension> &,
+        Vector<double> &,
+        const hp::QCollection<deal_II_dimension> &,
+        const NormType &,
+        const Function<deal_II_space_dimension> *,
+        const double);
 
-    template
-    void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension>
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>&,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const VEC&,
-     const Function<deal_II_space_dimension>&,
-     Vector<float>&,
-     const hp::QCollection<deal_II_dimension>&,
-     const NormType&,
-     const Function<deal_II_space_dimension>*,
-     const double);
+      template void
+      integrate_difference<deal_II_dimension,
+                           VEC,
+                           Vector<float>,
+                           deal_II_space_dimension>(
+        const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
+          &,
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const Function<deal_II_space_dimension> &,
+        Vector<float> &,
+        const hp::QCollection<deal_II_dimension> &,
+        const NormType &,
+        const Function<deal_II_space_dimension> *,
+        const double);
 
-    template
-    void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension>
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const VEC&,
-     const Function<deal_II_space_dimension>&,
-     Vector<float>&,
-     const hp::QCollection<deal_II_dimension>&,
-     const NormType&,
-     const Function<deal_II_space_dimension>*,
-     const double);
+      template void
+      integrate_difference<deal_II_dimension,
+                           VEC,
+                           Vector<float>,
+                           deal_II_space_dimension>(
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const Function<deal_II_space_dimension> &,
+        Vector<float> &,
+        const hp::QCollection<deal_II_dimension> &,
+        const NormType &,
+        const Function<deal_II_space_dimension> *,
+        const double);
 
     \}
 #endif
-}
+  }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace VectorTools \{
-    template
-    double compute_global_error<deal_II_dimension,deal_II_space_dimension,Vector<float> >(
-        const Triangulation<deal_II_dimension,deal_II_space_dimension> &,
+    namespace VectorTools
+    \{
+      template double
+      compute_global_error<deal_II_dimension,
+                           deal_II_space_dimension,
+                           Vector<float>>(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
         const Vector<float> &,
         const NormType &,
         const double);
 
-    template
-    double compute_global_error<deal_II_dimension,deal_II_space_dimension,Vector<double> >(
-        const Triangulation<deal_II_dimension,deal_II_space_dimension> &,
+      template double
+      compute_global_error<deal_II_dimension,
+                           deal_II_space_dimension,
+                           Vector<double>>(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
         const Vector<double> &,
         const NormType &,
         const double);
     \}
 #endif
-}
+  }

--- a/source/numerics/vector_tools_interpolate.inst.in
+++ b/source/numerics/vector_tools_interpolate.inst.in
@@ -15,113 +15,123 @@
 
 
 
-for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace VectorTools \{
+    namespace VectorTools
+    \{
 
-    template
-    void interpolate
-    (const Mapping<deal_II_dimension,deal_II_space_dimension> &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const Function<deal_II_space_dimension, VEC::value_type>&,
-     VEC&,
-     const ComponentMask&);
+      template void
+      interpolate(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const ComponentMask &);
 
-    template
-    void interpolate
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const Function<deal_II_space_dimension, VEC::value_type>&,
-     VEC&,
-     const ComponentMask&);
+      template void
+      interpolate(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const ComponentMask &);
 
-    template
-    void interpolate
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const FullMatrix<double>&,
-     const VEC&,
-     VEC&);
+      template void
+      interpolate(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const FullMatrix<double> &,
+        const VEC &,
+        VEC &);
 
-    template
-    void get_position_vector
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     VEC&,
-     const ComponentMask&);
+      template void
+      get_position_vector(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        VEC &,
+        const ComponentMask &);
 
     \}
 #endif
-}
+  }
 
 
 
-//TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension, deal_II_space_dimension>
+// TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension,
+// deal_II_space_dimension>
 // where applicable and move to codimension cases above also when applicable
-for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension == deal_II_space_dimension
 
-    namespace VectorTools \{
+    namespace VectorTools
+    \{
 
-    template
-    void interpolate
-    (const Mapping<deal_II_dimension>&,
-     const hp::DoFHandler<deal_II_dimension>&,
-     const Function<deal_II_dimension, VEC::value_type>&,
-     VEC&,
-     const ComponentMask&);
-    template
-    void interpolate
-    (const hp::DoFHandler<deal_II_dimension>&,
-     const Function<deal_II_dimension, VEC::value_type>&,
-     VEC&,
-     const ComponentMask&);
+      template void
+      interpolate(const Mapping<deal_II_dimension> &,
+                  const hp::DoFHandler<deal_II_dimension> &,
+                  const Function<deal_II_dimension, VEC::value_type> &,
+                  VEC &,
+                  const ComponentMask &);
+      template void
+      interpolate(const hp::DoFHandler<deal_II_dimension> &,
+                  const Function<deal_II_dimension, VEC::value_type> &,
+                  VEC &,
+                  const ComponentMask &);
 
-    template
-    void interpolate_based_on_material_id(const Mapping<deal_II_dimension, deal_II_space_dimension>&,
-                                          const DoFHandler<deal_II_dimension, deal_II_space_dimension>&,
-                                          const std::map< types::material_id, const Function<deal_II_space_dimension, VEC::value_type>* >&,
-                                          VEC&,
-                                          const ComponentMask&);
+      template void
+      interpolate_based_on_material_id(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const std::map<
+          types::material_id,
+          const Function<deal_II_space_dimension, VEC::value_type> *> &,
+        VEC &,
+        const ComponentMask &);
 
-    template
-    void interpolate_based_on_material_id(const Mapping<deal_II_dimension>&,
-                                          const hp::DoFHandler<deal_II_dimension>&,
-                                          const std::map< types::material_id, const Function<deal_II_dimension, VEC::value_type>* >&,
-                                          VEC&,
-                                          const ComponentMask&);
+      template void
+      interpolate_based_on_material_id(
+        const Mapping<deal_II_dimension> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const std::map<types::material_id,
+                       const Function<deal_II_dimension, VEC::value_type> *> &,
+        VEC &,
+        const ComponentMask &);
 
     \}
 #endif
-}
+  }
 
 
-for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace VectorTools \{
-    template
-    void interpolate_to_different_mesh
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension> &,
-     const VEC                           &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension> &,
-     VEC                                 &);
+    namespace VectorTools
+    \{
+      template void
+      interpolate_to_different_mesh(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        VEC &);
 
-    template
-    void interpolate_to_different_mesh
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension> &,
-     const VEC                           &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension> &,
-     const ConstraintMatrix              &,
-     VEC                                 &);
+      template void
+      interpolate_to_different_mesh(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const VEC &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ConstraintMatrix &,
+        VEC &);
 
-    template
-    void interpolate_to_different_mesh
-    (const InterGridMap<DoFHandler<deal_II_dimension,deal_II_space_dimension> > &,
-     const VEC                                          &,
-     const ConstraintMatrix                             &,
-     VEC                                                &);
+      template void
+      interpolate_to_different_mesh(
+        const InterGridMap<
+          DoFHandler<deal_II_dimension, deal_II_space_dimension>> &,
+        const VEC &,
+        const ConstraintMatrix &,
+        VEC &);
     \}
 #endif
-
-}
+  }

--- a/source/numerics/vector_tools_mean_value.inst.in
+++ b/source/numerics/vector_tools_mean_value.inst.in
@@ -14,36 +14,39 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace VectorTools \{
+    namespace VectorTools
+    \{
 
-    template
-    VEC::value_type compute_mean_value<deal_II_dimension>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>&,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const Quadrature<deal_II_dimension>&,
-     const VEC&,
-     const unsigned int);
+      template VEC::value_type
+      compute_mean_value<deal_II_dimension>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension> &,
+        const VEC &,
+        const unsigned int);
 
-    template
-    VEC::value_type compute_mean_value<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
-     const Quadrature<deal_II_dimension>&,
-     const VEC&,
-     const unsigned int);
+      template VEC::value_type
+      compute_mean_value<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension> &,
+        const VEC &,
+        const unsigned int);
 
     \}
 #endif
-}
+  }
 
 
 
 for (VEC : VECTOR_TYPES)
-{
-    namespace VectorTools \{
-    template
-    void subtract_mean_value(VEC &, const std::vector<bool> &);
+  {
+    namespace VectorTools
+    \{
+      template void
+      subtract_mean_value(VEC &, const std::vector<bool> &);
     \}
-}
+  }

--- a/source/numerics/vector_tools_point_gradient.inst.in
+++ b/source/numerics/vector_tools_point_gradient.inst.in
@@ -13,68 +13,66 @@
 //
 // ---------------------------------------------------------------------
 
-for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension == deal_II_space_dimension
 
-    namespace VectorTools \{
+    namespace VectorTools
+    \{
 
-    template
-    void point_gradient (
-        const hp::DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&,
-        std::vector<Tensor<1,deal_II_space_dimension,VEC::value_type> >&);
+      template void
+      point_gradient(
+        const hp::DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const Point<deal_II_dimension> &,
+        std::vector<Tensor<1, deal_II_space_dimension, VEC::value_type>> &);
 
-    template
-    Tensor<1,deal_II_space_dimension,VEC::value_type> point_gradient (
-        const hp::DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&);
+      template Tensor<1, deal_II_space_dimension, VEC::value_type>
+      point_gradient(const hp::DoFHandler<deal_II_dimension> &,
+                     const VEC &,
+                     const Point<deal_II_dimension> &);
 
-    template
-    void point_gradient (
-        const hp::MappingCollection<deal_II_dimension>&,
-        const hp::DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&,
-        std::vector<Tensor<1,deal_II_space_dimension,VEC::value_type> >&);
+      template void
+      point_gradient(
+        const hp::MappingCollection<deal_II_dimension> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const Point<deal_II_dimension> &,
+        std::vector<Tensor<1, deal_II_space_dimension, VEC::value_type>> &);
 
-    template
-    Tensor<1,deal_II_space_dimension,VEC::value_type> point_gradient (
-        const hp::MappingCollection<deal_II_dimension>&,
-        const hp::DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&);
+      template Tensor<1, deal_II_space_dimension, VEC::value_type>
+      point_gradient(const hp::MappingCollection<deal_II_dimension> &,
+                     const hp::DoFHandler<deal_II_dimension> &,
+                     const VEC &,
+                     const Point<deal_II_dimension> &);
 
-    template
-    void point_gradient (
-        const DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&,
-        std::vector<Tensor<1,deal_II_space_dimension,VEC::value_type> >&);
+      template void
+      point_gradient(
+        const DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const Point<deal_II_dimension> &,
+        std::vector<Tensor<1, deal_II_space_dimension, VEC::value_type>> &);
 
-    template
-    Tensor<1,deal_II_space_dimension,VEC::value_type> point_gradient (
-        const DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&);
+      template Tensor<1, deal_II_space_dimension, VEC::value_type>
+      point_gradient(const DoFHandler<deal_II_dimension> &,
+                     const VEC &,
+                     const Point<deal_II_dimension> &);
 
-    template
-    void point_gradient (
-        const Mapping<deal_II_dimension>&,
-        const DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&,
-        std::vector<Tensor<1,deal_II_space_dimension,VEC::value_type> >&);
+      template void
+      point_gradient(
+        const Mapping<deal_II_dimension> &,
+        const DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const Point<deal_II_dimension> &,
+        std::vector<Tensor<1, deal_II_space_dimension, VEC::value_type>> &);
 
-    template
-    Tensor<1,deal_II_space_dimension,VEC::value_type> point_gradient (
-        const Mapping<deal_II_dimension>&,
-        const DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&);
+      template Tensor<1, deal_II_space_dimension, VEC::value_type>
+      point_gradient(const Mapping<deal_II_dimension> &,
+                     const DoFHandler<deal_II_dimension> &,
+                     const VEC &,
+                     const Point<deal_II_dimension> &);
 
     \}
 #endif
-}
+  }

--- a/source/numerics/vector_tools_point_value.inst.in
+++ b/source/numerics/vector_tools_point_value.inst.in
@@ -14,151 +14,150 @@
 // ---------------------------------------------------------------------
 
 
-//TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension, deal_II_space_dimension>
+// TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension,
+// deal_II_space_dimension>
 // where applicable and move to codimension cases above also when applicable
-for (VEC : VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension == deal_II_space_dimension
 
-    namespace VectorTools \{
+    namespace VectorTools
+    \{
 
-    template
-    void point_value<deal_II_dimension> (
-        const hp::DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&,
-        Vector<VEC::value_type>&);
+      template void
+      point_value<deal_II_dimension>(const hp::DoFHandler<deal_II_dimension> &,
+                                     const VEC &,
+                                     const Point<deal_II_dimension> &,
+                                     Vector<VEC::value_type> &);
 
-    template
-    VEC::value_type point_value<deal_II_dimension> (
-        const hp::DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&);
+      template VEC::value_type
+      point_value<deal_II_dimension>(const hp::DoFHandler<deal_II_dimension> &,
+                                     const VEC &,
+                                     const Point<deal_II_dimension> &);
 
-    template
-    void point_value<deal_II_dimension> (
-        const hp::MappingCollection<deal_II_dimension>&,
-        const hp::DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&,
-        Vector<VEC::value_type>&);
+      template void
+      point_value<deal_II_dimension>(
+        const hp::MappingCollection<deal_II_dimension> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const Point<deal_II_dimension> &,
+        Vector<VEC::value_type> &);
 
-    template
-    VEC::value_type point_value<deal_II_dimension> (
-        const hp::MappingCollection<deal_II_dimension>&,
-        const hp::DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&);
+      template VEC::value_type
+      point_value<deal_II_dimension>(
+        const hp::MappingCollection<deal_II_dimension> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const Point<deal_II_dimension> &);
 
-    template
-    void point_difference<deal_II_dimension> (
-        const DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Function<deal_II_dimension, VEC::value_type>&,
-        Vector<VEC::value_type>&,
-        const Point<deal_II_dimension>&);
+      template void
+      point_difference<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const Function<deal_II_dimension, VEC::value_type> &,
+        Vector<VEC::value_type> &,
+        const Point<deal_II_dimension> &);
 
-    template
-    void point_difference<deal_II_dimension> (
-        const Mapping<deal_II_dimension>&,
-        const DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Function<deal_II_dimension,VEC::value_type>&,
-        Vector<VEC::value_type>&,
-        const Point<deal_II_dimension>&);
+      template void
+      point_difference<deal_II_dimension>(
+        const Mapping<deal_II_dimension> &,
+        const DoFHandler<deal_II_dimension> &,
+        const VEC &,
+        const Function<deal_II_dimension, VEC::value_type> &,
+        Vector<VEC::value_type> &,
+        const Point<deal_II_dimension> &);
 
-    template
-    void point_value<deal_II_dimension> (
-        const DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&,
-        Vector<VEC::value_type>&);
+      template void
+      point_value<deal_II_dimension>(const DoFHandler<deal_II_dimension> &,
+                                     const VEC &,
+                                     const Point<deal_II_dimension> &,
+                                     Vector<VEC::value_type> &);
 
-    template
-    VEC::value_type point_value<deal_II_dimension> (
-        const DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&);
+      template VEC::value_type
+      point_value<deal_II_dimension>(const DoFHandler<deal_II_dimension> &,
+                                     const VEC &,
+                                     const Point<deal_II_dimension> &);
 
-    template
-    void point_value<deal_II_dimension> (
-        const Mapping<deal_II_dimension>&,
-        const DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&,
-        Vector<VEC::value_type>&);
+      template void
+      point_value<deal_II_dimension>(const Mapping<deal_II_dimension> &,
+                                     const DoFHandler<deal_II_dimension> &,
+                                     const VEC &,
+                                     const Point<deal_II_dimension> &,
+                                     Vector<VEC::value_type> &);
 
-    template
-    VEC::value_type point_value<deal_II_dimension> (
-        const Mapping<deal_II_dimension>&,
-        const DoFHandler<deal_II_dimension>&,
-        const VEC&,
-        const Point<deal_II_dimension>&);
+      template VEC::value_type
+      point_value<deal_II_dimension>(const Mapping<deal_II_dimension> &,
+                                     const DoFHandler<deal_II_dimension> &,
+                                     const VEC &,
+                                     const Point<deal_II_dimension> &);
 
     \}
 #endif
-}
+  }
 
 
 
-//TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension, deal_II_space_dimension>
+// TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension,
+// deal_II_space_dimension>
 // where applicable and move to codimension cases above also when applicable
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
-    namespace VectorTools \{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+    namespace VectorTools
+    \{
 
 #if deal_II_dimension == deal_II_space_dimension
 
-    template
-    void create_point_source_vector<deal_II_dimension>
-    (const Mapping<deal_II_dimension>    &,
-     const DoFHandler<deal_II_dimension> &,
-     const Point<deal_II_dimension>      &,
-     Vector<double>                      &);
-    template
-    void create_point_source_vector<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &,
-     const Point<deal_II_dimension>      &,
-     Vector<double>                      &);
+      template void
+      create_point_source_vector<deal_II_dimension>(
+        const Mapping<deal_II_dimension> &,
+        const DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        Vector<double> &);
+      template void
+      create_point_source_vector<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        Vector<double> &);
 
-    template
-    void create_point_source_vector<deal_II_dimension>
-    (const hp::MappingCollection<deal_II_dimension>    &,
-     const hp::DoFHandler<deal_II_dimension> &,
-     const Point<deal_II_dimension>      &,
-     Vector<double>                      &);
-    template
-    void create_point_source_vector<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension> &,
-     const Point<deal_II_dimension>      &,
-     Vector<double>                      &);
-    template
-    void create_point_source_vector<deal_II_dimension>
-    (const Mapping<deal_II_dimension>    &,
-     const DoFHandler<deal_II_dimension> &,
-     const Point<deal_II_dimension>      &,
-     const Point<deal_II_dimension>      &,
-     Vector<double>                      &);
-    template
-    void create_point_source_vector<deal_II_dimension>
-    (const DoFHandler<deal_II_dimension> &,
-     const Point<deal_II_dimension>      &,
-     const Point<deal_II_dimension>      &,
-     Vector<double>                      &);
+      template void
+      create_point_source_vector<deal_II_dimension>(
+        const hp::MappingCollection<deal_II_dimension> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        Vector<double> &);
+      template void
+      create_point_source_vector<deal_II_dimension>(
+        const hp::DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        Vector<double> &);
+      template void
+      create_point_source_vector<deal_II_dimension>(
+        const Mapping<deal_II_dimension> &,
+        const DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        Vector<double> &);
+      template void
+      create_point_source_vector<deal_II_dimension>(
+        const DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        Vector<double> &);
 
-    template
-    void create_point_source_vector<deal_II_dimension>
-    (const hp::MappingCollection<deal_II_dimension>    &,
-     const hp::DoFHandler<deal_II_dimension> &,
-     const Point<deal_II_dimension>      &,
-     const Point<deal_II_dimension>      &,
-     Vector<double>                      &);
-    template
-    void create_point_source_vector<deal_II_dimension>
-    (const hp::DoFHandler<deal_II_dimension> &,
-     const Point<deal_II_dimension>      &,
-     const Point<deal_II_dimension>      &,
-     Vector<double>                      &);
+      template void
+      create_point_source_vector<deal_II_dimension>(
+        const hp::MappingCollection<deal_II_dimension> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        Vector<double> &);
+      template void
+      create_point_source_vector<deal_II_dimension>(
+        const hp::DoFHandler<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        const Point<deal_II_dimension> &,
+        Vector<double> &);
 #endif
     \}
-}
+  }

--- a/source/numerics/vector_tools_project.inst.in
+++ b/source/numerics/vector_tools_project.inst.in
@@ -14,33 +14,35 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension == deal_II_space_dimension
-    namespace VectorTools \{
+    namespace VectorTools
+    \{
 
-    template
-    void project<deal_II_dimension, VEC, deal_II_space_dimension>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>      &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>   &,
-     const ConstraintMatrix                &,
-     const Quadrature<deal_II_dimension>   &,
-     const Function<deal_II_space_dimension,VEC::value_type>     &,
-     VEC                                   &,
-     const bool,
-     const Quadrature<deal_II_dimension-1> &,
-     const bool);
+      template void
+      project<deal_II_dimension, VEC, deal_II_space_dimension>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ConstraintMatrix &,
+        const Quadrature<deal_II_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const bool,
+        const Quadrature<deal_II_dimension - 1> &,
+        const bool);
 
-    template
-    void project<deal_II_dimension, VEC, deal_II_space_dimension>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>   &,
-     const ConstraintMatrix                &,
-     const Quadrature<deal_II_dimension>   &,
-     const Function<deal_II_space_dimension,VEC::value_type>     &,
-     VEC                                   &,
-     const bool,
-     const Quadrature<deal_II_dimension-1> &,
-     const bool);
+      template void
+      project<deal_II_dimension, VEC, deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ConstraintMatrix &,
+        const Quadrature<deal_II_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const bool,
+        const Quadrature<deal_II_dimension - 1> &,
+        const bool);
     \}
 #endif
-}
+  }

--- a/source/numerics/vector_tools_project_codim.inst.in
+++ b/source/numerics/vector_tools_project_codim.inst.in
@@ -14,33 +14,35 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension < deal_II_space_dimension
-    namespace VectorTools \{
+    namespace VectorTools
+    \{
 
-    template
-    void project<deal_II_dimension, VEC, deal_II_space_dimension>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>      &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>   &,
-     const ConstraintMatrix                &,
-     const Quadrature<deal_II_dimension>   &,
-     const Function<deal_II_space_dimension,VEC::value_type>     &,
-     VEC                                   &,
-     const bool,
-     const Quadrature<deal_II_dimension-1> &,
-     const bool);
+      template void
+      project<deal_II_dimension, VEC, deal_II_space_dimension>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ConstraintMatrix &,
+        const Quadrature<deal_II_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const bool,
+        const Quadrature<deal_II_dimension - 1> &,
+        const bool);
 
-    template
-    void project<deal_II_dimension, VEC, deal_II_space_dimension>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>   &,
-     const ConstraintMatrix                &,
-     const Quadrature<deal_II_dimension>   &,
-     const Function<deal_II_space_dimension,VEC::value_type>     &,
-     VEC                                   &,
-     const bool,
-     const Quadrature<deal_II_dimension-1> &,
-     const bool);
+      template void
+      project<deal_II_dimension, VEC, deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ConstraintMatrix &,
+        const Quadrature<deal_II_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const bool,
+        const Quadrature<deal_II_dimension - 1> &,
+        const bool);
     \}
 #endif
-}
+  }

--- a/source/numerics/vector_tools_project_hp.inst.in
+++ b/source/numerics/vector_tools_project_hp.inst.in
@@ -14,33 +14,36 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_VECTOR_TYPES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace VectorTools \{
+    namespace VectorTools
+    \{
 
-    template
-    void project
-    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>      &,
-     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>   &,
-     const ConstraintMatrix                &,
-     const hp::QCollection<deal_II_dimension>   &,
-     const Function<deal_II_space_dimension,VEC::value_type>     &,
-     VEC                                   &,
-     const bool,
-     const hp::QCollection<deal_II_dimension-1> &,
-     const bool);
+      template void
+      project(
+        const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
+          &,
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ConstraintMatrix &,
+        const hp::QCollection<deal_II_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const bool,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const bool);
 
-    template
-    void project
-    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>   &,
-     const ConstraintMatrix                &,
-     const hp::QCollection<deal_II_dimension>   &,
-     const Function<deal_II_space_dimension,VEC::value_type>     &,
-     VEC                                   &,
-     const bool,
-     const hp::QCollection<deal_II_dimension-1> &,
-     const bool);
+      template void
+      project(
+        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ConstraintMatrix &,
+        const hp::QCollection<deal_II_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const bool,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const bool);
     \}
 #endif
-}
+  }

--- a/source/numerics/vector_tools_project_qp.inst.in
+++ b/source/numerics/vector_tools_project_qp.inst.in
@@ -13,19 +13,22 @@
 //
 // ---------------------------------------------------------------------
 
-for (VEC: REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
-{
-    namespace VectorTools \{
+for (VEC : REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
+  {
+    namespace VectorTools
+    \{
 
-    template
-    void project<deal_II_dimension,VEC,deal_II_dimension>(
-        const Mapping<deal_II_dimension, deal_II_dimension>   &,
-        const DoFHandler<deal_II_dimension,deal_II_dimension> &,
+      template void
+      project<deal_II_dimension, VEC, deal_II_dimension>(
+        const Mapping<deal_II_dimension, deal_II_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_dimension> &,
         const ConstraintMatrix &,
         const Quadrature<deal_II_dimension> &,
-        const std::function<VEC::value_type (const DoFHandler<deal_II_dimension, deal_II_dimension>::active_cell_iterator &, const unsigned int)> &,
+        const std::function<VEC::value_type(
+          const DoFHandler<deal_II_dimension,
+                           deal_II_dimension>::active_cell_iterator &,
+          const unsigned int)> &,
         VEC &);
 
     \}
-
-}
+  }

--- a/source/numerics/vector_tools_project_qpmf.inst.in
+++ b/source/numerics/vector_tools_project_qpmf.inst.in
@@ -15,27 +15,31 @@
 
 
 
-for (VEC: REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
-{
-    namespace VectorTools \{
+for (VEC : REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
+  {
+    namespace VectorTools
+    \{
 
-    template
-    void project<deal_II_dimension, VEC>(
-        std::shared_ptr<const MatrixFree<deal_II_dimension,VEC::value_type> > matrix_free,
+      template void
+      project<deal_II_dimension, VEC>(
+        std::shared_ptr<const MatrixFree<deal_II_dimension, VEC::value_type>>
+                                matrix_free,
         const ConstraintMatrix &constraints,
-        const std::function< VectorizedArray<VEC::value_type> (const unsigned int, const unsigned int)> &,
+        const std::function<VectorizedArray<
+          VEC::value_type>(const unsigned int, const unsigned int)> &,
         VEC &,
         const unsigned int);
 
-    template
-    void project<deal_II_dimension, VEC>(
-        std::shared_ptr<const MatrixFree<deal_II_dimension,VEC::value_type> > matrix_free,
+      template void
+      project<deal_II_dimension, VEC>(
+        std::shared_ptr<const MatrixFree<deal_II_dimension, VEC::value_type>>
+                                matrix_free,
         const ConstraintMatrix &constraints,
         const unsigned int,
-        const std::function< VectorizedArray<VEC::value_type> (const unsigned int, const unsigned int)> &,
+        const std::function<VectorizedArray<
+          VEC::value_type>(const unsigned int, const unsigned int)> &,
         VEC &,
         const unsigned int);
 
     \}
-
-}
+  }

--- a/source/numerics/vector_tools_rhs.inst.in
+++ b/source/numerics/vector_tools_rhs.inst.in
@@ -14,97 +14,109 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
+for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
 #if deal_II_dimension <= deal_II_space_dimension
-    namespace VectorTools \{
-    template
-    void create_right_hand_side<deal_II_dimension,deal_II_space_dimension,VEC >
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>          &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>       &,
-     const Quadrature<deal_II_dimension>                               &,
-     const Function<deal_II_space_dimension, VEC::value_type>          &,
-     VEC                                                               &,
-     const ConstraintMatrix                                            &);
+    namespace VectorTools
+    \{
+      template void
+      create_right_hand_side<deal_II_dimension, deal_II_space_dimension, VEC>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const ConstraintMatrix &);
 
-    template
-    void create_right_hand_side<deal_II_dimension,deal_II_space_dimension,VEC >
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>       &,
-     const Quadrature<deal_II_dimension>                               &,
-     const Function<deal_II_space_dimension, VEC::value_type>          &,
-     VEC                                                               &,
-     const ConstraintMatrix                                            &);
+      template void
+      create_right_hand_side<deal_II_dimension, deal_II_space_dimension, VEC>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const ConstraintMatrix &);
     \}
 #endif
-}
+  }
 
-//TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension, deal_II_space_dimension>
+// TODO[SP]: replace <deal_II_dimension> by <deal_II_dimension,
+// deal_II_space_dimension>
 // where applicable and move to codimension cases above also when applicable
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
-{
-    namespace VectorTools \{
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+    namespace VectorTools
+    \{
 
 #if deal_II_dimension == deal_II_space_dimension
-    template
-    void create_right_hand_side<deal_II_dimension, deal_II_space_dimension, Vector<double> >
-    (const hp::MappingCollection<deal_II_dimension> &,
-     const hp::DoFHandler<deal_II_dimension>        &,
-     const hp::QCollection<deal_II_dimension>       &,
-     const Function<deal_II_space_dimension, Vector<double>::value_type> &,
-     Vector<double>                                 &,
-     const ConstraintMatrix                         &);
+      template void
+      create_right_hand_side<deal_II_dimension,
+                             deal_II_space_dimension,
+                             Vector<double>>(
+        const hp::MappingCollection<deal_II_dimension> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const hp::QCollection<deal_II_dimension> &,
+        const Function<deal_II_space_dimension, Vector<double>::value_type> &,
+        Vector<double> &,
+        const ConstraintMatrix &);
 
-    template
-    void create_right_hand_side<deal_II_dimension, deal_II_space_dimension, Vector<double> >
-    (const hp::DoFHandler<deal_II_dimension>  &,
-     const hp::QCollection<deal_II_dimension> &,
-     const Function<deal_II_space_dimension, Vector<double>::value_type> &,
-     Vector<double>                           &,
-     const ConstraintMatrix                   &);
+      template void
+      create_right_hand_side<deal_II_dimension,
+                             deal_II_space_dimension,
+                             Vector<double>>(
+        const hp::DoFHandler<deal_II_dimension> &,
+        const hp::QCollection<deal_II_dimension> &,
+        const Function<deal_II_space_dimension, Vector<double>::value_type> &,
+        Vector<double> &,
+        const ConstraintMatrix &);
 
-#if deal_II_dimension > 1
-    template
-    void
-    create_boundary_right_hand_side<deal_II_dimension, deal_II_space_dimension, Vector<double> >
-    (const Mapping<deal_II_dimension>      &,
-     const DoFHandler<deal_II_dimension>   &,
-     const Quadrature<deal_II_dimension-1> &,
-     const Function<deal_II_space_dimension, Vector<double>::value_type> &,
-     Vector<double>                        &,
-     const std::set<types::boundary_id>    &);
-#endif
+#  if deal_II_dimension > 1
+      template void
+      create_boundary_right_hand_side<deal_II_dimension,
+                                      deal_II_space_dimension,
+                                      Vector<double>>(
+        const Mapping<deal_II_dimension> &,
+        const DoFHandler<deal_II_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const Function<deal_II_space_dimension, Vector<double>::value_type> &,
+        Vector<double> &,
+        const std::set<types::boundary_id> &);
+#  endif
 
-    template
-    void
-    create_boundary_right_hand_side<deal_II_dimension, deal_II_space_dimension, Vector<double> >
-    (const DoFHandler<deal_II_dimension>   &,
-     const Quadrature<deal_II_dimension-1> &,
-     const Function<deal_II_space_dimension, Vector<double>::value_type> &,
-     Vector<double>                        &,
-     const std::set<types::boundary_id>    &);
+      template void
+      create_boundary_right_hand_side<deal_II_dimension,
+                                      deal_II_space_dimension,
+                                      Vector<double>>(
+        const DoFHandler<deal_II_dimension> &,
+        const Quadrature<deal_II_dimension - 1> &,
+        const Function<deal_II_space_dimension, Vector<double>::value_type> &,
+        Vector<double> &,
+        const std::set<types::boundary_id> &);
 
-#if deal_II_dimension > 1
-    template
-    void
-    create_boundary_right_hand_side<deal_II_dimension, deal_II_space_dimension, Vector<double> >
-    (const hp::MappingCollection<deal_II_dimension> &,
-     const hp::DoFHandler<deal_II_dimension>        &,
-     const hp::QCollection<deal_II_dimension-1>     &,
-     const Function<deal_II_space_dimension, Vector<double>::value_type> &,
-     Vector<double>                                 &,
-     const std::set<types::boundary_id>             &);
-#endif
+#  if deal_II_dimension > 1
+      template void
+      create_boundary_right_hand_side<deal_II_dimension,
+                                      deal_II_space_dimension,
+                                      Vector<double>>(
+        const hp::MappingCollection<deal_II_dimension> &,
+        const hp::DoFHandler<deal_II_dimension> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const Function<deal_II_space_dimension, Vector<double>::value_type> &,
+        Vector<double> &,
+        const std::set<types::boundary_id> &);
+#  endif
 
-    template
-    void
-    create_boundary_right_hand_side<deal_II_dimension, deal_II_space_dimension, Vector<double> >
-    (const hp::DoFHandler<deal_II_dimension>    &,
-     const hp::QCollection<deal_II_dimension-1> &,
-     const Function<deal_II_space_dimension, Vector<double>::value_type> &,
-     Vector<double>                             &,
-     const std::set<types::boundary_id>         &);
+      template void
+      create_boundary_right_hand_side<deal_II_dimension,
+                                      deal_II_space_dimension,
+                                      Vector<double>>(
+        const hp::DoFHandler<deal_II_dimension> &,
+        const hp::QCollection<deal_II_dimension - 1> &,
+        const Function<deal_II_space_dimension, Vector<double>::value_type> &,
+        Vector<double> &,
+        const std::set<types::boundary_id> &);
 
 
 #endif
     \}
-}
+  }

--- a/source/opencascade/boundary_lib.inst.in
+++ b/source/opencascade/boundary_lib.inst.in
@@ -16,11 +16,11 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class NormalProjectionBoundary<deal_II_dimension, 3>;
     template class DirectionalProjectionBoundary<deal_II_dimension, 3>;
     template class NormalToMeshProjectionBoundary<deal_II_dimension, 3>;
 #if deal_II_dimension <= 2
     template class DirectionalProjectionBoundary<deal_II_dimension, 2>;
 #endif
-}
+  }

--- a/source/opencascade/manifold_lib.inst.in
+++ b/source/opencascade/manifold_lib.inst.in
@@ -16,7 +16,7 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     template class NormalProjectionManifold<deal_II_dimension, 3>;
     template class DirectionalProjectionManifold<deal_II_dimension, 3>;
     template class NormalToMeshProjectionManifold<deal_II_dimension, 3>;
@@ -27,4 +27,4 @@ for (deal_II_dimension : DIMENSIONS)
     template class ArclengthProjectionLineManifold<deal_II_dimension, 2>;
     template class NURBSPatchManifold<deal_II_dimension, 2>;
 #endif
-}
+  }

--- a/source/opencascade/utilities.inst.in
+++ b/source/opencascade/utilities.inst.in
@@ -14,49 +14,50 @@
 // ---------------------------------------------------------------------
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
 #if deal_II_dimension > 1
     // Explicit instantiations for dim = 2 and 3
-    template
-    std::vector<TopoDS_Edge> create_curves_from_triangulation_boundary
-    (const Triangulation<2, deal_II_dimension> &triangulation,
-     const Mapping<2, deal_II_dimension> &mapping);
+    template std::vector<TopoDS_Edge> create_curves_from_triangulation_boundary(
+      const Triangulation<2, deal_II_dimension> &triangulation,
+      const Mapping<2, deal_II_dimension> &      mapping);
 
-    template bool point_compare(const Point<deal_II_dimension>& p1,
-                                const Point<deal_II_dimension>& p2,
-                                const Tensor<1,deal_II_dimension>& direction,
-                                const double       tolerance );
+    template bool point_compare(const Point<deal_II_dimension> &    p1,
+                                const Point<deal_II_dimension> &    p2,
+                                const Tensor<1, deal_II_dimension> &direction,
+                                const double                        tolerance);
 
-    template Point<deal_II_dimension> point(const gp_Pnt &p, const double &tolerance);
+    template Point<deal_II_dimension> point(const gp_Pnt &p,
+                                            const double &tolerance);
 
-    template  gp_Pnt point(const Point<deal_II_dimension> &p);
+    template gp_Pnt point(const Point<deal_II_dimension> &p);
 
-    template
-    TopoDS_Edge interpolation_curve(std::vector<Point<deal_II_dimension> >& curve_points,
-                                    const Tensor<1, deal_II_dimension>& direction,
-                                    const bool closed,
-                                    const double tolerance);
+    template TopoDS_Edge interpolation_curve(
+      std::vector<Point<deal_II_dimension>> & curve_points,
+      const Tensor<1, deal_II_dimension> &direction,
+      const bool                          closed,
+      const double                        tolerance);
 
-    template Point<deal_II_dimension> push_forward(const TopoDS_Shape &in_shape,
-            const double u,
-            const double v);
+    template Point<deal_II_dimension> push_forward(
+      const TopoDS_Shape &in_shape, const double u, const double v);
 
-    template Point<deal_II_dimension> line_intersection(const TopoDS_Shape &in_shape,
-            const Point<deal_II_dimension> &origin,
-            const Tensor<1,deal_II_dimension> &direction,
-            const double tolerance);
+    template Point<deal_II_dimension> line_intersection(
+      const TopoDS_Shape &                in_shape,
+      const Point<deal_II_dimension> &    origin,
+      const Tensor<1, deal_II_dimension> &direction,
+      const double                        tolerance);
 
-    template void create_triangulation(const TopoDS_Face &face,
-                                       Triangulation<2,deal_II_dimension> &tria);
+    template void create_triangulation(
+      const TopoDS_Face &face, Triangulation<2, deal_II_dimension> &tria);
 
     template std::tuple<Point<deal_II_dimension>, TopoDS_Shape, double, double>
-    project_point_and_pull_back(const TopoDS_Shape &in_shape,
-                                const Point<deal_II_dimension>& origin,
-                                const double tolerance);
+    project_point_and_pull_back(const TopoDS_Shape &            in_shape,
+                                const Point<deal_II_dimension> &origin,
+                                const double                    tolerance);
 
-    template Point<deal_II_dimension> closest_point(const TopoDS_Shape &in_shape,
-            const Point<deal_II_dimension> &origin,
-            const double tolerance);
+    template Point<deal_II_dimension> closest_point(
+      const TopoDS_Shape &            in_shape,
+      const Point<deal_II_dimension> &origin,
+      const double                    tolerance);
 
 #endif
-}
+  }

--- a/source/particles/particle.inst.in
+++ b/source/particles/particle.inst.in
@@ -15,12 +15,11 @@
 
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace Particles
     \{
-    template
-    class Particle <deal_II_dimension,deal_II_space_dimension>;
+      template class Particle<deal_II_dimension, deal_II_space_dimension>;
     \}
 #endif
-}
+  }

--- a/source/particles/particle_accessor.inst.in
+++ b/source/particles/particle_accessor.inst.in
@@ -15,12 +15,12 @@
 
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace Particles
     \{
-    template
-    class ParticleAccessor <deal_II_dimension,deal_II_space_dimension>;
+      template class ParticleAccessor<deal_II_dimension,
+                                      deal_II_space_dimension>;
     \}
 #endif
-}
+  }

--- a/source/particles/particle_handler.inst.in
+++ b/source/particles/particle_handler.inst.in
@@ -15,12 +15,12 @@
 
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace Particles
     \{
-    template
-    class ParticleHandler <deal_II_dimension,deal_II_space_dimension>;
+      template class ParticleHandler<deal_II_dimension,
+                                     deal_II_space_dimension>;
     \}
 #endif
-}
+  }

--- a/source/particles/particle_iterator.inst.in
+++ b/source/particles/particle_iterator.inst.in
@@ -15,12 +15,12 @@
 
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
+  {
 #if deal_II_dimension <= deal_II_space_dimension
     namespace Particles
     \{
-    template
-    class ParticleIterator <deal_II_dimension,deal_II_space_dimension>;
+      template class ParticleIterator<deal_II_dimension,
+                                      deal_II_space_dimension>;
     \}
 #endif
-}
+  }

--- a/source/physics/elasticity/kinematics.inst.in
+++ b/source/physics/elasticity/kinematics.inst.in
@@ -15,64 +15,60 @@
 
 
 for (deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
-{
-
+  {
     namespace Physics
     \{
-    namespace Elasticity
-    \{
-    namespace Kinematics
-    \{
-    template
-    Tensor<2,deal_II_dimension,number>
-    F<deal_II_dimension,number>(const Tensor<2,deal_II_dimension,number>&);
+      namespace Elasticity
+      \{
+        namespace Kinematics
+        \{
+          template Tensor<2, deal_II_dimension, number>
+          F<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    Tensor<2,deal_II_dimension,number>
-    F_iso<deal_II_dimension,number>(const Tensor<2,deal_II_dimension,number>&);
+          template Tensor<2, deal_II_dimension, number>
+          F_iso<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    F_vol<deal_II_dimension,number>(const Tensor<2,deal_II_dimension,number>&);
+          template SymmetricTensor<2, deal_II_dimension, number>
+          F_vol<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    C<deal_II_dimension,number>(const Tensor<2,deal_II_dimension,number>&);
+          template SymmetricTensor<2, deal_II_dimension, number>
+          C<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    b<deal_II_dimension,number>(const Tensor<2,deal_II_dimension,number>&);
+          template SymmetricTensor<2, deal_II_dimension, number>
+          b<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    E<deal_II_dimension,number>(const Tensor<2,deal_II_dimension,number>&);
+          template SymmetricTensor<2, deal_II_dimension, number>
+          E<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    epsilon<deal_II_dimension,number>(const Tensor<2,deal_II_dimension,number>&);
+          template SymmetricTensor<2, deal_II_dimension, number>
+          epsilon<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    e<deal_II_dimension,number>(const Tensor<2,deal_II_dimension,number>&);
+          template SymmetricTensor<2, deal_II_dimension, number>
+          e<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    Tensor<2,deal_II_dimension,number>
-    l<deal_II_dimension,number>(
-        const Tensor<2,deal_II_dimension,number>&,
-        const Tensor<2,deal_II_dimension,number>&);
+          template Tensor<2, deal_II_dimension, number>
+          l<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &,
+            const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    d<deal_II_dimension,number>(
-        const Tensor<2,deal_II_dimension,number>&,
-        const Tensor<2,deal_II_dimension,number>&);
+          template SymmetricTensor<2, deal_II_dimension, number>
+          d<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &,
+            const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    Tensor<2,deal_II_dimension,number>
-    w<deal_II_dimension,number>(
-        const Tensor<2,deal_II_dimension,number>&,
-        const Tensor<2,deal_II_dimension,number>&);
+          template Tensor<2, deal_II_dimension, number>
+          w<deal_II_dimension, number>(
+            const Tensor<2, deal_II_dimension, number> &,
+            const Tensor<2, deal_II_dimension, number> &);
+        \}
+      \}
     \}
-    \}
-    \}
-}
+  }

--- a/source/physics/elasticity/standard_tensors.inst.in
+++ b/source/physics/elasticity/standard_tensors.inst.in
@@ -15,39 +15,38 @@
 
 
 for (deal_II_dimension : DIMENSIONS)
-{
+  {
     namespace Physics
     \{
-    namespace Elasticity
-    \{
-    template
-    class StandardTensors<deal_II_dimension>;
+      namespace Elasticity
+      \{
+        template class StandardTensors<deal_II_dimension>;
+      \}
     \}
-    \}
-}
+  }
 
 
 for (deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
-{
+  {
     namespace Physics
     \{
-    namespace Elasticity
-    \{
-    template
-    SymmetricTensor<4,deal_II_dimension,number>
-    StandardTensors<deal_II_dimension>::Dev_P<number>(const Tensor<2,deal_II_dimension,number> &);
+      namespace Elasticity
+      \{
+        template SymmetricTensor<4, deal_II_dimension, number>
+        StandardTensors<deal_II_dimension>::Dev_P<number>(
+          const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<4,deal_II_dimension,number>
-    StandardTensors<deal_II_dimension>::Dev_P_T<number>(const Tensor<2,deal_II_dimension,number> &);
+        template SymmetricTensor<4, deal_II_dimension, number>
+        StandardTensors<deal_II_dimension>::Dev_P_T<number>(
+          const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    StandardTensors<deal_II_dimension>::ddet_F_dC<number>(const Tensor<2,deal_II_dimension,number> &);
+        template SymmetricTensor<2, deal_II_dimension, number>
+        StandardTensors<deal_II_dimension>::ddet_F_dC<number>(
+          const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<4,deal_II_dimension,number>
-    StandardTensors<deal_II_dimension>::dC_inv_dC<number>(const Tensor<2,deal_II_dimension,number> &);
+        template SymmetricTensor<4, deal_II_dimension, number>
+        StandardTensors<deal_II_dimension>::dC_inv_dC<number>(
+          const Tensor<2, deal_II_dimension, number> &);
+      \}
     \}
-    \}
-}
+  }

--- a/source/physics/transformations.inst.in
+++ b/source/physics/transformations.inst.in
@@ -15,207 +15,144 @@
 
 
 for (deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
-{
-
+  {
     namespace Physics
     \{
-    namespace Transformations
-    \{
-    template
-    Tensor<1,deal_II_dimension,number>
-    nansons_formula (
-        const Tensor<1,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+      namespace Transformations
+      \{
+        template Tensor<1, deal_II_dimension, number>
+        nansons_formula(const Tensor<1, deal_II_dimension, number> &,
+                        const Tensor<2, deal_II_dimension, number> &);
 
-    namespace Contravariant
-    \{
-    template
-    Tensor<1,deal_II_dimension,number>
-    push_forward (
-        const Tensor<1,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+        namespace Contravariant
+        \{
+          template Tensor<1, deal_II_dimension, number>
+          push_forward(const Tensor<1, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    Tensor<2,deal_II_dimension,number>
-    push_forward (
-        const Tensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+          template Tensor<2, deal_II_dimension, number>
+          push_forward(const Tensor<2, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    push_forward (
-        const SymmetricTensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+          template SymmetricTensor<2, deal_II_dimension, number>
+          push_forward(const SymmetricTensor<2, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    Tensor<4,deal_II_dimension,number>
-    push_forward (
-        const Tensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+          template Tensor<4, deal_II_dimension, number>
+          push_forward(const Tensor<4, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<4,deal_II_dimension,number>
-    push_forward (
-        const SymmetricTensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+          template SymmetricTensor<4, deal_II_dimension, number>
+          push_forward(const SymmetricTensor<4, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    Tensor<1,deal_II_dimension,number>
-    pull_back (
-        const Tensor<1,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+          template Tensor<1, deal_II_dimension, number>
+          pull_back(const Tensor<1, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    Tensor<2,deal_II_dimension,number>
-    pull_back (
-        const Tensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+          template Tensor<2, deal_II_dimension, number>
+          pull_back(const Tensor<2, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    pull_back (
-        const SymmetricTensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+          template SymmetricTensor<2, deal_II_dimension, number>
+          pull_back(const SymmetricTensor<2, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    Tensor<4,deal_II_dimension,number>
-    pull_back (
-        const Tensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+          template Tensor<4, deal_II_dimension, number>
+          pull_back(const Tensor<4, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
 
-    template
-    SymmetricTensor<4,deal_II_dimension,number>
-    pull_back (
-        const SymmetricTensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
+          template SymmetricTensor<4, deal_II_dimension, number>
+          pull_back(const SymmetricTensor<4, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+        \}
+
+        namespace Covariant
+        \{
+          template Tensor<1, deal_II_dimension, number>
+          push_forward(const Tensor<1, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
+
+          template Tensor<2, deal_II_dimension, number>
+          push_forward(const Tensor<2, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
+
+          template SymmetricTensor<2, deal_II_dimension, number>
+          push_forward(const SymmetricTensor<2, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
+
+          template Tensor<4, deal_II_dimension, number>
+          push_forward(const Tensor<4, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
+
+          template SymmetricTensor<4, deal_II_dimension, number>
+          push_forward(const SymmetricTensor<4, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
+
+          template Tensor<1, deal_II_dimension, number>
+          pull_back(const Tensor<1, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+
+          template Tensor<2, deal_II_dimension, number>
+          pull_back(const Tensor<2, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+
+          template SymmetricTensor<2, deal_II_dimension, number>
+          pull_back(const SymmetricTensor<2, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+
+          template Tensor<4, deal_II_dimension, number>
+          pull_back(const Tensor<4, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+
+          template SymmetricTensor<4, deal_II_dimension, number>
+          pull_back(const SymmetricTensor<4, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+        \}
+
+        namespace Piola
+        \{
+          template Tensor<1, deal_II_dimension, number>
+          push_forward(const Tensor<1, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
+
+          template Tensor<2, deal_II_dimension, number>
+          push_forward(const Tensor<2, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
+
+          template SymmetricTensor<2, deal_II_dimension, number>
+          push_forward(const SymmetricTensor<2, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
+
+          template Tensor<4, deal_II_dimension, number>
+          push_forward(const Tensor<4, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
+
+          template SymmetricTensor<4, deal_II_dimension, number>
+          push_forward(const SymmetricTensor<4, deal_II_dimension, number> &,
+                       const Tensor<2, deal_II_dimension, number> &);
+
+          template Tensor<1, deal_II_dimension, number>
+          pull_back(const Tensor<1, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+
+          template Tensor<2, deal_II_dimension, number>
+          pull_back(const Tensor<2, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+
+          template SymmetricTensor<2, deal_II_dimension, number>
+          pull_back(const SymmetricTensor<2, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+
+          template Tensor<4, deal_II_dimension, number>
+          pull_back(const Tensor<4, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+
+          template SymmetricTensor<4, deal_II_dimension, number>
+          pull_back(const SymmetricTensor<4, deal_II_dimension, number> &,
+                    const Tensor<2, deal_II_dimension, number> &);
+        \}
+
+      \}
     \}
-
-    namespace Covariant
-    \{
-    template
-    Tensor<1,deal_II_dimension,number>
-    push_forward (
-        const Tensor<1,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    Tensor<2,deal_II_dimension,number>
-    push_forward (
-        const Tensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    push_forward (
-        const SymmetricTensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    Tensor<4,deal_II_dimension,number>
-    push_forward (
-        const Tensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    SymmetricTensor<4,deal_II_dimension,number>
-    push_forward (
-        const SymmetricTensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    Tensor<1,deal_II_dimension,number>
-    pull_back (
-        const Tensor<1,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    Tensor<2,deal_II_dimension,number>
-    pull_back (
-        const Tensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    pull_back (
-        const SymmetricTensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    Tensor<4,deal_II_dimension,number>
-    pull_back (
-        const Tensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    SymmetricTensor<4,deal_II_dimension,number>
-    pull_back (
-        const SymmetricTensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-    \}
-
-    namespace Piola
-    \{
-    template
-    Tensor<1,deal_II_dimension,number>
-    push_forward (
-        const Tensor<1,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    Tensor<2,deal_II_dimension,number>
-    push_forward (
-        const Tensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    push_forward (
-        const SymmetricTensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    Tensor<4,deal_II_dimension,number>
-    push_forward (
-        const Tensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    SymmetricTensor<4,deal_II_dimension,number>
-    push_forward (
-        const SymmetricTensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    Tensor<1,deal_II_dimension,number>
-    pull_back (
-        const Tensor<1,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    Tensor<2,deal_II_dimension,number>
-    pull_back (
-        const Tensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    SymmetricTensor<2,deal_II_dimension,number>
-    pull_back (
-        const SymmetricTensor<2,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    Tensor<4,deal_II_dimension,number>
-    pull_back (
-        const Tensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-
-    template
-    SymmetricTensor<4,deal_II_dimension,number>
-    pull_back (
-        const SymmetricTensor<4,deal_II_dimension,number> &,
-        const Tensor<2,deal_II_dimension,number> &);
-    \}
-
-    \}
-    \}
-}
+  }


### PR DESCRIPTION
It turns out that the last find invocation in the `indent` script had been
wrong forever. In that version the `format_inst` method gets called once with
all files as parameters and (because `format_inst` expects only one file as
parameter at a time) only the first inst.in file got reindented. Depending on
locale find returns a different ordering, thus, different people get different
results.

Fix this. Further, run the full indent script to get all .inst.in files into a
consistent state.

Closes #6676