### PR TITLE
Deprecate FunctionMap

### DIFF
--- a/doc/news/changes/minor/20180611DanielArndt
+++ b/doc/news/changes/minor/20180611DanielArndt
@@ -1,0 +1,4 @@
+Deprecated: FunctionMap is deprecated. It is recommended to
+use the aliased type directly.
+<br>
+(Daniel Arndt, 2018/06/11)

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -1239,11 +1239,12 @@ namespace Step13
     {
       Vector<float> estimated_error_per_cell(
         this->triangulation->n_active_cells());
-      KellyErrorEstimator<dim>::estimate(this->dof_handler,
-                                         QGauss<dim - 1>(3),
-                                         typename FunctionMap<dim>::type(),
-                                         this->solution,
-                                         estimated_error_per_cell);
+      KellyErrorEstimator<dim>::estimate(
+        this->dof_handler,
+        QGauss<dim - 1>(3),
+        std::map<types::boundary_id, const Function<dim> *>(),
+        this->solution,
+        estimated_error_per_cell);
       GridRefinement::refine_and_coarsen_fixed_number(*this->triangulation,
                                                       estimated_error_per_cell,
                                                       0.3,

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -894,11 +894,12 @@ namespace Step14
     {
       Vector<float> estimated_error_per_cell(
         this->triangulation->n_active_cells());
-      KellyErrorEstimator<dim>::estimate(this->dof_handler,
-                                         QGauss<dim - 1>(3),
-                                         typename FunctionMap<dim>::type(),
-                                         this->solution,
-                                         estimated_error_per_cell);
+      KellyErrorEstimator<dim>::estimate(
+        this->dof_handler,
+        QGauss<dim - 1>(3),
+        std::map<types::boundary_id, const Function<dim> *>(),
+        this->solution,
+        estimated_error_per_cell);
       GridRefinement::refine_and_coarsen_fixed_number(*this->triangulation,
                                                       estimated_error_per_cell,
                                                       0.3,
@@ -970,9 +971,10 @@ namespace Step14
       // here is described in more detail in the documentation of that class.
       Vector<float> estimated_error_per_cell(
         this->triangulation->n_active_cells());
+      std::map<types::boundary_id, const Function<dim> *> dummy_function_map;
       KellyErrorEstimator<dim>::estimate(this->dof_handler,
                                          *this->face_quadrature,
-                                         typename FunctionMap<dim>::type(),
+                                         dummy_function_map,
                                          this->solution,
                                          estimated_error_per_cell);
 

--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -377,11 +377,12 @@ namespace Step15
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(3),
-                                       typename FunctionMap<dim>::type(),
-                                       present_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(3),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      present_solution,
+      estimated_error_per_cell);
 
     GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                     estimated_error_per_cell,

--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -280,10 +280,11 @@ namespace Step16
     constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
 
-    std::set<types::boundary_id>          dirichlet_boundary_ids = {0};
-    Functions::ZeroFunction<dim>          homogeneous_dirichlet_bc;
-    const typename FunctionMap<dim>::type dirichlet_boundary_functions = {
-      {types::boundary_id(0), &homogeneous_dirichlet_bc}};
+    std::set<types::boundary_id> dirichlet_boundary_ids = {0};
+    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc;
+    const std::map<types::boundary_id, const Function<dim> *>
+      dirichlet_boundary_functions = {
+        {types::boundary_id(0), &homogeneous_dirichlet_bc}};
     VectorTools::interpolate_boundary_values(
       static_cast<const DoFHandler<dim> &>(dof_handler),
       dirichlet_boundary_functions,
@@ -575,11 +576,12 @@ namespace Step16
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(3),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(3),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell);
     GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                     estimated_error_per_cell,
                                                     0.3,

--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -763,15 +763,16 @@ namespace Step17
     const Vector<double> localized_solution(solution);
 
     Vector<float> local_error_per_cell(triangulation.n_active_cells());
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(2),
-                                       typename FunctionMap<dim>::type(),
-                                       localized_solution,
-                                       local_error_per_cell,
-                                       ComponentMask(),
-                                       nullptr,
-                                       MultithreadInfo::n_threads(),
-                                       this_mpi_process);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(2),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      localized_solution,
+      local_error_per_cell,
+      ComponentMask(),
+      nullptr,
+      MultithreadInfo::n_threads(),
+      this_mpi_process);
 
     // Now all processes have computed error indicators for their own
     // cells and stored them in the respective elements of the

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -1444,15 +1444,16 @@ namespace Step18
   {
     // First, let each process compute error indicators for the cells it owns:
     Vector<float> error_per_cell(triangulation.n_active_cells());
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(2),
-                                       typename FunctionMap<dim>::type(),
-                                       incremental_displacement,
-                                       error_per_cell,
-                                       ComponentMask(),
-                                       nullptr,
-                                       MultithreadInfo::n_threads(),
-                                       this_mpi_process);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(2),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      incremental_displacement,
+      error_per_cell,
+      ComponentMask(),
+      nullptr,
+      MultithreadInfo::n_threads(),
+      this_mpi_process);
 
     // Then set up a global vector into which we merge the local indicators
     // from each of the %parallel processes:

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -939,12 +939,13 @@ namespace Step22
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
     FEValuesExtractors::Scalar pressure(dim);
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell,
-                                       fe.component_mask(pressure));
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell,
+      fe.component_mask(pressure));
 
     GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                     estimated_error_per_cell,

--- a/examples/step-26/step-26.cc
+++ b/examples/step-26/step-26.cc
@@ -338,11 +338,12 @@ namespace Step26
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(fe.degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(fe.degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell);
 
     GridRefinement::refine_and_coarsen_fixed_fraction(triangulation,
                                                       estimated_error_per_cell,

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -411,11 +411,12 @@ namespace Step27
     // class as always. Estimating the smoothness is done in the respective
     // function of this class; that function is discussed further down below:
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       face_quadrature_collection,
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      face_quadrature_collection,
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell);
 
 
     Vector<float> smoothness_indicators(triangulation.n_active_cells());

--- a/examples/step-28/step-28.cc
+++ b/examples/step-28/step-28.cc
@@ -1053,11 +1053,12 @@ namespace Step28
   template <int dim>
   void EnergyGroup<dim>::estimate_errors(Vector<float> &error_indicators) const
   {
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(fe.degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       error_indicators);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(fe.degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      error_indicators);
     error_indicators /= solution.linfty_norm();
   }
 

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -1973,11 +1973,12 @@ namespace Step31
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-    KellyErrorEstimator<dim>::estimate(temperature_dof_handler,
-                                       QGauss<dim - 1>(temperature_degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       temperature_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      temperature_dof_handler,
+      QGauss<dim - 1>(temperature_degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      temperature_solution,
+      estimated_error_per_cell);
 
     GridRefinement::refine_and_coarsen_fixed_fraction(triangulation,
                                                       estimated_error_per_cell,

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -3486,7 +3486,7 @@ namespace Step32
       KellyErrorEstimator<dim>::estimate(
         temperature_dof_handler,
         QGauss<dim - 1>(parameters.temperature_degree + 1),
-        typename FunctionMap<dim>::type(),
+        std::map<types::boundary_id, const Function<dim> *>(),
         temperature_solution,
         estimated_error_per_cell,
         ComponentMask(),

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -527,11 +527,12 @@ namespace Step40
     TimerOutput::Scope t(computing_timer, "refine");
 
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(3),
-                                       typename FunctionMap<dim>::type(),
-                                       locally_relevant_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(3),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      locally_relevant_solution,
+      estimated_error_per_cell);
     parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
       triangulation, estimated_error_per_cell, 0.3, 0.03);
     triangulation.execute_coarsening_and_refinement();

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -1918,11 +1918,12 @@ namespace Step42
     else
       {
         Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
-        KellyErrorEstimator<dim>::estimate(dof_handler,
-                                           QGauss<dim - 1>(fe.degree + 2),
-                                           typename FunctionMap<dim>::type(),
-                                           solution,
-                                           estimated_error_per_cell);
+        KellyErrorEstimator<dim>::estimate(
+          dof_handler,
+          QGauss<dim - 1>(fe.degree + 2),
+          std::map<types::boundary_id, const Function<dim> *>(),
+          solution,
+          estimated_error_per_cell);
 
         parallel::distributed::GridRefinement ::refine_and_coarsen_fixed_number(
           triangulation, estimated_error_per_cell, 0.3, 0.03);

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -723,12 +723,13 @@ namespace Step45
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
     FEValuesExtractors::Scalar pressure(dim);
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell,
-                                       fe.component_mask(pressure));
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell,
+      fe.component_mask(pressure));
 
     parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
       triangulation, estimated_error_per_cell, 0.3, 0.0);

--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -618,7 +618,7 @@ code like the following:
     stokes_component_mask[d] = true;
   KellyErrorEstimator<dim>::estimate (dof_handler,
                                       face_q_collection,
-                                      typename FunctionMap<dim>::type(),
+                                      std::map<types::boundary_id, const Function<dim>*>(),
                                       solution,
                                       stokes_estimated_error_per_cell,
                                       stokes_component_mask);
@@ -628,7 +628,7 @@ code like the following:
     elasticity_component_mask[dim+1+d] = true;
   KellyErrorEstimator<dim>::estimate (dof_handler,
                                       face_q_collection,
-                                      typename FunctionMap<dim>::type(),
+                                      std::map<types::boundary_id, const Function<dim>*>(),
                                       solution,
                                       elasticity_estimated_error_per_cell,
                                       elasticity_component_mask);

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -949,22 +949,22 @@ namespace Step46
     face_q_collection.push_back(elasticity_face_quadrature);
 
     const FEValuesExtractors::Vector velocities(0);
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       face_q_collection,
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       stokes_estimated_error_per_cell,
-                                       fe_collection.component_mask(
-                                         velocities));
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      face_q_collection,
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      stokes_estimated_error_per_cell,
+      fe_collection.component_mask(velocities));
 
     const FEValuesExtractors::Vector displacements(dim + 1);
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       face_q_collection,
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       elasticity_estimated_error_per_cell,
-                                       fe_collection.component_mask(
-                                         displacements));
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      face_q_collection,
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      elasticity_estimated_error_per_cell,
+      fe_collection.component_mask(displacements));
 
     // We then normalize error estimates by dividing by their norm and scale
     // the fluid error indicators by a factor of 4 as discussed in the

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -281,8 +281,8 @@ namespace Step50
     constraints.reinit(locally_relevant_set);
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    std::set<types::boundary_id>     dirichlet_boundary_ids;
-    typename FunctionMap<dim>::type  dirichlet_boundary;
+    std::set<types::boundary_id>                        dirichlet_boundary_ids;
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
     Functions::ConstantFunction<dim> homogeneous_dirichlet_bc(1.0);
     dirichlet_boundary_ids.insert(0);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
@@ -842,12 +842,12 @@ namespace Step50
     temp_solution.reinit(locally_relevant_set, MPI_COMM_WORLD);
     temp_solution = solution;
 
-    KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                         mg_dof_handler),
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       temp_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      mg_dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      temp_solution,
+      estimated_error_per_cell);
 
     parallel::distributed::GridRefinement::refine_and_coarsen_fixed_fraction(
       triangulation, estimated_error_per_cell, 0.3, 0.0);

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -448,8 +448,8 @@ namespace Step51
 
     constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
-    typename FunctionMap<dim>::type boundary_functions;
-    Solution<dim>                   solution_function;
+    std::map<types::boundary_id, const Function<dim> *> boundary_functions;
+    Solution<dim>                                       solution_function;
     boundary_functions[0] = &solution_function;
     VectorTools::project_boundary_values(dof_handler,
                                          boundary_functions,
@@ -1329,8 +1329,9 @@ namespace Step51
               Vector<float> estimated_error_per_cell(
                 triangulation.n_active_cells());
 
-              FEValuesExtractors::Scalar      scalar(dim);
-              typename FunctionMap<dim>::type neumann_boundary;
+              FEValuesExtractors::Scalar scalar(dim);
+              std::map<types::boundary_id, const Function<dim> *>
+                neumann_boundary;
               KellyErrorEstimator<dim>::estimate(dof_handler_local,
                                                  QGauss<dim - 1>(3),
                                                  neumann_boundary,

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -690,12 +690,13 @@ namespace Step55
         Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
         FEValuesExtractors::Vector velocities(0);
-        KellyErrorEstimator<dim>::estimate(dof_handler,
-                                           QGauss<dim - 1>(3),
-                                           typename FunctionMap<dim>::type(),
-                                           locally_relevant_solution,
-                                           estimated_error_per_cell,
-                                           fe.component_mask(velocities));
+        KellyErrorEstimator<dim>::estimate(
+          dof_handler,
+          QGauss<dim - 1>(3),
+          std::map<types::boundary_id, const Function<dim> *>(),
+          locally_relevant_solution,
+          estimated_error_per_cell,
+          fe.component_mask(velocities));
         parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
           triangulation, estimated_error_per_cell, 0.3, 0.0);
         triangulation.execute_coarsening_and_refinement();

--- a/examples/step-57/step-57.cc
+++ b/examples/step-57/step-57.cc
@@ -588,12 +588,13 @@ namespace Step57
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
     FEValuesExtractors::Vector velocity(0);
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       present_solution,
-                                       estimated_error_per_cell,
-                                       fe.component_mask(velocity));
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      present_solution,
+      estimated_error_per_cell,
+      fe.component_mask(velocity));
 
     GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                     estimated_error_per_cell,

--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -469,12 +469,12 @@ void Step6<dim>::solve()
 // Secondly, the function wants a list of boundary indicators for those
 // boundaries where we have imposed Neumann values of the kind
 // $\partial_n u(\mathbf x) = h(\mathbf x)$, along with a function $h(\mathbf
-// x)$ for each such boundary. This information is represented by an object of
-// type <code>FunctionMap::type</code> that is a typedef to a map from boundary
-// indicators to function objects describing the Neumann boundary values. In the
-// present example program, we do not use Neumann boundary values, so this map
-// is empty, and in fact constructed using the default constructor of the map in
-// the place where the function call expects the respective function argument.
+// x)$ for each such boundary. This information is represented by a map from
+// boundary indicators to function objects describing the Neumann boundary
+// values. In the present example program, we do not use Neumann boundary
+// values, so this map is empty, and in fact constructed using the default
+// constructor of the map in the place where the function call expects the
+// respective function argument.
 //
 // The output is a vector of values for all active cells. While it may
 // make sense to compute the <b>value</b> of a solution degree of freedom
@@ -487,11 +487,12 @@ void Step6<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   // The above function returned one error indicator value for each cell in
   // the <code>estimated_error_per_cell</code> array. Refinement is now done

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -819,7 +819,7 @@ namespace Step7
             KellyErrorEstimator<dim>::estimate(
               dof_handler,
               QGauss<dim - 1>(3),
-              typename FunctionMap<dim>::type(),
+              std::map<types::boundary_id, const Function<dim> *>(),
               solution,
               estimated_error_per_cell);
 

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -487,11 +487,12 @@ namespace Step8
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(2),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(2),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell);
 
     GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                     estimated_error_per_cell,

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/iterator_range.h>
 #include <deal.II/base/smartpointer.h>
@@ -29,7 +30,6 @@
 #include <deal.II/dofs/dof_faces.h>
 #include <deal.II/dofs/dof_iterator_selector.h>
 #include <deal.II/dofs/dof_levels.h>
-#include <deal.II/dofs/function_map.h>
 #include <deal.II/dofs/number_cache.h>
 
 #include <deal.II/hp/fe_collection.h>
@@ -855,8 +855,6 @@ public:
    * reason that a @p map rather than a @p set is used is the same as
    * described in the documentation of that variant of
    * DoFTools::make_boundary_sparsity_pattern() that takes a map.
-   * To this end, the type of the @p boundary_ids argument is the same
-   * as typename FunctionMap<spacedim,number>::type.
    *
    * There is, however, another overload of this function that takes
    * a @p set argument (see below).

--- a/include/deal.II/dofs/function_map.h
+++ b/include/deal.II/dofs/function_map.h
@@ -15,6 +15,7 @@
 
 #ifndef dealii_function_map_h
 #define dealii_function_map_h
