### PR TITLE
Fix CUDAWrappers group documentation

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -176,6 +176,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_WITH_CXX14=1 \
                          DEAL_II_WITH_CXX17=1 \
                          DEAL_II_WITH_CUDA=1 \
+                         DEAL_II_COMPILER_CUDA_AWARE=1 \
                          DEAL_II_WITH_GSL=1 \
                          DEAL_II_WITH_GMSH=1 \
                          DEAL_II_WITH_HDF5=1 \

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -96,6 +96,13 @@
 #cmakedefine DEAL_II_RESTRICT @DEAL_II_RESTRICT@
 #cmakedefine DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
 
+/*
+ * A variable to tell if the compiler used in the current compilation process
+ * understands CUDA code.
+ */
+#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#  define DEAL_II_COMPILER_CUDA_AWARE
+#endif
 
 /***********************************************************************
  * CPU features:

--- a/include/deal.II/base/cuda.h
+++ b/include/deal.II/base/cuda.h
@@ -20,7 +20,7 @@
 
 #include <deal.II/base/exceptions.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 #  include <cusolverDn.h>
 #  include <cusolverSp.h>
 #  include <cusparse.h>
@@ -58,7 +58,7 @@ namespace Utilities
        */
       ~Handle();
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
       cusolverDnHandle_t cusolver_dn_handle;
 
       cusolverSpHandle_t cusolver_sp_handle;
