### PR TITLE
Fix using DEAL_II_INVOKE_AUTOPILOT with CUDA enabled

### DIFF
--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -44,6 +44,11 @@ MACRO(DEAL_II_INVOKE_AUTOPILOT)
     SET(_make_command " $ make")
   ENDIF()
 
+  # Make sure we can treat CUDA targets if available
+  IF(DEAL_II_WITH_CUDA)
+    ENABLE_LANGUAGE(CUDA)
+  ENDIF()
+
   # Define and setup a compilation target:
   ADD_EXECUTABLE(${TARGET} ${TARGET_SRC})
   DEAL_II_SETUP_TARGET(${TARGET})


### PR DESCRIPTION
`DEAL_II_INVOKE_AUTOPILOT` invokes `DEAL_II_SETUP_TARGET` which tries to setup CUDA targets.
In particular, 
```
TARGET_COMPILE_OPTIONS(${_target} PUBLIC
         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler ${_cxx_flags}>
         $<$<COMPILE_LANGUAGE:CUDA>:${_cuda_flags}>
         )
```
is executed and fails with
```
$<COMPILE_LANGUAGE:CUDA>
$<COMPILE_LANGUAGE:...> Unknown language.
```
when invoked from any code that didn't enable `cmake` language support for `CUDA`.