### PR TITLE
Decrement counters in Subscriptor only upon success

### DIFF
--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -185,18 +185,22 @@ Subscriptor::unsubscribe(const char *id) const
   if (counter == 0)
     return;
 
-  --counter;
-
 #ifdef DEAL_II_WITH_THREADS
   std::lock_guard<std::mutex> lock(mutex);
 #endif
 
   map_iterator it = counter_map.find(name);
-  AssertNothrow(it != counter_map.end(),
-                ExcNoSubscriber(object_info->name(), name));
-  AssertNothrow(it->second > 0, ExcNoSubscriber(object_info->name(), name));
-
-  it->second--;
+  if (it == counter_map.end() || it->second == 0)
+    {
+      AssertNothrow(it != counter_map.end(),
+                    ExcNoSubscriber(object_info->name(), name));
+      AssertNothrow(it->second > 0, ExcNoSubscriber(object_info->name(), name));
+    }
+  else
+    {
+      --counter;
+      it->second--;
+    }
 }
 
 

--- a/tests/base/unsubscribe_subscriptor.cc
+++ b/tests/base/unsubscribe_subscriptor.cc
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that unsubscribing with a wrong id is handled correctly
+
+
+#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/subscriptor.h>
+
+#include <iostream>
+#include <vector>
+
+#include "../tests.h"
+
+class Test : public Subscriptor
+{};
+
+int
+main()
+{
+  deal_II_exceptions::disable_abort_on_exception();
+
+  initlog();
+
+  Subscriptor subscriptor;
+  subscriptor.subscribe("a");
+  subscriptor.unsubscribe("b");
+  subscriptor.unsubscribe("a");
+
+  return 0;
+}

--- a/tests/base/unsubscribe_subscriptor.debug.output
+++ b/tests/base/unsubscribe_subscriptor.debug.output
@@ -1,0 +1,12 @@
+
+DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <subscriptor.cc> in function
+    void dealii::Subscriptor::unsubscribe(const char*) const
+The violated condition was: 
+    it != counter_map.end()
+Additional information: 
+    No subscriber with identifier <b> subscribes to this object of class N6dealii11SubscriptorE. Consequently, it cannot be unsubscribed.
+--------------------------------------------------------
+


### PR DESCRIPTION
As reported by Coverity, we accessed `it->second` even if `it` is not valid in case `AssertNothrow` does not abort the program. This PR makes sure that the counters are only accessed and decremented if the assertions pass.