### PR TITLE
Implement variable size serialization.

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -1032,9 +1032,10 @@ namespace parallel
          *
          * The data will be written in a separate file, whose name
          * consists of the stem @p filename and an attached identifier
-         * <tt>-fixed.data</tt>.
+         * <tt>-fixed.data</tt> for fixed size data and <tt>-variable.data</tt>
+         * for variable size data.
          *
-         * All processors write into that file simultaneously via MPIIO.
+         * All processors write into these files simultaneously via MPIIO.
          * Each processor's position to write to will be determined
          * from the provided @p parallel_forest.
          *
@@ -1050,10 +1051,13 @@ namespace parallel
          *
          * The data will be read from separate file, whose name
          * consists of the stem @p filename and an attached identifier
-         * <tt>-fixed.data</tt>. The @p n_attached_deserialize parameter
-         * is required to gather the memory offsets for each callback.
+         * <tt>-fixed.data</tt> for fixed size data and <tt>-variable.data</tt>
+         * for variable size data.
+         * The @p n_attached_deserialize_fixed and @p n_attached_deserialize_variable
+         * parameters are required to gather the memory offsets for each
+         * callback.
          *
-         * All processors read from that file simultaneously via MPIIO.
+         * All processors read from these files simultaneously via MPIIO.
          * Each processor's position to read from will be determined
          * from the provided @p parallel_forest.
          *
@@ -1064,7 +1068,8 @@ namespace parallel
         load(const typename dealii::internal::p4est::types<dim>::forest
                *                parallel_forest,
              const char *       filename,
-             const unsigned int n_attached_deserialize);
+             const unsigned int n_attached_deserialize_fixed,
+             const unsigned int n_attached_deserialize_variable);
 
         /**
          * Clears all containers and associated data, and resets member

--- a/tests/mpi/p4est_save_05.with_p4est=true.mpirun=5.output
+++ b/tests/mpi/p4est_save_05.with_p4est=true.mpirun=5.output
@@ -1,0 +1,66 @@
+
+DEAL:0::writing with 3
+DEAL:0::packing cell 0_2:00 with data size=4 accumulated data=0
+DEAL:0::packing cell 0_2:01 with data size=8 accumulated data=1
+DEAL:0::packing cell 0_2:02 with data size=12 accumulated data=3
+DEAL:0::packing cell 0_2:03 with data size=16 accumulated data=6
+DEAL:0::packing cell 0_1:1 with data size=20 accumulated data=10
+DEAL:0::#cells = 16
+DEAL:0::Checksum: 2822439380
+DEAL:0::reading with 5
+DEAL:0::unpacking cell 0_2:00 with data size=4 accumulated data=0
+DEAL:0::unpacking cell 0_2:01 with data size=8 accumulated data=1
+DEAL:0::unpacking cell 0_2:02 with data size=12 accumulated data=3
+DEAL:0::unpacking cell 0_2:03 with data size=16 accumulated data=6
+DEAL:0::#cells = 16
+DEAL:0::Checksum: 2822439380
+DEAL:0::OK
+
+DEAL:1::writing with 3
+DEAL:1::packing cell 0_1:2 with data size=4 accumulated data=0
+DEAL:1::packing cell 0_1:3 with data size=8 accumulated data=1
+DEAL:1::packing cell 1_1:0 with data size=12 accumulated data=3
+DEAL:1::packing cell 1_1:1 with data size=16 accumulated data=6
+DEAL:1::packing cell 1_1:2 with data size=20 accumulated data=10
+DEAL:1::packing cell 1_1:3 with data size=24 accumulated data=15
+DEAL:1::#cells = 16
+DEAL:1::Checksum: 0
+DEAL:1::reading with 5
+DEAL:1::unpacking cell 0_1:1 with data size=20 accumulated data=10
+DEAL:1::unpacking cell 0_1:2 with data size=4 accumulated data=0
+DEAL:1::#cells = 16
+DEAL:1::Checksum: 0
+
+
+DEAL:2::writing with 3
+DEAL:2::packing cell 2_1:0 with data size=4 accumulated data=0
+DEAL:2::packing cell 2_1:1 with data size=8 accumulated data=1
+DEAL:2::packing cell 2_1:2 with data size=12 accumulated data=3
+DEAL:2::packing cell 2_1:3 with data size=16 accumulated data=6
+DEAL:2::packing cell 3_0: with data size=20 accumulated data=10
+DEAL:2::#cells = 16
+DEAL:2::Checksum: 0
+DEAL:2::reading with 5
+DEAL:2::unpacking cell 0_1:3 with data size=8 accumulated data=1
+DEAL:2::unpacking cell 1_1:0 with data size=12 accumulated data=3
+DEAL:2::unpacking cell 1_1:1 with data size=16 accumulated data=6
+DEAL:2::unpacking cell 1_1:2 with data size=20 accumulated data=10
+DEAL:2::unpacking cell 1_1:3 with data size=24 accumulated data=15
+DEAL:2::#cells = 16
+DEAL:2::Checksum: 0
+
+
+DEAL:3::reading with 5
+DEAL:3::#cells = 16
+DEAL:3::Checksum: 0
+
+
+DEAL:4::reading with 5
+DEAL:4::unpacking cell 2_1:0 with data size=4 accumulated data=0
+DEAL:4::unpacking cell 2_1:1 with data size=8 accumulated data=1
+DEAL:4::unpacking cell 2_1:2 with data size=12 accumulated data=3
+DEAL:4::unpacking cell 2_1:3 with data size=16 accumulated data=6
+DEAL:4::unpacking cell 3_0: with data size=20 accumulated data=10
+DEAL:4::#cells = 16
+DEAL:4::Checksum: 0
+


### PR DESCRIPTION
This is a follow-up to #6920.

We will store serialized data of variable size in a separate file via MPIIO, similar to #6864. Because of that, I increased the version number stored in the corresponding `.info` file as well. We don't have to do this, since we did not increase it since the last release. What do you think about that?

This is one step closer to #3511.

 @bangerth -- FYI