### PR TITLE
Fix bug in template instantiations of active_fe_indices_transfer.cc

### DIFF
--- a/source/distributed/active_fe_indices_transfer.cc
+++ b/source/distributed/active_fe_indices_transfer.cc
@@ -206,7 +206,7 @@ namespace parallel
 
 
 // explicit instantiations
-#  include "feindices_transfer.inst"
+#  include "active_fe_indices_transfer.inst"
 
 DEAL_II_NAMESPACE_CLOSE
 


### PR DESCRIPTION
Hi @marcfehling  and @bangerth I think that there is a small bug in the instantiations of  active_fe_indices_transfer. This is related to PR #6961

Deal.ii does not compile. I get: fatal_ error: 'feindices_transfer.inst' file not found

This commit fix it. @marcfehling Is this fix ok for you?

I run the test mpi/hp_active_fe_indices_transfer_01 and it passed