### PR TITLE
Match doxygen markup in the .cc file to that in the .h file.

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -699,7 +699,8 @@ namespace GridTools
    *   std::vector<std::vector<Point<dim>>>,
    *   std::vector<std::vector<unsigned int>>>
    * @endcode
-   * The type is abbreviated above to improve readability of this page.
+   * The type is abbreviated in the online documentation to improve readability
+   * of this page.
    *
    * @author Giovanni Alzetta, 2017
    */
@@ -776,7 +777,8 @@ namespace GridTools
    *   std::vector<std::vector<Point<spacedim>>>,
    *   std::vector<std::vector<unsigned int>>>
    * @endcode
-   * The type is abbreviated above to improve readability of this page.
+   * The type is abbreviated in the online documentation to improve readability
+   * of this page.
    *
    * @author Giovanni Alzetta, 2017-2018
    */
@@ -1532,7 +1534,8 @@ namespace GridTools
    *            std::map< unsigned int, unsigned int>,
    *            std::map< unsigned int, std::vector<unsigned int>>>
    * @endcode
-   * The type is abbreviated above to improve readability of this page.
+   * The type is abbreviated in the online documentation to improve readability
+   * of this page.
    *
    * @author Giovanni Alzetta, 2017
    */

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1860,9 +1860,13 @@ namespace GridTools
 
 
   template <int spacedim>
+#ifndef DOXYGEN
   std::tuple<std::vector<std::vector<unsigned int>>,
              std::map<unsigned int, unsigned int>,
              std::map<unsigned int, std::vector<unsigned int>>>
+#else
+  return_type
+#endif
   guess_point_owner(
     const std::vector<std::vector<BoundingBox<spacedim>>> &global_bboxes,
     const std::vector<Point<spacedim>> &                   points)
@@ -3987,10 +3991,14 @@ namespace GridTools
 
 
   template <int dim, int spacedim>
+#ifndef DOXYGEN
   std::tuple<
     std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>,
     std::vector<std::vector<Point<dim>>>,
     std::vector<std::vector<unsigned int>>>
+#else
+  return_type
+#endif
   compute_point_locations(
     const Cache<dim, spacedim> &        cache,
     const std::vector<Point<spacedim>> &points,
@@ -4488,12 +4496,16 @@ namespace GridTools
 
 
   template <int dim, int spacedim>
+#ifndef DOXYGEN
   std::tuple<
     std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>,
     std::vector<std::vector<Point<dim>>>,
     std::vector<std::vector<unsigned int>>,
     std::vector<std::vector<Point<spacedim>>>,
     std::vector<std::vector<unsigned int>>>
+#else
+  return_type
+#endif
   distributed_compute_point_locations(
     const GridTools::Cache<dim, spacedim> &                cache,
     const std::vector<Point<spacedim>> &                   local_points,


### PR DESCRIPTION
This is necessary because we run both the .h and the .cc files through doxygen.
If we don't do this, then doxygen will show functions with different markup
twice in the online documentation.