### PR TITLE
contrib/utilities: rename to indent and indent-all

### DIFF
--- a/cmake/setup_custom_targets.cmake
+++ b/cmake/setup_custom_targets.cmake
@@ -103,18 +103,18 @@ ENDIF()
 # Provide an indentation target for indenting uncommitted changes and changes on
 # the current feature branch
 #
-ADD_CUSTOM_TARGET(indent-branch
+ADD_CUSTOM_TARGET(indent
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  COMMAND ./contrib/utilities/indent-branch
+  COMMAND ./contrib/utilities/indent
   COMMENT "Indenting recently changed files in the deal.II directories"
   )
 
 #
 # Provide "indent" target for indenting all headers and source files
 #
-ADD_CUSTOM_TARGET(indent
+ADD_CUSTOM_TARGET(indent-all
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  COMMAND ./contrib/utilities/indent
+  COMMAND ./contrib/utilities/indent-all
   COMMENT "Indenting all files in the deal.II directories"
   )
 
@@ -155,9 +155,9 @@ FILE(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/print_info.cmake
 #    setup_tests    - set up testsuite subprojects
 #    prune_tests    - remove all testsuite subprojects
 #
-#    indent         - indent all headers and source files
-#    indent-branch  - indent all headers and source files that changed since the
+#    indent         - indent all headers and source files that changed since the
 #                     last commit to master, including untracked ones
+#    indent-all     - indent all headers and source files
 ")
 
 #

--- a/contrib/git-hooks/pre-commit
+++ b/contrib/git-hooks/pre-commit
@@ -20,18 +20,18 @@
 
 BASEDIR="$(git rev-parse --show-toplevel 2>/dev/null)"
 
-if [ ! -f "${BASEDIR}"/contrib/utilities/indent-branch ]; then
+if [ ! -f "${BASEDIR}"/contrib/utilities/indent ]; then
   echo "*** This script must be run from within the deal.II git repository."
   exit 1
 fi
 
 cd "${BASEDIR}"
-OUTPUT="$(REPORT_ONLY=true "${BASEDIR}"/contrib/utilities/indent-branch)"
+OUTPUT="$(REPORT_ONLY=true "${BASEDIR}"/contrib/utilities/indent)"
 
 if [ ! -z "${OUTPUT}" ]; then
   echo "git commit aborted due to formatting issues:"
   echo "${OUTPUT}"
   echo ""
-  echo "Please run ./contrib/utilities/indent-branch to fix these issues and try again."
+  echo "Please run ./contrib/utilities/indent to fix these issues and try again."
   exit 1
 fi

--- a/contrib/utilities/check_indentation.sh
+++ b/contrib/utilities/check_indentation.sh
@@ -34,6 +34,6 @@ else
 	echo "Running indentation test on Pull Request #${TRAVIS_PULL_REQUEST}"
 fi
 
-./contrib/utilities/indent
+./contrib/utilities/indent-all
 git diff
 git diff-files --quiet 

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2018 by the deal.II authors
+## Copyright (C) 2018 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -9,19 +9,15 @@
 ## it, and/or modify it under the terms of the GNU Lesser General
 ## Public License as published by the Free Software Foundation; either
 ## version 2.1 of the License, or (at your option) any later version.
-## The full text of the license can be found in the file LICENSE.md at
-## the top level directory of deal.II.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
 ##
 ## ---------------------------------------------------------------------
 
 #
-# This script indents all source files of deal.II according to our usual
-# code formatting standards. It is used to ensure that our code base looks
-# uniform, as uniformity helps make code easier to read.
-#
-# While we're already touching every file, this script also makes
-# sure we set permissions correctly and checks for correct unix-style line
-# endings.
+# This script does the same thing as contrib/utilities/indent but only
+# reformats files which have changed (or have been added but neither
+# staged/commited) since the last merge commit to the master branch.
 #
 # The script needs to be executed as
 #   ./contrib/utilities/indent
@@ -54,15 +50,15 @@ checks
 # Process all source and header files:
 #
 
-process "tests include source examples" ".*\.(cc|h|cu|cuh)" format_file
-process "source" ".*\.inst.in" format_inst
+process_changed "tests include source examples" ".*\.(cc|h|cu|cuh)" format_file
+process_changed "source" ".*\.inst.in" format_inst
 
 #
 # Fix permissions and convert to unix line ending if necessary:
 #
 
-process "tests include source examples" \
+process_changed "tests include source examples" \
   ".*\.(cc|h|cu|cuh|inst.in|output.*|cmake)" fix_permissions
 
-process "tests include source examples" \
+process_changed "tests include source examples" \
   ".*\.(cc|h|cu|cuh|inst.in|cmake)" dos_to_unix

--- a/contrib/utilities/indent-all
+++ b/contrib/utilities/indent-all
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2018 by the deal.II authors
+## Copyright (C) 2012 - 2018 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -9,26 +9,30 @@
 ## it, and/or modify it under the terms of the GNU Lesser General
 ## Public License as published by the Free Software Foundation; either
 ## version 2.1 of the License, or (at your option) any later version.
-## The full text of the license can be found in the file LICENSE at
-## the top level of the deal.II distribution.
+## The full text of the license can be found in the file LICENSE.md at
+## the top level directory of deal.II.
 ##
 ## ---------------------------------------------------------------------
 
 #
-# This script does the same thing as contrib/utilities/indent but only
-# reformats files which have changed (or have been added but neither
-# staged/commited) since the last merge commit to the master branch.
+# This script indents all source files of deal.II according to our usual
+# code formatting standards. It is used to ensure that our code base looks
+# uniform, as uniformity helps make code easier to read.
+#
+# While we're already touching every file, this script also makes
+# sure we set permissions correctly and checks for correct unix-style line
+# endings.
 #
 # The script needs to be executed as
-#   ./contrib/utilities/indent-branch
+#   ./contrib/utilities/indent-all
 # from the top-level directory of the source tree, or via
-#   make indent-branch
+#   make indent-all
 # from a build directory.
 #
 # Note: If the script is invoked with REPORT_ONLY=true set,
-#   REPORT_ONLY=true ./contrib/utilities/indent-branch
+#   REPORT_ONLY=true ./contrib/utilities/indent-all
 # or,
-#   make REPORT_ONLY=true indent-branch
+#   make REPORT_ONLY=true indent-all
 # then indentation errors will only be reported without any actual file
 # changes.
 #
@@ -50,15 +54,15 @@ checks
 # Process all source and header files:
 #
 
-process_changed "tests include source examples" ".*\.(cc|h|cu|cuh)" format_file
-process_changed "source" ".*\.inst.in" format_inst
+process "tests include source examples" ".*\.(cc|h|cu|cuh)" format_file
+process "source" ".*\.inst.in" format_inst
 
 #
 # Fix permissions and convert to unix line ending if necessary:
 #
 
-process_changed "tests include source examples" \
+process "tests include source examples" \
   ".*\.(cc|h|cu|cuh|inst.in|output.*|cmake)" fix_permissions
 
-process_changed "tests include source examples" \
+process "tests include source examples" \
   ".*\.(cc|h|cu|cuh|inst.in|cmake)" dos_to_unix

--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -20,7 +20,7 @@
 
 #
 # This function checks that we are in the root directory and that
-# clang-format is available. It is called by both indent and indent-branch
+# clang-format is available. It is called by both indent and indent-all
 # to ensure that the rest of the indentation pipeline makes sense.
 #
 

--- a/doc/doxygen/headers/coding_conventions.h
+++ b/doc/doxygen/headers/coding_conventions.h
@@ -50,7 +50,7 @@ on each of your files. This will make sure indentation is conforming to the
 style guidelines outlined in this page. Alternatively, you can run
 <code>
 <pre>
-  make indent-branch
+  make indent
 </pre>
 </code>
 in whatever directory you set up the library to be compiled in to indent all


### PR DESCRIPTION
Now that everything is working, see #6810, and as discussed on #6673, this
commit renames "indent-branch" to "indent", and "indent" to "indent-all".