### PR TITLE
Fix documentation of template instantiations

### DIFF
--- a/cmake/scripts/expand_instantiations.cc
+++ b/cmake/scripts/expand_instantiations.cc
@@ -26,7 +26,7 @@
 // --------------------
 //
 // The input file is typically located in share/deal.II/template-arguments in
-// the build directory and it is built from config/template-arguments.in to
+// the build directory and it is built from cmake/config/template-arguments.in to
 // contain the list of vectors etc. that make sense for the current
 // configuration. For example, the list of VECTORS is going to contain PETSc
 // vectors if so configured.

--- a/cmake/scripts/expand_instantiations.cc
+++ b/cmake/scripts/expand_instantiations.cc
@@ -19,11 +19,10 @@
 // is given as arguments on the command line and contains entries of the
 // following form:
 // --------------------
-// REAL_SCALARS    := { double; float; long double }
+// REAL_SCALARS    := { double; float}
 // COMPLEX_SCALARS := { std::complex<double>;
-//                      std::complex<float>;
-//                      std::complex<long double> }
-// VECTORS := { Vector<double>; Vector<float>; Vector<long double> }
+//                      std::complex<float>}
+// VECTORS := { Vector<double>; Vector<float>}
 // --------------------
 //
 // The input file is typically located in share/deal.II/template-arguments in
@@ -55,7 +54,7 @@
 
 // a map from the keys in the expansion lists to the list itself. For
 // instance, the example above will lead to the entry
-//      expansion_lists[REAL_SCALARS] = (double, float, long double)
+//      expansion_lists[REAL_SCALARS] = (double, float)
 // in this map, among others
 std::map<std::string, std::list<std::string> >  expansion_lists;
 
@@ -284,7 +283,7 @@ std::string substitute_tokens (const std::string &text,
 
 
 // read and parse the expansion lists like
-//   REAL_SCALARS    := { double; float; long double }
+//   REAL_SCALARS    := { double; float}
 // as specified at the top of the file and store them in the global
 // expansion_lists variable
 void read_expansion_lists (const std::string &filename)

--- a/doc/doxygen/headers/instantiations.h
+++ b/doc/doxygen/headers/instantiations.h
@@ -62,11 +62,9 @@
  * arguments is supported and explicit instantiations are provided in
  * the library. In particular, this includes all the linear algebra
  * classes that are templatized on the type of the scalar underlying
- * stored values: we only support <code>double</code>,
- * <code>float</code>, and in some cases <code>long double</code>,
- * <code>std::complex@<double@></code>,
- * <code>std::complex@<float@></code>, and <code>std::complex@<long
- * double@></code>.
+ * stored values: we only support <code>double</code>, <code>float</code>,
+ * and in some cases <code>std::complex@<double@></code> and
+ * <code>std::complex@<float@></code>.
  * 
  *
  * @section Inst2 A few instantiations, most of which are known
@@ -83,7 +81,8 @@
  * the library for <code>Vector&lt;double&gt;</code>,
  * <code>Vector&lt;float&gt;</code>, <code>BlockVector&lt;double&gt;</code>,
  * and <code>BlockVector&lt;float&gt;</code>, for example. However, they may
- * also be used with other vector types as long as they satisfy certain
+ * also be used with other vector types, such as  <code>long double</code>
+ * and <code>std::complex@<long double@></code>, as long as they satisfy certain
  * interfaces, including vector types that are not part of the library but
  * possibly defined in an application program. In such a case, applications
  * can instantiate these templates by hand as described in the next section.
@@ -94,7 +93,7 @@
  * Choose one of your source files to provide the required
  * instantiations. Say that you want the class template <tt>XXXX</tt>,
  * defined in the header file <tt>xxxx.h</tt>, instantiated with the
- * template parameter <tt>Lager</tt>. Then, your file should contain
+ * template parameter <tt>long double</tt>. Then, your file should contain
  * the lines
  * @code
  *                   // Include class template declaration
@@ -104,7 +103,7 @@
  *
  * ...
  *
- * template class XXXX<Lager>;
+ * template class XXXX<long double>;
  * @endcode
  *
  * 


### PR DESCRIPTION
The instantiations for long double and std::complex<long double> were removed in commit 352537aca

I modified the documentation. Let me know if you are happy with the new text!