### PR TITLE
Avoid warning about unused variable in configure_tapeless_mode

### DIFF
--- a/include/deal.II/differentiation/ad/ad_drivers.h
+++ b/include/deal.II/differentiation/ad/ad_drivers.h
@@ -1273,7 +1273,7 @@ namespace Differentiation
       template <typename ADNumberType>
       typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
                               NumberTypes::adolc_tapeless>::type
-      configure_tapeless_mode(const unsigned int n_directional_derivatives)
+      configure_tapeless_mode(const unsigned int /*n_directional_derivatives*/)
       {
         AssertThrow(false, ExcRequiresAdolC());
       }


### PR DESCRIPTION
[CDash](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=4259) complains about the unused variable for builds without `ADOLC`.