### PR TITLE
Avoid using unistd.h and sleep

### DIFF
--- a/tests/base/mutex_01.cc
+++ b/tests/base/mutex_01.cc
@@ -18,8 +18,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -48,7 +46,7 @@ main()
 
   Threads::Thread<> t = Threads::new_thread(&test);
 
-  sleep(2);
+  std::this_thread::sleep_for(std::chrono::seconds(2));
   deallog << "1" << std::endl;
 
   mutex.release();

--- a/tests/base/task_01.cc
+++ b/tests/base/task_01.cc
@@ -20,15 +20,13 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
 void
 test()
 {
-  sleep(3);
+  std::this_thread::sleep_for(std::chrono::seconds(3));
   deallog << "OK" << std::endl;
 }
 

--- a/tests/base/task_02.cc
+++ b/tests/base/task_02.cc
@@ -18,15 +18,13 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
 int
 test()
 {
-  sleep(3);
+  std::this_thread::sleep_for(std::chrono::seconds(3));
   return 42;
 }
 

--- a/tests/base/task_03.cc
+++ b/tests/base/task_03.cc
@@ -19,8 +19,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -28,7 +26,7 @@ void
 test(int i)
 {
   deallog << "Task " << i << " starting..." << std::endl;
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   deallog << "Task " << i << " finished!" << std::endl;
 }
 

--- a/tests/base/task_04.cc
+++ b/tests/base/task_04.cc
@@ -18,8 +18,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -37,7 +35,7 @@ test(int i)
       t2.join();
     }
 
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   deallog << "Task " << i << " finished!" << std::endl;
 }
 

--- a/tests/base/task_05.cc
+++ b/tests/base/task_05.cc
@@ -25,8 +25,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 

