### PR TITLE
Reflow some code samples.

### DIFF
--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -48,15 +48,12 @@ DEAL_II_NAMESPACE_OPEN
  * template argument type of this class needs to be @p const as well. The
  * following code snippet gives an example:
  * @code
- *   std::vector<int>       array       = get_data();  // a writable array
- *
- *   ArrayView<int> view (&array[5], 5);               // a view of
- * elements 5..9 (inclusive) view[2] = 42; // array[7] is set to 42
- *
- *   ArrayView<const int> const_view (&array[5], 5);   // same view, but
- * read-only int element_7 = const_view[2];                    // returns 42
- *   const_view[2] = 42;                               // error, can't write
- * into this view
+ * std::vector<int> array = get_data(); // a writable array
+ * ArrayView<int> view (&array[5], 5); // a view of elements 5..9 (inclusive)
+ * view[2] = 42; // array[7] is set to 42
+ * ArrayView<const int> const_view (&array[5], 5); // same view, but read-only
+ * int element_7 = const_view[2]; // set element_7 to 42
+ * const_view[2] = 42; // this line won't compile; can't write into this view
  * @endcode
  * In either case, accessing an element of a view does not change the
  * ArrayView object itself, and consequently ArrayView::operator[] is a @p

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2036,26 +2036,25 @@ namespace DataOutBase
    * <code>std::vector@<std::pair@<double,std::string@> @></code>):
    *
    * @code
-   *  template <int dim>
-   *  void MyEquation<dim>::output_results () const
-   *  {
-   *    DataOut<dim> data_out;
+   * template <int dim>
+   * void MyEquation<dim>::output_results () const
+   * {
+   *   DataOut<dim> data_out;
    *
-   *    data_out.attach_dof_handler (dof_handler);
-   *    data_out.add_data_vector (solution, "U");
-   *    data_out.build_patches ();
+   *   data_out.attach_dof_handler(dof_handler);
+   *   data_out.add_data_vector(solution, "U");
+   *   data_out.build_patches();
    *
-   *    const std::string filename = "solution-" +
-   *                                 Utilities::int_to_string (timestep_number,
-   * 3) +
-   *                                 ".vtu";
-   *    std::ofstream output (filename.c_str());
-   *    data_out.write_vtu (output);
+   *   const std::string filename = "solution-" +
+   *                                Utilities::int_to_string (timestep_n, 3) +
+   *                                ".vtu";
+   *   std::ofstream output(filename);
+   *   data_out.write_vtu(output);
    *
-   *    times_and_names.emplace_back (time, filename);
-   *    std::ofstream pvd_output ("solution.pvd");
-   *    DataOutBase::write_pvd_record (pvd_output, times_and_names);
-   *  }
+   *   times_and_names.emplace_back (time, filename);
+   *   std::ofstream pvd_output ("solution.pvd");
+   *   DataOutBase::write_pvd_record (pvd_output, times_and_names);
+   * }
    * @endcode
    *
    * @note See DataOutInterface::write_vtu, DataOutInterface::write_pvtu_record,
@@ -2095,21 +2094,21 @@ namespace DataOutBase
    * multiple time steps. Here is an example of how the function would be
    * used:
    * @code
-   *  const unsigned int number_of_time_steps = 3;
-   *  std::vector<std::vector<std::string > > piece_names(number_of_time_steps);
+   * const unsigned int number_of_time_steps = 3;
+   * std::vector<std::vector<std::string > > piece_names(number_of_time_steps);
    *
-   *  piece_names[0].emplace_back("subdomain_01.time_step_0.vtk");
-   *  piece_names[0].emplace_back("subdomain_02.time_step_0.vtk");
+   * piece_names[0].emplace_back("subdomain_01.time_step_0.vtk");
+   * piece_names[0].emplace_back("subdomain_02.time_step_0.vtk");
    *
-   *  piece_names[1].emplace_back("subdomain_01.time_step_1.vtk");
-   *  piece_names[1].emplace_back("subdomain_02.time_step_1.vtk");
+   * piece_names[1].emplace_back("subdomain_01.time_step_1.vtk");
+   * piece_names[1].emplace_back("subdomain_02.time_step_1.vtk");
    *
-   *  piece_names[2].emplace_back("subdomain_01.time_step_2.vtk");
-   *  piece_names[2].emplace_back("subdomain_02.time_step_2.vtk");
+   * piece_names[2].emplace_back("subdomain_01.time_step_2.vtk");
+   * piece_names[2].emplace_back("subdomain_02.time_step_2.vtk");
    *
