### PR TITLE
Add codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,32 @@
+codecov:
+  max_report_age: off
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment: off
+
+ignore: 
+  - "bundled"
+  - "cmake"
+  - "contrib"
+  - "doc"
+  - "examples"
+  - "tests"

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 /tests/run_test.cmake -export-ignore
 /tests/tests.h -export-ignore
 .clang-format export-ignore
+.codecov.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore


### PR DESCRIPTION
Currently, the [`codecov` page](https://codecov.io/gh/dealii/dealii/) includes results for folders we are actually not interested in. This PR restricts the tracked folder to `include` and `source`.