### PR TITLE
Fix sundials documentation

### DIFF
--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -178,14 +178,14 @@ namespace SUNDIALS
    * VectorType y(2);
    * VectorType y_dot(2);
    *
+   * double kappa = 1.0;
+   *
    * FullMatrix<double> A(2,2);
    * A(0,1) = -1.0;
    * A(1,0) = kappa*kappa;
    *
    * FullMatrix<double> J(2,2);
    * FullMatrix<double> Jinv(2,2);
-   *
-   * double kappa = 1.0;
    *
    * IDA time_stepper;
    *

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -300,7 +300,8 @@ namespace SUNDIALS
 
     double next_time = data.initial_time;
 
-    output_step(0, solution, 0);
+    if (output_step)
+      output_step(0, solution, 0);
 
     while (t < data.final_time)
       {


### PR DESCRIPTION
Fixed sundials/ida.h example of use.

Bug fixed in sundials/arkode.cc if output_step function is not defined. Now the example in the documentation works. 