### PR TITLE
Deprecate parallel::distributed::Vector

### DIFF
--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -31,7 +31,7 @@
 
 #include <deal.II/fe/component_mask.h>
 
-#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 
 #include <string>
 #include <vector>

--- a/include/deal.II/lac/parallel_block_vector.h
+++ b/include/deal.II/lac/parallel_block_vector.h
@@ -50,8 +50,12 @@ namespace parallel
      * @see
      * @ref GlossBlockLA "Block (linear algebra)"
      * @author Katharina Kormann, Martin Kronbichler, 2011
+     *
+     * @deprecated Use LinearAlgebra::distributed::BlockVector instead.
      */
-    using LinearAlgebra::distributed::BlockVector;
+    template <typename Number>
+    using BlockVector DEAL_II_DEPRECATED =
+      LinearAlgebra::distributed::BlockVector<Number>;
 
     /*@}*/
   } // namespace distributed

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -137,8 +137,12 @@ namespace parallel
      * not rely on this class to automatically detect the unsupported case.
      *
      * @author Katharina Kormann, Martin Kronbichler, 2010, 2011
+     *
+     * @deprecated Use LinearAlgebra::distributed::Vector instead.
      */
-    using LinearAlgebra::distributed::Vector;
+    template <typename Number>
+    using Vector DEAL_II_DEPRECATED =
+      LinearAlgebra::distributed::Vector<Number>;
 
     /*@}*/
   } // namespace distributed

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -38,9 +38,9 @@
 
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/la_vector.h>
-#include <deal.II/lac/parallel_block_vector.h>
-#include <deal.II/lac/parallel_vector.h>
 #include <deal.II/lac/petsc_parallel_block_vector.h>
 #include <deal.II/lac/petsc_parallel_vector.h>
 #include <deal.II/lac/trilinos_parallel_block_vector.h>

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -28,9 +28,9 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/la_vector.h>
-#include <deal.II/lac/parallel_block_vector.h>
-#include <deal.II/lac/parallel_vector.h>
 #include <deal.II/lac/petsc_parallel_block_vector.h>
 #include <deal.II/lac/petsc_parallel_vector.h>
 #include <deal.II/lac/trilinos_parallel_block_vector.h>

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -35,7 +35,7 @@
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/lac/constraint_matrix.h>
-#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>
@@ -78,7 +78,8 @@ public:
   }
 
   void
-  compute_diagonal_by_face(parallel::distributed::Vector<number> &result) const
+  compute_diagonal_by_face(
+    LinearAlgebra::distributed::Vector<number> &result) const
   {
     int dummy;
     result = 0;
@@ -91,7 +92,8 @@ public:
   }
 
   void
-  compute_diagonal_by_cell(parallel::distributed::Vector<number> &result) const
+  compute_diagonal_by_cell(
+    LinearAlgebra::distributed::Vector<number> &result) const
   {
     int dummy;
     result.zero_out_ghosts();
@@ -100,7 +102,8 @@ public:
   }
 
   void
-  initialize_dof_vector(parallel::distributed::Vector<number> &vector) const
+  initialize_dof_vector(
+    LinearAlgebra::distributed::Vector<number> &vector) const
   {
     data.initialize_dof_vector(vector);
   }
