### PR TITLE
Use clang-tidy's modernize-deprecated-headers

### DIFF
--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -78,7 +78,7 @@
 // output files. The first header provides the <code>mkdir</code> function and
 // the second lets us determine what happened if <code>mkdir</code> fails.
 #include <sys/stat.h>
-#include <errno.h>
+#include <cerrno>
 
 namespace Step42
 {

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -49,7 +49,7 @@
 #include <sstream>
 
 // we use uint32_t and uint8_t below, which are declared here:
-#include <stdint.h>
+#include <cstdint>
 
 #ifdef DEAL_II_WITH_ZLIB
 #  include <zlib.h>

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -49,7 +49,7 @@
 #endif
 
 #ifndef DEAL_II_MSVC
-#  include <stdlib.h>
+#  include <cstdlib>
 #endif
 
 

--- a/tests/quick_tests/adolc.cc
+++ b/tests/quick_tests/adolc.cc
@@ -24,7 +24,8 @@
 #include <adolc/adouble.h>
 #include <adolc/drivers/drivers.h>
 #include <adolc/taping.h>
-#include <math.h>
+
+#include <cmath>
 
 using namespace dealii;
 


### PR DESCRIPTION
Clean up the `run_clang_tidy.sh`a bit and at the 'modernize-deprecated-headers` check. Related to #5938.