### PR TITLE
Fix clang-tidy findings for muParser

### DIFF
--- a/bundled/muparser_v2_2_4/src/muParserTokenReader.cpp
+++ b/bundled/muparser_v2_2_4/src/muParserTokenReader.cpp
@@ -902,7 +902,7 @@ namespace mu
     std::size_t iEnd(0), iSkip(0);
 
     // parser over escaped '\"' end replace them with '"'
-    for(iEnd=(int)strBuf.find( _T("\"") ); iEnd!=0 && iEnd!=string_type::npos; iEnd=(int)strBuf.find( _T("\""), iEnd))
+    for(iEnd=(int)strBuf.find( _T('\"') ); iEnd!=0 && iEnd!=string_type::npos; iEnd=(int)strBuf.find( _T('\"'), iEnd))
     {
       if (strBuf[iEnd-1]!='\\') break;
       strBuf.replace(iEnd-1, 2, _T("\"") );


### PR DESCRIPTION
This makes clang-tidy happy.