--- a/tests/base/task_06.cc
+++ b/tests/base/task_06.cc
@@ -19,8 +19,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -28,7 +26,7 @@ void
 test(int i)
 {
   deallog << "Task " << i << " starting..." << std::endl;
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   if (i < 10)
     {
       Threads::new_task(test, 10 + i).join();

--- a/tests/base/task_07.cc
+++ b/tests/base/task_07.cc
@@ -18,8 +18,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -27,7 +25,7 @@ void
 test(int i)
 {
   deallog << "Task " << i << " starting..." << std::endl;
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   deallog << "Task " << i << " finished!" << std::endl;
 }
 

--- a/tests/base/task_08.cc
+++ b/tests/base/task_08.cc
@@ -20,15 +20,13 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
 void
 test(int i)
 {
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   deallog << "Task " << i << " finished!" << std::endl;
 }
 

--- a/tests/base/task_10.cc
+++ b/tests/base/task_10.cc
@@ -18,15 +18,13 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
 void
 test()
 {
-  sleep(3);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   deallog << "OK" << std::endl;
 }
 

--- a/tests/base/task_11.cc
+++ b/tests/base/task_11.cc
@@ -18,8 +18,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 Threads::Mutex mutex;
@@ -36,7 +34,7 @@ a_task()
 
   // Sleep some time to make sure all other concurrently running tasks enter
   // here.
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
 
   mutex.acquire();
   n_running--;

--- a/tests/base/task_12.cc
+++ b/tests/base/task_12.cc
@@ -19,8 +19,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -30,7 +28,7 @@ double
 test(int i)
 {
   deallog << "Task " << i << " starting..." << std::endl;
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   deallog << "Task " << i << " finished!" << std::endl;
 
   return 3.141;

--- a/tests/base/task_12_capture.cc
+++ b/tests/base/task_12_capture.cc
@@ -22,8 +22,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -33,7 +31,7 @@ double
 test(int i)
 {
   deallog << "Task " << i << " starting..." << std::endl;
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   deallog << "Task " << i << " finished!" << std::endl;
 
   return 3.141;

--- a/tests/base/task_13.cc
+++ b/tests/base/task_13.cc
@@ -22,8 +22,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -33,7 +31,7 @@ double
 test(int i)
 {
   deallog << "Task " << i << " starting..." << std::endl;
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   deallog << "Task " << i << " finished!" << std::endl;
 
   return 3.141;

--- a/tests/base/thread_12.cc
+++ b/tests/base/thread_12.cc
@@ -19,8 +19,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -30,7 +28,7 @@ double
 test(int i)
 {
   deallog << "Task " << i << " starting..." << std::endl;
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   deallog << "Task " << i << " finished!" << std::endl;
 
   return 3.141;

--- a/tests/base/thread_local_storage_01.cc
+++ b/tests/base/thread_local_storage_01.cc
@@ -56,7 +56,7 @@ execute(int i)
 
   // wait in order to make sure that the
   // thread lives longer than the TLS object
-  sleep(5);
+  std::this_thread::sleep_for(std::chrono::seconds(5));
 }
 
 

--- a/tests/base/thread_local_storage_02.cc
+++ b/tests/base/thread_local_storage_02.cc
@@ -66,7 +66,7 @@ execute(int i)
 
   // wait in order to make sure that the
   // thread lives longer than the TLS object
-  sleep(5);
+  std::this_thread::sleep_for(std::chrono::seconds(5));
 }
 
 

--- a/tests/base/thread_local_storage_05.cc
+++ b/tests/base/thread_local_storage_05.cc
@@ -19,8 +19,6 @@
 #include <deal.II/base/thread_local_storage.h>
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -78,7 +76,7 @@ test()
     }
 
   // let threads work through their first part
-  sleep(3);
+  std::this_thread::sleep_for(std::chrono::seconds(3));
 
   // then reset the thread local object and release the mutices so the
   // threads can actually run to an end

--- a/tests/base/thread_local_storage_06.cc
+++ b/tests/base/thread_local_storage_06.cc
@@ -20,8 +20,6 @@
 #include <deal.II/base/thread_local_storage.h>
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -90,7 +88,7 @@ test()
     }
 
   // let threads work through their first part
-  sleep(3);
+  std::this_thread::sleep_for(std::chrono::seconds(3));
 
   // then reset the thread local object and release the mutices so the
   // threads can actually run to an end

--- a/tests/base/thread_validity_07.cc
+++ b/tests/base/thread_validity_07.cc
@@ -19,8 +19,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -28,7 +26,7 @@ void
 worker()
 {
   deallog << "Worker thread is starting." << std::endl;
-  sleep(3);
+  std::this_thread::sleep_for(std::chrono::seconds(3));
   deallog << "Worker thread is finished." << std::endl;
 }
 

--- a/tests/base/thread_validity_08.cc
+++ b/tests/base/thread_validity_08.cc
@@ -18,8 +18,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include <atomic>
 
 #include "../tests.h"
@@ -65,7 +63,7 @@ main()
   {
     Threads::new_thread(worker);
   }
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
 
   // let abandoned thread continue
   mutex.release();

--- a/tests/base/thread_validity_09.cc
+++ b/tests/base/thread_validity_09.cc
@@ -21,8 +21,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include <atomic>
 
 #include "../tests.h"
@@ -58,7 +56,7 @@ main()
   {
     Threads::new_thread(worker);
   }
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
 
   const unsigned int sz = 1000000;
   char *             p  = new char[sz];

--- a/tests/base/thread_validity_10.cc
+++ b/tests/base/thread_validity_10.cc
@@ -19,8 +19,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 
@@ -31,7 +29,7 @@ int            spin_lock = 0;
 int
 worker()
 {
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   return 42;
 }
 

--- a/tests/base/thread_validity_13.cc
+++ b/tests/base/thread_validity_13.cc
@@ -21,8 +21,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 

--- a/tests/base/thread_validity_14.cc
+++ b/tests/base/thread_validity_14.cc
@@ -21,8 +21,6 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <unistd.h>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/no_flux_constraints_02.cc
+++ b/tests/mpi/no_flux_constraints_02.cc
@@ -135,7 +135,7 @@ test()
     constraints.print(file);
   }
   MPI_Barrier(MPI_COMM_WORLD);
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   if (myid == 0)
     {
       // sort and merge the constraint matrices on proc 0, generate a checksum

--- a/tests/mpi/no_flux_constraints_03.cc
+++ b/tests/mpi/no_flux_constraints_03.cc
@@ -108,7 +108,7 @@ test()
     constraints.print(file);
   }
   MPI_Barrier(MPI_COMM_WORLD);
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   if (myid == 0)
     {
       // sort and merge the constraint matrices on proc 0, generate a checksum

--- a/tests/mpi/simple_mpi_01.cc
+++ b/tests/mpi/simple_mpi_01.cc
@@ -39,7 +39,6 @@ test_mpi()
   for (unsigned int i = 1; i < numprocs; ++i)
     {
       MPI_Barrier(MPI_COMM_WORLD);
-      //      system("sleep 1");
 
       if (myid == 0)
         {

--- a/tests/mpi/trilinos_01.cc
+++ b/tests/mpi/trilinos_01.cc
@@ -71,7 +71,7 @@ test()
           MPI_Iprobe(0, 12345, MPI_COMM_WORLD, &flag, &status);
           std::cout << flag << std::endl;
 
-          sleep(1);
+          std::this_thread::sleep_for(std::chrono::seconds(1));
         }
 
       Assert(flag != 0, ExcMessage("hang in has_ghost_elements()"));


### PR DESCRIPTION
This PR aims to remove any usage of the platform-dependent `sleep`.