### PR TITLE
doxygen: remove trailing // in tutorials

### DIFF
--- a/doc/doxygen/scripts/program2doxygen
+++ b/doc/doxygen/scripts/program2doxygen
@@ -37,12 +37,18 @@ $state =  $comment_mode;
 print " * \n";
 
 do {
-    # substitute tabs. also make sure that we don't output comment end
-    # markers that might confuse doxygen
+
+    # Make sure that we don't output comment end markers that might confuse
+    # doxygen.
     s!/\*!/ \*!g;
     s!\*/!\* /!g;
 
+    # substitute tabs
     s/\t/        /g;
+
+    # Remove "//" if it is present at the end of a line. These comments exist
+    # to force a specific formatting of the line for clang-format.
+    s!//$!!g;
 
     # We are entering code fragments
     if (($state != $code_fragment_mode) && m!^\s*//\s*\@code!)

--- a/doc/doxygen/scripts/program2plain
+++ b/doc/doxygen/scripts/program2plain
@@ -15,12 +15,16 @@
 
 # Remove all comments from the source file
 
-# The variable tracing whether we are inside a block comment
+# The output of this script is used as the source for the "The plain program"
+# block at the end of each tutorial.
 
-my $block_comment = 0;
 while (<>) {
-    # Eliminate //-comment lines
+    # Eliminate comment lines starting with "//"
     next if (m!^\s*//!);
+
+    # Remove "//" if it is present at the end of a line. These comments exist
+    # to force a specific formatting of the line for clang-format
+    s!//$!!g;
 
     # Otherwise print the line
     print;


### PR DESCRIPTION
We introduced "//" markers (see for example "shape_grad" lines in
step-8) to force a specific formatting for clang-format. Make sure we
don't output these markers to the tutorial pages.