### PR TITLE
Be less aggressive when deprecating classes

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -30,6 +30,7 @@
 #include <deal.II/dofs/dof_faces.h>
 #include <deal.II/dofs/dof_iterator_selector.h>
 #include <deal.II/dofs/dof_levels.h>
+#include <deal.II/dofs/function_map.h> // keep for backward-compatibility
 #include <deal.II/dofs/number_cache.h>
 
 #include <deal.II/hp/fe_collection.h>

--- a/include/deal.II/dofs/function_map.h
+++ b/include/deal.II/dofs/function_map.h
@@ -15,7 +15,6 @@
 
 #ifndef dealii_function_map_h
 #define dealii_function_map_h
-#warning This file is deprecated.
 
 #include <deal.II/base/config.h>
 

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -28,6 +28,7 @@
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_iterator_selector.h>
+#include <deal.II/dofs/function_map.h> // keep for backward-compatibility
 #include <deal.II/dofs/number_cache.h>
 
 #include <deal.II/hp/dof_faces.h>

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -56,19 +56,6 @@ namespace internals
 template <typename number>
 class AffineConstraints;
 
-/**
- * ConstraintMatrix has been renamed to AffineConstraints. Provide a
- * compatibility typedef that defaults to AffineConstraints<double>.
- *
- * @deprecated Use AffineConstraints<double> instead of ConstraintMatrix
- */
-using ConstraintMatrix = AffineConstraints<double>;
-// Note: Unfortunately, we cannot move this compatibility typedef into
-// constraint_matrix.h directly. This would break a lot of user projects
-// that include constraint_matrix.h transitively due to various deal.II
-// headers that include the file.
-
-
 // TODO[WB]: We should have a function of the kind
 //   AffineConstraints::add_constraint (const size_type constrained_dof,
 //     const std::vector<std::pair<size_type, number> > &entries,

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -17,8 +17,18 @@
 #ifndef dealii_constraint_matrix_h
 #define dealii_constraint_matrix_h
 
-#warning This file is deprecated. Use <deal.II/lac/affine_constraints.h> instead.
-
 #include <deal.II/lac/affine_constraints.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * ConstraintMatrix has been renamed to AffineConstraints. Provide a
+ * compatibility typedef that defaults to AffineConstraints<double>.
+ *
+ * @deprecated Use AffineConstraints<double> instead of ConstraintMatrix
+ */
+using ConstraintMatrix DEAL_II_DEPRECATED = AffineConstraints<double>;
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -24,7 +24,8 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/constraint_matrix.h> // keep for backward-compatibility
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include <deal.II/matrix_free/face_info.h>

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -35,8 +35,9 @@
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/q_collection.h>
 
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/block_vector_base.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/constraint_matrix.h> // keep for backward-compatibility
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/vector_operation.h>
 

--- a/include/deal.II/multigrid/mg_transfer_block.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_block.templates.h
@@ -23,7 +23,8 @@
 
 #include <deal.II/grid/tria_iterator.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/constraint_matrix.h> // keep for backward-compatibility
 #include <deal.II/lac/sparse_matrix.h>
 
 #include <deal.II/multigrid/mg_base.h>

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -24,9 +24,10 @@
 
 #include <deal.II/fe/component_mask.h>
 
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/block_vector.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/constraint_matrix.h> // keep for backward-compatibility
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/vector_memory.h>
 

--- a/include/deal.II/multigrid/mg_transfer_component.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_component.templates.h
@@ -23,7 +23,8 @@
 
 #include <deal.II/grid/tria_iterator.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/constraint_matrix.h> // keep for backward-compatibility
 #include <deal.II/lac/sparse_matrix.h>
 
 #include <deal.II/multigrid/mg_base.h>

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -22,6 +22,8 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
 
+#include <deal.II/dofs/function_map.h> // keep for backward-compatibility
+
 #include <deal.II/fe/component_mask.h>
 
 #include <map>

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -23,6 +23,8 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/thread_management.h>
 
+#include <deal.II/dofs/function_map.h> // keep for backward-compatibility
+
 #include <deal.II/lac/affine_constraints.h>
 
 #include <map>

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -25,6 +25,7 @@
 #include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/function_map.h> // keep for backward-compatibility
 
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/mapping_collection.h>


### PR DESCRIPTION
Fixes #6765. In particular, don't use `#warning` in header files we want to keep for backward-compatibility. 
Also, move the `ConstraintMatrix` alias into the correct header file and deprecate it.