### PR TITLE
Restrict directories to apply clang-format to

### DIFF
--- a/bundled/.clang-format
+++ b/bundled/.clang-format
@@ -1,0 +1,6 @@
+#
+# The clang-format (Clang 6) style file used by deal.II.
+# This directory shall not be formatted.
+#
+
+DisableFormat: true

--- a/cmake/.clang-format
+++ b/cmake/.clang-format
@@ -1,0 +1,6 @@
+#
+# The clang-format (Clang 6) style file used by deal.II.
+# This directory shall not be formatted.
+#
+
+DisableFormat: true

--- a/contrib/.clang-format
+++ b/contrib/.clang-format
@@ -1,0 +1,6 @@
+#
+# The clang-format (Clang 6) style file used by deal.II.
+# This directory shall not be formatted.
+#
+
+DisableFormat: true

--- a/doc/.clang-format
+++ b/doc/.clang-format
@@ -1,0 +1,6 @@
+#
+# The clang-format (Clang 6) style file used by deal.II.
+# This directory shall not be formatted.
+#
+
+DisableFormat: true


### PR DESCRIPTION
In view of #6698, it is helpful to ensure that `bundled`,`cmake`, `contrib` and `doc` are never formatted by `clang-tidy`.