### PR TITLE
Fixes a typo in step-16 results.dox

### DIFF
--- a/examples/step-16/doc/results.dox
+++ b/examples/step-16/doc/results.dox
@@ -78,7 +78,7 @@ example. In that case, it would be simpler if one could use a black-box
 preconditioner that uses some sort of multigrid hierarchy for good performance
 but can figure out level matrices and similar things by itself. Algebraic
 multigrid methods do exactly this, and we will use them in step-31 for the
-solution of a Stokes problemm and in step-32 and step-40 for a parallel
+solution of a Stokes problem and in step-32 and step-40 for a parallel
 variation.
 
 Finally, one may want to think how to use geometric multigrid for other kinds of


### PR DESCRIPTION
This corrects "solution of a Stokes problemm and" to "solution of a Stokes problem and" in the results.dox file for step-16.