### PR TITLE
Enable 'hp::DofHandler' for 'p::d::SolutionTransfer'.

### DIFF
--- a/doc/news/changes/major/20180815Fehling
+++ b/doc/news/changes/major/20180815Fehling
@@ -1,0 +1,6 @@
+New: The parallel::distributed::SolutionTransfer class is now capable
+of transferring data that has been associated with a hp::DoFHandler
+object. See the class documentation of the former on how to use this
+new functionality.
+<br>
+(Marc Fehling, 2018/08/15)

--- a/include/deal.II/distributed/active_fe_indices_transfer.h
+++ b/include/deal.II/distributed/active_fe_indices_transfer.h
@@ -38,6 +38,12 @@ namespace parallel
      * cell what parallel::distributed::SolutionTransfer does for the values
      * of degrees of freedom defined on a parallel::distributed::Triangulation.
      *
+     * If refinement is involved in the data transfer process, the children of
+     * a refined cell inherit the `active_fe_index` from their parent. If
+     * cells get coarsened into one, the latter will get the least dominating
+     * `active_fe_index` amongst its children, as determined by the function
+     * hp::FECollection::find_least_face_dominating_fe().
+     *
      * @note If you use more than one object to attach data to a
      * parallel::distributed::Triangulation at the same time (e.g. a
      * parallel::distributed::SolutionTransfer object), the calls to

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -316,6 +316,11 @@ public:
   static const unsigned int space_dimension = spacedim;
 
   /**
+   * Make the type of this DoFHandler available in function templates.
+   */
+  static const bool is_hp_dof_handler = false;
+
+  /**
    * When the arrays holding the DoF indices are set up, but before they are
    * filled with actual values, they are set to an invalid value, in order to
    * monitor possible problems. This invalid value is the constant defined

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -238,6 +238,11 @@ namespace hp
     static const unsigned int space_dimension = spacedim;
 
     /**
+     * Make the type of this DoFHandler available in function templates.
+     */
+    static const bool is_hp_dof_handler = true;
+
+    /**
      * When the arrays holding the DoF indices are set up, but before they are
      * filled with actual values, they are set to an invalid value, in order
      * to monitor possible problems. This invalid value is the constant

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -27,6 +27,8 @@
 #  include <deal.II/grid/tria_accessor.h>
 #  include <deal.II/grid/tria_iterator.h>
 
+#  include <deal.II/hp/dof_handler.h>
+
 #  include <deal.II/lac/block_vector.h>
 #  include <deal.II/lac/la_parallel_block_vector.h>
 #  include <deal.II/lac/la_parallel_vector.h>
@@ -91,7 +93,7 @@ namespace parallel
           this,
           std::placeholders::_1,
           std::placeholders::_2),
-        /*returns_variable_size_data=*/false);
+        /*returns_variable_size_data=*/DoFHandlerType::is_hp_dof_handler);
     }
 
 
