### PR TITLE
Unify allocate/delete_device_data in base/cuda.h

### DIFF
--- a/doc/news/changes/minor/20180901DanielArndt
+++ b/doc/news/changes/minor/20180901DanielArndt
@@ -1,0 +1,5 @@
+New: Utilities::CUDA::allocate_device_data() and
+Utilities::CUDA::delete_device_data() help to manage data on CUDA devices
+using std::unique_ptr.
+<br>
+(Daniel Arndt, 2018/09/01)

--- a/include/deal.II/base/cuda.h
+++ b/include/deal.II/base/cuda.h
@@ -104,23 +104,6 @@ namespace Utilities
     }
 
     /**
-     * Deleter to be used for `std::unique_ptr` pointing to device memory.
-     */
-    template <typename Number>
-    void
-    delete_device_data(Number *device_ptr) noexcept
-    {
-#ifdef DEAL_II_COMPILER_CUDA_AWARE
-      const cudaError_t error_code = cudaFree(device_ptr);
-      (void)error_code;
-      AssertNothrow(error_code == cudaSuccess,
-                    dealii::ExcCudaError(cudaGetErrorString(error_code)));
-#else
-      (void)device_ptr;
-#endif
-    }
-
-    /**
      * Allocator to be used for `std::unique_ptr` pointing to device memory.
      */
     template <typename Number>
@@ -133,6 +116,29 @@ namespace Utilities
       return device_ptr;
 #else
       (void)size;
+      Assert(
+        false,
+        ExcMessage(
+          "This function can only be used if deal.II is built with CUDA support!"));
+#endif
+    }
+
+    /**
+     * Deleter to be used for `std::unique_ptr` pointing to device memory.
+     */
+    template <typename Number>
+    void
+    delete_device_data(Number *device_ptr) noexcept
+    {
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
+      const cudaError_t error_code = cudaFree(device_ptr);
+      AssertNothrowCuda(error_code);
+#else
+      (void)device_ptr;
+      AssertNothrow(
+        false,
+        ExcMessage(
+          "This function can only be used if deal.II is built with CUDA support!"));
 #endif
     }
 

--- a/include/deal.II/base/cuda.h
+++ b/include/deal.II/base/cuda.h
@@ -104,6 +104,39 @@ namespace Utilities
     }
 
     /**
+     * Deleter to be used for `std::unique_ptr` pointing to device memory.
+     */
+    template <typename Number>
+    void
+    delete_device_data(Number *device_ptr) noexcept
+    {
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
+      const cudaError_t error_code = cudaFree(device_ptr);
+      (void)error_code;
+      AssertNothrow(error_code == cudaSuccess,
+                    dealii::ExcCudaError(cudaGetErrorString(error_code)));
+#else
+      (void)device_ptr;
+#endif
+    }
+
+    /**
+     * Allocator to be used for `std::unique_ptr` pointing to device memory.
+     */
+    template <typename Number>
+    Number *
+    allocate_device_data(const std::size_t size)
+    {
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
+      Number *device_ptr;
+      Utilities::CUDA::malloc(device_ptr, size);
+      return device_ptr;
+#else
+      (void)size;
+#endif
+    }
+
+    /**
      * Copy the elements in @p pointer_dev to the host in @p vector_host.
      */
     template <typename T>


### PR DESCRIPTION
This PR unifies the various `allocate/delete_device_*` we introduced to be able to use `std::unique_ptr` in the `CUDAWrappers` classes.