### PR TITLE
Fix instantiations of SymmetricTensor

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -578,7 +578,7 @@ public:
    * describe a symmetric tensor. In $d$ space dimensions, this number equals
    * $\frac 12 (d^2+d)$ for symmetric tensors of rank 2.
    */
-  static const unsigned int n_independent_components =
+  static constexpr unsigned int n_independent_components =
     internal::SymmetricTensorAccessors::StorageType<rank_, dim, Number>::
       n_independent_components;
 

--- a/source/base/symmetric_tensor.cc
+++ b/source/base/symmetric_tensor.cc
@@ -30,7 +30,8 @@ template <int rank, int dim, typename Number>
 const unsigned int SymmetricTensor<rank, dim, Number>::dimension;
 
 template <int rank, int dim, typename Number>
-const unsigned int SymmetricTensor<rank, dim, Number>::n_independent_components;
+constexpr unsigned int
+  SymmetricTensor<rank, dim, Number>::n_independent_components;
 
 
 // explicit instantiations


### PR DESCRIPTION
After applying the other `clang-tidy` PRs, it turned out that both `gcc` and `clang` were complaining about undefined references to `SymmetricTensor::n_independent_components`. Using `constexpr` instead solves this problem.