### PR TITLE
Deprecate MGTools::extract_non_interface_dofs

### DIFF
--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -253,9 +253,16 @@ namespace MGTools
   extract_inner_interface_dofs(const DoFHandler<dim, spacedim> &mg_dof_handler,
                                std::vector<IndexSet> &          interface_dofs);
 
-
+  /**
+   * For each level in a multigrid hierarchy, produce a std::set of degrees of
+   * freedoms that are not located along interfaces of this level to cells that
+   * only exist on coarser levels.
+   *
+   * @deprecated Use extract_inner_interface_dofs() for computing the complement
+   * of degrees of freedoms instead.
+   */
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED void
   extract_non_interface_dofs(
     const DoFHandler<dim, spacedim> &               mg_dof_handler,
     std::vector<std::set<types::global_dof_index>> &non_interface_dofs);


### PR DESCRIPTION
MGTools::extract_non_interface_dofs was first introduced in 843d6fe and d4681a2 where it was used inside of MGConstrainedDoFs::initialize to initialize `std::vector<std::set<types::global_dof_index> > non_refinement_edge_indices`. This latter variable was removed in 1e88b55 along with a few others. Currently, MGTools::extract_non_interface_dofs is not used anywhere, is not documented and not tested.
Hence, it is very likely that is also never used in user code and I vote for removing it in the long run, i.e. deprecating it.
The same 