### PR TITLE
Don't use math functions not preceded with std::

### DIFF
--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -337,7 +337,7 @@ DerivativeForm<order, dim, spacedim, Number>::determinant() const
         for (unsigned int j = 0; j < dim; ++j)
           G[i][j] = DF_t[i] * DF_t[j];
 
-      return (sqrt(dealii::determinant(G)));
+      return (std::sqrt(dealii::determinant(G)));
     }
 }
 

--- a/include/deal.II/lac/utilities.h
+++ b/include/deal.II/lac/utilities.h
@@ -238,7 +238,7 @@ namespace Utilities
                     "real-valued Hyperbolic rotation does not exist for (" +
                     std::to_string(f) + "," + std::to_string(g) + ")"));
       const NumberType u =
-        std::copysign(sqrt((1. - tau) * (1. + tau)),
+        std::copysign(std::sqrt((1. - tau) * (1. + tau)),
                       f); // <-- more stable than std::sqrt(1.-tau*tau)
       std::array<NumberType, 3> csr;
       csr[0] = 1. / u;       // c

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -2982,7 +2982,7 @@ namespace DataOutBase
 
       // normalize the gradient
       double gradient_norm =
-        sqrt(pow(gradient[0], 2.0) + pow(gradient[1], 2.0));
+        std::sqrt(std::pow(gradient[0], 2.0) + std::pow(gradient[1], 2.0));
       gradient[0] /= gradient_norm;
       gradient[1] /= gradient_norm;
 

--- a/source/base/flow_function.cc
+++ b/source/base/flow_function.cc
@@ -323,10 +323,10 @@ namespace Functions
         const Point<dim> &p  = points[k];
         const double      x  = numbers::PI / 2. * p(0);
         const double      y  = numbers::PI / 2. * p(1);
-        const double      cx = cos(x);
-        const double      cy = cos(y);
-        const double      sx = sin(x);
-        const double      sy = sin(y);
+        const double      cx = std::cos(x);
+        const double      cy = std::cos(y);
+        const double      sx = std::sin(x);
+        const double      sy = std::sin(y);
 
         if (dim == 2)
           {
@@ -337,8 +337,8 @@ namespace Functions
         else if (dim == 3)
           {
             const double z  = numbers::PI / 2. * p(2);
-            const double cz = cos(z);
-            const double sz = sin(z);
+            const double cz = std::cos(z);
+            const double sz = std::sin(z);
 
             values[0][k] = cx * cx * cy * sy * cz * sz;
             values[1][k] = cx * sx * cy * cy * cz * sz;
@@ -372,10 +372,10 @@ namespace Functions
         const Point<dim> &p   = points[k];
         const double      x   = numbers::PI / 2. * p(0);
         const double      y   = numbers::PI / 2. * p(1);
-        const double      c2x = cos(2 * x);
-        const double      c2y = cos(2 * y);
-        const double      s2x = sin(2 * x);
-        const double      s2y = sin(2 * y);
+        const double      c2x = std::cos(2 * x);
+        const double      c2y = std::cos(2 * y);
+        const double      s2x = std::sin(2 * x);
+        const double      s2y = std::sin(2 * y);
         const double      cx2 = .5 + .5 * c2x; // cos^2 x
         const double      cy2 = .5 + .5 * c2y; // cos^2 y
 
@@ -391,8 +391,8 @@ namespace Functions
         else if (dim == 3)
           {
             const double z   = numbers::PI / 2. * p(2);
-            const double c2z = cos(2 * z);
-            const double s2z = sin(2 * z);
+            const double c2z = std::cos(2 * z);
+            const double s2z = std::sin(2 * z);
             const double cz2 = .5 + .5 * c2z; // cos^2 z
 
             values[0][k][0] = -.125 * numbers::PI * s2x * s2y * s2z;
@@ -453,10 +453,10 @@ namespace Functions
         const Point<dim> &p   = points[k];
         const double      x   = numbers::PI / 2. * p(0);
         const double      y   = numbers::PI / 2. * p(1);
-        const double      c2x = cos(2 * x);
-        const double      c2y = cos(2 * y);
-        const double      s2x = sin(2 * x);
-        const double      s2y = sin(2 * y);
+        const double      c2x = std::cos(2 * x);
+        const double      c2y = std::cos(2 * y);
+        const double      s2x = std::sin(2 * x);
+        const double      s2y = std::sin(2 * y);
         const double      pi2 = .25 * numbers::PI * numbers::PI;
 
         if (dim == 2)
@@ -470,8 +470,8 @@ namespace Functions
         else if (dim == 3)
           {
             const double z   = numbers::PI * p(2);
-            const double c2z = cos(2 * z);
-            const double s2z = sin(2 * z);
+            const double c2z = std::cos(2 * z);
+            const double s2z = std::sin(2 * z);
 
             values[0][k] +=
               -.5 * viscosity * pi2 * (1. + 2. * c2x) * s2y * s2z -
@@ -497,7 +497,7 @@ namespace Functions
 
   StokesLSingularity::StokesLSingularity()
     : omega(3. / 2. * numbers::PI)
-    , coslo(cos(lambda * omega))
+    , coslo(std::cos(lambda * omega))
     , lp(1. + lambda)
     , lm(1. - lambda)
   {}
@@ -506,42 +506,44 @@ namespace Functions
   inline double
   StokesLSingularity::Psi(double phi) const
   {
-    return coslo * (sin(lp * phi) / lp - sin(lm * phi) / lm) - cos(lp * phi) +
-           cos(lm * phi);
+    return coslo * (std::sin(lp * phi) / lp - std::sin(lm * phi) / lm) -
+           std::cos(lp * phi) + std::cos(lm * phi);
   }
 
 
   inline double
   StokesLSingularity::Psi_1(double phi) const
   {
-    return coslo * (cos(lp * phi) - cos(lm * phi)) + lp * sin(lp * phi) -
-           lm * sin(lm * phi);
+    return coslo * (std::cos(lp * phi) - std::cos(lm * phi)) +
+           lp * std::sin(lp * phi) - lm * std::sin(lm * phi);
   }
 
 
   inline double
   StokesLSingularity::Psi_2(double phi) const
   {
-    return coslo * (lm * sin(lm * phi) - lp * sin(lp * phi)) +
-           lp * lp * cos(lp * phi) - lm * lm * cos(lm * phi);
+    return coslo * (lm * std::sin(lm * phi) - lp * std::sin(lp * phi)) +
+           lp * lp * std::cos(lp * phi) - lm * lm * std::cos(lm * phi);
   }
 
 
   inline double
   StokesLSingularity::Psi_3(double phi) const
   {
-    return coslo * (lm * lm * cos(lm * phi) - lp * lp * cos(lp * phi)) +
-           lm * lm * lm * sin(lm * phi) - lp * lp * lp * sin(lp * phi);
+    return coslo *
+             (lm * lm * std::cos(lm * phi) - lp * lp * std::cos(lp * phi)) +
+           lm * lm * lm * std::sin(lm * phi) -
+           lp * lp * lp * std::sin(lp * phi);
   }
 
 
   inline double
   StokesLSingularity::Psi_4(double phi) const
   {
-    return coslo *
-             (lp * lp * lp * sin(lp * phi) - lm * lm * lm * sin(lm * phi)) +
-           lm * lm * lm * lm * cos(lm * phi) -
-           lp * lp * lp * lp * cos(lp * phi);
+    return coslo * (lp * lp * lp * std::sin(lp * phi) -
+                    lm * lm * lm * std::sin(lm * phi)) +
+           lm * lm * lm * lm * std::cos(lm * phi) -
+           lp * lp * lp * lp * std::cos(lp * phi);
   }
 
 
@@ -566,12 +568,12 @@ namespace Functions
           {
             const double phi = std::atan2(y, -x) + numbers::PI;
             const double r2  = x * x + y * y;
-            const double rl  = pow(r2, lambda / 2.);
-            const double rl1 = pow(r2, lambda / 2. - .5);
+            const double rl  = std::pow(r2, lambda / 2.);
+            const double rl1 = std::pow(r2, lambda / 2. - .5);
             values[0][k] =
-              rl * (lp * sin(phi) * Psi(phi) + cos(phi) * Psi_1(phi));
+              rl * (lp * std::sin(phi) * Psi(phi) + std::cos(phi) * Psi_1(phi));
             values[1][k] =
-              rl * (lp * cos(phi) * Psi(phi) - sin(phi) * Psi_1(phi));
+              rl * (lp * std::cos(phi) * Psi(phi) - std::sin(phi) * Psi_1(phi));
             values[2][k] = -rl1 * (lp * lp * Psi_1(phi) + Psi_3(phi)) / lm +
                            this->mean_pressure;
           }
@@ -606,15 +608,15 @@ namespace Functions
           {
             const double phi  = std::atan2(y, -x) + numbers::PI;
             const double r2   = x * x + y * y;
-            const double r    = sqrt(r2);
-            const double rl   = pow(r2, lambda / 2.);
-            const double rl1  = pow(r2, lambda / 2. - .5);
-            const double rl2  = pow(r2, lambda / 2. - 1.);
+            const double r    = std::sqrt(r2);
+            const double rl   = std::pow(r2, lambda / 2.);
+            const double rl1  = std::pow(r2, lambda / 2. - .5);
+            const double rl2  = std::pow(r2, lambda / 2. - 1.);
             const double psi  = Psi(phi);
             const double psi1 = Psi_1(phi);
             const double psi2 = Psi_2(phi);
-            const double cosp = cos(phi);
-            const double sinp = sin(phi);
+            const double cosp = std::cos(phi);
+            const double sinp = std::sin(phi);
 
             // Derivatives of u with respect to r, phi
             const double udr = lambda * rl1 * (lp * sinp * psi + cosp * psi1);
@@ -697,8 +699,8 @@ namespace Functions
         const double    y   = 2. * numbers::PI * p(1);
         const double    elx = std::exp(lbda * x);
 
-        values[0][k] = 1. - elx * cos(y);
-        values[1][k] = .5 / numbers::PI * lbda * elx * sin(y);
+        values[0][k] = 1. - elx * std::cos(y);
+        values[1][k] = .5 / numbers::PI * lbda * elx * std::sin(y);
         values[2][k] = -.5 * elx * elx + p_average + this->mean_pressure;
       }
   }
@@ -721,8 +723,8 @@ namespace Functions
         const double y = points[i](1);
 
         const double elx = std::exp(lbda * x);
-        const double cy  = cos(2 * numbers::PI * y);
-        const double sy  = sin(2 * numbers::PI * y);
+        const double cy  = std::cos(2 * numbers::PI * y);
+        const double sy  = std::sin(2 * numbers::PI * y);
 
         // u
         gradients[0][i][0] = -lbda * elx * cy;
@@ -755,12 +757,12 @@ namespace Functions
             const double    x   = p(0);
             const double    y   = zp * p(1);
             const double    elx = std::exp(lbda * x);
-            const double    u   = 1. - elx * cos(y);
-            const double    ux  = -lbda * elx * cos(y);
-            const double    uy  = elx * zp * sin(y);
-            const double    v   = lbda / zp * elx * sin(y);
-            const double    vx  = lbda * lbda / zp * elx * sin(y);
-            const double    vy  = zp * lbda / zp * elx * cos(y);
+            const double    u   = 1. - elx * std::cos(y);
+            const double    ux  = -lbda * elx * std::cos(y);
+            const double    uy  = elx * zp * std::sin(y);
+            const double    v   = lbda / zp * elx * std::sin(y);
+            const double    vx  = lbda * lbda / zp * elx * std::sin(y);
+            const double    vy  = zp * lbda / zp * elx * std::cos(y);
 
             values[0][k] = u * ux + v * uy;
             values[1][k] = u * vx + v * vy;

--- a/source/base/function_lib_cutoff.cc
+++ b/source/base/function_lib_cutoff.cc
@@ -215,7 +215,7 @@ namespace Functions
         if (d >= r)
           return 0.;
         const double e = -r * r / (r * r - d * d);
-        return ((e < -50) ? 0. : numbers::E * exp(e));
+        return ((e < -50) ? 0. : numbers::E * std::exp(e));
       }
     return 0.;
   }
@@ -244,7 +244,7 @@ namespace Functions
           else
             {
               const double e = -r * r / (r * r - d * d);
-              values[i]      = (e < -50) ? 0. : numbers::E * exp(e);
+              values[i]      = (e < -50) ? 0. : numbers::E * std::exp(e);
             }
         }
     else
@@ -270,7 +270,7 @@ namespace Functions
           {
             const double e = -r * r / (r * r - d * d);
             if (e > -50)
-              val = numbers::E * exp(e);
+              val = numbers::E * std::exp(e);
           }
 
         if (this->selected == CutOffFunctionBase<dim>::no_component)
@@ -295,10 +295,10 @@ namespace Functions
     if (d >= r)
       return Tensor<1, dim>();
     const double e = -d * d / (r - d) / (r + d);
-    return ((e < -50) ?
-              Point<dim>() :
-              (p - this->center) / d *
-                (-2.0 * r * r / pow(-r * r + d * d, 2.0) * d * exp(e)));
+    return ((e < -50) ? Point<dim>() :
+                        (p - this->center) / d *
+                          (-2.0 * r * r / std::pow(-r * r + d * d, 2.0) * d *
+                           std::exp(e)));
   }
 
 

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -184,37 +184,37 @@ namespace internal
   double
   mu_ceil(double value)
   {
-    return ceil(value);
+    return std::ceil(value);
   }
 
   double
   mu_floor(double value)
   {
-    return floor(value);
+    return std::floor(value);
   }
 
   double
   mu_cot(double value)
   {
-    return 1.0 / tan(value);
+    return 1.0 / std::tan(value);
   }
 
   double
   mu_csc(double value)
   {
-    return 1.0 / sin(value);
+    return 1.0 / std::sin(value);
   }
 
   double
   mu_sec(double value)
   {
-    return 1.0 / cos(value);
+    return 1.0 / std::cos(value);
   }
 
   double
   mu_log(double value)
   {
-    return log(value);
+    return std::log(value);
   }
 
   double
