### PR TITLE
Use brace initializers for default arguments.

### DIFF
--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1947,7 +1947,7 @@ namespace DoFTools
     SparsityPattern &                block_list,
     const DoFHandler<dim, spacedim> &dof_handler,
     const unsigned int               level,
-    const std::vector<bool> &        selected_dofs = std::vector<bool>(),
+    const std::vector<bool> &        selected_dofs = {},
     const types::global_dof_index    offset        = 0);
 
   /**
@@ -2156,7 +2156,7 @@ namespace DoFTools
     const DoFHandlerType &                dof_handler,
     std::vector<types::global_dof_index> &dofs_per_component,
     const bool                            vector_valued_once = false,
-    std::vector<unsigned int> target_component = std::vector<unsigned int>());
+    std::vector<unsigned int> target_component = {});
 
   /**
    * Count the degrees of freedom in each block. This function is similar to

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1943,12 +1943,11 @@ namespace DoFTools
    */
   template <int dim, int spacedim>
   void
-  make_cell_patches(
-    SparsityPattern &                block_list,
-    const DoFHandler<dim, spacedim> &dof_handler,
-    const unsigned int               level,
-    const std::vector<bool> &        selected_dofs = {},
-    const types::global_dof_index    offset        = 0);
+  make_cell_patches(SparsityPattern &                block_list,
+                    const DoFHandler<dim, spacedim> &dof_handler,
+                    const unsigned int               level,
+                    const std::vector<bool> &        selected_dofs = {},
+                    const types::global_dof_index    offset        = 0);
 
   /**
    * Create an incidence matrix that for every vertex on a given level of a
@@ -2156,7 +2155,7 @@ namespace DoFTools
     const DoFHandlerType &                dof_handler,
     std::vector<types::global_dof_index> &dofs_per_component,
     const bool                            vector_valued_once = false,
-    std::vector<unsigned int> target_component = {});
+    std::vector<unsigned int>             target_component   = {});
 
   /**
    * Count the degrees of freedom in each block. This function is similar to

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -484,12 +484,11 @@ namespace GridGenerator
    */
   template <int dim, int spacedim>
   void
