### PR TITLE
Address clang-tidy suggestions

### DIFF
--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -1389,7 +1389,7 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::
               }
 
           // finally add a corresponding range
-          ranges.push_back(std::make_tuple(
+          ranges.emplace_back(std::forward_as_tuple(
             output_component,
             output_component + patch_space_dim - 1,
             name,
@@ -1428,7 +1428,7 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::
               }
 
           // finally add a corresponding range
-          ranges.push_back(std::make_tuple(
+          ranges.emplace_back(std::forward_as_tuple(
             output_component,
             output_component + size - 1,
             name,

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1983,7 +1983,7 @@ namespace GridGenerator
 
       auto min_line_length = [](const Triangulation<2> &tria) -> double {
         double length = std::numeric_limits<double>::max();
-        for (const auto cell : tria.active_cell_iterators())
+        for (const auto &cell : tria.active_cell_iterators())
           for (unsigned int n = 0; n < GeometryInfo<2>::lines_per_cell; ++n)
             length = std::min(length, cell->line(n)->diameter());
         return length;
@@ -4214,7 +4214,7 @@ namespace GridGenerator
                             line->vertex_index(1) + offset;
                           boundary_line.manifold_id = line->manifold_id();
                           subcell_data.boundary_lines.push_back(
-                            std::move(boundary_line));
+                            boundary_line); // trivially-copyable
                         }
                   };
 
@@ -4257,7 +4257,7 @@ namespace GridGenerator
 
                           boundary_quad.manifold_id = face->manifold_id();
                           subcell_data.boundary_quads.push_back(
-                            std::move(boundary_quad));
+                            boundary_quad); // trivially-copyable
                         }
                     for (const auto &cell : tria.cell_iterators())
                       for (unsigned int l = 0; l < 12; ++l)
@@ -4272,7 +4272,7 @@ namespace GridGenerator
                             boundary_line.manifold_id =
                               cell->line(l)->manifold_id();
                             subcell_data.boundary_lines.push_back(
-                              std::move(boundary_line));
+                              boundary_line); // trivially_copyable
                           }
                   };
 

--- a/tests/quick_tests/sundials-ida.cc
+++ b/tests/quick_tests/sundials-ida.cc
@@ -72,7 +72,7 @@ public:
     time_stepper.reinit_vector = [&](Vector<double> &v) { v.reinit(2); };
 
 
-    typedef Vector<double> VectorType;
+    using VectorType = Vector<double>;
 
     time_stepper.residual = [&](const double /*t*/,
                                 const VectorType &y,


### PR DESCRIPTION
This addresses the `clang-tidy` warnings in https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=3303.