@@ -226,7 +226,7 @@ namespace internal
   double
   mu_erfc(double value)
   {
-    return boost::math::erfc(value);
+    return std::erfc(value);
   }
 
   // returns a random value in the range [0,1] initializing the generator

--- a/source/fe/fe_rt_bubbles.cc
+++ b/source/fe/fe_rt_bubbles.cc
@@ -213,7 +213,8 @@ FE_RT_Bubbles<dim>::get_dpo_vector(const unsigned int deg)
     dofs_per_face *= deg + 1;
 
   // ...plus the interior DoFs for the total of dim*(deg+1)^dim
-  const unsigned int interior_dofs = dim * (deg - 1) * pow(deg + 1, dim - 1);
+  const unsigned int interior_dofs =
+    dim * (deg - 1) * Utilities::pow(deg + 1, dim - 1);
 
   std::vector<unsigned int> dpo(dim + 1);
   dpo[dim - 1] = dofs_per_face;

--- a/source/fe/fe_series.cc
+++ b/source/fe/fe_series.cc
@@ -212,7 +212,7 @@ namespace FESeries
         const double x = 2.0 * (x_q[d] - 0.5);
         Assert((x_q[d] <= 1.0) && (x_q[d] >= 0.), ExcLegendre(d, x_q[d]));
         const int ind = indices[d];
