### PR TITLE
Improved description compute point locations

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -766,6 +766,8 @@ namespace GridTools
    * In a serial execution the first three elements of the tuple are the same
    * as in GridTools::compute_point_locations .
    *
+   * Note: this function is a collective operation.
+   *
    * @note The actual return type of this function, i.e., the type referenced
    * above as @p return_type, is
    * @code


### PR DESCRIPTION
From https://github.com/dealii/dealii/pull/6240 I understood that there's a big flaw in the documentation of GridTools::distributed_compute_point_locations : it is a collective operation. I added a small note about this in the documentation.
Best,
Giovanni