### PR TITLE
Introduce min and max to VectorOperation

### DIFF
--- a/doc/news/changes/minor/20180618SvenjaSchoeder
+++ b/doc/news/changes/minor/20180618SvenjaSchoeder
@@ -1,0 +1,6 @@
+New: The LinearAlgebra::distributed::Vector::compress() function has
+gained two new combine operations VectorOperation::min and
+VectorOperation::max to define the entry at the owning processor as
+the minimum/maximum of its own value and the one coming from a ghost.
+<br>
+(Svenja Schoeder, 2018/06/18)

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -329,6 +329,43 @@ namespace Utilities
         return a;
       }
 
+      // In the import_from_ghosted_array_finish we need to calculate maximal
+      // and minimal value on number types, which is not straight forward for
+      // complex numbers. Therfore, comparison of complex numbers is
+      // prohibited and throw an assert.
+      template <typename Number>
+      Number
+      get_min(const Number a, const Number b)
+      {
+        return std::min(a, b);
+      }
+
+      template <typename Number>
+      std::complex<Number>
+      get_min(const std::complex<Number> a, const std::complex<Number>)
+      {
+        AssertThrow(false,
+                    ExcMessage("VectorOperation::min max not"
+                               "implemented for complex numbers"));
+        return a;
+      }
+
+      template <typename Number>
+      Number
+      get_max(const Number a, const Number b)
+      {
+        return std::max(a, b);
+      }
+
+      template <typename Number>
+      std::complex<Number>
+      get_max(const std::complex<Number> a, const std::complex<Number>)
+      {
+        AssertThrow(false,
+                    ExcMessage("VectorOperation::min max not "
+                               "implemented for complex numbers"));
+        return a;
+      }
     } // namespace internal
 
 
@@ -403,11 +440,29 @@ namespace Utilities
           // local values. For insert, nothing is done here (but in debug mode
           // we assert that the specified value is either zero or matches with
           // the ones already present
-          if (vector_operation != dealii::VectorOperation::insert)
+          if (vector_operation == dealii::VectorOperation::add)
             for (; my_imports != import_indices_data.end(); ++my_imports)
               for (unsigned int j = my_imports->first; j < my_imports->second;
                    j++)
                 locally_owned_array[j] += *read_position++;
+          else if (vector_operation == dealii::VectorOperation::min)
+            for (; my_imports != import_indices_data.end(); ++my_imports)
+              for (unsigned int j = my_imports->first; j < my_imports->second;
+                   j++)
+                {
+                  locally_owned_array[j] =
+                    internal::get_min(*read_position, locally_owned_array[j]);
+                  read_position++;
+                }
+          else if (vector_operation == dealii::VectorOperation::max)
+            for (; my_imports != import_indices_data.end(); ++my_imports)
+              for (unsigned int j = my_imports->first; j < my_imports->second;
+                   j++)
+                {
+                  locally_owned_array[j] =
+                    internal::get_max(*read_position, locally_owned_array[j]);
+                  read_position++;
+                }
           else
             for (; my_imports != import_indices_data.end(); ++my_imports)
               for (unsigned int j = my_imports->first; j < my_imports->second;

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -329,10 +329,10 @@ namespace Utilities
         return a;
       }
 
-      // In the import_from_ghosted_array_finish we need to calculate maximal
-      // and minimal value on number types, which is not straight forward for
-      // complex numbers. Therfore, comparison of complex numbers is
-      // prohibited and throw an assert.
+      // In the import_from_ghosted_array_finish we might need to calculate the
+      // maximal and minimal value for the given number type, which is not
+      // straight forward for complex numbers. Therefore, comparison of complex
+      // numbers is prohibited and throws an exception.
       template <typename Number>
       Number
       get_min(const Number a, const Number b)
