### PR TITLE
Fix Utilities::MPI::compute_point_to_point_communication_pattern

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -198,10 +198,10 @@ namespace Utilities
         }
 
 #  if DEAL_II_MPI_VERSION_GTE(2, 2)
-      // Get a binary vector from the `destinations`
+      // Calculate the number of messages to send to each process
       std::vector<unsigned int> dest_vector(n_procs);
       for (const auto &el : destinations)
-        dest_vector[el] = 1;
+        ++dest_vector[el];
 
       // Find how many processes will send to this one
       // by reducing with sum and then scattering the


### PR DESCRIPTION
Fixes #6937. This is a fixup to #6851. Currently, the `mpi/fe_tools_extrapolate*` are failing.
For each `MPI` process, there might be more than one message to send to the same recipient and we have to account for that.

