### PR TITLE
Matrixfree vectorization mask

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -220,7 +220,11 @@ public:
    * sums them into the vector @p dst. The function also applies constraints
    * during the write operation. The functionality is hence similar to the
    * function AffineConstraints::distribute_local_to_global. If vectorization
-   * is enabled, the DoF values for several cells are used.
+   * is enabled, the DoF values for several cells are used. The mask can be
+   * used to suppress the write access for some of the vectorized cells, e.g.
+   * in case of local time stepping, where some cells are excluded from a
+   * call. A value of `true` in the bitset means that the respective lane
+   * index will be processed, whereas a value of `false` skips this index.
    *
    * If this class was constructed without a MatrixFree object and the
    * information is acquired on the fly through a
@@ -240,8 +244,11 @@ public:
    */
   template <typename VectorType>
   void
-  distribute_local_to_global(VectorType &       dst,
-                             const unsigned int first_index = 0) const;
+  distribute_local_to_global(
+    VectorType &       dst,
+    const unsigned int first_index = 0,
+    const std::bitset<VectorizedArray<Number>::n_array_elements> mask =
+      std::bitset<VectorizedArray<Number>::n_array_elements>().flip()) const;
 
   /**
    * Takes the values stored internally on dof values of the current cell and
@@ -251,7 +258,11 @@ public:
    * by the current cell are overwritten. Thus, if a degree of freedom is
    * associated to more than one cell (as usual in continuous finite
    * elements), the values will be overwritten and only the value written last
-   * is retained.
+   * is retained. The mask can be used to suppress the write access for some
+   * of the vectorized cells, e.g. in case of local time stepping, where some
+   * cells are excluded from a call. A value of `true` in the bitset means
+   * that the respective lane index will be processed, whereas a value of
+   * `false` skips this index.
    *
    * If this class was constructed without a MatrixFree object and the
    * information is acquired on the fly through a
@@ -271,7 +282,11 @@ public:
    */
   template <typename VectorType>
   void
-  set_dof_values(VectorType &dst, const unsigned int first_index = 0) const;
+  set_dof_values(
+    VectorType &       dst,
+    const unsigned int first_index = 0,
+    const std::bitset<VectorizedArray<Number>::n_array_elements> mask =
+      std::bitset<VectorizedArray<Number>::n_array_elements>().flip()) const;
 
   //@}
 
@@ -786,9 +801,11 @@ protected:
    */
   template <typename VectorType, typename VectorOperation>
   void
-  read_write_operation(const VectorOperation &operation,
-                       VectorType *           vectors[],
-                       const bool             apply_constraints = true) const;
+  read_write_operation(
+    const VectorOperation &                                      operation,
+    VectorType *                                                 vectors[],
+    const std::bitset<VectorizedArray<Number>::n_array_elements> mask,
+    const bool apply_constraints = true) const;
 
   /**
    * A unified function to read from and write into vectors based on the given
@@ -799,8 +816,10 @@ protected:
    */
   template <typename VectorType, typename VectorOperation>
   void
