### PR TITLE
Add table iterators

### DIFF
--- a/doc/news/changes/minor/20180820DavidWells
+++ b/doc/news/changes/minor/20180820DavidWells
@@ -1,0 +1,4 @@
+New: Table and FullMatrix now have complete (both mutable and const)
+random-access iterators.
+<br>
+(David Wells, 2018/08/20)

--- a/include/deal.II/base/linear_index_iterator.h
+++ b/include/deal.II/base/linear_index_iterator.h
@@ -504,7 +504,7 @@ inline bool
 LinearIndexIterator<DerivedIterator, AccessorType>::
 operator>(const DerivedIterator &other) const
 {
-  return other < *this;
+  return other < static_cast<const DerivedIterator &>(*this);
 }
 
 

--- a/include/deal.II/base/polynomials_abf.h
+++ b/include/deal.II/base/polynomials_abf.h
@@ -23,7 +23,6 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 #include <deal.II/base/thread_management.h>

--- a/include/deal.II/base/polynomials_bdm.h
+++ b/include/deal.II/base/polynomials_bdm.h
@@ -23,7 +23,6 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/thread_management.h>
 

--- a/include/deal.II/base/polynomials_nedelec.h
+++ b/include/deal.II/base/polynomials_nedelec.h
@@ -24,7 +24,6 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 

--- a/include/deal.II/base/polynomials_p.h
+++ b/include/deal.II/base/polynomials_p.h
@@ -23,7 +23,6 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
 
 #include <vector>

--- a/include/deal.II/base/polynomials_raviart_thomas.h
+++ b/include/deal.II/base/polynomials_raviart_thomas.h
@@ -23,7 +23,6 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 

--- a/include/deal.II/base/polynomials_rt_bubbles.h
+++ b/include/deal.II/base/polynomials_rt_bubbles.h
@@ -23,7 +23,6 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_raviart_thomas.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
 
 #include <vector>

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -25,6 +25,8 @@
 #include <deal.II/fe/fe_values_extractors.h>
 #include <deal.II/fe/mapping.h>
 
+#include <deal.II/lac/full_matrix.h>
+
 #include <memory>
 
 

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -19,19 +19,9 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/geometry_info.h>
-#include <deal.II/base/point.h>
-#include <deal.II/base/subscriptor.h>
-#include <deal.II/base/table.h>
-#include <deal.II/base/tensor.h>
-#include <deal.II/base/vector_slice.h>
-
-#include <deal.II/fe/fe_update_flags.h>
 
 #include <deal.II/lac/block_indices.h>
-#include <deal.II/lac/full_matrix.h>
 
-#include <string>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/fe/fe_bdm.h
+++ b/include/deal.II/fe/fe_bdm.h
@@ -21,7 +21,6 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_bdm.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
 #include <deal.II/fe/fe.h>

--- a/include/deal.II/fe/fe_bernardi_raugel.h
+++ b/include/deal.II/fe/fe_bernardi_raugel.h
@@ -21,7 +21,6 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_bernardi_raugel.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
 #include <deal.II/fe/fe.h>

--- a/include/deal.II/fe/fe_rt_bubbles.h
+++ b/include/deal.II/fe/fe_rt_bubbles.h
@@ -21,7 +21,6 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_rt_bubbles.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
 #include <deal.II/fe/fe.h>

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -25,7 +25,6 @@
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/symmetric_tensor.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/vector_slice.h>
 
 #include <deal.II/dofs/dof_accessor.h>

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -19,8 +19,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/table.h>
-
 #include <deal.II/fe/mapping.h>
 
 #include <cmath>

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -19,7 +19,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/table.h>
 #include <deal.II/base/thread_management.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -19,16 +19,11 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/array_view.h>
 #include <deal.II/base/derivative_form.h>
-#include <deal.II/base/qprojector.h>
-#include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/table.h>
-
-#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/base/quadrature.h>
 
 #include <deal.II/fe/mapping.h>
-
-#include <deal.II/grid/tria_iterator.h>
 
 #include <cmath>
 

--- a/include/deal.II/lac/block_sparse_matrix.h
+++ b/include/deal.II/lac/block_sparse_matrix.h
@@ -19,8 +19,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/table.h>
-
 #include <deal.II/lac/block_matrix_base.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/block_vector.h>