+#warning This file is deprecated.
 
 #include <deal.II/base/config.h>
 
@@ -73,13 +74,16 @@ class Function;
  * @author Wolfgang Bangerth, Ralf Hartmann, 2001
  */
 template <int dim, typename Number = double>
-struct FunctionMap
+struct DEAL_II_DEPRECATED FunctionMap
 {
   /**
    * Declare the type as discussed above. Since we can't name it FunctionMap
    * (as that would ambiguate a possible constructor of this class), name it
    * in the fashion of the standard container local typedefs.
+   *
+   * @deprecated Use the alias type directly.
    */
+  DEAL_II_DEPRECATED
   typedef std::map<types::boundary_id, const Function<dim, Number> *> type;
 };
 

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -21,13 +21,13 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
 #include <deal.II/base/iterator_range.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/template_constraints.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_iterator_selector.h>
-#include <deal.II/dofs/function_map.h>
 #include <deal.II/dofs/number_cache.h>
 
 #include <deal.II/hp/dof_faces.h>
@@ -648,8 +648,6 @@ namespace hp
      * reason that a @p map rather than a @p set is used is the same as
      * described in the documentation of that variant of
      * DoFTools::make_boundary_sparsity_pattern() that takes a map.
-     * To this end, the type of the @p boundary_ids argument is the same
-     * as typename FunctionMap<spacedim,number>::type.
      *
      * There is, however, another overload of this function that takes
      * a @p set argument (see below).

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -31,8 +31,6 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 class DoFHandler;
-template <int dim, typename Number>
-struct FunctionMap;
 
 
 /**
@@ -81,8 +79,9 @@ public:
    */
   template <int dim, int spacedim>
   DEAL_II_DEPRECATED void
