### PR TITLE
Improve deprecation messages

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -389,9 +389,15 @@ _Pragma("GCC diagnostic pop")
  * http://goodliffe.blogspot.com/2009/07/c-how-to-say-warning-to-visual-studio-c.html
  */
 
-#define DEAL_II_STRINGIZE_HELPER(x) #x
-#define DEAL_II_STRINGIZE(x) DEAL_II_STRINGIZE_HELPER(x)
-#define DEAL_II_WARNING(desc) message(__FILE__ "(" DEAL_II_STRINGIZE(__LINE__) ") : Warning: " #desc)
+#ifdef _MSC_VER
+  #define DEAL_II_STRINGIZE_HELPER(x) #x
+  #define DEAL_II_STRINGIZE(x) DEAL_II_STRINGIZE_HELPER(x)
+  #define DEAL_II_DO_PRAGMA(x) __pragma(x)
+  #define DEAL_II_WARNING(desc) DEAL_II_DO_PRAGMA(message(__FILE__ "(" DEAL_II_STRINGIZE(__LINE__) ") : warning: " #desc))
+#else
+  #define DEAL_II_DO_PRAGMA(x) _Pragma(#x)
+  #define DEAL_II_WARNING(desc) DEAL_II_DO_PRAGMA(message(#desc))
+#endif
 
 /***********************************************************************
  * Final inclusions:

--- a/include/deal.II/base/sacado_product_type.h
+++ b/include/deal.II/base/sacado_product_type.h
@@ -3,8 +3,7 @@
 
 #include <deal.II/base/config.h>
 
-#pragma DEAL_II_WARNING( \
-  "This file is deprecated. Use <deal.II/differentiation/ad/sacado_product_types.h> instead.")
+DEAL_II_WARNING(`"This file is deprecated. Use <deal.II/differentiation/ad/sacado_product_types.h> instead.")
 
 #include <deal.II/differentiation/ad/sacado_product_types.h>
 

--- a/include/deal.II/dofs/function_map.h
+++ b/include/deal.II/dofs/function_map.h
@@ -20,6 +20,6 @@
 
 #include <deal.II/dofs/deprecated_function_map.h>
 
-#pragma DEAL_II_WARNING("This file is deprecated.")
+DEAL_II_WARNING("This file is deprecated.")
 
 #endif

--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -18,7 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-#pragma DEAL_II_WARNING( \
-  "This file is deprecated. Use the Manifold classes instead.")
+DEAL_II_WARNING("This file is deprecated. Use the Manifold classes instead.")
 
 #endif

--- a/include/deal.II/grid/tria_boundary_lib.h
+++ b/include/deal.II/grid/tria_boundary_lib.h
@@ -18,7 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-#pragma DEAL_II_WARNING( \
-  "This file is deprecated.Use the Manifold classes instead.")
+DEAL_II_WARNING("This file is deprecated.Use the Manifold classes instead.")
 
 #endif

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#pragma DEAL_II_WARNING( \
+DEAL_II_WARNING(
   "This file is deprecated. Use <deal.II/lac/affine_constraints.h> instead.")
 
 #include <deal.II/lac/affine_constraints.h>

--- a/include/deal.II/lac/parallel_block_vector.h
+++ b/include/deal.II/lac/parallel_block_vector.h
@@ -20,7 +20,7 @@
 
 #include <deal.II/lac/la_parallel_block_vector.h>
 
-#pragma DEAL_II_WARNING( \
+DEAL_II_WARNING(
   "This file is deprecated. Use <deal.II/lac/la_block_vector.h> and LinearAlgebra::distributed::BlockVector instead.")
 
 #include <cstring>

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -20,7 +20,7 @@
 
 #include <deal.II/lac/la_parallel_vector.h>
 
-#pragma DEAL_II_WARNING( \
+DEAL_II_WARNING(
   "This file is deprecated. Use <deal.II/lac/la_parallel_vector.h> and LinearAlgebra::distributed::Vector instead.")
 
 #include <cstring>

--- a/include/deal.II/lac/petsc_parallel_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_parallel_block_sparse_matrix.h
@@ -21,7 +21,7 @@
 
 #include <deal.II/lac/petsc_block_sparse_matrix.h>
 
-#pragma DEAL_II_WARNING( \
+DEAL_II_WARNING(
   "This file is deprecated. Use deal.II/lac/petsc_block_sparse_matrix.h instead!")
 
 #endif // dealii_petsc_parallel_block_sparse_matrix_h

--- a/include/deal.II/lac/petsc_parallel_block_vector.h
+++ b/include/deal.II/lac/petsc_parallel_block_vector.h
@@ -21,7 +21,7 @@
 
 #include <deal.II/lac/petsc_block_vector.h>
 
-#pragma DEAL_II_WARNING( \
+DEAL_II_WARNING(
   "This file is deprecated. Use deal.II/lac/petsc_block_vector.h instead!")
 
 #endif

--- a/include/deal.II/lac/petsc_parallel_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_parallel_sparse_matrix.h
@@ -20,8 +20,8 @@
 
 #  include <deal.II/lac/petsc_sparse_matrix.h>
 
-#  pragma DEAL_II_WARNING( \
-    "This file is deprecated. Use deal.II/lac/petsc_sparse_matrix.h instead.")
+DEAL_II_WARNING(
+  "This file is deprecated. Use deal.II/lac/petsc_sparse_matrix.h instead.")
 
 #endif
 /*---------------------- petsc_parallel_sparse_matrix.h ---------------------*/

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -20,8 +20,8 @@
 
 #  include <deal.II/lac/petsc_vector.h>
 
-#  pragma DEAL_II_WARNING( \
-    "This file is deprecated. Use deal.II/lac/petsc_vector.h instead!")
+DEAL_II_WARNING(
+  "This file is deprecated. Use deal.II/lac/petsc_vector.h instead!")
 
 #endif
 /*------------------------- petsc_parallel_vector.h -------------------------*/

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -127,7 +127,7 @@ CPUClock::now() noexcept
   getrusage(RUSAGE_SELF, &usage);
   system_cpu_duration = usage.ru_utime.tv_sec + 1.e-6 * usage.ru_utime.tv_usec;
 #else
-#  pragma DEAL_II_WARNING("Unsupported platform. Porting not finished.")
+  DEAL_II_WARNING("Unsupported platform. Porting not finished.")
 #endif
   return time_point(
     internal::TimerImplementation::from_seconds<duration>(system_cpu_duration));


### PR DESCRIPTION
As https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=3554 shows, #6949 didn't work as expected for `gcc` and `clang`. This PR provides a more fine-grained implementation. Tested in https://godbolt.org/g/E52VFN.