### PR TITLE
Fix using the remaining iterative solvers with CUDAWrappers::Vector

### DIFF
--- a/doc/news/changes/minor/20180817DanielArndt
+++ b/doc/news/changes/minor/20180817DanielArndt
@@ -1,0 +1,5 @@
+New: There is LinearAlgebra::CUDAWrappers::Vector::norm_sqr() for computing
+the squared l2-norm and LinearAlgebra::CUDAWrappers::Vector::swap()
+for swapping two vectors.
+<br>
+(Daniel Arndt, 2018/08/17)

--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -45,8 +45,9 @@ namespace LinearAlgebra
      *
      * @note Only float and double are supported.
      *
-     * @ingroup CUDAWrappers Vectors
-     * @author Karl Ljungkvist, Bruno Turcksin, 2016
+     * @see CUDAWrappers
+     * @ingroup Vectors
+     * @author Karl Ljungkvist, Bruno Turcksin, Daniel Arndt, 2016, 2018
      */
     template <typename Number>
     class Vector : public VectorSpaceVector<Number>
@@ -232,6 +233,12 @@ namespace LinearAlgebra
        */
       virtual real_type
       l2_norm() const override;
+
+      /**
+       * Return the square of the $l_2$-norm.
+       */
+      real_type
+      norm_sqr() const;
 
       /**
        * Return the maximum norm of the vector (i.e., the maximum absolute

--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -97,6 +97,24 @@ namespace LinearAlgebra
       operator=(Vector<Number> &&v) = default;
 
       /**
+       * Swap the contents of this vector and the other vector @p v. One could do
+       * this operation with a temporary variable and copying over the data
+       * elements, but this function is significantly more efficient since it
+       * only swaps the pointers to the data of the two vectors and therefore
+       * does not need to allocate temporary storage and move data around.
+       *
+       * This function is analogous to the @p swap function of all C++
+       * standard containers. Also, there is a global function
+       * <tt>swap(u,v)</tt> that simply calls <tt>u.swap(v)</tt>, again in
+       * analogy to standard functions.
+       *
+       * This function is virtual in order to allow for derived classes to
+       * handle memory separately.
+       */
+      virtual void
+      swap(Vector<Number> &v);
+
+      /**
        * Reinit functionality. The flag <tt>omit_zeroing_entries</tt>
        * determines whether the vector should be filled with zero (false) or
        * left untouched (true).
@@ -324,10 +342,31 @@ namespace LinearAlgebra
        */
       size_type n_elements;
     };
+  } // namespace CUDAWrappers
+} // namespace LinearAlgebra
 
+// ---------------------------- Inline functions --------------------------
 
+/**
+ * Global function @p swap which overloads the default implementation of the
+ * C++ standard library which uses a temporary object. The function simply
+ * exchanges the data of the two vectors.
+ *
+ * @relatesalso Vector
+ * @author Daniel Arndt, 2018
+ */
+template <typename Number>
+inline void
+swap(LinearAlgebra::CUDAWrappers::Vector<Number> &u,
+     LinearAlgebra::CUDAWrappers::Vector<Number> &v)
+{
+  u.swap(v);
+}
 
-    // ---------------------------- Inline functions --------------------------
+namespace LinearAlgebra
+{
+  namespace CUDAWrappers
+  {
     template <typename Number>
     inline Number *
     Vector<Number>::get_values() const
@@ -350,6 +389,16 @@ namespace LinearAlgebra
     Vector<Number>::locally_owned_elements() const
     {
       return complete_index_set(n_elements);
+    }
+
+
+
+    template <typename Number>
+    inline void
+    Vector<Number>::swap(Vector<Number> &v)
+    {
+      std::swap(val, v.val);
+      std::swap(n_elements, v.n_elements);
     }
   } // namespace CUDAWrappers
 } // namespace LinearAlgebra

--- a/include/deal.II/lac/solver_fire.h
+++ b/include/deal.II/lac/solver_fire.h
@@ -132,7 +132,8 @@ public:
    * Constructor. Use an object of type GrowingVectorMemory as a default to
    * allocate memory.
    */
