### PR TITLE
Refactored data transfer across distributed meshes.

### DIFF
--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -65,29 +65,31 @@ namespace internal
     template <>
     struct types<2>
     {
-      using connectivity = p4est_connectivity_t;
-      using forest       = p4est_t;
-      using tree         = p4est_tree_t;
-      using quadrant     = p4est_quadrant_t;
-      using topidx       = p4est_topidx_t;
-      using locidx       = p4est_locidx_t;
-      using gloidx       = p4est_gloidx_t;
-      using balance_type = p4est_connect_type_t;
-      using ghost        = p4est_ghost_t;
+      using connectivity     = p4est_connectivity_t;
+      using forest           = p4est_t;
+      using tree             = p4est_tree_t;
+      using quadrant         = p4est_quadrant_t;
+      using topidx           = p4est_topidx_t;
+      using locidx           = p4est_locidx_t;
+      using gloidx           = p4est_gloidx_t;
+      using balance_type     = p4est_connect_type_t;
+      using ghost            = p4est_ghost_t;
+      using transfer_context = p4est_transfer_context_t;
     };
 
     template <>
     struct types<3>
     {
-      using connectivity = p8est_connectivity_t;
-      using forest       = p8est_t;
-      using tree         = p8est_tree_t;
-      using quadrant     = p8est_quadrant_t;
-      using topidx       = p4est_topidx_t;
-      using locidx       = p4est_locidx_t;
-      using gloidx       = p4est_gloidx_t;
-      using balance_type = p8est_connect_type_t;
-      using ghost        = p8est_ghost_t;
+      using connectivity     = p8est_connectivity_t;
+      using forest           = p8est_t;
+      using tree             = p8est_tree_t;
+      using quadrant         = p8est_quadrant_t;
+      using topidx           = p4est_topidx_t;
+      using locidx           = p4est_locidx_t;
+      using gloidx           = p4est_gloidx_t;
+      using balance_type     = p8est_connect_type_t;
+      using ghost            = p8est_ghost_t;
+      using transfer_context = p8est_transfer_context_t;
     };
 
 
@@ -228,6 +230,46 @@ namespace internal
                 void *                                     user_data);
 
       static constexpr unsigned int max_level = P4EST_MAXLEVEL;
+
+      static void (&transfer_fixed)(const types<2>::gloidx *dest_gfq,
+                                    const types<2>::gloidx *src_gfq,
+                                    MPI_Comm                mpicomm,
+                                    int                     tag,
+                                    void *                  dest_data,
+                                    const void *            src_data,
+                                    size_t                  data_size);
+
+      static types<2>::transfer_context *(&transfer_fixed_begin)(
+        const types<2>::gloidx *dest_gfq,
+        const types<2>::gloidx *src_gfq,
+        MPI_Comm                mpicomm,
+        int                     tag,
+        void *                  dest_data,
+        const void *            src_data,
+        size_t                  data_size);
+
+      static void (&transfer_fixed_end)(types<2>::transfer_context *tc);
+
+      static void (&transfer_custom)(const types<2>::gloidx *dest_gfq,
+                                     const types<2>::gloidx *src_gfq,
+                                     MPI_Comm                mpicomm,
+                                     int                     tag,
+                                     void *                  dest_data,
+                                     const int *             dest_sizes,
+                                     const void *            src_data,
+                                     const int *             src_sizes);
+
+      static types<2>::transfer_context *(&transfer_custom_begin)(
+        const types<2>::gloidx *dest_gfq,
+        const types<2>::gloidx *src_gfq,
+        MPI_Comm                mpicomm,
+        int                     tag,
+        void *                  dest_data,
+        const int *             dest_sizes,
+        const void *            src_data,
+        const int *             src_sizes);
+
+      static void (&transfer_custom_end)(types<2>::transfer_context *tc);
     };
 
 
@@ -349,9 +391,47 @@ namespace internal
 
       static size_t (&connectivity_memory_used)(types<3>::connectivity *p4est);
 
