### PR TITLE
fix failing HDF5 test

### DIFF
--- a/tests/mpi/data_out_hdf5_02.cc
+++ b/tests/mpi/data_out_hdf5_02.cc
@@ -92,7 +92,12 @@ check()
   names[2] = "x3";
   names[3] = "x4";
   names[4] = "i";
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>> vectors;
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
 
   DataOutBase::DataOutFilter data_filter(
     DataOutBase::DataOutFilterFlags(false, false));


### PR DESCRIPTION
follow up to https://github.com/dealii/dealii/pull/6816

```
$ ctest -R "data_out_hdf5_02"
Test project /Users/davydden/libs-sources/deal.ii/deal.ii/_build
    Start 2013: mpi/data_out_hdf5_02.mpirun=1.debug
1/2 Test #2013: mpi/data_out_hdf5_02.mpirun=1.debug .....   Passed    2.57 sec
    Start 2014: mpi/data_out_hdf5_02.mpirun=1.release
2/2 Test #2014: mpi/data_out_hdf5_02.mpirun=1.release ...   Passed    2.70 sec

100% tests passed, 0 tests failed out of 2
```