@@ -207,8 +209,9 @@ namespace parallel
     SolutionTransfer<dim, VectorType, DoFHandlerType>::pack_callback(
       const typename Triangulation<dim, DoFHandlerType::space_dimension>::
         cell_iterator &cell_,
-      const typename Triangulation<dim, DoFHandlerType::space_dimension>::
-        CellStatus /*status*/)
+      const typename Triangulation<dim,
+                                   DoFHandlerType::space_dimension>::CellStatus
+        status)
     {
       typename DoFHandlerType::cell_iterator cell(*cell_, dof_handler);
 
@@ -216,17 +219,87 @@ namespace parallel
       std::vector<::dealii::Vector<typename VectorType::value_type>> dofvalues(
         input_vectors.size());
 
-      auto cit_input = input_vectors.cbegin();
-      auto it_output = dofvalues.begin();
-      for (; cit_input != input_vectors.cend(); ++cit_input, ++it_output)
+      if (DoFHandlerType::is_hp_dof_handler)
         {
-          it_output->reinit(cell->get_fe().dofs_per_cell);
-          cell->get_interpolated_dof_values(*(*cit_input), *it_output);
+          unsigned int dofs_per_cell = numbers::invalid_unsigned_int;
+          unsigned int fe_index      = numbers::invalid_unsigned_int;
+
+          switch (status)
+            {
+              case parallel::distributed::Triangulation<
+                dim,
+                DoFHandlerType::space_dimension>::CELL_PERSIST:
+              case parallel::distributed::Triangulation<
+                dim,
+                DoFHandlerType::space_dimension>::CELL_REFINE:
+                {
+                  dofs_per_cell = cell->get_fe().dofs_per_cell;
+                  fe_index      = cell->active_fe_index();
+                  break;
+                }
+
+              case parallel::distributed::Triangulation<
+                dim,
+                DoFHandlerType::space_dimension>::CELL_COARSEN:
+                {
+                  // In case of coarsening, we need to find a suitable fe index
+                  // for the parent cell. We choose the 'least face dominating
+                  // fe index' on all children from the associated FECollection.
+                  std::set<unsigned int> fe_indices_children;
+                  for (unsigned int child_index = 0;
+                       child_index < GeometryInfo<dim>::max_children_per_cell;
+                       ++child_index)
+                    fe_indices_children.insert(
+                      cell->child(child_index)->active_fe_index());
+
+                  fe_index =
+                    dof_handler->get_fe_collection()
+                      .find_least_face_dominating_fe(fe_indices_children);
+
+                  Assert(
+                    fe_index != numbers::invalid_unsigned_int,
+                    ExcMessage(
+                      "No FiniteElement has been found in your FECollection "
+                      "that dominates all children of a cell you are trying "
+                      "to coarsen!"));
+
+                  dofs_per_cell = dof_handler->get_fe(fe_index).dofs_per_cell;
+                }
+                break;
+
+              default:
+                Assert(false, ExcInternalError());
+                break;
+            }
+
+          auto it_input  = input_vectors.cbegin();
+          auto it_output = dofvalues.begin();
+          for (; it_input != input_vectors.cend(); ++it_input, ++it_output)
+            {
+              it_output->reinit(dofs_per_cell);
+              cell->get_interpolated_dof_values(*(*it_input),
+                                                *it_output,
+                                                fe_index);
+            }
+        }
+      else
+        {
+          auto it_input  = input_vectors.cbegin();
+          auto it_output = dofvalues.begin();
+          for (; it_input != input_vectors.cend(); ++it_input, ++it_output)
+            {
+              it_output->reinit(cell->get_fe().dofs_per_cell);
+              cell->get_interpolated_dof_values(*(*it_input), *it_output);
+            }
         }
 
-      // to get consistent data sizes on each cell for the fixed size transfer,
-      // we won't allow compression
-      return Utilities::pack(dofvalues, /*allow_compression=*/false);
+      // We choose to compress the packed data depending on the registered
+      // dofhandler object. In case of hp, we write in the variable size buffer
+      // and thus allow compression. In the other case, we use the fixed size
+      // buffer and require consistent data sizes on each cell, so we leave it
+      // uncompressed.
+      return Utilities::pack(
+        dofvalues, /*allow_compression=*/DoFHandlerType::is_hp_dof_handler);
     }
 
 
@@ -236,8 +309,9 @@ namespace parallel
     SolutionTransfer<dim, VectorType, DoFHandlerType>::unpack_callback(
       const typename Triangulation<dim, DoFHandlerType::space_dimension>::
         cell_iterator &cell_,
-      const typename Triangulation<dim, DoFHandlerType::space_dimension>::
-        CellStatus /*status*/,
+      const typename Triangulation<dim,
+                                   DoFHandlerType::space_dimension>::CellStatus
+        status,
       const boost::iterator_range<std::vector<char>::const_iterator>
         &                        data_range,
       std::vector<VectorType *> &all_out)
@@ -247,27 +321,93 @@ namespace parallel
       const std::vector<::dealii::Vector<typename VectorType::value_type>>
         dofvalues = Utilities::unpack<
           std::vector<::dealii::Vector<typename VectorType::value_type>>>(
-          data_range.begin(), data_range.end(), /*allow_compression=*/false);
+          data_range.begin(),
+          data_range.end(),
+          /*allow_compression=*/DoFHandlerType::is_hp_dof_handler);
 
       // check if sizes match
       Assert(dofvalues.size() == all_out.size(), ExcInternalError());
 