-   *  std::ofstream visit_output ("master_file.visit");
+   * std::ofstream visit_output ("master_file.visit");
    *
-   *  DataOutBase::write_visit_record(visit_output, piece_names);
+   * DataOutBase::write_visit_record(visit_output, piece_names);
    * @endcode
    *
    * This function is documented in the "Creating a master file for parallel"
@@ -2127,25 +2126,25 @@ namespace DataOutBase
    * each timestep. Here is an example of how the function would be
    * used:
    * @code
-   *  const unsigned int number_of_time_steps = 3;
-   *  std::vector<std::pair<double,std::vector<std::string > > >
+   * const unsigned int number_of_time_steps = 3;
+   * std::vector<std::pair<double,std::vector<std::string > > >
    * times_and_piece_names(number_of_time_steps);
    *
-   *  times_and_piece_names[0].first = 0.0;
-   *  times_and_piece_names[0].second.emplace_back("subdomain_01.time_step_0.vtk");
-   *  times_and_piece_names[0].second.emplace_back("subdomain_02.time_step_0.vtk");
+   * times_and_piece_names[0].first = 0.0;
+   * times_and_piece_names[0].second.emplace_back("subdomain_01.time_step_0.vtk");
+   * times_and_piece_names[0].second.emplace_back("subdomain_02.time_step_0.vtk");
    *
-   *  times_and_piece_names[1].first = 0.5;
-   *  times_and_piece_names[1].second.emplace_back("subdomain_01.time_step_1.vtk");
-   *  times_and_piece_names[1].second.emplace_back("subdomain_02.time_step_1.vtk");
+   * times_and_piece_names[1].first = 0.5;
+   * times_and_piece_names[1].second.emplace_back("subdomain_01.time_step_1.vtk");
+   * times_and_piece_names[1].second.emplace_back("subdomain_02.time_step_1.vtk");
    *
-   *  times_and_piece_names[2].first = 1.0;
-   *  times_and_piece_names[2].second.emplace_back("subdomain_01.time_step_2.vtk");
-   *  times_and_piece_names[2].second.emplace_back("subdomain_02.time_step_2.vtk");
+   * times_and_piece_names[2].first = 1.0;
+   * times_and_piece_names[2].second.emplace_back("subdomain_01.time_step_2.vtk");
+   * times_and_piece_names[2].second.emplace_back("subdomain_02.time_step_2.vtk");
    *
-   *  std::ofstream visit_output ("master_file.visit");
+   * std::ofstream visit_output ("master_file.visit");
    *
-   *  DataOutBase::write_visit_record(visit_output, times_and_piece_names);
+   * DataOutBase::write_visit_record(visit_output, times_and_piece_names);
    * @endcode
    *
    * This function is documented in the "Creating a master file for parallel"
@@ -2438,21 +2437,17 @@ namespace DataOutBase
  *
  * Usage is as follows:
  * @code
- *                               // within function declaring parameters:
- *   ...
- *   prm.enter_subsection ("Output format options");
- *     DataOutInterface<dim>::declare_parameters (prm);
- *   prm.leave_subsection ();
- *   ...
+ *   // within function declaring parameters:
+ *   prm.enter_subsection("Output format options");
+ *   DataOutInterface<dim>::declare_parameters(prm);
+ *   prm.leave_subsection();
  *
- *
- *                               // within function doing the output:
  *   ...
+ *   // within function doing the output:
  *   DataOut<dim> out;
- *   prm.enter_subsection ("Output format options");
- *   out.parse_parameters (prm);
- *   prm.leave_subsection ();
- *   ...
+ *   prm.enter_subsection("Output format options");
+ *   out.parse_parameters(prm);
+ *   prm.leave_subsection();
  * @endcode
  * Note that in the present example, the class <tt>DataOut</tt> was used.
  * However, any other class derived from <tt>DataOutInterface</tt> would work
@@ -2687,16 +2682,18 @@ public:
    * DataOutFilter:
    *
    * @code
-   * DataOutBase::DataOutFilter
-   * data_filter(DataOutBase::DataOutFilterFlags(true, true));
-   * std::vector<XDMFEntry>       xdmf_entries;
+   * DataOutBase::DataOutFilterFlags flags(true, true)
+   * DataOutBase::DataOutFilter data_filter(flags);
+   * std::vector<XDMFEntry> xdmf_entries;
    * // Filter the data and store it in data_filter
    * data_out.write_filtered_data(data_filter);
    * // Write the filtered data to HDF5
    * data_out.write_hdf5_parallel(data_filter, "solution.h5", MPI_COMM_WORLD);
    * // Create an XDMF entry detailing the HDF5 file