-        res *= sqrt(2.0) * gsl_sf_legendre_Pl(ind, x);
+        res *= std::sqrt(2.0) * gsl_sf_legendre_Pl(ind, x);
       }
     return res;
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -1619,7 +1619,7 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::fill_fe_values(
                     G[i][j] = DX_t[i] * DX_t[j];
 
                 output_data.JxW_values[point] =
-                  sqrt(determinant(G)) * weights[point];
+                  std::sqrt(determinant(G)) * weights[point];
 
                 if (cell_similarity == CellSimilarity::inverted_translation)
                   {

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -2915,7 +2915,7 @@ MappingQGeneric<dim, spacedim>::fill_fe_values(
                     G[i][j] = DX_t[i] * DX_t[j];
 
                 output_data.JxW_values[point] =
-                  sqrt(determinant(G)) * weights[point];
+                  std::sqrt(determinant(G)) * weights[point];
 
                 if (computed_cell_similarity ==
                     CellSimilarity::inverted_translation)

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -2992,7 +2992,7 @@ namespace GridGenerator
                                     p + Point<dim>(+1, 0) * (radius / 2),
                                     p + Point<dim>(0, +1) * (radius / 2),
                                     p + Point<dim>(+1, +1) *
-                                          (radius / (2 * sqrt(2.0))),
+                                          (radius / (2 * std::sqrt(2.0))),
                                     p + Point<dim>(0, +1) * radius,
                                     p + Point<dim>(+1, +1) *
                                           (radius / std::sqrt(2.0))};
@@ -3757,7 +3757,7 @@ namespace GridGenerator
       center + Point<dim>(+1, 0, 0) * radius,
       center + Point<dim>(+1, 0, 0) * (radius / 2.),
       center + Point<dim>(0, +1, 0) * (radius / 2.),
-      center + Point<dim>(+1, +1, 0) * (radius / (2 * sqrt(2.0))),
+      center + Point<dim>(+1, +1, 0) * (radius / (2 * std::sqrt(2.0))),
       center + Point<dim>(0, +1, 0) * radius,
       center + Point<dim>(+1, +1, 0) * (radius / std::sqrt(2.0)),
       center + Point<dim>(0, 0, 1) * radius / 2.,

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -1712,25 +1712,25 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
 
   // (I) rotate the camera to the chosen polar angle
   camera_position_temp[1] =
-    cos(angle_factor * svg_flags.polar_angle) * camera_position[1] -
-    sin(angle_factor * svg_flags.polar_angle) * camera_position[2];
+    std::cos(angle_factor * svg_flags.polar_angle) * camera_position[1] -
+    std::sin(angle_factor * svg_flags.polar_angle) * camera_position[2];
   camera_position_temp[2] =
-    sin(angle_factor * svg_flags.polar_angle) * camera_position[1] +
-    cos(angle_factor * svg_flags.polar_angle) * camera_position[2];
+    std::sin(angle_factor * svg_flags.polar_angle) * camera_position[1] +
+    std::cos(angle_factor * svg_flags.polar_angle) * camera_position[2];
 
   camera_direction_temp[1] =
-    cos(angle_factor * svg_flags.polar_angle) * camera_direction[1] -
-    sin(angle_factor * svg_flags.polar_angle) * camera_direction[2];
+    std::cos(angle_factor * svg_flags.polar_angle) * camera_direction[1] -
+    std::sin(angle_factor * svg_flags.polar_angle) * camera_direction[2];
   camera_direction_temp[2] =
-    sin(angle_factor * svg_flags.polar_angle) * camera_direction[1] +
-    cos(angle_factor * svg_flags.polar_angle) * camera_direction[2];
+    std::sin(angle_factor * svg_flags.polar_angle) * camera_direction[1] +
+    std::cos(angle_factor * svg_flags.polar_angle) * camera_direction[2];
 
   camera_horizontal_temp[1] =
-    cos(angle_factor * svg_flags.polar_angle) * camera_horizontal[1] -
-    sin(angle_factor * svg_flags.polar_angle) * camera_horizontal[2];
+    std::cos(angle_factor * svg_flags.polar_angle) * camera_horizontal[1] -
+    std::sin(angle_factor * svg_flags.polar_angle) * camera_horizontal[2];
   camera_horizontal_temp[2] =
-    sin(angle_factor * svg_flags.polar_angle) * camera_horizontal[1] +
-    cos(angle_factor * svg_flags.polar_angle) * camera_horizontal[2];
+    std::sin(angle_factor * svg_flags.polar_angle) * camera_horizontal[1] +
+    std::cos(angle_factor * svg_flags.polar_angle) * camera_horizontal[2];
 
   camera_position[1] = camera_position_temp[1];
   camera_position[2] = camera_position_temp[2];
@@ -1743,25 +1743,25 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
 
   // (II) rotate the camera to the chosen azimuth angle
   camera_position_temp[0] =
-    cos(angle_factor * svg_flags.azimuth_angle) * camera_position[0] -
-    sin(angle_factor * svg_flags.azimuth_angle) * camera_position[1];
+    std::cos(angle_factor * svg_flags.azimuth_angle) * camera_position[0] -
+    std::sin(angle_factor * svg_flags.azimuth_angle) * camera_position[1];
   camera_position_temp[1] =
-    sin(angle_factor * svg_flags.azimuth_angle) * camera_position[0] +
-    cos(angle_factor * svg_flags.azimuth_angle) * camera_position[1];
+    std::sin(angle_factor * svg_flags.azimuth_angle) * camera_position[0] +
+    std::cos(angle_factor * svg_flags.azimuth_angle) * camera_position[1];
 
   camera_direction_temp[0] =
-    cos(angle_factor * svg_flags.azimuth_angle) * camera_direction[0] -
-    sin(angle_factor * svg_flags.azimuth_angle) * camera_direction[1];
+    std::cos(angle_factor * svg_flags.azimuth_angle) * camera_direction[0] -
+    std::sin(angle_factor * svg_flags.azimuth_angle) * camera_direction[1];
   camera_direction_temp[1] =
-    sin(angle_factor * svg_flags.azimuth_angle) * camera_direction[0] +
-    cos(angle_factor * svg_flags.azimuth_angle) * camera_direction[1];
+    std::sin(angle_factor * svg_flags.azimuth_angle) * camera_direction[0] +
+    std::cos(angle_factor * svg_flags.azimuth_angle) * camera_direction[1];
 
   camera_horizontal_temp[0] =
-    cos(angle_factor * svg_flags.azimuth_angle) * camera_horizontal[0] -
-    sin(angle_factor * svg_flags.azimuth_angle) * camera_horizontal[1];
+    std::cos(angle_factor * svg_flags.azimuth_angle) * camera_horizontal[0] -
+    std::sin(angle_factor * svg_flags.azimuth_angle) * camera_horizontal[1];
   camera_horizontal_temp[1] =
-    sin(angle_factor * svg_flags.azimuth_angle) * camera_horizontal[0] +
-    cos(angle_factor * svg_flags.azimuth_angle) * camera_horizontal[1];
+    std::sin(angle_factor * svg_flags.azimuth_angle) * camera_horizontal[0] +
+    std::cos(angle_factor * svg_flags.azimuth_angle) * camera_horizontal[1];
 
   camera_position[0] = camera_position_temp[0];
   camera_position[1] = camera_position_temp[1];
@@ -1777,11 +1777,11 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
   camera_position[1] = y_min + .5 * y_dimension;
 
   camera_position[0] += 2. * std::max(x_dimension, y_dimension) *
-                        sin(angle_factor * svg_flags.polar_angle) *
-                        sin(angle_factor * svg_flags.azimuth_angle);
+                        std::sin(angle_factor * svg_flags.polar_angle) *
+                        std::sin(angle_factor * svg_flags.azimuth_angle);
   camera_position[1] -= 2. * std::max(x_dimension, y_dimension) *
-                        sin(angle_factor * svg_flags.polar_angle) *
-                        cos(angle_factor * svg_flags.azimuth_angle);
+                        std::sin(angle_factor * svg_flags.polar_angle) *
+                        std::cos(angle_factor * svg_flags.azimuth_angle);
 
 
   // determine the bounding box of the given triangulation on the projection
@@ -2312,9 +2312,9 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
                 }
 
               float distance_to_camera =
-                sqrt(pow(point[0] - camera_position[0], 2.) +
-                     pow(point[1] - camera_position[1], 2.) +
-                     pow(point[2] - camera_position[2], 2.));
+                std::sqrt(std::pow(point[0] - camera_position[0], 2.) +
+                          std::pow(point[1] - camera_position[1], 2.) +
+                          std::pow(point[2] - camera_position[2], 2.));
               float distance_factor =
                 distance_to_camera / (2. * std::max(x_dimension, y_dimension));
 
@@ -2326,10 +2326,11 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
                                            camera_focus);
 
               const unsigned int font_size_this_cell =
