### PR TITLE
Move extra static constexpr member declaration to header

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -946,6 +946,14 @@ private:
 
 #ifndef DOXYGEN
 
+// provide declarations for static members
+template <int rank, int dim, typename Number>
+const unsigned int SymmetricTensor<rank, dim, Number>::dimension;
+
+template <int rank_, int dim, typename Number>
+constexpr unsigned int
+  SymmetricTensor<rank_, dim, Number>::n_independent_components;
+
 namespace internal
 {
   namespace SymmetricTensorAccessors

--- a/source/base/symmetric_tensor.cc
+++ b/source/base/symmetric_tensor.cc
@@ -24,16 +24,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
-// provide definitions for static members
-template <int rank, int dim, typename Number>
-const unsigned int SymmetricTensor<rank, dim, Number>::dimension;
-
-template <int rank, int dim, typename Number>
-constexpr unsigned int
-  SymmetricTensor<rank, dim, Number>::n_independent_components;
-
-
 // explicit instantiations
 #include "symmetric_tensor.inst"
 


### PR DESCRIPTION
This makes `clang-4.0` happy for `Number` template parameters for which we don't provide an explicit instantiation. Fixes the tests in https://cdash.kyomu.43-1.org/viewTest.php?onlyfailed&buildid=2425 and passes the testsuite with `clang-4.0`, `clang-6.0` and `gcc-8`.