-   * new_xdmf_entry = data_out.create_xdmf_entry(data_filter, "solution.h5",
-   * simulation_time, MPI_COMM_WORLD);
+   * auto new_xdmf_entry = data_out.create_xdmf_entry(data_filter,
+   *                                                  "solution.h5",
+   *                                                  simulation_time,
+   *                                                  MPI_COMM_WORLD);
    * // Add the XDMF entry to the list
    * xdmf_entries.push_back(new_xdmf_entry);
    * // Create an XDMF file from all stored entries
@@ -2714,8 +2711,8 @@ public:
    * with the DataOutFilter:
    *
    * @code
-   * DataOutBase::DataOutFilter
-   * data_filter(DataOutBase::DataOutFilterFlags(true, true));
+   * DataOutBase::DataOutFilterFlags flags(true, true)
+   * DataOutBase::DataOutFilter data_filter(flags);
    * // Filter the data and store it in data_filter
    * data_out.write_filtered_data(data_filter);
    * // Write the filtered data to HDF5

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -53,27 +53,30 @@ class TensorFunction;
  * object represents. Access to function objects therefore is through the
  * following methods:
  * @code
- *   // access to one component at one point
- *   double value        (const Point<dim>   &p,
- *                        const unsigned int  component = 0) const;
+ * // access to one component at one point
+ * double
+ * value(const Point<dim> & p,
+ *       const unsigned int component = 0) const;
  *
- *   // return all components at one point
- *   void   vector_value (const Point<dim>   &p,
- *                        Vector<double>     &value) const;
+ * // return all components at one point
+ * void
+ * vector_value(const Point<dim> &p,
+ *              Vector<double> &  value) const;
  * @endcode
  *
  * For more efficiency, there are other functions returning one or all
  * components at a list of points at once:
  * @code
- *   // access to one component at several points
- *   void   value_list (const std::vector<Point<dim> >  &point_list,
- *                      std::vector<double>             &value_list,
- *                      const unsigned int  component = 0) const;
+ * // access to one component at several points
+ * void
+ * value_list(const std::vector<Point<dim>> &point_list,
+ *            std::vector<double> &          value_list,
+ *            const unsigned int             component = 0) const;
  *
- *   // return all components at several points
- *   void   vector_value_list (const std::vector<Point<dim> >    &point_list,
- *                             std::vector<Vector<double> >      &value_list)
- * const;
+ * // return all components at several points
+ * void
+ * vector_value_list(const std::vector<Point<dim>> &point_list,
+ *                   std::vector<Vector<double>> &  value_list) const;
  * @endcode
  *
  * Furthermore, there are functions returning the gradient of the function or
