### PR TITLE
Use different FESystem constructor in tests

### DIFF
--- a/tests/grid/grid_tools_extract_used_vertices_03.cc
+++ b/tests/grid/grid_tools_extract_used_vertices_03.cc
@@ -41,7 +41,7 @@ test(const Point<spacedim> &p)
   tria.refine_global(1);
 
   // Vector fe
-  FESystem<dim, spacedim>   fe({FE_Q<dim, spacedim>(1) ^ spacedim});
+  FESystem<dim, spacedim>   fe{FE_Q<dim, spacedim>(1), spacedim};
   DoFHandler<dim, spacedim> dh(tria);
   dh.distribute_dofs(fe);
 

--- a/tests/grid/grid_tools_find_closest_vertex_01.cc
+++ b/tests/grid/grid_tools_find_closest_vertex_01.cc
@@ -41,7 +41,7 @@ test(const Point<spacedim> &p)
   tria.refine_global(1);
 
   // Vector fe
-  FESystem<dim, spacedim>   fe({FE_Q<dim, spacedim>(1) ^ spacedim});
+  FESystem<dim, spacedim>   fe{FE_Q<dim, spacedim>(1), spacedim};
   DoFHandler<dim, spacedim> dh(tria);
   dh.distribute_dofs(fe);
 


### PR DESCRIPTION
This PR avoids calling the fancy `FESystem` constructors when the test is not intended to actually test the constructor. The Intel C++ Compiler doesn't support these constructors before version 19.