-  read_write_operation_contiguous(const VectorOperation &operation,
-                                  VectorType *           vectors[]) const;
+  read_write_operation_contiguous(
+    const VectorOperation &                                      operation,
+    VectorType *                                                 vectors[],
+    const std::bitset<VectorizedArray<Number>::n_array_elements> mask) const;
 
   /**
    * A unified function to read from and write into vectors based on the given
@@ -3927,9 +3946,10 @@ template <int dim, int n_components_, typename Number, bool is_face>
 template <typename VectorType, typename VectorOperation>
 inline void
 FEEvaluationBase<dim, n_components_, Number, is_face>::read_write_operation(
-  const VectorOperation &operation,
-  VectorType *           src[],
-  const bool             apply_constraints) const
+  const VectorOperation &                                      operation,
+  VectorType *                                                 src[],
+  const std::bitset<VectorizedArray<Number>::n_array_elements> mask,
+  const bool apply_constraints) const
 {
   // Case 1: No MatrixFree object given, simple case because we do not need to
   // process constraints and need not care about vectorization -> go to
@@ -3960,7 +3980,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::read_write_operation(
         [cell] >=
       internal::MatrixFreeFunctions::DoFInfo::IndexStorageVariants::contiguous)
     {
-      read_write_operation_contiguous(operation, src);
+      read_write_operation_contiguous(operation, src, mask);
       return;
     }
 
@@ -3969,6 +3989,9 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::read_write_operation(
 
   constexpr unsigned int n_vectorization =
     VectorizedArray<Number>::n_array_elements;
+  Assert(mask.count() == n_vectorization,
+         ExcNotImplemented("Masking currently not implemented for "
+                           "non-contiguous DoF storage"));
   const unsigned int dofs_per_component =
     this->data->dofs_per_component_on_cell;
   if (dof_info->index_storage_variants
@@ -4371,8 +4394,10 @@ template <int dim, int n_components_, typename Number, bool is_face>
 template <typename VectorType, typename VectorOperation>
 inline void
 FEEvaluationBase<dim, n_components_, Number, is_face>::
-  read_write_operation_contiguous(const VectorOperation &operation,
-                                  VectorType *           src[]) const
+  read_write_operation_contiguous(
+    const VectorOperation &                                      operation,
+    VectorType *                                                 src[],
+    const std::bitset<VectorizedArray<Number>::n_array_elements> mask) const
 {
   // This functions processes the functions read_dof_values,
   // distribute_local_to_global, and set_dof_values with the same code for
@@ -4388,6 +4413,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::
   const internal::MatrixFreeFunctions::DoFInfo::DoFAccessIndex ind =
     is_face ? dof_access_index :
               internal::MatrixFreeFunctions::DoFInfo::dof_access_cell;
+  const unsigned int n_lanes = mask.count();
 
   const std::vector<unsigned int> &dof_indices_cont =
     dof_info->dof_indices_contiguous[ind];
@@ -4395,8 +4421,9 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::
   // Simple case: We have contiguous storage, so we can simply copy out the
   // data
   if (dof_info->index_storage_variants[ind][cell] ==
-      internal::MatrixFreeFunctions::DoFInfo::IndexStorageVariants::
-        interleaved_contiguous)
+        internal::MatrixFreeFunctions::DoFInfo::IndexStorageVariants::
+          interleaved_contiguous &&
+      n_lanes == VectorizedArray<Number>::n_array_elements)
     {
       const unsigned int dof_index =
         dof_indices_cont[cell * VectorizedArray<Number>::n_array_elements] +
@@ -4424,6 +4451,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::
   // some transformations
   const unsigned int vectorization_populated =
     dof_info->n_vectorization_lanes_filled[ind][this->cell];
+
   unsigned int dof_indices[VectorizedArray<Number>::n_array_elements];
   for (unsigned int v = 0; v < vectorization_populated; ++v)
     dof_indices[v] =
@@ -4432,6 +4460,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::
                                             [first_selected_component] *
         dof_info->dof_indices_interleave_strides
           [ind][cell * VectorizedArray<Number>::n_array_elements + v];
+
   for (unsigned int v = vectorization_populated;
        v < VectorizedArray<Number>::n_array_elements;
        ++v)
@@ -4439,7 +4468,8 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::
 
   // In the case with contiguous cell indices, we know that there are no
   // constraints and that the indices within each element are contiguous
-  if (vectorization_populated == VectorizedArray<Number>::n_array_elements)
+  if (vectorization_populated == VectorizedArray<Number>::n_array_elements &&
+      n_lanes == VectorizedArray<Number>::n_array_elements)
     {
       if (dof_info->index_storage_variants[ind][cell] ==
           internal::MatrixFreeFunctions::DoFInfo::IndexStorageVariants::
@@ -4543,20 +4573,23 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::
           {
             if (n_components == 1 || n_fe_components == 1)
               for (unsigned int v = 0; v < vectorization_populated; ++v)
-                for (unsigned int i = 0; i < data->dofs_per_component_on_cell;
-                     ++i)
-                  operation.process_dof(dof_indices[v] + i,
-                                        *src[comp],
-                                        values_dofs[comp][i][v]);
-            else
-              for (unsigned int v = 0; v < vectorization_populated; ++v)
-                for (unsigned int i = 0; i < data->dofs_per_component_on_cell;
-                     ++i)
-                  operation.process_dof(dof_indices[v] + i +
-                                          comp *
-                                            data->dofs_per_component_on_cell,
-                                        *src[0],
-                                        values_dofs[comp][i][v]);
+                if (mask[v] == true)
+                  for (unsigned int i = 0; i < data->dofs_per_component_on_cell;
+                       ++i)
+                    operation.process_dof(dof_indices[v] + i,
+                                          *src[comp],
+                                          values_dofs[comp][i][v]);
+                else
+                  for (unsigned int v = 0; v < vectorization_populated; ++v)
+                    if (mask[v] == true)
+                      for (unsigned int i = 0;
+                           i < data->dofs_per_component_on_cell;
+                           ++i)
+                        operation.process_dof(
+                          dof_indices[v] + i +
+                            comp * data->dofs_per_component_on_cell,
+                          *src[0],
+                          values_dofs[comp][i][v]);
           }
         else
           {
@@ -4568,21 +4601,24 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::
                                VectorizedArray<Number>::n_array_elements + 1);
             if (n_components == 1 || n_fe_components == 1)
               for (unsigned int v = 0; v < vectorization_populated; ++v)
-                for (unsigned int i = 0; i < data->dofs_per_component_on_cell;
-                     ++i)
-                  operation.process_dof(dof_indices[v] + i * offsets[v],
-                                        *src[comp],
-                                        values_dofs[comp][i][v]);
-            else
-              for (unsigned int v = 0; v < vectorization_populated; ++v)
-                for (unsigned int i = 0; i < data->dofs_per_component_on_cell;
-                     ++i)
-                  operation.process_dof(
-                    dof_indices[v] +
-                      (i + comp * data->dofs_per_component_on_cell) *
-                        offsets[v],
-                    *src[0],
-                    values_dofs[comp][i][v]);
+                if (mask[v] == true)
+                  for (unsigned int i = 0; i < data->dofs_per_component_on_cell;
+                       ++i)
+                    operation.process_dof(dof_indices[v] + i * offsets[v],
+                                          *src[comp],
+                                          values_dofs[comp][i][v]);
+                else
+                  for (unsigned int v = 0; v < vectorization_populated; ++v)
+                    if (mask[v] == true)
+                      for (unsigned int i = 0;
+                           i < data->dofs_per_component_on_cell;
+                           ++i)
+                        operation.process_dof(
+                          dof_indices[v] +
+                            (i + comp * data->dofs_per_component_on_cell) *
+                              offsets[v],
+                          *src[0],
+                          values_dofs[comp][i][v]);
           }
       }
 }
@@ -4608,7 +4644,11 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::read_dof_values(
         get_vector_component(const_cast<VectorType &>(src), d + first_index);
 
   internal::VectorReader<Number> reader;
-  read_write_operation(reader, src_data, true);
+  read_write_operation(
+    reader,
+    src_data,
+    std::bitset<VectorizedArray<Number>::n_array_elements>().flip(),
+    true);
 
 #  ifdef DEBUG
   dof_values_initialized = true;
@@ -4636,7 +4676,11 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::read_dof_values_plain(
         get_vector_component(const_cast<VectorType &>(src), d + first_index);
 
   internal::VectorReader<Number> reader;
-  read_write_operation(reader, src_data, false);
+  read_write_operation(
+    reader,
+    src_data,
+    std::bitset<VectorizedArray<Number>::n_array_elements>().flip(),
+    false);
 
 #  ifdef DEBUG
   dof_values_initialized = true;
@@ -4649,8 +4693,10 @@ template <int dim, int n_components_, typename Number, bool is_face>
 template <typename VectorType>
 inline void
 FEEvaluationBase<dim, n_components_, Number, is_face>::
-  distribute_local_to_global(VectorType &       dst,
-                             const unsigned int first_index) const
+  distribute_local_to_global(
+    VectorType &                                                 dst,
+    const unsigned int                                           first_index,
+    const std::bitset<VectorizedArray<Number>::n_array_elements> mask) const
 {
   Assert(dof_values_initialized == true,
          internal::ExcAccessToUninitializedField());
@@ -4667,7 +4713,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::
                                                               d + first_index);
 
   internal::VectorDistributorLocalToGlobal<Number> distributor;
-  read_write_operation(distributor, dst_data);
+  read_write_operation(distributor, dst_data, mask);
 }
 
 
@@ -4676,8 +4722,9 @@ template <int dim, int n_components_, typename Number, bool is_face>
 template <typename VectorType>
 inline void
 FEEvaluationBase<dim, n_components_, Number, is_face>::set_dof_values(
-  VectorType &       dst,
-  const unsigned int first_index) const
+  VectorType &                                                 dst,
+  const unsigned int                                           first_index,
+  const std::bitset<VectorizedArray<Number>::n_array_elements> mask) const
 {
   Assert(dof_values_initialized == true,
          internal::ExcAccessToUninitializedField());
@@ -4694,7 +4741,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face>::set_dof_values(
                                                               d + first_index);
 
   internal::VectorSetter<Number> setter;
-  read_write_operation(setter, dst_data);
+  read_write_operation(setter, dst_data, mask);
 }
 
 

--- a/tests/matrix_free/advect_1d_vectorization_mask.cc
+++ b/tests/matrix_free/advect_1d_vectorization_mask.cc
@@ -1,0 +1,353 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// similar to  advect_1d but testing the mask for distribute_local_to_global
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/fe/fe_dgq.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+#include <deal.II/matrix_free/matrix_free.h>
+#include <deal.II/matrix_free/operators.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+std::ofstream logfile("output");
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d   = fe_degree + 1,
+          typename number     = double,
+          typename VectorType = Vector<number>,
+          int n_components    = 1>
+class MatrixFreeAdvectionBasic
+{
+public:
+  MatrixFreeAdvectionBasic(const MatrixFree<dim, number> &data,
+                           const bool         zero_within_loop       = true,
+                           const unsigned int start_vector_component = 0)
+    : data(data)
+    , zero_within_loop(zero_within_loop)
+    , start_vector_component(start_vector_component)
+  {
+    for (unsigned int d = 0; d < dim; ++d)
+      advection[d] = 0.4 + 0.12 * d;
+  }
+
+  void
+  vmult(VectorType &dst, const VectorType &src) const
+  {
+    if (!zero_within_loop)
+      dst = 0;
+    data.loop(&MatrixFreeAdvectionBasic::local_apply,
+              &MatrixFreeAdvectionBasic::local_apply_face,
+              &MatrixFreeAdvectionBasic::local_apply_boundary_face,
+              this,
+              dst,
+              src,
+              zero_within_loop,
+              MatrixFree<dim, number>::DataAccessOnFaces::values,
+              MatrixFree<dim, number>::DataAccessOnFaces::values);
+
+    FEEvaluation<dim, fe_degree, fe_degree + 1, n_components, number> phi(data);
+
+    const unsigned int dofs_per_cell = phi.dofs_per_cell;
+
+    AlignedVector<VectorizedArray<number>> coefficients(phi.dofs_per_cell);
+    MatrixFreeOperators::
+      CellwiseInverseMassMatrix<dim, fe_degree, n_components, number>
+        inverse(phi);
+
+    for (unsigned int cell = 0; cell < data.n_cell_batches(); ++cell)
+      {
+        phi.reinit(cell);
+        phi.read_dof_values(dst);
+
+        inverse.fill_inverse_JxW_values(coefficients);
+        inverse.apply(coefficients,
+                      n_components,
+                      phi.begin_dof_values(),
+                      phi.begin_dof_values());
+
+        phi.set_dof_values(dst);
+      }
+  }
+
+private:
+  void
+  local_apply(const MatrixFree<dim, number> &              data,
+              VectorType &                                 dst,
+              const VectorType &                           src,
+              const std::pair<unsigned int, unsigned int> &cell_range) const
+  {
+    FEEvaluation<dim, fe_degree, n_q_points_1d, n_components, number> phi(
+      data, 0, 0, start_vector_component);
+
+    const unsigned int n_vect = VectorizedArray<number>::n_array_elements;
+
+    for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
+      {
+        phi.reinit(cell);
+        phi.read_dof_values(src);
+        phi.evaluate(true, false);
+        for (unsigned int q = 0; q < phi.n_q_points; ++q)
+          phi.submit_gradient(advection * phi.get_value(q), q);
+        phi.integrate(false, true);
+        for (unsigned int v = 0; v < n_vect; ++v)
+          {
+            std::bitset<n_vect> mask;
+            mask[v] = true;
+            phi.distribute_local_to_global(dst, 0, mask);
+          }
+      }
+  }
+
+  void
+  local_apply_face(
+    const MatrixFree<dim, number> &              data,
+    VectorType &                                 dst,
+    const VectorType &                           src,
+    const std::pair<unsigned int, unsigned int> &face_range) const
+  {
+    FEFaceEvaluation<dim, fe_degree, n_q_points_1d, n_components, number> phi_m(
+      data, true, 0, 0, start_vector_component);
+    FEFaceEvaluation<dim, fe_degree, n_q_points_1d, n_components, number> phi_p(
+      data, false, 0, 0, start_vector_component);
+    typedef typename FEFaceEvaluation<dim,
+                                      fe_degree,
+                                      n_q_points_1d,
+                                      n_components,
+                                      number>::value_type value_type;
+
+    const unsigned int n_vect = VectorizedArray<number>::n_array_elements;
+
+    for (unsigned int face = face_range.first; face < face_range.second; face++)
+      {
+        phi_m.reinit(face);
+        phi_m.read_dof_values(src);
+        phi_m.evaluate(true, false);
+        phi_p.reinit(face);
+        phi_p.read_dof_values(src);
+        phi_p.evaluate(true, false);
+
+        for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
+          {
+            value_type u_minus = phi_m.get_value(q),
+                       u_plus  = phi_p.get_value(q);
+            const VectorizedArray<number> normal_times_advection =
+              advection * phi_m.get_normal_vector(q);
+            const value_type flux_times_normal =
+              make_vectorized_array<number>(0.5) *
+              ((u_minus + u_plus) * normal_times_advection +
+               std::abs(normal_times_advection) * (u_minus - u_plus));
+            phi_m.submit_value(-flux_times_normal, q);
+            phi_p.submit_value(flux_times_normal, q);
+          }
+
+        phi_m.integrate(true, false);
+        for (unsigned int v = 0; v < n_vect; ++v)
+          {
+            std::bitset<n_vect> mask;
+            mask[v] = true;
+            phi_m.distribute_local_to_global(dst, 0, mask);
+          }
+        phi_p.integrate(true, false);
+        for (unsigned int v = 0; v < n_vect; ++v)
+          {
+            std::bitset<n_vect> mask;
+            mask[v] = true;
+            phi_p.distribute_local_to_global(dst, 0, mask);
+          }
+      }
+  }
+
+  void
+  local_apply_boundary_face(
+    const MatrixFree<dim, number> &              data,
+    VectorType &                                 dst,
+    const VectorType &                           src,
+    const std::pair<unsigned int, unsigned int> &face_range) const
+  {
+    FEFaceEvaluation<dim, fe_degree, n_q_points_1d, n_components, number>
+                                                          fe_eval(data, true, 0, 0, start_vector_component);
+    typedef typename FEFaceEvaluation<dim,
+                                      fe_degree,
+                                      n_q_points_1d,
+                                      n_components,
+                                      number>::value_type value_type;
+
+    const unsigned int n_vect = VectorizedArray<number>::n_array_elements;
+
+    for (unsigned int face = face_range.first; face < face_range.second; face++)
+      {
+        fe_eval.reinit(face);
+        fe_eval.read_dof_values(src);
+        fe_eval.evaluate(true, false);
+
+        for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
+          {
+            value_type                    u_minus = fe_eval.get_value(q);
+            value_type                    u_plus  = -u_minus;
+            const VectorizedArray<number> normal_times_advection =
+              advection * fe_eval.get_normal_vector(q);
+            const value_type flux_times_normal =
+              make_vectorized_array<number>(0.5) *
+              ((u_minus + u_plus) * normal_times_advection +
+               std::abs(normal_times_advection) * (u_minus - u_plus));
+            fe_eval.submit_value(-flux_times_normal, q);
+          }
+
+        fe_eval.integrate(true, false);
+        for (unsigned int v = 0; v < n_vect; ++v)
+          {
+            std::bitset<n_vect> mask =
+              std::bitset<VectorizedArray<number>::n_array_elements>();
+            mask[v] = true;
+            fe_eval.distribute_local_to_global(dst, 0, mask);
+          }
+      }
+  }
+
+  const MatrixFree<dim, number> &         data;
+  const bool                              zero_within_loop;
+  const unsigned int                      start_vector_component;
+  Tensor<1, dim, VectorizedArray<number>> advection;
+};
+
+
+
+template <int dim>
+class AnalyticFunction : public Function<dim>
+{
+public:
+  static_assert(dim == 1, "Only 1D implemented");
+  AnalyticFunction()
+    : Function<dim>(1)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int) const override
+  {
+    return std::sin(3 * numbers::PI * p[0] / 0.8);
+  }
+};
+
+
+
+template <int dim>
+class AnalyticDerivative : public Function<dim>
+{
+public:
+  static_assert(dim == 1, "Only 1D implemented");
+  AnalyticDerivative()
+    : Function<dim>(1)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int) const override
+  {
+    Tensor<1, dim> advection;
+    for (unsigned int d = 0; d < dim; ++d)
+      advection[d] = 0.4 + 0.12 * d;
+
+    return -std::cos(3 * numbers::PI * p[0] / 0.8) * advection[0] * 3 *
+           numbers::PI / 0.8;
+  }
+};
+
+
+
+template <int dim, int fe_degree>
+void
+test(const unsigned int n_refine)
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, 0, 0.8);
+  tria.refine_global(n_refine);
+
+  FE_DGQ<dim>     fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  if (n_refine == 3)
+    {
+      deallog << "Testing " << dof.get_fe().get_name();
+      deallog << std::endl;
+    }
+
+  LinearAlgebra::distributed::Vector<double> in, out;
+
+  const QGauss<1>                                  quad(fe_degree + 1);
+  typename MatrixFree<dim, double>::AdditionalData data;
+  data.tasks_parallel_scheme = MatrixFree<dim, double>::AdditionalData::none;
+  data.mapping_update_flags_inner_faces =
+    (update_gradients | update_JxW_values);
+  data.mapping_update_flags_boundary_faces =
+    (update_gradients | update_JxW_values);
+
+  MatrixFree<dim, double> mf_data;
+  mf_data.reinit(dof, constraints, quad, data);
+
+  mf_data.initialize_dof_vector(in);
+  mf_data.initialize_dof_vector(out);
+
+  VectorTools::interpolate(dof, AnalyticFunction<dim>(), in);
+
+  MatrixFreeAdvectionBasic<dim,
+                           fe_degree,
+                           fe_degree + 1,
+                           double,
+                           LinearAlgebra::distributed::Vector<double>>
+    mf2(mf_data);
+  mf2.vmult(out, in);
+
+  VectorTools::interpolate(dof, AnalyticDerivative<dim>(), in);
+  out -= in;
+
+  double diff_norm = out.linfty_norm();
+  deallog << "Norm of difference:          " << diff_norm << " " << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  for (unsigned int r = 3; r < 9; ++r)
+    test<1, 2>(r);
+
+  for (unsigned int r = 3; r < 9; ++r)
+    test<1, 4>(r);
+
+  for (unsigned int r = 3; r < 9; ++r)
+    test<1, 5>(r);
+}

--- a/tests/matrix_free/advect_1d_vectorization_mask.output
+++ b/tests/matrix_free/advect_1d_vectorization_mask.output
@@ -1,0 +1,22 @@
+
+DEAL::Testing FE_DGQ<1>(2)
+DEAL::Norm of difference:          0.531539 
+DEAL::Norm of difference:          0.135407 
+DEAL::Norm of difference:          0.0340112 
+DEAL::Norm of difference:          0.00851279 
+DEAL::Norm of difference:          0.00212882 
+DEAL::Norm of difference:          0.000532245 
+DEAL::Testing FE_DGQ<1>(4)
+DEAL::Norm of difference:          0.00529591 
+DEAL::Norm of difference:          0.000336014 
+DEAL::Norm of difference:          2.10801e-05 
+DEAL::Norm of difference:          1.31874e-06 
+DEAL::Norm of difference:          8.24413e-08 
+DEAL::Norm of difference:          5.15331e-09 
+DEAL::Testing FE_DGQ<1>(5)
+DEAL::Norm of difference:          0.000346887 
+DEAL::Norm of difference:          1.09982e-05 
+DEAL::Norm of difference:          3.44938e-07 
+DEAL::Norm of difference:          1.07881e-08 
+DEAL::Norm of difference:          3.35085e-10 
+DEAL::Norm of difference:          9.72689e-12 


### PR DESCRIPTION
Add a mask argument to filter out some vector lanes in FEEvaluationBase
Complemented by a test, which is almost the same as advect_1d but the distribute_local_to_global is called with the mask argument and each entry is written separately, yielding the same results as the original test.
This commit is required for local time stepping using the MatrixFree framework, because some cells of batches must be excluded from read/write operations when operating on different time steps compared to their neighbor cells.