-  subdivided_parallelepiped(
-    Triangulation<dim, spacedim> &              tria,
-    const Point<spacedim> &                     origin,
-    const std::array<Tensor<1, spacedim>, dim> &edges,
-    const std::vector<unsigned int> &subdivisions = {},
-    const bool                       colorize     = false);
+  subdivided_parallelepiped(Triangulation<dim, spacedim> &              tria,
+                            const Point<spacedim> &                     origin,
+                            const std::array<Tensor<1, spacedim>, dim> &edges,
+                            const std::vector<unsigned int> &subdivisions = {},
+                            const bool                       colorize = false);
 
   /**
    * Hypercube with a layer of hypercubes around it. The first two parameters

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -488,7 +488,7 @@ namespace GridGenerator
     Triangulation<dim, spacedim> &              tria,
     const Point<spacedim> &                     origin,
     const std::array<Tensor<1, spacedim>, dim> &edges,
-    const std::vector<unsigned int> &subdivisions = std::vector<unsigned int>(),
+    const std::vector<unsigned int> &subdivisions = {},
     const bool                       colorize     = false);
 
   /**

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -889,10 +889,9 @@ namespace GridTools
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
   unsigned int
-  find_closest_vertex(
-    const MeshType<dim, spacedim> &mesh,
-    const Point<spacedim> &        p,
-    const std::vector<bool> &      marked_vertices = {});
+  find_closest_vertex(const MeshType<dim, spacedim> &mesh,
+                      const Point<spacedim> &        p,
+                      const std::vector<bool> &      marked_vertices = {});
 
   /**
    * Find and return the index of the used vertex (or marked vertex) in a
@@ -921,11 +920,10 @@ namespace GridTools
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
   unsigned int
-  find_closest_vertex(
-    const Mapping<dim, spacedim> & mapping,
-    const MeshType<dim, spacedim> &mesh,
-    const Point<spacedim> &        p,
-    const std::vector<bool> &      marked_vertices = {});
+  find_closest_vertex(const Mapping<dim, spacedim> & mapping,
+                      const MeshType<dim, spacedim> &mesh,
+                      const Point<spacedim> &        p,
+                      const std::vector<bool> &      marked_vertices = {});
 
 
   /**
@@ -992,13 +990,13 @@ namespace GridTools
 #  ifndef _MSC_VER
   typename MeshType<dim, spacedim>::active_cell_iterator
 #  else
-  typename dealii::internal::
-    ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type
+  typename dealii::internal::ActiveCellIterator<dim,
+                                                spacedim,
+                                                MeshType<dim, spacedim>>::type
 #  endif
-  find_active_cell_around_point(
-    const MeshType<dim, spacedim> &mesh,
-    const Point<spacedim> &        p,
-    const std::vector<bool> &      marked_vertices = {});
+  find_active_cell_around_point(const MeshType<dim, spacedim> &mesh,
+                                const Point<spacedim> &        p,
+                                const std::vector<bool> &marked_vertices = {});
 
   /**
    * Find and return an iterator to the active cell that surrounds a given
@@ -1094,11 +1092,10 @@ namespace GridTools
               ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type,
             Point<dim>>
 #  endif
-  find_active_cell_around_point(
-    const Mapping<dim, spacedim> & mapping,
-    const MeshType<dim, spacedim> &mesh,
-    const Point<spacedim> &        p,
-    const std::vector<bool> &      marked_vertices = {});
+  find_active_cell_around_point(const Mapping<dim, spacedim> & mapping,
+                                const MeshType<dim, spacedim> &mesh,
+                                const Point<spacedim> &        p,
+                                const std::vector<bool> &marked_vertices = {});
 
   /**
    * A version of the previous function that exploits an already existing

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -892,7 +892,7 @@ namespace GridTools
   find_closest_vertex(
     const MeshType<dim, spacedim> &mesh,
     const Point<spacedim> &        p,
-    const std::vector<bool> &      marked_vertices = std::vector<bool>());
+    const std::vector<bool> &      marked_vertices = {});
 
   /**
    * Find and return the index of the used vertex (or marked vertex) in a
@@ -925,7 +925,7 @@ namespace GridTools
     const Mapping<dim, spacedim> & mapping,
     const MeshType<dim, spacedim> &mesh,
     const Point<spacedim> &        p,
-    const std::vector<bool> &      marked_vertices = std::vector<bool>());
+    const std::vector<bool> &      marked_vertices = {});
 
 
   /**
@@ -998,7 +998,7 @@ namespace GridTools
   find_active_cell_around_point(
     const MeshType<dim, spacedim> &mesh,
     const Point<spacedim> &        p,
-    const std::vector<bool> &      marked_vertices = std::vector<bool>());
+    const std::vector<bool> &      marked_vertices = {});
 
   /**
    * Find and return an iterator to the active cell that surrounds a given
@@ -1098,7 +1098,7 @@ namespace GridTools
     const Mapping<dim, spacedim> & mapping,
     const MeshType<dim, spacedim> &mesh,
     const Point<spacedim> &        p,
-    const std::vector<bool> &      marked_vertices = std::vector<bool>());
+    const std::vector<bool> &      marked_vertices = {});
 
   /**
    * A version of the previous function that exploits an already existing
@@ -1127,7 +1127,7 @@ namespace GridTools
     const std::vector<std::vector<Tensor<1, spacedim>>> &vertex_to_cell_centers,
     const typename MeshType<dim, spacedim>::active_cell_iterator &cell_hint =
       typename MeshType<dim, spacedim>::active_cell_iterator(),
-    const std::vector<bool> &marked_vertices = std::vector<bool>());
+    const std::vector<bool> &marked_vertices = {});
 
   /**
    * A version of the previous function where we use that mapping on a given
@@ -1172,7 +1172,7 @@ namespace GridTools
     const Point<spacedim> &     p,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &
                              cell_hint = typename Triangulation<dim, spacedim>::active_cell_iterator(),
-    const std::vector<bool> &marked_vertices = std::vector<bool>());
+    const std::vector<bool> &marked_vertices = {});
 
   /**
    * A variant of the previous find_active_cell_around_point() function that,
@@ -1206,7 +1206,7 @@ namespace GridTools
     const MeshType<dim, spacedim> &mesh,
     const Point<spacedim> &        p,
     const double                   tolerance       = 1e-12,
-    const std::vector<bool> &      marked_vertices = std::vector<bool>());
+    const std::vector<bool> &      marked_vertices = {});
 
   /**
    * Return a list of all descendants of the given cell that are active. For

--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -169,7 +169,7 @@ namespace MGTools
   count_dofs_per_block(
     const DoFHandlerType &                             dof_handler,
     std::vector<std::vector<types::global_dof_index>> &dofs_per_block,
-    std::vector<unsigned int> target_block = std::vector<unsigned int>());
+    std::vector<unsigned int> target_block = {});
 
   /**
    * Count the dofs component-wise on each level.
@@ -184,7 +184,7 @@ namespace MGTools
     const DoFHandler<dim, spacedim> &                  mg_dof,
     std::vector<std::vector<types::global_dof_index>> &result,
     const bool                                         only_once = false,
-    std::vector<unsigned int> target_component = std::vector<unsigned int>());
+    std::vector<unsigned int> target_component = {});
 
   /**
    * Generate a list of those degrees of freedom at the boundary of the domain

--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -169,7 +169,7 @@ namespace MGTools
   count_dofs_per_block(
     const DoFHandlerType &                             dof_handler,
     std::vector<std::vector<types::global_dof_index>> &dofs_per_block,
-    std::vector<unsigned int> target_block = {});
+    std::vector<unsigned int>                          target_block = {});
 
   /**
    * Count the dofs component-wise on each level.
@@ -183,8 +183,8 @@ namespace MGTools
   count_dofs_per_component(
     const DoFHandler<dim, spacedim> &                  mg_dof,
     std::vector<std::vector<types::global_dof_index>> &result,
-    const bool                                         only_once = false,
-    std::vector<unsigned int> target_component = {});
+    const bool                                         only_once        = false,
+    std::vector<unsigned int>                          target_component = {});
 
   /**
    * Generate a list of those degrees of freedom at the boundary of the domain

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -410,8 +410,8 @@ namespace MatrixCreator
       &                                     boundary_functions,
     Vector<number> &                        rhs_vector,
     std::vector<types::global_dof_index> &  dof_to_boundary_mapping,
-    const Function<spacedim, number> *const weight = 0,
-    std::vector<unsigned int> component_mapping = {});
+    const Function<spacedim, number> *const weight            = 0,
+    std::vector<unsigned int>               component_mapping = {});
 
 
   /**
@@ -428,8 +428,8 @@ namespace MatrixCreator
       &                                     boundary_functions,
     Vector<number> &                        rhs_vector,
     std::vector<types::global_dof_index> &  dof_to_boundary_mapping,
-    const Function<spacedim, number> *const a   = nullptr,
-    std::vector<unsigned int> component_mapping = {});
+    const Function<spacedim, number> *const a                 = nullptr,
+    std::vector<unsigned int>               component_mapping = {});
 
   /**
    * Same function as above, but for hp objects.
@@ -445,8 +445,8 @@ namespace MatrixCreator
       &                                     boundary_functions,
     Vector<number> &                        rhs_vector,
     std::vector<types::global_dof_index> &  dof_to_boundary_mapping,
-    const Function<spacedim, number> *const a   = nullptr,
-    std::vector<unsigned int> component_mapping = {});
+    const Function<spacedim, number> *const a                 = nullptr,
+    std::vector<unsigned int>               component_mapping = {});
 
   /**
    * Same function as above, but for hp objects.
@@ -461,8 +461,8 @@ namespace MatrixCreator
       &                                     boundary_functions,
     Vector<number> &                        rhs_vector,
     std::vector<types::global_dof_index> &  dof_to_boundary_mapping,
-    const Function<spacedim, number> *const a   = nullptr,
-    std::vector<unsigned int> component_mapping = {});
+    const Function<spacedim, number> *const a                 = nullptr,
+    std::vector<unsigned int>               component_mapping = {});
 
   /**
    * Assemble the Laplace matrix. If no coefficient is given (i.e., if the

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -411,7 +411,7 @@ namespace MatrixCreator
     Vector<number> &                        rhs_vector,
     std::vector<types::global_dof_index> &  dof_to_boundary_mapping,
     const Function<spacedim, number> *const weight = 0,
-    std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
+    std::vector<unsigned int> component_mapping = {});
 
 
   /**
@@ -429,7 +429,7 @@ namespace MatrixCreator
     Vector<number> &                        rhs_vector,
     std::vector<types::global_dof_index> &  dof_to_boundary_mapping,
     const Function<spacedim, number> *const a   = nullptr,
-    std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
+    std::vector<unsigned int> component_mapping = {});
 
   /**
    * Same function as above, but for hp objects.
@@ -446,7 +446,7 @@ namespace MatrixCreator
     Vector<number> &                        rhs_vector,
     std::vector<types::global_dof_index> &  dof_to_boundary_mapping,
     const Function<spacedim, number> *const a   = nullptr,
-    std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
+    std::vector<unsigned int> component_mapping = {});
 
   /**
    * Same function as above, but for hp objects.
@@ -462,7 +462,7 @@ namespace MatrixCreator
     Vector<number> &                        rhs_vector,
     std::vector<types::global_dof_index> &  dof_to_boundary_mapping,
     const Function<spacedim, number> *const a   = nullptr,
-    std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
+    std::vector<unsigned int> component_mapping = {});
 
   /**
    * Assemble the Laplace matrix. If no coefficient is given (i.e., if the

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -1356,7 +1356,7 @@ namespace VectorTools
       &                                        boundary_functions,
     const Quadrature<dim - 1> &                q,
     std::map<types::global_dof_index, number> &boundary_values,
-    std::vector<unsigned int> component_mapping = {});
+    std::vector<unsigned int>                  component_mapping = {});
 
   /**
    * Call the project_boundary_values() function, see above, with
@@ -1370,7 +1370,7 @@ namespace VectorTools
       &                                        boundary_function,
     const Quadrature<dim - 1> &                q,
     std::map<types::global_dof_index, number> &boundary_values,
-    std::vector<unsigned int> component_mapping = {});
+    std::vector<unsigned int>                  component_mapping = {});
 
   /**
    * Same as above, but for objects of type hp::DoFHandler
@@ -1384,7 +1384,7 @@ namespace VectorTools
       &                                        boundary_functions,
     const hp::QCollection<dim - 1> &           q,
     std::map<types::global_dof_index, number> &boundary_values,
-    std::vector<unsigned int> component_mapping = {});
+    std::vector<unsigned int>                  component_mapping = {});
 
   /**
    * Call the project_boundary_values() function, see above, with
@@ -1398,7 +1398,7 @@ namespace VectorTools
       &                                        boundary_function,
     const hp::QCollection<dim - 1> &           q,
     std::map<types::global_dof_index, number> &boundary_values,
-    std::vector<unsigned int> component_mapping = {});
+    std::vector<unsigned int>                  component_mapping = {});
 
   /**
    * Project a function to the boundary of the domain, using the given
@@ -3054,8 +3054,7 @@ namespace VectorTools
    */
   template <typename VectorType>
   void
