### PR TITLE
Fix rare out of bound memory access in write_gmv_reorder_data_vectors

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -401,6 +401,10 @@ namespace DataOutBase
       const std::vector<Patch<dim, spacedim>> &patches,
       Table<2, Number> &                       data_vectors)
     {
+      // If there is nothing to write, just return
+      if (patches.size() == 0)
+        return;
+
       // unlike in the main function, we don't have here the data_names field,
       // so we initialize it with the number of data sets in the first patch.
       // the equivalence of these two definitions is checked in the main
@@ -7594,6 +7598,9 @@ DataOutBase::write_filtered_data(
   // no cells it actually owns, and in that case it is legit if there are no
   // patches
   Assert(patches.size() > 0, ExcNoPatches());
+#else
+  if (patches.size() == 0)
+	  return;
 #endif
 
   compute_sizes<dim, spacedim>(patches, n_node, n_cell);

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7600,7 +7600,7 @@ DataOutBase::write_filtered_data(
   Assert(patches.size() > 0, ExcNoPatches());
 #else
   if (patches.size() == 0)
-	  return;
+    return;
 #endif
 
   compute_sizes<dim, spacedim>(patches, n_node, n_cell);

--- a/tests/data_out/data_out_filter_02.cc
+++ b/tests/data_out/data_out_filter_02.cc
@@ -13,7 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
-// This test checks that writing empty vectors does not access unallocated memory.
+// This test checks that writing empty vectors does not access unallocated
+// memory.
 
 #include <deal.II/dofs/dof_handler.h>
 

--- a/tests/data_out/data_out_filter_02.cc
+++ b/tests/data_out/data_out_filter_02.cc
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// This test checks that writing empty vectors does not access unallocated memory.
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/sparsity_pattern.h>
+
+#include <deal.II/numerics/data_out.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+test()
+{
+  Triangulation<dim> tria(Triangulation<dim>::MeshSmoothing::none, true);
+  GridGenerator::hyper_cube(tria, 1., 2.);
+  tria.refine_global(1);
+
+  FE_Q<dim> fe1(1);
+
+  DoFHandler<dim> dof1(tria);
+  dof1.distribute_dofs(fe1);
+
+  Vector<double> v1(dof1.n_dofs());
+
+  DataOut<dim> data_out;
+  data_out.add_data_vector(dof1, v1, "linear");
+
+  DataOutBase::DataOutFilter data_filter(
+    DataOutBase::DataOutFilterFlags(true, false));
+
+  data_out.write_filtered_data(data_filter);
+
+  deallog << "Number of filtered nodes: " << data_filter.n_nodes() << std::endl;
+
+  deallog << "ok" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  initlog();
+  test<2>();
+  test<3>();
+
+  return 0;
+}

--- a/tests/data_out/data_out_filter_02.with_hdf5=true.output
+++ b/tests/data_out/data_out_filter_02.with_hdf5=true.output
@@ -1,0 +1,5 @@
+
+DEAL::Number of filtered nodes: 0
+DEAL::ok
+DEAL::Number of filtered nodes: 0
+DEAL::ok


### PR DESCRIPTION
`write_gmv_reorder_data_vectors` accesses the zeroth element of the `patches` vector without checking for the size of the vector. That is often not a problem, because many functions calling this function first check for the size of the patches vector, but `DataOutBase::write_filtered_data` does not. Fix this both in the calling function, and the function itself. The attached test fails on master with a segmentation fault, but correctly does not write anything in the fixed version.