### PR TITLE
Avoid #warning using MSVC

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -388,9 +388,9 @@ _Pragma("GCC diagnostic pop")
  * http://goodliffe.blogspot.com/2009/07/c-how-to-say-warning-to-visual-studio-c.html
  */
 
-#define STRINGIZE_HELPER(x) #x
-#define STRINGIZE(x) STRINGIZE_HELPER(x)
-#define WARNING(desc) message(__FILE__ "(" STRINGIZE(__LINE__) ") : Warning: " #desc)
+#define DEAL_II_STRINGIZE_HELPER(x) #x
+#define DEAL_II_STRINGIZE(x) DEAL_II_STRINGIZE_HELPER(x)
+#define DEAL_II_WARNING(desc) message(__FILE__ "(" DEAL_II_STRINGIZE(__LINE__) ") : Warning: " #desc)
 
 /***********************************************************************
  * Final inclusions:

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -382,6 +382,15 @@ _Pragma("GCC diagnostic pop")
 
 #endif
 
+/***********************************************************************
+ * Define a portable preprocessor macro that generates custom warnings
+ * reporting the line and the file where the warning appears. Taken from:
+ * http://goodliffe.blogspot.com/2009/07/c-how-to-say-warning-to-visual-studio-c.html
+ */
+
+#define STRINGIZE_HELPER(x) #x
+#define STRINGIZE(x) STRINGIZE_HELPER(x)
+#define WARNING(desc) message(__FILE__ "(" STRINGIZE(__LINE__) ") : Warning: " #desc)
 
 /***********************************************************************
  * Final inclusions:

--- a/include/deal.II/base/sacado_product_type.h
+++ b/include/deal.II/base/sacado_product_type.h
@@ -1,6 +1,10 @@
 #ifndef dealii_sacado_product_type_h_deprecated
 #define dealii_sacado_product_type_h_deprecated
-#warning This file is deprecated. Use <deal.II/differentiation/ad/sacado_product_types.h> instead.
+
+#include <deal.II/base/config.h>
+
+#pragma WARNING( \
+  "This file is deprecated. Use <deal.II/differentiation/ad/sacado_product_types.h> instead.")
 
 #include <deal.II/differentiation/ad/sacado_product_types.h>
 

--- a/include/deal.II/base/sacado_product_type.h
+++ b/include/deal.II/base/sacado_product_type.h
@@ -3,7 +3,7 @@
 
 #include <deal.II/base/config.h>
 
-#pragma WARNING( \
+#pragma DEAL_II_WARNING( \
   "This file is deprecated. Use <deal.II/differentiation/ad/sacado_product_types.h> instead.")
 
 #include <deal.II/differentiation/ad/sacado_product_types.h>

--- a/include/deal.II/dofs/function_map.h
+++ b/include/deal.II/dofs/function_map.h
@@ -20,6 +20,6 @@
 
 #include <deal.II/dofs/deprecated_function_map.h>
 
-#pragma WARNING("This file is deprecated.")
+#pragma DEAL_II_WARNING("This file is deprecated.")
 
 #endif

--- a/include/deal.II/dofs/function_map.h
+++ b/include/deal.II/dofs/function_map.h
@@ -20,6 +20,6 @@
 
 #include <deal.II/dofs/deprecated_function_map.h>
 
-#warning "This file is deprecated."
+#pragma WARNING("This file is deprecated.")
 
 #endif

--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#pragma WARNING("This file is deprecated. Use the Manifold classes instead.")
+#pragma DEAL_II_WARNING( \
+  "This file is deprecated. Use the Manifold classes instead.")
 
 #endif

--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -18,6 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-#warning This file is deprecated. Use the Manifold classes instead.
+#pragma WARNING("This file is deprecated. Use the Manifold classes instead.")
 
 #endif

--- a/include/deal.II/grid/tria_boundary_lib.h
+++ b/include/deal.II/grid/tria_boundary_lib.h
@@ -18,6 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-#warning This file is deprecated. Use the Manifold classes instead.
+#pragma WARNING("This file is deprecated.Use the Manifold classes instead.")
 
 #endif

--- a/include/deal.II/grid/tria_boundary_lib.h
+++ b/include/deal.II/grid/tria_boundary_lib.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#pragma WARNING("This file is deprecated.Use the Manifold classes instead.")
+#pragma DEAL_II_WARNING( \
+  "This file is deprecated.Use the Manifold classes instead.")
 
 #endif

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -17,7 +17,8 @@
 #ifndef dealii_constraint_matrix_h
 #define dealii_constraint_matrix_h
 
-#warning This file is deprecated. Use <deal.II/lac/affine_constraints.h> instead.
+#pragma WARNING( \
+  "This file is deprecated. Use <deal.II/lac/affine_constraints.h> instead.")
 
 #include <deal.II/lac/affine_constraints.h>
 

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -17,7 +17,9 @@
 #ifndef dealii_constraint_matrix_h
 #define dealii_constraint_matrix_h
 
-#pragma WARNING( \
+#include <deal.II/base/config.h>
+
+#pragma DEAL_II_WARNING( \
   "This file is deprecated. Use <deal.II/lac/affine_constraints.h> instead.")
 
 #include <deal.II/lac/affine_constraints.h>

--- a/include/deal.II/lac/parallel_block_vector.h
+++ b/include/deal.II/lac/parallel_block_vector.h
@@ -20,7 +20,8 @@
 
 #include <deal.II/lac/la_parallel_block_vector.h>
 
-#warning This file is deprecated. Use <deal.II/lac/la_block_vector.h> and LinearAlgebra::distributed::BlockVector instead.
+#pragma WARNING( \
+  "This file is deprecated. Use <deal.II/lac/la_block_vector.h> and LinearAlgebra::distributed::BlockVector instead.")
 
 #include <cstring>
 #include <iomanip>

--- a/include/deal.II/lac/parallel_block_vector.h
+++ b/include/deal.II/lac/parallel_block_vector.h
@@ -20,7 +20,7 @@
 
 #include <deal.II/lac/la_parallel_block_vector.h>
 
-#pragma WARNING( \
+#pragma DEAL_II_WARNING( \
   "This file is deprecated. Use <deal.II/lac/la_block_vector.h> and LinearAlgebra::distributed::BlockVector instead.")
 
 #include <cstring>

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -20,7 +20,7 @@
 
 #include <deal.II/lac/la_parallel_vector.h>
 
-#pragma WARNING( \
+#pragma DEAL_II_WARNING( \
   "This file is deprecated. Use <deal.II/lac/la_parallel_vector.h> and LinearAlgebra::distributed::Vector instead.")
 
 #include <cstring>

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -20,7 +20,8 @@
 
 #include <deal.II/lac/la_parallel_vector.h>
 
-#warning This file is deprecated. Use <deal.II/lac/la_parallel_vector.h> and LinearAlgebra::distributed::Vector instead.
+#pragma WARNING( \
+  "This file is deprecated. Use <deal.II/lac/la_parallel_vector.h> and LinearAlgebra::distributed::Vector instead.")
 
 #include <cstring>
 #include <iomanip>

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -127,7 +127,7 @@ CPUClock::now() noexcept
   getrusage(RUSAGE_SELF, &usage);
   system_cpu_duration = usage.ru_utime.tv_sec + 1.e-6 * usage.ru_utime.tv_usec;
 #else
-#  pragma WARNING("Unsupported platform. Porting not finished.")
+#  pragma DEAL_II_WARNING("Unsupported platform. Porting not finished.")
 #endif
   return time_point(
     internal::TimerImplementation::from_seconds<duration>(system_cpu_duration));

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -127,7 +127,7 @@ CPUClock::now() noexcept
   getrusage(RUSAGE_SELF, &usage);
   system_cpu_duration = usage.ru_utime.tv_sec + 1.e-6 * usage.ru_utime.tv_usec;
 #else
-#  warning "Unsupported platform. Porting not finished."
+#  pragma WARNING("Unsupported platform. Porting not finished.")
 #endif
   return time_point(
     internal::TimerImplementation::from_seconds<duration>(system_cpu_duration));


### PR DESCRIPTION
`MSVC` doesn't know about `#warning` so we need an alternative to not break every code using deprecated header files.