### PR TITLE
cmake check for using and DEAL_II_DEPRECATED

### DIFF
--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -312,6 +312,10 @@ CHECK_CXX_SOURCE_COMPILES(
             [[deprecated]] void test();
           };
 
+          template <int dim>
+          struct foo {};
+          using bar [[deprecated]] = foo<2>;
+
           int main () {}
   "
   DEAL_II_COMPILER_HAS_CXX14_ATTRIBUTE_DEPRECATED
@@ -328,6 +332,10 @@ CHECK_CXX_SOURCE_COMPILES(
             __attribute__((deprecated)) bob(int i);
             __attribute__((deprecated)) void test();
           };
+
+          template <int dim>
+          struct foo {};
+          using bar __attribute__((deprecated)) = foo<2>;
 
           int main () {}
   "


### PR DESCRIPTION
it turns out the intel compiler doesn't like deprecated using:
```
In file included from /ssd/deal-git/source/lac/affine_constraints.cc(16):
/ssd/deal-git/include/deal.II/lac/affine_constraints.h(65): warning #2651: attribute does not apply to any entity
  using ConstraintMatrix DEAL_II_DEPRECATED = AffineConstraints<double>;
```

This updates the cmake check to stop this from happening.