-
-
       static constexpr unsigned int max_level = P8EST_MAXLEVEL;
+
+      static void (&transfer_fixed)(const types<3>::gloidx *dest_gfq,
+                                    const types<3>::gloidx *src_gfq,
+                                    MPI_Comm                mpicomm,
+                                    int                     tag,
+                                    void *                  dest_data,
+                                    const void *            src_data,
+                                    size_t                  data_size);
+
+      static types<3>::transfer_context *(&transfer_fixed_begin)(
+        const types<3>::gloidx *dest_gfq,
+        const types<3>::gloidx *src_gfq,
+        MPI_Comm                mpicomm,
+        int                     tag,
+        void *                  dest_data,
+        const void *            src_data,
+        size_t                  data_size);
+
+      static void (&transfer_fixed_end)(types<3>::transfer_context *tc);
+
+      static void (&transfer_custom)(const types<3>::gloidx *dest_gfq,
+                                     const types<3>::gloidx *src_gfq,
+                                     MPI_Comm                mpicomm,
+                                     int                     tag,
+                                     void *                  dest_data,
+                                     const int *             dest_sizes,
+                                     const void *            src_data,
+                                     const int *             src_sizes);
+
+      static types<3>::transfer_context *(&transfer_custom_begin)(
+        const types<3>::gloidx *dest_gfq,
+        const types<3>::gloidx *src_gfq,
+        MPI_Comm                mpicomm,
+        int                     tag,
+        void *                  dest_data,
+        const int *             dest_sizes,
+        const void *            src_data,
+        const int *             src_sizes);
+
+      static void (&transfer_custom_end)(types<3>::transfer_context *tc);
     };
 
 

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -198,13 +198,6 @@ namespace parallel
 
 
       /**
-       * Return the size in bytes that need to be stored per cell.
-       */
-      unsigned int
-      get_data_size() const;
-
-
-      /**
        * Prepare the serialization of the given vector. The serialization is
        * done by Triangulation::save(). The given vector needs all information
        * on the locally active DoFs (it must be ghosted). See documentation of
@@ -267,8 +260,8 @@ namespace parallel
         const typename Triangulation<dim, DoFHandlerType::space_dimension>::
           cell_iterator &cell,
         const typename Triangulation<dim, DoFHandlerType::space_dimension>::
-          CellStatus status,
-        void *       data);
+          CellStatus       status,
+        std::vector<char> &data);
 
       /**
        * A callback function used to unpack the data on the current mesh that
@@ -280,16 +273,19 @@ namespace parallel
         const typename Triangulation<dim, DoFHandlerType::space_dimension>::
           cell_iterator &cell,
         const typename Triangulation<dim, DoFHandlerType::space_dimension>::
-          CellStatus               status,
-        const void *               data,
+          CellStatus status,
+        const boost::iterator_range<std::vector<char>::const_iterator>
+                                   data_range,
         std::vector<VectorType *> &all_out);
 
 
       /**
-       *
+       * Registers the pack_callback() function to the
+       * parallel::distributed::Triangulation that has been assigned to the
+       * DoFHandler class member and stores the returning handle.
        */
       void
-      register_data_attach(const std::size_t size);
+      register_data_attach();
     };
 
 

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -342,11 +342,11 @@ namespace Particles
 
     /**
      * Callback function that should be called before every refinement
-     * and when writing checkpoints.  This function is used to
+     * and when writing checkpoints. This function is used to
      * register store_particles() with the triangulation.
      */
     void
