### PR TITLE
Silence gcc-8 warnings in bundled TBB

### DIFF
--- a/bundled/tbb-2018_U2/include/tbb/concurrent_vector.h
+++ b/bundled/tbb-2018_U2/include/tbb/concurrent_vector.h
@@ -74,7 +74,7 @@ namespace internal {
     //! Exception helper function
     template<typename T>
     void handle_unconstructed_elements(T* array, size_t n_of_elements){
-        std::memset( array, 0, n_of_elements * sizeof( T ) );
+        std::memset( (void*)array, 0, n_of_elements * sizeof( T ) );
     }
 
     //! Base class of concurrent vector implementation.

--- a/bundled/tbb-2018_U2/include/tbb/internal/_concurrent_unordered_impl.h
+++ b/bundled/tbb-2018_U2/include/tbb/internal/_concurrent_unordered_impl.h
@@ -1468,7 +1468,7 @@ private:
         if (my_buckets[segment] == NULL) {
             size_type sz = segment_size(segment);
             raw_iterator * new_segment = my_allocator.allocate(sz);
-            std::memset(new_segment, 0, sz*sizeof(raw_iterator));
+            std::memset((void*)new_segment, 0, sz*sizeof(raw_iterator));
 
             if (my_buckets[segment].compare_and_swap( new_segment, NULL) != NULL)
                 my_allocator.deallocate(new_segment, sz);


### PR DESCRIPTION
TBB is using `std::memset` for classes that are not trivially-copyable. This might in general not to be safe, but is nothing we can do anything about. Hence, we should just silence the warning. According to the [`gcc` documentation](https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html) casting to `void *` is the easiest way to do so. There are also PRs that suggest this upstream.