@@ -109,15 +112,15 @@ public:
 private:
   void
   local_diagonal_dummy(const MatrixFree<dim, number> &,
-                       parallel::distributed::Vector<number> &,
+                       LinearAlgebra::distributed::Vector<number> &,
                        const int &,
                        const std::pair<unsigned int, unsigned int> &) const
   {}
 
   void
   local_diagonal_face(
-    const MatrixFree<dim, number> &        data,
-    parallel::distributed::Vector<number> &dst,
+    const MatrixFree<dim, number> &             data,
+    LinearAlgebra::distributed::Vector<number> &dst,
     const int &,
     const std::pair<unsigned int, unsigned int> &face_range) const
   {
@@ -207,8 +210,8 @@ private:
 
   void
   local_diagonal_boundary(
-    const MatrixFree<dim, number> &        data,
-    parallel::distributed::Vector<number> &dst,
+    const MatrixFree<dim, number> &             data,
+    LinearAlgebra::distributed::Vector<number> &dst,
     const int &,
     const std::pair<unsigned int, unsigned int> &face_range) const
   {
@@ -251,8 +254,8 @@ private:
 
   void
   local_diagonal_by_cell(
-    const MatrixFree<dim, number> &        data,
-    parallel::distributed::Vector<number> &dst,
+    const MatrixFree<dim, number> &             data,
+    LinearAlgebra::distributed::Vector<number> &dst,
     const int &,
     const std::pair<unsigned int, unsigned int> &cell_range) const
   {
@@ -339,7 +342,7 @@ test()
   LaplaceOperator<dim, fe_degree, n_q_points_1d, number> fine_matrix;
   fine_matrix.initialize(mapping, dof);
 
-  parallel::distributed::Vector<number> res1, res2;
+  LinearAlgebra::distributed::Vector<number> res1, res2;
   fine_matrix.initialize_dof_vector(res1);
   fine_matrix.initialize_dof_vector(res2);
 
@@ -356,7 +359,7 @@ test()
       LaplaceOperator<dim, fe_degree, n_q_points_1d, number> fine_matrix;
       fine_matrix.initialize(mapping, dof, level);
 
-      parallel::distributed::Vector<number> res1, res2;
+      LinearAlgebra::distributed::Vector<number> res1, res2;
       fine_matrix.initialize_dof_vector(res1);
       fine_matrix.initialize_dof_vector(res2);
 

--- a/tests/matrix_free/matrix_vector_21.cc
+++ b/tests/matrix_free/matrix_vector_21.cc
@@ -35,8 +35,8 @@
 
 #include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
-#include <deal.II/lac/parallel_block_vector.h>
-#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparsity_pattern.h>
 
@@ -52,10 +52,10 @@
 
 template <int dim, int fe_degree, typename Number>
 void
-helmholtz_operator(const MatrixFree<dim, Number> &                   data,
-                   parallel::distributed::BlockVector<Number> &      dst,
-                   const parallel::distributed::BlockVector<Number> &src,
-                   const std::pair<unsigned int, unsigned int> &     cell_range)
+helmholtz_operator(const MatrixFree<dim, Number> &                        data,
+                   LinearAlgebra::distributed::BlockVector<Number> &      dst,
+                   const LinearAlgebra::distributed::BlockVector<Number> &src,
+                   const std::pair<unsigned int, unsigned int> &cell_range)
 {
   FEEvaluation<dim, fe_degree, fe_degree + 1, 2, Number> fe_eval(data);
   const unsigned int n_q_points = fe_eval.n_q_points;
@@ -90,15 +90,16 @@ public:
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in) : data(data_in){};
 
   void
-  vmult(parallel::distributed::BlockVector<Number> &      dst,
-        const parallel::distributed::BlockVector<Number> &src) const
+  vmult(LinearAlgebra::distributed::BlockVector<Number> &      dst,
+        const LinearAlgebra::distributed::BlockVector<Number> &src) const
   {
     for (unsigned int i = 0; i < dst.size(); ++i)
       dst[i] = 0;
-    const std::function<void(const MatrixFree<dim, Number> &,
-                             parallel::distributed::BlockVector<Number> &,
-                             const parallel::distributed::BlockVector<Number> &,
-                             const std::pair<unsigned int, unsigned int> &)>
+    const std::function<void(
+      const MatrixFree<dim, Number> &,
+      LinearAlgebra::distributed::BlockVector<Number> &,
+      const LinearAlgebra::distributed::BlockVector<Number> &,
+      const std::pair<unsigned int, unsigned int> &)>
       wrap = helmholtz_operator<dim, fe_degree, Number>;
     data.cell_loop(wrap, dst, src);
   };
@@ -169,9 +170,9 @@ test()
     mf_data.reinit(dof, constraints, quad, data);
   }
 
-  MatrixFreeTest<dim, fe_degree, number>     mf(mf_data);
-  parallel::distributed::Vector<number>      ref;
-  parallel::distributed::BlockVector<number> in(2), out(2);
+  MatrixFreeTest<dim, fe_degree, number>          mf(mf_data);
+  LinearAlgebra::distributed::Vector<number>      ref;
+  LinearAlgebra::distributed::BlockVector<number> in(2), out(2);
   for (unsigned int i = 0; i < 2; ++i)
     {
       mf_data.initialize_dof_vector(in.block(i));

--- a/tests/matrix_free/multigrid_dg_periodic.cc
+++ b/tests/matrix_free/multigrid_dg_periodic.cc
@@ -35,7 +35,7 @@
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/lac/constraint_matrix.h>
-#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/lac/solver_cg.h>
 
@@ -91,31 +91,31 @@ public:
   }
 
   void
-  vmult(parallel::distributed::Vector<number> &      dst,
-        const parallel::distributed::Vector<number> &src) const
+  vmult(LinearAlgebra::distributed::Vector<number> &      dst,
+        const LinearAlgebra::distributed::Vector<number> &src) const
   {
     dst = 0;
     vmult_add(dst, src);
   }
 
   void
-  Tvmult(parallel::distributed::Vector<number> &      dst,
-         const parallel::distributed::Vector<number> &src) const
+  Tvmult(LinearAlgebra::distributed::Vector<number> &      dst,
+         const LinearAlgebra::distributed::Vector<number> &src) const
   {
     dst = 0;
     vmult_add(dst, src);
   }
 
   void
-  Tvmult_add(parallel::distributed::Vector<number> &      dst,
-             const parallel::distributed::Vector<number> &src) const
+  Tvmult_add(LinearAlgebra::distributed::Vector<number> &      dst,
+             const LinearAlgebra::distributed::Vector<number> &src) const
   {
     vmult_add(dst, src);
   }
 
   void
-  vmult_add(parallel::distributed::Vector<number> &      dst,
-            const parallel::distributed::Vector<number> &src) const
+  vmult_add(LinearAlgebra::distributed::Vector<number> &      dst,
+            const LinearAlgebra::distributed::Vector<number> &src) const
   {
     Assert(src.partitioners_are_globally_compatible(
              *data.get_dof_info(0).vector_partitioner),
@@ -152,14 +152,15 @@ public:
   }
 
   void
-  initialize_dof_vector(parallel::distributed::Vector<number> &vector) const
+  initialize_dof_vector(
+    LinearAlgebra::distributed::Vector<number> &vector) const
   {
     if (!vector.partitioners_are_compatible(
           *data.get_dof_info(0).vector_partitioner))
       data.initialize_dof_vector(vector);
   }
 
-  const parallel::distributed::Vector<number> &
+  const LinearAlgebra::distributed::Vector<number> &
   get_matrix_diagonal_inverse() const
   {
     return inverse_diagonal_entries;
@@ -168,9 +169,9 @@ public:
 
 private:
   void
-  local_apply(const MatrixFree<dim, number> &              data,
-              parallel::distributed::Vector<number> &      dst,
-              const parallel::distributed::Vector<number> &src,
+  local_apply(const MatrixFree<dim, number> &                   data,
+              LinearAlgebra::distributed::Vector<number> &      dst,
+              const LinearAlgebra::distributed::Vector<number> &src,
               const std::pair<unsigned int, unsigned int> &cell_range) const
   {
     FEEvaluation<dim, fe_degree, n_q_points_1d, 1, number> phi(data);
@@ -189,10 +190,10 @@ private:
 
   void
   local_apply_face(
-    const MatrixFree<dim, number> &              data,
-    parallel::distributed::Vector<number> &      dst,
-    const parallel::distributed::Vector<number> &src,
-    const std::pair<unsigned int, unsigned int> &face_range) const
+    const MatrixFree<dim, number> &                   data,
+    LinearAlgebra::distributed::Vector<number> &      dst,
+    const LinearAlgebra::distributed::Vector<number> &src,
+    const std::pair<unsigned int, unsigned int> &     face_range) const
   {
     FEFaceEvaluation<dim, fe_degree, n_q_points_1d, 1, number> fe_eval(data,
                                                                        true);
@@ -238,10 +239,10 @@ private:
 
   void
   local_apply_boundary(
-    const MatrixFree<dim, number> &              data,
-    parallel::distributed::Vector<number> &      dst,
-    const parallel::distributed::Vector<number> &src,
-    const std::pair<unsigned int, unsigned int> &face_range) const
+    const MatrixFree<dim, number> &                   data,
+    LinearAlgebra::distributed::Vector<number> &      dst,
+    const LinearAlgebra::distributed::Vector<number> &src,
+    const std::pair<unsigned int, unsigned int> &     face_range) const
   {
     FEFaceEvaluation<dim, fe_degree, n_q_points_1d, 1, number> fe_eval(data,
                                                                        true);
@@ -292,8 +293,8 @@ private:
 
   void
   local_diagonal_cell(
-    const MatrixFree<dim, number> &        data,
-    parallel::distributed::Vector<number> &dst,
+    const MatrixFree<dim, number> &             data,
+    LinearAlgebra::distributed::Vector<number> &dst,
     const unsigned int &,
     const std::pair<unsigned int, unsigned int> &cell_range) const
   {
@@ -323,8 +324,8 @@ private:
 
   void
   local_diagonal_face(
-    const MatrixFree<dim, number> &        data,
-    parallel::distributed::Vector<number> &dst,
+    const MatrixFree<dim, number> &             data,
+    LinearAlgebra::distributed::Vector<number> &dst,
     const unsigned int &,
     const std::pair<unsigned int, unsigned int> &face_range) const
   {
@@ -409,8 +410,8 @@ private:
 
   void
   local_diagonal_boundary(
-    const MatrixFree<dim, number> &        data,
-    parallel::distributed::Vector<number> &dst,
+    const MatrixFree<dim, number> &             data,
+    LinearAlgebra::distributed::Vector<number> &dst,
     const unsigned int &,
     const std::pair<unsigned int, unsigned int> &face_range) const
   {
@@ -453,15 +454,15 @@ private:
   }
 
 
-  MatrixFree<dim, number>               data;
-  parallel::distributed::Vector<number> inverse_diagonal_entries;
+  MatrixFree<dim, number>                    data;
+  LinearAlgebra::distributed::Vector<number> inverse_diagonal_entries;
 };
 
 
 
 template <typename MATRIX, typename Number>
 class MGCoarseIterative
-  : public MGCoarseGridBase<parallel::distributed::Vector<Number>>
+  : public MGCoarseGridBase<LinearAlgebra::distributed::Vector<Number>>
 {
 public:
   MGCoarseIterative()
@@ -475,11 +476,11 @@ public:
 
   virtual void
   operator()(const unsigned int,
-             parallel::distributed::Vector<double> &      dst,
-             const parallel::distributed::Vector<double> &src) const
+             LinearAlgebra::distributed::Vector<double> &      dst,
+             const LinearAlgebra::distributed::Vector<double> &src) const
   {
     ReductionControl solver_control(1e4, 1e-50, 1e-7, false, false);
-    SolverCG<parallel::distributed::Vector<double>> solver_coarse(
+    SolverCG<LinearAlgebra::distributed::Vector<double>> solver_coarse(
       solver_control);
     solver_coarse.solve(*coarse_matrix, dst, src, PreconditionIdentity());
   }
@@ -492,7 +493,7 @@ public:
 template <typename LAPLACEOPERATOR>
 class MGTransferMF
   : public MGTransferPrebuilt<
-      parallel::distributed::Vector<typename LAPLACEOPERATOR::value_type>>
+      LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>
 {
 public:
   MGTransferMF(const MGLevelObject<LAPLACEOPERATOR> &laplace) :
@@ -503,16 +504,15 @@ public:
    */
   template <int dim, class InVector, int spacedim>
   void
-  copy_to_mg(
-    const DoFHandler<dim, spacedim> &mg_dof,
-    MGLevelObject<
-      parallel::distributed::Vector<typename LAPLACEOPERATOR::value_type>> &dst,
-    const InVector &src) const
+  copy_to_mg(const DoFHandler<dim, spacedim> &         mg_dof,
+             MGLevelObject<LinearAlgebra::distributed::Vector<
+               typename LAPLACEOPERATOR::value_type>> &dst,
+             const InVector &                          src) const
   {
     for (unsigned int level = dst.min_level(); level <= dst.max_level();
          ++level)
       laplace_operator[level].initialize_dof_vector(dst[level]);
-    MGTransferPrebuilt<parallel::distributed::Vector<
+    MGTransferPrebuilt<LinearAlgebra::distributed::Vector<
       typename LAPLACEOPERATOR::value_type>>::copy_to_mg(mg_dof, dst, src);
   }
 
@@ -534,7 +534,7 @@ do_test(const DoFHandler<dim> &dof)
   LaplaceOperator<dim, fe_degree, n_q_points_1d, number> fine_matrix;
   fine_matrix.initialize(mapping, dof);
 
-  parallel::distributed::Vector<number> in, sol;
+  LinearAlgebra::distributed::Vector<number> in, sol;
   fine_matrix.initialize_dof_vector(in);
   fine_matrix.initialize_dof_vector(sol);
 
@@ -556,11 +556,11 @@ do_test(const DoFHandler<dim> &dof)
   mg_coarse.initialize(mg_matrices[0]);
 
   typedef PreconditionChebyshev<LevelMatrixType,
-                                parallel::distributed::Vector<number>>
+                                LinearAlgebra::distributed::Vector<number>>
     SMOOTHER;
   MGSmootherPrecondition<LevelMatrixType,
                          SMOOTHER,
-                         parallel::distributed::Vector<number>>
+                         LinearAlgebra::distributed::Vector<number>>
     mg_smoother;
 
   MGLevelObject<typename SMOOTHER::AdditionalData> smoother_data;
@@ -580,18 +580,18 @@ do_test(const DoFHandler<dim> &dof)
   MGTransferMF<LevelMatrixType> mg_transfer(mg_matrices);
   mg_transfer.build_matrices(dof);
 
-  mg::Matrix<parallel::distributed::Vector<double>> mg_matrix(mg_matrices);
+  mg::Matrix<LinearAlgebra::distributed::Vector<double>> mg_matrix(mg_matrices);
 
-  Multigrid<parallel::distributed::Vector<double>> mg(
+  Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
     dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
-                 parallel::distributed::Vector<double>,
+                 LinearAlgebra::distributed::Vector<double>,
                  MGTransferMF<LevelMatrixType>>
     preconditioner(dof, mg, mg_transfer);
 
   {
-    ReductionControl                                control(30, 1e-20, 1e-10);
-    SolverCG<parallel::distributed::Vector<double>> solver(control);
+    ReductionControl control(30, 1e-20, 1e-10);
+    SolverCG<LinearAlgebra::distributed::Vector<double>> solver(control);
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 }

--- a/tests/matrix_free/multigrid_dg_sip_01.cc
+++ b/tests/matrix_free/multigrid_dg_sip_01.cc
@@ -35,7 +35,7 @@
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/lac/constraint_matrix.h>
-#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/lac/solver_cg.h>
 
@@ -90,44 +90,45 @@ public:
   }
 
   void
-  vmult(parallel::distributed::Vector<number> &      dst,
-        const parallel::distributed::Vector<number> &src) const
+  vmult(LinearAlgebra::distributed::Vector<number> &      dst,
+        const LinearAlgebra::distributed::Vector<number> &src) const
   {
     dst = 0;
     vmult_add(dst, src);
   }
 
   void
-  Tvmult(parallel::distributed::Vector<number> &      dst,
-         const parallel::distributed::Vector<number> &src) const
+  Tvmult(LinearAlgebra::distributed::Vector<number> &      dst,
+         const LinearAlgebra::distributed::Vector<number> &src) const
   {
     dst = 0;
     vmult_add(dst, src);
   }
 
   void
-  Tvmult_add(parallel::distributed::Vector<number> &      dst,
-             const parallel::distributed::Vector<number> &src) const
+  Tvmult_add(LinearAlgebra::distributed::Vector<number> &      dst,
+             const LinearAlgebra::distributed::Vector<number> &src) const
   {
     vmult_add(dst, src);
   }
 
   void
-  vmult_add(parallel::distributed::Vector<number> &      dst,
-            const parallel::distributed::Vector<number> &src) const
+  vmult_add(LinearAlgebra::distributed::Vector<number> &      dst,
+            const LinearAlgebra::distributed::Vector<number> &src) const
   {
     if (!src.partitioners_are_globally_compatible(
           *data.get_dof_info(0).vector_partitioner))
       {
-        parallel::distributed::Vector<number> src_copy;
+        LinearAlgebra::distributed::Vector<number> src_copy;
         src_copy.reinit(data.get_dof_info().vector_partitioner);
         src_copy = src;
-        const_cast<parallel::distributed::Vector<number> &>(src).swap(src_copy);
+        const_cast<LinearAlgebra::distributed::Vector<number> &>(src).swap(
+          src_copy);
       }
     if (!dst.partitioners_are_globally_compatible(
           *data.get_dof_info(0).vector_partitioner))
       {
-        parallel::distributed::Vector<number> dst_copy;
+        LinearAlgebra::distributed::Vector<number> dst_copy;
         dst_copy.reinit(data.get_dof_info().vector_partitioner);
         dst_copy = dst;
         dst.swap(dst_copy);
@@ -162,12 +163,13 @@ public:
   }
 
   void
-  initialize_dof_vector(parallel::distributed::Vector<number> &vector) const
+  initialize_dof_vector(
+    LinearAlgebra::distributed::Vector<number> &vector) const
   {
     data.initialize_dof_vector(vector);
   }
 
-  const parallel::distributed::Vector<number> &
+  const LinearAlgebra::distributed::Vector<number> &
   get_matrix_diagonal_inverse() const
   {
     return inverse_diagonal_entries;
@@ -176,9 +178,9 @@ public:
 
 private:
   void
-  local_apply(const MatrixFree<dim, number> &              data,
-              parallel::distributed::Vector<number> &      dst,
-              const parallel::distributed::Vector<number> &src,
+  local_apply(const MatrixFree<dim, number> &                   data,
+              LinearAlgebra::distributed::Vector<number> &      dst,
+              const LinearAlgebra::distributed::Vector<number> &src,
               const std::pair<unsigned int, unsigned int> &cell_range) const
   {
     FEEvaluation<dim, fe_degree, n_q_points_1d, 1, number> phi(data);
@@ -197,10 +199,10 @@ private:
 
   void
   local_apply_face(
-    const MatrixFree<dim, number> &              data,
-    parallel::distributed::Vector<number> &      dst,
-    const parallel::distributed::Vector<number> &src,
-    const std::pair<unsigned int, unsigned int> &face_range) const
+    const MatrixFree<dim, number> &                   data,
+    LinearAlgebra::distributed::Vector<number> &      dst,
+    const LinearAlgebra::distributed::Vector<number> &src,
+    const std::pair<unsigned int, unsigned int> &     face_range) const
   {
     FEFaceEvaluation<dim, fe_degree, n_q_points_1d, 1, number> fe_eval(data,
                                                                        true);
@@ -246,10 +248,10 @@ private:
 
   void
   local_apply_boundary(
-    const MatrixFree<dim, number> &              data,
-    parallel::distributed::Vector<number> &      dst,
-    const parallel::distributed::Vector<number> &src,
-    const std::pair<unsigned int, unsigned int> &face_range) const
+    const MatrixFree<dim, number> &                   data,
+    LinearAlgebra::distributed::Vector<number> &      dst,
+    const LinearAlgebra::distributed::Vector<number> &src,
+    const std::pair<unsigned int, unsigned int> &     face_range) const
   {
     FEFaceEvaluation<dim, fe_degree, n_q_points_1d, 1, number> fe_eval(data,
                                                                        true);
@@ -298,8 +300,8 @@ private:
 
   void
   local_diagonal_cell(
-    const MatrixFree<dim, number> &        data,
-    parallel::distributed::Vector<number> &dst,
+    const MatrixFree<dim, number> &             data,
+    LinearAlgebra::distributed::Vector<number> &dst,
     const unsigned int &,
     const std::pair<unsigned int, unsigned int> &cell_range) const
   {
@@ -329,8 +331,8 @@ private:
 
   void
   local_diagonal_face(
-    const MatrixFree<dim, number> &        data,
-    parallel::distributed::Vector<number> &dst,
+    const MatrixFree<dim, number> &             data,
+    LinearAlgebra::distributed::Vector<number> &dst,
     const unsigned int &,
     const std::pair<unsigned int, unsigned int> &face_range) const
   {
@@ -415,8 +417,8 @@ private:
 
   void
   local_diagonal_boundary(
-    const MatrixFree<dim, number> &        data,
-    parallel::distributed::Vector<number> &dst,
+    const MatrixFree<dim, number> &             data,
+    LinearAlgebra::distributed::Vector<number> &dst,
     const unsigned int &,
     const std::pair<unsigned int, unsigned int> &face_range) const
   {
@@ -459,15 +461,15 @@ private:
   }
 
 
-  MatrixFree<dim, number>               data;
-  parallel::distributed::Vector<number> inverse_diagonal_entries;
+  MatrixFree<dim, number>                    data;
+  LinearAlgebra::distributed::Vector<number> inverse_diagonal_entries;
 };
 
 
 
 template <typename MATRIX, typename Number>
 class MGCoarseIterative
-  : public MGCoarseGridBase<parallel::distributed::Vector<Number>>
+  : public MGCoarseGridBase<LinearAlgebra::distributed::Vector<Number>>
 {
 public:
   MGCoarseIterative()
@@ -481,11 +483,11 @@ public:
 
   virtual void
   operator()(const unsigned int,
-             parallel::distributed::Vector<double> &      dst,
-             const parallel::distributed::Vector<double> &src) const
+             LinearAlgebra::distributed::Vector<double> &      dst,
+             const LinearAlgebra::distributed::Vector<double> &src) const
   {
     ReductionControl solver_control(1e4, 1e-50, 1e-10, false, false);
-    SolverCG<parallel::distributed::Vector<double>> solver_coarse(
+    SolverCG<LinearAlgebra::distributed::Vector<double>> solver_coarse(
       solver_control);
     solver_coarse.solve(*coarse_matrix, dst, src, PreconditionIdentity());
   }
@@ -541,7 +543,7 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
   LaplaceOperator<dim, fe_degree, n_q_points_1d, number> fine_matrix;
   fine_matrix.initialize(mapping, dof);
 
-  parallel::distributed::Vector<number> in, sol;
+  LinearAlgebra::distributed::Vector<number> in, sol;
   fine_matrix.initialize_dof_vector(in);
   fine_matrix.initialize_dof_vector(sol);
 
@@ -564,11 +566,11 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
   mg_coarse.initialize(mg_matrices[0]);
 
   typedef PreconditionChebyshev<LevelMatrixType,
-                                parallel::distributed::Vector<number>>
+                                LinearAlgebra::distributed::Vector<number>>
     SMOOTHER;
   MGSmootherPrecondition<LevelMatrixType,
                          SMOOTHER,
-                         parallel::distributed::Vector<number>>
+                         LinearAlgebra::distributed::Vector<number>>
     mg_smoother;
 
   MGLevelObject<typename SMOOTHER::AdditionalData> smoother_data;
@@ -595,18 +597,18 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
                                                  mg_constrained_dofs);
   mg_transfer.build(dof);
 
-  mg::Matrix<parallel::distributed::Vector<double>> mg_matrix(mg_matrices);
+  mg::Matrix<LinearAlgebra::distributed::Vector<double>> mg_matrix(mg_matrices);
 
-  Multigrid<parallel::distributed::Vector<double>> mg(
+  Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
     dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
-                 parallel::distributed::Vector<double>,
+                 LinearAlgebra::distributed::Vector<double>,
                  MGTransferMF<dim, LevelMatrixType>>
     preconditioner(dof, mg, mg_transfer);
 
   {
-    ReductionControl                                control(30, 1e-20, 1e-7);
-    SolverCG<parallel::distributed::Vector<double>> solver(control);
+    ReductionControl control(30, 1e-20, 1e-7);
+    SolverCG<LinearAlgebra::distributed::Vector<double>> solver(control);
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 }

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -36,7 +36,7 @@
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/lac/constraint_matrix.h>
-#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/lac/solver_cg.h>
 
@@ -93,44 +93,45 @@ public:
   }
 
   void
-  vmult(parallel::distributed::Vector<number> &      dst,
-        const parallel::distributed::Vector<number> &src) const
+  vmult(LinearAlgebra::distributed::Vector<number> &      dst,
+        const LinearAlgebra::distributed::Vector<number> &src) const
   {
     dst = 0;
     vmult_add(dst, src);
   }
 
   void
-  Tvmult(parallel::distributed::Vector<number> &      dst,
-         const parallel::distributed::Vector<number> &src) const
+  Tvmult(LinearAlgebra::distributed::Vector<number> &      dst,
+         const LinearAlgebra::distributed::Vector<number> &src) const
   {
     dst = 0;
     vmult_add(dst, src);
   }
 
   void
-  Tvmult_add(parallel::distributed::Vector<number> &      dst,
-             const parallel::distributed::Vector<number> &src) const
+  Tvmult_add(LinearAlgebra::distributed::Vector<number> &      dst,
+             const LinearAlgebra::distributed::Vector<number> &src) const
   {
     vmult_add(dst, src);
   }
 
   void
-  vmult_add(parallel::distributed::Vector<number> &      dst,
-            const parallel::distributed::Vector<number> &src) const
+  vmult_add(LinearAlgebra::distributed::Vector<number> &      dst,
+            const LinearAlgebra::distributed::Vector<number> &src) const
   {
     if (!src.partitioners_are_globally_compatible(
           *data.get_dof_info(0).vector_partitioner))
       {
-        parallel::distributed::Vector<number> src_copy;
+        LinearAlgebra::distributed::Vector<number> src_copy;
         src_copy.reinit(data.get_dof_info().vector_partitioner);
         src_copy = src;
-        const_cast<parallel::distributed::Vector<number> &>(src).swap(src_copy);
+        const_cast<LinearAlgebra::distributed::Vector<number> &>(src).swap(
+          src_copy);
       }
     if (!dst.partitioners_are_globally_compatible(
           *data.get_dof_info(0).vector_partitioner))
       {
-        parallel::distributed::Vector<number> dst_copy;
+        LinearAlgebra::distributed::Vector<number> dst_copy;
         dst_copy.reinit(data.get_dof_info().vector_partitioner);
         dst_copy = dst;
         dst.swap(dst_copy);
@@ -165,12 +166,13 @@ public:
   }
 
   void
-  initialize_dof_vector(parallel::distributed::Vector<number> &vector) const
+  initialize_dof_vector(
+    LinearAlgebra::distributed::Vector<number> &vector) const
   {
     data.initialize_dof_vector(vector);
   }
 
-  const parallel::distributed::Vector<number> &
+  const LinearAlgebra::distributed::Vector<number> &
   get_matrix_diagonal_inverse() const
   {
     return inverse_diagonal_entries;
@@ -179,9 +181,9 @@ public:
 
 private:
   void
-  local_apply(const MatrixFree<dim, number> &              data,
-              parallel::distributed::Vector<number> &      dst,
-              const parallel::distributed::Vector<number> &src,
+  local_apply(const MatrixFree<dim, number> &                   data,
+              LinearAlgebra::distributed::Vector<number> &      dst,
+              const LinearAlgebra::distributed::Vector<number> &src,
               const std::pair<unsigned int, unsigned int> &cell_range) const
   {
     FEEvaluation<dim, fe_degree, n_q_points_1d, 1, number> phi(data);
@@ -200,10 +202,10 @@ private:
 
   void
   local_apply_face(
-    const MatrixFree<dim, number> &              data,
-    parallel::distributed::Vector<number> &      dst,
-    const parallel::distributed::Vector<number> &src,
-    const std::pair<unsigned int, unsigned int> &face_range) const
+    const MatrixFree<dim, number> &                   data,
+    LinearAlgebra::distributed::Vector<number> &      dst,
+    const LinearAlgebra::distributed::Vector<number> &src,
+    const std::pair<unsigned int, unsigned int> &     face_range) const
   {
     FEFaceEvaluation<dim, fe_degree, n_q_points_1d, 1, number> fe_eval(data,
                                                                        true);
@@ -249,10 +251,10 @@ private:
 
   void
   local_apply_boundary(
-    const MatrixFree<dim, number> &              data,
-    parallel::distributed::Vector<number> &      dst,
-    const parallel::distributed::Vector<number> &src,
-    const std::pair<unsigned int, unsigned int> &face_range) const
+    const MatrixFree<dim, number> &                   data,
+    LinearAlgebra::distributed::Vector<number> &      dst,
+    const LinearAlgebra::distributed::Vector<number> &src,
+    const std::pair<unsigned int, unsigned int> &     face_range) const
   {
     FEFaceEvaluation<dim, fe_degree, n_q_points_1d, 1, number> fe_eval(data,
                                                                        true);
@@ -299,8 +301,8 @@ private:
 
   void
   local_diagonal_cell(
-    const MatrixFree<dim, number> &        data,
-    parallel::distributed::Vector<number> &dst,
+    const MatrixFree<dim, number> &             data,
+    LinearAlgebra::distributed::Vector<number> &dst,
     const unsigned int &,
     const std::pair<unsigned int, unsigned int> &cell_range) const
   {
@@ -371,15 +373,15 @@ private:
       }
   }
 
-  MatrixFree<dim, number>               data;
-  parallel::distributed::Vector<number> inverse_diagonal_entries;
+  MatrixFree<dim, number>                    data;
+  LinearAlgebra::distributed::Vector<number> inverse_diagonal_entries;
 };
 
 
 
 template <typename MATRIX, typename Number>
 class MGCoarseIterative
-  : public MGCoarseGridBase<parallel::distributed::Vector<Number>>
+  : public MGCoarseGridBase<LinearAlgebra::distributed::Vector<Number>>
 {
 public:
   MGCoarseIterative()
@@ -393,11 +395,11 @@ public:
 
   virtual void
   operator()(const unsigned int,
-             parallel::distributed::Vector<double> &      dst,
-             const parallel::distributed::Vector<double> &src) const
+             LinearAlgebra::distributed::Vector<double> &      dst,
+             const LinearAlgebra::distributed::Vector<double> &src) const
   {
     ReductionControl solver_control(1e4, 1e-50, 1e-10, false, false);
-    SolverCG<parallel::distributed::Vector<double>> solver_coarse(
+    SolverCG<LinearAlgebra::distributed::Vector<double>> solver_coarse(
       solver_control);
     solver_coarse.solve(*coarse_matrix, dst, src, PreconditionIdentity());
   }
@@ -453,7 +455,7 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
   LaplaceOperator<dim, fe_degree, n_q_points_1d, number> fine_matrix;
   fine_matrix.initialize(mapping, dof);
 
-  parallel::distributed::Vector<number> in, sol;
+  LinearAlgebra::distributed::Vector<number> in, sol;
   fine_matrix.initialize_dof_vector(in);
   fine_matrix.initialize_dof_vector(sol);
 
@@ -476,11 +478,11 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
   mg_coarse.initialize(mg_matrices[0]);
 
   typedef PreconditionChebyshev<LevelMatrixType,
-                                parallel::distributed::Vector<number>>
+                                LinearAlgebra::distributed::Vector<number>>
     SMOOTHER;
   MGSmootherPrecondition<LevelMatrixType,
                          SMOOTHER,
-                         parallel::distributed::Vector<number>>
+                         LinearAlgebra::distributed::Vector<number>>
     mg_smoother;
 
   MGLevelObject<typename SMOOTHER::AdditionalData> smoother_data;
@@ -507,18 +509,18 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
                                                  mg_constrained_dofs);
   mg_transfer.build(dof);
 
-  mg::Matrix<parallel::distributed::Vector<double>> mg_matrix(mg_matrices);
+  mg::Matrix<LinearAlgebra::distributed::Vector<double>> mg_matrix(mg_matrices);
 
-  Multigrid<parallel::distributed::Vector<double>> mg(
+  Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
     dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
-                 parallel::distributed::Vector<double>,
+                 LinearAlgebra::distributed::Vector<double>,
                  MGTransferMF<dim, LevelMatrixType>>
     preconditioner(dof, mg, mg_transfer);
 
   {
-    ReductionControl                                control(30, 1e-20, 1e-7);
-    SolverCG<parallel::distributed::Vector<double>> solver(control);
+    ReductionControl control(30, 1e-20, 1e-7);
+    SolverCG<LinearAlgebra::distributed::Vector<double>> solver(control);
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 }


### PR DESCRIPTION
We replaced `parallel::distributed::Vector` by `LinearAlgebra::distributed::Vector` and `parallel::distributed::BlockVector` by `LinearAlgebra::distributed::BlockVector`. This should also be reflectected in our code base by deprecating the `parallel::*` versions.