-    register_store_callback_function(const bool serialization);
+    register_store_callback_function();
 
     /**
      * Callback function that should be called after every refinement
@@ -511,7 +511,7 @@ namespace Particles
     store_particles(
       const typename Triangulation<dim, spacedim>::cell_iterator &cell,
       const typename Triangulation<dim, spacedim>::CellStatus     status,
-      void *                                                      data) const;
+      std::vector<char> &                                         data) const;
 
     /**
      * Called by listener functions after a refinement step. The local map
@@ -521,7 +521,8 @@ namespace Particles
     load_particles(
       const typename Triangulation<dim, spacedim>::cell_iterator &cell,
       const typename Triangulation<dim, spacedim>::CellStatus     status,
-      const void *                                                data);
+      const boost::iterator_range<std::vector<char>::const_iterator>
+        data_range);
   };
 
   /* ---------------------- inline and template functions ------------------ */

--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -509,6 +509,50 @@ namespace internal
 
     constexpr unsigned int functions<2>::max_level;
 
+    void (&functions<2>::transfer_fixed)(const types<2>::gloidx *dest_gfq,
+                                         const types<2>::gloidx *src_gfq,
+                                         MPI_Comm                mpicomm,
+                                         int                     tag,
+                                         void *                  dest_data,
+                                         const void *            src_data,
+                                         size_t                  data_size) =
+      p4est_transfer_fixed;
+
+    types<2>::transfer_context *(&functions<2>::transfer_fixed_begin)(
+      const types<2>::gloidx *dest_gfq,
+      const types<2>::gloidx *src_gfq,
+      MPI_Comm                mpicomm,
+      int                     tag,
+      void *                  dest_data,
+      const void *            src_data,
+      size_t                  data_size) = p4est_transfer_fixed_begin;
+
+    void (&functions<2>::transfer_fixed_end)(types<2>::transfer_context *tc) =
+      p4est_transfer_fixed_end;
+
+    void (&functions<2>::transfer_custom)(const types<2>::gloidx *dest_gfq,
+                                          const types<2>::gloidx *src_gfq,
+                                          MPI_Comm                mpicomm,
+                                          int                     tag,
+                                          void *                  dest_data,
+                                          const int *             dest_sizes,
+                                          const void *            src_data,
+                                          const int *             src_sizes) =
+      p4est_transfer_custom;
+
+    types<2>::transfer_context *(&functions<2>::transfer_custom_begin)(
+      const types<2>::gloidx *dest_gfq,
+      const types<2>::gloidx *src_gfq,
+      MPI_Comm                mpicomm,
+      int                     tag,
+      void *                  dest_data,
+      const int *             dest_sizes,
+      const void *            src_data,
+      const int *             src_sizes) = p4est_transfer_custom_begin;
+
+    void (&functions<2>::transfer_custom_end)(types<2>::transfer_context *tc) =
+      p4est_transfer_custom_end;
+
 
 
     int (&functions<3>::quadrant_compare)(const void *v1, const void *v2) =
@@ -651,6 +695,50 @@ namespace internal
       types<3>::connectivity *p4est) = p8est_connectivity_memory_used;
 
     constexpr unsigned int functions<3>::max_level;
+
+    void (&functions<3>::transfer_fixed)(const types<3>::gloidx *dest_gfq,
+                                         const types<3>::gloidx *src_gfq,
+                                         MPI_Comm                mpicomm,
+                                         int                     tag,
+                                         void *                  dest_data,
+                                         const void *            src_data,
+                                         size_t                  data_size) =
+      p8est_transfer_fixed;
+
+    types<3>::transfer_context *(&functions<3>::transfer_fixed_begin)(
+      const types<3>::gloidx *dest_gfq,
+      const types<3>::gloidx *src_gfq,
+      MPI_Comm                mpicomm,
+      int                     tag,
+      void *                  dest_data,
+      const void *            src_data,
+      size_t                  data_size) = p8est_transfer_fixed_begin;
+
+    void (&functions<3>::transfer_fixed_end)(types<3>::transfer_context *tc) =
+      p8est_transfer_fixed_end;
+
+    void (&functions<3>::transfer_custom)(const types<3>::gloidx *dest_gfq,
+                                          const types<3>::gloidx *src_gfq,
+                                          MPI_Comm                mpicomm,
+                                          int                     tag,
+                                          void *                  dest_data,
+                                          const int *             dest_sizes,
+                                          const void *            src_data,
+                                          const int *             src_sizes) =
+      p8est_transfer_custom;
+
+    types<3>::transfer_context *(&functions<3>::transfer_custom_begin)(
+      const types<3>::gloidx *dest_gfq,
+      const types<3>::gloidx *src_gfq,
+      MPI_Comm                mpicomm,
+      int                     tag,
+      void *                  dest_data,
+      const int *             dest_sizes,
+      const void *            src_data,
+      const int *             src_sizes) = p8est_transfer_custom_begin;
+
+    void (&functions<3>::transfer_custom_end)(types<3>::transfer_context *tc) =
+      p8est_transfer_custom_end;
 
 
 

