### PR TITLE
Avoid constraint matrix headers h

### DIFF
--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -28,7 +28,7 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria_accessor.h>

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -35,7 +35,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria_accessor.h>

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -31,7 +31,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>

--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -33,7 +33,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>

--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -28,7 +28,7 @@
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/utilities.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/sparse_matrix.h>

--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -28,7 +28,7 @@
 #include <deal.II/base/multithread_info.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/grid/tria.h>

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -34,7 +34,7 @@
 #include <deal.II/lac/petsc_parallel_sparse_matrix.h>
 #include <deal.II/lac/petsc_solver.h>
 #include <deal.II/lac/petsc_precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/distributed/shared_tria.h>
 #include <deal.II/grid/tria.h>

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -35,7 +35,7 @@
 #include <deal.II/lac/block_sparse_matrix.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -31,7 +31,7 @@
 #include <deal.II/lac/block_sparse_matrix.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>

--- a/examples/step-23/step-23.cc
+++ b/examples/step-23/step-23.cc
@@ -32,7 +32,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>

--- a/examples/step-24/step-24.cc
+++ b/examples/step-24/step-24.cc
@@ -32,7 +32,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>

--- a/examples/step-25/step-25.cc
+++ b/examples/step-25/step-25.cc
@@ -36,7 +36,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria_accessor.h>

--- a/examples/step-26/step-26.cc
+++ b/examples/step-26/step-26.cc
@@ -30,7 +30,7 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_refinement.h>

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -33,7 +33,7 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria_accessor.h>

--- a/examples/step-28/step-28.cc
+++ b/examples/step-28/step-28.cc
@@ -40,7 +40,7 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_refinement.h>
 #include <deal.II/grid/grid_out.h>

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -31,7 +31,7 @@
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -37,7 +37,7 @@
 #include <deal.II/lac/solver_bicgstab.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_gmres.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -42,7 +42,7 @@
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/sparse_ilu.h>
 #include <deal.II/lac/sparse_direct.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>

--- a/examples/step-36/step-36.cc
+++ b/examples/step-36/step-36.cc
@@ -42,7 +42,7 @@
 #include <deal.II/numerics/vector_tools.h>
 #include <deal.II/numerics/matrix_tools.h>
 #include <deal.II/numerics/data_out.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/full_matrix.h>
 
 // IndexSet is used to set the size of each PETScWrappers::MPI::Vector:

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -25,7 +25,7 @@
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/la_parallel_vector.h>

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -53,7 +53,7 @@ namespace LA
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/solver_cg.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include <deal.II/lac/petsc_parallel_sparse_matrix.h>

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -29,7 +29,7 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/index_set.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -37,7 +37,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/solver_bicgstab.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -38,7 +38,7 @@
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -58,7 +58,7 @@
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_selector.h>
 #include <deal.II/lac/sparse_direct.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 // Here are the headers necessary to use the LinearOperator class.
 // These are also all conveniently packaged into a single

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -45,7 +45,7 @@
 #include <deal.II/distributed/grid_refinement.h>
 
 #include <deal.II/lac/solver_cg.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 #include <deal.II/lac/trilinos_solver.h>
 #include <deal.II/lac/trilinos_precondition.h>

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -34,7 +34,7 @@
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparse_direct.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -29,7 +29,7 @@
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/numerics/vector_tools.h>

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -35,7 +35,7 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/conditional_ostream.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/sparse_matrix.h>

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -30,7 +30,7 @@
 #include <deal.II/base/work_stream.h>
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/lac/vector.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_bicgstab.h>

--- a/examples/step-52/step-52.cc
+++ b/examples/step-52/step-52.cc
@@ -37,7 +37,7 @@
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/sparse_direct.h>
 
 #include <deal.II/numerics/vector_tools.h>

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -46,7 +46,7 @@ namespace LA
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/solver_minres.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include <deal.II/lac/petsc_parallel_sparse_matrix.h>

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -30,7 +30,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_gmres.h>
 

--- a/examples/step-57/step-57.cc
+++ b/examples/step-57/step-57.cc
@@ -32,7 +32,7 @@
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/sparse_direct.h>
 
 #include <deal.II/grid/tria.h>

--- a/examples/step-59/step-59.cc
+++ b/examples/step-59/step-59.cc
@@ -27,7 +27,7 @@
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/la_parallel_vector.h>

--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -66,7 +66,7 @@
 // the global solution is continuous. We are also going to store the boundary
 // conditions in this object. The following file contains a class which is
 // used to handle these constraints:
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 
 // In order to refine our grids locally, we need a function from the library
 // that decides which cells to flag for refinement or coarsening based on the

--- a/examples/step-60/step-60.cc
+++ b/examples/step-60/step-60.cc
@@ -142,7 +142,7 @@
 // We'll discuss its use in detail later on in the `setup_coupling` method.
 #include <deal.II/non_matching/coupling.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/sparse_direct.h>

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -31,7 +31,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_refinement.h>

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -31,7 +31,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_refinement.h>

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -29,7 +29,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/solver_bicgstab.h>
 #include <deal.II/lac/precondition.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_refinement.h>

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -62,7 +62,7 @@ class AffineConstraints;
  *
  * @deprecated Use AffineConstraints<double> instead of ConstraintMatrix
  */
-using ConstraintMatrix = AffineConstraints<double>;
+using ConstraintMatrix DEAL_II_DEPRECATED = AffineConstraints<double>;
 // Note: Unfortunately, we cannot move this compatibility typedef into
 // constraint_matrix.h directly. This would break a lot of user projects
 // that include constraint_matrix.h transitively due to various deal.II

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -24,7 +24,7 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include <deal.II/matrix_free/face_info.h>

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -35,8 +35,8 @@
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/q_collection.h>
 
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/block_vector_base.h>
-#include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/vector_operation.h>
 

--- a/include/deal.II/multigrid/mg_transfer_block.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_block.templates.h
@@ -23,7 +23,7 @@
 
 #include <deal.II/grid/tria_iterator.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/sparse_matrix.h>
 
 #include <deal.II/multigrid/mg_base.h>

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -24,9 +24,9 @@
 
 #include <deal.II/fe/component_mask.h>
 
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/block_vector.h>
-#include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/vector_memory.h>
 

--- a/include/deal.II/multigrid/mg_transfer_component.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_component.templates.h
@@ -23,7 +23,7 @@
 
 #include <deal.II/grid/tria_iterator.h>
 
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/sparse_matrix.h>
 
 #include <deal.II/multigrid/mg_base.h>


### PR DESCRIPTION
Supersedes #6785 partly and fixes the warnings in https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&onlydeltap&buildid=2675. Additionally, deprecate the `ConstraintMatrix` alias.