### PR TITLE
contrib/utilities/indent: Only touch files that actually changed

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -75,9 +75,19 @@ fi
 # - -n 50 calls the following script with up to 50 file names at a time
 # - -P 10 calls the following script up to 10 times in parallel
 #
+
+indent()
+{
+  f=$1
+  clang-format "$f" > "$f.tmp"
+  diff -q "$f" "$f.tmp" >/dev/null || mv "$f.tmp" "$f"
+  rm -f "$f.tmp"
+}
+export -f indent
+
 find tests include source examples \
   \( -name '*.cc' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' \) -print0 |
-  xargs -0 -n 50 -P 10 clang-format -i
+  xargs -0 -n 1 -P 10 -I {} bash -c 'indent "$@"' _ {}
 
 #
 # Use the same process to set file permissions for all source files.


### PR DESCRIPTION
Running ./contrib/utilities/indent with clang-format has the unfortunate
side effect that all files get a new mtime and have to be recompiled.

Thus, use the same temporary file workaround for a call to clang-format
as well.

Closes #6760