### PR TITLE
Avoid using NOLINT

### DIFF
--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -1362,7 +1362,7 @@ FullMatrix<number>::invert(const FullMatrix<number2> &M)
     {
       // avoid overwriting source
       // by destination matrix:
-      const FullMatrix<number2> M2 = M; // NOLINT
+      const FullMatrix<number> M2 = *this;
       invert(M2);
     }
   else
@@ -1552,7 +1552,7 @@ FullMatrix<number>::cholesky(const FullMatrix<number2> &A)
     {
       // avoid overwriting source
       // by destination matrix:
-      const FullMatrix<number2> A2 = A; // NOLINT
+      const FullMatrix<number> A2 = *this;
       cholesky(A2);
     }
   else

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -2867,8 +2867,8 @@ namespace VectorTools
           // now that we have a q_collection object with all the right
           // quadrature points, create an hp::FEFaceValues object that we can
           // use to evaluate the boundary values at
-          const dealii::hp::MappingCollection<dim, spacedim> mapping_collection(
-            mapping); // NOLINT
+          const auto mapping_collection =
+            dealii::hp::MappingCollection<dim, spacedim>(mapping);
           dealii::hp::FEFaceValues<dim, spacedim> x_fe_values(
             mapping_collection,
             finite_elements,


### PR DESCRIPTION
Just as in #6718, there are more places were `NOLINT` didn't survive `clang-format` and restoring it turns out to be awkward. Instead, this PR rewrites the relevant places (or adds `noexcept`) in a way `clang-tidy` is not complaining.
The only places remaining are the move constructor for `FESytem` and for `FiniteElement` where `clang-tidy` wants have a `noexcept` specifier but `clang` is complaining that the calculated specifier would be different (and this illegal). In the end, the `noexcept` specifier for defaulted operators is determined automatically by the compiler anyway.