### PR TITLE
 Avoid crash for no iteration in GMRES eigenvalue approximation 

### DIFF
--- a/doc/news/changes/minor/20180615DanielArndt
+++ b/doc/news/changes/minor/20180615DanielArndt
@@ -1,0 +1,4 @@
+Fixed: The eigenvalue approximation in SolverGMRES failed if no iterations
+were performed. Now, there is simply no output in this case.
+<br>
+(Daniel Arndt, 2018/06/15)

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -743,8 +743,9 @@ SolverGMRES<VectorType>::compute_eigs_and_cond(
   const boost::signals2::signal<void(double)> &cond_signal)
 {
   // Avoid copying the Hessenberg matrix if it isn't needed.
-  if (!eigenvalues_signal.empty() || !hessenberg_signal.empty() ||
-      !cond_signal.empty())
+  if ((!eigenvalues_signal.empty() || !hessenberg_signal.empty() ||
+       !cond_signal.empty()) &&
+      dim > 0)
     {
       LAPACKFullMatrix<double> mat(dim, dim);
       for (unsigned int i = 0; i < dim; ++i)

--- a/tests/lac/gmres_eigenvalues_02.cc
+++ b/tests/lac/gmres_eigenvalues_02.cc
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// test that GMRES eigenvalue approximation doesn't crash
+// when no iterations are performed.
+
+#include <deal.II/lac/lapack_full_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/vector.h>
+
+#include "../tests.h"
+
+template <typename number>
+void
+test()
+{
+  const unsigned int n = 2;
+  ;
+  Vector<number> rhs(n), sol(n);
+  rhs = 0.;
+
+  LAPACKFullMatrix<number> matrix(n, n);
+
+  for (unsigned int i = 0; i < n; ++i)
+    matrix(i, i) = std::sqrt(i + 1);
+
+  SolverControl control;
+  {
+    SolverGMRES<Vector<number>> solver(control);
+    solver.connect_eigenvalues_slot(
+      [](const std::vector<std::complex<double>> &eigenvalues) {
+        deallog << "n_eigenvalues: " << eigenvalues.size();
+      });
+    solver.solve(matrix, sol, rhs, PreconditionIdentity());
+  }
+
+  {
+    SolverCG<Vector<number>> solver(control);
+    solver.connect_eigenvalues_slot([](const std::vector<double> &eigenvalues) {
+      deallog << "n_eigenvalues: " << eigenvalues.size();
+    });
+    solver.solve(matrix, sol, rhs, PreconditionIdentity());
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+  test<double>();
+}

--- a/tests/lac/gmres_eigenvalues_02.with_lapack=true.output
+++ b/tests/lac/gmres_eigenvalues_02.with_lapack=true.output
@@ -1,0 +1,6 @@
+
+DEAL:GMRES::Starting value 0.00000
+DEAL:GMRES::Convergence step 0 value 0.00000
+DEAL:cg::Starting value 0.00000
+DEAL:cg::Convergence step 0 value 0.00000
+DEAL::OK


### PR DESCRIPTION
Previously, we were trying to call `LAPACKFullMatrix::compute_eigenvalues` with an empty matrix when the GMRES solver converged immediately and eigenvalue approximation was requested. This PR simply avoids to output information in that case.