--- a/tests/particles/particle_handler_05.cc
+++ b/tests/particles/particle_handler_05.cc
@@ -106,8 +106,7 @@ test()
     tr.signals.pre_distributed_refinement.connect(std::bind(
       &Particles::ParticleHandler<dim,
                                   spacedim>::register_store_callback_function,
-      &particle_handler,
-      false));
+      &particle_handler));
 
     tr.signals.post_distributed_refinement.connect(std::bind(
       &Particles::ParticleHandler<dim,

--- a/tests/serialization/particle_handler_01.cc
+++ b/tests/serialization/particle_handler_01.cc
@@ -111,8 +111,7 @@ test()
   tr.signals.pre_distributed_save.connect(std::bind(
     &Particles::ParticleHandler<dim,
                                 spacedim>::register_store_callback_function,
-    &particle_handler,
-    true));
+    &particle_handler));
 
   // save data to archive
   std::ostringstream oss;


### PR DESCRIPTION
This pull requests reworks the data transfer interface of deal.II to p4est using its new API. This is one milestone on the way to use the variable transfer functionality of p4est (see e.g. #3511).

The data to be transferred is no longer attached to each p4est quadrant, but will be handled in separate containers, that will be modified using the <tt>pack/unpack</tt> functions of the <tt>Utilities</tt> namespace.

- I force deal.II to be linked againt at least p4est 2.0 and dropped all backward compatibilities. It would be really tedious and confusing to keep them.
- Since there is no more need to stick to the p4est quadrant user data format, there is no need to use the <tt>void *</tt> pointers anymore to adress memory. Instead, the buffers will be built using the serialization functions of the <tt>Utilities</tt> namespace, thus they are of type ``std::vector<char>``.
The <tt>pack_callback</tt> functions now take references to ``std::vector<char>``, to which they will append their data for each cell. The <tt>unpack_callback</tt> functions will take iterator pairs to denote the memory from which they are allowed to read. Out of convenience, I choose <tt>boost::iterator_pairs</tt> to do this job.
- I introduced a new class <tt>DataTransfer</tt> in the private scope of the <tt>parallel::distributed::Triangulation</tt> class, that takes care of all the data transfer across refinement, repartitioning and to the file system. For the latter case, a separate file with the stored data will be generated, to which all processors will write simultaneously. Thus it is still possible to restart any simulation with a different amount of processors.
- Classes that want to append data are no longer required to know the amount of bytes that they are allowed to write/read. This is now the responsibility of the <tt>DataTransfer</tt> class.

I changed all data appending classes in deal.II to this new functionality, so that all tests pass. However, I am not happy with the current state of the <tt>ParticleHandler</tt> class. It relies heavily on the use of <tt>void *</tt> pointers, and I thought it would be the best way for the moment to cast the ``std::vector<char>`` back to them.

However, the <tt>ParticleHandler</tt> class would be predestined for the variable transfer functionality. My plan is to serialize the corresponding fraction of the underlying multimap of particles directly using the <tt>pack/unpack</tt> functions of the <tt>Utilities</tt> namespace. This will be my next field of activity for applying the variable transfer functionality.

See also #6790 for discussion on the <tt>ParticleHandler</tt>.