### PR TITLE
Make n_array_elements static const again

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -162,7 +162,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static constexpr unsigned int n_array_elements = 1;
+  static const unsigned int n_array_elements = 1;
 
   // POD means that there should be no user-defined constructors, destructors
   // and copy functions (the standard is somewhat relaxed in C++2011, though).
@@ -568,7 +568,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static constexpr unsigned int n_array_elements = 8;
+  static const unsigned int n_array_elements = 8;
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -970,7 +970,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static constexpr unsigned int n_array_elements = 16;
+  static const unsigned int n_array_elements = 16;
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -1405,7 +1405,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static constexpr unsigned int n_array_elements = 4;
+  static const unsigned int n_array_elements = 4;
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -1784,7 +1784,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static constexpr unsigned int n_array_elements = 8;
+  static const unsigned int n_array_elements = 8;
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -2194,7 +2194,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static constexpr unsigned int n_array_elements = 2;
+  static const unsigned int n_array_elements = 2;
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -2532,7 +2532,7 @@ public:
   /**
    * This gives the number of vectors collected in this class.
    */
-  static constexpr unsigned int n_array_elements = 4;
+  static const unsigned int n_array_elements = 4;
 
   /**
    * This function can be used to set all data fields to a given scalar.

--- a/source/base/vectorization.cc
+++ b/source/base/vectorization.cc
@@ -17,7 +17,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-constexpr unsigned int VectorizedArray<double>::n_array_elements;
-constexpr unsigned int VectorizedArray<float>::n_array_elements;
+const unsigned int VectorizedArray<double>::n_array_elements;
+const unsigned int VectorizedArray<float>::n_array_elements;
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Fixes #6728. I am still puzzled why `macOS` behaves that weird, but this works.

`n_array_elements` is `odr-used` so we definitely need an extra definition (which is now in `vectorization.cc`) in case it is declared as `static const`. In C++17 the extra definition would be redundant if we declare the variable `static constexpr`.
Nevertheless, `macOS` dropped the symbol even when using C++17 and having the extra definition.