### PR TITLE
Add missing include files in boundary_*.h

### DIFF
--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -16,6 +16,8 @@
 #ifndef dealii_tria_boundary_h
 #define dealii_tria_boundary_h
 
+#include <deal.II/base/config.h>
+
 #warning This file is deprecated. Use the Manifold classes instead.
 
 #endif

--- a/include/deal.II/grid/tria_boundary_lib.h
+++ b/include/deal.II/grid/tria_boundary_lib.h
@@ -16,6 +16,8 @@
 #ifndef dealii_tria_boundary_lib_h
 #define dealii_tria_boundary_lib_h
 
+#include <deal.II/base/config.h>
+
 #warning This file is deprecated. Use the Manifold classes instead.
 
 #endif


### PR DESCRIPTION
We need `base/config.h` for the `all-headers` tests to pass.