### PR TITLE
Static variable cannot be allocated inside a __device__ function

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1079,18 +1079,15 @@ namespace internal
 
 
     template <typename ArrayElementType>
-    DEAL_II_CUDA_HOST_DEV ArrayElementType &
-                          subscript(ArrayElementType *,
-                                    const unsigned int,
-                                    std::integral_constant<int, 0>)
+    ArrayElementType &
+    subscript(ArrayElementType *,
+              const unsigned int,
+              std::integral_constant<int, 0>)
     {
-      // We cannot use Assert in a CUDA kernel
-#ifndef __CUDA_ARCH__
       Assert(
         false,
         ExcMessage(
           "Cannot access elements of an object of type Tensor<rank,0,Number>."));
-#endif
       static ArrayElementType t;
       return t;
     }


### PR DESCRIPTION
Fix the following error:
`dynamic initialization is not supported for function-scope static variables within a __device__/__global__ function`

This was found by trying to compile the whole library with `nvcc`