### PR TITLE
Make an argument of GridGenerator::merge_triangulations() a reference.

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1182,7 +1182,7 @@ namespace GridGenerator
   void
   merge_triangulations(
     const std::initializer_list<const Triangulation<dim, spacedim> *const>
-                                  triangulations,
+      &                           triangulations,
     Triangulation<dim, spacedim> &result,
     const double                  duplicated_vertex_tolerance = 1.0e-12,
     const bool                    copy_manifold_ids           = false);

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -4141,7 +4141,7 @@ namespace GridGenerator
   void
   merge_triangulations(
     const std::initializer_list<const Triangulation<dim, spacedim> *const>
-                                  triangulations,
+      &                           triangulations,
     Triangulation<dim, spacedim> &result,
     const double                  duplicated_vertex_tolerance,
     const bool                    copy_manifold_ids)

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -73,7 +73,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
       merge_triangulations(
         const std::initializer_list<
           const Triangulation<deal_II_dimension, deal_II_space_dimension>
-            *const>,
+            *const> &,
         Triangulation<deal_II_dimension, deal_II_space_dimension> &,
         const double,
         const bool);


### PR DESCRIPTION
Nothing earth shaking, just staying consistent with how we treat most other
non-trivial argument types.