@@ -345,7 +345,7 @@ namespace Utilities
       get_min(const std::complex<Number> a, const std::complex<Number>)
       {
         AssertThrow(false,
-                    ExcMessage("VectorOperation::min max not"
+                    ExcMessage("VectorOperation::min not "
                                "implemented for complex numbers"));
         return a;
       }
@@ -362,7 +362,7 @@ namespace Utilities
       get_max(const std::complex<Number> a, const std::complex<Number>)
       {
         AssertThrow(false,
-                    ExcMessage("VectorOperation::min max not "
+                    ExcMessage("VectorOperation::max not "
                                "implemented for complex numbers"));
         return a;
       }

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -417,12 +417,18 @@ namespace LinearAlgebra
        * ghost element is found, it is compared to the value on the owning
        * processor and an exception is thrown if these elements do not agree.
        * If called with VectorOperation::min or VectorOperation::max the
-       * minimum or maximum on all elements across the processors is set. If
-       * a processor does not set values for the ghosts, the value 0.0 is
-       * assumed, which can be the minimal or maximal value across all
-       * processors. The operations min and max are reasonable if all
-       * processors set relevant values or set values that do not alter the
-       * results, e.g. small values for the max operation.
+       * minimum or maximum on all elements across the processors is set.
+       * @note This vector class has a fixed set of ghost entries attached to
+       * the local representation. As a consequence, all ghost entries are
+       * assumed to be valid and will be unconditionally exchanged according
+       * to the given VectorOperation. Make sure to initialize all ghost
+       * entries with the neutral element of the given VectorOperation. The
+       * neutral element is zero for VectorOperation::add and
+       * VectorOperation::insert, `+inf` for VectorOperation::min, and `-inf`
+       * for VectorOperation::max or touch all ghost entries. If all values
+       * are initialized with values below zero and compress is called with
+       * VectorOperation::max two times subsequently, the maximal value
+       * after the second calculation will be zero.
        */
       virtual void
       compress(::dealii::VectorOperation::values operation) override;

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -402,7 +402,7 @@ namespace LinearAlgebra
        * @ref GlossCompress "Compressing distributed vectors and matrices"
        * in the glossary.
        *
-       * There are two variants for this function. If called with argument @p
+       * There are four variants for this function. If called with argument @p
        * VectorOperation::add adds all the data accumulated in ghost elements
        * to the respective elements on the owning processor and clears the
        * ghost array afterwards. If called with argument @p
@@ -416,6 +416,13 @@ namespace LinearAlgebra
        * actually consistent between processors, i.e., whenever a non-zero
        * ghost element is found, it is compared to the value on the owning
        * processor and an exception is thrown if these elements do not agree.
+       * If called with VectorOperation::min or VectorOperation::max the
+       * minimum or maximum on all elements across the processors is set. If
+       * a processor does not set values for the ghosts, the value 0.0 is
+       * assumed, which can be the minimal or maximal value across all
+       * processors. The operations min and max are reasonable if all
+       * processors set relevant values or set values that do not alter the
+       * results, e.g. small values for the max operation.
        */
       virtual void
       compress(::dealii::VectorOperation::values operation) override;

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -416,18 +416,18 @@ namespace LinearAlgebra
        * actually consistent between processors, i.e., whenever a non-zero
        * ghost element is found, it is compared to the value on the owning
        * processor and an exception is thrown if these elements do not agree.
-       * If called with VectorOperation::min or VectorOperation::max the
+       * If called with VectorOperation::min or VectorOperation::max, the
        * minimum or maximum on all elements across the processors is set.
        * @note This vector class has a fixed set of ghost entries attached to
        * the local representation. As a consequence, all ghost entries are
-       * assumed to be valid and will be unconditionally exchanged according
+       * assumed to be valid and will be exchanged unconditionally according
        * to the given VectorOperation. Make sure to initialize all ghost
-       * entries with the neutral element of the given VectorOperation. The
-       * neutral element is zero for VectorOperation::add and
-       * VectorOperation::insert, `+inf` for VectorOperation::min, and `-inf`
-       * for VectorOperation::max or touch all ghost entries. If all values
-       * are initialized with values below zero and compress is called with
-       * VectorOperation::max two times subsequently, the maximal value
+       * entries with the neutral element of the given VectorOperation or
+       * touch all ghost entries. The neutral element is zero for
+       * VectorOperation::add and VectorOperation::insert, `+inf` for
+       * VectorOperation::min, and `-inf` for VectorOperation::max. If all
+       * values are initialized with values below zero and compress is called
+       * with VectorOperation::max two times subsequently, the maximal value
        * after the second calculation will be zero.
        */
       virtual void

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -252,10 +252,10 @@ namespace LinearAlgebra
 
   namespace internal
   {
-    // In the import_from_ghosted_array_finish we need to calculate maximal
-    // and minimal value on number types, which is not straight forward for
-    // complex numbers. Therfore, comparison of complex numbers is
-    // prohibited and throw an assert.
+    // In the import_from_ghosted_array_finish we need to calculate the maximal
+    // and minimal value for the given number type, which is not straight
+    // forward for complex numbers. Therefore, comparison of complex numbers is
+    // prohibited and throws an assert.
     template <typename Number>
     Number
     get_min(const Number a, const Number b)
@@ -268,7 +268,7 @@ namespace LinearAlgebra
     get_min(const std::complex<Number> a, const std::complex<Number>)
     {
       AssertThrow(false,
-                  ExcMessage("VectorOperation::min max not"
+                  ExcMessage("VectorOperation::min not "
                              "implemented for complex numbers"));
       return a;
     }
@@ -285,7 +285,7 @@ namespace LinearAlgebra
     get_max(const std::complex<Number> a, const std::complex<Number>)
     {
       AssertThrow(false,
-                  ExcMessage("VectorOperation::min max not "
+                  ExcMessage("VectorOperation::max not "
                              "implemented for complex numbers"));
       return a;
     }

--- a/include/deal.II/lac/vector_operation.h
+++ b/include/deal.II/lac/vector_operation.h
@@ -50,7 +50,15 @@ struct VectorOperation
     /**
      * The current operation is an addition.
      */
-    add
+    add,
+    /**
+     * The current operation is a minimization.
+     */
+    min,
+    /**
+     * The current operation is a maximization.
+     */
+    max
   };
 };
 

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -615,7 +615,7 @@ namespace LinearAlgebra
                                               cudaMemcpyHostToDevice);
           AssertCuda(error_code);
         }
-      else
+      else if (operation == VectorOperation::add)
         {
           // Create a temporary vector on the device
           Number *    tmp;
@@ -644,6 +644,8 @@ namespace LinearAlgebra
           error_code = cudaFree(tmp);
           AssertCuda(error_code);
         }
+      else
+        AssertThrow(false, ExcNotImplemented());
     }
 
 

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -187,8 +187,14 @@ namespace LinearAlgebra
 
       if (operation == VectorOperation::insert)
         vector->Export(source_vector, import, Insert);
