### PR TITLE
Require TBB 4.2.0 or newer.

### DIFF
--- a/cmake/configure/configure_1_threads.cmake
+++ b/cmake/configure/configure_1_threads.cmake
@@ -138,6 +138,25 @@ MACRO(FEATURE_THREADS_FIND_EXTERNAL var)
   IF(TBB_FOUND)
     SET(${var} TRUE)
   ENDIF()
+
+  #
+  # TBB versions before 4.2 are missing some explicit calls to std::atomic::load
+  # in ternary expressions; these cause compilation errors in some compilers
+  # (such as GCC 8.1 and newer). To fix this we simply blacklist all older
+  # versions:
+  #
+  IF(TBB_VERSION VERSION_LESS "4.2")
+    MESSAGE(STATUS
+      "The externally provided TBB library is older than version 4.2.0, which "
+      "cannot be used with deal.II."
+      )
+    SET(THREADS_ADDITIONAL_ERROR_STRING
+      "The externally provided TBB library is older than version\n"
+      "4.2.0, which is the oldest version compatible with deal.II and its\n"
+      "supported compilers."
+      )
+    SET(${var} FALSE)
+  ENDIF()
 ENDMACRO()
 
 


### PR DESCRIPTION
TBB 4.1 is not compatible with newer versions of GCC due to some missing `std::atomic::load` calls, so lets blacklist all older versions.

Fixes #6711. @bangerth Would you mind checking to make sure that we print the right error message on that centOS machine?