### PR TITLE
hp::DoFHandler::distribute_dofs on p::d::Triangulation fails.

### DIFF
--- a/doc/news/changes/minor/20180720MarcFehling
+++ b/doc/news/changes/minor/20180720MarcFehling
@@ -1,0 +1,5 @@
+Fixed: hp::DoFHandler::distribute_dofs() now works on
+parallel::distributed::Triangulation<3> objects that
+contain artificial cells.
+<br>
+(Marc Fehling, 2018/07/20)

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -705,10 +705,12 @@ namespace internal
                      cell = dof_handler.begin_active();
                    cell != dof_handler.end();
                    ++cell)
-                for (unsigned int l = 0; l < GeometryInfo<dim>::lines_per_cell;
-                     ++l)
-                  line_fe_association[cell->active_fe_index()]
-                                     [cell->line_index(l)] = true;
+                if (!cell->is_artificial())
+                  for (unsigned int l = 0;
+                       l < GeometryInfo<dim>::lines_per_cell;
+                       ++l)
+                    line_fe_association[cell->active_fe_index()]
+                                       [cell->line_index(l)] = true;
 
               // first check which of the lines is used at all,
               // i.e. is associated with a finite element. we do this

--- a/tests/mpi/hp_distribute_dofs_01.cc
+++ b/tests/mpi/hp_distribute_dofs_01.cc
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// hp::DoFHandler::distribute_dofs failed
+// if a processor only owns artificial cells
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/hp/dof_handler.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(
+    MPI_COMM_WORLD,
+    typename Triangulation<dim>::MeshSmoothing(
+      Triangulation<dim>::smoothing_on_refinement |
+      Triangulation<dim>::smoothing_on_coarsening));
+
+  GridGenerator::hyper_cube(tria, -1.0, 1.0);
+  tria.refine_global(1);
+
+  const unsigned int max_degree = (dim == 2) ? 4 : 8;
+
+  hp::DoFHandler<dim>   dh(tria);
+  hp::FECollection<dim> fe_collection;
+  for (unsigned int degree = 1; degree <= max_degree; ++degree)
+    fe_collection.push_back(FE_Q<dim>(degree));
+
+  dh.distribute_dofs(fe_collection); // <-- fails
+
+  // make sure no processor is
+  // hanging
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+
+  unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  deallog.push(Utilities::int_to_string(myid));
+
+  if (myid == 0)
+    {
+      initlog();
+
+      deallog.push("2d");
+      test<2>();
+      deallog.pop();
+      deallog.push("3d");
+      test<3>();
+      deallog.pop();
+    }
+  else
+    {
+      test<2>();
+      test<3>();
+    }
+}

--- a/tests/mpi/hp_distribute_dofs_01.mpirun=1.output
+++ b/tests/mpi/hp_distribute_dofs_01.mpirun=1.output
@@ -1,0 +1,3 @@
+
+DEAL:0:2d::OK
+DEAL:0:3d::OK

--- a/tests/mpi/hp_distribute_dofs_01.mpirun=2.output
+++ b/tests/mpi/hp_distribute_dofs_01.mpirun=2.output
@@ -1,0 +1,3 @@
+
+DEAL:0:2d::OK
+DEAL:0:3d::OK


### PR DESCRIPTION
While preparing the `ActiveFEIndicesTransfer` class for the parallel distributed implementation of the `hp::DoFHandler`, I encountered an assertion triggered while trying to distribute dofs on a distributed mesh. I provided a small test case which throws the error when running `.mpirun=2.debug`.

```
id: 0 n_active_cells: 8
id: 1 n_active_cells: 1
--------------------------------------------------------                                                                                                                                                                               
An error occurred in line <3781> of file </path/to/dealii/include/deal.II/dofs/dof_accessor.templates.h> in function                                                                                                              
    unsigned int dealii::DoFCellAccessor<DoFHandlerType, lda>::active_fe_index() const [with DoFHandlerType = dealii::hp::DoFHandler<3, 3>; bool level_dof_access = false]                                                             
The violated condition was:                                                                                                                                                                                                            
    (dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension, DoFHandlerType::space_dimension> *>( this->dof_handler) != nullptr) || (this->is_locally_owned() || this->is_ghost())                                            
Additional information:                                                                                                                                                                                                                
    You can only query active_fe_index information on cells that are either locally owned or (after distributing degrees of freedom) are ghost cells.                                                                                  
--------------------------------------------------------
```
For some reason, this only happens in the `dim=3` case. In this case, the first processor owns all 8 cells, whereas the second one just has one artificial cell.

Shall we skip artificial cells while distributing dofs?

@bangerth -- FYI