### PR TITLE
Replace MPI_Comm functions by those of Utilities namespace.

### DIFF
--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -424,8 +424,7 @@ namespace
       {
         // do the same as in Utilities::MPI::n_mpi_processes() here,
         // but without error checking to not throw again.
-        int n_proc = 1;
-        MPI_Comm_size(MPI_COMM_WORLD, &n_proc);
+        const int n_proc = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
         if (n_proc > 1)
           {
             std::cerr

--- a/source/base/process_grid.cc
+++ b/source/base/process_grid.cc
@@ -51,8 +51,7 @@ namespace
 
     // Below we always try to create 2D processor grids:
 
-    int n_processes;
-    MPI_Comm_size(mpi_comm, &n_processes);
+    const int n_processes = Utilities::MPI::n_mpi_processes(mpi_comm);
 
     // Get the total number of cores we can occupy in a rectangular dense matrix
     // with rectangular blocks when every core owns only a single block:

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1493,16 +1493,12 @@ namespace parallel
       const std::string fname_fixed = std::string(filename) + "_fixed.data";
 
       // ----- copied -----
-      // from DataOutInterface::write_vtu_parallel
+      // from DataOutInterface::write_vtu_in_parallel
       // TODO: write general MPIIO interface
-      int myrank, nproc;
-      int ierr = MPI_Comm_rank(mpi_communicator, &myrank);
-      AssertThrowMPI(ierr);
-      ierr = MPI_Comm_size(mpi_communicator, &nproc);
-      AssertThrowMPI(ierr);
+      const int myrank = Utilities::MPI::this_mpi_process(mpi_communicator);
 
       MPI_Info info;
-      ierr = MPI_Info_create(&info);
+      int      ierr = MPI_Info_create(&info);
       AssertThrowMPI(ierr);
       MPI_File fh;
       ierr = MPI_File_open(mpi_communicator,
@@ -1573,16 +1569,12 @@ namespace parallel
       const std::string fname_fixed = std::string(filename) + "_fixed.data";
 
       // ----- copied -----
-      // from DataOutInterface::write_vtu_parallel
+      // from DataOutInterface::write_vtu_in_parallel
       // TODO: write general MPIIO interface
-      int myrank, nproc;
-      int ierr = MPI_Comm_rank(mpi_communicator, &myrank);
-      AssertThrowMPI(ierr);
-      ierr = MPI_Comm_size(mpi_communicator, &nproc);
-      AssertThrowMPI(ierr);
+      const int myrank = Utilities::MPI::this_mpi_process(mpi_communicator);
 
       MPI_Info info;
-      ierr = MPI_Info_create(&info);
+      int      ierr = MPI_Info_create(&info);
       AssertThrowMPI(ierr);
       MPI_File fh;
       ierr = MPI_File_open(mpi_communicator,


### PR DESCRIPTION
This deals with an open request of pull request #6864.

Instead of using <tt>MPI_Comm_rank</tt> and <tt>MPI_Comm_size</tt>, we want to use the corresponding ones of the <tt>Utilities</tt> namespace.