-  initialize(const DoFHandler<dim, spacedim> &      dof,
-             const typename FunctionMap<dim>::type &function_map,
+  initialize(const DoFHandler<dim, spacedim> &dof,
+             const std::map<types::boundary_id, const Function<spacedim> *>
+               &                  function_map,
              const ComponentMask &component_mask = ComponentMask());
 
   /**
@@ -272,9 +271,9 @@ MGConstrainedDoFs::initialize(const DoFHandler<dim, spacedim> &dof)
 template <int dim, int spacedim>
 inline void
 MGConstrainedDoFs::initialize(
-  const DoFHandler<dim, spacedim> &      dof,
-  const typename FunctionMap<dim>::type &function_map,
-  const ComponentMask &                  component_mask)
+  const DoFHandler<dim, spacedim> &                               dof,
+  const std::map<types::boundary_id, const Function<spacedim> *> &function_map,
+  const ComponentMask &component_mask)
 {
   initialize(dof);
 

--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -208,8 +208,9 @@ namespace MGTools
   template <int dim, int spacedim>
   void
   make_boundary_list(
-    const DoFHandler<dim, spacedim> &               mg_dof,
-    const typename FunctionMap<dim>::type &         function_map,
+    const DoFHandler<dim, spacedim> &mg_dof,
+    const std::map<types::boundary_id, const Function<spacedim> *>
+      &                                             function_map,
     std::vector<std::set<types::global_dof_index>> &boundary_indices,
     const ComponentMask &component_mask = ComponentMask());
 
@@ -222,10 +223,11 @@ namespace MGTools
    */
   template <int dim, int spacedim>
   void
-  make_boundary_list(const DoFHandler<dim, spacedim> &      mg_dof,
-                     const typename FunctionMap<dim>::type &function_map,
-                     std::vector<IndexSet> &                boundary_indices,
-                     const ComponentMask &component_mask = ComponentMask());
+  make_boundary_list(const DoFHandler<dim, spacedim> &           mg_dof,
+                     const std::map<types::boundary_id,
+                                    const Function<spacedim> *> &function_map,
+                     std::vector<IndexSet> &boundary_indices,
+                     const ComponentMask &  component_mask = ComponentMask());
 
   /**
    * The same function as above, but return an IndexSet rather than a

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -22,8 +22,6 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
 
-#include <deal.II/dofs/function_map.h>
-
 #include <deal.II/fe/component_mask.h>
 
 #include <map>
@@ -339,7 +337,8 @@ public:
     const Mapping<dim, spacedim> &mapping,
     const DoFHandlerType &        dof,
     const Quadrature<dim - 1> &   quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                       neumann_bc,
     const InputVector &       solution,
     Vector<float> &           error,
@@ -359,7 +358,8 @@ public:
   estimate(
     const DoFHandlerType &     dof,
     const Quadrature<dim - 1> &quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                       neumann_bc,
     const InputVector &       solution,
     Vector<float> &           error,
@@ -389,7 +389,8 @@ public:
     const Mapping<dim, spacedim> &mapping,
     const DoFHandlerType &        dof,
     const Quadrature<dim - 1> &   quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                                     neumann_bc,
     const std::vector<const InputVector *> &solutions,
     std::vector<Vector<float> *> &          errors,
@@ -409,7 +410,8 @@ public:
   estimate(
     const DoFHandlerType &     dof,
     const Quadrature<dim - 1> &quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                                     neumann_bc,
     const std::vector<const InputVector *> &solutions,
     std::vector<Vector<float> *> &          errors,
@@ -431,7 +433,8 @@ public:
     const Mapping<dim, spacedim> &  mapping,
     const DoFHandlerType &          dof,
     const hp::QCollection<dim - 1> &quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                       neumann_bc,
     const InputVector &       solution,
     Vector<float> &           error,
@@ -452,7 +455,8 @@ public:
   estimate(
     const DoFHandlerType &          dof,
     const hp::QCollection<dim - 1> &quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                       neumann_bc,
     const InputVector &       solution,
     Vector<float> &           error,
@@ -474,7 +478,8 @@ public:
     const Mapping<dim, spacedim> &  mapping,
     const DoFHandlerType &          dof,
     const hp::QCollection<dim - 1> &quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                                     neumann_bc,
     const std::vector<const InputVector *> &solutions,
     std::vector<Vector<float> *> &          errors,
@@ -495,7 +500,8 @@ public:
   estimate(
     const DoFHandlerType &          dof,
     const hp::QCollection<dim - 1> &quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                                     neumann_bc,
     const std::vector<const InputVector *> &solutions,
     std::vector<Vector<float> *> &          errors,
@@ -619,7 +625,8 @@ public:
     const Mapping<1, spacedim> &mapping,
     const DoFHandlerType &      dof,
     const Quadrature<0> &       quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                       neumann_bc,
     const InputVector &       solution,
     Vector<float> &           error,
@@ -639,7 +646,8 @@ public:
   estimate(
     const DoFHandlerType &dof,
     const Quadrature<0> & quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                       neumann_bc,
     const InputVector &       solution,
     Vector<float> &           error,
@@ -669,7 +677,8 @@ public:
     const Mapping<1, spacedim> &mapping,
     const DoFHandlerType &      dof,
     const Quadrature<0> &       quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                                     neumann_bc,
     const std::vector<const InputVector *> &solutions,
     std::vector<Vector<float> *> &          errors,
@@ -689,7 +698,8 @@ public:
   estimate(
     const DoFHandlerType &dof,
     const Quadrature<0> & quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                                     neumann_bc,
     const std::vector<const InputVector *> &solutions,
     std::vector<Vector<float> *> &          errors,
@@ -711,7 +721,8 @@ public:
     const Mapping<1, spacedim> &mapping,
     const DoFHandlerType &      dof,
     const hp::QCollection<0> &  quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                       neumann_bc,
     const InputVector &       solution,
     Vector<float> &           error,
@@ -732,7 +743,8 @@ public:
   estimate(
     const DoFHandlerType &    dof,
     const hp::QCollection<0> &quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                       neumann_bc,
     const InputVector &       solution,
     Vector<float> &           error,
@@ -754,7 +766,8 @@ public:
     const Mapping<1, spacedim> &mapping,
     const DoFHandlerType &      dof,
     const hp::QCollection<0> &  quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                                     neumann_bc,
     const std::vector<const InputVector *> &solutions,
     std::vector<Vector<float> *> &          errors,
@@ -775,7 +788,8 @@ public:
   estimate(
     const DoFHandlerType &    dof,
     const hp::QCollection<0> &quadrature,
-    const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+    const std::map<types::boundary_id,
+                   const Function<spacedim, typename InputVector::value_type> *>
       &                                     neumann_bc,
     const std::vector<const InputVector *> &solutions,
     std::vector<Vector<float> *> &          errors,

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -176,9 +176,10 @@ namespace internal
        * Some more references to input data to the
        * KellyErrorEstimator::estimate() function.
        */
-      const typename FunctionMap<spacedim, number>::type *neumann_bc;
-      const ComponentMask                                 component_mask;
-      const Function<spacedim> *                          coefficients;
+      const std::map<types::boundary_id, const Function<spacedim, number> *>
+        *                       neumann_bc;
+      const ComponentMask       component_mask;
+      const Function<spacedim> *coefficients;
 
       /**
        * Constructor.
@@ -192,9 +193,10 @@ namespace internal
         const unsigned int        n_solution_vectors,
         const types::subdomain_id subdomain_id,
         const types::material_id  material_id,
-        const typename FunctionMap<spacedim, number>::type *neumann_bc,
-        const ComponentMask &                               component_mask,
-        const Function<spacedim> *                          coefficients);
+        const std::map<types::boundary_id, const Function<spacedim, number> *>
+          *                       neumann_bc,
+        const ComponentMask &     component_mask,
+        const Function<spacedim> *coefficients);
 
       /**
        * Resize the arrays so that they fit the number of quadrature points
@@ -216,9 +218,10 @@ namespace internal
       const unsigned int        n_solution_vectors,
       const types::subdomain_id subdomain_id,
       const types::material_id  material_id,
-      const typename FunctionMap<spacedim, number>::type *neumann_bc,
-      const ComponentMask &                               component_mask,
-      const Function<spacedim> *                          coefficients)
+      const std::map<types::boundary_id, const Function<spacedim, number> *>
+        *                       neumann_bc,
+      const ComponentMask &     component_mask,
+      const Function<spacedim> *coefficients)
       : finite_element(fe)
       , face_quadratures(face_quadratures)
       , fe_face_values_cell(mapping,
@@ -1075,7 +1078,8 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const Mapping<dim, spacedim> &mapping,
   const DoFHandlerType &        dof_handler,
   const Quadrature<dim - 1> &   quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                       neumann_bc,
   const InputVector &       solution,
   Vector<float> &           error,
@@ -1110,7 +1114,8 @@ void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const DoFHandlerType &     dof_handler,
   const Quadrature<dim - 1> &quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                       neumann_bc,
   const InputVector &       solution,
   Vector<float> &           error,
@@ -1143,7 +1148,8 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const Mapping<dim, spacedim> &  mapping,
   const DoFHandlerType &          dof_handler,
   const hp::QCollection<dim - 1> &quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                       neumann_bc,
   const InputVector &       solution,
   Vector<float> &           error,
@@ -1178,7 +1184,8 @@ void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const DoFHandlerType &          dof_handler,
   const hp::QCollection<dim - 1> &quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                       neumann_bc,
   const InputVector &       solution,
   Vector<float> &           error,
@@ -1212,7 +1219,8 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const Mapping<dim, spacedim> &  mapping,
   const DoFHandlerType &          dof_handler,
   const hp::QCollection<dim - 1> &face_quadratures,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                                     neumann_bc,
   const std::vector<const InputVector *> &solutions,
   std::vector<Vector<float> *> &          errors,
@@ -1256,13 +1264,10 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   Assert(solutions.size() == errors.size(),
          ExcIncompatibleNumberOfElements(solutions.size(), errors.size()));
 
-  for (typename FunctionMap<spacedim, typename InputVector::value_type>::type::
-         const_iterator i = neumann_bc.begin();
-       i != neumann_bc.end();
-       ++i)
-    Assert(i->second->n_components == n_components,
-           ExcInvalidBoundaryFunction(i->first,
-                                      i->second->n_components,
+  for (const auto &boundary_function : neumann_bc)
+    Assert(boundary_function.second->n_components == n_components,
+           ExcInvalidBoundaryFunction(boundary_function.first,
+                                      boundary_function.second->n_components,
                                       n_components));
 
   Assert(component_mask.represents_n_components(n_components),
@@ -1383,7 +1388,8 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const Mapping<dim, spacedim> &mapping,
   const DoFHandlerType &        dof_handler,
   const Quadrature<dim - 1> &   quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                                     neumann_bc,
   const std::vector<const InputVector *> &solutions,
   std::vector<Vector<float> *> &          errors,
@@ -1416,7 +1422,8 @@ void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const DoFHandlerType &     dof_handler,
   const Quadrature<dim - 1> &quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                                     neumann_bc,
   const std::vector<const InputVector *> &solutions,
   std::vector<Vector<float> *> &          errors,
@@ -1449,7 +1456,8 @@ void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const DoFHandlerType &          dof_handler,
   const hp::QCollection<dim - 1> &quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                                     neumann_bc,
   const std::vector<const InputVector *> &solutions,
   std::vector<Vector<float> *> &          errors,

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -23,8 +23,6 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/thread_management.h>
 
-#include <deal.II/dofs/function_map.h>
-
 #include <deal.II/lac/affine_constraints.h>
 
 #include <map>

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -20,11 +20,11 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/dofs/dof_handler.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/mapping_collection.h>
@@ -1006,8 +1006,7 @@ namespace VectorTools
    * The keys of this map correspond to the number @p boundary_id of the face.
    * numbers::internal_face_boundary_id is an illegal value for this key since
    * it is reserved for interior faces. For an example of how to use this
-   * argument with a non-empty map, see the step-16 tutorial program. (Note
-   * that the argument type is equal to the FunctionMap type.)
+   * argument with a non-empty map, see the step-16 tutorial program.
    *
    * The flags in the last parameter, @p component_mask denote which
    * components of the finite element space shall be interpolated. If it is
@@ -1972,11 +1971,12 @@ namespace VectorTools
   template <int dim, int spacedim, template <int, int> class DoFHandlerType>
   void
   compute_nonzero_normal_flux_constraints(
-    const DoFHandlerType<dim, spacedim> & dof_handler,
-    const unsigned int                    first_vector_component,
-    const std::set<types::boundary_id> &  boundary_ids,
-    typename FunctionMap<spacedim>::type &function_map,
-    AffineConstraints<double> &           constraints,
+    const DoFHandlerType<dim, spacedim> &dof_handler,
+    const unsigned int                   first_vector_component,
+    const std::set<types::boundary_id> & boundary_ids,
+    const std::map<types::boundary_id, const Function<spacedim> *>
+      &                           function_map,
+    AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping = StaticMappingQ1<dim>::mapping);
 
   /**
@@ -2019,11 +2019,12 @@ namespace VectorTools
   template <int dim, int spacedim, template <int, int> class DoFHandlerType>
   void
   compute_nonzero_tangential_flux_constraints(
-    const DoFHandlerType<dim, spacedim> & dof_handler,
-    const unsigned int                    first_vector_component,
-    const std::set<types::boundary_id> &  boundary_ids,
-    typename FunctionMap<spacedim>::type &function_map,
-    AffineConstraints<double> &           constraints,
+    const DoFHandlerType<dim, spacedim> &dof_handler,
+    const unsigned int                   first_vector_component,
+    const std::set<types::boundary_id> & boundary_ids,
+    const std::map<types::boundary_id, const Function<spacedim> *>
+      &                           function_map,
+    AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping = StaticMappingQ1<dim>::mapping);
 
   /**

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6916,8 +6916,8 @@ namespace VectorTools
     AffineConstraints<double> &          constraints,
     const Mapping<dim, spacedim> &       mapping)
   {
-    ZeroFunction<dim>                            zero_function(dim);
-    typename FunctionMap<spacedim>::type         function_map;
+    ZeroFunction<dim>                                        zero_function(dim);
+    std::map<types::boundary_id, const Function<spacedim> *> function_map;
     std::set<types::boundary_id>::const_iterator it = boundary_ids.begin();
     for (; it != boundary_ids.end(); ++it)
       function_map[*it] = &zero_function;
@@ -6932,12 +6932,13 @@ namespace VectorTools
   template <int dim, int spacedim, template <int, int> class DoFHandlerType>
   void
   compute_nonzero_normal_flux_constraints(
-    const DoFHandlerType<dim, spacedim> & dof_handler,
-    const unsigned int                    first_vector_component,
-    const std::set<types::boundary_id> &  boundary_ids,
-    typename FunctionMap<spacedim>::type &function_map,
-    AffineConstraints<double> &           constraints,
-    const Mapping<dim, spacedim> &        mapping)
+    const DoFHandlerType<dim, spacedim> &dof_handler,
+    const unsigned int                   first_vector_component,
+    const std::set<types::boundary_id> & boundary_ids,
+    const std::map<types::boundary_id, const Function<spacedim> *>
+      &                           function_map,
+    AffineConstraints<double> &   constraints,
+    const Mapping<dim, spacedim> &mapping)
   {
     Assert(dim > 1,
            ExcMessage("This function is not useful in 1d because it amounts "
@@ -7117,7 +7118,7 @@ namespace VectorTools
 
                     const Point<dim> point = fe_values.quadrature_point(i);
                     Vector<double>   b_values(dim);
-                    function_map[*b_id]->vector_value(point, b_values);
+                    function_map.at(*b_id)->vector_value(point, b_values);
 
                     // now enter the (dofs,(normal_vector,cell)) entry into
                     // the map
@@ -7528,8 +7529,8 @@ namespace VectorTools
     AffineConstraints<double> &          constraints,
     const Mapping<dim, spacedim> &       mapping)
   {
-    ZeroFunction<dim>                            zero_function(dim);
-    typename FunctionMap<spacedim>::type         function_map;
+    ZeroFunction<dim>                                        zero_function(dim);
+    std::map<types::boundary_id, const Function<spacedim> *> function_map;
     std::set<types::boundary_id>::const_iterator it = boundary_ids.begin();
     for (; it != boundary_ids.end(); ++it)
       function_map[*it] = &zero_function;
@@ -7544,12 +7545,13 @@ namespace VectorTools
   template <int dim, int spacedim, template <int, int> class DoFHandlerType>
   void
   compute_nonzero_tangential_flux_constraints(
-    const DoFHandlerType<dim, spacedim> & dof_handler,
-    const unsigned int                    first_vector_component,
-    const std::set<types::boundary_id> &  boundary_ids,
-    typename FunctionMap<spacedim>::type &function_map,
-    AffineConstraints<double> &           constraints,
-    const Mapping<dim, spacedim> &        mapping)
+    const DoFHandlerType<dim, spacedim> &dof_handler,
+    const unsigned int                   first_vector_component,
+    const std::set<types::boundary_id> & boundary_ids,
+    const std::map<types::boundary_id, const Function<spacedim> *>
+      &                           function_map,
+    AffineConstraints<double> &   constraints,
+    const Mapping<dim, spacedim> &mapping)
   {
     AffineConstraints<double> no_normal_flux_constraints(
       constraints.get_local_lines());
@@ -7647,7 +7649,7 @@ namespace VectorTools
 
                       const Point<dim> point = fe_values.quadrature_point(i);
                       const double     b_value =
-                        function_map[*b_id]->value(point, component);
+                        function_map.at(*b_id)->value(point, component);
                       dof_to_b_value.insert(
                         std::make_pair(face_dofs[i], b_value));
                     }

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -1253,8 +1253,9 @@ namespace MGTools
   template <int dim, int spacedim>
   void
   make_boundary_list(
-    const DoFHandler<dim, spacedim> &               dof,
-    const typename FunctionMap<dim>::type &         function_map,
+    const DoFHandler<dim, spacedim> &dof,
+    const std::map<types::boundary_id, const Function<spacedim> *>
+      &                                             function_map,
     std::vector<std::set<types::global_dof_index>> &boundary_indices,
     const ComponentMask &                           component_mask)
   {
@@ -1263,10 +1264,8 @@ namespace MGTools
                                 dof.get_triangulation().n_global_levels()));
 
     std::set<types::boundary_id> boundary_ids;
-    typename std::map<types::boundary_id, const Function<dim> *>::const_iterator
-      it = function_map.begin();
-    for (; it != function_map.end(); ++it)
-      boundary_ids.insert(it->first);
+    for (const auto &boundary_function : function_map)
+      boundary_ids.insert(boundary_function.first);
 
     std::vector<IndexSet> boundary_indexset;
     make_boundary_list(dof, boundary_ids, boundary_indexset, component_mask);
@@ -1278,20 +1277,19 @@ namespace MGTools
 
   template <int dim, int spacedim>
   void
-  make_boundary_list(const DoFHandler<dim, spacedim> &      dof,
-                     const typename FunctionMap<dim>::type &function_map,
-                     std::vector<IndexSet> &                boundary_indices,
-                     const ComponentMask &                  component_mask)
+  make_boundary_list(const DoFHandler<dim, spacedim> &           dof,
+                     const std::map<types::boundary_id,
+                                    const Function<spacedim> *> &function_map,
+                     std::vector<IndexSet> &boundary_indices,
+                     const ComponentMask &  component_mask)
   {
     Assert(boundary_indices.size() == dof.get_triangulation().n_global_levels(),
            ExcDimensionMismatch(boundary_indices.size(),
                                 dof.get_triangulation().n_global_levels()));
 
     std::set<types::boundary_id> boundary_ids;
-    typename std::map<types::boundary_id, const Function<dim> *>::const_iterator
-      it = function_map.begin();
-    for (; it != function_map.end(); ++it)
-      boundary_ids.insert(it->first);
+    for (const auto &boundary_function : function_map)
+      boundary_ids.insert(boundary_function.first);
 
     make_boundary_list(dof, boundary_ids, boundary_indices, component_mask);
   }

--- a/source/multigrid/mg_tools.inst.in
+++ b/source/multigrid/mg_tools.inst.in
@@ -106,14 +106,16 @@ for (deal_II_dimension : DIMENSIONS)
 #if deal_II_dimension > 1
       template void
       make_boundary_list(const DoFHandler<deal_II_dimension> &,
-                         const FunctionMap<deal_II_dimension>::type &,
+                         const std::map<types::boundary_id,
+                                        const Function<deal_II_dimension> *> &,
                          std::vector<std::set<types::global_dof_index>> &,
                          const ComponentMask &);
 #endif
 
       template void
       make_boundary_list(const DoFHandler<deal_II_dimension> &,
-                         const FunctionMap<deal_II_dimension>::type &,
+                         const std::map<types::boundary_id,
+                                        const Function<deal_II_dimension> *> &,
                          std::vector<IndexSet> &,
                          const ComponentMask &);
 

--- a/source/numerics/error_estimator.inst.in
+++ b/source/numerics/error_estimator.inst.in
@@ -29,136 +29,160 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 #if deal_II_dimension != 1 && deal_II_dimension <= deal_II_space_dimension
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const Quadrature<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const VEC &,
-        Vector<float> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension,
-                                  deal_II_space_dimension>::Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const Quadrature<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const VEC &,
+      Vector<float> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const KellyErrorEstimator<deal_II_dimension,
+                                deal_II_space_dimension>::Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const Quadrature<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const VEC &,
-        Vector<float> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension,
-                                  deal_II_space_dimension>::Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const Quadrature<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const VEC &,
+      Vector<float> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const KellyErrorEstimator<deal_II_dimension,
+                                deal_II_space_dimension>::Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const Quadrature<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const std::vector<const VEC *> &,
-        std::vector<Vector<float> *> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension,
-                                  deal_II_space_dimension>::Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const Quadrature<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const std::vector<const VEC *> &,
+      std::vector<Vector<float> *> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const KellyErrorEstimator<deal_II_dimension,
+                                deal_II_space_dimension>::Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const Quadrature<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const std::vector<const VEC *> &,
-        std::vector<Vector<float> *> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension,
-                                  deal_II_space_dimension>::Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const Quadrature<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const std::vector<const VEC *> &,
+      std::vector<Vector<float> *> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const KellyErrorEstimator<deal_II_dimension,
+                                deal_II_space_dimension>::Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const hp::QCollection<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const VEC &,
-        Vector<float> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension,
-                                  deal_II_space_dimension>::Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::QCollection<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const VEC &,
+      Vector<float> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const KellyErrorEstimator<deal_II_dimension,
+                                deal_II_space_dimension>::Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const hp::QCollection<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const VEC &,
-        Vector<float> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension,
-                                  deal_II_space_dimension>::Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::QCollection<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const VEC &,
+      Vector<float> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const KellyErrorEstimator<deal_II_dimension,
+                                deal_II_space_dimension>::Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const hp::QCollection<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const std::vector<const VEC *> &,
-        std::vector<Vector<float> *> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension,
-                                  deal_II_space_dimension>::Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::QCollection<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const std::vector<const VEC *> &,
+      std::vector<Vector<float> *> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const KellyErrorEstimator<deal_II_dimension,
+                                deal_II_space_dimension>::Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const hp::QCollection<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const std::vector<const VEC *> &,
-        std::vector<Vector<float> *> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const KellyErrorEstimator<deal_II_dimension,
-                                  deal_II_space_dimension>::Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::QCollection<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const std::vector<const VEC *> &,
+      std::vector<Vector<float> *> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const KellyErrorEstimator<deal_II_dimension,
+                                deal_II_space_dimension>::Strategy);
 
 #endif
   }

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -64,7 +64,8 @@ KellyErrorEstimator<1, spacedim>::estimate(
   const Mapping<1, spacedim> &mapping,
   const DoFHandlerType &      dof_handler,
   const Quadrature<0> &       quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                       neumann_bc,
   const InputVector &       solution,
   Vector<float> &           error,
@@ -100,7 +101,8 @@ void
 KellyErrorEstimator<1, spacedim>::estimate(
   const DoFHandlerType &dof_handler,
   const Quadrature<0> & quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                       neumann_bc,
   const InputVector &       solution,
   Vector<float> &           error,
@@ -133,7 +135,8 @@ void
 KellyErrorEstimator<1, spacedim>::estimate(
   const DoFHandlerType &dof_handler,
   const Quadrature<0> & quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                                     neumann_bc,
   const std::vector<const InputVector *> &solutions,
   std::vector<Vector<float> *> &          errors,
@@ -167,7 +170,8 @@ KellyErrorEstimator<1, spacedim>::estimate(
   const Mapping<1, spacedim> &mapping,
   const DoFHandlerType &      dof_handler,
   const hp::QCollection<0> &  quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                       neumann_bc,
   const InputVector &       solution,
   Vector<float> &           error,
@@ -202,7 +206,8 @@ void
 KellyErrorEstimator<1, spacedim>::estimate(
   const DoFHandlerType &    dof_handler,
   const hp::QCollection<0> &quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                       neumann_bc,
   const InputVector &       solution,
   Vector<float> &           error,
@@ -235,7 +240,8 @@ void
 KellyErrorEstimator<1, spacedim>::estimate(
   const DoFHandlerType &    dof_handler,
   const hp::QCollection<0> &quadrature,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                                     neumann_bc,
   const std::vector<const InputVector *> &solutions,
   std::vector<Vector<float> *> &          errors,
@@ -269,7 +275,8 @@ KellyErrorEstimator<1, spacedim>::estimate(
   const Mapping<1, spacedim> & /*mapping*/,
   const DoFHandlerType & /*dof_handler*/,
   const hp::QCollection<0> &,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     & /*neumann_bc*/,
   const std::vector<const InputVector *> & /*solutions*/,
   std::vector<Vector<float> *> & /*errors*/,
@@ -292,7 +299,8 @@ KellyErrorEstimator<1, spacedim>::estimate(
   const Mapping<1, spacedim> &mapping,
   const DoFHandlerType &      dof_handler,
   const Quadrature<0> &,
-  const typename FunctionMap<spacedim, typename InputVector::value_type>::type
+  const std::map<types::boundary_id,
+                 const Function<spacedim, typename InputVector::value_type> *>
     &                                     neumann_bc,
   const std::vector<const InputVector *> &solutions,
   std::vector<Vector<float> *> &          errors,
@@ -340,13 +348,10 @@ KellyErrorEstimator<1, spacedim>::estimate(
                     "indicator for internal boundaries in your boundary "
                     "value map."));
 
-  for (typename FunctionMap<spacedim, typename InputVector::value_type>::type::
-         const_iterator i = neumann_bc.begin();
-       i != neumann_bc.end();
-       ++i)
-    Assert(i->second->n_components == n_components,
-           ExcInvalidBoundaryFunction(i->first,
-                                      i->second->n_components,
+  for (const auto boundary_function : neumann_bc)
+    Assert(boundary_function.second->n_components == n_components,
+           ExcInvalidBoundaryFunction(boundary_function.first,
+                                      boundary_function.second->n_components,
                                       n_components));
 
   Assert(component_mask.represents_n_components(n_components),
@@ -371,13 +376,10 @@ KellyErrorEstimator<1, spacedim>::estimate(
            (coefficient->n_components == 1),
          ExcInvalidCoefficient());
 
-  for (typename FunctionMap<spacedim, typename InputVector::value_type>::type::
-         const_iterator i = neumann_bc.begin();
-       i != neumann_bc.end();
-       ++i)
-    Assert(i->second->n_components == n_components,
-           ExcInvalidBoundaryFunction(i->first,
-                                      i->second->n_components,
+  for (const auto &boundary_function : neumann_bc)
+    Assert(boundary_function.second->n_components == n_components,
+           ExcInvalidBoundaryFunction(boundary_function.first,
+                                      boundary_function.second->n_components,
                                       n_components));
 
   // reserve one slot for each cell and set it to zero

--- a/source/numerics/error_estimator_1d.inst.in
+++ b/source/numerics/error_estimator_1d.inst.in
@@ -21,128 +21,152 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 #if deal_II_dimension == 1 && deal_II_dimension <= deal_II_space_dimension
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const Quadrature<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const VEC &,
-        Vector<float> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const Quadrature<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const VEC &,
+      Vector<float> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const Quadrature<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const VEC &,
-        Vector<float> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const Quadrature<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const VEC &,
+      Vector<float> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const Quadrature<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const std::vector<const VEC *> &,
-        std::vector<Vector<float> *> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const Quadrature<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const std::vector<const VEC *> &,
+      std::vector<Vector<float> *> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const Quadrature<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const std::vector<const VEC *> &,
-        std::vector<Vector<float> *> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const Quadrature<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const std::vector<const VEC *> &,
+      std::vector<Vector<float> *> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const hp::QCollection<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const VEC &,
-        Vector<float> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::QCollection<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const VEC &,
+      Vector<float> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const hp::QCollection<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const VEC &,
-        Vector<float> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::QCollection<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const VEC &,
+      Vector<float> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const hp::QCollection<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const std::vector<const VEC *> &,
-        std::vector<Vector<float> *> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::QCollection<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const std::vector<const VEC *> &,
+      std::vector<Vector<float> *> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const Strategy);
 
     template void
-    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::
-      estimate<VEC, DH<deal_II_dimension, deal_II_space_dimension>>(
-        const DH<deal_II_dimension, deal_II_space_dimension> &,
-        const hp::QCollection<deal_II_dimension - 1> &,
-        const FunctionMap<deal_II_space_dimension, VEC::value_type>::type &,
-        const std::vector<const VEC *> &,
-        std::vector<Vector<float> *> &,
-        const ComponentMask &,
-        const Function<deal_II_space_dimension> *,
-        const unsigned int,
-        const types::subdomain_id,
-        const types::material_id,
-        const Strategy);
+    KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
+      VEC,
+      DH<deal_II_dimension, deal_II_space_dimension>>(
+      const DH<deal_II_dimension, deal_II_space_dimension> &,
+      const hp::QCollection<deal_II_dimension - 1> &,
+      const std::map<types::boundary_id,
+                     const Function<deal_II_space_dimension, VEC::value_type> *>
+        &,
+      const std::vector<const VEC *> &,
+      std::vector<Vector<float> *> &,
+      const ComponentMask &,
+      const Function<deal_II_space_dimension> *,
+      const unsigned int,
+      const types::subdomain_id,
+      const types::material_id,
+      const Strategy);
 
 #endif
   }

--- a/source/numerics/vector_tools_constraints.inst.in
+++ b/source/numerics/vector_tools_constraints.inst.in
@@ -26,38 +26,42 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 #  if deal_II_dimension != 1
       template void
       compute_nonzero_normal_flux_constraints(
-        const DoFHandler<deal_II_dimension> & dof_handler,
-        const unsigned int                    first_vector_component,
-        const std::set<types::boundary_id> &  boundary_ids,
-        FunctionMap<deal_II_dimension>::type &function_map,
-        AffineConstraints<double> &           constraints,
-        const Mapping<deal_II_dimension> &    mapping);
+        const DoFHandler<deal_II_dimension> &dof_handler,
+        const unsigned int                   first_vector_component,
+        const std::set<types::boundary_id> & boundary_ids,
+        const std::map<types::boundary_id, const Function<deal_II_dimension> *>
+          &                               function_map,
+        AffineConstraints<double> &       constraints,
+        const Mapping<deal_II_dimension> &mapping);
 
       template void
       compute_nonzero_normal_flux_constraints(
         const hp::DoFHandler<deal_II_dimension> &dof_handler,
         const unsigned int                       first_vector_component,
         const std::set<types::boundary_id> &     boundary_ids,
-        FunctionMap<deal_II_dimension>::type &   function_map,
-        AffineConstraints<double> &              constraints,
-        const Mapping<deal_II_dimension> &       mapping);
+        const std::map<types::boundary_id, const Function<deal_II_dimension> *>
+          &                               function_map,
+        AffineConstraints<double> &       constraints,
+        const Mapping<deal_II_dimension> &mapping);
 
       template void
       compute_nonzero_tangential_flux_constraints(
-        const DoFHandler<deal_II_dimension> & dof_handler,
-        const unsigned int                    first_vector_component,
-        const std::set<types::boundary_id> &  boundary_ids,
-        FunctionMap<deal_II_dimension>::type &function_map,
-        AffineConstraints<double> &           constraints,
-        const Mapping<deal_II_dimension> &    mapping);
+        const DoFHandler<deal_II_dimension> &dof_handler,
+        const unsigned int                   first_vector_component,
+        const std::set<types::boundary_id> & boundary_ids,
+        const std::map<types::boundary_id, const Function<deal_II_dimension> *>
+          &                               function_map,
+        AffineConstraints<double> &       constraints,
+        const Mapping<deal_II_dimension> &mapping);
       template void
       compute_nonzero_tangential_flux_constraints(
         const hp::DoFHandler<deal_II_dimension> &dof_handler,
         const unsigned int                       first_vector_component,
         const std::set<types::boundary_id> &     boundary_ids,
-        FunctionMap<deal_II_dimension>::type &   function_map,
-        AffineConstraints<double> &              constraints,
-        const Mapping<deal_II_dimension> &       mapping);
+        const std::map<types::boundary_id, const Function<deal_II_dimension> *>
+          &                               function_map,
+        AffineConstraints<double> &       constraints,
+        const Mapping<deal_II_dimension> &mapping);
 
       template void
       compute_no_normal_flux_constraints(

--- a/tests/bits/joa_1.cc
+++ b/tests/bits/joa_1.cc
@@ -808,10 +808,8 @@ LaplaceProblem<dim>::solve()
 // list of boundaries where we have
 // imposed Neumann value, and the
 // corresponding Neumann values. This
-// information is represented by an
-// object of type
-// <code>FunctionMap@<dim@>::type</code> that is
-// essentially a map from boundary
+// information is represented by
+// a map from boundary
 // indicators to function objects
 // describing Neumann boundary values
 // (in the present example program,
@@ -841,11 +839,12 @@ LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   // The above function returned one
   // error indicator value for each

--- a/tests/bits/static_condensation.cc
+++ b/tests/bits/static_condensation.cc
@@ -539,7 +539,7 @@ HelmholtzProblem<dim>::refine_grid()
           Vector<float> estimated_error_per_cell(
             triangulation.n_active_cells());
 
-          typename FunctionMap<dim>::type neumann_boundary;
+          std::map<types::boundary_id, const Function<dim> *> neumann_boundary;
           KellyErrorEstimator<dim>::estimate(dof_handler,
                                              QGauss<dim - 1>(3),
                                              neumann_boundary,

--- a/tests/bits/step-13.cc
+++ b/tests/bits/step-13.cc
@@ -632,11 +632,12 @@ namespace LaplaceSolver
   {
     Vector<float> estimated_error_per_cell(
       this->triangulation->n_active_cells());
-    KellyErrorEstimator<dim>::estimate(this->dof_handler,
-                                       QGauss<dim - 1>(3),
-                                       typename FunctionMap<dim>::type(),
-                                       this->solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      this->dof_handler,
+      QGauss<dim - 1>(3),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      this->solution,
+      estimated_error_per_cell);
     GridRefinement::refine_and_coarsen_fixed_number(*this->triangulation,
                                                     estimated_error_per_cell,
                                                     0.3,

--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -786,11 +786,12 @@ namespace LaplaceSolver
   {
     Vector<float> estimated_error_per_cell(
       this->triangulation->n_active_cells());
-    KellyErrorEstimator<dim>::estimate(this->dof_handler,
-                                       QGauss<dim - 1>(3),
-                                       typename FunctionMap<dim>::type(),
-                                       this->solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      this->dof_handler,
+      QGauss<dim - 1>(3),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      this->solution,
+      estimated_error_per_cell);
     GridRefinement::refine_and_coarsen_fixed_number(*this->triangulation,
                                                     estimated_error_per_cell,
                                                     0.3,
@@ -847,11 +848,12 @@ namespace LaplaceSolver
   RefinementWeightedKelly<dim>::refine_grid()
   {
     Vector<float> estimated_error(this->triangulation->n_active_cells());
-    KellyErrorEstimator<dim>::estimate(this->dof_handler,
-                                       *this->face_quadrature,
-                                       typename FunctionMap<dim>::type(),
-                                       this->solution,
-                                       estimated_error);
+    KellyErrorEstimator<dim>::estimate(
+      this->dof_handler,
+      *this->face_quadrature,
+      std::map<types::boundary_id, const Function<dim> *>(),
+      this->solution,
+      estimated_error);
 
     typename DoFHandler<dim>::active_cell_iterator cell = this->dof_handler
                                                             .begin_active(),

--- a/tests/bits/step-51.cc
+++ b/tests/bits/step-51.cc
@@ -350,8 +350,8 @@ namespace Step51
 
     constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
-    typename FunctionMap<dim>::type boundary_functions;
-    Solution<dim>                   solution_function;
+    std::map<types::boundary_id, const Function<dim> *> boundary_functions;
+    Solution<dim>                                       solution_function;
     boundary_functions[0] = &solution_function;
     VectorTools::project_boundary_values(dof_handler,
                                          boundary_functions,

--- a/tests/bits/step-51p.cc
+++ b/tests/bits/step-51p.cc
@@ -350,8 +350,8 @@ namespace Step51
 
     constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
-    typename FunctionMap<dim>::type boundary_functions;
-    Solution<dim>                   solution_function;
+    std::map<types::boundary_id, const Function<dim> *> boundary_functions;
+    Solution<dim>                                       solution_function;
     boundary_functions[0] = &solution_function;
     VectorTools::project_boundary_values(dof_handler,
                                          boundary_functions,

--- a/tests/bits/step-6-racoptimize-2.cc
+++ b/tests/bits/step-6-racoptimize-2.cc
@@ -296,11 +296,12 @@ LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   GridRefinement::refine_and_coarsen_optimize(triangulation,
                                               estimated_error_per_cell,

--- a/tests/bits/step-6-racoptimize.cc
+++ b/tests/bits/step-6-racoptimize.cc
@@ -296,11 +296,12 @@ LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   GridRefinement::refine_and_coarsen_optimize(triangulation,
                                               estimated_error_per_cell);

--- a/tests/bits/step-6.cc
+++ b/tests/bits/step-6.cc
@@ -291,11 +291,12 @@ LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                   estimated_error_per_cell,

--- a/tests/bits/step-7.cc
+++ b/tests/bits/step-7.cc
@@ -415,7 +415,7 @@ HelmholtzProblem<dim>::refine_grid()
           Vector<float> estimated_error_per_cell(
             triangulation.n_active_cells());
 
-          typename FunctionMap<dim>::type neumann_boundary;
+          std::map<types::boundary_id, const Function<dim> *> neumann_boundary;
           KellyErrorEstimator<dim>::estimate(dof_handler,
                                              QGauss<dim - 1>(3),
                                              neumann_boundary,

--- a/tests/bits/step-8.cc
+++ b/tests/bits/step-8.cc
@@ -336,7 +336,7 @@ ElasticProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  typename FunctionMap<dim>::type neumann_boundary;
+  std::map<types::boundary_id, const Function<dim> *> neumann_boundary;
   KellyErrorEstimator<dim>::estimate(dof_handler,
                                      QGauss<dim - 1>(2),
                                      neumann_boundary,

--- a/tests/data_out/data_out_postprocessor_tensor_01.cc
+++ b/tests/data_out/data_out_postprocessor_tensor_01.cc
@@ -299,11 +299,12 @@ namespace Step8
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(2),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(2),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell);
 
     GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                     estimated_error_per_cell,

--- a/tests/data_out/data_out_postprocessor_vector_03.cc
+++ b/tests/data_out/data_out_postprocessor_vector_03.cc
@@ -237,11 +237,12 @@ Step6<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                   estimated_error_per_cell,

--- a/tests/dofs/dof_renumbering.cc
+++ b/tests/dofs/dof_renumbering.cc
@@ -146,8 +146,7 @@ check_renumbering(DoFHandler<dim> &mgdof, bool discontinuous)
       // behavior of the
       // DoFRenumbering::component_wise set
       // of functions before December 2005
-      DoFRenumbering::component_wise(static_cast<DoFHandler<dim> &>(mgdof),
-                                     order);
+      DoFRenumbering::component_wise(mgdof, order);
       print_dofs(mgdof, level);
     }
 }

--- a/tests/dofs/dof_tools_14.cc
+++ b/tests/dofs/dof_tools_14.cc
@@ -31,8 +31,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   // no other args
   deallog << dof_handler.n_boundary_dofs() << std::endl;
 
-  // with FunctionMap
-  typename FunctionMap<dim>::type fm;
+  // with std::map
+  std::map<types::boundary_id, const Function<dim> *> fm;
   fm[0] = nullptr;
   deallog << dof_handler.n_boundary_dofs(fm) << std::endl;
 

--- a/tests/dofs/dof_tools_16a.cc
+++ b/tests/dofs/dof_tools_16a.cc
@@ -22,8 +22,9 @@
 // check
 //   DoFTools::
 //   make_boundary_sparsity_pattern (const DoFHandler<dim> &,
-//                                   const typename FunctionMap<dim>::type &
-//                                   const std::vector<unsigned int> &
+//                                   const std::map<types::boundary_id, const
+//                                   Function<dim>*> & const
+//                                   std::vector<unsigned int> &
 //                               SparsityPattern       &);
 
 
@@ -43,7 +44,7 @@ check_this(const DoFHandler<dim> &dof_handler)
   DoFTools::map_dof_to_boundary_indices(dof_handler, set, map);
 
   // create sparsity pattern
-  typename FunctionMap<dim>::type boundary_ids;
+  std::map<types::boundary_id, const Function<dim> *> boundary_ids;
   boundary_ids[0] = nullptr;
   SparsityPattern sp(dof_handler.n_boundary_dofs(boundary_ids),
                      dof_handler.max_couplings_between_dofs());

--- a/tests/dofs/dof_tools_16b.cc
+++ b/tests/dofs/dof_tools_16b.cc
@@ -22,8 +22,9 @@
 // check
 //   DoFTools::
 //   make_boundary_sparsity_pattern (const DoFHandler<dim>     &,
-//                                   const typename FunctionMap<dim>::type &
-//                                   const std::vector<unsigned int> &
+//                                   const std::map<types::boundary_id, const
+//                                   Function<dim>*> & const
+//                                   std::vector<unsigned int> &
 //                               DynamicSparsityPattern &);
 
 
@@ -43,7 +44,7 @@ check_this(const DoFHandler<dim> &dof_handler)
   DoFTools::map_dof_to_boundary_indices(dof_handler, set, map);
 
   // create sparsity pattern
-  typename FunctionMap<dim>::type boundary_ids;
+  std::map<types::boundary_id, const Function<dim> *> boundary_ids;
   boundary_ids[0] = nullptr;
   DynamicSparsityPattern sp(dof_handler.n_boundary_dofs(boundary_ids));
   DoFTools::make_boundary_sparsity_pattern(dof_handler, boundary_ids, map, sp);

--- a/tests/dofs/dof_tools_16c.cc
+++ b/tests/dofs/dof_tools_16c.cc
@@ -22,8 +22,9 @@
 // check
 //   DoFTools::
 //   make_boundary_sparsity_pattern (const DoFHandler<dim> &,
-//                                   const typename FunctionMap<dim>::type &
-//                                   const std::vector<unsigned int> &
+//                                   const std::map<types::boundary_id, const
+//                                   Function<dim>*> & const
+//                                   std::vector<unsigned int> &
 //                               BlockSparsityPattern  &);
 
 
@@ -42,7 +43,7 @@ check_this(const DoFHandler<dim> &dof_handler)
   set.insert(0);
   DoFTools::map_dof_to_boundary_indices(dof_handler, set, map);
 
-  typename FunctionMap<dim>::type boundary_ids;
+  std::map<types::boundary_id, const Function<dim> *> boundary_ids;
   boundary_ids[0] = nullptr;
   const unsigned int n_boundary_dofs =
     dof_handler.n_boundary_dofs(boundary_ids);

--- a/tests/dofs/dof_tools_16d.cc
+++ b/tests/dofs/dof_tools_16d.cc
@@ -22,8 +22,9 @@
 // check
 //   DoFTools::
 //   make_boundary_sparsity_pattern (const DoFHandler<dim> &,
-//                                   const typename FunctionMap<dim>::type &
-//                                   const std::vector<unsigned int> &
+//                                   const std::map<types::boundary_id, const
+//                                   Function<dim>*> & const
+//                                   std::vector<unsigned int> &
 //                               BlockDynamicSparsityPattern  &);
 
 
@@ -42,7 +43,7 @@ check_this(const DoFHandler<dim> &dof_handler)
   set.insert(0);
   DoFTools::map_dof_to_boundary_indices(dof_handler, set, map);
 
-  typename FunctionMap<dim>::type boundary_ids;
+  std::map<types::boundary_id, const Function<dim> *> boundary_ids;
   boundary_ids[0] = nullptr;
   const types::global_dof_index n_boundary_dofs =
     dof_handler.n_boundary_dofs(boundary_ids);

--- a/tests/dofs/range_based_for_step-6.cc
+++ b/tests/dofs/range_based_for_step-6.cc
@@ -277,11 +277,12 @@ Step6<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                   estimated_error_per_cell,

--- a/tests/fail/circular_01.cc
+++ b/tests/fail/circular_01.cc
@@ -468,11 +468,12 @@ void
 LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     face_quadrature_collection,
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    face_quadrature_collection,
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   Vector<float> smoothness_indicators(triangulation.n_active_cells());
   estimate_smoothness(smoothness_indicators);

--- a/tests/fail/hp-step-14.cc
+++ b/tests/fail/hp-step-14.cc
@@ -796,11 +796,12 @@ namespace LaplaceSolver
   {
     Vector<float> estimated_error_per_cell(
       this->triangulation->n_active_cells());
-    KellyErrorEstimator<dim>::estimate(this->dof_handler,
-                                       QGauss<dim - 1>(3),
-                                       typename FunctionMap<dim>::type(),
-                                       this->solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      this->dof_handler,
+      QGauss<dim - 1>(3),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      this->solution,
+      estimated_error_per_cell);
     GridRefinement::refine_and_coarsen_fixed_number(*this->triangulation,
                                                     estimated_error_per_cell,
                                                     0.3,
@@ -857,11 +858,12 @@ namespace LaplaceSolver
   RefinementWeightedKelly<dim>::refine_grid()
   {
     Vector<float> estimated_error(this->triangulation->n_active_cells());
-    KellyErrorEstimator<dim>::estimate(this->dof_handler,
-                                       (*this->face_quadrature)[0],
-                                       typename FunctionMap<dim>::type(),
-                                       this->solution,
-                                       estimated_error);
+    KellyErrorEstimator<dim>::estimate(
+      this->dof_handler,
+      (*this->face_quadrature)[0],
+      std::map<types::boundary_id, const Function<dim> *>(),
+      this->solution,
+      estimated_error);
 
     typename hp::DoFHandler<dim>::active_cell_iterator
       cell = this->dof_handler.begin_active(),

--- a/tests/fe/abf_01.cc
+++ b/tests/fe/abf_01.cc
@@ -499,7 +499,7 @@ project(const Mapping<dim> &    mapping,
                  // the different boundary parts. We want the
                  // @p{function} to hold on all parts of the
                  // boundary
-        typename FunctionMap<dim>::type boundary_functions;
+        std::map<types::boundary_id, const Function<dim>*> boundary_functions;
         for (types::boundary_id c=0; c<255; ++c)
           boundary_functions[c] = &function;
         project_boundary_values (dof, boundary_functions, q_boundary,

--- a/tests/fe/deformed_projection.h
+++ b/tests/fe/deformed_projection.h
@@ -549,17 +549,15 @@ project(const Mapping<dim> &    mapping,
     if (project_to_boundary_first == true)
     // boundary projection required
     {
-      /*
-               // set up a list of boundary functions for
-                        // the different boundary parts. We want the
-                                 // @p{function} to hold on all parts of the
-                                          // boundary
-                                          typename FunctionMap<dim>::type
-         boundary_functions; for (unsigned char c=0; c<255; ++c)
-                                          boundary_functions[c] = &function;
-                                          project_boundary_values (dof,
-         boundary_functions, q_boundary, boundary_values);
-      */
+      //   // set up a list of boundary functions for
+      //   // the different boundary parts. We want the
+      //   // @p{function} to hold on all parts of the
+      //   // boundary
+      //   std::map<types::boundary_id, const Function<dim>*>
+      //   boundary_functions; for (unsigned char c=0; c<255; ++c)
+      //     boundary_functions[c] = &function;
+      //     project_boundary_values (dof,
+      //   boundary_functions, q_boundary, boundary_values);
     }
 
 

--- a/tests/fe/fe_enriched_step-36.cc
+++ b/tests/fe/fe_enriched_step-36.cc
@@ -503,11 +503,12 @@ namespace Step36
       face_quadrature_formula.push_back(QGauss<dim - 1>(3));
       face_quadrature_formula.push_back(QGauss<dim - 1>(3));
 
-      KellyErrorEstimator<dim>::estimate(dof_handler,
-                                         face_quadrature_formula,
-                                         typename FunctionMap<dim>::type(),
-                                         sol,
-                                         error);
+      KellyErrorEstimator<dim>::estimate(
+        dof_handler,
+        face_quadrature_formula,
+        std::map<types::boundary_id, const Function<dim> *>(),
+        sol,
+        error);
     }
 
     // sum up for a global:

--- a/tests/fe/fe_enriched_step-36b.cc
+++ b/tests/fe/fe_enriched_step-36b.cc
@@ -709,11 +709,12 @@ namespace Step36
       face_quadrature_formula.push_back(dealii::QGauss<dim - 1>(3));
       face_quadrature_formula.push_back(dealii::QGauss<dim - 1>(3));
 
-      KellyErrorEstimator<dim>::estimate(dof_handler,
-                                         face_quadrature_formula,
-                                         typename FunctionMap<dim>::type(),
-                                         sol,
-                                         error);
+      KellyErrorEstimator<dim>::estimate(
+        dof_handler,
+        face_quadrature_formula,
+        std::map<types::boundary_id, const Function<dim> *>(),
+        sol,
+        error);
     }
 
     // sum up for a global:

--- a/tests/grid/mesh_3d_12.cc
+++ b/tests/grid/mesh_3d_12.cc
@@ -56,7 +56,11 @@ void check_this(Triangulation<3> &tria)
   VectorTools::interpolate(dof_handler, Functions::SquareFunction<3>(), u);
 
   KellyErrorEstimator<3>::estimate(
-    dof_handler, QGauss<2>(2), FunctionMap<3>::type(), u, e);
+    dof_handler,
+    QGauss<2>(2),
+    std::map<types::boundary_id, const Function<3> *>(),
+    u,
+    e);
 
   deallog << "  " << static_cast<double>(e.l1_norm()) << std::endl;
   deallog << "  " << static_cast<double>(e.l2_norm()) << std::endl;

--- a/tests/hp/boundary_matrices.cc
+++ b/tests/hp/boundary_matrices.cc
@@ -98,8 +98,8 @@ check()
   hp::DoFHandler<dim> dof(tr);
   dof.distribute_dofs(element);
 
-  MySquareFunction<dim>           coefficient;
-  typename FunctionMap<dim>::type function_map;
+  MySquareFunction<dim>                               coefficient;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   function_map[0] = &coefficient;
 
   hp::QCollection<dim - 1> face_quadrature;

--- a/tests/hp/boundary_matrices_hp.cc
+++ b/tests/hp/boundary_matrices_hp.cc
@@ -118,8 +118,8 @@ check()
 
   dof.distribute_dofs(element);
 
-  MySquareFunction<dim>           coefficient;
-  typename FunctionMap<dim>::type function_map;
+  MySquareFunction<dim>                               coefficient;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   function_map[0] = &coefficient;
 
   hp::QCollection<dim - 1> face_quadrature;

--- a/tests/hp/crash_17.cc
+++ b/tests/hp/crash_17.cc
@@ -468,11 +468,12 @@ void
 LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     face_quadrature_collection,
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    face_quadrature_collection,
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   Vector<float> smoothness_indicators(triangulation.n_active_cells());
   estimate_smoothness(smoothness_indicators);

--- a/tests/hp/crash_18.cc
+++ b/tests/hp/crash_18.cc
@@ -473,11 +473,12 @@ void
 LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     face_quadrature_collection,
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    face_quadrature_collection,
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   Vector<float> smoothness_indicators(triangulation.n_active_cells());
   estimate_smoothness(smoothness_indicators);

--- a/tests/hp/matrices.cc
+++ b/tests/hp/matrices.cc
@@ -78,8 +78,8 @@ void
 check_boundary(const hp::DoFHandler<dim> &       dof,
                const hp::MappingCollection<dim> &mapping)
 {
-  MySquareFunction<dim>           coefficient;
-  typename FunctionMap<dim>::type function_map;
+  MySquareFunction<dim>                               coefficient;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   function_map[0] = &coefficient;
 
   hp::QCollection<dim - 1> face_quadrature;
@@ -181,7 +181,7 @@ check()
 
   Functions::ExpFunction<dim> coefficient;
 
-  typename FunctionMap<dim>::type function_map;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   function_map[0] = &coefficient;
 
   for (unsigned int test = 0; test < 2; ++test)

--- a/tests/hp/matrices_hp.cc
+++ b/tests/hp/matrices_hp.cc
@@ -76,8 +76,8 @@ void
 check_boundary(const hp::DoFHandler<dim> &       dof,
                const hp::MappingCollection<dim> &mapping)
 {
-  MySquareFunction<dim>           coefficient;
-  typename FunctionMap<dim>::type function_map;
+  MySquareFunction<dim>                               coefficient;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   function_map[0] = &coefficient;
 
   hp::QCollection<dim - 1> face_quadrature;
@@ -193,7 +193,7 @@ check()
 
   Functions::ExpFunction<dim> coefficient;
 
-  typename FunctionMap<dim>::type function_map;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   function_map[0] = &coefficient;
 
   for (unsigned int test = 0; test < 2; ++test)

--- a/tests/hp/step-13.cc
+++ b/tests/hp/step-13.cc
@@ -638,11 +638,12 @@ namespace LaplaceSolver
   {
     Vector<float> estimated_error_per_cell(
       this->triangulation->n_active_cells());
-    KellyErrorEstimator<dim>::estimate(this->dof_handler,
-                                       QGauss<dim - 1>(3),
-                                       typename FunctionMap<dim>::type(),
-                                       this->solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      this->dof_handler,
+      QGauss<dim - 1>(3),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      this->solution,
+      estimated_error_per_cell);
     GridRefinement::refine_and_coarsen_fixed_number(*this->triangulation,
                                                     estimated_error_per_cell,
                                                     0.3,

--- a/tests/hp/step-27.cc
+++ b/tests/hp/step-27.cc
@@ -288,11 +288,12 @@ namespace Step27
   LaplaceProblem<dim>::postprocess(const unsigned int cycle)
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       face_quadrature_collection,
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      face_quadrature_collection,
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell);
 
 
     Vector<float> smoothness_indicators(triangulation.n_active_cells());

--- a/tests/hp/step-6.cc
+++ b/tests/hp/step-6.cc
@@ -293,11 +293,12 @@ LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                   estimated_error_per_cell,

--- a/tests/hp/step-7.cc
+++ b/tests/hp/step-7.cc
@@ -415,7 +415,7 @@ HelmholtzProblem<dim>::refine_grid()
           Vector<float> estimated_error_per_cell(
             triangulation.n_active_cells());
 
-          typename FunctionMap<dim>::type neumann_boundary;
+          std::map<types::boundary_id, const Function<dim> *> neumann_boundary;
           KellyErrorEstimator<dim>::estimate(dof_handler,
                                              QGauss<dim - 1>(3),
                                              neumann_boundary,

--- a/tests/hp/step-8.cc
+++ b/tests/hp/step-8.cc
@@ -336,7 +336,7 @@ ElasticProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  typename FunctionMap<dim>::type neumann_boundary;
+  std::map<types::boundary_id, const Function<dim> *> neumann_boundary;
   KellyErrorEstimator<dim>::estimate(dof_handler,
                                      QGauss<dim - 1>(2),
                                      neumann_boundary,

--- a/tests/lac/constrained_linear_operator_01.cc
+++ b/tests/lac/constrained_linear_operator_01.cc
@@ -214,11 +214,12 @@ Step6<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(dof_handler,
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                   estimated_error_per_cell,

--- a/tests/lac/matrices_02.cc
+++ b/tests/lac/matrices_02.cc
@@ -72,8 +72,8 @@ template <int dim>
 void
 check_boundary(const DoFHandler<dim> &dof, const Mapping<dim> &mapping)
 {
-  MySquareFunction<dim>           coefficient;
-  typename FunctionMap<dim>::type function_map;
+  MySquareFunction<dim>                               coefficient;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   function_map[0] = &coefficient;
 
   QGauss<dim - 1> face_quadrature(6);
@@ -170,7 +170,7 @@ check()
 
   Functions::ExpFunction<dim> coefficient;
 
-  typename FunctionMap<dim>::type function_map;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   function_map[0] = &coefficient;
 
   for (unsigned int test = 0; test < 2; ++test)

--- a/tests/lac/schur_complement_03.cc
+++ b/tests/lac/schur_complement_03.cc
@@ -344,12 +344,13 @@ namespace Step22
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
     FEValuesExtractors::Scalar pressure(dim);
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell,
-                                       fe.component_mask(pressure));
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell,
+      fe.component_mask(pressure));
     GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                     estimated_error_per_cell,
                                                     0.3,

--- a/tests/matrix_free/matrix_vector_mg.cc
+++ b/tests/matrix_free/matrix_vector_mg.cc
@@ -96,8 +96,8 @@ test()
   mg_sparsities.resize(0, nlevels - 1);
   mg_ref_matrices.resize(0, nlevels - 1);
 
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   std::vector<std::set<types::global_dof_index>> boundary_indices(nlevels);
   MGTools::make_boundary_list(dof, dirichlet_boundary, boundary_indices);

--- a/tests/matrix_free/multigrid_dg_sip_01.cc
+++ b/tests/matrix_free/multigrid_dg_sip_01.cc
@@ -587,9 +587,9 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
     }
   mg_smoother.initialize(mg_matrices, smoother_data);
 
-  MGConstrainedDoFs               mg_constrained_dofs;
-  ZeroFunction<dim>               zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  MGConstrainedDoFs                                   mg_constrained_dofs;
+  ZeroFunction<dim>                                   zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
   mg_constrained_dofs.initialize(dof, dirichlet_boundary);
 

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -499,9 +499,9 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
     }
   mg_smoother.initialize(mg_matrices, smoother_data);
 
-  MGConstrainedDoFs               mg_constrained_dofs;
-  ZeroFunction<dim>               zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  MGConstrainedDoFs                                   mg_constrained_dofs;
+  ZeroFunction<dim>                                   zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
   mg_constrained_dofs.initialize(dof, dirichlet_boundary);
 

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -74,9 +74,9 @@ public:
     addit_data.level_mg_handler = level;
 
     // extract the constraints due to Dirichlet boundary conditions
-    ConstraintMatrix                constraints;
-    Functions::ZeroFunction<dim>    zero;
-    typename FunctionMap<dim>::type functions;
+    ConstraintMatrix                                    constraints;
+    Functions::ZeroFunction<dim>                        zero;
+    std::map<types::boundary_id, const Function<dim> *> functions;
     for (std::set<types::boundary_id>::const_iterator it =
            dirichlet_boundaries.begin();
          it != dirichlet_boundaries.end();

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -103,8 +103,8 @@ do_test(const DoFHandler<dim> &dof)
   DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
 
   // Dirichlet BC
-  Functions::ZeroFunction<dim>    zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  Functions::ZeroFunction<dim>                        zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
 
   // fine-level constraints

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -63,10 +63,11 @@ public:
 
 
   void
-  initialize(const Mapping<dim> &                   mapping,
-             const DoFHandler<dim> &                dof_handler,
-             const MGConstrainedDoFs &              mg_constrained_dofs,
-             const typename FunctionMap<dim>::type &dirichlet_boundary,
+  initialize(const Mapping<dim> &     mapping,
+             const DoFHandler<dim> &  dof_handler,
+             const MGConstrainedDoFs &mg_constrained_dofs,
+             const std::map<types::boundary_id, const Function<dim> *>
+               &                dirichlet_boundary,
              const unsigned int level = numbers::invalid_unsigned_int)
   {
     const QGauss<1>                                  quad(n_q_points_1d);
@@ -513,9 +514,9 @@ do_test(const DoFHandler<dim> &dof)
   DoFTools::make_hanging_node_constraints(dof, hanging_node_constraints);
   hanging_node_constraints.close();
 
-  MGConstrainedDoFs               mg_constrained_dofs;
-  Functions::ZeroFunction<dim>    zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  MGConstrainedDoFs                                   mg_constrained_dofs;
+  Functions::ZeroFunction<dim>                        zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
   mg_constrained_dofs.initialize(dof, dirichlet_boundary);
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -140,8 +140,8 @@ do_test(const DoFHandler<dim> &dof)
   DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
 
   // Dirichlet BC
-  Functions::ZeroFunction<dim>    zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  Functions::ZeroFunction<dim>                        zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
 
   // fine-level constraints

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.cc
@@ -64,12 +64,13 @@ public:
 
 
   void
-  initialize(const Mapping<dim> &                   mapping,
-             const DoFHandler<dim> &                dof_handler,
-             const MGConstrainedDoFs &              mg_constrained_dofs,
-             const typename FunctionMap<dim>::type &dirichlet_boundary,
-             const unsigned int                     level,
-             const bool                             threaded)
+  initialize(const Mapping<dim> &     mapping,
+             const DoFHandler<dim> &  dof_handler,
+             const MGConstrainedDoFs &mg_constrained_dofs,
+             const std::map<types::boundary_id, const Function<dim> *>
+               &                dirichlet_boundary,
+             const unsigned int level,
+             const bool         threaded)
   {
     const QGauss<1>                                  quad(n_q_points_1d);
     typename MatrixFree<dim, number>::AdditionalData addit_data;
@@ -520,9 +521,9 @@ do_test(const DoFHandler<dim> &dof, const bool threaded)
   DoFTools::make_hanging_node_constraints(dof, hanging_node_constraints);
   hanging_node_constraints.close();
 
-  MGConstrainedDoFs               mg_constrained_dofs;
-  Functions::ZeroFunction<dim>    zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  MGConstrainedDoFs                                   mg_constrained_dofs;
+  Functions::ZeroFunction<dim>                        zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
   mg_constrained_dofs.initialize(dof, dirichlet_boundary);
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -140,8 +140,8 @@ do_test(const DoFHandler<dim> &dof)
   DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
 
   // Dirichlet BC
-  Functions::ZeroFunction<dim>    zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  Functions::ZeroFunction<dim>                        zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
 
   // fine-level constraints

--- a/tests/matrix_free/parallel_multigrid_adaptive_05.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_05.cc
@@ -61,12 +61,13 @@ public:
 
 
   void
-  initialize(const Mapping<dim> &                   mapping,
-             const DoFHandler<dim> &                dof_handler,
-             const MGConstrainedDoFs &              mg_constrained_dofs,
-             const typename FunctionMap<dim>::type &dirichlet_boundary,
-             const unsigned int                     level,
-             const bool                             threaded)
+  initialize(const Mapping<dim> &     mapping,
+             const DoFHandler<dim> &  dof_handler,
+             const MGConstrainedDoFs &mg_constrained_dofs,
+             const std::map<types::boundary_id, const Function<dim> *>
+               &                dirichlet_boundary,
+             const unsigned int level,
+             const bool         threaded)
   {
     const QGauss<1>                                  quad(n_q_points_1d);
     typename MatrixFree<dim, number>::AdditionalData addit_data;
@@ -517,9 +518,9 @@ do_test(const DoFHandler<dim> &dof, const bool threaded)
   DoFTools::make_hanging_node_constraints(dof, hanging_node_constraints);
   hanging_node_constraints.close();
 
-  MGConstrainedDoFs               mg_constrained_dofs;
-  Functions::ZeroFunction<dim>    zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  MGConstrainedDoFs                                   mg_constrained_dofs;
+  Functions::ZeroFunction<dim>                        zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
   mg_constrained_dofs.initialize(dof, dirichlet_boundary);
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_06.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06.cc
@@ -225,8 +225,8 @@ do_test(const DoFHandler<dim> &dof, const unsigned int nb)
   DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
 
   // Dirichlet BC
-  ZeroFunction<dim>               zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  ZeroFunction<dim>                                   zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
 
   // fine-level constraints

--- a/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
@@ -141,8 +141,8 @@ do_test(const DoFHandler<dim> &dof)
   DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
 
   // Dirichlet BC
-  ZeroFunction<dim>               zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  ZeroFunction<dim>                                   zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
 
   // fine-level constraints

--- a/tests/matrix_free/parallel_multigrid_adaptive_07.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_07.cc
@@ -243,8 +243,8 @@ do_test(const std::vector<const DoFHandler<dim> *> &dof)
     DoFTools::extract_locally_relevant_dofs(*dof[i], locally_relevant_dofs[i]);
 
   // Dirichlet BC
-  ZeroFunction<dim>               zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  ZeroFunction<dim>                                   zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
 
   // fine-level constraints

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -73,9 +73,9 @@ public:
     addit_data.level_mg_handler = level;
 
     // extract the constraints due to Dirichlet boundary conditions
-    ConstraintMatrix                constraints;
-    Functions::ZeroFunction<dim>    zero;
-    typename FunctionMap<dim>::type functions;
+    ConstraintMatrix                                    constraints;
+    Functions::ZeroFunction<dim>                        zero;
+    std::map<types::boundary_id, const Function<dim> *> functions;
     for (std::set<types::boundary_id>::const_iterator it =
            dirichlet_boundaries.begin();
          it != dirichlet_boundaries.end();
@@ -375,9 +375,9 @@ do_test(const DoFHandler<dim> &dof)
       mg_matrices[level].initialize(mapping, dof, dirichlet_boundaries, level);
     }
 
-  MGConstrainedDoFs               mg_constrained_dofs;
-  Functions::ZeroFunction<dim>    zero_function;
-  typename FunctionMap<dim>::type dirichlet_boundary;
+  MGConstrainedDoFs                                   mg_constrained_dofs;
+  Functions::ZeroFunction<dim>                        zero_function;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
   mg_constrained_dofs.initialize(dof, dirichlet_boundary);
 

--- a/tests/matrix_free/step-37.cc
+++ b/tests/matrix_free/step-37.cc
@@ -436,8 +436,8 @@ namespace Step37
     mg_matrices.resize(0, nlevels - 1);
     mg_constraints.resize(0, nlevels - 1);
 
-    typename FunctionMap<dim>::type dirichlet_boundary;
-    Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     std::vector<std::set<types::global_dof_index>> boundary_indices(
       triangulation.n_levels());

--- a/tests/meshworker/step-50-mesh_loop.cc
+++ b/tests/meshworker/step-50-mesh_loop.cc
@@ -244,8 +244,8 @@ namespace Step50
     constraints.reinit(locally_relevant_set);
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    std::set<types::boundary_id>     dirichlet_boundary_ids;
-    typename FunctionMap<dim>::type  dirichlet_boundary;
+    std::set<types::boundary_id>                        dirichlet_boundary_ids;
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
     Functions::ConstantFunction<dim> homogeneous_dirichlet_bc(1.0);
     dirichlet_boundary_ids.insert(0);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;

--- a/tests/mpi/interpolate_to_different_mesh_02.cc
+++ b/tests/mpi/interpolate_to_different_mesh_02.cc
@@ -247,11 +247,12 @@ SeventhProblem<dim>::run(unsigned int cycle)
   else
     {
       Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
-      KellyErrorEstimator<dim>::estimate(dof_handler,
-                                         QGauss<dim - 1>(3),
-                                         typename FunctionMap<dim>::type(),
-                                         locally_relevant_solution,
-                                         estimated_error_per_cell);
+      KellyErrorEstimator<dim>::estimate(
+        dof_handler,
+        QGauss<dim - 1>(3),
+        std::map<types::boundary_id, const Function<dim> *>(),
+        locally_relevant_solution,
+        estimated_error_per_cell);
 
       parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
         triangulation, estimated_error_per_cell, 0.5, 0.3);

--- a/tests/mpi/muelu_periodicity.cc
+++ b/tests/mpi/muelu_periodicity.cc
@@ -718,12 +718,13 @@ namespace Step22
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
     FEValuesExtractors::Scalar pressure(dim);
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell,
-                                       fe.component_mask(pressure));
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell,
+      fe.component_mask(pressure));
 
     parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
       triangulation, estimated_error_per_cell, 0.3, 0.0);

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -193,8 +193,8 @@ namespace Step50
     constraints.clear();
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    typename FunctionMap<dim>::type dirichlet_boundary;
-    Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     VectorTools::interpolate_boundary_values(
       static_cast<const DoFHandler<dim> &>(mg_dof_handler),
@@ -461,12 +461,12 @@ namespace Step50
     temp_solution.reinit(idx, MPI_COMM_WORLD);
     temp_solution = solution;
 
-    KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                         mg_dof_handler),
-                                       QGauss<dim - 1>(3),
-                                       typename FunctionMap<dim>::type(),
-                                       temp_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      mg_dof_handler,
+      QGauss<dim - 1>(3),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      temp_solution,
+      estimated_error_per_cell);
     GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                     estimated_error_per_cell,
                                                     0.3,

--- a/tests/mpi/multigrid_uniform.cc
+++ b/tests/mpi/multigrid_uniform.cc
@@ -193,8 +193,8 @@ namespace Step50
     constraints.clear();
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    typename FunctionMap<dim>::type dirichlet_boundary;
-    Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     VectorTools::interpolate_boundary_values(
       static_cast<const DoFHandler<dim> &>(mg_dof_handler),
@@ -442,12 +442,12 @@ namespace Step50
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-    KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                         mg_dof_handler),
-                                       QGauss<dim - 1>(3),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      mg_dof_handler,
+      QGauss<dim - 1>(3),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell);
     GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                     estimated_error_per_cell,
                                                     0.3,

--- a/tests/mpi/periodicity_01.cc
+++ b/tests/mpi/periodicity_01.cc
@@ -296,11 +296,12 @@ namespace Step40
   LaplaceProblem<dim>::refine_grid()
   {
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(3),
-                                       typename FunctionMap<dim>::type(),
-                                       locally_relevant_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(3),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      locally_relevant_solution,
+      estimated_error_per_cell);
     parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
       triangulation, estimated_error_per_cell, 0.3, 0.03);
 

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -727,12 +727,13 @@ namespace Step22
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
     FEValuesExtractors::Scalar pressure(dim);
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell,
-                                       fe.component_mask(pressure));
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell,
+      fe.component_mask(pressure));
 
     // Note: this test does
     parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -814,12 +814,13 @@ namespace Step22
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
     FEValuesExtractors::Scalar pressure(dim);
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       solution,
-                                       estimated_error_per_cell,
-                                       fe.component_mask(pressure));
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      solution,
+      estimated_error_per_cell,
+      fe.component_mask(pressure));
 
     parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
       triangulation, estimated_error_per_cell, 0.3, 0.0);

--- a/tests/mpi/step-37.cc
+++ b/tests/mpi/step-37.cc
@@ -327,9 +327,10 @@ namespace Step37
       DoFTools::make_hanging_node_constraints(
         dof_handler, hanging_nodes_laplace_constraints);
 
-      std::set<types::boundary_id>    dirichlet_boundary_ids;
-      typename FunctionMap<dim>::type dirichlet_boundary_functions;
-      PotentialBCFunction<dim>        bc_func(240, Point<dim>());
+      std::set<types::boundary_id> dirichlet_boundary_ids;
+      std::map<types::boundary_id, const Function<dim> *>
+                               dirichlet_boundary_functions;
+      PotentialBCFunction<dim> bc_func(240, Point<dim>());
       dirichlet_boundary_ids.insert(0);
       dirichlet_boundary_functions[0] = &bc_func;
       VectorTools::interpolate_boundary_values(*mapping.get(),

--- a/tests/mpi/trilinos_distribute_04.cc
+++ b/tests/mpi/trilinos_distribute_04.cc
@@ -98,8 +98,8 @@ test()
   cm.reinit(locally_relevant_set);
   DoFTools::make_hanging_node_constraints(dofh, cm);
 
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   VectorTools::interpolate_boundary_values(dofh, dirichlet_boundary, cm);
 

--- a/tests/multigrid/boundary_01.cc
+++ b/tests/multigrid/boundary_01.cc
@@ -19,7 +19,6 @@
 #include <deal.II/base/function.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
@@ -67,8 +66,8 @@ check_fe(FiniteElement<dim> &fe)
   Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
-  Functions::ZeroFunction<dim>    zero;
-  typename FunctionMap<dim>::type fmap;
+  Functions::ZeroFunction<dim>                        zero;
+  std::map<types::boundary_id, const Function<dim> *> fmap;
   fmap.insert(std::make_pair(0, &zero));
 
   DoFHandler<dim> mgdof(tr);

--- a/tests/multigrid/constrained_dofs_01.cc
+++ b/tests/multigrid/constrained_dofs_01.cc
@@ -21,7 +21,6 @@
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
@@ -75,8 +74,8 @@ check_fe(FiniteElement<dim> &fe)
     parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   setup_tria(tr);
 
-  Functions::ZeroFunction<dim>    zero;
-  typename FunctionMap<dim>::type fmap;
+  Functions::ZeroFunction<dim>                        zero;
+  std::map<types::boundary_id, const Function<dim> *> fmap;
   fmap.insert(std::make_pair(0, &zero));
 
   DoFHandler<dim> dofh(tr);
@@ -125,8 +124,8 @@ check_fe(FiniteElement<dim> &fe)
         cell->update_cell_dof_indices_cache();
       }
 
-    typename FunctionMap<dim>::type dirichlet_boundary;
-    Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     mg_constrained_dofs_ref.initialize(dofhref, dirichlet_boundary);
   }
@@ -135,8 +134,8 @@ check_fe(FiniteElement<dim> &fe)
 
   MGConstrainedDoFs mg_constrained_dofs;
 
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   mg_constrained_dofs.initialize(dofh, dirichlet_boundary);
 

--- a/tests/multigrid/constrained_dofs_02.cc
+++ b/tests/multigrid/constrained_dofs_02.cc
@@ -21,7 +21,6 @@
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
@@ -136,8 +135,8 @@ check_fe(FiniteElement<dim> &fe)
     parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   setup_tria(tr);
 
-  Functions::ZeroFunction<dim>    zero;
-  typename FunctionMap<dim>::type fmap;
+  Functions::ZeroFunction<dim>                        zero;
+  std::map<types::boundary_id, const Function<dim> *> fmap;
   fmap.insert(std::make_pair(0, &zero));
 
   DoFHandler<dim> dofh(tr);
@@ -186,8 +185,8 @@ check_fe(FiniteElement<dim> &fe)
         cell->update_cell_dof_indices_cache();
       }
 
-    typename FunctionMap<dim>::type dirichlet_boundary;
-    Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     mg_constrained_dofs_ref.initialize(dofhref, dirichlet_boundary);
   }
@@ -196,8 +195,8 @@ check_fe(FiniteElement<dim> &fe)
 
   MGConstrainedDoFs mg_constrained_dofs;
 
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   mg_constrained_dofs.initialize(dofh, dirichlet_boundary);
 

--- a/tests/multigrid/constrained_dofs_03.cc
+++ b/tests/multigrid/constrained_dofs_03.cc
@@ -21,7 +21,6 @@
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>

--- a/tests/multigrid/dof_01.cc
+++ b/tests/multigrid/dof_01.cc
@@ -19,7 +19,6 @@
 #include <deal.II/base/function.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
@@ -77,8 +76,8 @@ check_fe(FiniteElement<dim> &fe)
   Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
-  Functions::ZeroFunction<dim>    zero;
-  typename FunctionMap<dim>::type fmap;
+  Functions::ZeroFunction<dim>                        zero;
+  std::map<types::boundary_id, const Function<dim> *> fmap;
   fmap.insert(std::make_pair(0, &zero));
 
   DoFHandler<dim> mgdof(tr);

--- a/tests/multigrid/dof_02.cc
+++ b/tests/multigrid/dof_02.cc
@@ -19,7 +19,6 @@
 #include <deal.II/base/function.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
@@ -83,8 +82,8 @@ check_fe(FiniteElement<dim> &fe)
   Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
-  Functions::ZeroFunction<dim>    zero;
-  typename FunctionMap<dim>::type fmap;
+  Functions::ZeroFunction<dim>                        zero;
+  std::map<types::boundary_id, const Function<dim> *> fmap;
   fmap.insert(std::make_pair(0, &zero));
 
   DoFHandler<dim> mgdof(tr);

--- a/tests/multigrid/events_01.cc
+++ b/tests/multigrid/events_01.cc
@@ -154,7 +154,7 @@ namespace Step50
     constraints.reinit(locally_relevant_set);
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    typename FunctionMap<dim>::type  dirichlet_boundary;
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
     Functions::ConstantFunction<dim> homogeneous_dirichlet_bc(0.0);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     VectorTools::interpolate_boundary_values(mg_dof_handler,
@@ -500,12 +500,12 @@ namespace Step50
     temp_solution.reinit(locally_relevant_set, MPI_COMM_WORLD);
     temp_solution = solution;
 
-    KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                         mg_dof_handler),
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       temp_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      mg_dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      temp_solution,
+      estimated_error_per_cell);
 
     parallel::distributed::GridRefinement::refine_and_coarsen_fixed_fraction(
       triangulation, estimated_error_per_cell, 0.3, 0.0);

--- a/tests/multigrid/interface_matrix_entry_01.cc
+++ b/tests/multigrid/interface_matrix_entry_01.cc
@@ -95,8 +95,8 @@ test()
   constraints.reinit(locally_relevant_set);
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-  std::set<types::boundary_id>     dirichlet_boundary_ids;
-  typename FunctionMap<dim>::type  dirichlet_boundary;
+  std::set<types::boundary_id>                        dirichlet_boundary_ids;
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   Functions::ConstantFunction<dim> homogeneous_dirichlet_bc(0.0);
   dirichlet_boundary_ids.insert(0);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;

--- a/tests/multigrid/mg_coarse_01.cc
+++ b/tests/multigrid/mg_coarse_01.cc
@@ -211,7 +211,7 @@ namespace Step50
     constraints.reinit(locally_relevant_set);
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    typename FunctionMap<dim>::type  dirichlet_boundary;
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
     Functions::ConstantFunction<dim> homogeneous_dirichlet_bc(0.0);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     VectorTools::interpolate_boundary_values(mg_dof_handler,
@@ -587,12 +587,12 @@ namespace Step50
     temp_solution.reinit(locally_relevant_set, MPI_COMM_WORLD);
     temp_solution = solution;
 
-    KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                         mg_dof_handler),
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       temp_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      mg_dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      temp_solution,
+      estimated_error_per_cell);
 
     parallel::distributed::GridRefinement::refine_and_coarsen_fixed_fraction(
       triangulation, estimated_error_per_cell, 0.3, 0.0);

--- a/tests/multigrid/mg_output_dirichlet.cc
+++ b/tests/multigrid/mg_output_dirichlet.cc
@@ -206,8 +206,9 @@ check_simple(const FiniteElement<dim> &fe)
 
   Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr, -1, 1);
-  typename FunctionMap<dim>::type dirichlet_boundary_functions;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *>
+                               dirichlet_boundary_functions;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary_functions[0] = &homogeneous_dirichlet_bc;
 
   tr.refine_global(1);

--- a/tests/multigrid/mg_output_neumann.cc
+++ b/tests/multigrid/mg_output_neumann.cc
@@ -206,7 +206,8 @@ check_simple(const FiniteElement<dim> &fe)
 
   Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr, -1, 1);
-  typename FunctionMap<dim>::type dirichlet_boundary_functions;
+  std::map<types::boundary_id, const Function<dim> *>
+    dirichlet_boundary_functions;
 
   tr.refine_global(1);
   refine_mesh(tr);

--- a/tests/multigrid/mg_renumbered_01.cc
+++ b/tests/multigrid/mg_renumbered_01.cc
@@ -340,8 +340,8 @@ template <int dim>
 void
 LaplaceProblem<dim>::test()
 {
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    dirichlet_bc(fe.n_components());
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> dirichlet_bc(fe.n_components());
   dirichlet_boundary[0] = &dirichlet_bc;
 
   const unsigned int min_l = mg_matrices.min_level();

--- a/tests/multigrid/mg_renumbered_02.cc
+++ b/tests/multigrid/mg_renumbered_02.cc
@@ -292,8 +292,8 @@ template <int dim>
 void
 LaplaceProblem<dim>::test_boundary()
 {
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    dirichlet_bc(fe.n_components());
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> dirichlet_bc(fe.n_components());
   dirichlet_boundary[0] = &dirichlet_bc;
   MGTools::make_boundary_list(mg_dof_handler_renumbered,
                               dirichlet_boundary,

--- a/tests/multigrid/mg_renumbered_03.cc
+++ b/tests/multigrid/mg_renumbered_03.cc
@@ -349,8 +349,8 @@ template <int dim>
 void
 LaplaceProblem<dim>::test()
 {
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    dirichlet_bc(fe.n_components());
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> dirichlet_bc(fe.n_components());
   dirichlet_boundary[0] = &dirichlet_bc;
 
   MGConstrainedDoFs mg_constrained_dofs;

--- a/tests/multigrid/step-16-02.cc
+++ b/tests/multigrid/step-16-02.cc
@@ -255,8 +255,8 @@ LaplaceProblem<dim>::setup_system()
 
   constraints.clear();
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values(mapping,

--- a/tests/multigrid/step-16-03.cc
+++ b/tests/multigrid/step-16-03.cc
@@ -174,8 +174,8 @@ LaplaceProblem<dim>::setup_system()
 
   constraints.clear();
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values(mapping,
@@ -419,12 +419,12 @@ LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                       mg_dof_handler),
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    mg_dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
   GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                   estimated_error_per_cell,
                                                   0.3,

--- a/tests/multigrid/step-16-04.cc
+++ b/tests/multigrid/step-16-04.cc
@@ -178,8 +178,8 @@ LaplaceProblem<dim>::setup_system()
 
   constraints.clear();
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values(mapping,
@@ -444,12 +444,12 @@ LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                       mg_dof_handler),
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    mg_dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
   GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                   estimated_error_per_cell,
                                                   0.3,

--- a/tests/multigrid/step-16-05.cc
+++ b/tests/multigrid/step-16-05.cc
@@ -178,8 +178,8 @@ LaplaceProblem<dim>::setup_system()
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
   DoFTools::make_hanging_node_constraints(mg_dof_handler,
                                           hanging_node_constraints);
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values(mapping,

--- a/tests/multigrid/step-16-06.cc
+++ b/tests/multigrid/step-16-06.cc
@@ -178,8 +178,8 @@ LaplaceProblem<dim>::setup_system()
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
   DoFTools::make_hanging_node_constraints(mg_dof_handler,
                                           hanging_node_constraints);
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values(mapping,

--- a/tests/multigrid/step-16-07.cc
+++ b/tests/multigrid/step-16-07.cc
@@ -180,8 +180,8 @@ LaplaceProblem<dim>::setup_system()
 
   constraints.clear();
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values(mapping,
@@ -514,12 +514,12 @@ LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                       mg_dof_handler),
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    mg_dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
   GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                   estimated_error_per_cell,
                                                   0.3,

--- a/tests/multigrid/step-16-50-mpi-linear-operator.cc
+++ b/tests/multigrid/step-16-50-mpi-linear-operator.cc
@@ -207,8 +207,8 @@ namespace Step50
     constraints.reinit(locally_relevant_set);
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    typename FunctionMap<dim>::type dirichlet_boundary;
-    Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc;
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc;
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     VectorTools::interpolate_boundary_values(mg_dof_handler,
                                              dirichlet_boundary,
@@ -504,12 +504,12 @@ namespace Step50
     temp_solution.reinit(locally_relevant_set, MPI_COMM_WORLD);
     temp_solution = solution;
 
-    KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                         mg_dof_handler),
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       temp_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      mg_dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      temp_solution,
+      estimated_error_per_cell);
 
     const double threshold =
       0.6 * Utilities::MPI::max(estimated_error_per_cell.linfty_norm(),

--- a/tests/multigrid/step-16-50-mpi-smoother.cc
+++ b/tests/multigrid/step-16-50-mpi-smoother.cc
@@ -207,8 +207,8 @@ namespace Step50
     constraints.reinit(locally_relevant_set);
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    typename FunctionMap<dim>::type dirichlet_boundary;
-    Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc;
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc;
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     VectorTools::interpolate_boundary_values(mg_dof_handler,
                                              dirichlet_boundary,
@@ -493,12 +493,12 @@ namespace Step50
     temp_solution.reinit(locally_relevant_set, MPI_COMM_WORLD);
     temp_solution = solution;
 
-    KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                         mg_dof_handler),
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       temp_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      mg_dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      temp_solution,
+      estimated_error_per_cell);
 
     const double threshold =
       0.6 * Utilities::MPI::max(estimated_error_per_cell.linfty_norm(),

--- a/tests/multigrid/step-16-50-mpi.cc
+++ b/tests/multigrid/step-16-50-mpi.cc
@@ -207,8 +207,8 @@ namespace Step50
     constraints.reinit(locally_relevant_set);
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    typename FunctionMap<dim>::type dirichlet_boundary;
-    Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc;
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc;
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     VectorTools::interpolate_boundary_values(mg_dof_handler,
                                              dirichlet_boundary,
@@ -490,12 +490,12 @@ namespace Step50
     temp_solution.reinit(locally_relevant_set, MPI_COMM_WORLD);
     temp_solution = solution;
 
-    KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                         mg_dof_handler),
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       temp_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      mg_dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      temp_solution,
+      estimated_error_per_cell);
 
     const double threshold =
       0.6 * Utilities::MPI::max(estimated_error_per_cell.linfty_norm(),

--- a/tests/multigrid/step-16-50-serial.cc
+++ b/tests/multigrid/step-16-50-serial.cc
@@ -178,8 +178,8 @@ LaplaceProblem<dim>::setup_system()
 
   constraints.clear();
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values(mapping,
@@ -414,12 +414,12 @@ LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                       mg_dof_handler),
-                                     QGauss<dim - 1>(degree + 1),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    mg_dof_handler,
+    QGauss<dim - 1>(degree + 1),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
 
   const double threshold = 0.6 * estimated_error_per_cell.linfty_norm();
   GridRefinement::refine(triangulation, estimated_error_per_cell, threshold);

--- a/tests/multigrid/step-16-bdry1.cc
+++ b/tests/multigrid/step-16-bdry1.cc
@@ -256,8 +256,8 @@ LaplaceProblem<dim>::setup_system()
 
   constraints.clear();
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values(mapping,

--- a/tests/multigrid/step-16.cc
+++ b/tests/multigrid/step-16.cc
@@ -180,8 +180,8 @@ LaplaceProblem<dim>::setup_system()
 
   constraints.clear();
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
   MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values(mapping,
@@ -515,12 +515,12 @@ LaplaceProblem<dim>::refine_grid()
 {
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
-  KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                       mg_dof_handler),
-                                     QGauss<dim - 1>(3),
-                                     typename FunctionMap<dim>::type(),
-                                     solution,
-                                     estimated_error_per_cell);
+  KellyErrorEstimator<dim>::estimate(
+    mg_dof_handler,
+    QGauss<dim - 1>(3),
+    std::map<types::boundary_id, const Function<dim> *>(),
+    solution,
+    estimated_error_per_cell);
   GridRefinement::refine_and_coarsen_fixed_number(triangulation,
                                                   estimated_error_per_cell,
                                                   0.3,

--- a/tests/multigrid/step-50_01.cc
+++ b/tests/multigrid/step-50_01.cc
@@ -208,7 +208,7 @@ namespace Step50
     constraints.reinit(locally_relevant_set);
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    typename FunctionMap<dim>::type  dirichlet_boundary;
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
     Functions::ConstantFunction<dim> homogeneous_dirichlet_bc(0.0);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     VectorTools::interpolate_boundary_values(mg_dof_handler,
@@ -513,12 +513,12 @@ namespace Step50
     temp_solution.reinit(locally_relevant_set, MPI_COMM_WORLD);
     temp_solution = solution;
 
-    KellyErrorEstimator<dim>::estimate(static_cast<DoFHandler<dim> &>(
-                                         mg_dof_handler),
-                                       QGauss<dim - 1>(degree + 1),
-                                       typename FunctionMap<dim>::type(),
-                                       temp_solution,
-                                       estimated_error_per_cell);
+    KellyErrorEstimator<dim>::estimate(
+      mg_dof_handler,
+      QGauss<dim - 1>(degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      temp_solution,
+      estimated_error_per_cell);
 
     parallel::distributed::GridRefinement::refine_and_coarsen_fixed_fraction(
       triangulation, estimated_error_per_cell, 0.3, 0.0);

--- a/tests/multigrid/step-50_02.cc
+++ b/tests/multigrid/step-50_02.cc
@@ -212,8 +212,8 @@ namespace Step50
     constraints.reinit(locally_relevant_set);
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
-    std::set<types::boundary_id>     dirichlet_boundary_ids;
-    typename FunctionMap<dim>::type  dirichlet_boundary;
+    std::set<types::boundary_id>                        dirichlet_boundary_ids;
+    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
     Functions::ConstantFunction<dim> homogeneous_dirichlet_bc(1.0);
     dirichlet_boundary_ids.insert(0);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;

--- a/tests/multigrid/transfer_04.cc
+++ b/tests/multigrid/transfer_04.cc
@@ -21,7 +21,6 @@
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>

--- a/tests/multigrid/transfer_04a.cc
+++ b/tests/multigrid/transfer_04a.cc
@@ -21,7 +21,6 @@
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
@@ -121,8 +120,8 @@ check_fe(FiniteElement<dim> &fe)
     }
 
 
-  Functions::ZeroFunction<dim>    zero;
-  typename FunctionMap<dim>::type fmap;
+  Functions::ZeroFunction<dim>                        zero;
+  std::map<types::boundary_id, const Function<dim> *> fmap;
   fmap.insert(std::make_pair(0, &zero));
 
   DoFHandler<dim> dofh(tr);

--- a/tests/multigrid/transfer_04b.cc
+++ b/tests/multigrid/transfer_04b.cc
@@ -21,7 +21,6 @@
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
@@ -121,8 +120,8 @@ check_fe(FiniteElement<dim> &fe)
     }
 
 
-  Functions::ZeroFunction<dim>    zero;
-  typename FunctionMap<dim>::type fmap;
+  Functions::ZeroFunction<dim>                        zero;
+  std::map<types::boundary_id, const Function<dim> *> fmap;
   fmap.insert(std::make_pair(0, &zero));
 
   DoFHandler<dim> dofh(tr);

--- a/tests/multigrid/transfer_05.cc
+++ b/tests/multigrid/transfer_05.cc
@@ -22,7 +22,6 @@
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_q.h>
 
@@ -106,9 +105,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs(fe);
 
-      MGConstrainedDoFs               mg_constrained_dofs;
-      ZeroFunction<dim>               zero_function;
-      typename FunctionMap<dim>::type dirichlet_boundary;
+      MGConstrainedDoFs                                   mg_constrained_dofs;
+      ZeroFunction<dim>                                   zero_function;
+      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
       dirichlet_boundary[0] = &zero_function;
       mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
 

--- a/tests/multigrid/transfer_06.cc
+++ b/tests/multigrid/transfer_06.cc
@@ -23,7 +23,6 @@
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/function_map.h>
 
 #include <deal.II/fe/fe_q.h>
 
@@ -118,9 +117,9 @@ check(const unsigned int fe_degree)
 
       const std::vector<const DoFHandler<dim> *> mgdof_ptr{&mgdof_1, &mgdof_2};
 
-      std::vector<MGConstrainedDoFs>  mg_constrained_dofs_vector(2);
-      ZeroFunction<dim>               zero_function;
-      typename FunctionMap<dim>::type dirichlet_boundary;
+      std::vector<MGConstrainedDoFs> mg_constrained_dofs_vector(2);
+      ZeroFunction<dim>              zero_function;
+      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
       dirichlet_boundary[0] = &zero_function;
       for (unsigned int i = 0; i < mgdof_ptr.size(); ++i)
         mg_constrained_dofs_vector[i].initialize(*mgdof_ptr[i],

--- a/tests/multigrid/transfer_matrix_free_01.cc
+++ b/tests/multigrid/transfer_matrix_free_01.cc
@@ -67,9 +67,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs(fe);
 
-      MGConstrainedDoFs               mg_constrained_dofs;
-      Functions::ZeroFunction<dim>    zero_function;
-      typename FunctionMap<dim>::type dirichlet_boundary;
+      MGConstrainedDoFs                                   mg_constrained_dofs;
+      Functions::ZeroFunction<dim>                        zero_function;
+      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
       dirichlet_boundary[0] = &zero_function;
       mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
 

--- a/tests/multigrid/transfer_matrix_free_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02.cc
@@ -96,9 +96,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs(fe);
 
-      MGConstrainedDoFs               mg_constrained_dofs;
-      Functions::ZeroFunction<dim>    zero_function;
-      typename FunctionMap<dim>::type dirichlet_boundary;
+      MGConstrainedDoFs                                   mg_constrained_dofs;
+      Functions::ZeroFunction<dim>                        zero_function;
+      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
       dirichlet_boundary[0] = &zero_function;
       mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
 

--- a/tests/multigrid/transfer_matrix_free_02_block.cc
+++ b/tests/multigrid/transfer_matrix_free_02_block.cc
@@ -100,9 +100,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs(fe);
 
-      MGConstrainedDoFs               mg_constrained_dofs;
-      ZeroFunction<dim>               zero_function;
-      typename FunctionMap<dim>::type dirichlet_boundary;
+      MGConstrainedDoFs                                   mg_constrained_dofs;
+      ZeroFunction<dim>                                   zero_function;
+      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
       dirichlet_boundary[0] = &zero_function;
       mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
 

--- a/tests/multigrid/transfer_matrix_free_02_block_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02_block_02.cc
@@ -111,9 +111,9 @@ check(const unsigned int fe_degree)
 
       const std::vector<const DoFHandler<dim> *> mgdof_ptr{&mgdof_1, &mgdof_2};
 
-      std::vector<MGConstrainedDoFs>  mg_constrained_dofs_vector(2);
-      ZeroFunction<dim>               zero_function;
-      typename FunctionMap<dim>::type dirichlet_boundary;
+      std::vector<MGConstrainedDoFs> mg_constrained_dofs_vector(2);
+      ZeroFunction<dim>              zero_function;
+      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
       dirichlet_boundary[0] = &zero_function;
       for (unsigned int i = 0; i < mgdof_ptr.size(); ++i)
         mg_constrained_dofs_vector[i].initialize(*mgdof_ptr[i],

--- a/tests/multigrid/transfer_matrix_free_03.cc
+++ b/tests/multigrid/transfer_matrix_free_03.cc
@@ -65,9 +65,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs(fe);
 
-      MGConstrainedDoFs               mg_constrained_dofs;
-      Functions::ZeroFunction<dim>    zero_function;
-      typename FunctionMap<dim>::type dirichlet_boundary;
+      MGConstrainedDoFs                                   mg_constrained_dofs;
+      Functions::ZeroFunction<dim>                        zero_function;
+      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
       dirichlet_boundary[0] = &zero_function;
       mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
 

--- a/tests/multigrid/transfer_matrix_free_06.cc
+++ b/tests/multigrid/transfer_matrix_free_06.cc
@@ -98,9 +98,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs(fe);
 
-      MGConstrainedDoFs               mg_constrained_dofs;
-      Functions::ZeroFunction<dim>    zero_function;
-      typename FunctionMap<dim>::type dirichlet_boundary;
+      MGConstrainedDoFs                                   mg_constrained_dofs;
+      Functions::ZeroFunction<dim>                        zero_function;
+      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
       dirichlet_boundary[0] = &zero_function;
       mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
 

--- a/tests/multigrid/transfer_prebuilt_03.cc
+++ b/tests/multigrid/transfer_prebuilt_03.cc
@@ -63,8 +63,8 @@ check_simple(const FiniteElement<dim> &fe)
   mgdof.distribute_dofs(fe);
   mgdof.distribute_mg_dofs(fe);
 
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    homogeneous_dirichlet_bc(1);
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
 
   MGConstrainedDoFs mg_constrained_dofs;

--- a/tests/multigrid/transfer_prebuilt_04.cc
+++ b/tests/multigrid/transfer_prebuilt_04.cc
@@ -65,9 +65,9 @@ check()
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs(fe);
 
-      MGConstrainedDoFs               mg_constrained_dofs;
-      Functions::ZeroFunction<dim>    zero_function;
-      typename FunctionMap<dim>::type dirichlet_boundary;
+      MGConstrainedDoFs                                   mg_constrained_dofs;
+      Functions::ZeroFunction<dim>                        zero_function;
+      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
       dirichlet_boundary[0] = &zero_function;
       mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
 

--- a/tests/multigrid/transfer_select.cc
+++ b/tests/multigrid/transfer_select.cc
@@ -59,8 +59,7 @@ check_select(const FiniteElement<dim> &fe,
   DoFHandler<dim> &dof = mgdof;
   mgdof.distribute_dofs(fe);
   mgdof.distribute_mg_dofs(fe);
-  DoFRenumbering::component_wise(static_cast<DoFHandler<dim> &>(mgdof),
-                                 target_component);
+  DoFRenumbering::component_wise(mgdof, target_component);
   vector<types::global_dof_index> ndofs(
     *std::max_element(target_component.begin(), target_component.end()) + 1);
   DoFTools::count_dofs_per_component(dof, ndofs, true, target_component);

--- a/tests/multigrid/transfer_system_adaptive_02.cc
+++ b/tests/multigrid/transfer_system_adaptive_02.cc
@@ -152,8 +152,8 @@ check(const FiniteElement<dim> &fe)
     DoFRenumbering::component_wise(mg_dof_handler, level);
 
   std::vector<std::set<unsigned int>> boundary_indices(tr.n_levels());
-  typename FunctionMap<dim>::type     dirichlet_boundary;
-  Functions::ZeroFunction<dim>        dirichlet_bc(fe.n_components());
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> dirichlet_bc(fe.n_components());
   dirichlet_boundary[3] = &dirichlet_bc;
 
   MGConstrainedDoFs mg_constrained_dofs;

--- a/tests/multigrid/transfer_system_adaptive_04.cc
+++ b/tests/multigrid/transfer_system_adaptive_04.cc
@@ -153,8 +153,8 @@ check(const FiniteElement<dim> &fe)
 
   std::vector<std::set<types::global_dof_index>> boundary_indices(
     tr.n_levels());
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    dirichlet_bc(fe.n_components());
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> dirichlet_bc(fe.n_components());
   dirichlet_boundary[3] = &dirichlet_bc;
 
   MGTools::make_boundary_list(mg_dof_handler,

--- a/tests/multigrid/transfer_system_adaptive_06.cc
+++ b/tests/multigrid/transfer_system_adaptive_06.cc
@@ -153,8 +153,8 @@ check(const FiniteElement<dim> &fe)
 
   std::vector<std::set<types::global_dof_index>> boundary_indices(
     tr.n_levels());
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    dirichlet_bc(fe.n_components());
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> dirichlet_bc(fe.n_components());
   dirichlet_boundary[3] = &dirichlet_bc;
 
   MGTools::make_boundary_list(mg_dof_handler,

--- a/tests/multigrid/transfer_system_adaptive_08.cc
+++ b/tests/multigrid/transfer_system_adaptive_08.cc
@@ -157,8 +157,8 @@ check(const FiniteElement<dim> &fe)
 
   std::vector<std::set<types::global_dof_index>> boundary_indices(
     tr.n_levels());
-  typename FunctionMap<dim>::type dirichlet_boundary;
-  Functions::ZeroFunction<dim>    dirichlet_bc(fe.n_components());
+  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
+  Functions::ZeroFunction<dim> dirichlet_bc(fe.n_components());
   dirichlet_boundary[3] = &dirichlet_bc;
 
   MGTools::make_boundary_list(mg_dof_handler,

--- a/tests/numerics/error_estimator_02.cc
+++ b/tests/numerics/error_estimator_02.cc
@@ -300,7 +300,7 @@ test_neumann(const NeumanBC<dim> &func)
   dealii::deallog << std::endl;
 
   // call Kelly
-  typename dealii::FunctionMap<dim>::type function_map;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   function_map[0] = &func;
 
   dealii::Vector<float> error(dof_handler.n_dofs());
@@ -420,7 +420,7 @@ test_regular(const MyFunction<dim> &func)
   dealii::KellyErrorEstimator<dim>::estimate(
     dof_handler,
     face_quadrature_formula,
-    typename dealii::FunctionMap<dim>::type(),
+    std::map<types::boundary_id, const Function<dim> *>(),
     values,
     error,
     dealii::ComponentMask(),
@@ -550,7 +550,7 @@ test_irregular(const MyFunction<dim> &func)
   dealii::KellyErrorEstimator<dim>::estimate(
     dof_handler,
     face_quadrature_formula,
-    typename dealii::FunctionMap<dim>::type(),
+    std::map<types::boundary_id, const Function<dim> *>(),
     values,
     error,
     dealii::ComponentMask(),
@@ -719,7 +719,7 @@ test(const MySecondFunction<dim> &func)
   dealii::KellyErrorEstimator<dim>::estimate(
     dof_handler,
     face_quadrature_formula,
-    typename dealii::FunctionMap<dim>::type(),
+    std::map<types::boundary_id, const Function<dim> *>(),
     values,
     error,
     dealii::ComponentMask(),

--- a/tests/numerics/error_estimator_02_complex.cc
+++ b/tests/numerics/error_estimator_02_complex.cc
@@ -244,7 +244,8 @@ test_neumann(const NeumanBC<dim> &func)
   dealii::deallog << std::endl;
 
   // call Kelly
-  typename dealii::FunctionMap<dim, std::complex<double>>::type function_map;
+  std::map<types::boundary_id, const Function<dim, std::complex<double>> *>
+    function_map;
   function_map[0] = &func;
 
   dealii::Vector<float> error(dof_handler.n_dofs());
@@ -364,7 +365,7 @@ test_regular(const MyFunction<dim> &func)
   dealii::KellyErrorEstimator<dim>::estimate(
     dof_handler,
     face_quadrature_formula,
-    typename dealii::FunctionMap<dim, std::complex<double>>::type(),
+    std::map<types::boundary_id, const Function<dim, std::complex<double>> *>(),
     values,
     error,
     dealii::ComponentMask(),
@@ -494,7 +495,7 @@ test_irregular(const MyFunction<dim> &func)
   dealii::KellyErrorEstimator<dim>::estimate(
     dof_handler,
     face_quadrature_formula,
-    typename dealii::FunctionMap<dim, std::complex<double>>::type(),
+    std::map<types::boundary_id, const Function<dim, std::complex<double>> *>(),
     values,
     error,
     dealii::ComponentMask(),
@@ -665,7 +666,7 @@ test(const MySecondFunction<dim> &func)
   dealii::KellyErrorEstimator<dim>::estimate(
     dof_handler,
     face_quadrature_formula,
-    typename dealii::FunctionMap<dim, std::complex<double>>::type(),
+    std::map<types::boundary_id, const Function<dim, std::complex<double>> *>(),
     values,
     error,
     dealii::ComponentMask(),

--- a/tests/numerics/normal_flux_inhom_01.cc
+++ b/tests/numerics/normal_flux_inhom_01.cc
@@ -48,7 +48,7 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   dof.distribute_dofs(fe);
 
   Functions::ConstantFunction<dim> constant_function(1., dim);
-  typename FunctionMap<dim>::type  function_map;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   for (unsigned int j = 0; j < GeometryInfo<dim>::faces_per_cell; ++j)
     function_map[j] = &constant_function;
 

--- a/tests/numerics/project_boundary_01.cc
+++ b/tests/numerics/project_boundary_01.cc
@@ -163,7 +163,7 @@ check()
           DoFHandler<dim> dof(tr);
           dof.distribute_dofs(fe);
 
-          typename FunctionMap<dim>::type function_map;
+          std::map<types::boundary_id, const Function<dim> *> function_map;
           function_map[0] = function_list[i];
 
           // interpolate boundary values

--- a/tests/numerics/project_boundary_rt_01.cc
+++ b/tests/numerics/project_boundary_rt_01.cc
@@ -147,9 +147,9 @@ test_projection(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   QGauss<dim - 1>      quadrature(degree + 2);
   MappingQGeneric<dim> mapping(1);
 
-  TestFunction<dim>                         f(degree - 1);
-  std::map<types::global_dof_index, double> boundary_constraints;
-  typename FunctionMap<dim>::type           boundary_map;
+  TestFunction<dim>                                   f(degree - 1);
+  std::map<types::global_dof_index, double>           boundary_constraints;
+  std::map<types::boundary_id, const Function<dim> *> boundary_map;
   for (types::boundary_id i = 0; i < 255; ++i)
     boundary_map[i] = &f;
   VectorTools::project_boundary_values(

--- a/tests/numerics/tangential_flux_inhom_01.cc
+++ b/tests/numerics/tangential_flux_inhom_01.cc
@@ -49,7 +49,7 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   dof.distribute_dofs(fe);
 
   Functions::ConstantFunction<dim> constant_function(1., dim);
-  typename FunctionMap<dim>::type  function_map;
+  std::map<types::boundary_id, const Function<dim> *> function_map;
   for (unsigned int j = 0; j < GeometryInfo<dim>::faces_per_cell; ++j)
     function_map[j] = &constant_function;
 

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -657,15 +657,16 @@ namespace Step18
   TopLevel<dim>::refine_initial_grid()
   {
     Vector<float> error_per_cell(triangulation.n_active_cells());
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(2),
-                                       typename FunctionMap<dim>::type(),
-                                       incremental_displacement,
-                                       error_per_cell,
-                                       ComponentMask(),
-                                       nullptr,
-                                       MultithreadInfo::n_threads(),
-                                       this_mpi_process);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(2),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      incremental_displacement,
+      error_per_cell,
+      ComponentMask(),
+      nullptr,
+      MultithreadInfo::n_threads(),
+      this_mpi_process);
     const unsigned int n_local_cells =
       triangulation.n_locally_owned_active_cells();
     PETScWrappers::MPI::Vector distributed_error_per_cell(

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -673,15 +673,16 @@ namespace Step18
   TopLevel<dim>::refine_initial_grid()
   {
     Vector<float> error_per_cell(triangulation.n_active_cells());
-    KellyErrorEstimator<dim>::estimate(dof_handler,
-                                       QGauss<dim - 1>(2),
-                                       typename FunctionMap<dim>::type(),
-                                       incremental_displacement,
-                                       error_per_cell,
-                                       ComponentMask(),
-                                       nullptr,
-                                       MultithreadInfo::n_threads(),
-                                       this_mpi_process);
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(2),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      incremental_displacement,
+      error_per_cell,
+      ComponentMask(),
+      nullptr,
+      MultithreadInfo::n_threads(),
+      this_mpi_process);
     const unsigned int n_local_cells =
       triangulation.n_locally_owned_active_cells();
     PETScWrappers::MPI::Vector distributed_error_per_cell(

--- a/tests/trilinos/solver_control_06.cc
+++ b/tests/trilinos/solver_control_06.cc
@@ -491,11 +491,12 @@ Test_Solver_Output::refine_grid()
   TimerOutput::Scope t(timer, "refine");
 
   Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
-  KellyErrorEstimator<2>::estimate(dof_handler,
-                                   QGauss<2 - 1>(3),
-                                   typename FunctionMap<2>::type(),
-                                   locally_relevant_solution,
-                                   estimated_error_per_cell);
+  KellyErrorEstimator<2>::estimate(
+    dof_handler,
+    QGauss<2 - 1>(3),
+    std::map<types::boundary_id, const Function<2> *>(),
+    locally_relevant_solution,
+    estimated_error_per_cell);
   parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
     triangulation, estimated_error_per_cell, 0.3, 0.03);
   triangulation.execute_coarsening_and_refinement();

--- a/tests/vector_tools/boundaries.cc
+++ b/tests/vector_tools/boundaries.cc
@@ -142,7 +142,7 @@ check()
       DoFHandler<dim> dof(tr);
       dof.distribute_dofs(fe);
 
-      typename FunctionMap<dim>::type function_map;
+      std::map<types::boundary_id, const Function<dim> *> function_map;
       function_map[0] = function_list[i];
 
       // interpolate boundary values

--- a/tests/vector_tools/boundaries_complex.cc
+++ b/tests/vector_tools/boundaries_complex.cc
@@ -149,7 +149,8 @@ check()
       DoFHandler<dim> dof(tr);
       dof.distribute_dofs(fe);
 
-      typename FunctionMap<dim, std::complex<double>>::type function_map;
+      std::map<types::boundary_id, const Function<dim, std::complex<double>> *>
+        function_map;
       function_map[0] = function_list[i];
 
       // interpolate boundary values

--- a/tests/vector_tools/boundaries_complex_hp.cc
+++ b/tests/vector_tools/boundaries_complex_hp.cc
@@ -150,7 +150,8 @@ check()
       hp::DoFHandler<dim> dof(tr);
       dof.distribute_dofs(fe);
 
-      typename FunctionMap<dim, std::complex<double>>::type function_map;
+      std::map<types::boundary_id, const Function<dim, std::complex<double>> *>
+        function_map;
       function_map[0] = function_list[i];
 
       // interpolate boundary values


### PR DESCRIPTION
Fixes #2247. I agree that the clarity outweighs the lengthy type description.