### PR TITLE
Support for transfer of variable size data.

### DIFF
--- a/doc/news/changes/incompatibilities/20180720Fehling
+++ b/doc/news/changes/incompatibilities/20180720Fehling
@@ -8,4 +8,9 @@ const boost::iterator_range<std::vector<char>::const_iterator &>`, where
 the last argument describes an iterator range, from which the callback
 function is allowed to read.
 <br>
-(Marc Fehling, 2018/07/07)
+Further, the `register_data_attach()` function now requires a boolean
+argument `returns_variable_size_data`, which denotes if the registered 
+pack_callback function interacts with the fixed size (`=false`) or
+variable size (`=true`) buffer for data transfer.
+<br>
+(Marc Fehling, 2018/07/20)

--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -794,11 +794,13 @@ namespace parallel
       matrix_dofs_child.reinit(dofs_per_cell, number_of_values);
       matrix_quadrature.reinit(n_q_points, number_of_values);
 
-      handle = triangulation->register_data_attach(std::bind(
-        &ContinuousQuadratureDataTransfer<dim, DataType>::pack_function,
-        this,
-        std::placeholders::_1,
-        std::placeholders::_2));
+      handle = triangulation->register_data_attach(
+        std::bind(
+          &ContinuousQuadratureDataTransfer<dim, DataType>::pack_function,
+          this,
+          std::placeholders::_1,
+          std::placeholders::_2),
+        /*returns_variable_size_data=*/false);
     }
 
 

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -85,11 +85,13 @@ namespace parallel
                        *>(&dof_handler->get_triangulation())));
       Assert(tria != nullptr, ExcInternalError());
 
-      handle = tria->register_data_attach(std::bind(
-        &SolutionTransfer<dim, VectorType, DoFHandlerType>::pack_callback,
-        this,
-        std::placeholders::_1,
-        std::placeholders::_2));
+      handle = tria->register_data_attach(
+        std::bind(
+          &SolutionTransfer<dim, VectorType, DoFHandlerType>::pack_callback,
+          this,
+          std::placeholders::_1,
+          std::placeholders::_2),
+        /*returns_variable_size_data=*/false);
     }
 
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1046,8 +1046,8 @@ namespace Particles
                       std::placeholders::_1,
                       std::placeholders::_2);
 
-        handle =
-          non_const_triangulation->register_data_attach(callback_function);
+        handle = non_const_triangulation->register_data_attach(
+          callback_function, /*returns_variable_size_data=*/false);
       }
   }
 
@@ -1082,8 +1082,8 @@ namespace Particles
                       std::placeholders::_1,
                       std::placeholders::_2);
 
-        handle =
-          non_const_triangulation->register_data_attach(callback_function);
+        handle = non_const_triangulation->register_data_attach(
+          callback_function, /*returns_variable_size_data=*/false);
       }
 
     // Check if something was stored and load it

--- a/tests/mpi/attach_data_01.with_p4est=true.mpirun=1.output
+++ b/tests/mpi/attach_data_01.with_p4est=true.mpirun=1.output
@@ -16,7 +16,7 @@ DEAL:0::myid=0 cellid=3_1:0 coarsening
 DEAL:0::myid=0 cellid=3_1:1 coarsening
 DEAL:0::myid=0 cellid=3_1:2 coarsening
 DEAL:0::myid=0 cellid=3_1:3 coarsening
-DEAL:0::handle=0
+DEAL:0::handle=1
 DEAL:0::packing cell 0_1:0 with data=0 status=REFINE
 DEAL:0::packing cell 0_1:1 with data=1 status=PERSIST
 DEAL:0::packing cell 0_1:2 with data=2 status=PERSIST

--- a/tests/mpi/attach_data_01.with_p4est=true.mpirun=3.output
+++ b/tests/mpi/attach_data_01.with_p4est=true.mpirun=3.output
@@ -4,7 +4,7 @@ DEAL:0::myid=0 cellid=0_1:0 refining
 DEAL:0::myid=0 cellid=0_1:1
 DEAL:0::myid=0 cellid=0_1:2
 DEAL:0::myid=0 cellid=0_1:3
-DEAL:0::handle=0
+DEAL:0::handle=1
 DEAL:0::packing cell 0_1:0 with data=0 status=REFINE
 DEAL:0::packing cell 0_1:1 with data=1 status=PERSIST
 DEAL:0::packing cell 0_1:2 with data=2 status=PERSIST
@@ -24,7 +24,7 @@ DEAL:1::myid=1 cellid=2_1:0
 DEAL:1::myid=1 cellid=2_1:1
 DEAL:1::myid=1 cellid=2_1:2
 DEAL:1::myid=1 cellid=2_1:3
-DEAL:1::handle=0
+DEAL:1::handle=1
 DEAL:1::packing cell 1_1:0 with data=0 status=PERSIST
 DEAL:1::packing cell 1_1:1 with data=1 status=PERSIST
 DEAL:1::packing cell 1_1:2 with data=2 status=PERSIST
@@ -49,7 +49,7 @@ DEAL:2::myid=2 cellid=3_1:0 coarsening
 DEAL:2::myid=2 cellid=3_1:1 coarsening
 DEAL:2::myid=2 cellid=3_1:2 coarsening
 DEAL:2::myid=2 cellid=3_1:3 coarsening
-DEAL:2::handle=0
+DEAL:2::handle=1
 DEAL:2::packing cell 3_0: with data=0 status=COARSEN
 DEAL:2::cells after: 16
 DEAL:2::unpacking cell 2_1:0 with data=4 status=PERSIST

--- a/tests/mpi/attach_data_01.with_p4est=true.mpirun=8.output
+++ b/tests/mpi/attach_data_01.with_p4est=true.mpirun=8.output
@@ -4,7 +4,7 @@ DEAL:0::myid=0 cellid=0_1:0 refining
 DEAL:0::myid=0 cellid=0_1:1         
 DEAL:0::myid=0 cellid=0_1:2         
 DEAL:0::myid=0 cellid=0_1:3         
-DEAL:0::handle=0                    
+DEAL:0::handle=1                    
 DEAL:0::packing cell 0_1:0 with data=0 status=REFINE
 DEAL:0::packing cell 0_1:1 with data=1 status=PERSIST
 DEAL:0::packing cell 0_1:2 with data=2 status=PERSIST
@@ -15,7 +15,7 @@ DEAL:0::Checksum: 2822439380
 DEAL:0::OK                                            
 
 DEAL:1::cells before: 16
-DEAL:1::handle=0        
+DEAL:1::handle=1        
 DEAL:1::cells after: 16 
 DEAL:1::Checksum: 0     
 DEAL:1::OK              
@@ -26,7 +26,7 @@ DEAL:2::myid=2 cellid=1_1:0
 DEAL:2::myid=2 cellid=1_1:1
 DEAL:2::myid=2 cellid=1_1:2
 DEAL:2::myid=2 cellid=1_1:3
-DEAL:2::handle=0           
+DEAL:2::handle=1           
 DEAL:2::packing cell 1_1:0 with data=0 status=PERSIST
 DEAL:2::packing cell 1_1:1 with data=1 status=PERSIST
 DEAL:2::packing cell 1_1:2 with data=2 status=PERSIST
@@ -39,7 +39,7 @@ DEAL:2::OK
 
 
 DEAL:3::cells before: 16
-DEAL:3::handle=0
+DEAL:3::handle=1
 DEAL:3::cells after: 16
 DEAL:3::unpacking cell 0_1:3 with data=3 status=PERSIST
 DEAL:3::Checksum: 0
@@ -51,7 +51,7 @@ DEAL:4::myid=4 cellid=2_1:0
 DEAL:4::myid=4 cellid=2_1:1
 DEAL:4::myid=4 cellid=2_1:2
 DEAL:4::myid=4 cellid=2_1:3
-DEAL:4::handle=0
+DEAL:4::handle=1
 DEAL:4::packing cell 2_1:0 with data=0 status=PERSIST
 DEAL:4::packing cell 2_1:1 with data=1 status=PERSIST
 DEAL:4::packing cell 2_1:2 with data=2 status=PERSIST
@@ -66,7 +66,7 @@ DEAL:4::OK
 
 
 DEAL:5::cells before: 16
-DEAL:5::handle=0
+DEAL:5::handle=1
 DEAL:5::cells after: 16
 DEAL:5::Checksum: 0
 DEAL:5::OK
@@ -77,7 +77,7 @@ DEAL:6::myid=6 cellid=3_1:0 coarsening
 DEAL:6::myid=6 cellid=3_1:1 coarsening
 DEAL:6::myid=6 cellid=3_1:2 coarsening
 DEAL:6::myid=6 cellid=3_1:3 coarsening
-DEAL:6::handle=0
+DEAL:6::handle=1
 DEAL:6::packing cell 3_0: with data=0 status=COARSEN
 DEAL:6::cells after: 16
 DEAL:6::unpacking cell 2_1:0 with data=0 status=PERSIST
@@ -89,7 +89,7 @@ DEAL:6::OK
 
 
 DEAL:7::cells before: 16
-DEAL:7::handle=0
+DEAL:7::handle=1
 DEAL:7::cells after: 16
 DEAL:7::unpacking cell 3_0: with data=0 status=COARSEN
 DEAL:7::Checksum: 0

--- a/tests/mpi/attach_data_02.with_p4est=true.mpirun=1.output
+++ b/tests/mpi/attach_data_02.with_p4est=true.mpirun=1.output
@@ -1,0 +1,48 @@
+
+DEAL:0::cells before: 16
+DEAL:0::myid=0 cellid=0_1:0 refining
+DEAL:0::myid=0 cellid=0_1:1
+DEAL:0::myid=0 cellid=0_1:2
+DEAL:0::myid=0 cellid=0_1:3
+DEAL:0::myid=0 cellid=1_1:0
+DEAL:0::myid=0 cellid=1_1:1
+DEAL:0::myid=0 cellid=1_1:2
+DEAL:0::myid=0 cellid=1_1:3
+DEAL:0::myid=0 cellid=2_1:0
+DEAL:0::myid=0 cellid=2_1:1
+DEAL:0::myid=0 cellid=2_1:2
+DEAL:0::myid=0 cellid=2_1:3
+DEAL:0::myid=0 cellid=3_1:0 coarsening
+DEAL:0::myid=0 cellid=3_1:1 coarsening
+DEAL:0::myid=0 cellid=3_1:2 coarsening
+DEAL:0::myid=0 cellid=3_1:3 coarsening
+DEAL:0::handle=0
+DEAL:0::packing cell 0_1:0 with data size=4 accumulated data=0 status=REFINE
+DEAL:0::packing cell 0_1:1 with data size=8 accumulated data=1 status=PERSIST
+DEAL:0::packing cell 0_1:2 with data size=12 accumulated data=3 status=PERSIST
+DEAL:0::packing cell 0_1:3 with data size=16 accumulated data=6 status=PERSIST
+DEAL:0::packing cell 1_1:0 with data size=20 accumulated data=10 status=PERSIST
+DEAL:0::packing cell 1_1:1 with data size=24 accumulated data=15 status=PERSIST
+DEAL:0::packing cell 1_1:2 with data size=28 accumulated data=21 status=PERSIST
+DEAL:0::packing cell 1_1:3 with data size=32 accumulated data=28 status=PERSIST
+DEAL:0::packing cell 2_1:0 with data size=36 accumulated data=36 status=PERSIST
+DEAL:0::packing cell 2_1:1 with data size=40 accumulated data=45 status=PERSIST
+DEAL:0::packing cell 2_1:2 with data size=44 accumulated data=55 status=PERSIST
+DEAL:0::packing cell 2_1:3 with data size=48 accumulated data=66 status=PERSIST
+DEAL:0::packing cell 3_0: with data size=52 accumulated data=78 status=COARSEN
+DEAL:0::cells after: 16
+DEAL:0::unpacking cell 0_1:0 with data size=4 accumulated data=0 status=REFINE
+DEAL:0::unpacking cell 0_1:1 with data size=8 accumulated data=1 status=PERSIST
+DEAL:0::unpacking cell 0_1:2 with data size=12 accumulated data=3 status=PERSIST
+DEAL:0::unpacking cell 0_1:3 with data size=16 accumulated data=6 status=PERSIST
+DEAL:0::unpacking cell 1_1:0 with data size=20 accumulated data=10 status=PERSIST
+DEAL:0::unpacking cell 1_1:1 with data size=24 accumulated data=15 status=PERSIST
+DEAL:0::unpacking cell 1_1:2 with data size=28 accumulated data=21 status=PERSIST
+DEAL:0::unpacking cell 1_1:3 with data size=32 accumulated data=28 status=PERSIST
+DEAL:0::unpacking cell 2_1:0 with data size=36 accumulated data=36 status=PERSIST
+DEAL:0::unpacking cell 2_1:1 with data size=40 accumulated data=45 status=PERSIST
+DEAL:0::unpacking cell 2_1:2 with data size=44 accumulated data=55 status=PERSIST
+DEAL:0::unpacking cell 2_1:3 with data size=48 accumulated data=66 status=PERSIST
+DEAL:0::unpacking cell 3_0: with data size=52 accumulated data=78 status=COARSEN
+DEAL:0::Checksum: 2822439380
+DEAL:0::OK

--- a/tests/mpi/attach_data_02.with_p4est=true.mpirun=3.output
+++ b/tests/mpi/attach_data_02.with_p4est=true.mpirun=3.output
@@ -1,0 +1,62 @@
+
+DEAL:0::cells before: 16
+DEAL:0::myid=0 cellid=0_1:0 refining
+DEAL:0::myid=0 cellid=0_1:1
+DEAL:0::myid=0 cellid=0_1:2
+DEAL:0::myid=0 cellid=0_1:3
+DEAL:0::handle=0
+DEAL:0::packing cell 0_1:0 with data size =4 accumulated data=0 status=REFINE
+DEAL:0::packing cell 0_1:1 with data size =8 accumulated data=1 status=PERSIST
+DEAL:0::packing cell 0_1:2 with data size =12 accumulated data=3 status=PERSIST
+DEAL:0::packing cell 0_1:3 with data size =16 accumulated data=6 status=PERSIST
+DEAL:0::cells after: 16
+DEAL:0::unpacking cell 0_1:0 with data size=4 accumulated data=0 status=REFINE
+DEAL:0::unpacking cell 0_1:1 with data size=8 accumulated data=1 status=PERSIST
+DEAL:0::Checksum: 2822439380
+DEAL:0::OK
+
+DEAL:1::cells before: 16
+DEAL:1::myid=1 cellid=1_1:0
+DEAL:1::myid=1 cellid=1_1:1
+DEAL:1::myid=1 cellid=1_1:2
+DEAL:1::myid=1 cellid=1_1:3
+DEAL:1::myid=1 cellid=2_1:0
+DEAL:1::myid=1 cellid=2_1:1
+DEAL:1::myid=1 cellid=2_1:2
+DEAL:1::myid=1 cellid=2_1:3
+DEAL:1::handle=0
+DEAL:1::packing cell 1_1:0 with data size =4 accumulated data=0 status=PERSIST
+DEAL:1::packing cell 1_1:1 with data size =8 accumulated data=1 status=PERSIST
+DEAL:1::packing cell 1_1:2 with data size =12 accumulated data=3 status=PERSIST
+DEAL:1::packing cell 1_1:3 with data size =16 accumulated data=6 status=PERSIST
+DEAL:1::packing cell 2_1:0 with data size =20 accumulated data=10 status=PERSIST
+DEAL:1::packing cell 2_1:1 with data size =24 accumulated data=15 status=PERSIST
+DEAL:1::packing cell 2_1:2 with data size =28 accumulated data=21 status=PERSIST
+DEAL:1::packing cell 2_1:3 with data size =32 accumulated data=28 status=PERSIST
+DEAL:1::cells after: 16
+DEAL:1::unpacking cell 0_1:2 with data size=12 accumulated data=3 status=PERSIST
+DEAL:1::unpacking cell 0_1:3 with data size=16 accumulated data=6 status=PERSIST
+DEAL:1::unpacking cell 1_1:0 with data size=4 accumulated data=0 status=PERSIST
+DEAL:1::unpacking cell 1_1:1 with data size=8 accumulated data=1 status=PERSIST
+DEAL:1::unpacking cell 1_1:2 with data size=12 accumulated data=3 status=PERSIST
+DEAL:1::unpacking cell 1_1:3 with data size=16 accumulated data=6 status=PERSIST
+DEAL:1::Checksum: 0
+DEAL:1::OK
+
+
+DEAL:2::cells before: 16
+DEAL:2::myid=2 cellid=3_1:0 coarsening
+DEAL:2::myid=2 cellid=3_1:1 coarsening
+DEAL:2::myid=2 cellid=3_1:2 coarsening
+DEAL:2::myid=2 cellid=3_1:3 coarsening
+DEAL:2::handle=0
+DEAL:2::packing cell 3_0: with data size =4 accumulated data=0 status=COARSEN
+DEAL:2::cells after: 16
+DEAL:2::unpacking cell 2_1:0 with data size=20 accumulated data=10 status=PERSIST
+DEAL:2::unpacking cell 2_1:1 with data size=24 accumulated data=15 status=PERSIST
+DEAL:2::unpacking cell 2_1:2 with data size=28 accumulated data=21 status=PERSIST
+DEAL:2::unpacking cell 2_1:3 with data size=32 accumulated data=28 status=PERSIST
+DEAL:2::unpacking cell 3_0: with data size=4 accumulated data=0 status=COARSEN
+DEAL:2::Checksum: 0
+DEAL:2::OK
+

--- a/tests/mpi/attach_data_02.with_p4est=true.mpirun=8.output
+++ b/tests/mpi/attach_data_02.with_p4est=true.mpirun=8.output
@@ -1,0 +1,97 @@
+
+DEAL:0::cells before: 16
+DEAL:0::myid=0 cellid=0_1:0 refining
+DEAL:0::myid=0 cellid=0_1:1
+DEAL:0::myid=0 cellid=0_1:2
+DEAL:0::myid=0 cellid=0_1:3
+DEAL:0::handle=0
+DEAL:0::packing cell 0_1:0 with data size =4 accumulated data=0 status=REFINE
+DEAL:0::packing cell 0_1:1 with data size =8 accumulated data=1 status=PERSIST
+DEAL:0::packing cell 0_1:2 with data size =12 accumulated data=3 status=PERSIST
+DEAL:0::packing cell 0_1:3 with data size =16 accumulated data=6 status=PERSIST
+DEAL:0::cells after: 16
+DEAL:0::unpacking cell 0_1:0 with data size=4 accumulated data=0 status=REFINE
+DEAL:0::Checksum: 2822439380
+DEAL:0::OK
+
+DEAL:1::cells before: 16
+DEAL:1::handle=0
+DEAL:1::cells after: 16
+DEAL:1::Checksum: 0
+DEAL:1::OK
+
+
+DEAL:2::cells before: 16
+DEAL:2::myid=2 cellid=1_1:0
+DEAL:2::myid=2 cellid=1_1:1
+DEAL:2::myid=2 cellid=1_1:2
+DEAL:2::myid=2 cellid=1_1:3
+DEAL:2::handle=0
+DEAL:2::packing cell 1_1:0 with data size =4 accumulated data=0 status=PERSIST
+DEAL:2::packing cell 1_1:1 with data size =8 accumulated data=1 status=PERSIST
+DEAL:2::packing cell 1_1:2 with data size =12 accumulated data=3 status=PERSIST
+DEAL:2::packing cell 1_1:3 with data size =16 accumulated data=6 status=PERSIST
+DEAL:2::cells after: 16
+DEAL:2::unpacking cell 0_1:1 with data size=8 accumulated data=1 status=PERSIST
+DEAL:2::unpacking cell 0_1:2 with data size=12 accumulated data=3 status=PERSIST
+DEAL:2::Checksum: 0
+DEAL:2::OK
+
+
+DEAL:3::cells before: 16
+DEAL:3::handle=0
+DEAL:3::cells after: 16
+DEAL:3::unpacking cell 0_1:3 with data size=16 accumulated data=6 status=PERSIST
+DEAL:3::Checksum: 0
+DEAL:3::OK
+
+
+DEAL:4::cells before: 16
+DEAL:4::myid=4 cellid=2_1:0
+DEAL:4::myid=4 cellid=2_1:1
+DEAL:4::myid=4 cellid=2_1:2
+DEAL:4::myid=4 cellid=2_1:3
+DEAL:4::handle=0
+DEAL:4::packing cell 2_1:0 with data size =4 accumulated data=0 status=PERSIST
+DEAL:4::packing cell 2_1:1 with data size =8 accumulated data=1 status=PERSIST
+DEAL:4::packing cell 2_1:2 with data size =12 accumulated data=3 status=PERSIST
+DEAL:4::packing cell 2_1:3 with data size =16 accumulated data=6 status=PERSIST
+DEAL:4::cells after: 16
+DEAL:4::unpacking cell 1_1:0 with data size=4 accumulated data=0 status=PERSIST
+DEAL:4::unpacking cell 1_1:1 with data size=8 accumulated data=1 status=PERSIST
+DEAL:4::unpacking cell 1_1:2 with data size=12 accumulated data=3 status=PERSIST
+DEAL:4::unpacking cell 1_1:3 with data size=16 accumulated data=6 status=PERSIST
+DEAL:4::Checksum: 0
+DEAL:4::OK
+
+
+DEAL:5::cells before: 16
+DEAL:5::handle=0
+DEAL:5::cells after: 16
+DEAL:5::Checksum: 0
+DEAL:5::OK
+
+
+DEAL:6::cells before: 16
+DEAL:6::myid=6 cellid=3_1:0 coarsening
+DEAL:6::myid=6 cellid=3_1:1 coarsening
+DEAL:6::myid=6 cellid=3_1:2 coarsening
+DEAL:6::myid=6 cellid=3_1:3 coarsening
+DEAL:6::handle=0
+DEAL:6::packing cell 3_0: with data size =4 accumulated data=0 status=COARSEN
+DEAL:6::cells after: 16
+DEAL:6::unpacking cell 2_1:0 with data size=4 accumulated data=0 status=PERSIST
+DEAL:6::unpacking cell 2_1:1 with data size=8 accumulated data=1 status=PERSIST
+DEAL:6::unpacking cell 2_1:2 with data size=12 accumulated data=3 status=PERSIST
+DEAL:6::unpacking cell 2_1:3 with data size=16 accumulated data=6 status=PERSIST
+DEAL:6::Checksum: 0
+DEAL:6::OK
+
+
+DEAL:7::cells before: 16
+DEAL:7::handle=0
+DEAL:7::cells after: 16
+DEAL:7::unpacking cell 3_0: with data size=4 accumulated data=0 status=COARSEN
+DEAL:7::Checksum: 0
+DEAL:7::OK
+

--- a/tests/mpi/repartition_02.cc
+++ b/tests/mpi/repartition_02.cc
@@ -121,7 +121,9 @@ test()
 
       deallog << "* global refine:" << std::endl;
 
-      unsigned int handle = tr.register_data_attach(pack_function<dim>);
+      unsigned int handle =
+        tr.register_data_attach(pack_function<dim>,
+                                /*returns_variable_size_data=*/false);
 
       tr.refine_global(1);
 
@@ -136,7 +138,8 @@ test()
 
       deallog << "* repartition:" << std::endl;
 
-      handle = tr.register_data_attach(pack_function<dim>);
+      handle = tr.register_data_attach(pack_function<dim>,
+                                       /*returns_variable_size_data=*/false);
 
       tr.repartition();
 


### PR DESCRIPTION
This pull request integrates the transfer of variable size data across meshes using the newly introduced function with `p4est-2.0`.

The only change I made to the API of `p::d::Triangulation` is a second parameter for the `register_data_attach` function called `packs_variable_size_data`. This flag decides whether data will be packed in the fixed or variable size buffer.

Currently, only the low-level interface in `p::d::Triangulation` makes use of this feature (i.e. functions `register_data_attach` and `notify_ready_to_unpack`). Serialization with variable size data will be introduced in a different pull request, as well as integration in `SolutionTransfer` and `ParticleHandler`.

This is one step closer to #3511.