### PR TITLE
Disable -Wclass-memaccess for non-CXX17 builds and in bundled boost

### DIFF
--- a/bundled/boost-1.62.0/include/boost/container/detail/copy_move_algo.hpp
+++ b/bundled/boost-1.62.0/include/boost/container/detail/copy_move_algo.hpp
@@ -34,7 +34,12 @@
 // other
 #include <boost/core/no_exceptions_support.hpp>
 // std
-#include <cstring> //for emmove/memcpy
+#include <cstring> //for memmove/memcpy
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 80000)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 
 namespace boost {
 namespace container {
@@ -1140,5 +1145,10 @@ void move_assign_range_alloc_n( Allocator &a, I inp_start, typename allocator_tr
 
 }  //namespace container {
 }  //namespace boost {
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 80000)
+#pragma GCC diagnostic pop
+#endif
+
 
 #endif   //#ifndef BOOST_CONTAINER_DETAIL_COPY_MOVE_ALGO_HPP

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -86,6 +86,14 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-literal-suffix")
 #
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-psabi")
 
+#
+# Disable warnings regarding improper direct memory access
+# if compiling without C++17 support
+#
+IF(NOT DEAL_II_WITH_CXX17)
+  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-class-memaccess")
+ENDIF()
+
 IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   #
   # Silence Clang warnings about unused compiler parameters (works around a


### PR DESCRIPTION
Fixes #6875. In particular, the change in the bundled boost is https://github.com/boostorg/container/commit/62a8b6666eb0f12242fb1e99daa98533ce74e735#diff-59a4378d0ecc3c6d408d78ca682ab8ae