### PR TITLE
Fix compiling with older Intel compilers

### DIFF
--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -439,6 +439,7 @@ public:
   FESystem(const std::vector<const FiniteElement<dim, spacedim> *> &fes,
            const std::vector<unsigned int> &multiplicities);
 
+#  if !defined(__INTEL_COMPILER) || __INTEL_COMPILER >= 1900
   /**
    * Constructor taking an arbitrary number of parameters of type
    * <code>std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned
@@ -477,9 +478,10 @@ public:
    * would have expected).
    *
    * @warning This feature is not available for Intel compilers
-   * prior to version 19.0
+   * prior to version 19.0. Defining this
+   * constructor leads to internal compiler errors for Intel compilers prior
+   * to 18.0.
    */
-#  if !defined(__INTEL_COMPILER) || __INTEL_COMPILER >= 1900
   template <
     class... FEPairs,
     typename = typename enable_if_all<
@@ -499,7 +501,8 @@ public:
    * @endcode
    *
    * @warning This feature is not available for Intel compilers
-   * prior to version 19.0
+   * prior to version 19.0. The constructor is just not selected for overload
+   * resolution.
    */
   FESystem(
     const std::initializer_list<

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -475,7 +475,11 @@ public:
    * In other words, if no multiplicity for an element is explicitly specified
    * via the exponentiation operation, then it is assumed to be one (as one
    * would have expected).
+   *
+   * @warning This feature is not available for Intel compilers
+   * prior to version 19.0
    */
+#  if !defined(__INTEL_COMPILER) || __INTEL_COMPILER >= 1900
   template <
     class... FEPairs,
     typename = typename enable_if_all<
@@ -493,11 +497,15 @@ public:
    *   FiniteElementType1<dim,spacedim> fe_2;
    *   FESystem<dim,spacedim> fe_system = { fe_1^dim, fe_2^1 };
    * @endcode
+   *
+   * @warning This feature is not available for Intel compilers
+   * prior to version 19.0
    */
   FESystem(
     const std::initializer_list<
       std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int>>
       &fe_systems);
+#  endif
 
   /**
    * Copy constructor. This constructor is deleted, i.e., copying
@@ -1272,6 +1280,7 @@ namespace internal
 
 
 
+#    if !defined(__INTEL_COMPILER) || __INTEL_COMPILER >= 1900
 // We are just forwarding/delegating to the constructor taking a
 // std::initializer_list. If we decide to remove the deprecated constructors, we
 // might just use the variadic constructor with a suitable static_assert instead
@@ -1316,6 +1325,7 @@ FESystem<dim, spacedim>::FESystem(
 
   initialize(fes, multiplicities);
 }
+#    endif
 
 #  endif // DOXYGEN
 


### PR DESCRIPTION
This PR fixes compiling with Intel 2016 and 2017 for me. The problematic PR was #5090, more specifically commit dc2d367d062ea093e036172e003ad90d4cb030ee. In particular, the second part
```
std::is_base_of<FiniteElement<dim, spacedim>, typename std::decay<FEPairs>::type>::value)
```
in
```
template <class... FEPairs,
            typename = typename enable_if_all<
              (std::is_same<typename std::decay<FEPairs>::type,
                            std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int>>::value
               ||
               std::is_base_of<FiniteElement<dim, spacedim>,
                               typename std::decay<FEPairs>::type>::value)
              ...
              >::type
            >
  FESystem (FEPairs &&... fe_pairs);
```
caused internal compiler errors in the older compilers even if we were not using them at all. (In fact, it dependends on the existence of other member variables for these problems to be visable). 
Since we know that these constructors are not working properly for anything before `Intel 19`, I decided to just disable them all together and not just the problematic part.
I didn't touch the tests respective tests `fe_system_03` and `fe_system_04` since the behavior doesn't change anyway.

I tested compiling with `ICC-16` and `ICC-17` and additionally ran the `FESystem` tests for `ICC 19`.