-  SolverFIRE(SolverControl &solver_control, const AdditionalData &data);
+  SolverFIRE(SolverControl &       solver_control,
+             const AdditionalData &data = AdditionalData());
 
   /**
    * Virtual destructor.

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -329,13 +329,6 @@ SolverMinRes<VectorType>::solve(const MatrixType &        A,
       // All vectors have to be shifted
       // one iteration step.
       // This should be changed one time.
-      //
-      // the previous code was like this:
-      //   m[2] = m[1];
-      //   m[1] = m[0];
-      // but it can be made more efficient,
-      // since the value of m[0] is no more
-      // needed in the next iteration
       swap(*m[2], *m[1]);
       swap(*m[1], *m[0]);
 

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -457,7 +457,7 @@ SolverQMRS<VectorType>::iterate(const MatrixType &        A,
       // Double and vector updates
       rho               = u * r;
       const double beta = rho / rho_old;
-      q.sadd(beta, u);
+      q.sadd(beta, 1., u);
     }
   return IterationResult(SolverControl::success, res);
 }

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -597,7 +597,16 @@ namespace LinearAlgebra
     typename Vector<Number>::real_type
     Vector<Number>::l2_norm() const
     {
-      return std::sqrt((*this) * (*this));
+      return std::sqrt(norm_sqr());
+    }
+
+
+
+    template <typename Number>
+    typename Vector<Number>::real_type
+    Vector<Number>::norm_sqr() const
+    {
+      return (*this) * (*this);
     }
 
 

--- a/tests/cuda/solver_04.cu
+++ b/tests/cuda/solver_04.cu
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Check that dealii::SolverBicgstab works with CUDAWrappers::SparseMatrix
+
+#include <deal.II/base/cuda.h>
+#include <deal.II/base/exceptions.h>
+
+#include <deal.II/lac/cuda_sparse_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/solver_bicgstab.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/vector.h>
+
+#include "../testmatrix.h"
+#include "../tests.h"
+
+void
+test(Utilities::CUDA::Handle &cuda_handle)
+{
+  // Build the sparse matrix on the host
+  const unsigned int   problem_size = 10;
+  unsigned int         size         = (problem_size - 1) * (problem_size - 1);
+  FDMatrix             testproblem(problem_size, problem_size);
+  SparsityPattern      structure(size, size, 5);
+  SparseMatrix<double> A;
+  testproblem.five_point_structure(structure);
+  structure.compress();
+  A.reinit(structure);
+  testproblem.five_point(A);
+
+  // Solve on the host
+  PreconditionIdentity prec_no;
+  SolverControl        control(100, 1.e-10);
+  SolverBicgstab<>     bicgstab_host(control);
+  Vector<double>       sol_host(size);
+  Vector<double>       rhs_host(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rhs_host[i] = static_cast<double>(i);
+  bicgstab_host.solve(A, sol_host, rhs_host, prec_no);
+
+  // Solve on the device
+  CUDAWrappers::SparseMatrix<double>          A_dev(cuda_handle, A);
+  LinearAlgebra::CUDAWrappers::Vector<double> sol_dev(size);
+  LinearAlgebra::CUDAWrappers::Vector<double> rhs_dev(size);
+  LinearAlgebra::ReadWriteVector<double>      rw_vector(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rw_vector[i] = static_cast<double>(i);
+  rhs_dev.import(rw_vector, VectorOperation::insert);
+  SolverBicgstab<LinearAlgebra::CUDAWrappers::Vector<double>> bicgstab_dev(
+    control);
+  bicgstab_dev.solve(A_dev, sol_dev, rhs_dev, prec_no);
+
+  // Check the result
+  rw_vector.import(sol_dev, VectorOperation::insert);
+  for (unsigned int i = 0; i < size; ++i)
+    AssertThrow(std::fabs(rw_vector[i] - sol_host[i]) < 1e-8,
+                ExcInternalError());
+}
+
+int
+main()
+{
+  initlog();
+  deallog.depth_console(0);
+
+  Utilities::CUDA::Handle cuda_handle;
+  test(cuda_handle);
+
+  deallog << "OK" << std::endl;
+
+  return 0;
+}

--- a/tests/cuda/solver_04.output
+++ b/tests/cuda/solver_04.output
@@ -1,0 +1,6 @@
+
+DEAL:Bicgstab::Starting value 416.989
+DEAL:Bicgstab::Convergence step 23 value 1.39578e-11
+DEAL:Bicgstab::Starting value 416.989
+DEAL:Bicgstab::Convergence step 23 value 1.39578e-11
+DEAL::OK

--- a/tests/cuda/solver_05.cu
+++ b/tests/cuda/solver_05.cu
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Check that dealii::SolverFGMRES works with CUDAWrappers::SparseMatrix
+
+#include <deal.II/base/cuda.h>
+#include <deal.II/base/exceptions.h>
+
+#include <deal.II/lac/cuda_sparse_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/vector.h>
+
+#include "../testmatrix.h"
+#include "../tests.h"
+
+void
+test(Utilities::CUDA::Handle &cuda_handle)
+{
+  // Build the sparse matrix on the host
+  const unsigned int   problem_size = 10;
+  unsigned int         size         = (problem_size - 1) * (problem_size - 1);
+  FDMatrix             testproblem(problem_size, problem_size);
+  SparsityPattern      structure(size, size, 5);
+  SparseMatrix<double> A;
+  testproblem.five_point_structure(structure);
+  structure.compress();
+  A.reinit(structure);
+  testproblem.five_point(A);
+
+  // Solve on the host
+  PreconditionIdentity prec_no;
+  SolverControl        control(100, 1.e-10);
+  SolverFGMRES<>       fgmres_host(control);
+  Vector<double>       sol_host(size);
+  Vector<double>       rhs_host(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rhs_host[i] = static_cast<double>(i);
+  fgmres_host.solve(A, sol_host, rhs_host, prec_no);
+
+  // Solve on the device
+  CUDAWrappers::SparseMatrix<double>          A_dev(cuda_handle, A);
+  LinearAlgebra::CUDAWrappers::Vector<double> sol_dev(size);
+  LinearAlgebra::CUDAWrappers::Vector<double> rhs_dev(size);
+  LinearAlgebra::ReadWriteVector<double>      rw_vector(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rw_vector[i] = static_cast<double>(i);
+  rhs_dev.import(rw_vector, VectorOperation::insert);
+  SolverFGMRES<LinearAlgebra::CUDAWrappers::Vector<double>> fgmres_dev(control);
+  fgmres_dev.solve(A_dev, sol_dev, rhs_dev, prec_no);
+
+  // Check the result
+  rw_vector.import(sol_dev, VectorOperation::insert);
+  for (unsigned int i = 0; i < size; ++i)
+    AssertThrow(std::fabs(rw_vector[i] - sol_host[i]) < 1e-8,
+                ExcInternalError());
+}
+
+int
+main()
+{
+  initlog();
+  deallog.depth_console(0);
+
+  Utilities::CUDA::Handle cuda_handle;
+  test(cuda_handle);
+
+  deallog << "OK" << std::endl;
+
+  return 0;
+}

--- a/tests/cuda/solver_05.output
+++ b/tests/cuda/solver_05.output
@@ -1,0 +1,6 @@
+
+DEAL:FGMRES::Starting value 416.989
+DEAL:FGMRES::Convergence step 31 value 3.31663e-11
+DEAL:FGMRES::Starting value 416.989
+DEAL:FGMRES::Convergence step 31 value 3.31763e-11
+DEAL::OK

--- a/tests/cuda/solver_06.cu
+++ b/tests/cuda/solver_06.cu
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Check that dealii::SolverFIRE works with CUDAWrappers::SparseMatrix
+
+#include <deal.II/base/cuda.h>
+#include <deal.II/base/exceptions.h>
+
+#include <deal.II/lac/cuda_sparse_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_fire.h>
+#include <deal.II/lac/vector.h>
+
+#include "../testmatrix.h"
+#include "../tests.h"
+
+void
+test(Utilities::CUDA::Handle &cuda_handle)
+{
+  // Build the sparse matrix on the host
+  const unsigned int   problem_size = 10;
+  unsigned int         size         = (problem_size - 1) * (problem_size - 1);
+  FDMatrix             testproblem(problem_size, problem_size);
+  SparsityPattern      structure(size, size, 5);
+  SparseMatrix<double> A;
+  testproblem.five_point_structure(structure);
+  structure.compress();
+  A.reinit(structure);
+  testproblem.five_point(A);
+
+  // Solve on the host
+  PreconditionIdentity prec_no;
+  SolverControl        control(10000, 1.e-3);
+  SolverFIRE<>         fire_host(control);
+  Vector<double>       sol_host(size);
+  Vector<double>       rhs_host(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rhs_host[i] = static_cast<double>(i);
+  fire_host.solve(A, sol_host, rhs_host, prec_no);
+
+  // Solve on the device
+  CUDAWrappers::SparseMatrix<double>          A_dev(cuda_handle, A);
+  LinearAlgebra::CUDAWrappers::Vector<double> sol_dev(size);
+  LinearAlgebra::CUDAWrappers::Vector<double> rhs_dev(size);
+  LinearAlgebra::ReadWriteVector<double>      rw_vector(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rw_vector[i] = static_cast<double>(i);
+  rhs_dev.import(rw_vector, VectorOperation::insert);
+  SolverFIRE<LinearAlgebra::CUDAWrappers::Vector<double>> fire_dev(control);
+  fire_dev.solve(A_dev, sol_dev, rhs_dev, prec_no);
+
+  // Check the result
+  rw_vector.import(sol_dev, VectorOperation::insert);
+  for (unsigned int i = 0; i < size; ++i)
+    AssertThrow(std::fabs(rw_vector[i] - sol_host[i]) < 1e-8,
+                ExcInternalError());
+}
+
+int
+main()
+{
+  initlog();
+  deallog.depth_console(0);
+
+  Utilities::CUDA::Handle cuda_handle;
+  test(cuda_handle);
+
+  deallog << "OK" << std::endl;
+
+  return 0;
+}

--- a/tests/cuda/solver_06.output
+++ b/tests/cuda/solver_06.output
@@ -1,0 +1,6 @@
+
+DEAL:FIRE::Starting value 173880.
+DEAL:FIRE::Convergence step 465 value 0.000927878
+DEAL:FIRE::Starting value 173880.
+DEAL:FIRE::Convergence step 465 value 0.000927878
+DEAL::OK

--- a/tests/cuda/solver_07.cu
+++ b/tests/cuda/solver_07.cu
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Check that dealii::SolverMinRes works with CUDAWrappers::SparseMatrix
+
+#include <deal.II/base/cuda.h>
+#include <deal.II/base/exceptions.h>
+
+#include <deal.II/lac/cuda_sparse_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_minres.h>
+#include <deal.II/lac/vector.h>
+
+#include "../testmatrix.h"
+#include "../tests.h"
+
+void
+test(Utilities::CUDA::Handle &cuda_handle)
+{
+  // Build the sparse matrix on the host
+  const unsigned int   problem_size = 10;
+  unsigned int         size         = (problem_size - 1) * (problem_size - 1);
+  FDMatrix             testproblem(problem_size, problem_size);
+  SparsityPattern      structure(size, size, 5);
+  SparseMatrix<double> A;
+  testproblem.five_point_structure(structure);
+  structure.compress();
+  A.reinit(structure);
+  testproblem.five_point(A);
+
+  // Solve on the host
+  PreconditionIdentity prec_no;
+  SolverControl        control(100, 1.e-10);
+  SolverMinRes<>       minres_host(control);
+  Vector<double>       sol_host(size);
+  Vector<double>       rhs_host(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rhs_host[i] = static_cast<double>(i);
+  minres_host.solve(A, sol_host, rhs_host, prec_no);
+
+  // Solve on the device
+  CUDAWrappers::SparseMatrix<double>          A_dev(cuda_handle, A);
+  LinearAlgebra::CUDAWrappers::Vector<double> sol_dev(size);
+  LinearAlgebra::CUDAWrappers::Vector<double> rhs_dev(size);
+  LinearAlgebra::ReadWriteVector<double>      rw_vector(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rw_vector[i] = static_cast<double>(i);
+  rhs_dev.import(rw_vector, VectorOperation::insert);
+  SolverMinRes<LinearAlgebra::CUDAWrappers::Vector<double>> minres_dev(control);
+  minres_dev.solve(A_dev, sol_dev, rhs_dev, prec_no);
+
+  // Check the result
+  rw_vector.import(sol_dev, VectorOperation::insert);
+  for (unsigned int i = 0; i < size; ++i)
+    AssertThrow(std::fabs(rw_vector[i] - sol_host[i]) < 1e-8,
+                ExcInternalError());
+}
+
+int
+main()
+{
+  initlog();
+  deallog.depth_console(0);
+
+  Utilities::CUDA::Handle cuda_handle;
+  test(cuda_handle);
+
+  deallog << "OK" << std::endl;
+
+  return 0;
+}

--- a/tests/cuda/solver_07.output
+++ b/tests/cuda/solver_07.output
@@ -1,0 +1,6 @@
+
+DEAL:minres::Starting value 416.989
+DEAL:minres::Convergence step 31 value 8.71122e-12
+DEAL:minres::Starting value 416.989
+DEAL:minres::Convergence step 31 value 8.71119e-12
+DEAL::OK

--- a/tests/cuda/solver_08.cu
+++ b/tests/cuda/solver_08.cu
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Check that dealii::SolverQMRS works with CUDAWrappers::SparseMatrix
+
+#include <deal.II/base/cuda.h>
+#include <deal.II/base/exceptions.h>
+
+#include <deal.II/lac/cuda_sparse_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_qmrs.h>
+#include <deal.II/lac/vector.h>
+
+#include "../testmatrix.h"
+#include "../tests.h"
+
+void
+test(Utilities::CUDA::Handle &cuda_handle)
+{
+  // Build the sparse matrix on the host
+  const unsigned int   problem_size = 10;
+  unsigned int         size         = (problem_size - 1) * (problem_size - 1);
+  FDMatrix             testproblem(problem_size, problem_size);
+  SparsityPattern      structure(size, size, 5);
+  SparseMatrix<double> A;
+  testproblem.five_point_structure(structure);
+  structure.compress();
+  A.reinit(structure);
+  testproblem.five_point(A);
+
+  // Solve on the host
+  PreconditionIdentity prec_no;
+  SolverControl        control(1000, 1.e-3);
+  SolverQMRS<>         qmrs_host(control);
+  Vector<double>       sol_host(size);
+  Vector<double>       rhs_host(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rhs_host[i] = static_cast<double>(i);
+  qmrs_host.solve(A, sol_host, rhs_host, prec_no);
+
+  // Solve on the device
+  CUDAWrappers::SparseMatrix<double>          A_dev(cuda_handle, A);
+  LinearAlgebra::CUDAWrappers::Vector<double> sol_dev(size);
+  LinearAlgebra::CUDAWrappers::Vector<double> rhs_dev(size);
+  LinearAlgebra::ReadWriteVector<double>      rw_vector(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rw_vector[i] = static_cast<double>(i);
+  rhs_dev.import(rw_vector, VectorOperation::insert);
+  SolverQMRS<LinearAlgebra::CUDAWrappers::Vector<double>> qmrs_dev(control);
+  qmrs_dev.solve(A_dev, sol_dev, rhs_dev, prec_no);
+
+  // Check the result
+  rw_vector.import(sol_dev, VectorOperation::insert);
+  for (unsigned int i = 0; i < size; ++i)
+    AssertThrow(std::fabs(rw_vector[i] - sol_host[i]) < 1e-8,
+                ExcInternalError());
+}
+
+int
+main()
+{
+  initlog();
+  deallog.depth_console(0);
+
+  Utilities::CUDA::Handle cuda_handle;
+  test(cuda_handle);
+
+  deallog << "OK" << std::endl;
+
+  return 0;
+}

--- a/tests/cuda/solver_08.output
+++ b/tests/cuda/solver_08.output
@@ -1,0 +1,6 @@
+
+DEAL:SQMR::Starting value 416.989
+DEAL:SQMR::Convergence step 22 value 0.000879597
+DEAL:SQMR::Starting value 416.989
+DEAL:SQMR::Convergence step 22 value 0.000879597
+DEAL::OK

--- a/tests/cuda/solver_09.cu
+++ b/tests/cuda/solver_09.cu
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Check that dealii::SolverRichardson works with CUDAWrappers::SparseMatrix
+
+#include <deal.II/base/cuda.h>
+#include <deal.II/base/exceptions.h>
+
+#include <deal.II/lac/cuda_sparse_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_richardson.h>
+#include <deal.II/lac/vector.h>
+
+#include "../testmatrix.h"
+#include "../tests.h"
+
+template <typename MatrixType>
+class PreconditionOperator
+{
+public:
+  PreconditionOperator(const MatrixType &inverse_diagonal_matrix_)
+    : inverse_diagonal_matrix(inverse_diagonal_matrix_)
+  {}
+
+  template <typename VectorType>
+  void
+  vmult(VectorType &u, const VectorType &v) const
+  {
+    inverse_diagonal_matrix.vmult(u, v);
+  }
+
+private:
+  const MatrixType &inverse_diagonal_matrix;
+};
+
+
+void
+test(Utilities::CUDA::Handle &cuda_handle)
+{
+  // Build the sparse matrix on the host
+  const unsigned int   problem_size = 10;
+  unsigned int         size         = (problem_size - 1) * (problem_size - 1);
+  FDMatrix             testproblem(problem_size, problem_size);
+  SparsityPattern      structure(size, size, 5);
+  SparseMatrix<double> A;
+  testproblem.five_point_structure(structure);
+  structure.compress();
+  A.reinit(structure);
+  testproblem.five_point(A);
+  SparseMatrix<double> A_diagonal_inverse;
+  A_diagonal_inverse.reinit(structure);
+  for (unsigned int i = 0; i < size; ++i)
+    A_diagonal_inverse(i, i) = 1. / A(i, i);
+
+  // Solve on the host
+  PreconditionOperator<SparseMatrix<double>> preconditioner(A_diagonal_inverse);
+  SolverControl                              control(1000, 1.e-2);
+  SolverRichardson<>                         richardson_host(control);
+  Vector<double>                             sol_host(size);
+  Vector<double>                             rhs_host(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rhs_host[i] = static_cast<double>(i);
+  richardson_host.solve(A, sol_host, rhs_host, preconditioner);
+
+  // Solve on the device
+  CUDAWrappers::SparseMatrix<double> A_dev(cuda_handle, A);
+  CUDAWrappers::SparseMatrix<double> A_diagonal_inverse_dev(cuda_handle,
+                                                            A_diagonal_inverse);
+  PreconditionOperator<CUDAWrappers::SparseMatrix<double>> preconditioner_dev(
+    A_diagonal_inverse_dev);
+  LinearAlgebra::CUDAWrappers::Vector<double> sol_dev(size);
+  LinearAlgebra::CUDAWrappers::Vector<double> rhs_dev(size);
+  LinearAlgebra::ReadWriteVector<double>      rw_vector(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rw_vector[i] = static_cast<double>(i);
+  rhs_dev.import(rw_vector, VectorOperation::insert);
+  SolverRichardson<LinearAlgebra::CUDAWrappers::Vector<double>> richardson_dev(
+    control);
+  richardson_dev.solve(A_dev, sol_dev, rhs_dev, preconditioner_dev);
+
+  // Check the result
+  rw_vector.import(sol_dev, VectorOperation::insert);
+  for (unsigned int i = 0; i < size; ++i)
+    AssertThrow(std::fabs(rw_vector[i] - sol_host[i]) < 1e-8,
+                ExcInternalError());
+}
+
+int
+main()
+{
+  initlog();
+  deallog.depth_console(0);
+
+  Utilities::CUDA::Handle cuda_handle;
+  test(cuda_handle);
+
+  deallog << "OK" << std::endl;
+
+  return 0;
+}

--- a/tests/cuda/solver_09.output
+++ b/tests/cuda/solver_09.output
@@ -1,0 +1,6 @@
+
+DEAL:Richardson::Starting value 416.989
+DEAL:Richardson::Convergence step 207 value 0.00982595
+DEAL:Richardson::Starting value 416.989
+DEAL:Richardson::Convergence step 207 value 0.00982595
+DEAL::OK

--- a/tests/cuda/solver_10.cu
+++ b/tests/cuda/solver_10.cu
@@ -1,0 +1,134 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Check that dealii::SolverRelaxation works with CUDAWrappers::SparseMatrix
+
+#include <deal.II/base/cuda.h>
+#include <deal.II/base/exceptions.h>
+
+#include <deal.II/lac/cuda_sparse_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_relaxation.h>
+#include <deal.II/lac/vector.h>
+
+#include "../testmatrix.h"
+#include "../tests.h"
+
+
+template <typename MatrixType>
+class RelaxationOperator
+{
+public:
+  RelaxationOperator(const MatrixType &system_matrix_,
+                     const MatrixType &inverse_diagonal_matrix_)
+    : system_matrix(system_matrix_)
+    , inverse_diagonal_matrix(inverse_diagonal_matrix_)
+  {}
+
+  template <typename VectorType>
+  void
+  step(VectorType &u, const VectorType &v) const
+  {
+    // u = u - omega*inverse_diagonal_matrix*(system_matrix*u-v)
+    const double omega = 1.;
+    VectorType   tmp_1(v.size());
+    system_matrix.vmult(tmp_1, u);
+    tmp_1 -= v;
+    VectorType tmp_2(u.size());
+    inverse_diagonal_matrix.vmult(tmp_2, tmp_1);
+    tmp_2 *= omega;
+    u -= tmp_2;
+  }
+
+  template <typename VectorType>
+  void
+  Tstep(VectorType &u, const VectorType &v) const
+  {
+    AssertThrow(false, ExcNotImplemented());
+  }
+
+private:
+  const MatrixType &system_matrix;
+  const MatrixType &inverse_diagonal_matrix;
+};
+
+
+void
+test(Utilities::CUDA::Handle &cuda_handle)
+{
+  // Build the sparse matrix on the host
+  const unsigned int   problem_size = 10;
+  unsigned int         size         = (problem_size - 1) * (problem_size - 1);
+  FDMatrix             testproblem(problem_size, problem_size);
+  SparsityPattern      structure(size, size, 5);
+  SparseMatrix<double> A;
+  testproblem.five_point_structure(structure);
+  structure.compress();
+  A.reinit(structure);
+  testproblem.five_point(A);
+  SparseMatrix<double> A_diagonal_inverse;
+  A_diagonal_inverse.reinit(structure);
+  for (unsigned int i = 0; i < size; ++i)
+    A_diagonal_inverse(i, i) = 1. / A(i, i);
+
+  // Solve on the host
+  RelaxationOperator<SparseMatrix<double>> relaxation_operator(
+    A, A_diagonal_inverse);
+  SolverControl      control(1000, 1.e-3);
+  SolverRelaxation<> relaxation_host(control);
+  Vector<double>     sol_host(size);
+  Vector<double>     rhs_host(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rhs_host[i] = static_cast<double>(i);
+  relaxation_host.solve(A, sol_host, rhs_host, relaxation_operator);
+
+  // Solve on the device
+  CUDAWrappers::SparseMatrix<double> A_dev(cuda_handle, A);
+  CUDAWrappers::SparseMatrix<double> A_diagonal_inverse_dev(cuda_handle,
+                                                            A_diagonal_inverse);
+  RelaxationOperator<CUDAWrappers::SparseMatrix<double>>
+                                              relaxation_operator_dev(A_dev, A_diagonal_inverse_dev);
+  LinearAlgebra::CUDAWrappers::Vector<double> sol_dev(size);
+  LinearAlgebra::CUDAWrappers::Vector<double> rhs_dev(size);
+  LinearAlgebra::ReadWriteVector<double>      rw_vector(size);
+  for (unsigned int i = 0; i < size; ++i)
+    rw_vector[i] = static_cast<double>(i);
+  rhs_dev.import(rw_vector, VectorOperation::insert);
+  SolverRelaxation<LinearAlgebra::CUDAWrappers::Vector<double>> relaxation_dev(
+    control);
+  relaxation_dev.solve(A_dev, sol_dev, rhs_dev, relaxation_operator_dev);
+
+  // Check the result
+  rw_vector.import(sol_dev, VectorOperation::insert);
+  for (unsigned int i = 0; i < size; ++i)
+    AssertThrow(std::fabs(rw_vector[i] - sol_host[i]) < 1e-8,
+                ExcInternalError());
+}
+
+int
+main()
+{
+  initlog();
+  deallog.depth_console(10);
+
+  Utilities::CUDA::Handle cuda_handle;
+  test(cuda_handle);
+
+  deallog << "OK" << std::endl;
+
+  return 0;
+}

--- a/tests/cuda/solver_10.output
+++ b/tests/cuda/solver_10.output
@@ -1,0 +1,6 @@
+
+DEAL:Relaxation::Starting value 416.989
+DEAL:Relaxation::Convergence step 253 value 0.000976934
+DEAL:Relaxation::Starting value 416.989
+DEAL:Relaxation::Convergence step 253 value 0.000976934
+DEAL::OK


### PR DESCRIPTION
Builds on #7072.
Specifically, this PR
- adds `CUDAWrappers::Vector::norm_sqr()` needed for `SolverQMRS`,
- fixes a call in `SolverQMRS` to `VectorType::sadd(double, VectorType)` to using `VectorType::sadd(double, double, VectorType)` (which is part of the common interface),
- replaces the assignment in `SolverMINRES` using `swap` to one using move semantics, and
- adds a test for all the remaining iterative solvers.