### PR TITLE
bugfix for TrilinosWrapper::SparseMatrix ::add and ::copy_from

### DIFF
--- a/doc/news/changes/minor/20180614UweKoecher
+++ b/doc/news/changes/minor/20180614UweKoecher
@@ -1,0 +1,4 @@
+Bugfix: Fixed bugs for TrilinosWrapper::SparseMatrix::add(factor, other_matrix)
+and TrilinosWrapper::SparseMatrix::copy_from(other_matrix) for the case of
+non-contiguous rows.
+(Uwe Koecher 2018/06/14)

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -520,6 +520,16 @@ namespace TrilinosWrappers
     typedef dealii::types::global_dof_index size_type;
 
     /**
+     * Exception
+     */
+    DeclException1(ExcAccessToNonlocalRow,
+                   std::size_t,
+                   << "You tried to access row " << arg1
+                   << " of a non-contiguous locally owned row set."
+                   << " The row " << arg1
+                   << " is not stored locally and can't be accessed.");
+
+    /**
      * A structure that describes some of the traits of this class in terms of
      * its run-time behavior. Some other classes (such as the block matrix
      * classes) that take one or other of the matrix classes as its template

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -416,10 +416,11 @@ namespace TrilinosWrappers
         // Try to copy all the rows of the matrix one by one. In case of error
         // (i.e., the column indices are different), we need to abort and blow
         // away the matrix.
-        for (size_type row = local_range.first; row < local_range.second; ++row)
+        for (const auto &row : locally_owned_range_indices())
           {
             const int row_local = matrix->RowMap().LID(
               static_cast<TrilinosWrappers::types::int_type>(row));
+            Assert((row_local >= 0), ExcAccessToNonlocalRow(row));
 
             int             n_entries, rhs_n_entries;
             TrilinosScalar *value_ptr, *rhs_value_ptr;
@@ -1439,6 +1440,7 @@ namespace TrilinosWrappers
     int ncols = -1;
     int local_row =
       matrix->LRID(static_cast<TrilinosWrappers::types::int_type>(row));
+    Assert((local_row >= 0), ExcAccessToNonlocalRow(row));
 
     // on the processor who owns this
     // row, we'll have a non-negative
@@ -1449,7 +1451,7 @@ namespace TrilinosWrappers
         AssertThrow(ierr == 0, ExcTrilinosError(ierr));
       }
 
-    return ncols;
+    return static_cast<unsigned int>(ncols);
   }
 
 
@@ -1885,10 +1887,11 @@ namespace TrilinosWrappers
     const std::pair<size_type, size_type> local_range = rhs.local_range();
     const bool same_col_map = matrix->ColMap().SameAs(rhs.matrix->ColMap());
 
-    for (size_type row = local_range.first; row < local_range.second; ++row)
+    for (const auto &row : locally_owned_range_indices())
       {
         const int row_local = matrix->RowMap().LID(
           static_cast<TrilinosWrappers::types::int_type>(row));
+        Assert((row_local >= 0), ExcAccessToNonlocalRow(row));
 
         // First get a view to the matrix columns of both matrices. Note that
         // the data is in local index spaces so we need to be careful not only

--- a/tests/trilinos/sparse_matrix_add_03.cc
+++ b/tests/trilinos/sparse_matrix_add_03.cc
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2004 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test TrilinosWrappers::SparseMatrix::add(factor, other_matrix)
+// for the case of a non-contiguous set of rows.
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
+#include <deal.II/lac/vector_operation.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+
+void
+test()
+{
+  const auto MyPID{Utilities::MPI::this_mpi_process(MPI_COMM_WORLD)};
+  const auto NumProc{Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)};
+
+  if (!MyPID)
+    deallog << "NumProc=" << NumProc << std::endl;
+
+  // create non-contiguous index set for NumProc > 1
+  dealii::IndexSet parallel_partitioning(NumProc * 2);
+
+  // non-contiguous
+  parallel_partitioning.add_index(MyPID);
+  parallel_partitioning.add_index(NumProc + MyPID);
+
+  // create sparsity pattern from parallel_partitioning
+
+  // The sparsity pattern corresponds to a [FE_DGQ<1>(p=0)]^2 FESystem,
+  // on a triangulation in which each MPI process owns 2 cells,
+  // with reordered dofs by its components, such that the rows in the
+  // final matrix are locally not in a contiguous set.
+
+  dealii::TrilinosWrappers::SparsityPattern sp_M(parallel_partitioning,
+                                                 MPI_COMM_WORLD,
+                                                 2);
+
+  sp_M.add(MyPID, MyPID);
+  sp_M.add(MyPID, NumProc + MyPID);
+  sp_M.add(NumProc + MyPID, MyPID);
+  sp_M.add(NumProc + MyPID, NumProc + MyPID);
+
+  sp_M.compress();
+
+  // create matrix with dummy entries on the diagonal
+  dealii::TrilinosWrappers::SparseMatrix M0;
+  M0.reinit(sp_M);
+  M0 = 0;
+
+  for (const auto &i : parallel_partitioning)
+    M0.set(i, i, dealii::numbers::PI);
+
+  M0.compress(dealii::VectorOperation::insert);
+
+  ////////////////////////////////////////////////////////////////////////
+  // test ::add(TrilinosScalar, SparseMatrix)
+  //
+
+  dealii::TrilinosWrappers::SparseMatrix M1;
+  M1.reinit(sp_M);
+  M1 = 0;
+  M1.add(1.0, M0);
+
+  // check
+  for (const auto &i : parallel_partitioning)
+    {
+      const auto &el = M1.el(i, i);
+
+      if (!MyPID)
+        deallog << "i = " << i << " , j = " << i << " , el = " << el
+                << std::endl;
+
+      AssertThrow(el == dealii::numbers::PI, dealii::ExcInternalError());
+    }
+
+  if (!MyPID)
+    deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+
+  test();
+}

--- a/tests/trilinos/sparse_matrix_add_03.with_trilinos=true.with_mpi=true.mpirun=3.output
+++ b/tests/trilinos/sparse_matrix_add_03.with_trilinos=true.with_mpi=true.mpirun=3.output
@@ -1,0 +1,5 @@
+
+DEAL::NumProc=3
+DEAL::i = 0 , j = 0 , el = 3.14159
+DEAL::i = 3 , j = 3 , el = 3.14159
+DEAL::OK

--- a/tests/trilinos/sparse_matrix_copy_from_02.cc
+++ b/tests/trilinos/sparse_matrix_copy_from_02.cc
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2004 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test TrilinosWrappers::SparseMatrix::copy_from(other_matrix)
+// for the case of a non-contiguous set of rows.
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
+#include <deal.II/lac/vector_operation.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+
+void
+test()
+{
+  const auto MyPID{Utilities::MPI::this_mpi_process(MPI_COMM_WORLD)};
+  const auto NumProc{Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)};
+
+  if (!MyPID)
+    deallog << "NumProc=" << NumProc << std::endl;
+
+  // create non-contiguous index set for NumProc > 1
+  dealii::IndexSet parallel_partitioning(NumProc * 2);
+
+  // non-contiguous
+  parallel_partitioning.add_index(MyPID);
+  parallel_partitioning.add_index(NumProc + MyPID);
+
+  // create sparsity pattern from parallel_partitioning
+
+  // The sparsity pattern corresponds to a [FE_DGQ<1>(p=0)]^2 FESystem,
+  // on a triangulation in which each MPI process owns 2 cells,
+  // with reordered dofs by its components, such that the rows in the
+  // final matrix are locally not in a contiguous set.
+
+  dealii::TrilinosWrappers::SparsityPattern sp_M(parallel_partitioning,
+                                                 MPI_COMM_WORLD,
+                                                 2);
+
+  sp_M.add(MyPID, MyPID);
+  sp_M.add(MyPID, NumProc + MyPID);
+  sp_M.add(NumProc + MyPID, MyPID);
+  sp_M.add(NumProc + MyPID, NumProc + MyPID);
+
+  sp_M.compress();
+
+  // create matrix with dummy entries on the diagonal
+  dealii::TrilinosWrappers::SparseMatrix M0;
+  M0.reinit(sp_M);
+  M0 = 0;
+
+  for (const auto &i : parallel_partitioning)
+    M0.set(i, i, dealii::numbers::PI);
+
+  M0.compress(dealii::VectorOperation::insert);
+
+  ////////////////////////////////////////////////////////////////////////
+  // test ::add(TrilinosScalar, SparseMatrix)
+  //
+
+  dealii::TrilinosWrappers::SparseMatrix M1;
+  M1.reinit(sp_M); // avoid deep copy
+  M1 = 0;
+  M1.copy_from(M0);
+
+  // check
+  for (const auto &i : parallel_partitioning)
+    {
+      const auto &el = M1.el(i, i);
+
+      if (!MyPID)
+        deallog << "i = " << i << " , j = " << i << " , el = " << el
+                << std::endl;
+
+      AssertThrow(el == dealii::numbers::PI, dealii::ExcInternalError());
+    }
+
+  if (!MyPID)
+    deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+
+  test();
+}

--- a/tests/trilinos/sparse_matrix_copy_from_02.with_trilinos=true.with_mpi=true.mpirun=3.output
+++ b/tests/trilinos/sparse_matrix_copy_from_02.with_trilinos=true.with_mpi=true.mpirun=3.output
@@ -1,0 +1,5 @@
+
+DEAL::NumProc=3
+DEAL::i = 0 , j = 0 , el = 3.14159
+DEAL::i = 3 , j = 3 , el = 3.14159
+DEAL::OK


### PR DESCRIPTION
When reordering the dofs, e.g. component wise, it can happen that the locally owned rows do not be in a contiguous set. This PR resolves that issue. This is a bugfix.

A test program can currently be found on http://bitbucket.org/dtmproject/unittest-001
I'll write a file for the test suite, but I think I need support from you.