--- a/include/deal.II/lac/petsc_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_block_sparse_matrix.h
@@ -21,8 +21,6 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
-#  include <deal.II/base/table.h>
-
 #  include <deal.II/lac/block_matrix_base.h>
 #  include <deal.II/lac/block_sparsity_pattern.h>
 #  include <deal.II/lac/exceptions.h>

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -21,7 +21,6 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 
-#  include <deal.II/base/table.h>
 #  include <deal.II/base/template_constraints.h>
 
 #  include <deal.II/lac/block_matrix_base.h>

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -13,7 +13,6 @@
 //
 // ---------------------------------------------------------------------
 
-#include <deal.II/base/table.h>
 #include <deal.II/base/table_handler.h>
 
 #include <boost/io/ios_state.hpp>

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -15,7 +15,6 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/polynomials_piecewise.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
 #include <boost/container/small_vector.hpp>

--- a/source/base/tensor_product_polynomials_bubbles.cc
+++ b/source/base/tensor_product_polynomials_bubbles.cc
@@ -15,7 +15,6 @@
 
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor_product_polynomials_bubbles.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/base/tensor_product_polynomials_const.cc
+++ b/source/base/tensor_product_polynomials_const.cc
@@ -15,7 +15,6 @@
 
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor_product_polynomials_const.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -18,7 +18,6 @@
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/std_cxx14/memory.h>
-#include <deal.II/base/table.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -18,7 +18,6 @@
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/std_cxx14/memory.h>
-#include <deal.II/base/table.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -17,7 +17,6 @@
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/std_cxx14/memory.h>
-#include <deal.II/base/table.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 

--- a/source/fe/fe_rt_bubbles.cc
+++ b/source/fe/fe_rt_bubbles.cc
@@ -17,7 +17,6 @@
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/std_cxx14/memory.h>
-#include <deal.II/base/table.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -24,9 +24,7 @@
 #include <deal.II/base/table.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
-#include <deal.II/dofs/dof_accessor.h>
-
-#include <deal.II/fe/fe.h>
+#include <deal.II/fe/fe_base.h>
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_q1.h>

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -17,7 +17,6 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/std_cxx14/memory.h>
-#include <deal.II/base/table.h>
 
 #include <deal.II/fe/mapping_q1.h>
 

--- a/tests/full_matrix/full_matrix_iterator_01.cc
+++ b/tests/full_matrix/full_matrix_iterator_01.cc
@@ -22,16 +22,20 @@
 #include "../tests.h"
 
 
+template <typename IteratorType>
 void
 test()
 {
   FullMatrix<double> A(3, 3);
 
   // test prefix operator
-  const FullMatrix<double>::const_iterator k = A.begin(), j = ++A.begin();
+  const IteratorType k = A.begin(), j = ++A.begin();
 
   AssertThrow(k < j, ExcInternalError());
   AssertThrow(j > k, ExcInternalError());
+
+  AssertThrow(k <= j, ExcInternalError());
+  AssertThrow(j >= k, ExcInternalError());
 
   AssertThrow(!(j < k), ExcInternalError());
   AssertThrow(!(k > j), ExcInternalError());
@@ -43,15 +47,12 @@ test()
   AssertThrow(!(k != k), ExcInternalError());
 
   // test postfix operator
-  FullMatrix<double>::const_iterator l = A.begin();
-  FullMatrix<double>::const_iterator m = l++;
+  IteratorType l = A.begin();
+  IteratorType m = l++;
 
   AssertThrow(m == k, ExcInternalError());
   AssertThrow(l > m, ExcInternalError());
   AssertThrow(l->column() == k->column() + 1, ExcInternalError());
-
-
-  deallog << "OK" << std::endl;
 }
 
 
@@ -63,7 +64,9 @@ main()
 
   try
     {
-      test();
+      test<FullMatrix<double>::iterator>();
+      test<FullMatrix<double>::const_iterator>();
+      deallog << "OK" << std::endl;
     }
   catch (std::exception &exc)
     {


### PR DESCRIPTION
Follow-up to #5959: this commit adds iterator interfaces to `Table` (and, subsequently, `FullMatrix`) based on the work done in the first PR.

I also went ahead and cleaned up our `table.h` inclusions: there were a lot of places where we `#include`ed this header that are no longer necessary.