### PR TITLE
Simplify some code in DataOut_DoFData.

### DIFF
--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -1389,16 +1389,11 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::
               }
 
           // finally add a corresponding range
-          std::tuple<unsigned int,
-                     unsigned int,
-                     std::string,
-                     DataComponentInterpretation::DataComponentInterpretation>
-            range(output_component,
-                  output_component + patch_space_dim - 1,
-                  name,
-                  DataComponentInterpretation::component_is_part_of_vector);
-
-          ranges.push_back(range);
+          ranges.push_back(std::make_tuple(
+            output_component,
+            output_component + patch_space_dim - 1,
+            name,
+            DataComponentInterpretation::component_is_part_of_vector));
 
           // increase the 'component' counter by the appropriate amount, same
           // for 'i', since we have already dealt with all these components


### PR DESCRIPTION
Brace initializers are nice :-) I tried to use 'emplace_back' instead of
'push_back', but that fails because the former does not know the
element type of the vector when it tries to match the given arguments,
and consequently doesn't know what to convert the brace-enclosed list
to. Performance is not a consideration here, so I didn't bother with
caring about this too much.