### PR TITLE
Improve deprecation check

### DIFF
--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -290,10 +290,11 @@ ENDIF()
 # - Wolfgang Bangerth, 2012
 #
 
-# some compilers compile the attributes but they do not work
-# so we treat errors as warnings:
+# Some compilers swallow the deprecation attribute, but emit a warning saying
+# that it is actually not supported such as:
 # "warning: use of the 'deprecated' attribute is a C++14 extension" (clang in c++11 mode)
 # "warning #1292: unknown attribute "deprecated"" (icc)
+# Hence, we treat warnings as errors:
 PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_FLAGS}")
 PUSH_CMAKE_REQUIRED("-Werror")
 PUSH_CMAKE_REQUIRED("-Wno-unused-command-line-argument")

--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -290,13 +290,12 @@ ENDIF()
 # - Wolfgang Bangerth, 2012
 #
 
-# some compilers compile the attributes but they do not work:
+# some compilers compile the attributes but they do not work
+# so we treat errors as warnings:
 # "warning: use of the 'deprecated' attribute is a C++14 extension" (clang in c++11 mode)
 # "warning #1292: unknown attribute "deprecated"" (icc)
 PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_FLAGS}")
 PUSH_CMAKE_REQUIRED("-Werror")
-PUSH_CMAKE_REQUIRED("-Wno-deprecated-declarations")
-PUSH_CMAKE_REQUIRED("-Wno-deprecated")
 PUSH_CMAKE_REQUIRED("-Wno-unused-command-line-argument")
 
 # first see if the compiler accepts the attribute
@@ -304,7 +303,6 @@ CHECK_CXX_SOURCE_COMPILES(
   "
           [[deprecated]] int old_fn ();
           int old_fn () { return 0; }
-          int (*fn_ptr)() = old_fn;
 
           struct [[deprecated]] bob
           {
@@ -321,7 +319,6 @@ CHECK_CXX_SOURCE_COMPILES(
   "
           __attribute__((deprecated)) int old_fn ();
           int old_fn () { return 0; }
-          int (*fn_ptr)() = old_fn;
 
           struct __attribute__((deprecated)) bob
           {

--- a/cmake/setup_compiler_flags_intel.cmake
+++ b/cmake/setup_compiler_flags_intel.cmake
@@ -104,6 +104,8 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-diag-disable=remark")
 #   -w2259  non-pointer conversion from "double" to "float" may
 #           lose significant bits
 #   -w2536  type qualifiers are meaningless here
+#   -w2651  attribute does not apply to any entity
+#           spurious for [[deprecated]]
 #   -w3415  the "always_inline" attribute is ignored on non-inline functions
 #           incorrectly triggered by inline functions in tensor.h
 #   -w15531 A portion of SIMD loop is serialized
@@ -124,6 +126,7 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd1478")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd1572")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd2259")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd2536")
+ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd2651")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd3415")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd15531")
 


### PR DESCRIPTION
This PR includes the suggestions I made in #6823. In particular, the spurious `w2651` warning is disabled (https://software.intel.com/en-us/forums/intel-c-compiler/topic/780710) and the test is simplified to not construct deprecated objects.
This PR fixes the warnings in https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=3314.