### PR TITLE
Replace Utilities::fixed_int_power by Utilities::pow

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -1550,10 +1550,9 @@ namespace internal
           Utilities::pow(fe_degree + 1, dim - 1) :
           (dim > 1 ? Utilities::fixed_power<dim - 1>(data.fe_degree + 1) : 1);
 
-      const unsigned int n_q_points =
-        fe_degree > -1 ?
-          Utilities::fixed_int_power<n_q_points_1d, dim - 1>::value :
-          data.n_q_points_face;
+      const unsigned int n_q_points = fe_degree > -1 ?
+                                        Utilities::pow(n_q_points_1d, dim - 1) :
+                                        data.n_q_points_face;
 
       if (integrate_grad == false)
         for (unsigned int c = 0; c < n_components; ++c)

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -353,7 +353,7 @@ MGTransferMatrixFree<dim, Number>::do_prolongate_add(
   const unsigned int n_child_dofs_1d = 2 * degree_size - element_is_continuous;
   const unsigned int n_scalar_cell_dofs =
     Utilities::fixed_power<dim>(n_child_dofs_1d);
-  const unsigned int three_to_dim = Utilities::fixed_int_power<3, dim>::value;
+  constexpr unsigned int three_to_dim = Utilities::pow(3, dim);
 
   for (unsigned int cell = 0; cell < n_owned_level_cells[to_level - 1];
        cell += vec_size)
@@ -468,7 +468,7 @@ MGTransferMatrixFree<dim, Number>::do_restrict_add(
   const unsigned int n_child_dofs_1d = 2 * degree_size - element_is_continuous;
   const unsigned int n_scalar_cell_dofs =
     Utilities::fixed_power<dim>(n_child_dofs_1d);
-  const unsigned int three_to_dim = Utilities::fixed_int_power<3, dim>::value;
+  constexpr unsigned int three_to_dim = Utilities::pow(3, dim);
 
   for (unsigned int cell = 0; cell < n_owned_level_cells[from_level - 1];
        cell += vec_size)

--- a/tests/cuda/matrix_vector_mf.h
+++ b/tests/cuda/matrix_vector_mf.h
@@ -63,9 +63,9 @@ public:
 
   static const unsigned int n_dofs_1d = fe_degree + 1;
   static const unsigned int n_local_dofs =
-    dealii::Utilities::fixed_int_power<fe_degree + 1, dim>::value;
+    dealii::Utilities::pow(fe_degree + 1, dim);
   static const unsigned int n_q_points =
-    dealii::Utilities::fixed_int_power<n_q_points_1d, dim>::value;
+    dealii::Utilities::pow(n_q_points_1d, dim);
 };
 
 

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -232,8 +232,7 @@ check(const unsigned int orientation, bool reverse)
     }
   const unsigned int n_constraints =
     Utilities::MPI::sum(n_local_constraints, MPI_COMM_WORLD);
-  const unsigned int n_expected_constraints =
-    Utilities::fixed_int_power<9, dim - 1>::value;
+  constexpr unsigned int n_expected_constraints = Utilities::pow(9, dim - 1);
   if (myid == 0)
     deallog << "n_constraints: " << n_constraints
             << " n_expected_constraints: " << n_expected_constraints


### PR DESCRIPTION
In the spirit of #7085, this replaces the remaining occurrences of `Utilities::fixed_int_power` in the code base.