### PR TITLE
Ignore deleted files when formatting

### DIFF
--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -247,7 +247,7 @@ process_changed()
   esac
 
   ( git ls-files --others --exclude-standard -- ${1};
-    git diff --name-only $COMMON_ANCESTOR_WITH_MASTER -- ${1} )|
+    git diff --name-only --diff-filter=d $COMMON_ANCESTOR_WITH_MASTER -- ${1} )|
       sort -u |
       grep -E "^${2}$" |
       ${XARGS} '\n' -n 1 -P 10 -I {} bash -c "${3} {}"


### PR DESCRIPTION
In case there are deleted files between the current branch and the common ancestor of the current branch and the last merge commit on the local master branch, we were previously trying to indent these (removed) files. This PR makes sure to ignore deleted files.