### PR TITLE
Return dereferenced IteratorOverIterators object by const reference

### DIFF
--- a/include/deal.II/base/iterator_range.h
+++ b/include/deal.II/base/iterator_range.h
@@ -142,7 +142,7 @@ public:
      * Dereferencing operator.
      * @return The iterator within the collection currently pointed to.
      */
-    BaseIterator operator*() const;
+    const BaseIterator &operator*() const;
 
     /**
      * Dereferencing operator.
@@ -231,8 +231,8 @@ private:
   /**
    * Iterators characterizing the begin and end of the range.
    */
-  const iterator it_begin;
-  const iterator it_end;
+  const IteratorOverIterators it_begin;
+  const IteratorOverIterators it_end;
 };
 
 
@@ -248,7 +248,8 @@ inline IteratorRange<Iterator>::IteratorOverIterators::IteratorOverIterators(
 
 
 template <typename Iterator>
-inline typename IteratorRange<Iterator>::IteratorOverIterators::BaseIterator
+inline const typename IteratorRange<
+  Iterator>::IteratorOverIterators::BaseIterator &
   IteratorRange<Iterator>::IteratorOverIterators::operator*() const
 {
   return element_of_iterator_collection;
@@ -316,7 +317,7 @@ template <typename Iterator>
 inline typename IteratorRange<Iterator>::IteratorOverIterators
 IteratorRange<Iterator>::begin()
 {
-  return IteratorOverIterators(it_begin);
+  return it_begin;
 }
 
 
@@ -324,7 +325,7 @@ template <typename Iterator>
 inline typename IteratorRange<Iterator>::IteratorOverIterators
 IteratorRange<Iterator>::end()
 {
-  return IteratorOverIterators(it_end);
+  return it_end;
 }
 
 


### PR DESCRIPTION
Without this PR, `clang`s `Wrange-loop-analysis` (enabled by `-Weverything`) complains about using `const auto& cell` for cell iterators :
```
step-8.cc:307:22: warning: loop variable 'cell' is always a copy because the range of type 'IteratorRange<dealii::DoFHandler<2, 2>::active_cell_iterator>' (aka 'IteratorRange<TriaActiveIterator<DoFCellAccessor<DoFHandler<2, 2>, false> > >') does not return a reference [-Wrange-loop-analysis]
    for (const auto &cell : dof_handler.active_cell_iterators())
                     ^
step-8.cc:638:9: note: in instantiation of member function 'Step8::ElasticProblem<2>::assemble_system' requested here
        assemble_system();
        ^
step-8.cc:655:26: note: in instantiation of member function 'Step8::ElasticProblem<2>::run' requested here
      elastic_problem_2d.run();
                         ^
step-8.cc:307:10: note: use non-reference type 'dealii::TriaActiveIterator<dealii::DoFCellAccessor<dealii::DoFHandler<2, 2>, false> >'
    for (const auto &cell : dof_handler.active_cell_iterators())
         ^~~~~~~~~~~~~~~~~~
```

In fact, the dereference operator returned a copy instead of a reference. Admittedly, this change is not relevant to performance at all. The intent is more to follow in-line with the idea of the warning: Don't suggest that the range element is taken by reference when it really is copied and tied to a const reference (and preferring passing by const reference over passing by const copy if possible).

There are more places that could also trigger this warning, but I would first want to get resonance to this one.