### PR TITLE
extend/rename get_vector_data_ranges() to return extra element in the…

### DIFF
--- a/doc/news/changes/minor/20180621DenisDavydov
+++ b/doc/news/changes/minor/20180621DenisDavydov
@@ -1,0 +1,4 @@
+New: Extend get_vector_data_ranges() to return extra element in
+the tuple to represent DataComponentInterpretation. The functions
+were renamed to get_nonscalar_data_ranges().
+(Denis Davydov 2018/06/21)

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -24,6 +24,8 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/table.h>
 
+#include <deal.II/numerics/data_component_interpretation.h>
+
 #include <limits>
 #include <string>
 #include <tuple>
@@ -1590,8 +1592,12 @@ namespace DataOutBase
   write_dx(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &            vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &            nonscalar_data_ranges,
     const DXFlags &flags,
     std::ostream & out);
 
@@ -1644,8 +1650,12 @@ namespace DataOutBase
   write_eps(
     const std::vector<Patch<2, spacedim>> &patches,
     const std::vector<std::string> &       data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const EpsFlags &flags,
     std::ostream &  out);
 
@@ -1659,8 +1669,12 @@ namespace DataOutBase
   write_eps(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const EpsFlags &flags,
     std::ostream &  out);
 
@@ -1679,8 +1693,12 @@ namespace DataOutBase
   write_gmv(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const GmvFlags &flags,
     std::ostream &  out);
 
@@ -1745,8 +1763,12 @@ namespace DataOutBase
   write_gnuplot(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                 vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &                 nonscalar_data_ranges,
     const GnuplotFlags &flags,
     std::ostream &      out);
 
@@ -1800,8 +1822,12 @@ namespace DataOutBase
   write_povray(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &                nonscalar_data_ranges,
     const PovrayFlags &flags,
     std::ostream &     out);
 
@@ -1816,8 +1842,12 @@ namespace DataOutBase
   write_tecplot(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                 vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &                 nonscalar_data_ranges,
     const TecplotFlags &flags,
     std::ostream &      out);
 
@@ -1845,8 +1875,12 @@ namespace DataOutBase
   write_tecplot_binary(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                 vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &                 nonscalar_data_ranges,
     const TecplotFlags &flags,
     std::ostream &      out);
 
@@ -1869,8 +1903,12 @@ namespace DataOutBase
   write_ucd(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const UcdFlags &flags,
     std::ostream &  out);
 
@@ -1879,7 +1917,7 @@ namespace DataOutBase
    * data is written in the traditional VTK format as opposed to the XML-based
    * format that write_vtu() produces.
    *
-   * The vector_data_ranges argument denotes ranges of components in the
+   * The nonscalar_data_ranges argument denotes ranges of components in the
    * output that are considered a vector, rather than simply a collection of
    * scalar fields. The VTK output format has special provisions that allow
    * these components to be output by a single name rather than having to
@@ -1898,8 +1936,12 @@ namespace DataOutBase
   write_vtk(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const VtkFlags &flags,
     std::ostream &  out);
 
@@ -1909,7 +1951,7 @@ namespace DataOutBase
    * data is written in the XML-based VTK format as opposed to the traditional
    * format that write_vtk() produces.
    *
-   * The vector_data_ranges argument denotes ranges of components in the
+   * The nonscalar_data_ranges argument denotes ranges of components in the
    * output that are considered a vector, rather than simply a collection of
    * scalar fields. The VTK output format has special provisions that allow
    * these components to be output by a single name rather than having to
@@ -1932,8 +1974,12 @@ namespace DataOutBase
   write_vtu(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const VtkFlags &flags,
     std::ostream &  out);
 
@@ -1965,8 +2011,12 @@ namespace DataOutBase
   write_vtu_main(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const VtkFlags &flags,
     std::ostream &  out);
 
@@ -1993,9 +2043,9 @@ namespace DataOutBase
    * is most easily called by calling DataOutInterfaces::write_pvtu_record(),
    * which determines the last two arguments by calling
    * DataOutInterface::get_dataset_names() and
-   * DataOutInterface::get_vector_data_ranges() functions. The second argument
-   * to this function specifies the names of the files that form the parallel
-   * set.
+   * DataOutInterface::get_nonscalar_data_ranges() functions. The second
+   * argument to this function specifies the names of the files that form the
+   * parallel set.
    *
    * @note Use DataOutBase::write_vtu() and DataOutInterface::write_vtu()
    * for writing each piece. Also note that
@@ -2016,8 +2066,12 @@ namespace DataOutBase
     std::ostream &                  out,
     const std::vector<std::string> &piece_names,
     const std::vector<std::string> &data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &vector_data_ranges);
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &nonscalar_data_ranges);
 
   /**
    * In ParaView it is possible to visualize time-dependent data tagged with
@@ -2184,8 +2238,12 @@ namespace DataOutBase
   write_svg(
     const std::vector<Patch<2, spacedim>> &patches,
     const std::vector<std::string> &       data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const SvgFlags &flags,
     std::ostream &  out);
 
@@ -2231,8 +2289,12 @@ namespace DataOutBase
   write_deal_II_intermediate(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                              vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &                              nonscalar_data_ranges,
     const Deal_II_IntermediateFlags &flags,
     std::ostream &                   out);
 
@@ -2274,8 +2336,12 @@ namespace DataOutBase
   write_filtered_data(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &            vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &            nonscalar_data_ranges,
     DataOutFilter &filtered_data);
 
   /**
@@ -2485,7 +2551,7 @@ namespace DataOutBase
  * name can be obtained by <tt>default_suffix</tt> without arguments.
  *
  * @ingroup output
- * @author Wolfgang Bangerth, 1999
+ * @author Wolfgang Bangerth, 1999, Denis Davydov, 2018
  */
 template <int dim, int spacedim = dim>
 class DataOutInterface
@@ -2614,7 +2680,7 @@ public:
    * fields can actually be found in the individual files that comprise the set
    * of parallel VTU files along with the names of these files. This function
    * gets the names and types of fields through the get_dataset_names() and
-   * get_vector_data_ranges() functions of this class. The second argument
+   * get_nonscalar_data_ranges() functions of this class. The second argument
    * to this function specifies the names of the files that form the parallel
    * set.
    *
@@ -2850,25 +2916,29 @@ protected:
    * output files that consist of more than one data set are to be
    * interpreted.
    *
-   * It returns a list of index pairs and corresponding name indicating which
-   * components of the output are to be considered vector-valued rather than
-   * just a collection of scalar data. The index pairs are inclusive; for
-   * example, if we have a Stokes problem in 2d with components (u,v,p), then
-   * the corresponding vector data range should be (0,1), and the returned
-   * list would consist of only a single element with a tuple such as
-   * (0,1,"velocity").
+   * It returns a list of index pairs and corresponding name and type indicating
+   * which components of the output are to be considered non vector- or
+   * tensor-valued rather than just a collection of scalar data. The index pairs
+   * are inclusive; for example, if we have a Stokes problem in 2d with
+   * components (u,v,p), then the corresponding vector data range should be
+   * (0,1), and the returned list would consist of only a single element with a
+   * tuple such as (0,1,"velocity").
    *
    * Since some of the derived classes do not know about vector data, this
    * function has a default implementation that simply returns an empty
    * string, meaning that all data is to be considered a collection of scalar
    * fields.
    */
-  virtual std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-  get_vector_data_ranges() const;
+  virtual std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+  get_nonscalar_data_ranges() const;
 
   /**
    * Validate that the names of the datasets returned by get_dataset_names() and
-   * get_vector_data_ranges() are valid. This currently consists of checking
+   * get_nonscalar_data_ranges() are valid. This currently consists of checking
    * that names are not used more than once. If an invalid state is encountered,
    * an Assert() will be triggered in debug mode.
    */
@@ -3104,8 +3174,12 @@ protected:
    * string, meaning that all data is to be considered a collection of scalar
    * fields.
    */
-  virtual std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-  get_vector_data_ranges() const override;
+  virtual std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+  get_nonscalar_data_ranges() const override;
 
 private:
   /**
@@ -3119,8 +3193,12 @@ private:
    * Information about whether certain components of the output field are to
    * be considered vectors.
    */
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-    vector_data_ranges;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    nonscalar_data_ranges;
 };
 
 

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2917,14 +2917,14 @@ protected:
    * interpreted.
    *
    * It returns a list of index pairs and corresponding name and type indicating
