### PR TITLE
AssertNothrowCUDA and AssertNothrowCusparse

### DIFF
--- a/doc/news/changes/minor/20180820DanielArndt-1
+++ b/doc/news/changes/minor/20180820DanielArndt-1
@@ -1,0 +1,4 @@
+New: There are nothrow versions of AssertCUDA and AssertCusparse, namely
+AssertNothrowCUDA and AssertNothrowCusparse.
+<br>
+(Daniel Arndt, 2018/08/20)

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1467,6 +1467,23 @@ namespace internal
 #  endif
 
 /**
+ * The non-throwing equivalent of AssertCuda.
+ *
+ * @ingroup Exceptions
+ * @author Daniel Arndt, 2018
+ */
+#  ifdef DEBUG
+#    define AssertNothrowCuda(error_code)      \
+      AssertNothrow(error_code == cudaSuccess, \
+                    dealii::ExcCudaError(cudaGetErrorString(error_code)))
+#  else
+#    define AssertNothrowCuda(error_code) \
+      {                                   \
+        (void)(error_code);               \
+      }
+#  endif
+
+/**
  * An assertion that checks that the error code produced by calling a cuSPARSE
  * routine is equal to CUSPARSE_STATUS_SUCCESS.
  *
@@ -1487,6 +1504,33 @@ namespace internal
       }
 #  endif
 
+/**
+ * The non-throwing equivalent of AssertCusparse.
+ *
+ * @ingroup Exceptions
+ * @author Daniel Arndt, 2018
+ */
+#  ifdef DEBUG
+#    define AssertNothrowCusparse(error_code)                               \
+      AssertNothrow(                                                        \
+        error_code == CUSPARSE_STATUS_SUCCESS,                              \
+        dealii::ExcCusparseError(                                           \
+          dealii::deal_II_exceptions::internals::get_cusparse_error_string( \
+            error_code)))
+#  else
+#    define AssertNothrowCusparse(error_code) \
+      {                                       \
+        (void)(error_code);                   \
+      }
+#  endif
+
+/**
+ * An assertion that checks that the error code produced by calling a cuSOLVER
+ * routine is equal to CUSOLVER_STATUS_SUCCESS.
+ *
+ * @ingroup Exceptions
+ * @author Bruno Turcksin, 2018
+ */
 #  ifdef DEBUG
 #    define AssertCusolver(error_code)                                      \
       Assert(                                                               \

--- a/source/lac/cuda_sparse_matrix.cu
+++ b/source/lac/cuda_sparse_matrix.cu
@@ -218,29 +218,30 @@ namespace CUDAWrappers
   {
     if (val_dev != nullptr)
       {
-        cudaError_t error_code = cudaFree(val_dev);
-        AssertCuda(error_code);
+        const cudaError_t error_code = cudaFree(val_dev);
+        AssertNothrowCuda(error_code);
         val_dev = nullptr;
       }
 
     if (column_index_dev != nullptr)
       {
-        cudaError_t error_code = cudaFree(column_index_dev);
-        AssertCuda(error_code);
+        const cudaError_t error_code = cudaFree(column_index_dev);
+        AssertNothrowCuda(error_code);
         column_index_dev = nullptr;
       }
 
     if (row_ptr_dev != nullptr)
       {
-        cudaError_t error_code = cudaFree(row_ptr_dev);
-        AssertCuda(error_code);
+        const cudaError_t error_code = cudaFree(row_ptr_dev);
+        AssertNothrowCuda(error_code);
         row_ptr_dev = nullptr;
       }
 
     if (descr != nullptr)
       {
-        cusparseStatus_t cusparse_error_code = cusparseDestroyMatDescr(descr);
-        AssertCusparse(cusparse_error_code);
+        const cusparseStatus_t cusparse_error_code =
+          cusparseDestroyMatDescr(descr);
+        AssertNothrowCusparse(cusparse_error_code);
         descr = nullptr;
       }
 


### PR DESCRIPTION
This PR adds `nothrow` versions of `AssertCUDA` and `AssertCusparse`, namely `AssertNothrowCUDA` and `AssertNothrowCusparse`.