### PR TITLE
Use static constexpr in VectorizedArray

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -162,7 +162,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static const unsigned int n_array_elements = 1;
+  static constexpr unsigned int n_array_elements = 1;
 
   // POD means that there should be no user-defined constructors, destructors
   // and copy functions (the standard is somewhat relaxed in C++2011, though).
@@ -568,7 +568,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static const unsigned int n_array_elements = 8;
+  static constexpr unsigned int n_array_elements = 8;
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -970,7 +970,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static const unsigned int n_array_elements = 16;
+  static constexpr unsigned int n_array_elements = 16;
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -1405,7 +1405,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static const unsigned int n_array_elements = 4;
+  static constexpr unsigned int n_array_elements = 4;
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -1784,7 +1784,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static const unsigned int n_array_elements = 8;
+  static constexpr unsigned int n_array_elements = 8;
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -2194,7 +2194,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static const unsigned int n_array_elements = 2;
+  static constexpr unsigned int n_array_elements = 2;
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -2532,7 +2532,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static const unsigned int n_array_elements = 4;
+  static constexpr unsigned int n_array_elements = 4;
 
   /**
    * This function can be used to set all data fields to a given scalar.


### PR DESCRIPTION
After applying the other `clang-tidy` PRs, it turned out that both `gcc` and `clang` were complaining about undefined references to `VectorizedArray::n_array_elements`. Using `constexpr` instead solves this problem.