### PR TITLE
Simplify GridOut::Gnuplot

### DIFF
--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -295,24 +295,11 @@ namespace GridOutFlags
     Gnuplot(const Gnuplot &flags);
 
     /**
-     * Move constructor. Needed since this class (for backwards compatibility)
-     * has a reference member variable.
-     */
-    Gnuplot(Gnuplot &&flags);
-
-    /**
      * Copy operator. Needed since this class (for backwards compatibility)
      * has a reference member variable.
      */
     Gnuplot &
     operator=(const Gnuplot &flags);
-
-    /**
-     * Move assignment operator. Needed since this class (for backwards
-     * compatibility) has a reference member variable.
-     */
-    Gnuplot &
-    operator=(Gnuplot &&flags);
 
     /**
      * Declare parameters in ParameterHandler.

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -168,12 +168,6 @@ namespace GridOutFlags
 
 
 
-  Gnuplot::Gnuplot(Gnuplot &&flags) :
-    Gnuplot(static_cast<const Gnuplot &>(flags))
-  {}
-
-
-
   Gnuplot &
   Gnuplot::operator=(const Gnuplot &flags)
   {
@@ -183,14 +177,6 @@ namespace GridOutFlags
     write_additional_boundary_lines = flags.write_additional_boundary_lines;
 
     return *this;
-  }
-
-
-
-  Gnuplot &
-  Gnuplot::operator=(Gnuplot &&flags)
-  {
-    return operator=(static_cast<const Gnuplot &>(flags));
   }
 
 


### PR DESCRIPTION
`clang-tidy` complained that the copy constructor was used inside the move constructor.
If the copy constructor and the move constructor are the same there really is no reason to have a move constructor. The copy constructor replaces it anyway. The same holds for the copy assignment and the move assignment operator.
In the end, we don't want to define any of these. So I don't see a problem already removing the two superfluous ones.