-      // check if we have enough dofs provided by the FE object
-      // to interpolate the transferred data correctly
-      for (auto it_dofvalues = dofvalues.begin();
-           it_dofvalues != dofvalues.end();
-           ++it_dofvalues)
-        Assert(
-          cell->get_fe().dofs_per_cell == it_dofvalues->size(),
-          ExcMessage(
-            "The transferred data was packed with a different number of dofs than the"
-            "currently registered FE object assigned to the DoFHandler has."));
+      if (DoFHandlerType::is_hp_dof_handler)
+        {
+          unsigned int fe_index = numbers::invalid_unsigned_int;
 
-      // distribute data for each registered vector on mesh
-      auto it_input  = dofvalues.cbegin();
-      auto it_output = all_out.begin();
-      for (; it_input != dofvalues.cend(); ++it_input, ++it_output)
-        cell->set_dof_values_by_interpolation(*it_input, *(*it_output));
+          switch (status)
+            {
+              case parallel::distributed::Triangulation<
+                dim,
+                DoFHandlerType::space_dimension>::CELL_PERSIST:
+              case parallel::distributed::Triangulation<
+                dim,
+                DoFHandlerType::space_dimension>::CELL_COARSEN:
+                {
+                  fe_index = cell->active_fe_index();
+                  break;
+                }
+
+              case parallel::distributed::Triangulation<
+                dim,
+                DoFHandlerType::space_dimension>::CELL_REFINE:
+                {
+                  // After refinement, this particular cell is no longer active,
+                  // and its children have inherited its fe index. However, to
+                  // unpack the data on the old cell, we need to recover its fe
+                  // index from one of the children. Just to be sure, we also
+                  // check if all children have the same fe index.
+                  fe_index = cell->child(0)->active_fe_index();
+                  for (unsigned int child_index = 1;
+                       child_index < GeometryInfo<dim>::max_children_per_cell;
+                       ++child_index)
+                    Assert(cell->child(child_index)->active_fe_index() ==
+                             fe_index,
+                           ExcInternalError());
+                  break;
+                }
+
+              default:
+                Assert(false, ExcInternalError());
+                break;
+            }
+
+          // check if we have enough dofs provided by the FE object
+          // to interpolate the transferred data correctly
+          for (auto it_dofvalues = dofvalues.begin();
+               it_dofvalues != dofvalues.end();
+               ++it_dofvalues)
+            Assert(
+              dof_handler->get_fe(fe_index).dofs_per_cell ==
+                it_dofvalues->size(),
+              ExcMessage(
+                "The transferred data was packed with a different number of dofs than the"
+                "currently registered FE object assigned to the DoFHandler has."));
+
+          // distribute data for each registered vector on mesh
+          auto it_input  = dofvalues.cbegin();
+          auto it_output = all_out.begin();
+          for (; it_input != dofvalues.cend(); ++it_input, ++it_output)
+            cell->set_dof_values_by_interpolation(*it_input,
+                                                  *(*it_output),
+                                                  fe_index);
+        }
+      else
+        {
+          // check if we have enough dofs provided by the FE object
+          // to interpolate the transferred data correctly
+          for (auto it_dofvalues = dofvalues.begin();
+               it_dofvalues != dofvalues.end();
+               ++it_dofvalues)
+            Assert(
+              cell->get_fe().dofs_per_cell == it_dofvalues->size(),
+              ExcMessage(
+                "The transferred data was packed with a different number of dofs than the"
+                "currently registered FE object assigned to the DoFHandler has."));
+
+          // distribute data for each registered vector on mesh
+          auto it_input  = dofvalues.cbegin();
+          auto it_output = all_out.begin();
+          for (; it_input != dofvalues.cend(); ++it_input, ++it_output)
+            cell->set_dof_values_by_interpolation(*it_input, *(*it_output));
+        }
     }
 
 

--- a/source/distributed/solution_transfer.inst.in
+++ b/source/distributed/solution_transfer.inst.in
@@ -43,17 +43,46 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
           ::dealii::LinearAlgebra::distributed::BlockVector<float>,
           DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
 
