### PR TITLE
Fix some clang-tidy findings

### DIFF
--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -962,7 +962,7 @@ namespace Step18
 
     // As in step-17, we only need to loop over all cells that belong to the
     // present processor:
-    for (const auto cell : dof_handler.active_cell_iterators())
+    for (const auto &cell : dof_handler.active_cell_iterators())
       if (cell->is_locally_owned())
         {
           cell_matrix = 0;

--- a/examples/step-36/step-36.cc
+++ b/examples/step-36/step-36.cc
@@ -258,7 +258,7 @@ namespace Step36
                          typename FunctionParser<dim>::ConstMap());
 
     std::vector<double> potential_values(n_q_points);
-    for (const auto cell : dof_handler.active_cell_iterators())
+    for (const auto &cell : dof_handler.active_cell_iterators())
       {
         fe_values.reinit(cell);
         cell_stiffness_matrix = 0;

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -304,7 +304,7 @@ namespace Step8
     std::vector<Tensor<1, dim>> rhs_values(n_q_points);
 
     // Now we can begin with the loop over all cells:
-    for (const auto cell : dof_handler.active_cell_iterators())
+    for (const auto &cell : dof_handler.active_cell_iterators())
       {
         cell_matrix = 0;
         cell_rhs    = 0;

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -45,8 +45,7 @@
 #include <deal.II/matrix_free/shape_info.h>
 #include <deal.II/matrix_free/task_info.h>
 
-#include <stdlib.h>
-
+#include <cstdlib>
 #include <limits>
 #include <list>
 #include <memory>

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -1080,7 +1080,7 @@ namespace DoFTools
       // note that even though we may visit a face twice if the neighboring
       // cells are equally refined, we can only visit each face with hanging
       // nodes once
-      for (const auto cell : dof_handler.active_cell_iterators())
+      for (const auto &cell : dof_handler.active_cell_iterators())
         {
           // artificial cells can at best neighbor ghost cells, but we're not
           // interested in these interfaces


### PR DESCRIPTION
Fixes the complains reported in [CDash](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=2875).