### PR TITLE
Use std::is_same instead of typeid in static_cast

### DIFF
--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -640,8 +640,9 @@ namespace TrilinosWrappers
         TrilinosBlockPayload(const Args &...)
         {
           static_assert(
-            typeid(PayloadBlockType) ==
-              typeid(internal::LinearOperatorImplementation::TrilinosPayload),
+            std::is_same<
+              PayloadBlockType,
+              internal::LinearOperatorImplementation::TrilinosPayload>::value,
             "TrilinosBlockPayload can only accept a payload of type TrilinosPayload.");
         }
       };


### PR DESCRIPTION
The previous implementation did not compile with`nvcc`