@@ -615,11 +618,11 @@ protected:
 /**
  * This class provides a way to convert a scalar function of the kind
  * @code
- *   RangeNumberType foo (const Point<dim> &);
+ * RangeNumberType foo (const Point<dim> &);
  * @endcode
  * into an object of type Function@<dim@>. Since the argument returns a
  * scalar, the result is clearly a Function object for which
- * <code>function.n_components==1</code>. The class works by storing a pointer
+ * <code>function.n_components == 1</code>. The class works by storing a pointer
  * to the given function and every time
  * <code>function.value(p,component)</code> is called, calls
  * <code>foo(p)</code> and returns the corresponding value. It also makes sure
@@ -641,52 +644,55 @@ protected:
  * argument. For example, if you need a Function object that returns the norm
  * of a point, you could write it like so:
  * @code
- *   template <int dim, typename RangeNumberType>
- *   class Norm : public Function<dim, RangeNumberType> {
- *     public:
- *       virtual RangeNumberType value (const Point<dim> &p,
- *                                  const unsigned int component) const
- *       {
- *         Assert (component == 0, ExcMessage ("This object is scalar!"));
- *         return p.norm();
- *       }
- *    };
+ * template <int dim, typename RangeNumberType>
+ * class Norm : public Function<dim, RangeNumberType>
+ * {
+ * public:
+ *   virtual RangeNumberType
+ *   value(const Point<dim> & p,
+ *         const unsigned int component) const
+ *   {
+ *     Assert (component == 0, ExcMessage ("This object is scalar!"));
+ *     return p.norm();
+ *   }
+ * };
  *
- *    Norm<2> my_norm_object;
+ * Norm<2> my_norm_object;
  * @endcode
  * and then pass the <code>my_norm_object</code> around, or you could write it
  * like so:
  * @code
- *   ScalarFunctionFromFunctionObject<dim, RangeNumberType> my_norm_object
- * (&Point<dim>::norm);
+ * ScalarFunctionFromFunctionObject<dim, RangeNumberType> my_norm_object(
+ *   &Point<dim>::norm);
  * @endcode
  *
  * Similarly, to generate an object that computes the distance to a point
  * <code>q</code>, we could do this:
  * @code
- *   template <int dim, typename RangeNumberType>
- *   class DistanceTo : public Function<dim, RangeNumberType> {
- *     public:
- *       DistanceTo (const Point<dim> &q) : q(q) {}
- *       virtual RangeNumberType value (const Point<dim> &p,
- *                                  const unsigned int component) const
- *       {
- *         Assert (component == 0, ExcMessage ("This object is scalar!"));
- *         return q.distance(p);
- *       }
- *     private:
- *       const Point<dim> q;
- *    };
+ * template <int dim, typename RangeNumberType>
+ * class DistanceTo : public Function<dim, RangeNumberType>
+ * {
+ * public:
+ *   DistanceTo (const Point<dim> &q) : q(q) {}
  *
- *    Point<2> q (2,3);
- *    DistanceTo<2> my_distance_object;
+ *   virtual RangeNumberType
+ *   value (const Point<dim> & p,
+ *          const unsigned int component) const
+ *   {
+ *     Assert(component == 0, ExcMessage("This object is scalar!"));
+ *     return q.distance(p);
+ *   }
+ * private:
+ *   const Point<dim> q;
+ * };
+ *
+ * Point<2> q (2, 3);
+ * DistanceTo<2> my_distance_object;
  * @endcode
  * or we could write it like so:
  * @code
- *    ScalarFunctionFromFunctionObject<dim, RangeNumberType>
- *      my_distance_object (std::bind (&Point<dim>::distance,
- *                                           q,
- *                                           std::placeholders::_1));
+ * ScalarFunctionFromFunctionObject<dim, RangeNumberType> my_distance_object(
+ *   std::bind(&Point<dim>::distance, q, std::placeholders::_1));
  * @endcode
  * The savings in work to write this are apparent.
  *
@@ -741,9 +747,13 @@ private:
  *
  * To be more concrete, let us consider the following example:
  * @code
- *   RangeNumberType one (const Point<2> &p) { return 1; }
- *   VectorFunctionFromScalarFunctionObject<2>
- *      component_mask (&one, 1, 3);
+ * RangeNumberType
+ * one(const Point<2> &p)
+ * {
+ *   return 1.0;
+ * }
+ *
+ * VectorFunctionFromScalarFunctionObject<2> component_mask(&one, 1, 3);
  * @endcode
  * Here, <code>component_mask</code> then represents a Function object that
  * for every point returns the vector $(0, 1, 0)^T$, i.e. a mask function that
@@ -818,13 +828,13 @@ private:
  * components be 0.
  *
  * For example: Say you created a class called
- *  @code
- *    class RightHandSide : public TensorFunction<rank,dim, RangeNumberType>
- *  @endcode
+ * @code
+ * class RightHandSide : public TensorFunction<rank,dim, RangeNumberType>
+ * @endcode
  * which extends the TensorFunction class and you have an object
- *  @code
- *    RightHandSide<1,dim, RangeNumberType> rhs;
- *  @endcode
+ * @code
+ * RightHandSide<1,dim, RangeNumberType> rhs;
+ * @endcode
  * of that class which you want to interpolate onto your mesh using the
  * VectorTools::interpolate function, but the finite element you use for the
  * DoFHandler object has 3 copies of a finite element with <tt>dim</tt>
@@ -832,11 +842,11 @@ private:
  * DoFHandler, you need an object of type Function that has 3*dim vector
  * components. Creating such an object from the existing <code>rhs</code>
  * object is done using this piece of code:
- *  @code
- *      RighHandSide<1,dim, RangeNumberType> rhs;
- *      VectorFunctionFromTensorFunction<dim, RangeNumberType>
- * rhs_vector_function (rhs, 0, 3*dim);
- *  @endcode
+ * @code
+ * RightHandSide<1,dim, RangeNumberType> rhs;
+ * VectorFunctionFromTensorFunction<dim, RangeNumberType> rhs_vector_function(
+ *   rhs, 0, 3*dim);
+ * @endcode
  * where the <code>dim</code> components of the tensor function are placed
  * into the first <code>dim</code> components of the function object.
  *


### PR DESCRIPTION
The content of @code/@endcode blocks must be less than 80 characters per line to prevent clang-format from rewrapping it in strange ways.

I went ahead and fixed three files: things look better now.

Part of #6814.