### PR TITLE
Simplify two functions.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12181,27 +12181,15 @@ template <int dim, int spacedim>
 typename Triangulation<dim, spacedim>::vertex_iterator
 Triangulation<dim, spacedim>::begin_vertex() const
 {
-  if (dim == 1)
-    {
-      // This does not work if dim==1 because TriaAccessor<0,1,spacedim> does
-      // not implement operator++
-      Assert(false, ExcNotImplemented());
-      return raw_vertex_iterator();
-    }
-  else
-    {
-      vertex_iterator i =
-        raw_vertex_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
-                            0,
-                            0);
-      if (i.state() != IteratorState::valid)
-        return i;
-      // This loop will end because every triangulation has used vertices.
-      while (i->used() == false)
-        if ((++i).state() != IteratorState::valid)
-          return i;
+  vertex_iterator i =
+    raw_vertex_iterator(const_cast<Triangulation<dim, spacedim> *>(this), 0, 0);
+  if (i.state() != IteratorState::valid)
+    return i;
+  // This loop will end because every triangulation has used vertices.
+  while (i->used() == false)
+    if ((++i).state() != IteratorState::valid)
       return i;
-    }
+  return i;
 }
 
 
@@ -12210,6 +12198,7 @@ template <int dim, int spacedim>
 typename Triangulation<dim, spacedim>::active_vertex_iterator
 Triangulation<dim, spacedim>::begin_active_vertex() const
 {
+  // every vertex is active
   return begin_vertex();
 }
 
@@ -12219,15 +12208,9 @@ template <int dim, int spacedim>
 typename Triangulation<dim, spacedim>::vertex_iterator
 Triangulation<dim, spacedim>::end_vertex() const
 {
-  if (dim == 1)
-    {
-      Assert(false, ExcNotImplemented());
-      return raw_vertex_iterator();
-    }
-  else
-    return raw_vertex_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
-                               -1,
-                               numbers::invalid_unsigned_int);
+  return raw_vertex_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
+                             -1,
+                             numbers::invalid_unsigned_int);
 }
 
 


### PR DESCRIPTION
These functions threw an exception in 1d, but this is not
the right place to check that condition: the assertion is currently
thrown because some other class does not implement a function. In
particular, this is about TriaAccessor<0,1>::operator++(), but that
already has the correct assertion that, if ever lifted, would
make the place that currently *also* checks the condition work
automatically.