### PR TITLE
Add class 'ActiveFEIndicesTransfer' for hp::DoFHandler on p::d::Triangulation.

### DIFF
--- a/doc/news/changes/minor/20180723MarcFehling
+++ b/doc/news/changes/minor/20180723MarcFehling
@@ -1,0 +1,6 @@
+New: Class parallel::distributed::ActiveFEIndicesTransfer
+has been introduced to transfer the active_fe_index of each
+cell across meshes in case of refinement/serialization, if a
+hp::DoFHandler has been used with a parallel::distributed::Triangulation.
+<br>
+(Marc Fehling, 2018/07/23)

--- a/include/deal.II/distributed/active_fe_indices_transfer.h
+++ b/include/deal.II/distributed/active_fe_indices_transfer.h
@@ -1,0 +1,205 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_distributed_active_fe_indices_transfer_h
+#define dealii_distributed_active_fe_indices_transfer_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/hp/dof_handler.h>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace parallel
+{
+  namespace distributed
+  {
+    /**
+     * This class transfers each cell's `active_fe_index` of a hp::FECollection
+     * attached to a hp::DoFHandler while refining and/or coarsening a
+     * distributed grid and handles the necessary communication.
+     *
+     * This class therefore does for the `active_fe_index` information of each
+     * cell what parallel::distributed::SolutionTransfer does for the values
+     * of degrees of freedom defined on a parallel::distributed::Triangulation.
+     *
+     * @note If you use more than one object to attach data to a
+     * parallel::distributed::Triangulation at the same time (e.g. a
+     * parallel::distributed::SolutionTransfer object), the calls to
+     * parallel::distributed::ActiveFEIndicesTransfer::prepare_for_transfer(),
+     * parallel::distributed::SolutionTransfer::prepare_for_coarsening_and_refinement()
+     * and parallel::distributed::SolutionTransfer::prepare_serialization(),
+     * as well as parallel::distributed::ActiveFEIndicesTransfer::unpack() and
+     * parallel::distributed::SolutionTransfer::interpolate(), or
+     * parallel::distributed::ActiveFEIndicesTransfer::deserialize() and
+     * parallel::distributed::SolutionTransfer::deserialize() for serialization,
+     * need to be in the same order, respectively.
+     *
+     * <h3>Transferring each cell's active_fe_index</h3>
+     *
+     * The following code snippet demonstrates how to transfer all active FE
+     * indices across refinement/coarsening of the triangulation that is
+     * registered to the hp::DoFHandler member object of this class.
+     *
+     * @code
+     * parallel::distributed::ActiveFEIndicesTransfer<dim, spacedim>
+     *   feidx_trans(hp_dof_handler);
+     * // flag some cells for refinement and coarsening, e.g.
+     * GridRefinement::refine_and_coarsen_fixed_fraction(tria,
+     *                                                   error_indicators,
+     *                                                   0.3,
+     *                                                   0.05);
+     *
+     * // prepare the triangulation,
+     * tria.prepare_coarsening_and_refinement();
+     *
+     * // prepare the SolutionTransfer object for coarsening and refinement
+     * // and give the solution vector that we intend to interpolate later,
+     * feidx_trans.prepare_for_transfer();
+     *
+     * // actually execute the refinement,
+     * tria.execute_coarsening_and_refinement();
+     *
+     * // unpack all active fe indices,
+     * feidx_trans.unpack();
+     *
+     * // redistribute dofs for further use,
+     * // using the active FE indices just restored
+     * hp_dof_handler.distribute_dofs(fe_collection);
+     * @endcode
+     *
+     *
+     * <h3>Use for serialization</h3>
+     *
+     * This class can be used to serialize and later deserialize a distributed
+     * mesh with attached data to separate files. If you use more than one
+     * hp::DoFHandler and therefore more than one
+     * parallel::distributed::ActiveFEIndicesTransfer object, they need to be
+     * serialized and deserialized in the same order.
+     *
+     * For serialization, the following code snippet saves not only the
+     * triangulation itself, but also the active FE indices of a hp::DoFHandler
+     * that works on this triangulation:
+     * @code
+     * parallel::distributed::ActiveFEIndicesTransfer<dim, spacedim>
+     *   feidx_trans(hp_dof_handler);
+     * feidx_trans.prepare_for_transfer();
+     *
+     * triangulation.save(filename);
+     * @endcode
+     *
+     * Later, during deserialization, both the triangulation and all active FE
+     * indices of the hp::DoFHandler can be restored as follows:
+     * @code
+     * //[create coarse mesh...]
+     * triangulation.load(filename);
+     *
+     * parallel::distributed::ActiveFEIndicesTransfer<dim, spacedim>
+     *   feidx_trans(hp_dof_handler);
+     * feidx_trans.deserialize();
+     *
+     * // distribute dofs for further use,
+     * // using the active FE indices just restored
+     * hp_dof_handler.distribute_dofs(fe_collection);
+     * @endcode
+     *
+     * @note See documentation of parallel::distributed::SolutionTransfer for
+     * matching code snippets in both cases.
+     *
+     * @ingroup distributed
+     * @author Marc Fehling, 2018
+     */
+    template <int dim, int spacedim = dim>
+    class ActiveFEIndicesTransfer
+    {
+    public:
+      /**
+       * Constructor.
+       *
+       * @param[in] dof The hp::DoFHandler on which all
+       *   operations will happen. At the time when this constructor
+       *   is called, the hp::DoFHandler still points to the triangulation
+       *   before the refinement in question happens.
+       */
+      ActiveFEIndicesTransfer(const hp::DoFHandler<dim, spacedim> &dof_handler);
+
+      /**
+       * Prepare the current object for coarsening and refinement or
+       * serialization.
+       */
+      void
+      prepare_for_transfer();
+
+      /**
+       * Unpack the information previously stored in this object before
+       * the mesh was refined or coarsened onto the current set of cells.
+       */
+      void
+      unpack();
+
+      /**
+       * Execute the deserialization of the stored information.
+       * This needs to be done after calling Triangulation::load().
+       */
+      void
+      deserialize();
+
+    private:
+      /**
+       * Pointer to the hp::DoFHandler to work with.
+       */
+      SmartPointer<const hp::DoFHandler<dim, spacedim>,
+                   ActiveFEIndicesTransfer<dim, spacedim>>
+        dof_handler;
+
+      /**
+       * The handle that the parallel::distributed::Triangulation has
+       * assigned to this object with which we can access our memory
+       * offset and our pack function.
+       */
+      unsigned int handle;
+
+      /**
+       * A callback function used to pack the data on the current mesh into
+       * objects that can later be retrieved after refinement, coarsening and
+       * repartitioning.
+       */
+      std::vector<char>
+      pack_callback(
+        const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+        const typename Triangulation<dim, spacedim>::CellStatus     status);
+
+      /**
+       * A callback function used to unpack the data on the current mesh that
+       * has been packed up previously on the mesh before refinement,
+       * coarsening and repartitioning.
+       */
+      void
+      unpack_callback(
+        const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+        const typename Triangulation<dim, spacedim>::CellStatus     status,
+        const boost::iterator_range<std::vector<char>::const_iterator>
+          &data_range);
+    };
+  } // namespace distributed
+} // namespace parallel
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/source/distributed/CMakeLists.txt
+++ b/source/distributed/CMakeLists.txt
@@ -17,6 +17,7 @@ INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
 SET(_unity_include_src
   grid_refinement.cc
+  active_fe_indices_transfer.cc
   solution_transfer.cc
   tria.cc
   tria_base.cc
@@ -38,6 +39,7 @@ SETUP_SOURCE_LIST("${_unity_include_src}"
 
 SET(_inst
   grid_refinement.inst.in
+  active_fe_indices_transfer.inst.in
   solution_transfer.inst.in
   tria.inst.in
   shared_tria.inst.in

--- a/source/distributed/active_fe_indices_transfer.cc
+++ b/source/distributed/active_fe_indices_transfer.cc
@@ -1,0 +1,213 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_P4EST
+
+#  include <deal.II/distributed/active_fe_indices_transfer.h>
+#  include <deal.II/distributed/tria.h>
+
+#  include <deal.II/dofs/dof_accessor.h>
+
+#  include <deal.II/hp/dof_handler.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace parallel
+{
+  namespace distributed
+  {
+    template <int dim, int spacedim>
+    ActiveFEIndicesTransfer<dim, spacedim>::ActiveFEIndicesTransfer(
+      const hp::DoFHandler<dim, spacedim> &dof_handler)
+      : dof_handler(&dof_handler, typeid(*this).name())
+      , handle(numbers::invalid_unsigned_int)
+    {
+      Assert(
+        (dynamic_cast<
+           const parallel::distributed::Triangulation<dim, spacedim> *>(
+           &(this->dof_handler)->get_triangulation()) != nullptr),
+        ExcMessage(
+          "parallel::distributed::ActiveFEIndicesTransfer requires a parallel::distributed::Triangulation object."));
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    ActiveFEIndicesTransfer<dim, spacedim>::prepare_for_transfer()
+    {
+      parallel::distributed::Triangulation<dim, spacedim> *tria =
+        (dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
+          const_cast<dealii::Triangulation<dim, spacedim> *>(
+            &dof_handler->get_triangulation())));
+      Assert(tria != nullptr, ExcInternalError());
+
+      handle = tria->register_data_attach(
+        std::bind(&ActiveFEIndicesTransfer<dim, spacedim>::pack_callback,
+                  this,
+                  std::placeholders::_1,
+                  std::placeholders::_2),
+        /*returns_variable_size_data=*/false);
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    ActiveFEIndicesTransfer<dim, spacedim>::unpack()
+    {
+      // TODO: casting away constness is bad
+      parallel::distributed::Triangulation<dim, spacedim> *tria =
+        (dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
+          const_cast<dealii::Triangulation<dim, spacedim> *>(
+            &dof_handler->get_triangulation())));
+      Assert(tria != nullptr, ExcInternalError());
+
+      tria->notify_ready_to_unpack(
+        handle,
+        std::bind(&ActiveFEIndicesTransfer<dim, spacedim>::unpack_callback,
+                  this,
+                  std::placeholders::_1,
+                  std::placeholders::_2,
+                  std::placeholders::_3));
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    ActiveFEIndicesTransfer<dim, spacedim>::deserialize()
+    {
+      // For deserialization, we need to register this object
+      // to the triangulation first to get a valid handle for
+      // data access.
+      prepare_for_transfer();
+      unpack();
+    }
+
+
+
+    template <int dim, int spacedim>
+    std::vector<char>
+    ActiveFEIndicesTransfer<dim, spacedim>::pack_callback(
+      const typename Triangulation<dim, spacedim>::cell_iterator &cell_,
+      const typename Triangulation<dim, spacedim>::CellStatus     status)
+    {
+      const typename hp::DoFHandler<dim, spacedim>::cell_iterator cell(
+        *cell_, dof_handler);
+
+      unsigned int fe_index = numbers::invalid_unsigned_int;
+
+      switch (status)
+        {
+          case parallel::distributed::Triangulation<dim,
+                                                    spacedim>::CELL_PERSIST:
+          case parallel::distributed::Triangulation<dim, spacedim>::CELL_REFINE:
+            fe_index = cell->active_fe_index();
+            break;
+
+          case parallel::distributed::Triangulation<dim,
+                                                    spacedim>::CELL_COARSEN:
+            // In this case, the callback function will be called on the parent
+            // cell which shall store the packed information. We need to choose
+            // from its children which ID to store.
+            {
+              std::set<unsigned int> fe_indices_children;
+              for (unsigned int child_index = 0;
+                   child_index < GeometryInfo<dim>::max_children_per_cell;
+                   ++child_index)
+                {
+                  typename hp::DoFHandler<dim, spacedim>::cell_iterator child =
+                    cell->child(child_index);
+
+                  fe_indices_children.insert(child->active_fe_index());
+                }
+
+              fe_index = dof_handler->get_fe().find_least_face_dominating_fe(
+                fe_indices_children);
+
+              Assert(fe_index != numbers::invalid_unsigned_int,
+                     ExcMessage(
+                       "No FiniteElement has been found in your FECollection "
+                       "that dominates all children of a cell you are trying "
+                       "to coarsen!"));
+            }
+            break;
+
+          default:
+            Assert(false, ExcInternalError());
+            break;
+        }
+
+      return Utilities::pack(fe_index, /*allow_compression=*/false);
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    ActiveFEIndicesTransfer<dim, spacedim>::unpack_callback(
+      const typename Triangulation<dim, spacedim>::cell_iterator &cell_,
+      const typename Triangulation<dim, spacedim>::CellStatus     status,
+      const boost::iterator_range<std::vector<char>::const_iterator>
+        &data_range)
+    {
+      typename hp::DoFHandler<dim, spacedim>::cell_iterator cell(*cell_,
+                                                                 dof_handler);
+
+      const unsigned int fe_index =
+        Utilities::unpack<unsigned int>(data_range.begin(),
+                                        data_range.end(),
+                                        /*allow_compression=*/false);
+
+      Assert(fe_index <= dof_handler->get_fe().size(), ExcInternalError());
+
+      switch (status)
+        {
+          case parallel::distributed::Triangulation<dim,
+                                                    spacedim>::CELL_PERSIST:
+          case parallel::distributed::Triangulation<dim,
+                                                    spacedim>::CELL_COARSEN:
+            cell->set_active_fe_index(fe_index);
+            break;
+
+          case parallel::distributed::Triangulation<dim, spacedim>::CELL_REFINE:
+            // In this case, the callback function will be called on the parent
+            // cell which stores the packed information. We need to distribute
+            // it on its children.
+            for (unsigned int child_index = 0;
+                 child_index < GeometryInfo<dim>::max_children_per_cell;
+                 ++child_index)
+              cell->child(child_index)->set_active_fe_index(fe_index);
+            break;
+
+          default:
+            Assert(false, ExcInternalError());
+            break;
+        }
+    }
+  } // namespace distributed
+} // namespace parallel
+
+
+// explicit instantiations
+#  include "feindices_transfer.inst"
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/source/distributed/active_fe_indices_transfer.inst.in
+++ b/source/distributed/active_fe_indices_transfer.inst.in
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+    namespace parallel
+    \{
+      namespace distributed
+      \{
+#if deal_II_dimension <= deal_II_space_dimension
+        template class ActiveFEIndicesTransfer<deal_II_dimension,
+                                               deal_II_space_dimension>;
+#endif
+      \}
+    \}
+  }

--- a/tests/mpi/hp_active_fe_indices_transfer_01.cc
+++ b/tests/mpi/hp_active_fe_indices_transfer_01.cc
@@ -1,0 +1,133 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// ActiveFEIndicesTransfer Test
+
+
+#include <deal.II/distributed/active_fe_indices_transfer.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/hp/dof_handler.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  // ------ setup ------
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+  tria.refine_global(1);
+  deallog << "cells before: " << tria.n_global_active_cells() << std::endl;
+
+  hp::DoFHandler<dim>   dh(tria);
+  hp::FECollection<dim> fe_collection;
+
+  // prepare FECollection with arbitrary number of entries
+  const unsigned int max_degree = 1 + std::pow(2, dim);
+  for (unsigned int i = 0; i < max_degree; ++i)
+    fe_collection.push_back(FE_Q<dim>(max_degree - i));
+
+  typename hp::DoFHandler<dim, dim>::active_cell_iterator cell;
+  unsigned int                                            i = 0;
+
+  for (cell = dh.begin_active(); cell != dh.end(); ++cell)
+    {
+      if (cell->is_locally_owned())
+        {
+          // set active fe index
+          if (!(cell->is_artificial()))
+            {
+              if (i >= fe_collection.size())
+                i = 0;
+              cell->set_active_fe_index(i++);
+            }
+
+          // set refinement/coarsening flags
+          if (cell->id().to_string() == "0_1:0")
+            cell->set_refine_flag();
+          else if (cell->parent()->id().to_string() ==
+                   ((dim == 2) ? "3_0:" : "7_0:"))
+            cell->set_coarsen_flag();
+
+          deallog << "myid=" << myid << " cellid=" << cell->id()
+                  << " fe_index=" << cell->active_fe_index()
+                  << " feq_degree=" << max_degree - cell->active_fe_index();
+          if (cell->coarsen_flag_set())
+            deallog << " coarsening";
+          else if (cell->refine_flag_set())
+            deallog << " refining";
+          deallog << std::endl;
+        }
+    }
+
+  dh.distribute_dofs(fe_collection);
+
+  // ----- transfer -----
+  parallel::distributed::ActiveFEIndicesTransfer<dim, dim> feidx_transfer(dh);
+
+  feidx_transfer.prepare_for_transfer();
+  tria.execute_coarsening_and_refinement();
+  deallog << "cells after: " << tria.n_global_active_cells() << std::endl;
+
+  feidx_transfer.unpack();
+
+  // for further calculations, distribute dofs after unpacking, i.e.
+  // dh.distribute_dofs(fe_collection);
+
+  // ------ verify ------
+  // check if all children adopted the correct id
+  for (cell = dh.begin_active(); cell != dh.end(); ++cell)
+    {
+      if (cell->is_locally_owned())
+        {
+          deallog << "myid=" << myid << " cellid=" << cell->id()
+                  << " fe_index=" << cell->active_fe_index()
+                  << " feq_degree=" << max_degree - cell->active_fe_index()
+                  << std::endl;
+        }
+    }
+
+  // make sure no processor is hanging
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/mpi/hp_active_fe_indices_transfer_01.with_p4est=true.mpirun=2.output
+++ b/tests/mpi/hp_active_fe_indices_transfer_01.with_p4est=true.mpirun=2.output
@@ -1,0 +1,175 @@
+
+DEAL:0:2d::cells before: 16
+DEAL:0:2d::myid=0 cellid=0_1:0 fe_index=0 feq_degree=5 refining
+DEAL:0:2d::myid=0 cellid=0_1:1 fe_index=1 feq_degree=4
+DEAL:0:2d::myid=0 cellid=0_1:2 fe_index=2 feq_degree=3
+DEAL:0:2d::myid=0 cellid=0_1:3 fe_index=3 feq_degree=2
+DEAL:0:2d::myid=0 cellid=1_1:0 fe_index=4 feq_degree=1
+DEAL:0:2d::myid=0 cellid=1_1:1 fe_index=0 feq_degree=5
+DEAL:0:2d::myid=0 cellid=1_1:2 fe_index=1 feq_degree=4
+DEAL:0:2d::myid=0 cellid=1_1:3 fe_index=2 feq_degree=3
+DEAL:0:2d::cells after: 16
+DEAL:0:2d::myid=0 cellid=0_1:1 fe_index=1 feq_degree=4
+DEAL:0:2d::myid=0 cellid=0_1:2 fe_index=2 feq_degree=3
+DEAL:0:2d::myid=0 cellid=0_1:3 fe_index=3 feq_degree=2
+DEAL:0:2d::myid=0 cellid=0_2:00 fe_index=0 feq_degree=5
+DEAL:0:2d::myid=0 cellid=0_2:01 fe_index=0 feq_degree=5
+DEAL:0:2d::myid=0 cellid=0_2:02 fe_index=0 feq_degree=5
+DEAL:0:2d::myid=0 cellid=0_2:03 fe_index=0 feq_degree=5
+DEAL:0:2d::OK
+DEAL:0:3d::cells before: 64
+DEAL:0:3d::myid=0 cellid=0_1:0 fe_index=0 feq_degree=9 refining
+DEAL:0:3d::myid=0 cellid=0_1:1 fe_index=1 feq_degree=8
+DEAL:0:3d::myid=0 cellid=0_1:2 fe_index=2 feq_degree=7
+DEAL:0:3d::myid=0 cellid=0_1:3 fe_index=3 feq_degree=6
+DEAL:0:3d::myid=0 cellid=0_1:4 fe_index=4 feq_degree=5
+DEAL:0:3d::myid=0 cellid=0_1:5 fe_index=5 feq_degree=4
+DEAL:0:3d::myid=0 cellid=0_1:6 fe_index=6 feq_degree=3
+DEAL:0:3d::myid=0 cellid=0_1:7 fe_index=7 feq_degree=2
+DEAL:0:3d::myid=0 cellid=1_1:0 fe_index=8 feq_degree=1
+DEAL:0:3d::myid=0 cellid=1_1:1 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=1_1:2 fe_index=1 feq_degree=8
+DEAL:0:3d::myid=0 cellid=1_1:3 fe_index=2 feq_degree=7
+DEAL:0:3d::myid=0 cellid=1_1:4 fe_index=3 feq_degree=6
+DEAL:0:3d::myid=0 cellid=1_1:5 fe_index=4 feq_degree=5
+DEAL:0:3d::myid=0 cellid=1_1:6 fe_index=5 feq_degree=4
+DEAL:0:3d::myid=0 cellid=1_1:7 fe_index=6 feq_degree=3
+DEAL:0:3d::myid=0 cellid=2_1:0 fe_index=7 feq_degree=2
+DEAL:0:3d::myid=0 cellid=2_1:1 fe_index=8 feq_degree=1
+DEAL:0:3d::myid=0 cellid=2_1:2 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=2_1:3 fe_index=1 feq_degree=8
+DEAL:0:3d::myid=0 cellid=2_1:4 fe_index=2 feq_degree=7
+DEAL:0:3d::myid=0 cellid=2_1:5 fe_index=3 feq_degree=6
+DEAL:0:3d::myid=0 cellid=2_1:6 fe_index=4 feq_degree=5
+DEAL:0:3d::myid=0 cellid=2_1:7 fe_index=5 feq_degree=4
+DEAL:0:3d::myid=0 cellid=3_1:0 fe_index=6 feq_degree=3
+DEAL:0:3d::myid=0 cellid=3_1:1 fe_index=7 feq_degree=2
+DEAL:0:3d::myid=0 cellid=3_1:2 fe_index=8 feq_degree=1
+DEAL:0:3d::myid=0 cellid=3_1:3 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=3_1:4 fe_index=1 feq_degree=8
+DEAL:0:3d::myid=0 cellid=3_1:5 fe_index=2 feq_degree=7
+DEAL:0:3d::myid=0 cellid=3_1:6 fe_index=3 feq_degree=6
+DEAL:0:3d::myid=0 cellid=3_1:7 fe_index=4 feq_degree=5
+DEAL:0:3d::cells after: 64
+DEAL:0:3d::myid=0 cellid=0_1:1 fe_index=1 feq_degree=8
+DEAL:0:3d::myid=0 cellid=0_1:2 fe_index=2 feq_degree=7
+DEAL:0:3d::myid=0 cellid=0_1:3 fe_index=3 feq_degree=6
+DEAL:0:3d::myid=0 cellid=0_1:4 fe_index=4 feq_degree=5
+DEAL:0:3d::myid=0 cellid=0_1:5 fe_index=5 feq_degree=4
+DEAL:0:3d::myid=0 cellid=0_1:6 fe_index=6 feq_degree=3
+DEAL:0:3d::myid=0 cellid=0_1:7 fe_index=7 feq_degree=2
+DEAL:0:3d::myid=0 cellid=1_1:0 fe_index=8 feq_degree=1
+DEAL:0:3d::myid=0 cellid=1_1:1 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=1_1:2 fe_index=1 feq_degree=8
+DEAL:0:3d::myid=0 cellid=1_1:3 fe_index=2 feq_degree=7
+DEAL:0:3d::myid=0 cellid=1_1:4 fe_index=3 feq_degree=6
+DEAL:0:3d::myid=0 cellid=1_1:5 fe_index=4 feq_degree=5
+DEAL:0:3d::myid=0 cellid=1_1:6 fe_index=5 feq_degree=4
+DEAL:0:3d::myid=0 cellid=1_1:7 fe_index=6 feq_degree=3
+DEAL:0:3d::myid=0 cellid=2_1:0 fe_index=7 feq_degree=2
+DEAL:0:3d::myid=0 cellid=2_1:1 fe_index=8 feq_degree=1
+DEAL:0:3d::myid=0 cellid=2_1:2 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=2_1:3 fe_index=1 feq_degree=8
+DEAL:0:3d::myid=0 cellid=2_1:4 fe_index=2 feq_degree=7
+DEAL:0:3d::myid=0 cellid=2_1:5 fe_index=3 feq_degree=6
+DEAL:0:3d::myid=0 cellid=2_1:6 fe_index=4 feq_degree=5
+DEAL:0:3d::myid=0 cellid=2_1:7 fe_index=5 feq_degree=4
+DEAL:0:3d::myid=0 cellid=0_2:00 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:01 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:02 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:03 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:04 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:05 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:06 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:07 fe_index=0 feq_degree=9
+DEAL:0:3d::OK 
+
+DEAL:1:2d::cells before: 16
+DEAL:1:2d::myid=1 cellid=2_1:0 fe_index=0 feq_degree=5
+DEAL:1:2d::myid=1 cellid=2_1:1 fe_index=1 feq_degree=4
+DEAL:1:2d::myid=1 cellid=2_1:2 fe_index=2 feq_degree=3
+DEAL:1:2d::myid=1 cellid=2_1:3 fe_index=3 feq_degree=2
+DEAL:1:2d::myid=1 cellid=3_1:0 fe_index=4 feq_degree=1 coarsening
+DEAL:1:2d::myid=1 cellid=3_1:1 fe_index=0 feq_degree=5 coarsening
+DEAL:1:2d::myid=1 cellid=3_1:2 fe_index=1 feq_degree=4 coarsening
+DEAL:1:2d::myid=1 cellid=3_1:3 fe_index=2 feq_degree=3 coarsening
+DEAL:1:2d::cells after: 16
+DEAL:1:2d::myid=1 cellid=3_0: fe_index=4 feq_degree=1 
+DEAL:1:2d::myid=1 cellid=1_1:0 fe_index=4 feq_degree=1
+DEAL:1:2d::myid=1 cellid=1_1:1 fe_index=0 feq_degree=5
+DEAL:1:2d::myid=1 cellid=1_1:2 fe_index=1 feq_degree=4
+DEAL:1:2d::myid=1 cellid=1_1:3 fe_index=2 feq_degree=3
+DEAL:1:2d::myid=1 cellid=2_1:0 fe_index=0 feq_degree=5
+DEAL:1:2d::myid=1 cellid=2_1:1 fe_index=1 feq_degree=4
+DEAL:1:2d::myid=1 cellid=2_1:2 fe_index=2 feq_degree=3
+DEAL:1:2d::myid=1 cellid=2_1:3 fe_index=3 feq_degree=2
+DEAL:1:2d::OK
+DEAL:1:3d::cells before: 64
+DEAL:1:3d::myid=1 cellid=4_1:0 fe_index=0 feq_degree=9
+DEAL:1:3d::myid=1 cellid=4_1:1 fe_index=1 feq_degree=8
+DEAL:1:3d::myid=1 cellid=4_1:2 fe_index=2 feq_degree=7
+DEAL:1:3d::myid=1 cellid=4_1:3 fe_index=3 feq_degree=6
+DEAL:1:3d::myid=1 cellid=4_1:4 fe_index=4 feq_degree=5
+DEAL:1:3d::myid=1 cellid=4_1:5 fe_index=5 feq_degree=4
+DEAL:1:3d::myid=1 cellid=4_1:6 fe_index=6 feq_degree=3
+DEAL:1:3d::myid=1 cellid=4_1:7 fe_index=7 feq_degree=2
+DEAL:1:3d::myid=1 cellid=5_1:0 fe_index=8 feq_degree=1
+DEAL:1:3d::myid=1 cellid=5_1:1 fe_index=0 feq_degree=9
+DEAL:1:3d::myid=1 cellid=5_1:2 fe_index=1 feq_degree=8
+DEAL:1:3d::myid=1 cellid=5_1:3 fe_index=2 feq_degree=7
+DEAL:1:3d::myid=1 cellid=5_1:4 fe_index=3 feq_degree=6
+DEAL:1:3d::myid=1 cellid=5_1:5 fe_index=4 feq_degree=5
+DEAL:1:3d::myid=1 cellid=5_1:6 fe_index=5 feq_degree=4
+DEAL:1:3d::myid=1 cellid=5_1:7 fe_index=6 feq_degree=3
+DEAL:1:3d::myid=1 cellid=6_1:0 fe_index=7 feq_degree=2
+DEAL:1:3d::myid=1 cellid=6_1:1 fe_index=8 feq_degree=1
+DEAL:1:3d::myid=1 cellid=6_1:2 fe_index=0 feq_degree=9
+DEAL:1:3d::myid=1 cellid=6_1:3 fe_index=1 feq_degree=8
+DEAL:1:3d::myid=1 cellid=6_1:4 fe_index=2 feq_degree=7
+DEAL:1:3d::myid=1 cellid=6_1:5 fe_index=3 feq_degree=6
+DEAL:1:3d::myid=1 cellid=6_1:6 fe_index=4 feq_degree=5
+DEAL:1:3d::myid=1 cellid=6_1:7 fe_index=5 feq_degree=4
+DEAL:1:3d::myid=1 cellid=7_1:0 fe_index=6 feq_degree=3 coarsening
+DEAL:1:3d::myid=1 cellid=7_1:1 fe_index=7 feq_degree=2 coarsening
+DEAL:1:3d::myid=1 cellid=7_1:2 fe_index=8 feq_degree=1 coarsening
+DEAL:1:3d::myid=1 cellid=7_1:3 fe_index=0 feq_degree=9 coarsening
+DEAL:1:3d::myid=1 cellid=7_1:4 fe_index=1 feq_degree=8 coarsening
+DEAL:1:3d::myid=1 cellid=7_1:5 fe_index=2 feq_degree=7 coarsening
+DEAL:1:3d::myid=1 cellid=7_1:6 fe_index=3 feq_degree=6 coarsening
+DEAL:1:3d::myid=1 cellid=7_1:7 fe_index=4 feq_degree=5 coarsening
+DEAL:1:3d::cells after: 64
+DEAL:1:3d::myid=1 cellid=7_0: fe_index=8 feq_degree=1
+DEAL:1:3d::myid=1 cellid=3_1:0 fe_index=6 feq_degree=3
+DEAL:1:3d::myid=1 cellid=3_1:1 fe_index=7 feq_degree=2
+DEAL:1:3d::myid=1 cellid=3_1:2 fe_index=8 feq_degree=1
+DEAL:1:3d::myid=1 cellid=3_1:3 fe_index=0 feq_degree=9
+DEAL:1:3d::myid=1 cellid=3_1:4 fe_index=1 feq_degree=8
+DEAL:1:3d::myid=1 cellid=3_1:5 fe_index=2 feq_degree=7
+DEAL:1:3d::myid=1 cellid=3_1:6 fe_index=3 feq_degree=6
+DEAL:1:3d::myid=1 cellid=3_1:7 fe_index=4 feq_degree=5
+DEAL:1:3d::myid=1 cellid=4_1:0 fe_index=0 feq_degree=9
+DEAL:1:3d::myid=1 cellid=4_1:1 fe_index=1 feq_degree=8
+DEAL:1:3d::myid=1 cellid=4_1:2 fe_index=2 feq_degree=7
+DEAL:1:3d::myid=1 cellid=4_1:3 fe_index=3 feq_degree=6
+DEAL:1:3d::myid=1 cellid=4_1:4 fe_index=4 feq_degree=5
+DEAL:1:3d::myid=1 cellid=4_1:5 fe_index=5 feq_degree=4
+DEAL:1:3d::myid=1 cellid=4_1:6 fe_index=6 feq_degree=3
+DEAL:1:3d::myid=1 cellid=4_1:7 fe_index=7 feq_degree=2
+DEAL:1:3d::myid=1 cellid=5_1:0 fe_index=8 feq_degree=1
+DEAL:1:3d::myid=1 cellid=5_1:1 fe_index=0 feq_degree=9
+DEAL:1:3d::myid=1 cellid=5_1:2 fe_index=1 feq_degree=8
+DEAL:1:3d::myid=1 cellid=5_1:3 fe_index=2 feq_degree=7
+DEAL:1:3d::myid=1 cellid=5_1:4 fe_index=3 feq_degree=6
+DEAL:1:3d::myid=1 cellid=5_1:5 fe_index=4 feq_degree=5
+DEAL:1:3d::myid=1 cellid=5_1:6 fe_index=5 feq_degree=4
+DEAL:1:3d::myid=1 cellid=5_1:7 fe_index=6 feq_degree=3
+DEAL:1:3d::myid=1 cellid=6_1:0 fe_index=7 feq_degree=2
+DEAL:1:3d::myid=1 cellid=6_1:1 fe_index=8 feq_degree=1
+DEAL:1:3d::myid=1 cellid=6_1:2 fe_index=0 feq_degree=9
+DEAL:1:3d::myid=1 cellid=6_1:3 fe_index=1 feq_degree=8
+DEAL:1:3d::myid=1 cellid=6_1:4 fe_index=2 feq_degree=7
+DEAL:1:3d::myid=1 cellid=6_1:5 fe_index=3 feq_degree=6
+DEAL:1:3d::myid=1 cellid=6_1:6 fe_index=4 feq_degree=5
+DEAL:1:3d::myid=1 cellid=6_1:7 fe_index=5 feq_degree=4
+DEAL:1:3d::OK
+

--- a/tests/mpi/hp_active_fe_indices_transfer_01.with_p4est=true.mpirun=8.output
+++ b/tests/mpi/hp_active_fe_indices_transfer_01.with_p4est=true.mpirun=8.output
@@ -1,0 +1,223 @@
+
+DEAL:0:2d::cells before: 16
+DEAL:0:2d::myid=0 cellid=0_1:0 fe_index=0 feq_degree=5 refining
+DEAL:0:2d::myid=0 cellid=0_1:1 fe_index=1 feq_degree=4
+DEAL:0:2d::myid=0 cellid=0_1:2 fe_index=2 feq_degree=3
+DEAL:0:2d::myid=0 cellid=0_1:3 fe_index=3 feq_degree=2
+DEAL:0:2d::cells after: 16
+DEAL:0:2d::myid=0 cellid=0_2:00 fe_index=0 feq_degree=5
+DEAL:0:2d::myid=0 cellid=0_2:01 fe_index=0 feq_degree=5
+DEAL:0:2d::myid=0 cellid=0_2:02 fe_index=0 feq_degree=5
+DEAL:0:2d::myid=0 cellid=0_2:03 fe_index=0 feq_degree=5
+DEAL:0:2d::OK
+DEAL:0:3d::cells before: 64
+DEAL:0:3d::myid=0 cellid=0_1:0 fe_index=0 feq_degree=9 refining
+DEAL:0:3d::myid=0 cellid=0_1:1 fe_index=1 feq_degree=8
+DEAL:0:3d::myid=0 cellid=0_1:2 fe_index=2 feq_degree=7
+DEAL:0:3d::myid=0 cellid=0_1:3 fe_index=3 feq_degree=6
+DEAL:0:3d::myid=0 cellid=0_1:4 fe_index=4 feq_degree=5
+DEAL:0:3d::myid=0 cellid=0_1:5 fe_index=5 feq_degree=4
+DEAL:0:3d::myid=0 cellid=0_1:6 fe_index=6 feq_degree=3
+DEAL:0:3d::myid=0 cellid=0_1:7 fe_index=7 feq_degree=2
+DEAL:0:3d::cells after: 64 
+DEAL:0:3d::myid=0 cellid=0_2:00 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:01 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:02 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:03 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:04 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:05 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:06 fe_index=0 feq_degree=9
+DEAL:0:3d::myid=0 cellid=0_2:07 fe_index=0 feq_degree=9
+DEAL:0:3d::OK
+
+DEAL:1:2d::cells before: 16
+DEAL:1:2d::cells after: 16
+DEAL:1:2d::OK
+DEAL:1:3d::cells before: 64
+DEAL:1:3d::myid=1 cellid=1_1:0 fe_index=0 feq_degree=9
+DEAL:1:3d::myid=1 cellid=1_1:1 fe_index=1 feq_degree=8
+DEAL:1:3d::myid=1 cellid=1_1:2 fe_index=2 feq_degree=7
+DEAL:1:3d::myid=1 cellid=1_1:3 fe_index=3 feq_degree=6
+DEAL:1:3d::myid=1 cellid=1_1:4 fe_index=4 feq_degree=5
+DEAL:1:3d::myid=1 cellid=1_1:5 fe_index=5 feq_degree=4
+DEAL:1:3d::myid=1 cellid=1_1:6 fe_index=6 feq_degree=3
+DEAL:1:3d::myid=1 cellid=1_1:7 fe_index=7 feq_degree=2
+DEAL:1:3d::cells after: 64
+DEAL:1:3d::myid=1 cellid=0_1:1 fe_index=1 feq_degree=8
+DEAL:1:3d::myid=1 cellid=0_1:2 fe_index=2 feq_degree=7
+DEAL:1:3d::myid=1 cellid=0_1:3 fe_index=3 feq_degree=6
+DEAL:1:3d::myid=1 cellid=0_1:4 fe_index=4 feq_degree=5
+DEAL:1:3d::myid=1 cellid=0_1:5 fe_index=5 feq_degree=4
+DEAL:1:3d::myid=1 cellid=0_1:6 fe_index=6 feq_degree=3
+DEAL:1:3d::myid=1 cellid=0_1:7 fe_index=7 feq_degree=2
+DEAL:1:3d::OK
+
+
+DEAL:2:2d::cells before: 16
+DEAL:2:2d::myid=2 cellid=1_1:0 fe_index=0 feq_degree=5
+DEAL:2:2d::myid=2 cellid=1_1:1 fe_index=1 feq_degree=4
+DEAL:2:2d::myid=2 cellid=1_1:2 fe_index=2 feq_degree=3
+DEAL:2:2d::myid=2 cellid=1_1:3 fe_index=3 feq_degree=2
+DEAL:2:2d::cells after: 16
+DEAL:2:2d::myid=2 cellid=0_1:1 fe_index=1 feq_degree=4
+DEAL:2:2d::myid=2 cellid=0_1:2 fe_index=2 feq_degree=3
+DEAL:2:2d::OK
+DEAL:2:3d::cells before: 64
+DEAL:2:3d::myid=2 cellid=2_1:0 fe_index=0 feq_degree=9
+DEAL:2:3d::myid=2 cellid=2_1:1 fe_index=1 feq_degree=8
+DEAL:2:3d::myid=2 cellid=2_1:2 fe_index=2 feq_degree=7
+DEAL:2:3d::myid=2 cellid=2_1:3 fe_index=3 feq_degree=6
+DEAL:2:3d::myid=2 cellid=2_1:4 fe_index=4 feq_degree=5
+DEAL:2:3d::myid=2 cellid=2_1:5 fe_index=5 feq_degree=4
+DEAL:2:3d::myid=2 cellid=2_1:6 fe_index=6 feq_degree=3
+DEAL:2:3d::myid=2 cellid=2_1:7 fe_index=7 feq_degree=2
+DEAL:2:3d::cells after: 64
+DEAL:2:3d::myid=2 cellid=1_1:0 fe_index=0 feq_degree=9
+DEAL:2:3d::myid=2 cellid=1_1:1 fe_index=1 feq_degree=8
+DEAL:2:3d::myid=2 cellid=1_1:2 fe_index=2 feq_degree=7
+DEAL:2:3d::myid=2 cellid=1_1:3 fe_index=3 feq_degree=6
+DEAL:2:3d::myid=2 cellid=1_1:4 fe_index=4 feq_degree=5
+DEAL:2:3d::myid=2 cellid=1_1:5 fe_index=5 feq_degree=4
+DEAL:2:3d::myid=2 cellid=1_1:6 fe_index=6 feq_degree=3
+DEAL:2:3d::myid=2 cellid=1_1:7 fe_index=7 feq_degree=2
+DEAL:2:3d::OK
+
+
+DEAL:3:2d::cells before: 16
+DEAL:3:2d::cells after: 16
+DEAL:3:2d::myid=3 cellid=0_1:3 fe_index=3 feq_degree=2
+DEAL:3:2d::OK
+DEAL:3:3d::cells before: 64
+DEAL:3:3d::myid=3 cellid=3_1:0 fe_index=0 feq_degree=9
+DEAL:3:3d::myid=3 cellid=3_1:1 fe_index=1 feq_degree=8
+DEAL:3:3d::myid=3 cellid=3_1:2 fe_index=2 feq_degree=7
+DEAL:3:3d::myid=3 cellid=3_1:3 fe_index=3 feq_degree=6
+DEAL:3:3d::myid=3 cellid=3_1:4 fe_index=4 feq_degree=5
+DEAL:3:3d::myid=3 cellid=3_1:5 fe_index=5 feq_degree=4
+DEAL:3:3d::myid=3 cellid=3_1:6 fe_index=6 feq_degree=3
+DEAL:3:3d::myid=3 cellid=3_1:7 fe_index=7 feq_degree=2
+DEAL:3:3d::cells after: 64
+DEAL:3:3d::myid=3 cellid=2_1:0 fe_index=0 feq_degree=9
+DEAL:3:3d::myid=3 cellid=2_1:1 fe_index=1 feq_degree=8
+DEAL:3:3d::myid=3 cellid=2_1:2 fe_index=2 feq_degree=7
+DEAL:3:3d::myid=3 cellid=2_1:3 fe_index=3 feq_degree=6
+DEAL:3:3d::myid=3 cellid=2_1:4 fe_index=4 feq_degree=5
+DEAL:3:3d::myid=3 cellid=2_1:5 fe_index=5 feq_degree=4
+DEAL:3:3d::myid=3 cellid=2_1:6 fe_index=6 feq_degree=3
+DEAL:3:3d::myid=3 cellid=2_1:7 fe_index=7 feq_degree=2
+DEAL:3:3d::OK
+
+
+DEAL:4:2d::cells before: 16
+DEAL:4:2d::myid=4 cellid=2_1:0 fe_index=0 feq_degree=5
+DEAL:4:2d::myid=4 cellid=2_1:1 fe_index=1 feq_degree=4
+DEAL:4:2d::myid=4 cellid=2_1:2 fe_index=2 feq_degree=3
+DEAL:4:2d::myid=4 cellid=2_1:3 fe_index=3 feq_degree=2
+DEAL:4:2d::cells after: 16
+DEAL:4:2d::myid=4 cellid=1_1:0 fe_index=0 feq_degree=5
+DEAL:4:2d::myid=4 cellid=1_1:1 fe_index=1 feq_degree=4
+DEAL:4:2d::myid=4 cellid=1_1:2 fe_index=2 feq_degree=3
+DEAL:4:2d::myid=4 cellid=1_1:3 fe_index=3 feq_degree=2
+DEAL:4:2d::OK
+DEAL:4:3d::cells before: 64
+DEAL:4:3d::myid=4 cellid=4_1:0 fe_index=0 feq_degree=9
+DEAL:4:3d::myid=4 cellid=4_1:1 fe_index=1 feq_degree=8
+DEAL:4:3d::myid=4 cellid=4_1:2 fe_index=2 feq_degree=7
+DEAL:4:3d::myid=4 cellid=4_1:3 fe_index=3 feq_degree=6
+DEAL:4:3d::myid=4 cellid=4_1:4 fe_index=4 feq_degree=5
+DEAL:4:3d::myid=4 cellid=4_1:5 fe_index=5 feq_degree=4
+DEAL:4:3d::myid=4 cellid=4_1:6 fe_index=6 feq_degree=3
+DEAL:4:3d::myid=4 cellid=4_1:7 fe_index=7 feq_degree=2
+DEAL:4:3d::cells after: 64
+DEAL:4:3d::myid=4 cellid=3_1:0 fe_index=0 feq_degree=9
+DEAL:4:3d::myid=4 cellid=3_1:1 fe_index=1 feq_degree=8
+DEAL:4:3d::myid=4 cellid=3_1:2 fe_index=2 feq_degree=7
+DEAL:4:3d::myid=4 cellid=3_1:3 fe_index=3 feq_degree=6
+DEAL:4:3d::myid=4 cellid=3_1:4 fe_index=4 feq_degree=5
+DEAL:4:3d::myid=4 cellid=3_1:5 fe_index=5 feq_degree=4
+DEAL:4:3d::myid=4 cellid=3_1:6 fe_index=6 feq_degree=3
+DEAL:4:3d::myid=4 cellid=3_1:7 fe_index=7 feq_degree=2
+DEAL:4:3d::OK
+
+
+DEAL:5:2d::cells before: 16
+DEAL:5:2d::cells after: 16
+DEAL:5:2d::OK
+DEAL:5:3d::cells before: 64
+DEAL:5:3d::myid=5 cellid=5_1:0 fe_index=0 feq_degree=9
+DEAL:5:3d::myid=5 cellid=5_1:1 fe_index=1 feq_degree=8
+DEAL:5:3d::myid=5 cellid=5_1:2 fe_index=2 feq_degree=7
+DEAL:5:3d::myid=5 cellid=5_1:3 fe_index=3 feq_degree=6
+DEAL:5:3d::myid=5 cellid=5_1:4 fe_index=4 feq_degree=5
+DEAL:5:3d::myid=5 cellid=5_1:5 fe_index=5 feq_degree=4
+DEAL:5:3d::myid=5 cellid=5_1:6 fe_index=6 feq_degree=3
+DEAL:5:3d::myid=5 cellid=5_1:7 fe_index=7 feq_degree=2
+DEAL:5:3d::cells after: 64
+DEAL:5:3d::myid=5 cellid=4_1:0 fe_index=0 feq_degree=9
+DEAL:5:3d::myid=5 cellid=4_1:1 fe_index=1 feq_degree=8
+DEAL:5:3d::myid=5 cellid=4_1:2 fe_index=2 feq_degree=7
+DEAL:5:3d::myid=5 cellid=4_1:3 fe_index=3 feq_degree=6
+DEAL:5:3d::myid=5 cellid=4_1:4 fe_index=4 feq_degree=5
+DEAL:5:3d::myid=5 cellid=4_1:5 fe_index=5 feq_degree=4
+DEAL:5:3d::myid=5 cellid=4_1:6 fe_index=6 feq_degree=3
+DEAL:5:3d::myid=5 cellid=4_1:7 fe_index=7 feq_degree=2
+DEAL:5:3d::OK
+
+
+DEAL:6:2d::cells before: 16
+DEAL:6:2d::myid=6 cellid=3_1:0 fe_index=0 feq_degree=5 coarsening
+DEAL:6:2d::myid=6 cellid=3_1:1 fe_index=1 feq_degree=4 coarsening
+DEAL:6:2d::myid=6 cellid=3_1:2 fe_index=2 feq_degree=3 coarsening
+DEAL:6:2d::myid=6 cellid=3_1:3 fe_index=3 feq_degree=2 coarsening
+DEAL:6:2d::cells after: 16
+DEAL:6:2d::myid=6 cellid=2_1:0 fe_index=0 feq_degree=5
+DEAL:6:2d::myid=6 cellid=2_1:1 fe_index=1 feq_degree=4
+DEAL:6:2d::myid=6 cellid=2_1:2 fe_index=2 feq_degree=3
+DEAL:6:2d::myid=6 cellid=2_1:3 fe_index=3 feq_degree=2
+DEAL:6:2d::OK
+DEAL:6:3d::cells before: 64
+DEAL:6:3d::myid=6 cellid=6_1:0 fe_index=0 feq_degree=9
+DEAL:6:3d::myid=6 cellid=6_1:1 fe_index=1 feq_degree=8
+DEAL:6:3d::myid=6 cellid=6_1:2 fe_index=2 feq_degree=7
+DEAL:6:3d::myid=6 cellid=6_1:3 fe_index=3 feq_degree=6
+DEAL:6:3d::myid=6 cellid=6_1:4 fe_index=4 feq_degree=5
+DEAL:6:3d::myid=6 cellid=6_1:5 fe_index=5 feq_degree=4
+DEAL:6:3d::myid=6 cellid=6_1:6 fe_index=6 feq_degree=3
+DEAL:6:3d::myid=6 cellid=6_1:7 fe_index=7 feq_degree=2
+DEAL:6:3d::cells after: 64
+DEAL:6:3d::myid=6 cellid=5_1:0 fe_index=0 feq_degree=9
+DEAL:6:3d::myid=6 cellid=5_1:1 fe_index=1 feq_degree=8
+DEAL:6:3d::myid=6 cellid=5_1:2 fe_index=2 feq_degree=7
+DEAL:6:3d::myid=6 cellid=5_1:3 fe_index=3 feq_degree=6
+DEAL:6:3d::myid=6 cellid=5_1:4 fe_index=4 feq_degree=5
+DEAL:6:3d::myid=6 cellid=5_1:5 fe_index=5 feq_degree=4
+DEAL:6:3d::myid=6 cellid=5_1:6 fe_index=6 feq_degree=3
+DEAL:6:3d::myid=6 cellid=5_1:7 fe_index=7 feq_degree=2
+DEAL:6:3d::OK
+
+
+DEAL:7:2d::cells before: 16
+DEAL:7:2d::cells after: 16
+DEAL:7:2d::myid=7 cellid=3_0: fe_index=3 feq_degree=2
+DEAL:7:2d::OK
+DEAL:7:3d::cells before: 64
+DEAL:7:3d::myid=7 cellid=7_1:0 fe_index=0 feq_degree=9 coarsening
+DEAL:7:3d::myid=7 cellid=7_1:1 fe_index=1 feq_degree=8 coarsening
+DEAL:7:3d::myid=7 cellid=7_1:2 fe_index=2 feq_degree=7 coarsening
+DEAL:7:3d::myid=7 cellid=7_1:3 fe_index=3 feq_degree=6 coarsening
+DEAL:7:3d::myid=7 cellid=7_1:4 fe_index=4 feq_degree=5 coarsening
+DEAL:7:3d::myid=7 cellid=7_1:5 fe_index=5 feq_degree=4 coarsening
+DEAL:7:3d::myid=7 cellid=7_1:6 fe_index=6 feq_degree=3 coarsening
+DEAL:7:3d::myid=7 cellid=7_1:7 fe_index=7 feq_degree=2 coarsening
+DEAL:7:3d::cells after: 64
+DEAL:7:3d::myid=7 cellid=7_0: fe_index=7 feq_degree=2
+DEAL:7:3d::myid=7 cellid=6_1:0 fe_index=0 feq_degree=9
+DEAL:7:3d::myid=7 cellid=6_1:1 fe_index=1 feq_degree=8
+DEAL:7:3d::myid=7 cellid=6_1:2 fe_index=2 feq_degree=7
+DEAL:7:3d::myid=7 cellid=6_1:3 fe_index=3 feq_degree=6
+DEAL:7:3d::myid=7 cellid=6_1:4 fe_index=4 feq_degree=5
+DEAL:7:3d::myid=7 cellid=6_1:5 fe_index=5 feq_degree=4
+DEAL:7:3d::myid=7 cellid=6_1:6 fe_index=6 feq_degree=3
+DEAL:7:3d::myid=7 cellid=6_1:7 fe_index=7 feq_degree=2
+DEAL:7:3d::OK
+


### PR DESCRIPTION
This is one step closer to use the `hp::DoFHandler` with `p::d::Triangulation` (see e.g. #3511).

We need a class that communicates all `active_fe_index` integers across mesh repartitioning (refinement/coarsening/serialization).

This closes #6237. See also for discussion.

@bangerth -- FYI