-   * which components of the output are to be considered non vector- or
+   * which components of the output are to be considered vector- or
    * tensor-valued rather than just a collection of scalar data. The index pairs
    * are inclusive; for example, if we have a Stokes problem in 2d with
    * components (u,v,p), then the corresponding vector data range should be
    * (0,1), and the returned list would consist of only a single element with a
-   * tuple such as (0,1,"velocity").
+   * tuple such as (0,1,"velocity",component_is_part_of_vector).
    *
-   * Since some of the derived classes do not know about vector data, this
+   * Since some of the derived classes do not know about non-scalar data, this
    * function has a default implementation that simply returns an empty
    * string, meaning that all data is to be considered a collection of scalar
    * fields.

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -973,11 +973,15 @@ protected:
   get_fes() const;
 
   /**
-   * Overload of the respective DataOutInterface::get_vector_data_ranges()
+   * Overload of the respective DataOutInterface::get_nonscalar_data_ranges()
    * function. See there for a more extensive documentation.
    */
-  virtual std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-  get_vector_data_ranges() const override;
+  virtual std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+  get_nonscalar_data_ranges() const override;
 
   /**
    * Make all template siblings friends. Needed for the merge_patches()
@@ -1129,22 +1133,22 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::merge_patches(
 
   // check equality of the vector data
   // specifications
-  Assert(get_vector_data_ranges().size() ==
-           source.get_vector_data_ranges().size(),
+  Assert(get_nonscalar_data_ranges().size() ==
+           source.get_nonscalar_data_ranges().size(),
          ExcMessage("Both sources need to declare the same components "
                     "as vectors."));
-  for (unsigned int i = 0; i < get_vector_data_ranges().size(); ++i)
+  for (unsigned int i = 0; i < get_nonscalar_data_ranges().size(); ++i)
     {
-      Assert(std::get<0>(get_vector_data_ranges()[i]) ==
-               std::get<0>(source.get_vector_data_ranges()[i]),
+      Assert(std::get<0>(get_nonscalar_data_ranges()[i]) ==
+               std::get<0>(source.get_nonscalar_data_ranges()[i]),
              ExcMessage("Both sources need to declare the same components "
                         "as vectors."));
-      Assert(std::get<1>(get_vector_data_ranges()[i]) ==
-               std::get<1>(source.get_vector_data_ranges()[i]),
+      Assert(std::get<1>(get_nonscalar_data_ranges()[i]) ==
+               std::get<1>(source.get_nonscalar_data_ranges()[i]),
              ExcMessage("Both sources need to declare the same components "
                         "as vectors."));
-      Assert(std::get<2>(get_vector_data_ranges()[i]) ==
-               std::get<2>(source.get_vector_data_ranges()[i]),
+      Assert(std::get<2>(get_nonscalar_data_ranges()[i]) ==
+               std::get<2>(source.get_nonscalar_data_ranges()[i]),
              ExcMessage("Both sources need to declare the same components "
                         "as vectors."));
     }

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -1323,11 +1323,20 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::get_dataset_names()
 
 
 template <typename DoFHandlerType, int patch_dim, int patch_space_dim>
-std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+std::vector<
+  std::tuple<unsigned int,
+             unsigned int,
+             std::string,
+             DataComponentInterpretation::DataComponentInterpretation>>
 DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::
-  get_vector_data_ranges() const
+  get_nonscalar_data_ranges() const
 {
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> ranges;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    ranges;
 
   // collect the ranges of dof and cell data
   typedef typename std::vector<std::shared_ptr<
@@ -1366,8 +1375,14 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::
               }
 
           // finally add a corresponding range
-          std::tuple<unsigned int, unsigned int, std::string> range(
-            output_component, output_component + patch_space_dim - 1, name);
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>
+            range(output_component,
+                  output_component + patch_space_dim - 1,
+                  name,
+                  DataComponentInterpretation::component_is_part_of_vector);
 
           ranges.push_back(range);
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -2762,7 +2762,11 @@ namespace DataOutBase
   write_ucd(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>> &,
     const UcdFlags &flags,
     std::ostream &  out)
   {
@@ -2849,7 +2853,11 @@ namespace DataOutBase
   write_dx(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>> &,
     const DXFlags &flags,
     std::ostream & out)
   {
@@ -3131,7 +3139,11 @@ namespace DataOutBase
   write_gnuplot(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>> &,
     const GnuplotFlags &flags,
     std::ostream &      out)
   {
@@ -3341,7 +3353,11 @@ namespace DataOutBase
   write_povray(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>> &,
     const PovrayFlags &flags,
     std::ostream &     out)
   {
@@ -3670,7 +3686,11 @@ namespace DataOutBase
   write_eps(
     const std::vector<Patch<dim, spacedim>> & /*patches*/,
     const std::vector<std::string> & /*data_names*/,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>> &,
     const EpsFlags & /*flags*/,
     std::ostream & /*out*/)
   {
@@ -3684,7 +3704,11 @@ namespace DataOutBase
   write_eps(
     const std::vector<Patch<2, spacedim>> &patches,
     const std::vector<std::string> & /*data_names*/,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>> &,
     const EpsFlags &flags,
     std::ostream &  out)
   {
@@ -4011,7 +4035,11 @@ namespace DataOutBase
   write_gmv(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>> &,
     const GmvFlags &flags,
     std::ostream &  out)
   {
@@ -4144,7 +4172,11 @@ namespace DataOutBase
   write_tecplot(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>> &,
     const TecplotFlags &flags,
     std::ostream &      out)
   {
@@ -4371,8 +4403,12 @@ namespace DataOutBase
   write_tecplot_binary(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                 vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &                 nonscalar_data_ranges,
     const TecplotFlags &flags,
     std::ostream &      out)
   {
@@ -4384,7 +4420,7 @@ namespace DataOutBase
 #ifndef DEAL_II_HAVE_TECPLOT
 
     // simply call the ASCII output function if the Tecplot API isn't present
-    write_tecplot(patches, data_names, vector_data_ranges, flags, out);
+    write_tecplot(patches, data_names, nonscalar_data_ranges, flags, out);
     return;
 
 #else
@@ -4392,7 +4428,7 @@ namespace DataOutBase
     // Tecplot binary output only good for 2D & 3D
     if (dim == 1)
       {
-        write_tecplot(patches, data_names, vector_data_ranges, flags, out);
+        write_tecplot(patches, data_names, nonscalar_data_ranges, flags, out);
         return;
       }
 
@@ -4408,7 +4444,7 @@ namespace DataOutBase
         Assert(false,
                ExcMessage("Specify the name of the tecplot_binary"
                           " file through the TecplotFlags interface."));
-        write_tecplot(patches, data_names, vector_data_ranges, flags, out);
+        write_tecplot(patches, data_names, nonscalar_data_ranges, flags, out);
         return;
       }
 
@@ -4697,8 +4733,12 @@ namespace DataOutBase
   write_vtk(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const VtkFlags &flags,
     std::ostream &  out)
   {
@@ -4825,28 +4865,30 @@ namespace DataOutBase
     // when writing, first write out all vector data, then handle the scalar
     // data sets that have been left over
     std::vector<bool> data_set_written(n_data_sets, false);
-    for (unsigned int n_th_vector = 0; n_th_vector < vector_data_ranges.size();
+    for (unsigned int n_th_vector = 0;
+         n_th_vector < nonscalar_data_ranges.size();
          ++n_th_vector)
       {
-        AssertThrow(std::get<1>(vector_data_ranges[n_th_vector]) >=
-                      std::get<0>(vector_data_ranges[n_th_vector]),
-                    ExcLowerRange(std::get<1>(vector_data_ranges[n_th_vector]),
-                                  std::get<0>(
-                                    vector_data_ranges[n_th_vector])));
-        AssertThrow(std::get<1>(vector_data_ranges[n_th_vector]) < n_data_sets,
-                    ExcIndexRange(std::get<1>(vector_data_ranges[n_th_vector]),
-                                  0,
-                                  n_data_sets));
-        AssertThrow(std::get<1>(vector_data_ranges[n_th_vector]) + 1 -
-                        std::get<0>(vector_data_ranges[n_th_vector]) <=
+        AssertThrow(
+          std::get<1>(nonscalar_data_ranges[n_th_vector]) >=
+            std::get<0>(nonscalar_data_ranges[n_th_vector]),
+          ExcLowerRange(std::get<1>(nonscalar_data_ranges[n_th_vector]),
+                        std::get<0>(nonscalar_data_ranges[n_th_vector])));
+        AssertThrow(
+          std::get<1>(nonscalar_data_ranges[n_th_vector]) < n_data_sets,
+          ExcIndexRange(std::get<1>(nonscalar_data_ranges[n_th_vector]),
+                        0,
+                        n_data_sets));
+        AssertThrow(std::get<1>(nonscalar_data_ranges[n_th_vector]) + 1 -
+                        std::get<0>(nonscalar_data_ranges[n_th_vector]) <=
                       3,
                     ExcMessage(
                       "Can't declare a vector with more than 3 components "
                       "in VTK"));
 
         // mark these components as already written:
-        for (unsigned int i = std::get<0>(vector_data_ranges[n_th_vector]);
-             i <= std::get<1>(vector_data_ranges[n_th_vector]);
+        for (unsigned int i = std::get<0>(nonscalar_data_ranges[n_th_vector]);
+             i <= std::get<1>(nonscalar_data_ranges[n_th_vector]);
              ++i)
           data_set_written[i] = true;
 
@@ -4854,15 +4896,16 @@ namespace DataOutBase
         // underscores unless a vector name has been specified
         out << "VECTORS ";
 
-        if (std::get<2>(vector_data_ranges[n_th_vector]) != "")
-          out << std::get<2>(vector_data_ranges[n_th_vector]);
+        if (std::get<2>(nonscalar_data_ranges[n_th_vector]) != "")
+          out << std::get<2>(nonscalar_data_ranges[n_th_vector]);
         else
           {
-            for (unsigned int i = std::get<0>(vector_data_ranges[n_th_vector]);
-                 i < std::get<1>(vector_data_ranges[n_th_vector]);
+            for (unsigned int i =
+                   std::get<0>(nonscalar_data_ranges[n_th_vector]);
+                 i < std::get<1>(nonscalar_data_ranges[n_th_vector]);
                  ++i)
               out << data_names[i] << "__";
-            out << data_names[std::get<1>(vector_data_ranges[n_th_vector])];
+            out << data_names[std::get<1>(nonscalar_data_ranges[n_th_vector])];
           }
 
         out << " double" << '\n';
@@ -4870,32 +4913,35 @@ namespace DataOutBase
         // now write data. pad all vectors to have three components
         for (unsigned int n = 0; n < n_nodes; ++n)
           {
-            switch (std::get<1>(vector_data_ranges[n_th_vector]) -
-                    std::get<0>(vector_data_ranges[n_th_vector]))
+            switch (std::get<1>(nonscalar_data_ranges[n_th_vector]) -
+                    std::get<0>(nonscalar_data_ranges[n_th_vector]))
               {
                 case 0:
                   out << data_vectors(
-                           std::get<0>(vector_data_ranges[n_th_vector]), n)
+                           std::get<0>(nonscalar_data_ranges[n_th_vector]), n)
                       << " 0 0" << '\n';
                   break;
 
                 case 1:
                   out << data_vectors(
-                           std::get<0>(vector_data_ranges[n_th_vector]), n)
+                           std::get<0>(nonscalar_data_ranges[n_th_vector]), n)
                       << ' '
                       << data_vectors(
-                           std::get<0>(vector_data_ranges[n_th_vector]) + 1, n)
+                           std::get<0>(nonscalar_data_ranges[n_th_vector]) + 1,
+                           n)
                       << " 0" << '\n';
                   break;
                 case 2:
                   out << data_vectors(
-                           std::get<0>(vector_data_ranges[n_th_vector]), n)
+                           std::get<0>(nonscalar_data_ranges[n_th_vector]), n)
                       << ' '
                       << data_vectors(
-                           std::get<0>(vector_data_ranges[n_th_vector]) + 1, n)
+                           std::get<0>(nonscalar_data_ranges[n_th_vector]) + 1,
+                           n)
                       << ' '
                       << data_vectors(
-                           std::get<0>(vector_data_ranges[n_th_vector]) + 2, n)
+                           std::get<0>(nonscalar_data_ranges[n_th_vector]) + 2,
+                           n)
                       << '\n';
                   break;
 
@@ -4975,13 +5021,17 @@ namespace DataOutBase
   write_vtu(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const VtkFlags &flags,
     std::ostream &  out)
   {
     write_vtu_header(out, flags);
-    write_vtu_main(patches, data_names, vector_data_ranges, flags, out);
+    write_vtu_main(patches, data_names, nonscalar_data_ranges, flags, out);
     write_vtu_footer(out);
 
     out << std::flush;
@@ -4993,8 +5043,12 @@ namespace DataOutBase
   write_vtu_main(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &             nonscalar_data_ranges,
     const VtkFlags &flags,
     std::ostream &  out)
   {
@@ -5021,12 +5075,13 @@ namespace DataOutBase
             << "  <PointData Scalars=\"scalars\">\n";
         std::vector<bool> data_set_written(data_names.size(), false);
         for (unsigned int n_th_vector = 0;
-             n_th_vector < vector_data_ranges.size();
+             n_th_vector < nonscalar_data_ranges.size();
              ++n_th_vector)
           {
             // mark these components as already written:
-            for (unsigned int i = std::get<0>(vector_data_ranges[n_th_vector]);
-                 i <= std::get<1>(vector_data_ranges[n_th_vector]);
+            for (unsigned int i =
+                   std::get<0>(nonscalar_data_ranges[n_th_vector]);
+                 i <= std::get<1>(nonscalar_data_ranges[n_th_vector]);
                  ++i)
               data_set_written[i] = true;
 
@@ -5034,16 +5089,17 @@ namespace DataOutBase
             // underscores unless a vector name has been specified
             out << "    <DataArray type=\"Float32\" Name=\"";
 
-            if (std::get<2>(vector_data_ranges[n_th_vector]) != "")
-              out << std::get<2>(vector_data_ranges[n_th_vector]);
+            if (std::get<2>(nonscalar_data_ranges[n_th_vector]) != "")
+              out << std::get<2>(nonscalar_data_ranges[n_th_vector]);
             else
               {
                 for (unsigned int i =
-                       std::get<0>(vector_data_ranges[n_th_vector]);
-                     i < std::get<1>(vector_data_ranges[n_th_vector]);
+                       std::get<0>(nonscalar_data_ranges[n_th_vector]);
+                     i < std::get<1>(nonscalar_data_ranges[n_th_vector]);
                      ++i)
                   out << data_names[i] << "__";
-                out << data_names[std::get<1>(vector_data_ranges[n_th_vector])];
+                out << data_names[std::get<1>(
+                  nonscalar_data_ranges[n_th_vector])];
               }
 
             out << "\" NumberOfComponents=\"3\"></DataArray>\n";
@@ -5211,7 +5267,7 @@ namespace DataOutBase
     // when writing, first write out all vector data, then handle the scalar
     // data sets that have been left over
     std::vector<bool> data_set_written(n_data_sets, false);
-    for (auto range : vector_data_ranges)
+    for (auto range : nonscalar_data_ranges)
       {
         const auto first_component = std::get<0>(range);
         const auto last_component  = std::get<1>(range);
@@ -5313,8 +5369,12 @@ namespace DataOutBase
     std::ostream &                  out,
     const std::vector<std::string> &piece_names,
     const std::vector<std::string> &data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &vector_data_ranges)
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &nonscalar_data_ranges)
   {
     AssertThrow(out, ExcIO());
 
@@ -5334,28 +5394,30 @@ namespace DataOutBase
 
     // We need to output in the same order as the write_vtu function does:
     std::vector<bool> data_set_written(n_data_sets, false);
-    for (unsigned int n_th_vector = 0; n_th_vector < vector_data_ranges.size();
+    for (unsigned int n_th_vector = 0;
+         n_th_vector < nonscalar_data_ranges.size();
          ++n_th_vector)
       {
-        AssertThrow(std::get<1>(vector_data_ranges[n_th_vector]) >=
-                      std::get<0>(vector_data_ranges[n_th_vector]),
-                    ExcLowerRange(std::get<1>(vector_data_ranges[n_th_vector]),
-                                  std::get<0>(
-                                    vector_data_ranges[n_th_vector])));
-        AssertThrow(std::get<1>(vector_data_ranges[n_th_vector]) < n_data_sets,
-                    ExcIndexRange(std::get<1>(vector_data_ranges[n_th_vector]),
-                                  0,
-                                  n_data_sets));
-        AssertThrow(std::get<1>(vector_data_ranges[n_th_vector]) + 1 -
-                        std::get<0>(vector_data_ranges[n_th_vector]) <=
+        AssertThrow(
+          std::get<1>(nonscalar_data_ranges[n_th_vector]) >=
+            std::get<0>(nonscalar_data_ranges[n_th_vector]),
+          ExcLowerRange(std::get<1>(nonscalar_data_ranges[n_th_vector]),
+                        std::get<0>(nonscalar_data_ranges[n_th_vector])));
+        AssertThrow(
+          std::get<1>(nonscalar_data_ranges[n_th_vector]) < n_data_sets,
+          ExcIndexRange(std::get<1>(nonscalar_data_ranges[n_th_vector]),
+                        0,
+                        n_data_sets));
+        AssertThrow(std::get<1>(nonscalar_data_ranges[n_th_vector]) + 1 -
+                        std::get<0>(nonscalar_data_ranges[n_th_vector]) <=
                       3,
                     ExcMessage(
                       "Can't declare a vector with more than 3 components "
                       "in VTK"));
 
         // mark these components as already written:
-        for (unsigned int i = std::get<0>(vector_data_ranges[n_th_vector]);
-             i <= std::get<1>(vector_data_ranges[n_th_vector]);
+        for (unsigned int i = std::get<0>(nonscalar_data_ranges[n_th_vector]);
+             i <= std::get<1>(nonscalar_data_ranges[n_th_vector]);
              ++i)
           data_set_written[i] = true;
 
@@ -5363,15 +5425,16 @@ namespace DataOutBase
         // underscores unless a vector name has been specified
         out << "    <PDataArray type=\"Float32\" Name=\"";
 
-        if (std::get<2>(vector_data_ranges[n_th_vector]) != "")
-          out << std::get<2>(vector_data_ranges[n_th_vector]);
+        if (std::get<2>(nonscalar_data_ranges[n_th_vector]) != "")
+          out << std::get<2>(nonscalar_data_ranges[n_th_vector]);
         else
           {
-            for (unsigned int i = std::get<0>(vector_data_ranges[n_th_vector]);
-                 i < std::get<1>(vector_data_ranges[n_th_vector]);
+            for (unsigned int i =
+                   std::get<0>(nonscalar_data_ranges[n_th_vector]);
+                 i < std::get<1>(nonscalar_data_ranges[n_th_vector]);
                  ++i)
               out << data_names[i] << "__";
-            out << data_names[std::get<1>(vector_data_ranges[n_th_vector])];
+            out << data_names[std::get<1>(nonscalar_data_ranges[n_th_vector])];
           }
 
         out << "\" NumberOfComponents=\"3\" format=\"ascii\"/>\n";
@@ -5534,7 +5597,11 @@ namespace DataOutBase
   write_svg(
     const std::vector<Patch<dim, spacedim>> &,
     const std::vector<std::string> &,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>> &,
     const SvgFlags &,
     std::ostream &)
   {
@@ -5546,8 +5613,12 @@ namespace DataOutBase
   write_svg(
     const std::vector<Patch<2, spacedim>> &patches,
     const std::vector<std::string> & /*data_names*/,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      & /*vector_data_ranges*/,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      & /*nonscalar_data_ranges*/,
     const SvgFlags &flags,
     std::ostream &  out)
   {
@@ -6532,8 +6603,12 @@ namespace DataOutBase
   write_deal_II_intermediate(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &vector_data_ranges,
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      &nonscalar_data_ranges,
     const Deal_II_IntermediateFlags & /*flags*/,
     std::ostream &out)
   {
@@ -6559,11 +6634,11 @@ namespace DataOutBase
     for (unsigned int i = 0; i < patches.size(); ++i)
       out << patches[i] << '\n';
 
-    out << vector_data_ranges.size() << '\n';
-    for (unsigned int i = 0; i < vector_data_ranges.size(); ++i)
-      out << std::get<0>(vector_data_ranges[i]) << ' '
-          << std::get<1>(vector_data_ranges[i]) << '\n'
-          << std::get<2>(vector_data_ranges[i]) << '\n';
+    out << nonscalar_data_ranges.size() << '\n';
+    for (unsigned int i = 0; i < nonscalar_data_ranges.size(); ++i)
+      out << std::get<0>(nonscalar_data_ranges[i]) << ' '
+          << std::get<1>(nonscalar_data_ranges[i]) << '\n'
+          << std::get<2>(nonscalar_data_ranges[i]) << '\n';
 
     out << '\n';
     // make sure everything now gets to disk
@@ -6603,7 +6678,7 @@ DataOutInterface<dim, spacedim>::write_dx(std::ostream &out) const
 {
   DataOutBase::write_dx(get_patches(),
                         get_dataset_names(),
-                        get_vector_data_ranges(),
+                        get_nonscalar_data_ranges(),
                         dx_flags,
                         out);
 }
@@ -6616,7 +6691,7 @@ DataOutInterface<dim, spacedim>::write_ucd(std::ostream &out) const
 {
   DataOutBase::write_ucd(get_patches(),
                          get_dataset_names(),
-                         get_vector_data_ranges(),
+                         get_nonscalar_data_ranges(),
                          ucd_flags,
                          out);
 }
@@ -6629,7 +6704,7 @@ DataOutInterface<dim, spacedim>::write_gnuplot(std::ostream &out) const
 {
   DataOutBase::write_gnuplot(get_patches(),
                              get_dataset_names(),
-                             get_vector_data_ranges(),
+                             get_nonscalar_data_ranges(),
                              gnuplot_flags,
                              out);
 }
@@ -6642,7 +6717,7 @@ DataOutInterface<dim, spacedim>::write_povray(std::ostream &out) const
 {
   DataOutBase::write_povray(get_patches(),
                             get_dataset_names(),
-                            get_vector_data_ranges(),
+                            get_nonscalar_data_ranges(),
                             povray_flags,
                             out);
 }
@@ -6655,7 +6730,7 @@ DataOutInterface<dim, spacedim>::write_eps(std::ostream &out) const
 {
   DataOutBase::write_eps(get_patches(),
                          get_dataset_names(),
-                         get_vector_data_ranges(),
+                         get_nonscalar_data_ranges(),
                          eps_flags,
                          out);
 }
@@ -6668,7 +6743,7 @@ DataOutInterface<dim, spacedim>::write_gmv(std::ostream &out) const
 {
   DataOutBase::write_gmv(get_patches(),
                          get_dataset_names(),
-                         get_vector_data_ranges(),
+                         get_nonscalar_data_ranges(),
                          gmv_flags,
                          out);
 }
@@ -6681,7 +6756,7 @@ DataOutInterface<dim, spacedim>::write_tecplot(std::ostream &out) const
 {
   DataOutBase::write_tecplot(get_patches(),
                              get_dataset_names(),
-                             get_vector_data_ranges(),
+                             get_nonscalar_data_ranges(),
                              tecplot_flags,
                              out);
 }
@@ -6694,7 +6769,7 @@ DataOutInterface<dim, spacedim>::write_tecplot_binary(std::ostream &out) const
 {
   DataOutBase::write_tecplot_binary(get_patches(),
                                     get_dataset_names(),
-                                    get_vector_data_ranges(),
+                                    get_nonscalar_data_ranges(),
                                     tecplot_flags,
                                     out);
 }
@@ -6707,7 +6782,7 @@ DataOutInterface<dim, spacedim>::write_vtk(std::ostream &out) const
 {
   DataOutBase::write_vtk(get_patches(),
                          get_dataset_names(),
-                         get_vector_data_ranges(),
+                         get_nonscalar_data_ranges(),
                          vtk_flags,
                          out);
 }
@@ -6718,7 +6793,7 @@ DataOutInterface<dim, spacedim>::write_vtu(std::ostream &out) const
 {
   DataOutBase::write_vtu(get_patches(),
                          get_dataset_names(),
-                         get_vector_data_ranges(),
+                         get_nonscalar_data_ranges(),
                          vtk_flags,
                          out);
 }
@@ -6729,7 +6804,7 @@ DataOutInterface<dim, spacedim>::write_svg(std::ostream &out) const
 {
   DataOutBase::write_svg(get_patches(),
                          get_dataset_names(),
-                         get_vector_data_ranges(),
+                         get_nonscalar_data_ranges(),
                          svg_flags,
                          out);
 }
@@ -6798,7 +6873,7 @@ DataOutInterface<dim, spacedim>::write_vtu_in_parallel(const char *filename,
     std::stringstream ss;
     DataOutBase::write_vtu_main(get_patches(),
                                 get_dataset_names(),
-                                get_vector_data_ranges(),
+                                get_nonscalar_data_ranges(),
                                 vtk_flags,
                                 ss);
     ierr = MPI_File_write_ordered(fh,
@@ -6837,7 +6912,7 @@ DataOutInterface<dim, spacedim>::write_pvtu_record(
   DataOutBase::write_pvtu_record(out,
                                  piece_names,
                                  get_dataset_names(),
-                                 get_vector_data_ranges());
+                                 get_nonscalar_data_ranges());
 }
 
 
@@ -6849,7 +6924,7 @@ DataOutInterface<dim, spacedim>::write_deal_II_intermediate(
 {
   DataOutBase::write_deal_II_intermediate(get_patches(),
                                           get_dataset_names(),
-                                          get_vector_data_ranges(),
+                                          get_nonscalar_data_ranges(),
                                           deal_II_intermediate_flags,
                                           out);
 }
@@ -6999,7 +7074,7 @@ DataOutInterface<dim, spacedim>::write_filtered_data(
 {
   DataOutBase::write_filtered_data(get_patches(),
                                    get_dataset_names(),
-                                   get_vector_data_ranges(),
+                                   get_nonscalar_data_ranges(),
                                    filtered_data);
 }
 
@@ -7008,8 +7083,12 @@ void
 DataOutBase::write_filtered_data(
   const std::vector<Patch<dim, spacedim>> &patches,
   const std::vector<std::string> &         data_names,
-  const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-    &                         vector_data_ranges,
+  const std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    &                         nonscalar_data_ranges,
   DataOutBase::DataOutFilter &filtered_data)
 {
   const unsigned int n_data_sets = data_names.size();
@@ -7049,45 +7128,46 @@ DataOutBase::write_filtered_data(
   for (n_th_vector = 0, data_set = 0; data_set < n_data_sets;)
     {
       // Advance n_th_vector to at least the current data set we are on
-      while (n_th_vector < vector_data_ranges.size() &&
-             std::get<0>(vector_data_ranges[n_th_vector]) < data_set)
+      while (n_th_vector < nonscalar_data_ranges.size() &&
+             std::get<0>(nonscalar_data_ranges[n_th_vector]) < data_set)
         n_th_vector++;
 
       // Determine the dimension of this data
-      if (n_th_vector < vector_data_ranges.size() &&
-          std::get<0>(vector_data_ranges[n_th_vector]) == data_set)
+      if (n_th_vector < nonscalar_data_ranges.size() &&
+          std::get<0>(nonscalar_data_ranges[n_th_vector]) == data_set)
         {
           // Multiple dimensions
-          pt_data_vector_dim = std::get<1>(vector_data_ranges[n_th_vector]) -
-                               std::get<0>(vector_data_ranges[n_th_vector]) + 1;
+          pt_data_vector_dim = std::get<1>(nonscalar_data_ranges[n_th_vector]) -
+                               std::get<0>(nonscalar_data_ranges[n_th_vector]) +
+                               1;
 
           // Ensure the dimensionality of the data is correct
           AssertThrow(
-            std::get<1>(vector_data_ranges[n_th_vector]) >=
-              std::get<0>(vector_data_ranges[n_th_vector]),
-            ExcLowerRange(std::get<1>(vector_data_ranges[n_th_vector]),
-                          std::get<0>(vector_data_ranges[n_th_vector])));
+            std::get<1>(nonscalar_data_ranges[n_th_vector]) >=
+              std::get<0>(nonscalar_data_ranges[n_th_vector]),
+            ExcLowerRange(std::get<1>(nonscalar_data_ranges[n_th_vector]),
+                          std::get<0>(nonscalar_data_ranges[n_th_vector])));
           AssertThrow(
-            std::get<1>(vector_data_ranges[n_th_vector]) < n_data_sets,
-            ExcIndexRange(std::get<1>(vector_data_ranges[n_th_vector]),
+            std::get<1>(nonscalar_data_ranges[n_th_vector]) < n_data_sets,
+            ExcIndexRange(std::get<1>(nonscalar_data_ranges[n_th_vector]),
                           0,
                           n_data_sets));
 
           // Determine the vector name. Concatenate all the component names with
           // double underscores unless a vector name has been specified
-          if (std::get<2>(vector_data_ranges[n_th_vector]) != "")
+          if (std::get<2>(nonscalar_data_ranges[n_th_vector]) != "")
             {
-              vector_name = std::get<2>(vector_data_ranges[n_th_vector]);
+              vector_name = std::get<2>(nonscalar_data_ranges[n_th_vector]);
             }
           else
             {
               vector_name = "";
-              for (i = std::get<0>(vector_data_ranges[n_th_vector]);
-                   i < std::get<1>(vector_data_ranges[n_th_vector]);
+              for (i = std::get<0>(nonscalar_data_ranges[n_th_vector]);
+                   i < std::get<1>(nonscalar_data_ranges[n_th_vector]);
                    ++i)
                 vector_name += data_names[i] + "__";
               vector_name +=
-                data_names[std::get<1>(vector_data_ranges[n_th_vector])];
+                data_names[std::get<1>(nonscalar_data_ranges[n_th_vector])];
             }
         }
       else
@@ -7761,10 +7841,18 @@ DataOutInterface<dim, spacedim>::memory_consumption() const
 
 
 template <int dim, int spacedim>
-std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-DataOutInterface<dim, spacedim>::get_vector_data_ranges() const
+std::vector<
+  std::tuple<unsigned int,
+             unsigned int,
+             std::string,
+             DataComponentInterpretation::DataComponentInterpretation>>
+DataOutInterface<dim, spacedim>::get_nonscalar_data_ranges() const
 {
-  return std::vector<std::tuple<unsigned int, unsigned int, std::string>>();
+  return std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>();
 }
 
 
@@ -7778,8 +7866,12 @@ DataOutInterface<dim, spacedim>::validate_dataset_names() const
     // complicated, because vector ranges might have a name or not.
     std::set<std::string> all_names;
 
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-                                   ranges      = this->get_vector_data_ranges();
+    const std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+                                   ranges = this->get_nonscalar_data_ranges();
     const std::vector<std::string> data_names  = this->get_dataset_names();
     const unsigned int             n_data_sets = data_names.size();
     std::vector<bool>              data_set_written(n_data_sets, false);
@@ -7838,8 +7930,13 @@ DataOutReader<dim, spacedim>::read(std::istream &in)
     tmp.swap(dataset_names);
   }
   {
-    std::vector<std::tuple<unsigned int, unsigned int, std::string>> tmp;
-    tmp.swap(vector_data_ranges);
+    std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      tmp;
+    tmp.swap(nonscalar_data_ranges);
   }
 
   // then check that we have the correct header of this file. both the first and
@@ -7905,13 +8002,13 @@ DataOutReader<dim, spacedim>::read(std::istream &in)
   for (unsigned int i = 0; i < n_patches; ++i)
     in >> patches[i];
 
-  unsigned int n_vector_data_ranges;
-  in >> n_vector_data_ranges;
-  vector_data_ranges.resize(n_vector_data_ranges);
-  for (unsigned int i = 0; i < n_vector_data_ranges; ++i)
+  unsigned int n_nonscalar_data_ranges;
+  in >> n_nonscalar_data_ranges;
+  nonscalar_data_ranges.resize(n_nonscalar_data_ranges);
+  for (unsigned int i = 0; i < n_nonscalar_data_ranges; ++i)
     {
-      in >> std::get<0>(vector_data_ranges[i]) >>
-        std::get<1>(vector_data_ranges[i]);
+      in >> std::get<0>(nonscalar_data_ranges[i]) >>
+        std::get<1>(nonscalar_data_ranges[i]);
 
       // read in the name of that vector range. because it is on a separate
       // line, we first need to read to the end of the previous line (nothing
@@ -7920,7 +8017,7 @@ DataOutReader<dim, spacedim>::read(std::istream &in)
       std::string name;
       getline(in, name);
       getline(in, name);
-      std::get<2>(vector_data_ranges[i]) = name;
+      std::get<2>(nonscalar_data_ranges[i]) = name;
     }
 
   AssertThrow(in, ExcIO());
@@ -7943,22 +8040,22 @@ DataOutReader<dim, spacedim>::merge(const DataOutReader<dim, spacedim> &source)
          ExcIncompatibleDatasetNames());
 
   // check equality of the vector data specifications
-  Assert(get_vector_data_ranges().size() ==
-           source.get_vector_data_ranges().size(),
+  Assert(get_nonscalar_data_ranges().size() ==
+           source.get_nonscalar_data_ranges().size(),
          ExcMessage("Both sources need to declare the same components "
                     "as vectors."));
-  for (unsigned int i = 0; i < get_vector_data_ranges().size(); ++i)
+  for (unsigned int i = 0; i < get_nonscalar_data_ranges().size(); ++i)
     {
-      Assert(std::get<0>(get_vector_data_ranges()[i]) ==
-               std::get<0>(source.get_vector_data_ranges()[i]),
+      Assert(std::get<0>(get_nonscalar_data_ranges()[i]) ==
+               std::get<0>(source.get_nonscalar_data_ranges()[i]),
              ExcMessage("Both sources need to declare the same components "
                         "as vectors."));
-      Assert(std::get<1>(get_vector_data_ranges()[i]) ==
-               std::get<1>(source.get_vector_data_ranges()[i]),
+      Assert(std::get<1>(get_nonscalar_data_ranges()[i]) ==
+               std::get<1>(source.get_nonscalar_data_ranges()[i]),
              ExcMessage("Both sources need to declare the same components "
                         "as vectors."));
-      Assert(std::get<2>(get_vector_data_ranges()[i]) ==
-               std::get<2>(source.get_vector_data_ranges()[i]),
+      Assert(std::get<2>(get_nonscalar_data_ranges()[i]) ==
+               std::get<2>(source.get_nonscalar_data_ranges()[i]),
              ExcMessage("Both sources need to declare the same components "
                         "as vectors."));
     }
@@ -8009,10 +8106,14 @@ DataOutReader<dim, spacedim>::get_dataset_names() const
 
 
 template <int dim, int spacedim>
-std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-DataOutReader<dim, spacedim>::get_vector_data_ranges() const
+std::vector<
+  std::tuple<unsigned int,
+             unsigned int,
+             std::string,
+             DataComponentInterpretation::DataComponentInterpretation>>
+DataOutReader<dim, spacedim>::get_nonscalar_data_ranges() const
 {
-  return vector_data_ranges;
+  return nonscalar_data_ranges;
 }
 
 

--- a/source/base/data_out_base.inst.in
+++ b/source/base/data_out_base.inst.in
@@ -39,8 +39,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &             nonscalar_data_ranges,
         const VtkFlags &flags,
         std::ostream &  out);
 
@@ -49,8 +53,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &             nonscalar_data_ranges,
         const VtkFlags &flags,
         std::ostream &  out);
 
@@ -59,8 +67,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &             nonscalar_data_ranges,
         const UcdFlags &flags,
         std::ostream &  out);
 
@@ -69,8 +81,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &            vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &            nonscalar_data_ranges,
         const DXFlags &flags,
         std::ostream & out);
 
@@ -79,8 +95,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &                 vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &                 nonscalar_data_ranges,
         const GnuplotFlags &flags,
         std::ostream &      out);
 
@@ -89,8 +109,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &                vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &                nonscalar_data_ranges,
         const PovrayFlags &flags,
         std::ostream &     out);
 
@@ -99,8 +123,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &             nonscalar_data_ranges,
         const EpsFlags &flags,
         std::ostream &  out);
 
@@ -109,8 +137,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &             nonscalar_data_ranges,
         const GmvFlags &flags,
         std::ostream &  out);
 
@@ -119,8 +151,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &                 vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &                 nonscalar_data_ranges,
         const TecplotFlags &flags,
         std::ostream &      out);
 
@@ -129,8 +165,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &                 vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &                 nonscalar_data_ranges,
         const TecplotFlags &flags,
         std::ostream &      out);
 
@@ -140,8 +180,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &             nonscalar_data_ranges,
         const SvgFlags &flags,
         std::ostream &  out);
 #  endif
@@ -150,8 +194,12 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &                              vector_data_ranges,
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
+          &                              nonscalar_data_ranges,
         const Deal_II_IntermediateFlags &flags,
         std::ostream &                   out);
 
@@ -167,7 +215,11 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
       write_filtered_data(
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>> &,
         const std::vector<std::string> &,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+        const std::vector<
+          std::tuple<unsigned int,
+                     unsigned int,
+                     std::string,
+                     DataComponentInterpretation::DataComponentInterpretation>>
           &,
         DataOutBase::DataOutFilter &);
 

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -2954,7 +2954,11 @@ GridOut::write_vtk(const Triangulation<dim, spacedim> &tria,
   DataOutBase::write_vtk(
     patches,
     triangulation_patch_data_names(),
-    std::vector<std::tuple<unsigned int, unsigned int, std::string>>(),
+    std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>(),
     vtk_flags,
     out);
 
@@ -2980,7 +2984,11 @@ GridOut::write_vtu(const Triangulation<dim, spacedim> &tria,
   DataOutBase::write_vtu(
     patches,
     triangulation_patch_data_names(),
-    std::vector<std::tuple<unsigned int, unsigned int, std::string>>(),
+    std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>(),
     vtu_flags,
     out);
 
@@ -3106,7 +3114,11 @@ GridOut::write_mesh_per_processor_as_vtu(
     }
 
   std::ofstream out(new_file.c_str());
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>>
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
                         vector_data_ranges;
   DataOutBase::VtkFlags flags;
   DataOutBase::write_vtu(patches, data_names, vector_data_ranges, flags, out);

--- a/tests/base/functions_04.cc
+++ b/tests/base/functions_04.cc
@@ -185,9 +185,15 @@ check_function(const Functions::FlowFunction<dim> &f,
       names[i] = std::string("comp");
     }
 
-  DataOutBase::DXFlags                                             dxflags;
-  DataOutBase::GnuplotFlags                                        gflags;
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  DataOutBase::DXFlags      dxflags;
+  DataOutBase::GnuplotFlags gflags;
+
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   if (dim == 2)
     DataOutBase::write_gnuplot(patches, names, vectors, gflags, out);
   else

--- a/tests/data_out/data_out_04.cc
+++ b/tests/data_out/data_out_04.cc
@@ -48,18 +48,32 @@ public:
     return DataOut<dim>::get_dataset_names();
   }
 
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-  get_vector_data_ranges() const
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+  get_nonscalar_data_ranges() const
   {
     // if we have enough components for a
     // vector solution, make the last dim
     // components a vector
-    std::vector<std::tuple<unsigned int, unsigned int, std::string>> retval;
+    std::vector<
+      std::tuple<unsigned int,
+                 unsigned int,
+                 std::string,
+                 DataComponentInterpretation::DataComponentInterpretation>>
+      retval;
     if (get_dataset_names().size() >= dim)
-      retval.push_back(std::tuple<unsigned int, unsigned int, std::string>(
-        get_dataset_names().size() - dim,
-        get_dataset_names().size() - 1,
-        "vector_data"));
+      retval.push_back(
+        std::tuple<unsigned int,
+                   unsigned int,
+                   std::string,
+                   DataComponentInterpretation::DataComponentInterpretation>(
+          get_dataset_names().size() - dim,
+          get_dataset_names().size() - 1,
+          "vector_data",
+          DataComponentInterpretation::component_is_part_of_vector));
     return retval;
   }
 };
@@ -82,10 +96,14 @@ public:
     return DataOutReader<dim>::get_dataset_names();
   }
 
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-  get_vector_data_ranges() const
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+  get_nonscalar_data_ranges() const
   {
-    return DataOutReader<dim>::get_vector_data_ranges();
+    return DataOutReader<dim>::get_nonscalar_data_ranges();
   }
 };
 
@@ -126,23 +144,24 @@ check_this(const DoFHandler<dim> &dof_handler,
     Assert(data_out.get_patches()[i] == reader.get_patches()[i],
            ExcInternalError());
 
-  deallog << data_out.get_vector_data_ranges().size() << std::endl;
-  Assert(data_out.get_vector_data_ranges().size() ==
-           reader.get_vector_data_ranges().size(),
+  deallog << data_out.get_nonscalar_data_ranges().size() << std::endl;
+  Assert(data_out.get_nonscalar_data_ranges().size() ==
+           reader.get_nonscalar_data_ranges().size(),
          ExcInternalError());
-  for (unsigned int i = 0; i < data_out.get_vector_data_ranges().size(); ++i)
+  for (unsigned int i = 0; i < data_out.get_nonscalar_data_ranges().size(); ++i)
     {
-      deallog << std::get<0>(data_out.get_vector_data_ranges()[i]) << ' '
-              << std::get<1>(data_out.get_vector_data_ranges()[i]) << ' '
-              << std::get<2>(data_out.get_vector_data_ranges()[i]) << std::endl;
-      Assert(std::get<0>(data_out.get_vector_data_ranges()[i]) ==
-               std::get<0>(reader.get_vector_data_ranges()[i]),
+      deallog << std::get<0>(data_out.get_nonscalar_data_ranges()[i]) << ' '
+              << std::get<1>(data_out.get_nonscalar_data_ranges()[i]) << ' '
+              << std::get<2>(data_out.get_nonscalar_data_ranges()[i])
+              << std::endl;
+      Assert(std::get<0>(data_out.get_nonscalar_data_ranges()[i]) ==
+               std::get<0>(reader.get_nonscalar_data_ranges()[i]),
              ExcInternalError());
-      Assert(std::get<1>(data_out.get_vector_data_ranges()[i]) ==
-               std::get<1>(reader.get_vector_data_ranges()[i]),
+      Assert(std::get<1>(data_out.get_nonscalar_data_ranges()[i]) ==
+               std::get<1>(reader.get_nonscalar_data_ranges()[i]),
              ExcInternalError());
-      Assert(std::get<2>(data_out.get_vector_data_ranges()[i]) ==
-               std::get<2>(reader.get_vector_data_ranges()[i]),
+      Assert(std::get<2>(data_out.get_nonscalar_data_ranges()[i]) ==
+               std::get<2>(reader.get_nonscalar_data_ranges()[i]),
              ExcInternalError());
     }
 

--- a/tests/data_out/data_out_base.cc
+++ b/tests/data_out/data_out_base.cc
@@ -48,7 +48,12 @@ write_patches(const std::vector<DataOutBase::Patch<dim, spacedim>> &patches,
   DataOutBase::VtkFlags                  vtkflags;
   DataOutBase::Deal_II_IntermediateFlags deal_II_intermediateflags;
 
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
 
   WRITE(dx);
   if (dim == 2)

--- a/tests/data_out/data_out_base_dx.cc
+++ b/tests/data_out/data_out_base_dx.cc
@@ -47,7 +47,12 @@ check(DataOutBase::DXFlags flags, std::ostream &out)
   names[3] = "x4";
   names[4] = "i";
 
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
 
   DataOutBase::write_dx(patches, names, vectors, flags, out);
 }
@@ -66,7 +71,12 @@ check_cont(unsigned int         ncells,
 
   std::vector<std::string> names(1);
   names[0] = "CutOff";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_dx(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_eps.cc
+++ b/tests/data_out/data_out_base_eps.cc
@@ -46,7 +46,12 @@ check(DataOutBase::EpsFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_eps(patches, names, vectors, flags, out);
 }
 
@@ -64,7 +69,12 @@ check_cont(unsigned int          ncells,
 
   std::vector<std::string> names(1);
   names[0] = "CutOff";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_eps(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_gmv.cc
+++ b/tests/data_out/data_out_base_gmv.cc
@@ -44,7 +44,12 @@ check(DataOutBase::GmvFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_gmv(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_gnuplot.cc
+++ b/tests/data_out/data_out_base_gnuplot.cc
@@ -44,7 +44,12 @@ check(DataOutBase::GnuplotFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_gnuplot(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_gnuplot_02.cc
+++ b/tests/data_out/data_out_base_gnuplot_02.cc
@@ -46,7 +46,12 @@ check(DataOutBase::GnuplotFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_gnuplot(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_gnuplot_labels.cc
+++ b/tests/data_out/data_out_base_gnuplot_labels.cc
@@ -49,7 +49,12 @@ check(DataOutBase::GnuplotFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_gnuplot(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_povray.cc
+++ b/tests/data_out/data_out_base_povray.cc
@@ -46,7 +46,12 @@ check(DataOutBase::PovrayFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_povray(patches, names, vectors, flags, out);
 }
 
@@ -64,7 +69,12 @@ check_cont(unsigned int             ncells,
 
   std::vector<std::string> names(1);
   names[0] = "CutOff";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_povray(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_tecplot.cc
+++ b/tests/data_out/data_out_base_tecplot.cc
@@ -44,7 +44,12 @@ check(DataOutBase::TecplotFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_tecplot(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_tecplot_bin.cc
+++ b/tests/data_out/data_out_base_tecplot_bin.cc
@@ -41,7 +41,12 @@ check(DataOutBase::TecplotFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_tecplot_binary(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtk.cc
+++ b/tests/data_out/data_out_base_vtk.cc
@@ -44,7 +44,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtk(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtk_02.cc
+++ b/tests/data_out/data_out_base_vtk_02.cc
@@ -46,7 +46,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtk(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtk_cycle.cc
+++ b/tests/data_out/data_out_base_vtk_cycle.cc
@@ -47,7 +47,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtk(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtk_time.cc
+++ b/tests/data_out/data_out_base_vtk_time.cc
@@ -47,7 +47,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtk(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtk_time_and_cycle.cc
+++ b/tests/data_out/data_out_base_vtk_time_and_cycle.cc
@@ -47,7 +47,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtk(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtu.cc
+++ b/tests/data_out/data_out_base_vtu.cc
@@ -40,7 +40,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtu(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtu_02.cc
+++ b/tests/data_out/data_out_base_vtu_02.cc
@@ -46,7 +46,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtu(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtu_compression_levels.cc
+++ b/tests/data_out/data_out_base_vtu_compression_levels.cc
@@ -41,7 +41,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtu(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtu_cycle.cc
+++ b/tests/data_out/data_out_base_vtu_cycle.cc
@@ -42,7 +42,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtu(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtu_time.cc
+++ b/tests/data_out/data_out_base_vtu_time.cc
@@ -42,7 +42,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtu(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_base_vtu_time_and_cycle.cc
+++ b/tests/data_out/data_out_base_vtu_time_and_cycle.cc
@@ -43,7 +43,12 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
   DataOutBase::write_vtu(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/data_out_faces_04.cc
+++ b/tests/data_out/data_out_faces_04.cc
@@ -48,10 +48,14 @@ public:
     return DataOutFaces<dim>::get_dataset_names();
   }
 
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-  get_vector_data_ranges() const
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+  get_nonscalar_data_ranges() const
   {
-    return DataOutFaces<dim>::get_vector_data_ranges();
+    return DataOutFaces<dim>::get_nonscalar_data_ranges();
   }
 };
 
@@ -73,10 +77,14 @@ public:
     return DataOutReader<dim - 1, dim>::get_dataset_names();
   }
 
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-  get_vector_data_ranges() const
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+  get_nonscalar_data_ranges() const
   {
-    return DataOutReader<dim - 1, dim>::get_vector_data_ranges();
+    return DataOutReader<dim - 1, dim>::get_nonscalar_data_ranges();
   }
 };
 
@@ -128,23 +136,24 @@ my_check_this(const DoFHandler<dim> &dof_handler,
     AssertThrow(data_out.get_patches()[i] == reader.get_patches()[i],
                 ExcInternalError());
 
-  deallog << data_out.get_vector_data_ranges().size() << std::endl;
-  Assert(data_out.get_vector_data_ranges().size() ==
-           reader.get_vector_data_ranges().size(),
+  deallog << data_out.get_nonscalar_data_ranges().size() << std::endl;
+  Assert(data_out.get_nonscalar_data_ranges().size() ==
+           reader.get_nonscalar_data_ranges().size(),
          ExcInternalError());
-  for (unsigned int i = 0; i < data_out.get_vector_data_ranges().size(); ++i)
+  for (unsigned int i = 0; i < data_out.get_nonscalar_data_ranges().size(); ++i)
     {
-      deallog << std::get<0>(data_out.get_vector_data_ranges()[i]) << ' '
-              << std::get<1>(data_out.get_vector_data_ranges()[i]) << ' '
-              << std::get<2>(data_out.get_vector_data_ranges()[i]) << std::endl;
-      Assert(std::get<0>(data_out.get_vector_data_ranges()[i]) ==
-               std::get<0>(reader.get_vector_data_ranges()[i]),
+      deallog << std::get<0>(data_out.get_nonscalar_data_ranges()[i]) << ' '
+              << std::get<1>(data_out.get_nonscalar_data_ranges()[i]) << ' '
+              << std::get<2>(data_out.get_nonscalar_data_ranges()[i])
+              << std::endl;
+      Assert(std::get<0>(data_out.get_nonscalar_data_ranges()[i]) ==
+               std::get<0>(reader.get_nonscalar_data_ranges()[i]),
              ExcInternalError());
-      Assert(std::get<1>(data_out.get_vector_data_ranges()[i]) ==
-               std::get<1>(reader.get_vector_data_ranges()[i]),
+      Assert(std::get<1>(data_out.get_nonscalar_data_ranges()[i]) ==
+               std::get<1>(reader.get_nonscalar_data_ranges()[i]),
              ExcInternalError());
-      Assert(std::get<2>(data_out.get_vector_data_ranges()[i]) ==
-               std::get<2>(reader.get_vector_data_ranges()[i]),
+      Assert(std::get<2>(data_out.get_nonscalar_data_ranges()[i]) ==
+               std::get<2>(reader.get_nonscalar_data_ranges()[i]),
              ExcInternalError());
     }
 

--- a/tests/data_out/data_out_reader_01.cc
+++ b/tests/data_out/data_out_reader_01.cc
@@ -40,7 +40,12 @@ check()
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
 
   std::ostringstream old_data;
   DataOutBase::write_deal_II_intermediate(

--- a/tests/data_out/data_out_rotation_04.cc
+++ b/tests/data_out/data_out_rotation_04.cc
@@ -48,10 +48,14 @@ public:
     return DataOutRotation<dim>::get_dataset_names();
   }
 
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-  get_vector_data_ranges() const
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+  get_nonscalar_data_ranges() const
   {
-    return DataOutRotation<dim>::get_vector_data_ranges();
+    return DataOutRotation<dim>::get_nonscalar_data_ranges();
   }
 };
 
@@ -73,10 +77,14 @@ public:
     return DataOutReader<dim + 1>::get_dataset_names();
   }
 
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-  get_vector_data_ranges() const
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+  get_nonscalar_data_ranges() const
   {
-    return DataOutReader<dim + 1>::get_vector_data_ranges();
+    return DataOutReader<dim + 1>::get_nonscalar_data_ranges();
   }
 };
 
@@ -130,23 +138,24 @@ my_check_this(const DoFHandler<dim> &dof_handler,
     AssertThrow(data_out.get_patches()[i] == reader.get_patches()[i],
                 ExcInternalError());
 
-  deallog << data_out.get_vector_data_ranges().size() << std::endl;
-  Assert(data_out.get_vector_data_ranges().size() ==
-           reader.get_vector_data_ranges().size(),
+  deallog << data_out.get_nonscalar_data_ranges().size() << std::endl;
+  Assert(data_out.get_nonscalar_data_ranges().size() ==
+           reader.get_nonscalar_data_ranges().size(),
          ExcInternalError());
-  for (unsigned int i = 0; i < data_out.get_vector_data_ranges().size(); ++i)
+  for (unsigned int i = 0; i < data_out.get_nonscalar_data_ranges().size(); ++i)
     {
-      deallog << std::get<0>(data_out.get_vector_data_ranges()[i]) << ' '
-              << std::get<1>(data_out.get_vector_data_ranges()[i]) << ' '
-              << std::get<2>(data_out.get_vector_data_ranges()[i]) << std::endl;
-      Assert(std::get<0>(data_out.get_vector_data_ranges()[i]) ==
-               std::get<0>(reader.get_vector_data_ranges()[i]),
+      deallog << std::get<0>(data_out.get_nonscalar_data_ranges()[i]) << ' '
+              << std::get<1>(data_out.get_nonscalar_data_ranges()[i]) << ' '
+              << std::get<2>(data_out.get_nonscalar_data_ranges()[i])
+              << std::endl;
+      Assert(std::get<0>(data_out.get_nonscalar_data_ranges()[i]) ==
+               std::get<0>(reader.get_nonscalar_data_ranges()[i]),
              ExcInternalError());
-      Assert(std::get<1>(data_out.get_vector_data_ranges()[i]) ==
-               std::get<1>(reader.get_vector_data_ranges()[i]),
+      Assert(std::get<1>(data_out.get_nonscalar_data_ranges()[i]) ==
+               std::get<1>(reader.get_nonscalar_data_ranges()[i]),
              ExcInternalError());
-      Assert(std::get<2>(data_out.get_vector_data_ranges()[i]) ==
-               std::get<2>(reader.get_vector_data_ranges()[i]),
+      Assert(std::get<2>(data_out.get_nonscalar_data_ranges()[i]) ==
+               std::get<2>(reader.get_nonscalar_data_ranges()[i]),
              ExcInternalError());
     }
 


### PR DESCRIPTION
… tuple to represent DataComponentInterpretation

part of https://github.com/dealii/dealii/pull/6807/

Failing tests (need to add `DataComponentInterpretation::DataComponentInterpretation`):

- [x]	870 - data_out/data_out_reader_01.debug (Failed)
- [x]	872 - data_out/data_out_base_vtk_cycle.debug (Failed)
- [x]	879 - data_out/data_out_base_dx.debug (Failed)
- [x]	881 - data_out/data_out_base_tecplot_bin.debug (Failed)
- [x]	883 - data_out/data_out_base_povray.debug (Failed)
- [x]	886 - data_out/data_out_base_vtu_time_and_cycle.debug (Failed)
- [x]	891 - data_out/data_out_base_vtk_02.debug (Failed)
- [x]	893 - data_out/data_out_base_vtu_cycle.debug (Failed)
- [x] 	895 - data_out/data_out_base_eps.debug (Failed)
- [x]	900 - data_out/data_out_base_tecplot.debug (Failed)
- [x]	901 - data_out/data_out_base_gmv.debug (Failed)
- [x]	910 - data_out/data_out_base_vtu.debug (Failed)
- [x]	912 - data_out/data_out_base_gnuplot_labels.debug (Failed)
- [x]	916 - data_out/data_out_rotation_04.debug (Failed)
- [x]	917 - data_out/data_out_faces_04.debug (Failed)
- [x]	918 - data_out/data_out_base_vtu_compression_levels.debug (Failed)
- [x]	919 - data_out/data_out_base.debug (Failed)
- [x]	920 - data_out/data_out_base_vtk_time_and_cycle.debug (Failed)
- [x] 	921 - data_out/data_out_04.debug (Failed)
- [x] 	922 - data_out/data_out_base_gnuplot.debug (Failed)
- [x]	924 - data_out/data_out_base_gnuplot_02.debug (Failed)
- [x]	927 - data_out/data_out_base_vtk_time.debug (Failed)
- [x] 	930 - data_out/data_out_base_vtu_time.debug (Failed)
- [x]	936 - data_out/data_out_base_vtu_02.debug (Failed)
- [x]	939 - data_out/data_out_base_vtk.debug (Failed)
- [x]	2233 - base/functions_04.debug (Failed)