### PR TITLE
Add alternative (clang) output for unsubscribe_subscriptor

### DIFF
--- a/tests/base/unsubscribe_subscriptor.debug.output.clang
+++ b/tests/base/unsubscribe_subscriptor.debug.output.clang
@@ -1,0 +1,12 @@
+
+DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <subscriptor.cc> in function
+    void dealii::Subscriptor::unsubscribe(const char *) const
+The violated condition was: 
+    it != counter_map.end()
+Additional information: 
+    No subscriber with identifier <b> subscribes to this object of class N6dealii11SubscriptorE. Consequently, it cannot be unsubscribed.
+--------------------------------------------------------
+


### PR DESCRIPTION
Apparently, `clang` decides to print the error message slightly differently, compare https://cdash.kyomu.43-1.org/testDetails.php?test=24260500&build=3920.