+        template class SolutionTransfer<
+          deal_II_dimension,
+          ::dealii::Vector<double>,
+          hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          ::dealii::LinearAlgebra::distributed::Vector<double>,
+          hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          ::dealii::LinearAlgebra::distributed::Vector<float>,
+          hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          ::dealii::LinearAlgebra::distributed::BlockVector<double>,
+          hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          ::dealii::LinearAlgebra::distributed::BlockVector<float>,
+          hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+
 
 #  ifdef DEAL_II_WITH_PETSC
         template class SolutionTransfer<
           deal_II_dimension,
           PETScWrappers::MPI::Vector,
           DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
-
         template class SolutionTransfer<
           deal_II_dimension,
           PETScWrappers::MPI::BlockVector,
           DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+
+        template class SolutionTransfer<
+          deal_II_dimension,
+          PETScWrappers::MPI::Vector,
+          hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          PETScWrappers::MPI::BlockVector,
+          hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
 #  endif
 
 #  ifdef DEAL_II_WITH_TRILINOS
@@ -61,11 +90,19 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
           deal_II_dimension,
           TrilinosWrappers::MPI::Vector,
           DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
-
         template class SolutionTransfer<
           deal_II_dimension,
           TrilinosWrappers::MPI::BlockVector,
           DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+
+        template class SolutionTransfer<
+          deal_II_dimension,
+          TrilinosWrappers::MPI::Vector,
+          hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
+        template class SolutionTransfer<
+          deal_II_dimension,
+          TrilinosWrappers::MPI::BlockVector,
+          hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
 #  endif
 
 #endif