-  subtract_mean_value(VectorType &             v,
-                      const std::vector<bool> &p_select = {});
+  subtract_mean_value(VectorType &v, const std::vector<bool> &p_select = {});
 
 
   /**

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -1356,7 +1356,7 @@ namespace VectorTools
       &                                        boundary_functions,
     const Quadrature<dim - 1> &                q,
     std::map<types::global_dof_index, number> &boundary_values,
-    std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
+    std::vector<unsigned int> component_mapping = {});
 
   /**
    * Call the project_boundary_values() function, see above, with
@@ -1370,7 +1370,7 @@ namespace VectorTools
       &                                        boundary_function,
     const Quadrature<dim - 1> &                q,
     std::map<types::global_dof_index, number> &boundary_values,
-    std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
+    std::vector<unsigned int> component_mapping = {});
 
   /**
    * Same as above, but for objects of type hp::DoFHandler
@@ -1384,7 +1384,7 @@ namespace VectorTools
       &                                        boundary_functions,
     const hp::QCollection<dim - 1> &           q,
     std::map<types::global_dof_index, number> &boundary_values,
-    std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
+    std::vector<unsigned int> component_mapping = {});
 
   /**
    * Call the project_boundary_values() function, see above, with
@@ -1398,7 +1398,7 @@ namespace VectorTools
       &                                        boundary_function,
     const hp::QCollection<dim - 1> &           q,
     std::map<types::global_dof_index, number> &boundary_values,
-    std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
+    std::vector<unsigned int> component_mapping = {});
 
   /**
    * Project a function to the boundary of the domain, using the given
@@ -1447,7 +1447,7 @@ namespace VectorTools
       &                        boundary_functions,
     const Quadrature<dim - 1> &q,
     AffineConstraints<number> &constraints,
-    std::vector<unsigned int>  component_mapping = std::vector<unsigned int>());
+    std::vector<unsigned int>  component_mapping = {});
 
   /**
    * Call the project_boundary_values() function, see above, with
@@ -1463,7 +1463,7 @@ namespace VectorTools
       &                        boundary_function,
     const Quadrature<dim - 1> &q,
     AffineConstraints<number> &constraints,
-    std::vector<unsigned int>  component_mapping = std::vector<unsigned int>());
+    std::vector<unsigned int>  component_mapping = {});
 
 
   /**
@@ -3055,7 +3055,7 @@ namespace VectorTools
   template <typename VectorType>
   void
   subtract_mean_value(VectorType &             v,
-                      const std::vector<bool> &p_select = std::vector<bool>());
+                      const std::vector<bool> &p_select = {});
 
 
   /**


### PR DESCRIPTION
C++11 allows us to write the initialization of default arguments of type
std::vector in a shorter and clearer way than before. The first patch
does this, the second just cleans up the indentation. I left this in
separate commits because this makes it easier to see what really
changed.