### PR TITLE
Fix undefined reference for PETSc complex scalar type

### DIFF
--- a/source/lac/full_matrix.cc
+++ b/source/lac/full_matrix.cc
@@ -68,6 +68,8 @@ TEMPL_OP_EQ(float, double);
 
 TEMPL_OP_EQ(std::complex<double>, std::complex<float>);
 TEMPL_OP_EQ(std::complex<float>, std::complex<double>);
+TEMPL_OP_EQ(std::complex<double>, double);
+TEMPL_OP_EQ(std::complex<float>, float);
 
 #undef TEMPL_OP_EQ
 


### PR DESCRIPTION
Fixes #6681.