@@ -77,7 +77,7 @@ namespace Utilities
     inline void
     malloc(T *&pointer, const unsigned int n_elements)
     {
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
       cudaError_t cuda_error_code =
         cudaMalloc(&pointer, n_elements * sizeof(T));
       AssertCuda(cuda_error_code);
@@ -94,7 +94,7 @@ namespace Utilities
     inline void
     free(T *&pointer)
     {
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
       cudaError_t cuda_error_code = cudaFree(pointer);
       AssertCuda(cuda_error_code);
       pointer = nullptr;
@@ -110,7 +110,7 @@ namespace Utilities
     inline void
     copy_to_host(const T *pointer_dev, std::vector<T> &vector_host)
     {
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
       cudaError_t cuda_error_code = cudaMemcpy(vector_host.data(),
                                                pointer_dev,
                                                vector_host.size() * sizeof(T),
@@ -130,7 +130,7 @@ namespace Utilities
     inline void
     copy_to_dev(const std::vector<T> &vector_host, T *pointer_dev)
     {
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
       cudaError_t cuda_error_code = cudaMemcpy(pointer_dev,
                                                vector_host.data(),
                                                vector_host.size() * sizeof(T),

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -346,6 +346,8 @@ namespace numbers
      * Return the complex-conjugate of the given number. Since the general
      * template is selected if number is not a complex data type, this
      * function simply returns the given number.
+     *
+     * @note This function can also be used in CUDA device code.
      */
     static DEAL_II_CUDA_HOST_DEV const number &
                                        conjugate(const number &x);
@@ -355,7 +357,7 @@ namespace numbers
      * general template is chosen for types not equal to std::complex, this
      * function simply returns the square of the given number.
      *
-     * @see CUDAWrappers
+     * @note This function can also be used in CUDA device code.
      */
     static DEAL_II_CUDA_HOST_DEV real_type
                                  abs_square(const number &x);

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -25,7 +25,7 @@
 #include <complex>
 #include <cstdlib>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 #  define DEAL_II_CUDA_HOST_DEV __host__ __device__
 #else
 #  define DEAL_II_CUDA_HOST_DEV

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -140,7 +140,7 @@ public:
   /**
    * Constructor. Set to zero.
    *
-   * @see CUDAWrappers
+   * @note This function can also be used in CUDA device code.
    */
   DEAL_II_CUDA_HOST_DEV
   Tensor();
@@ -191,7 +191,7 @@ public:
    * This is the non-const conversion operator that returns a writable
    * reference.
    *
-   * @see CUDAWrappers
+   * @note This function can also be used in CUDA device code.
    */
   DEAL_II_CUDA_HOST_DEV operator Number &();
 
@@ -201,7 +201,7 @@ public:
    *
    * This is the const conversion operator that returns a read-only reference.
    *
-   * @see CUDAWrappers
+   * @note This function can also be used in CUDA device code.
    */
   DEAL_II_CUDA_HOST_DEV operator const Number &() const;
 
@@ -264,7 +264,7 @@ public:
   /**
    * Multiply the scalar with a <tt>factor</tt>.
    *
-   * @see CUDAWrappers
+   * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
   DEAL_II_CUDA_HOST_DEV Tensor &
@@ -310,7 +310,7 @@ public:
    * Return the square of the Frobenius-norm of a tensor, i.e. the sum of the
    * absolute squares of all entries.
    *
-   * @see CUDAWrappers
+   * @note This function can also be used in CUDA device code.
    */
   DEAL_II_CUDA_HOST_DEV real_type
                         norm_square() const;
@@ -436,7 +436,7 @@ public:
   /**
    * Constructor. Initialize all entries to zero.
    *
-   * @see CUDAWrappers
+   * @note This function can also be used in CUDA device code.
    */
   DEAL_II_CUDA_HOST_DEV
   Tensor();
@@ -470,14 +470,14 @@ public:
   /**
    * Read-Write access operator.
    *
-   * @see CUDAWrappers
+   * @note This function can also be used in CUDA device code.
    */
   DEAL_II_CUDA_HOST_DEV value_type &operator[](const unsigned int i);
 
   /**
    * Read-only access operator.
    *
-   * @see CUDAWrappers
+   * @note This function can also be used in CUDA device code.
    */
   DEAL_II_CUDA_HOST_DEV const value_type &
                               operator[](const unsigned int i) const;
@@ -566,7 +566,7 @@ public:
    * Scale the tensor by <tt>factor</tt>, i.e. multiply all components by
    * <tt>factor</tt>.
    *
-   * @see CUDAWrappers
+   * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
   DEAL_II_CUDA_HOST_DEV Tensor &
@@ -613,7 +613,7 @@ public:
    * Return the square of the Frobenius-norm of a tensor, i.e. the sum of the
    * absolute squares of all entries.
    *
-   * @see CUDAWrappers
+   * @note This function can also be used in CUDA device code.
    */
   DEAL_II_CUDA_HOST_DEV typename numbers::NumberTraits<Number>::real_type
   norm_square() const;

--- a/include/deal.II/lac/cuda_atomic.h
+++ b/include/deal.II/lac/cuda_atomic.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/cuda_kernels.h
+++ b/include/deal.II/lac/cuda_kernels.h
@@ -43,6 +43,8 @@ namespace LinearAlgebra
 
       /**
        * Multiply each entry of @p val of size @p N by @p a.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -52,6 +54,8 @@ namespace LinearAlgebra
 
       /**
        * Functor defining the addition of two Numbers.
+       *
+       * @ingroup CUDAWrappers
        */
       struct Binop_Addition
       {
@@ -67,6 +71,8 @@ namespace LinearAlgebra
 
       /**
        * Functor defining the subtraction of two Numbers.
+       *
+       * @ingroup CUDAWrappers
        */
       struct Binop_Subtraction
       {
@@ -82,6 +88,8 @@ namespace LinearAlgebra
 
       /**
        * Apply the functor @tparam Binop to each element of @p v1 and @p v2.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number, typename Binop>
       __global__ void
@@ -92,6 +100,8 @@ namespace LinearAlgebra
       /**
        * Structure implementing the functions used to add elements when using a
        * reduction.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       struct ElemSum
@@ -114,6 +124,8 @@ namespace LinearAlgebra
       /**
        * Structure implementing the functions used to compute the L1 norm when
        * using a reduction.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       struct L1Norm
@@ -136,6 +148,8 @@ namespace LinearAlgebra
       /**
        * Structure implementing the functions used to compute the L-infinity
        * norm when using a reduction.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       struct LInfty
@@ -156,7 +170,9 @@ namespace LinearAlgebra
 
 
       /**
-       * Perform a reduction on @p v using @tparam Operation
+       * Perform a reduction on @p v using @tparam Operation.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number, typename Operation>
       __global__ void
@@ -167,6 +183,8 @@ namespace LinearAlgebra
       /**
        * Structure implementing the functions used to compute the dot product
        * norm when using a double vector reduction.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       struct DotProduct
@@ -189,6 +207,8 @@ namespace LinearAlgebra
       /**
        * Perform a binary operation on each element of @p v1 and @p v2 followed
        * by reduction on the resulting array.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number, typename Operation>
       __global__ void
@@ -201,6 +221,8 @@ namespace LinearAlgebra
 
       /**
        * Add @p a to each element of @p val.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -210,6 +232,8 @@ namespace LinearAlgebra
 
       /**
        * Addition of a multiple of a vector, i.e., <tt>val += a*V_val</tt>.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -223,6 +247,8 @@ namespace LinearAlgebra
       /**
        * Addition of multiple scaled vector, i.e., <tt>val += a*V_val +
        * b*W_val</tt>.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -238,6 +264,8 @@ namespace LinearAlgebra
       /**
        * Scaling and simple addition of a multiple of a vector, i.e. <tt>val =
        * = s*val + a*V_val</tt>
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -252,6 +280,8 @@ namespace LinearAlgebra
       /**
        * Scaling and multiple additions of scaled vectors, i.e. <tt>val =
        * = s*val + a*V_val + b*W_val</tt>
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -268,6 +298,8 @@ namespace LinearAlgebra
       /**
        * Scale each element of this vector by the corresponding element in the
        * argument.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -277,6 +309,8 @@ namespace LinearAlgebra
 
       /**
        * Assignment <tt>val = a*V_val</tt>.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -286,6 +320,8 @@ namespace LinearAlgebra
 
       /**
        * Assignment <tt>val = a*V_val + b*W_val</tt>.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -301,6 +337,8 @@ namespace LinearAlgebra
       /**
        * Perform a combined operation of a vector addition and a subsequent
        * inner product, returning the value of the inner product.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -315,6 +353,8 @@ namespace LinearAlgebra
 
       /**
        * Set each element of @p val to @p s.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -324,6 +364,8 @@ namespace LinearAlgebra
       /**
        * Set each element @v val to @p v using @p indices as permutation, i.e.,
        * <tt>val[indices[i]] = v[i]</tt>.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void
@@ -337,6 +379,8 @@ namespace LinearAlgebra
       /**
        * Add each element @v val to @p v using @p indices as permutation, i.e.,
        * <tt>val[indices[i]] += v[i]</tt>.
+       *
+       * @ingroup CUDAWrappers
        */
       template <typename Number>
       __global__ void

--- a/include/deal.II/lac/cuda_kernels.h
+++ b/include/deal.II/lac/cuda_kernels.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 
 #  include <deal.II/base/cuda_size.h>

--- a/include/deal.II/lac/cuda_kernels.templates.h
+++ b/include/deal.II/lac/cuda_kernels.templates.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/lac/cuda_kernels.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/cuda_solver_direct.h
+++ b/include/deal.II/lac/cuda_solver_direct.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 #  include <deal.II/base/cuda.h>
 
 #  include <deal.II/lac/cuda_sparse_matrix.h>

--- a/include/deal.II/lac/cuda_sparse_matrix.h
+++ b/include/deal.II/lac/cuda_sparse_matrix.h
@@ -20,7 +20,7 @@
 
 #include <deal.II/base/subscriptor.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 #  include <deal.II/base/cuda.h>
 
 #  include <deal.II/lac/cuda_vector.h>

--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -45,8 +45,7 @@ namespace LinearAlgebra
      *
      * @note Only float and double are supported.
      *
-     * @see CUDAWrappers
-     * @ingroup Vectors
+     * @ingroup CUDAWrappers Vectors
      * @author Karl Ljungkvist, Bruno Turcksin, 2016
      */
     template <typename Number>

--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 #  include <deal.II/base/tensor.h>
 #  include <deal.II/base/utilities.h>

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 #  include <deal.II/base/utilities.h>
 

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 #  include <deal.II/base/quadrature.h>
 #  include <deal.II/base/tensor.h>

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/matrix_free/cuda_matrix_free.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 #  include <deal.II/base/cuda_size.h>
 #  include <deal.II/base/graph_coloring.h>

--- a/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#if defined(DEAL_II_WITH_CUDA) && defined(__CUDACC__)
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
#7057 accidentally prevents `doxygen` from creating information in the `CUDAWrappers` group. [This](https://www.dealii.org/developer/doxygen/deal.II/group__CUDAWrappers.html) is a current version and [this](https://www.dealii.org/9.0.0/doxygen/deal.II/group__CUDAWrappers.html) the one for release 9.0.0.
This PR fixes the issue by introducing a `DEAL_II_COMPILER_CUDA_AWARE` preprocessor variable and enabling it unconditionally when `doxygen` runs.

Additionally, a few more classes and functions are imported into the group and we use a "note" remark instead of "see" for marking functions that can be run in device code. Unfortunately, neither of the two options creates links in the group.