### PR TITLE
Also deprecate the p::d::[Block]?Vector header files themselves

### DIFF
--- a/include/deal.II/lac/parallel_block_vector.h
+++ b/include/deal.II/lac/parallel_block_vector.h
@@ -20,6 +20,8 @@
 
 #include <deal.II/lac/la_parallel_block_vector.h>
 
+#warning This file is deprecated. Use <deal.II/lac/la_block_vector.h> and LinearAlgebra::distributed::BlockVector instead.
+
 #include <cstring>
 #include <iomanip>
 

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -20,6 +20,8 @@
 
 #include <deal.II/lac/la_parallel_vector.h>
 
+#warning This file is deprecated. Use <deal.II/lac/la_parallel_vector.h> and LinearAlgebra::distributed::Vector instead.
+
 #include <cstring>
 #include <iomanip>
 


### PR DESCRIPTION
As #6763 it is important to also have warnings in header files just consisting out of not more than deprecated aliases we want to remove in the future.
The aliases in this PR were deprecated in #6710 but we didn't deprecate the two files themselves.