### PR TITLE
Remove some more references to astyle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Since deal.II is a fairly large project with lots of contributors we use a
 set of
 [coding conventions](https://www.dealii.org/developer/doxygen/deal.II/CodingConventions.html)
 to keep the style of the source code in the library consistent. This
-convention essentially consists of using `astyle` for indentation, camel
+convention essentially consists of using `clang-format` for indentation, camel
 case for classes, and lower case letters with underscores for everything
 else. If you are new to the project then we will work with you to ensure
 your contributions are formatted with this style, so please do not think of

--- a/contrib/styles/README.md
+++ b/contrib/styles/README.md
@@ -1,12 +1,6 @@
 This folder contains style files for IDEs for deal.II
 ==============================================================
 
-Astyle
-------
-
-    astyle.rc - C++ style for astyle, see contrib/utilities/indent
-
-
 Atom
 ----
 


### PR DESCRIPTION
I just noticed that there are some more references to `astyle` left. This PR removes them.