-      else
+      else if (operation == VectorOperation::add)
         vector->Export(source_vector, import, Add);
+      else if (operation == VectorOperation::max)
+        vector->Export(source_vector, import, Epetra_Max);
+      else if (operation == VectorOperation::min)
+        vector->Export(source_vector, import, Epetra_Min);
+      else
+        AssertThrow(false, ExcNotImplemented());
     }
 
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1158,7 +1158,8 @@ namespace TrilinosWrappers
         else
           Assert(
             false,
-            "compress() can only be called with VectorOperation add, insert, or unknown");
+            ExcMessage(
+              "compress() can only be called with VectorOperation add, insert, or unknown"));
       }
     else
       {

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1155,6 +1155,10 @@ namespace TrilinosWrappers
           mode = Add;
         else if (operation == ::dealii::VectorOperation::insert)
           mode = Insert;
+        else
+          Assert(
+            false,
+            "compress() can only be called with VectorOperation add, insert, or unknown");
       }
     else
       {

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -560,6 +560,10 @@ namespace TrilinosWrappers
             mode = Add;
           else if (given_last_action == ::dealii::VectorOperation::insert)
             mode = Insert;
+          else
+            Assert(
+              false,
+              "compress() can only be called with VectorOperation add, insert, or unknown");
         }
       else
         {

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -563,7 +563,8 @@ namespace TrilinosWrappers
           else
             Assert(
               false,
-              "compress() can only be called with VectorOperation add, insert, or unknown");
+              ExcMessage(
+                "compress() can only be called with VectorOperation add, insert, or unknown"));
         }
       else
         {

--- a/tests/mpi/parallel_vector_22.cc
+++ b/tests/mpi/parallel_vector_22.cc
@@ -62,7 +62,7 @@ test()
   deallog << myid << ":"
           << "second owned entry: " << v(myid * 2 + 1) << std::endl;
 
-  // set ghost dof on not owning processor and maximize
+  // set ghost dof on owning processor and maximize
   if (myid)
     v(1) = 7. * myid;
   v.compress(VectorOperation::max);
@@ -72,7 +72,7 @@ test()
 
   // check
   deallog << myid << ":"
-          << "ghost entry: " << v(1) << std::endl;
+          << "ghost entry after max from owner: " << v(1) << std::endl;
 
   // ghosts are set to zero
   v.zero_out_ghosts();
@@ -83,9 +83,9 @@ test()
 
   // check
   deallog << myid << ":"
-          << "ghost entry: " << v(1) << std::endl;
+          << "ghost entry after min from zero: " << v(1) << std::endl;
 
-  // update of ghost value from owner and minimize
+  // set ghost dof on non-owning processors and minimize
   v.zero_out_ghosts();
   if (!myid)
     v(1) = -1.;
@@ -94,7 +94,44 @@ test()
 
   // check
   deallog << myid << ":"
-          << "ghost entry: " << v(1) << std::endl;
+          << "ghost entry after min from : " << v(1) << std::endl;
+
+  // set vector to 1, zeros in ghosts except on owner where -1. is set
+  v.zero_out_ghosts();
+  v = 1.0;
+  if (!myid)
+    v(1) = -1.0;
+
+  // maximize
+  v.compress(VectorOperation::max);
+  v.update_ghost_values();
+
+  // even if only one value is set (-1. on owner), the other values
+  // contribute a "0" and maximization receives zero and returns it
+  deallog << myid << ":"
+          << "ghost entry after max and partly init: " << v(1) << std::endl;
+
+  // however, if the ghost value is set on all processors, the
+  // maximum is -1:
+  v.zero_out_ghosts();
+  v    = 1.0;
+  v(1) = -1.0;
+  v.compress(VectorOperation::max);
+  v.update_ghost_values();
+  deallog << myid << ":"
+          << "ghost entry after max and full init: " << v(1) << std::endl;
+
+  // what happens in case max is called two times and all values were smaller
+  // than zero
+  v.zero_out_ghosts();
+  v    = -1.0;
+  v(1) = -1.0;
+  v.compress(VectorOperation::max);
+  deallog << myid << ":"
+          << "ghost entry after first max: " << v(1) << std::endl;
+  v.compress(VectorOperation::max);
+  deallog << myid << ":"
+          << "ghost entry after second max: " << v(1) << std::endl;
 
   if (myid == 0)
     deallog << "OK" << std::endl;

--- a/tests/mpi/parallel_vector_22.cc
+++ b/tests/mpi/parallel_vector_22.cc
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check LA::Vector::compress(VectorOperation::min/max) from ghosts
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <iostream>
+#include <vector>
+
+#include "../tests.h"
+
+
+void
+test()
+{
+  unsigned int myid    = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  unsigned int numproc = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+
+  if (myid == 0)
+    deallog << "numproc=" << numproc << std::endl;
+
+
+  // each processor owns 2 indices and all
+  // are ghosting element 1 (the second)
+  IndexSet local_owned(numproc * 2);
+  local_owned.add_range(myid * 2, myid * 2 + 2);
+  IndexSet local_relevant(numproc * 2);
+  local_relevant = local_owned;
+  local_relevant.add_range(1, 2);
+
+  // create vector
+  LinearAlgebra::distributed::Vector<double> v(local_owned,
+                                               local_relevant,
+                                               MPI_COMM_WORLD);
+
+  // set local values
+  v(myid * 2)     = myid * 2.0;
+  v(myid * 2 + 1) = myid * 2.0 + 1.0;
+  v.compress(VectorOperation::add);
+  v *= 2.0;
+
+  // check setup of vectors
+  deallog << myid << ":"
+          << "first owned entry: " << v(myid * 2) << std::endl;
+  deallog << myid << ":"
+          << "second owned entry: " << v(myid * 2 + 1) << std::endl;
+
+  // set ghost dof on not owning processor and maximize
+  if (myid)
+    v(1) = 7. * myid;
+  v.compress(VectorOperation::max);
+
+  // import ghosts onto all procs
+  v.update_ghost_values();
+
+  // check
+  deallog << myid << ":"
+          << "ghost entry: " << v(1) << std::endl;
+
+  // ghosts are set to zero
+  v.zero_out_ghosts();
+
+  // minimize
+  v.compress(VectorOperation::min);
+  v.update_ghost_values();
+
+  // check
+  deallog << myid << ":"
+          << "ghost entry: " << v(1) << std::endl;
+
+  // update of ghost value from owner and minimize
+  v.zero_out_ghosts();
+  if (!myid)
+    v(1) = -1.;
+  v.compress(VectorOperation::min);
+  v.update_ghost_values();
+
+  // check
+  deallog << myid << ":"
+          << "ghost entry: " << v(1) << std::endl;
+
+  if (myid == 0)
+    deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+
+  MPILogInitAll log;
+
+  test();
+}

--- a/tests/mpi/parallel_vector_22.mpirun=10.output
+++ b/tests/mpi/parallel_vector_22.mpirun=10.output
@@ -2,70 +2,110 @@
 DEAL:0::numproc=10
 DEAL:0::0:first owned entry: 0.00000
 DEAL:0::0:second owned entry: 2.00000
-DEAL:0::0:ghost entry: 63.0000
-DEAL:0::0:ghost entry: 0.00000
-DEAL:0::0:ghost entry: -1.00000
+DEAL:0::0:ghost entry after max from owner: 63.0000
+DEAL:0::0:ghost entry after min from zero: 0.00000
+DEAL:0::0:ghost entry after min from : -1.00000
+DEAL:0::0:ghost entry after max and partly init: 0.00000
+DEAL:0::0:ghost entry after max and full init: -1.00000
+DEAL:0::0:ghost entry after first max: -1.00000
+DEAL:0::0:ghost entry after second max: 0.00000
 DEAL:0::OK
 
 DEAL:1::1:first owned entry: 4.00000
 DEAL:1::1:second owned entry: 6.00000
-DEAL:1::1:ghost entry: 63.0000
-DEAL:1::1:ghost entry: 0.00000
-DEAL:1::1:ghost entry: -1.00000
+DEAL:1::1:ghost entry after max from owner: 63.0000
+DEAL:1::1:ghost entry after min from zero: 0.00000
+DEAL:1::1:ghost entry after min from : -1.00000
+DEAL:1::1:ghost entry after max and partly init: 0.00000
+DEAL:1::1:ghost entry after max and full init: -1.00000
+DEAL:1::1:ghost entry after first max: 0.00000
+DEAL:1::1:ghost entry after second max: 0.00000
 
 
 DEAL:2::2:first owned entry: 8.00000
 DEAL:2::2:second owned entry: 10.0000
-DEAL:2::2:ghost entry: 63.0000
-DEAL:2::2:ghost entry: 0.00000
-DEAL:2::2:ghost entry: -1.00000
+DEAL:2::2:ghost entry after max from owner: 63.0000
+DEAL:2::2:ghost entry after min from zero: 0.00000
+DEAL:2::2:ghost entry after min from : -1.00000
+DEAL:2::2:ghost entry after max and partly init: 0.00000
+DEAL:2::2:ghost entry after max and full init: -1.00000
+DEAL:2::2:ghost entry after first max: 0.00000
+DEAL:2::2:ghost entry after second max: 0.00000
 
 
 DEAL:3::3:first owned entry: 12.0000
 DEAL:3::3:second owned entry: 14.0000
-DEAL:3::3:ghost entry: 63.0000
-DEAL:3::3:ghost entry: 0.00000
-DEAL:3::3:ghost entry: -1.00000
+DEAL:3::3:ghost entry after max from owner: 63.0000
+DEAL:3::3:ghost entry after min from zero: 0.00000
+DEAL:3::3:ghost entry after min from : -1.00000
+DEAL:3::3:ghost entry after max and partly init: 0.00000
+DEAL:3::3:ghost entry after max and full init: -1.00000
+DEAL:3::3:ghost entry after first max: 0.00000
+DEAL:3::3:ghost entry after second max: 0.00000
 
 
 DEAL:4::4:first owned entry: 16.0000
 DEAL:4::4:second owned entry: 18.0000
-DEAL:4::4:ghost entry: 63.0000
-DEAL:4::4:ghost entry: 0.00000
-DEAL:4::4:ghost entry: -1.00000
+DEAL:4::4:ghost entry after max from owner: 63.0000
+DEAL:4::4:ghost entry after min from zero: 0.00000
+DEAL:4::4:ghost entry after min from : -1.00000
+DEAL:4::4:ghost entry after max and partly init: 0.00000
+DEAL:4::4:ghost entry after max and full init: -1.00000
+DEAL:4::4:ghost entry after first max: 0.00000
+DEAL:4::4:ghost entry after second max: 0.00000
 
 
 DEAL:5::5:first owned entry: 20.0000
 DEAL:5::5:second owned entry: 22.0000
-DEAL:5::5:ghost entry: 63.0000
-DEAL:5::5:ghost entry: 0.00000
-DEAL:5::5:ghost entry: -1.00000
+DEAL:5::5:ghost entry after max from owner: 63.0000
+DEAL:5::5:ghost entry after min from zero: 0.00000
+DEAL:5::5:ghost entry after min from : -1.00000
+DEAL:5::5:ghost entry after max and partly init: 0.00000
+DEAL:5::5:ghost entry after max and full init: -1.00000
+DEAL:5::5:ghost entry after first max: 0.00000
+DEAL:5::5:ghost entry after second max: 0.00000
 
 
 DEAL:6::6:first owned entry: 24.0000
 DEAL:6::6:second owned entry: 26.0000
-DEAL:6::6:ghost entry: 63.0000
-DEAL:6::6:ghost entry: 0.00000
-DEAL:6::6:ghost entry: -1.00000
+DEAL:6::6:ghost entry after max from owner: 63.0000
+DEAL:6::6:ghost entry after min from zero: 0.00000
+DEAL:6::6:ghost entry after min from : -1.00000
+DEAL:6::6:ghost entry after max and partly init: 0.00000
+DEAL:6::6:ghost entry after max and full init: -1.00000
+DEAL:6::6:ghost entry after first max: 0.00000
+DEAL:6::6:ghost entry after second max: 0.00000
 
 
 DEAL:7::7:first owned entry: 28.0000
 DEAL:7::7:second owned entry: 30.0000
-DEAL:7::7:ghost entry: 63.0000
-DEAL:7::7:ghost entry: 0.00000
-DEAL:7::7:ghost entry: -1.00000
+DEAL:7::7:ghost entry after max from owner: 63.0000
+DEAL:7::7:ghost entry after min from zero: 0.00000
+DEAL:7::7:ghost entry after min from : -1.00000
+DEAL:7::7:ghost entry after max and partly init: 0.00000
+DEAL:7::7:ghost entry after max and full init: -1.00000
+DEAL:7::7:ghost entry after first max: 0.00000
+DEAL:7::7:ghost entry after second max: 0.00000
 
 
 DEAL:8::8:first owned entry: 32.0000
 DEAL:8::8:second owned entry: 34.0000
-DEAL:8::8:ghost entry: 63.0000
-DEAL:8::8:ghost entry: 0.00000
-DEAL:8::8:ghost entry: -1.00000
+DEAL:8::8:ghost entry after max from owner: 63.0000
+DEAL:8::8:ghost entry after min from zero: 0.00000
+DEAL:8::8:ghost entry after min from : -1.00000
+DEAL:8::8:ghost entry after max and partly init: 0.00000
+DEAL:8::8:ghost entry after max and full init: -1.00000
+DEAL:8::8:ghost entry after first max: 0.00000
+DEAL:8::8:ghost entry after second max: 0.00000
 
 
 DEAL:9::9:first owned entry: 36.0000
 DEAL:9::9:second owned entry: 38.0000
-DEAL:9::9:ghost entry: 63.0000
-DEAL:9::9:ghost entry: 0.00000
-DEAL:9::9:ghost entry: -1.00000
+DEAL:9::9:ghost entry after max from owner: 63.0000
+DEAL:9::9:ghost entry after min from zero: 0.00000
+DEAL:9::9:ghost entry after min from : -1.00000
+DEAL:9::9:ghost entry after max and partly init: 0.00000
+DEAL:9::9:ghost entry after max and full init: -1.00000
+DEAL:9::9:ghost entry after first max: 0.00000
+DEAL:9::9:ghost entry after second max: 0.00000
 

--- a/tests/mpi/parallel_vector_22.mpirun=10.output
+++ b/tests/mpi/parallel_vector_22.mpirun=10.output
@@ -1,0 +1,71 @@
+
+DEAL:0::numproc=10
+DEAL:0::0:first owned entry: 0.00000
+DEAL:0::0:second owned entry: 2.00000
+DEAL:0::0:ghost entry: 63.0000
+DEAL:0::0:ghost entry: 0.00000
+DEAL:0::0:ghost entry: -1.00000
+DEAL:0::OK
+
+DEAL:1::1:first owned entry: 4.00000
+DEAL:1::1:second owned entry: 6.00000
+DEAL:1::1:ghost entry: 63.0000
+DEAL:1::1:ghost entry: 0.00000
+DEAL:1::1:ghost entry: -1.00000
+
+
+DEAL:2::2:first owned entry: 8.00000
+DEAL:2::2:second owned entry: 10.0000
+DEAL:2::2:ghost entry: 63.0000
+DEAL:2::2:ghost entry: 0.00000
+DEAL:2::2:ghost entry: -1.00000
+
+
+DEAL:3::3:first owned entry: 12.0000
+DEAL:3::3:second owned entry: 14.0000
+DEAL:3::3:ghost entry: 63.0000
+DEAL:3::3:ghost entry: 0.00000
+DEAL:3::3:ghost entry: -1.00000
+
+
+DEAL:4::4:first owned entry: 16.0000
+DEAL:4::4:second owned entry: 18.0000
+DEAL:4::4:ghost entry: 63.0000
+DEAL:4::4:ghost entry: 0.00000
+DEAL:4::4:ghost entry: -1.00000
+
+
+DEAL:5::5:first owned entry: 20.0000
+DEAL:5::5:second owned entry: 22.0000
+DEAL:5::5:ghost entry: 63.0000
+DEAL:5::5:ghost entry: 0.00000
+DEAL:5::5:ghost entry: -1.00000
+
+
+DEAL:6::6:first owned entry: 24.0000
+DEAL:6::6:second owned entry: 26.0000
+DEAL:6::6:ghost entry: 63.0000
+DEAL:6::6:ghost entry: 0.00000
+DEAL:6::6:ghost entry: -1.00000
+
+
+DEAL:7::7:first owned entry: 28.0000
+DEAL:7::7:second owned entry: 30.0000
+DEAL:7::7:ghost entry: 63.0000
+DEAL:7::7:ghost entry: 0.00000
+DEAL:7::7:ghost entry: -1.00000
+
+
+DEAL:8::8:first owned entry: 32.0000
+DEAL:8::8:second owned entry: 34.0000
+DEAL:8::8:ghost entry: 63.0000
+DEAL:8::8:ghost entry: 0.00000
+DEAL:8::8:ghost entry: -1.00000
+
+
+DEAL:9::9:first owned entry: 36.0000
+DEAL:9::9:second owned entry: 38.0000
+DEAL:9::9:ghost entry: 63.0000
+DEAL:9::9:ghost entry: 0.00000
+DEAL:9::9:ghost entry: -1.00000
+

--- a/tests/mpi/parallel_vector_22.mpirun=4.output
+++ b/tests/mpi/parallel_vector_22.mpirun=4.output
@@ -1,0 +1,29 @@
+
+DEAL:0::numproc=4
+DEAL:0::0:first owned entry: 0.00000
+DEAL:0::0:second owned entry: 2.00000
+DEAL:0::0:ghost entry: 21.0000
+DEAL:0::0:ghost entry: 0.00000
+DEAL:0::0:ghost entry: -1.00000
+DEAL:0::OK
+
+DEAL:1::1:first owned entry: 4.00000
+DEAL:1::1:second owned entry: 6.00000
+DEAL:1::1:ghost entry: 21.0000
+DEAL:1::1:ghost entry: 0.00000
+DEAL:1::1:ghost entry: -1.00000
+
+
+DEAL:2::2:first owned entry: 8.00000
+DEAL:2::2:second owned entry: 10.0000
+DEAL:2::2:ghost entry: 21.0000
+DEAL:2::2:ghost entry: 0.00000
+DEAL:2::2:ghost entry: -1.00000
+
+
+DEAL:3::3:first owned entry: 12.0000
+DEAL:3::3:second owned entry: 14.0000
+DEAL:3::3:ghost entry: 21.0000
+DEAL:3::3:ghost entry: 0.00000
+DEAL:3::3:ghost entry: -1.00000
+

--- a/tests/mpi/parallel_vector_22.mpirun=4.output
+++ b/tests/mpi/parallel_vector_22.mpirun=4.output
@@ -2,28 +2,44 @@
 DEAL:0::numproc=4
 DEAL:0::0:first owned entry: 0.00000
 DEAL:0::0:second owned entry: 2.00000
-DEAL:0::0:ghost entry: 21.0000
-DEAL:0::0:ghost entry: 0.00000
-DEAL:0::0:ghost entry: -1.00000
+DEAL:0::0:ghost entry after max from owner: 21.0000
+DEAL:0::0:ghost entry after min from zero: 0.00000
+DEAL:0::0:ghost entry after min from : -1.00000
+DEAL:0::0:ghost entry after max and partly init: 0.00000
+DEAL:0::0:ghost entry after max and full init: -1.00000
+DEAL:0::0:ghost entry after first max: -1.00000
+DEAL:0::0:ghost entry after second max: 0.00000
 DEAL:0::OK
 
 DEAL:1::1:first owned entry: 4.00000
 DEAL:1::1:second owned entry: 6.00000
-DEAL:1::1:ghost entry: 21.0000
-DEAL:1::1:ghost entry: 0.00000
-DEAL:1::1:ghost entry: -1.00000
+DEAL:1::1:ghost entry after max from owner: 21.0000
+DEAL:1::1:ghost entry after min from zero: 0.00000
+DEAL:1::1:ghost entry after min from : -1.00000
+DEAL:1::1:ghost entry after max and partly init: 0.00000
+DEAL:1::1:ghost entry after max and full init: -1.00000
+DEAL:1::1:ghost entry after first max: 0.00000
+DEAL:1::1:ghost entry after second max: 0.00000
 
 
 DEAL:2::2:first owned entry: 8.00000
 DEAL:2::2:second owned entry: 10.0000
-DEAL:2::2:ghost entry: 21.0000
-DEAL:2::2:ghost entry: 0.00000
-DEAL:2::2:ghost entry: -1.00000
+DEAL:2::2:ghost entry after max from owner: 21.0000
+DEAL:2::2:ghost entry after min from zero: 0.00000
+DEAL:2::2:ghost entry after min from : -1.00000
+DEAL:2::2:ghost entry after max and partly init: 0.00000
+DEAL:2::2:ghost entry after max and full init: -1.00000
+DEAL:2::2:ghost entry after first max: 0.00000
+DEAL:2::2:ghost entry after second max: 0.00000
 
 
 DEAL:3::3:first owned entry: 12.0000
 DEAL:3::3:second owned entry: 14.0000
-DEAL:3::3:ghost entry: 21.0000
-DEAL:3::3:ghost entry: 0.00000
-DEAL:3::3:ghost entry: -1.00000
+DEAL:3::3:ghost entry after max from owner: 21.0000
+DEAL:3::3:ghost entry after min from zero: 0.00000
+DEAL:3::3:ghost entry after min from : -1.00000
+DEAL:3::3:ghost entry after max and partly init: 0.00000
+DEAL:3::3:ghost entry after max and full init: -1.00000
+DEAL:3::3:ghost entry after first max: 0.00000
+DEAL:3::3:ghost entry after second max: 0.00000
 

--- a/tests/mpi/parallel_vector_23.cc
+++ b/tests/mpi/parallel_vector_23.cc
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check LA::Vector::compress(VectorOperation::min/max) from ghosts
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/read_write_vector.h>
+
+#include <iostream>
+#include <vector>
+
+#include "../tests.h"
+
+
+void
+test()
+{
+  unsigned int myid    = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  unsigned int numproc = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+
+  if (myid == 0)
+    deallog << "numproc=" << numproc << std::endl;
+
+
+  // each processor owns 2 indices and all
+  // are ghosting element 1 (the second)
+  IndexSet local_owned(numproc * 2);
+  local_owned.add_range(myid * 2, myid * 2 + 2);
+  IndexSet local_relevant(numproc * 2);
+  local_relevant = local_owned;
+  local_relevant.add_range(1, 2);
+
+  // create vector
+  LinearAlgebra::distributed::Vector<double> v(local_owned,
+                                               local_relevant,
+                                               MPI_COMM_WORLD);
+
+  // the read write vector additionally has ghost elements
+  IndexSet                               read_write_owned(numproc * 2);
+  LinearAlgebra::ReadWriteVector<double> read_write_vector(local_relevant);
+
+  read_write_vector.local_element(0) = myid;
+  read_write_vector(1)               = 2. * myid;
+
+  v.import(read_write_vector, VectorOperation::max);
+  v.update_ghost_values();
+
+  deallog << myid << ":"
+          << "ghost entry after max: " << v(1) << std::endl;
+
+  if (!myid)
+    read_write_vector(1) = -1.0;
+
+  v.import(read_write_vector, VectorOperation::min);
+  v.update_ghost_values();
+
+  deallog << myid << ":"
+          << "ghost entry after min: " << v(1) << std::endl;
+
+
+  if (myid == 0)
+    deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+
+  MPILogInitAll log;
+
+  test();
+}

--- a/tests/mpi/parallel_vector_23.mpirun=4.output
+++ b/tests/mpi/parallel_vector_23.mpirun=4.output
@@ -1,0 +1,17 @@
+
+DEAL:0::numproc=4
+DEAL:0::0:ghost entry after max: 6.00000
+DEAL:0::0:ghost entry after min: -1.00000
+DEAL:0::OK
+
+DEAL:1::1:ghost entry after max: 6.00000
+DEAL:1::1:ghost entry after min: -1.00000
+
+
+DEAL:2::2:ghost entry after max: 6.00000
+DEAL:2::2:ghost entry after min: -1.00000
+
+
+DEAL:3::3:ghost entry after max: 6.00000
+DEAL:3::3:ghost entry after min: -1.00000
+


### PR DESCRIPTION
The LinearAlgebra::distributed::Vector::compress() function has gained two new combine operations VectorOperation::min and VectorOperation::max to define the entry at the owning processor as the minimum/maximum of its own value and the one coming from a ghost.