### PR TITLE
Fix last remaining instance of passing shared_ptr<Partitioner> by value

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -97,13 +97,14 @@ namespace LinearAlgebra
         {}
 
         static void
-        import(const ::dealii::LinearAlgebra::ReadWriteVector<Number> & /*V*/,
-               ::dealii::VectorOperation::values /*operation*/,
-               std::shared_ptr<const ::dealii::Utilities::MPI::Partitioner>
-               /*communication_pattern*/,
-               const IndexSet & /*locally_owned_elem*/,
-               ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace>
-                 & /*data*/)
+        import(
+          const ::dealii::LinearAlgebra::ReadWriteVector<Number> & /*V*/,
+          ::dealii::VectorOperation::values /*operation*/,
+          const std::shared_ptr<const ::dealii::Utilities::MPI::Partitioner> &
+          /*communication_pattern*/,
+          const IndexSet & /*locally_owned_elem*/,
+          ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace>
+            & /*data*/)
         {}
 
         template <typename RealType>


### PR DESCRIPTION
Apparently, there is one missing instance with respect to #7104 as [`CDash`](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=4228) reports.