### PR TITLE
Extend doc on 'compute_line_dof_identities' and 'get_active_neighbors'.

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1232,7 +1232,14 @@ namespace GridTools
 
   /**
    * Extract the active cells around a given cell @p cell and return them in
-   * the vector @p active_neighbors.
+   * the vector @p active_neighbors. These neighbors are specifically the
+   * <i>face</i> neighbors of a cell or, if that neighbor is further
+   * refined, its active children that border on that face. On the other
+   * hand, the neighbors returned do not include cells that lie, for
+   * example, diagonally opposite to a vertex but are not face neighbors
+   * themselves. (In 3d, it also does not include cells that are
+   * adjacent to one of the edges of the current cell, but are not
+   * face neighbors.)
    *
    * @tparam MeshType A type that satisfies the requirements of the
    * @ref ConceptMeshType "MeshType concept".

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -872,6 +872,22 @@ namespace internal
                                            fe_index_2 =
                                              line->nth_active_fe_index(g);
 
+                        // as described in the hp paper, we only unify on lines
+                        // when there are at most two different FE objects
+                        // assigned on it.
+                        // however, more than two 'active_fe_indices' can be
+                        // attached that still fulfill the above criterion,
+                        // i.e. when two different FiniteElement objects are
+                        // assigned to neighboring cells that map their degrees
+                        // of freedom one-to-one.
+                        // we cannot verify with certainty if two dofs each of
+                        // separate FiniteElement objects actually map
+                        // one-to-one. however, checking for the number of
+                        // 'dofs_per_line' turned out to be a reasonable
+                        // approach, that also works for e.g. two different
+                        // FE_Q objects of the same order, from which one is
+                        // enhanced by a bubble function that is zero on the
+                        // boundary.
                         if ((dof_handler.get_fe(fe_index_1).dofs_per_line ==
                              dof_handler.get_fe(fe_index_2).dofs_per_line) &&
                             (dof_handler.get_fe(fe_index_1).dofs_per_line > 0))


### PR DESCRIPTION
Upon optimizing the dof unification algorithm, @bangerth and I extended the documentation of some parts in the code.