### PR TITLE
Assert non-negative exponents in Utilities::pow

### DIFF
--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -353,9 +353,26 @@ namespace Utilities
   constexpr unsigned int
   pow(const unsigned int base, const int iexp)
   {
-#ifdef DEAL_II_WITH_CXX17
-    AssertThrow(iexp >= 0, ExcMessage("The exponent must not be negative!"));
+#ifdef DEAL_II_WITH_CXX14
+    Assert(iexp >= 0, ExcMessage("The exponent must not be negative!"));
 #endif
+    // The "exponentiation by squaring" algorithm used below has to be
+    // compressed to one statement due to C++11's restrictions on constexpr
+    // functions. A more descriptive version would be:
+    //
+    // <code>
+    // if (iexp <= 0)
+    //   return 1;
+    //
+    // // if the current exponent is not divisible by two,
+    // // we need to account for that.
+    // const unsigned int prefactor = (iexp % 2 == 1) ? base : 1;
+    //
+    // // a^b = (a*a)^(b/2)      for b evenb
+    // // a^b = a*(a*a)^((b-1)/2 for b odd
+    // return prefactor * dealii::Utilities::pow(base*base, iexp/2);
+    // </code>
+
     return iexp <= 0 ? 1 :
                        (((iexp % 2 == 1) ? base : 1) *
                         dealii::Utilities::pow(base * base, iexp / 2));

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -347,12 +347,18 @@ namespace Utilities
 
   /**
    * A replacement for <code>std::pow</code> that allows compile-time
-   * calculations for constant expression arguments.
+   * calculations for constant expression arguments. The exponent @p iexp
+   * must not be negative.
    */
   constexpr unsigned int
-  pow(const unsigned int base, const unsigned int iexp)
+  pow(const unsigned int base, const int iexp)
   {
-    return iexp == 0 ? 1 : base * dealii::Utilities::pow(base, iexp - 1);
+#ifdef DEAL_II_WITH_CXX17
+    AssertThrow(iexp >= 0, ExcMessage("The exponent must not be negative!"));
+#endif
+    return iexp <= 0 ? 1 :
+                       (((iexp % 2 == 1) ? base : 1) *
+                        dealii::Utilities::pow(base * base, iexp / 2));
   }
 
   /**


### PR DESCRIPTION
I faced some problems when accidentally passing negative exponents to `Utilities::pow`.
Since the exponent has been an `unsigned int`, it just created an enormous call stack which finally aborted the program. Since we are returning an `unsigned int` even an exponent larger than 31 would just lead to an overflow.
This PR changes the type of the exponent to `int` so that we can test for negative numbers.
In case we have `C++17` support, it also asserts that the exponent is non-negative. Otherwise, the exponent is treated the same as 0, i.e., 1 is returned.
Finally, a more efficient "exponentiation by squaring" algorithm is used. 
Due to `C++11`'s limitations for `constexpr` everything had to fit in one statement unfortunately.