### PR TITLE
Fix more -Wrange-loop-analysis findings

### DIFF
--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -691,7 +691,7 @@ public:
      * Dereferencing operator. The returned value is the index of the element
      * inside the IndexSet.
      */
-    size_type operator*() const;
+    const size_type &operator*() const;
 
     /**
      * Does this iterator point to an existing element?
@@ -1283,7 +1283,7 @@ IndexSet::ElementIterator::is_valid() const
 
 
 
-inline IndexSet::size_type IndexSet::ElementIterator::operator*() const
+inline const IndexSet::size_type &IndexSet::ElementIterator::operator*() const
 {
   Assert(
     is_valid(),

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -691,7 +691,7 @@ public:
      * Dereferencing operator. The returned value is the index of the element
      * inside the IndexSet.
      */
-    const size_type &operator*() const;
+    size_type operator*() const;
 
     /**
      * Does this iterator point to an existing element?
@@ -1283,7 +1283,7 @@ IndexSet::ElementIterator::is_valid() const
 
 
 
-inline const IndexSet::size_type &IndexSet::ElementIterator::operator*() const
+inline IndexSet::size_type IndexSet::ElementIterator::operator*() const
 {
   Assert(
     is_valid(),

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -165,7 +165,7 @@ AffineConstraints<number>::is_consistent_in_parallel(
     {
       // find all lines to send to @p owner
       IndexSet indices_to_send = non_owned & locally_owned_dofs[owner];
-      for (const auto &row_idx : indices_to_send)
+      for (const auto row_idx : indices_to_send)
         {
           to_send[owner].push_back(get_line(row_idx));
         }

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -562,7 +562,7 @@ namespace LinearAlgebra
     stored_elements.print(out);
     out << std::endl;
     unsigned int i = 0;
-    for (const auto &idx : this->stored_elements)
+    for (const auto idx : this->stored_elements)
       out << "[" << idx << "]: " << values[i++] << '\n';
     out << std::flush;
 

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -528,7 +528,7 @@ namespace DoFRenumbering
             active_but_not_owned_dofs.subtract_set(locally_owned_dofs);
 
             std::set<types::global_dof_index> erase_these_indices;
-            for (const auto &p : active_but_not_owned_dofs)
+            for (const auto p : active_but_not_owned_dofs)
               {
                 const auto index = index_set_to_use.index_within_set(p);
                 Assert(index < index_set_to_use.n_elements(),

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1040,7 +1040,7 @@ namespace DoFTools
            ExcDimensionMismatch(selected_dofs.size(), dof_handler.n_dofs()));
     // preset all values by false
     std::fill(selected_dofs.begin(), selected_dofs.end(), false);
-    for (const auto &index : selected_dofs_as_index_set)
+    for (const auto index : selected_dofs_as_index_set)
       selected_dofs[index] = true;
   }
 

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1740,7 +1740,7 @@ namespace GridTools
     // Creating a bounding box for all active cell on coarser level
 
     for (unsigned int i = 0; i < refinement_level; ++i)
-      for (typename MeshType::cell_iterator cell :
+      for (const typename MeshType::cell_iterator &cell :
            mesh.active_cell_iterators_on_level(i))
         {
           bool                  has_predicate = false;

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -411,7 +411,7 @@ namespace TrilinosWrappers
         // Try to copy all the rows of the matrix one by one. In case of error
         // (i.e., the column indices are different), we need to abort and blow
         // away the matrix.
-        for (const auto &row : locally_owned_range_indices())
+        for (const auto row : locally_owned_range_indices())
           {
             const int row_local = matrix->RowMap().LID(
               static_cast<TrilinosWrappers::types::int_type>(row));
@@ -1905,7 +1905,7 @@ namespace TrilinosWrappers
 
     const bool same_col_map = matrix->ColMap().SameAs(rhs.matrix->ColMap());
 
-    for (const auto &row : locally_owned_range_indices())
+    for (const auto row : locally_owned_range_indices())
       {
         const int row_local = matrix->RowMap().LID(
           static_cast<TrilinosWrappers::types::int_type>(row));

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -348,7 +348,7 @@ KellyErrorEstimator<1, spacedim>::estimate(
                     "indicator for internal boundaries in your boundary "
                     "value map."));
 
-  for (const auto boundary_function : neumann_bc)
+  for (const auto &boundary_function : neumann_bc)
     {
       (void)boundary_function;
       Assert(boundary_function.second->n_components == n_components,


### PR DESCRIPTION
After #6844, this fixes the remaining complaints of `-Wrange-loop-analysis`.
Again, this is just for clarification.

These are examples of the previous warnings:
```
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../source/numerics/error_estimator_1d.cc:351:19: error: loop variable 'boundary_function' of type 'const std::pair<const unsigned int, const dealii::Function<1, std::complex<float> > *>' creates a copy from type 'const std::pair<const unsigned int, const dealii::Function<1, std::complex<float> > *>' [-Werror,-Wrange-loop-analysis]
  for (const auto boundary_function : neumann_bc)
                  ^
source/numerics/error_estimator_1d.inst:8366:33: note: in instantiation of function template specialization 'dealii::KellyErrorEstimator<1, 1>::estimate<dealii::Vector<std::complex<float> >, dealii::DoFHandler<1, 1> >' requested here
 KellyErrorEstimator< 1 ,  1 >::estimate<
                                ^
../source/numerics/error_estimator_1d.cc:351:8: note: use reference type 'const std::pair<const unsigned int, const dealii::Function<1, std::complex<float> > *> &' to prevent copying
  for (const auto boundary_function : neumann_bc)
```

```
../source/dofs/dof_renumbering.cc:531:30: error: loop variable 'p' is always a copy because the range of type 'dealii::IndexSet' does not return a reference [-Werror,-Wrange-loop-analysis]
            for (const auto &p : active_but_not_owned_dofs)
                             ^
source/dofs/dof_renumbering.inst:2675:2: note: in instantiation of function template specialization 'dealii::DoFRenumbering::compute_Cuthill_McKee<dealii::hp::DoFHandler<3, 3> >' requested here
 compute_Cuthill_McKee<hp::DoFHandler< 3 >>(
 ^
../source/dofs/dof_renumbering.cc:531:18: note: use non-reference type 'unsigned long long'
            for (const auto &p : active_but_not_owned_dofs)
```