### PR TITLE
Remove redundant namespace identifier

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -913,7 +913,7 @@ namespace VectorTools
         // values, but enforce
         // homogeneous boundary values
         // anyway
-        internal::interpolate_zero_boundary_values(dof, boundary_values);
+        interpolate_zero_boundary_values(dof, boundary_values);
 
       else
         // no homogeneous boundary values


### PR DESCRIPTION
Here, we are already in namespace `internal` so the identifier is not necessary. `MSVC` is complaining here.