--- a/tests/mpi/p4est_save_06.cc
+++ b/tests/mpi/p4est_save_06.cc
@@ -1,0 +1,177 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// save and load a triangulation with a different number of cpus
+// using variable size data transfer with an associated hp::DoFHandler
+
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/active_fe_indices_transfer.h>
+#include <deal.II/distributed/solution_transfer.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+
+#include <deal.II/lac/petsc_parallel_vector.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+test()
+{
+  unsigned int myid    = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  MPI_Comm     com_all = MPI_COMM_WORLD;
+  MPI_Comm     com_small;
+
+  // split the communicator in proc 0,1,2 and 3,4
+  MPI_Comm_split(com_all, (myid < 3) ? 0 : 1, myid, &com_small);
+
+  // write with small com
+  if (myid < 3)
+    {
+      deallog << "writing with " << Utilities::MPI::n_mpi_processes(com_small)
+              << std::endl;
+
+      parallel::distributed::Triangulation<dim> tr(com_small);
+      GridGenerator::hyper_cube(tr);
+      tr.refine_global(2);
+      for (typename Triangulation<dim>::active_cell_iterator cell =
+             tr.begin_active();
+           cell != tr.end();
+           ++cell)
+        if (!cell->is_ghost() && !cell->is_artificial())
+          if (cell->center().norm() < 0.3)
+            {
+              cell->set_refine_flag();
+            }
+
+      tr.execute_coarsening_and_refinement();
+
+      hp::DoFHandler<dim>   dh(tr);
+      hp::FECollection<dim> fe_collection;
+
+      // prepare FECollection with arbitrary number of entries
+      const unsigned int max_degree = 1 + std::pow(2, dim);
+      for (unsigned int i = 0; i < max_degree; ++i)
+        fe_collection.push_back(FE_Q<dim>(max_degree - i));
+
+      dh.distribute_dofs(fe_collection);
+
+      IndexSet locally_owned_dofs = dh.locally_owned_dofs();
+      IndexSet locally_relevant_dofs;
+      DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+
+      PETScWrappers::MPI::Vector x(locally_owned_dofs, com_small);
+      PETScWrappers::MPI::Vector rel_x(locally_owned_dofs,
+                                       locally_relevant_dofs,
+                                       com_small);
+
+      parallel::distributed::ActiveFEIndicesTransfer<dim, dim> feidx_transfer(
+        dh);
+      parallel::distributed::
+        SolutionTransfer<dim, PETScWrappers::MPI::Vector, hp::DoFHandler<dim>>
+          soltrans(dh);
+
+      for (unsigned int i = 0; i < locally_owned_dofs.n_elements(); ++i)
+        {
+          unsigned int idx = locally_owned_dofs.nth_index_in_set(i);
+          x(idx)           = idx;
+        }
+
+
+      x.compress(VectorOperation::insert);
+      rel_x = x;
+
+      feidx_transfer.prepare_for_transfer();
+      soltrans.prepare_serialization(rel_x);
+
+      tr.save("file");
+      deallog << "#cells: " << tr.n_global_active_cells() << std::endl
+              << "norm: " << x.l2_norm() << std::endl
+              << "Checksum: " << tr.get_checksum() << std::endl;
+    }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  deallog << "reading with " << Utilities::MPI::n_mpi_processes(com_all)
+          << std::endl;
+
+  {
+    parallel::distributed::Triangulation<dim> tr(com_all);
+
+    GridGenerator::hyper_cube(tr);
+    tr.load("file");
+
+    hp::DoFHandler<dim>   dh(tr);
+    hp::FECollection<dim> fe_collection;
+
+    // prepare FECollection with arbitrary number of entries
+    const unsigned int max_degree = 1 + std::pow(2, dim);
+    for (unsigned int i = 0; i < max_degree; ++i)
+      fe_collection.push_back(FE_Q<dim>(max_degree - i));
+
+    dh.distribute_dofs(fe_collection);
+
+    parallel::distributed::ActiveFEIndicesTransfer<dim> feidx_transfer(dh);
+    feidx_transfer.deserialize();
+
+    dh.distribute_dofs(fe_collection);
+
+    IndexSet locally_owned_dofs = dh.locally_owned_dofs();
+    IndexSet locally_relevant_dofs;
+
+    DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+
+    PETScWrappers::MPI::Vector solution(locally_owned_dofs, com_all);
+    solution = PetscScalar();
+
+    parallel::distributed::
+      SolutionTransfer<dim, PETScWrappers::MPI::Vector, hp::DoFHandler<dim>>
+        soltrans(dh);
+
+    soltrans.deserialize(solution);
+
+    deallog << "#cells: " << tr.n_global_active_cells() << std::endl
+            << "norm: " << solution.l2_norm() << std::endl
+            << "Checksum: " << tr.get_checksum() << std::endl;
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  test<2>();
+}

--- a/tests/mpi/p4est_save_06.with_p4est=true.with_petsc=true.mpirun=5.output
+++ b/tests/mpi/p4est_save_06.with_p4est=true.with_petsc=true.mpirun=5.output
@@ -1,0 +1,46 @@
+
+DEAL:0::writing with 3
+DEAL:0::#cells: 19
+DEAL:0::norm: 7114.44
+DEAL:0::Checksum: 136119115
+DEAL:0::reading with 5
+DEAL:0::#cells: 19
+DEAL:0::norm: 7114.44
+DEAL:0::Checksum: 136119115
+DEAL:0::OK
+
+DEAL:1::writing with 3
+DEAL:1::#cells: 19
+DEAL:1::norm: 7114.44
+DEAL:1::Checksum: 0
+DEAL:1::reading with 5
+DEAL:1::#cells: 19
+DEAL:1::norm: 7114.44
+DEAL:1::Checksum: 0
+DEAL:1::OK
+
+
+DEAL:2::writing with 3
+DEAL:2::#cells: 19
+DEAL:2::norm: 7114.44
+DEAL:2::Checksum: 0
+DEAL:2::reading with 5
+DEAL:2::#cells: 19
+DEAL:2::norm: 7114.44
+DEAL:2::Checksum: 0
+DEAL:2::OK
+
+
+DEAL:3::reading with 5
+DEAL:3::#cells: 19
+DEAL:3::norm: 7114.44
+DEAL:3::Checksum: 0
+DEAL:3::OK
+
+
+DEAL:4::reading with 5
+DEAL:4::#cells: 19
+DEAL:4::norm: 7114.44
+DEAL:4::Checksum: 0
+DEAL:4::OK
+

--- a/tests/mpi/solution_transfer_04.cc
+++ b/tests/mpi/solution_transfer_04.cc
@@ -1,0 +1,143 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test to check if SolutionTransfer works in parallel with hp::DoFHandler.
+// This tests is based on mpi/feindices_transfer.cc
+
+
+#include <deal.II/distributed/active_fe_indices_transfer.h>
+#include <deal.II/distributed/solution_transfer.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/hp/dof_handler.h>
+
+#include <deal.II/lac/trilinos_vector.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  // ------ setup ------
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+  tria.refine_global(1);
+
+  hp::DoFHandler<dim>   dh(tria);
+  hp::FECollection<dim> fe_collection;
+
+  // prepare FECollection with arbitrary number of entries
+  const unsigned int max_degree = 1 + std::pow(2, dim);
+  for (unsigned int i = 0; i < max_degree; ++i)
+    fe_collection.push_back(FE_Q<dim>(max_degree - i));
+
+  typename hp::DoFHandler<dim, dim>::active_cell_iterator cell;
+  unsigned int                                            i = 0;
+
+  for (cell = dh.begin_active(); cell != dh.end(); ++cell)
+    {
+      if (cell->is_locally_owned())
+        {
+          // set active fe index
+          if (!(cell->is_artificial()))
+            {
+              if (i >= fe_collection.size())
+                i = 0;
+              cell->set_active_fe_index(i++);
+            }
+
+          // set refinement/coarsening flags
+          if (cell->id().to_string() == "0_1:0")
+            cell->set_refine_flag();
+          else if (cell->parent()->id().to_string() ==
+                   ((dim == 2) ? "3_0:" : "7_0:"))
+            cell->set_coarsen_flag();
+        }
+    }
+
+
+  // ----- prepare solution -----
+  dh.distribute_dofs(fe_collection);
+  IndexSet locally_owned_dofs = dh.locally_owned_dofs();
+  IndexSet locally_relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+
+  TrilinosWrappers::MPI::Vector solution;
+  solution.reinit(locally_owned_dofs, MPI_COMM_WORLD);
+  for (unsigned int i = 0; i < solution.size(); ++i)
+    if (locally_owned_dofs.is_element(i))
+      solution(i) = i;
+
+  TrilinosWrappers::MPI::Vector old_solution;
+  old_solution.reinit(locally_owned_dofs,
+                      locally_relevant_dofs,
+                      MPI_COMM_WORLD);
+  old_solution = solution;
+
+
+  // ----- transfer -----
+  parallel::distributed::ActiveFEIndicesTransfer<dim> feidx_transfer(dh);
+  parallel::distributed::
+    SolutionTransfer<dim, TrilinosWrappers::MPI::Vector, hp::DoFHandler<dim>>
+      soltrans(dh);
+
+  feidx_transfer.prepare_for_transfer();
+  soltrans.prepare_for_coarsening_and_refinement(old_solution);
+  tria.execute_coarsening_and_refinement();
+
+  feidx_transfer.unpack();
+
+  dh.distribute_dofs(fe_collection);
+  locally_owned_dofs = dh.locally_owned_dofs();
+  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+
+  TrilinosWrappers::MPI::Vector new_solution;
+  new_solution.reinit(locally_owned_dofs, MPI_COMM_WORLD);
+  soltrans.interpolate(new_solution);
+
+  // make sure no processor is hanging
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/mpi/solution_transfer_04.with_p4est=true.with_trilinos=true.mpirun=2.output
+++ b/tests/mpi/solution_transfer_04.with_p4est=true.with_trilinos=true.mpirun=2.output
@@ -1,0 +1,7 @@
+
+DEAL:0:2d:: OK
+DEAL:0:3d:: OK
+
+DEAL:1:2d:: OK
+DEAL:1:3d:: OK
+


### PR DESCRIPTION
One big step closer to #3511.

This pull request takes care of the variable data transfer in case a `hp::DofHandler` is associated with a `p::d::SolutionTransfer` object. Depending on whether refinement or coarsening is scheduled, we need to choose with which FE object we want to pack/unpack our data. In case of refinement, the children inherit their parent's FE index. In case of coarsening, we choose to pack the data with the least face dominating FE index of all children.

Tests for transfer across mesh refinement and serialization are provided.

@bangerth @tjhei -- FYI