### PR TITLE
Make it even clearer that a function is 'virtual'.

### DIFF
--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2050,7 +2050,7 @@ public:
   /**
    * Destructor.
    */
-  ~FEValuesBase() override;
+  virtual ~FEValuesBase() override;
 
 
   /// @name ShapeAccess Access to shape function values. These fields are filled


### PR DESCRIPTION
I stumbled over this during @tjhei's presentation today where I thought a
destructor should be 'virtual', but it wasn't. I missed the 'override'
mark.

Have we decided that we don't make 'override' functions as 'virtual' any
more, or is this one simply an oversight?