-                static_cast<unsigned int>(
-                  .5 +
-                  cell_label_font_size *
-                    pow(.5, (float)cell->level() - 4. + 3.5 * distance_factor));
+                static_cast<unsigned int>(.5 +
+                                          cell_label_font_size *
+                                            std::pow(.5,
+                                                     (float)cell->level() - 4. +
+                                                       3.5 * distance_factor));
 
               out << "  <text"
                   << " x=\""

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -573,8 +573,8 @@ namespace GridTools
           {
             bool equal = true;
             for (unsigned int d = 0; d < spacedim; ++d)
-              equal &= (fabs(vertices[considered_vertices[j]](d) -
-                             vertices[considered_vertices[i]](d)) < tol);
+              equal &= (std::abs(vertices[considered_vertices[j]](d) -
+                                 vertices[considered_vertices[i]](d)) < tol);
             if (equal)
               {
                 new_vertex_numbers[considered_vertices[j]] =
@@ -2633,9 +2633,9 @@ namespace GridTools
     {
       if (cell->active())
         {
-          while (
-            current_cell_idx >=
-            floor((long)n_active_cells * (current_proc_idx + 1) / n_partitions))
+          while (current_cell_idx >=
+                 std::floor((long)n_active_cells * (current_proc_idx + 1) /
+                            n_partitions))
             ++current_proc_idx;
           cell->set_subdomain_id(current_proc_idx);
           ++current_cell_idx;

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -2273,7 +2273,7 @@ namespace GridTools
         if (i == direction)
           continue;
 
-        if (fabs(distance(i)) > 1.e-10)
+        if (std::abs(distance(i)) > 1.e-10)
           return false;
       }
 

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -53,7 +53,8 @@ namespace internal
     else
       {
         const Tensor<1, 3> dirUnit = dir / theta;
-        const Tensor<1, 3> tmp     = cos(theta) * u + sin(theta) * dirUnit;
+        const Tensor<1, 3> tmp =
+          std::cos(theta) * u + std::sin(theta) * dirUnit;
         return tmp / tmp.norm();
       }
   }
@@ -167,15 +168,15 @@ PolarManifold<dim, spacedim>::push_forward(
     switch (spacedim)
       {
         case 2:
-          p[0] = rho * cos(theta);
-          p[1] = rho * sin(theta);
+          p[0] = rho * std::cos(theta);
+          p[1] = rho * std::sin(theta);
           break;
         case 3:
           {
             const double phi = spherical_point[2];
-            p[0]             = rho * sin(theta) * cos(phi);
-            p[1]             = rho * sin(theta) * sin(phi);
-            p[2]             = rho * cos(theta);
+            p[0]             = rho * std::sin(theta) * std::cos(phi);
+            p[1]             = rho * std::sin(theta) * std::sin(phi);
+            p[2]             = rho * std::cos(theta);
             break;
           }
         default:
@@ -201,7 +202,7 @@ PolarManifold<dim, spacedim>::pull_back(
     {
       case 2:
         {
-          p[1] = atan2(R[1], R[0]);
+          p[1] = std::atan2(R[1], R[0]);
           if (p[1] < 0)
             p[1] += 2 * numbers::PI;
           break;
@@ -210,10 +211,10 @@ PolarManifold<dim, spacedim>::pull_back(
       case 3:
         {
           const double z = R[2];
-          p[2]           = atan2(R[1], R[0]); // phi
+          p[2]           = std::atan2(R[1], R[0]); // phi
           if (p[2] < 0)
-            p[2] += 2 * numbers::PI;                        // phi is periodic
-          p[1] = atan2(sqrt(R[0] * R[0] + R[1] * R[1]), z); // theta
+            p[2] += 2 * numbers::PI; // phi is periodic
+          p[1] = std::atan2(std::sqrt(R[0] * R[0] + R[1] * R[1]), z); // theta
           break;
         }
 
@@ -241,26 +242,26 @@ PolarManifold<dim, spacedim>::push_forward_gradient(
       {
         case 2:
           {
-            DX[0][0] = cos(theta);
-            DX[0][1] = -rho * sin(theta);
-            DX[1][0] = sin(theta);
-            DX[1][1] = rho * cos(theta);
+            DX[0][0] = std::cos(theta);
+            DX[0][1] = -rho * std::sin(theta);
+            DX[1][0] = std::sin(theta);
+            DX[1][1] = rho * std::cos(theta);
             break;
           }
 
         case 3:
           {
             const double phi = spherical_point[2];
-            DX[0][0]         = sin(theta) * cos(phi);
-            DX[0][1]         = rho * cos(theta) * cos(phi);
-            DX[0][2]         = -rho * sin(theta) * sin(phi);
+            DX[0][0]         = std::sin(theta) * std::cos(phi);
+            DX[0][1]         = rho * std::cos(theta) * std::cos(phi);
+            DX[0][2]         = -rho * std::sin(theta) * std::sin(phi);
 
-            DX[1][0] = sin(theta) * sin(phi);
-            DX[1][1] = rho * cos(theta) * sin(phi);
-            DX[1][2] = rho * sin(theta) * cos(phi);
+            DX[1][0] = std::sin(theta) * std::sin(phi);
+            DX[1][1] = rho * std::cos(theta) * std::sin(phi);
+            DX[1][2] = rho * std::sin(theta) * std::cos(phi);
 
-            DX[2][0] = cos(theta);
-            DX[2][1] = -rho * sin(theta);
+            DX[2][0] = std::cos(theta);
+            DX[2][1] = -rho * std::sin(theta);
             DX[2][2] = 0;
             break;
           }
@@ -881,7 +882,7 @@ namespace
                 else
                   {
                     const double costheta     = (directions[i]) * candidate;
-                    const double theta        = atan2(sintheta, costheta);
+                    const double theta        = std::atan2(sintheta, costheta);
                     const double sincthetaInv = theta / sintheta;
 
                     const double cosphi = vPerp * Clocalx;
@@ -1323,11 +1324,11 @@ TorusManifold<dim>::pull_back(const Point<3> &p) const
   double x     = p(0);
   double z     = p(1);
   double y     = p(2);
-  double phi   = atan2(y, x);
-  double theta = atan2(z, std::sqrt(x * x + y * y) - R);
-  double w =
-    std::sqrt(pow(y - sin(phi) * R, 2.0) + pow(x - cos(phi) * R, 2.0) + z * z) /
-    r;
+  double phi   = std::atan2(y, x);
+  double theta = std::atan2(z, std::sqrt(x * x + y * y) - R);
+  double w     = std::sqrt(std::pow(y - std::sin(phi) * R, 2.0) +
+                       std::pow(x - std::cos(phi) * R, 2.0) + z * z) /
+             r;
   return Point<3>(phi, theta, w);
 }
 
@@ -1341,9 +1342,9 @@ TorusManifold<dim>::push_forward(const Point<3> &chart_point) const
   double theta = chart_point(1);
   double w     = chart_point(2);
 
-  return Point<3>(cos(phi) * R + r * w * cos(theta) * cos(phi),
-                  r * w * sin(theta),
-                  sin(phi) * R + r * w * cos(theta) * sin(phi));
+  return Point<3>(std::cos(phi) * R + r * w * std::cos(theta) * std::cos(phi),
+                  r * w * std::sin(theta),
+                  std::sin(phi) * R + r * w * std::cos(theta) * std::sin(phi));
 }
 
 
@@ -1381,17 +1382,17 @@ TorusManifold<dim>::push_forward_gradient(const Point<3> &chart_point) const
   double theta = chart_point(1);
   double w     = chart_point(2);
 
-  DX[0][0] = -sin(phi) * R - r * w * cos(theta) * sin(phi);
-  DX[0][1] = -r * w * sin(theta) * cos(phi);
-  DX[0][2] = r * cos(theta) * cos(phi);
+  DX[0][0] = -std::sin(phi) * R - r * w * std::cos(theta) * std::sin(phi);
+  DX[0][1] = -r * w * std::sin(theta) * std::cos(phi);
+  DX[0][2] = r * std::cos(theta) * std::cos(phi);
 
   DX[1][0] = 0;
-  DX[1][1] = r * w * cos(theta);
-  DX[1][2] = r * sin(theta);
+  DX[1][1] = r * w * std::cos(theta);
+  DX[1][2] = r * std::sin(theta);
 
-  DX[2][0] = cos(phi) * R + r * w * cos(theta) * cos(phi);
-  DX[2][1] = -r * w * sin(theta) * sin(phi);
-  DX[2][2] = r * cos(theta) * sin(phi);
+  DX[2][0] = std::cos(phi) * R + r * w * std::cos(theta) * std::cos(phi);
+  DX[2][1] = -r * w * std::sin(theta) * std::sin(phi);
+  DX[2][2] = r * std::cos(theta) * std::sin(phi);
 
   return DX;
 }

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -1052,7 +1052,7 @@ namespace internal
           if (dofs_per_cell * block_size > 10000)
             block_size /= 4;
 
-          block_size = 1 << (unsigned int)(log2(block_size + 1));
+          block_size = 1 << (unsigned int)(std::log2(block_size + 1));
         }
       if (block_size > n_active_cells)
         block_size = std::max(1U, n_active_cells);

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -324,13 +324,13 @@ namespace OpenCASCADE
     extract_geometrical_shapes(shape, faces, edges, vertices);
 
     for (unsigned int i = 0; i < vertices.size(); ++i)
-      tolerance = fmax(tolerance, BRep_Tool::Tolerance(vertices[i]));
+      tolerance = std::fmax(tolerance, BRep_Tool::Tolerance(vertices[i]));
 
     for (unsigned int i = 0; i < edges.size(); ++i)
-      tolerance = fmax(tolerance, BRep_Tool::Tolerance(edges[i]));
+      tolerance = std::fmax(tolerance, BRep_Tool::Tolerance(edges[i]));
 
     for (unsigned int i = 0; i < faces.size(); ++i)
-      tolerance = fmax(tolerance, BRep_Tool::Tolerance(faces[i]));
+      tolerance = std::fmax(tolerance, BRep_Tool::Tolerance(faces[i]));
 
 
     return tolerance;

--- a/tests/petsc/19.cc
+++ b/tests/petsc/19.cc
@@ -33,7 +33,7 @@ test(PETScWrappers::MPI::Vector &v)
   for (unsigned int i = 0; i < v.size(); i += 1 + i)
     {
       v(i) = i;
-      norm = std::max(norm, fabs(i));
+      norm = std::max<double>(norm, i);
     }
   v.compress(VectorOperation::insert);
 


### PR DESCRIPTION
Occasionally, we have problems due to math functions not preceded with ` std::` using an inappropriate overload. This PR just adds `std::` to all of them.