### PR TITLE
CUDA preprocessor guard

### DIFF
--- a/include/deal.II/base/cuda.h
+++ b/include/deal.II/base/cuda.h
@@ -18,15 +18,15 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CUDA
+#include <deal.II/base/exceptions.h>
 
-#  include <deal.II/base/exceptions.h>
-
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 #  include <cusolverDn.h>
 #  include <cusolverSp.h>
 #  include <cusparse.h>
+#endif
 
-#  include <vector>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 namespace Utilities
@@ -58,6 +58,7 @@ namespace Utilities
        */
       ~Handle();
 
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
       cusolverDnHandle_t cusolver_dn_handle;
 
       cusolverSpHandle_t cusolver_sp_handle;
@@ -66,6 +67,7 @@ namespace Utilities
        * Handle to the cuSPARSE library.
        */
       cusparseHandle_t cusparse_handle;
+#endif
     };
 
     /**
@@ -75,9 +77,14 @@ namespace Utilities
     inline void
     malloc(T *&pointer, const unsigned int n_elements)
     {
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
       cudaError_t cuda_error_code =
         cudaMalloc(&pointer, n_elements * sizeof(T));
       AssertCuda(cuda_error_code);
+#else
+      (void)pointer;
+      (void)n_elements;
+#endif
     }
 
     /**
@@ -87,9 +94,13 @@ namespace Utilities
     inline void
     free(T *&pointer)
     {
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
       cudaError_t cuda_error_code = cudaFree(pointer);
       AssertCuda(cuda_error_code);
       pointer = nullptr;
+#else
+      (void)pointer;
+#endif
     }
 
     /**
@@ -99,11 +110,16 @@ namespace Utilities
     inline void
     copy_to_host(const T *pointer_dev, std::vector<T> &vector_host)
     {
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
       cudaError_t cuda_error_code = cudaMemcpy(vector_host.data(),
                                                pointer_dev,
                                                vector_host.size() * sizeof(T),
                                                cudaMemcpyDeviceToHost);
       AssertCuda(cuda_error_code);
+#else
+      (void)pointer_dev;
+      (void)vector_host;
+#endif
     }
 
     /**
@@ -114,17 +130,20 @@ namespace Utilities
     inline void
     copy_to_dev(const std::vector<T> &vector_host, T *pointer_dev)
     {
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
       cudaError_t cuda_error_code = cudaMemcpy(pointer_dev,
                                                vector_host.data(),
                                                vector_host.size() * sizeof(T),
                                                cudaMemcpyHostToDevice);
       AssertCuda(cuda_error_code);
+#else
+      (void)vector_host;
+      (void)pointer_dev;
+#endif
     }
   } // namespace CUDA
 } // namespace Utilities
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif
 
 #endif

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -25,8 +25,7 @@
 #include <complex>
 #include <cstdlib>
 
-#ifdef DEAL_II_WITH_CUDA
-#  include <cuda_runtime_api.h>
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 #  define DEAL_II_CUDA_HOST_DEV __host__ __device__
 #else
 #  define DEAL_II_CUDA_HOST_DEV

--- a/include/deal.II/lac/cuda_atomic.h
+++ b/include/deal.II/lac/cuda_atomic.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CUDA
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/cuda_kernels.h
+++ b/include/deal.II/lac/cuda_kernels.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CUDA
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 
 
 #  include <deal.II/base/cuda_size.h>

--- a/include/deal.II/lac/cuda_kernels.templates.h
+++ b/include/deal.II/lac/cuda_kernels.templates.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/lac/cuda_kernels.h>
 
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace LinearAlgebra
@@ -571,5 +573,7 @@ namespace LinearAlgebra
 } // namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
+
+#endif
 
 #endif

--- a/include/deal.II/lac/cuda_solver_direct.h
+++ b/include/deal.II/lac/cuda_solver_direct.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CUDA
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 #  include <deal.II/base/cuda.h>
 
 #  include <deal.II/lac/cuda_sparse_matrix.h>

--- a/include/deal.II/lac/cuda_sparse_matrix.h
+++ b/include/deal.II/lac/cuda_sparse_matrix.h
@@ -20,7 +20,7 @@
 
 #include <deal.II/base/subscriptor.h>
 
-#ifdef DEAL_II_WITH_CUDA
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 #  include <deal.II/base/cuda.h>
 
 #  include <deal.II/lac/cuda_vector.h>

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -40,7 +40,7 @@
 #  include <Epetra_Import.h>
 #endif
 
-#ifdef DEAL_II_WITH_CUDA
+#if defined(DEAL_II_WITH_CUDA)
 #  include <deal.II/lac/cuda_vector.h>
 
 #  include <cuda_runtime_api.h>
@@ -568,7 +568,7 @@ namespace LinearAlgebra
 
 
 
-#ifdef DEAL_II_WITH_CUDA
+#if defined(DEAL_II_WITH_CUDA)
   template <typename Number>
   void
   ReadWriteVector<Number>::import(

--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CUDA
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 
 #  include <deal.II/base/tensor.h>
 #  include <deal.II/base/utilities.h>

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CUDA
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 
 #  include <deal.II/base/utilities.h>
 

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CUDA
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 
 #  include <deal.II/base/quadrature.h>
 #  include <deal.II/base/tensor.h>
@@ -32,8 +32,6 @@
 
 #  include <deal.II/lac/affine_constraints.h>
 #  include <deal.II/lac/cuda_vector.h>
-
-#  include <cuda_runtime_api.h>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/matrix_free/cuda_matrix_free.h>
 
-#ifdef DEAL_II_WITH_CUDA
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 
 #  include <deal.II/base/cuda_size.h>
 #  include <deal.II/base/graph_coloring.h>

--- a/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -437,5 +438,7 @@ namespace CUDAWrappers
 } // namespace CUDAWrappers
 
 DEAL_II_NAMESPACE_CLOSE
+
+#endif
 
 #endif

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -183,7 +183,7 @@ namespace LinearAlgebra
     Vector<Number> &
     Vector<Number>::operator=(const Number s)
     {
-      Assert(s == Number(), ExcMessage("Onlyt 0 can be assigned to a vector."));
+      Assert(s == Number(), ExcMessage("Only 0 can be assigned to a vector."));
       (void)s;
 
       cudaError_t error_code = cudaMemset(val, 0, n_elements * sizeof(Number));

--- a/tests/all-headers/CMakeLists.txt
+++ b/tests/all-headers/CMakeLists.txt
@@ -45,17 +45,6 @@ FILE(GLOB_RECURSE _headers RELATIVE ${_include_dir}/deal.II
   ${_include_dir}/deal.II/*.h
   )
 
-#
-# Files that contain CUDA code cannot be sent to the host compiler so we removed
-# them from the list
-#
-LIST(REMOVE_ITEM _headers "lac/cuda_atomic.h"
-  "lac/cuda_kernels.h"
-  "lac/cuda_kernels.templates.h"
-  "matrix_free/cuda_fe_evaluation.h"
-  "matrix_free/cuda_hanging_nodes_internal.h"
-  "matrix_free/cuda_matrix_free.templates.h"
-  "matrix_free/cuda_tensor_product_kernels.h")
 
 # Do not test bundled headers to avoid issues when tests are run
 # for an already installed library


### PR DESCRIPTION
Improve preprocessing guards for CUDA. With this PR, CUDA code can only be seen by `nvcc`. This means that we can safely include headers containing cuda code in a `.cc`  and we don't need to remove the cuda headers from the `all-headers` tests.