### PR TITLE
Modify pushed flags for CLANGAUTODEBUG_BUG

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -277,7 +277,9 @@ IF(NOT DEFINED DEAL_II_WITH_CXX14 OR DEAL_II_WITH_CXX14)
     #
     # https://llvm.org/bugs/show_bug.cgi?id=16876
     #
-    PUSH_CMAKE_REQUIRED("-g")
+    SET(_flags "${DEAL_II_CXX_FLAGS_DEBUG}")
+    STRIP_FLAG(_flags "-Wa,--compress-debug-sections")
+    PUSH_CMAKE_REQUIRED("${_flags}")
     CHECK_CXX_SOURCE_COMPILES(
       "
       struct foo

--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -277,7 +277,7 @@ IF(NOT DEFINED DEAL_II_WITH_CXX14 OR DEAL_II_WITH_CXX14)
     #
     # https://llvm.org/bugs/show_bug.cgi?id=16876
     #
-    PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_FLAGS_DEBUG}")
+    PUSH_CMAKE_REQUIRED("-g")
     CHECK_CXX_SOURCE_COMPILES(
       "
       struct foo


### PR DESCRIPTION
As discussed in #6699, the check in question failes when configuring with `-Werror` with the message:
```
clang-6.0: error: argument unused during compilation: '-Wa,--compress-debug-sections' [-Werror,-Wunused-command-line-argument]
```
This change seems to work for `gcc-8`, `clang-6`, `MSVC 19` and `ICC 19` while pushing `-Wno-error` fails at least for `MSVC 19`.