### PR TITLE
Fix our usage of ':=' in MathJax.

### DIFF
--- a/doc/doxygen/headers/physics.h
+++ b/doc/doxygen/headers/physics.h
@@ -127,13 +127,13 @@ namespace Physics
    * in the current (spatial) configuration through the nonlinear map
    * @f[
    *  \mathbf{x}
-   *   := \boldsymbol{\varphi} \left( \mathbf{X} \right)
+   *   \dealcoloneq \boldsymbol{\varphi} \left( \mathbf{X} \right)
    *    = \mathbf{X} + \mathbf{u}(\mathbf{X}) \, ,
    * @f]
    * where the $\mathbf{u}(\mathbf{X})$ represents the displacement vector.
    * From this we can compute the deformation gradient tensor as
    * @f[
-   *  \mathbf{F} := \mathbf{I} + \nabla_{0}\mathbf{u} \, ,
+   *  \mathbf{F} \dealcoloneq \mathbf{I} + \nabla_{0}\mathbf{u} \, ,
    * @f]
    * wherein the differential operator $\nabla_{0}$ is defined as
    * $\frac{\partial}{\partial \mathbf{X}}$ and $\mathbf{I}$ is the identity
@@ -171,9 +171,11 @@ namespace Physics
    *
    * We then define the symmetric and skew-symmetric fourth-order unit tensors by
    * @f[
-   *      \mathcal{S} := \dfrac{1}{2}[\mathcal{I} + \overline{\mathcal{I}}]
-   *    \qquad \text{and} \qquad
-   *      \mathcal{W} := \dfrac{1}{2}[\mathcal{I} - \overline{\mathcal{I}}] \, ,
+   * \mathcal{S} \dealcoloneq
+   * \dfrac{1}{2}[\mathcal{I} + \overline{\mathcal{I}}]
+   * \qquad \text{and} \qquad
+   * \mathcal{W} \dealcoloneq
+   * \dfrac{1}{2}[\mathcal{I} - \overline{\mathcal{I}}] \, ,
    * @f]
    * such that
    * @f[

--- a/doc/doxygen/scripts/mod_header.pl.in
+++ b/doc/doxygen/scripts/mod_header.pl.in
@@ -14,3 +14,14 @@ if (m'</head>')
 }
 
 s/\$projectname// unless (m/<title>/);
+
+# Finally, define some extra commands for MathJax in every file. These are in an
+# undisplayed div so that the \newcommand text does not pop up and then
+# disappear while MathJax works.
+if (eof)
+{
+    CORE::say '<!--Extra macros for MathJax:-->';
+    CORE::say '<div style="display:none">';
+    CORE::say '\(\newcommand{\dealcoloneq}{\mathrel{\vcenter{:}}=}\)';
+    CORE::say '</div>';
+}

--- a/examples/step-12/doc/intro.dox
+++ b/examples/step-12/doc/intro.dox
@@ -38,7 +38,7 @@ of the domain.  Here, ${\mathbf \beta}={\mathbf \beta}({\bf x})$ denotes a
 vector field, $u$ the (scalar) solution
 function, $g$ a boundary value function,
 @f[
-\Gamma_-:=\{{\bf x}\in\Gamma, {\mathbf \beta}({\bf x})\cdot{\bf n}({\bf x})<0\}
+\Gamma_- \dealcoloneq \{{\bf x}\in\Gamma, {\mathbf \beta}({\bf x})\cdot{\bf n}({\bf x})<0\}
 @f]
 the inflow part of the boundary of the domain and ${\bf n}$ denotes
 the unit outward normal to the boundary $\Gamma$. This equation is the
@@ -47,7 +47,7 @@ step-9 of this tutorial.
 In particular, we solve the advection equation on
 $\Omega=[0,1]^2$ with ${\mathbf \beta}=\frac{1}{|x|}(-x_2, x_1)$
 representing a circular counterclockwise flow field, and $g=1$
-on ${\bf x}\in\Gamma_-^1:=[0,0.5]\times\{0\}$ and $g=0$ on ${\bf x}\in
+on ${\bf x}\in\Gamma_-^1 \dealcoloneq [0,0.5]\times\{0\}$ and $g=0$ on ${\bf x}\in
 \Gamma_-\setminus \Gamma_-^1$.
 
 We apply the well-known upwind discontinuous Galerkin method. To this

--- a/examples/step-14/doc/intro.dox
+++ b/examples/step-14/doc/intro.dox
@@ -124,7 +124,7 @@ with the neighbor cell $K'$, to obtain
 Using that for the normal vectors on adjacent cells we have $n'=-n$, we define the jump of the
 normal derivative by
 @f[
-  [\partial_n u_h] := \partial_n u_h|_K + \partial_{n'} u_h|_{K'}
+  [\partial_n u_h] \dealcoloneq \partial_n u_h|_K + \partial_{n'} u_h|_{K'}
   =
   \partial_n u_h|_K - \partial_n u_h|_{K'},
 @f]

--- a/examples/step-15/doc/intro.dox
+++ b/examples/step-15/doc/intro.dox
@@ -59,7 +59,7 @@ a damping parameter $\alpha^n$ to get better global convergence behavior:
   @f}
 with
   @f[
-    F(u):= -\nabla \cdot \left( \frac{1}{\sqrt{1+|\nabla u|^{2}}}\nabla u \right)
+    F(u) \dealcoloneq -\nabla \cdot \left( \frac{1}{\sqrt{1+|\nabla u|^{2}}}\nabla u \right)
   @f]
 and $F'(u,\delta u)$ the derivative of F in direction of $\delta u$:
 @f[
@@ -115,7 +115,7 @@ Reducing this space to a finite dimensional space with basis $\left\{
   \delta u^{n}=\sum_{j=0}^{N-1} \delta U_{j} \varphi_{j}.
 @f]
 
-Using the basis functions as test functions and defining $a_{n}:=\frac{1}
+Using the basis functions as test functions and defining $a_{n} \dealcoloneq \frac{1}
 {\sqrt{1+|\nabla u^{n}|^{2}}}$, we can rewrite the weak formulation:
 
 @f[
@@ -135,7 +135,7 @@ This linear system of equations can be rewritten as:
 where the entries of the matrix $A^{n}$ are given by:
 
 @f[
-  A^{n}_{ij}:= \left( \nabla \varphi_{i} , a_{n} \nabla \varphi_{j} \right) -
+  A^{n}_{ij} \dealcoloneq \left( \nabla \varphi_{i} , a_{n} \nabla \varphi_{j} \right) -
   \left(\nabla u^{n}\cdot \nabla \varphi_{i} , a_{n}^{3} \nabla u^{n} \cdot \nabla
   \varphi_{j} \right),
 @f]
@@ -143,7 +143,7 @@ where the entries of the matrix $A^{n}$ are given by:
 and the right hand side $b^{n}$ is given by:
 
 @f[
-  b^{n}_{i}:=-\left( \nabla \varphi_{i} , a_{n} \nabla u^{n}\right).
+  b^{n}_{i} \dealcoloneq -\left( \nabla \varphi_{i} , a_{n} \nabla u^{n}\right).
 @f]
 
 
@@ -301,4 +301,5 @@ follows:
 The testcase we solve is chosen as follows: We seek to find the solution of
 minimal surface over the unit disk $\Omega=\{\mathbf x: \|\mathbf
 x\|<1\}\subset {\mathbb R}^2$ where the surface attains the values
-$u(x,y)|{\partial\Omega} = g(x,y):=\sin(2 \pi (x+y))$ along the boundary.
+$u(x,y)|{\partial\Omega} = g(x,y) \dealcoloneq \sin(2 \pi (x+y))$ along the
+boundary.

--- a/examples/step-21/doc/intro.dox
+++ b/examples/step-21/doc/intro.dox
@@ -254,8 +254,8 @@ define that we want to evaluate it in the following sense:
   +
   \left(F(S^n_-) (\mathbf n \cdot \mathbf{u}^{n+1}_-), \sigma\right)_{\partial K_-},
 @f}
-where $\partial K_{-}:= \{x\in \partial K, \mathbf{u}(x) \cdot \mathbf{n}<0\}$
-denotes the inflow boundary and $\partial K_{+}:= \{\partial K \setminus
+where $\partial K_{-} \dealcoloneq \{x\in \partial K, \mathbf{u}(x) \cdot \mathbf{n}<0\}$
+denotes the inflow boundary and $\partial K_{+} \dealcoloneq \{\partial K \setminus
 \partial K_{-}\}$ is the outflow part of the boundary.
 The quantities $S_+,\mathbf{u}_+$ then correspond to the values of these
 variables on the present cell, whereas $S_-,\mathbf{u}_-$ (needed on the

--- a/examples/step-25/doc/intro.dox
+++ b/examples/step-25/doc/intro.dox
@@ -73,7 +73,7 @@ or implicit Euler method, respectively. Another important choice is
 $\theta=\frac{1}{2}$, which gives the second-order accurate
 Crank-Nicolson scheme. Henceforth, a superscript $n$ denotes the
 values of the variables at the $n^{\mathrm{th}}$ time step, i.e. at
-$t=t_n:= n k$, where $k$ is the (fixed) time step size. Thus,
+$t=t_n \dealcoloneq n k$, where $k$ is the (fixed) time step size. Thus,
 the split formulation of the time-discretized sine-Gordon equation becomes
 \f{eqnarray*}
   \frac{u^n - u^{n-1}}{k} - \left[\theta v^n + (1-\theta) v^{n-1}\right] &=& 0,\\

--- a/examples/step-34/doc/intro.dox
+++ b/examples/step-34/doc/intro.dox
@@ -154,7 +154,7 @@ $\mathbb{R}^n\backslash\Omega$, whose boundary is $ \Gamma_\infty \cup
 \Gamma$, where the "boundary" at infinity is defined as
 
 \f[
-\Gamma_\infty := \lim_{r\to\infty} \partial B_r(0).
+\Gamma_\infty \dealcoloneq \lim_{r\to\infty} \partial B_r(0).
 \f]
 
 In our program the normals are defined as <i>outer</i> to the domain
@@ -265,7 +265,7 @@ Notice that the fraction of angle (in 2d) or solid angle (in 3d)
 $\alpha(\mathbf{x})$ by which the point $\mathbf{x}$ sees the domain
 $\Omega$ can be defined using the double layer potential itself:
 \f[
-\alpha(\mathbf{x}) := 1 -
+\alpha(\mathbf{x}) \dealcoloneq 1 -
 \frac{1}{2(n-1)\pi}\int_{\partial \Omega} \frac{ (\mathbf{y}-\mathbf{x})\cdot\mathbf{n}_y  }
 { |\mathbf{y}-\mathbf{x}|^{n} }\phi(\mathbf{y})\,ds_y = 1+
 \int_{\partial \Omega} \frac{ \partial G(\mathbf{y}-\mathbf{x}) }{\partial \mathbf{n}_y} \, ds_y.
@@ -490,7 +490,7 @@ dimension $n$ of the surrounding space $\mathbb{R}^n$.
 We define the finite dimensional space $V_h$ as
 \f[
   \label{eq:definition-Vh}
-  V_h := \{ v \in C^0(\Gamma) \text{ s.t. } v|_{K_i} \in \mathcal{Q}^1(K_i),
+  V_h \dealcoloneq \{ v \in C^0(\Gamma) \text{ s.t. } v|_{K_i} \in \mathcal{Q}^1(K_i),
   \forall i\},
 \f]
 with basis functions $\psi_i(\mathbf{x})$ for which we will use the usual FE_Q
@@ -504,8 +504,8 @@ identified by the vector $\boldsymbol{\phi}$ of its coefficients
 $\phi_i$, that is:
 \f[
   \label{eq:definition-of-element}
-  \phi_h(\mathbf{x}) := \phi_i \psi_i(\mathbf{x}), \qquad
-  \boldsymbol{\phi} := \{ \phi_i \},
+  \phi_h(\mathbf{x}) \dealcoloneq \phi_i \psi_i(\mathbf{x}), \qquad
+  \boldsymbol{\phi} \dealcoloneq \{ \phi_i \},
 \f]
 where summation  is implied over repeated indexes. Note that we could use
 discontinuous elements here &mdash; in fact, there is no real reason to use
@@ -593,7 +593,7 @@ As usual in these cases, all integrations are performed on a reference
 simple domain, i.e., we assume that each element $K_i$ of
 $\mathcal{T}_h$ can be expressed as a linear (in two dimensions) or
 bi-linear (in three dimensions) transformation of the reference
-boundary element $\hat K := [0,1]^{n-1}$, and we perform the integrations after a
+boundary element $\hat K \dealcoloneq [0,1]^{n-1}$, and we perform the integrations after a
 change of variables from the real element $K_i$ to the reference
 element $\hat K$.
 

--- a/examples/step-38/doc/intro.dox
+++ b/examples/step-38/doc/intro.dox
@@ -35,7 +35,7 @@ a surface $S$ from a reference element $\hat S \subset \mathbb R^2$,
 i.e. each point $\hat{\mathbf x}\in\hat S$ induces a point ${\mathbf
   x}_S(\hat{\mathbf x}) \in S$. Then let
 @f[
-G_S:= (D \mathbf{x}_S)^T \ D \mathbf{x}_S
+G_S\dealcoloneq (D \mathbf{x}_S)^T \ D \mathbf{x}_S
 @f]
 denotes the corresponding first fundamental form, where $D
 \mathbf{x}_S=\left(\frac{\partial x_{S,i}(\hat{\mathbf x})}{\partial \hat x_j}\right)_{ij}$ is the 
@@ -47,11 +47,11 @@ constituted of quadrilaterals.
 We are now in position to define the tangential gradient of a function $v : S \rightarrow \mathbb
 R$ by
 @f[
-(\nabla_S v)\circ \mathbf x_S :=  D \mathbf x_S \ G_S^{-1} \ \nabla (v \circ \mathbf x_S).
+(\nabla_S v)\circ \mathbf x_S \dealcoloneq  D \mathbf x_S \ G_S^{-1} \ \nabla (v \circ \mathbf x_S).
 @f]
 The surface Laplacian (also called the Laplace-Beltrami operator) is then
-defined as  $\Delta_S:= \nabla_S \cdot \nabla_S$.
-Note that an alternate way to compute the surface gradient on smooth surfaces $\Gamma$ is 
+defined as  $\Delta_S \dealcoloneq \nabla_S \cdot \nabla_S$.
+Note that an alternate way to compute the surface gradient on smooth surfaces $\Gamma$ is
 @f[
 \nabla_S v = \nabla \tilde v - \mathbf n (\mathbf n \cdot \nabla \tilde v),
 @f]
@@ -76,7 +76,7 @@ and take advantage of the partition ${\mathbb T}$ to further write
   {\mathbb T}} \int_K f \ v  \qquad \forall v \in H^1_0(\Gamma).
 @f]
 Moreover, each integral in the above expression is computed in the reference
-element $\hat K:= [0,1]^2$ 
+element $\hat K \dealcoloneq [0,1]^2$
 so that
 @f{align*}
 \int_{K} \nabla_{K} u \cdot \nabla_{K} v 

--- a/examples/step-41/doc/intro.dox
+++ b/examples/step-41/doc/intro.dox
@@ -92,7 +92,7 @@ obstacle).
 
 An obvious way to obtain the variational formulation of the obstacle problem is to consider the total potential energy:
 @f{equation*}
- E(u):=\dfrac{1}{2}\int\limits_{\Omega} \nabla u \cdot \nabla u - \int\limits_{\Omega} fu.
+ E(u) \dealcoloneq \dfrac{1}{2}\int\limits_{\Omega} \nabla u \cdot \nabla u - \int\limits_{\Omega} fu.
 @f}
 We have to find a solution $u\in G$ of the following minimization problem:
 @f{equation*}
@@ -100,7 +100,7 @@ We have to find a solution $u\in G$ of the following minimization problem:
 @f}
 with the convex set of admissible displacements:
 @f{equation*}
- G:=\lbrace v\in V: v\geq g \text{ a.e. in } \Omega\rbrace,\quad V:=H^1_0(\Omega).
+ G \dealcoloneq \lbrace v\in V: v\geq g \text{ a.e. in } \Omega\rbrace,\quad V\dealcoloneq H^1_0(\Omega).
 @f}
 This set takes care of the third and fifth conditions above (the boundary
 values and the complementarity condition).
@@ -108,7 +108,7 @@ values and the complementarity condition).
 Consider now the minimizer $u\in G$ of $E$ and any other function $v\in
 G$. Then the function
 @f{equation*}
- F(\varepsilon) := E(u+\varepsilon(v-u)),\quad\varepsilon\in\left[0,1\right],
+ F(\varepsilon) \dealcoloneq E(u+\varepsilon(v-u)),\quad\varepsilon\in\left[0,1\right],
 @f}
 takes its minimum at $\varepsilon = 0$ (because $u$ is a minimizer of the
 energy functional $E(\cdot)$), so that $F'(0)\geq 0$ for any choice
@@ -142,7 +142,7 @@ condition above.
 The variational inequality above is awkward to work with. We would therefore
 like to reformulate it as an equivalent saddle point problem. We introduce a
 Lagrange multiplier $\lambda$ and the convex cone $K\subset V'$, $V'$
-dual space of $V$, $K:=\{\mu\in V': \langle\mu,v\rangle\geq 0,\quad \forall
+dual space of $V$, $K \dealcoloneq \{\mu\in V': \langle\mu,v\rangle\geq 0,\quad \forall
 v\in V, v \le 0 \}$ of
 Lagrange multipliers, where $\langle\cdot,\cdot\rangle$ denotes the duality
 pairing between $V'$ and $V$. Intuitively, $K$ is the cone of all "non-positive
@@ -157,8 +157,8 @@ This yields:
 @f}
 <i>with</i>
 @f{align*}
- a(u,v) &:= \left(\nabla u, \nabla v\right),\quad &&u,v\in V\\
- b(u,\mu) &:= \langle u,\mu\rangle,\quad &&u\in V,\quad\mu\in V'.
+ a(u,v) &\dealcoloneq \left(\nabla u, \nabla v\right),\quad &&u,v\in V\\
+ b(u,\mu) &\dealcoloneq \langle u,\mu\rangle,\quad &&u\in V,\quad\mu\in V'.
 @f}
 In other words, we can consider $\lambda$ as the negative of the additional, positive force that the
 obstacle exerts on the membrane. The inequality in the second line of the
@@ -215,7 +215,7 @@ With this, the equations above can be restated as
 
 Now we define for each degree of freedom $i$ the function
 @f{equation*}
- C([BU]_i,\Lambda_i):=-\Lambda_i + \min\lbrace 0, \Lambda_i + c([BU]_i - G_i) \rbrace,
+ C([BU]_i,\Lambda_i) \dealcoloneq -\Lambda_i + \min\lbrace 0, \Lambda_i + c([BU]_i - G_i) \rbrace,
 @f}
 with some $c>0$. (In this program we choose $c = 100$. It is a kind of a
 penalty parameter which depends on the problem itself and needs to be chosen
@@ -254,8 +254,8 @@ The algorithm for the primal-dual active set method works as follows (NOTE: $B =
 3. Define the new active and inactive sets by
  @f{equation*}
  \begin{split}
-  \mathcal{A}_{k+1}:=\lbrace i\in\mathcal{S}:\Lambda^k_i + c([BU^k]_i - G_i)< 0\rbrace,\\
-  \mathcal{F}_{k+1}:=\lbrace i\in\mathcal{S}:\Lambda^k_i + c([BU^k]_i - G_i)\geq 0\rbrace.
+  \mathcal{A}_{k+1} \dealcoloneq \lbrace i\in\mathcal{S}:\Lambda^k_i + c([BU^k]_i - G_i)< 0\rbrace,\\
+  \mathcal{F}_{k+1} \dealcoloneq \lbrace i\in\mathcal{S}:\Lambda^k_i + c([BU^k]_i - G_i)\geq 0\rbrace.
  \end{split}
  @f}
 4. If $\mathcal{A}_{k+1}=\mathcal{A}_k$ (and then, obviously, also
@@ -322,8 +322,8 @@ rows and columns whose indices belong to either the active set
 ${\mathcal{A}_k}$ or the inactive set ${\mathcal{F}_k}$.
 
 Rather than solving for updates $\delta U, \delta \Lambda$, we can also solve
-for the variables we are interested in right away by setting $\delta U^k :=
-U^{k+1} - U^k$ and $\delta \Lambda^k := \Lambda^{k+1} - \Lambda^k$ and
+for the variables we are interested in right away by setting $\delta U^k \dealcoloneq
+U^{k+1} - U^k$ and $\delta \Lambda^k \dealcoloneq \Lambda^{k+1} - \Lambda^k$ and
 bringing all known terms to the right hand side. This yields
 @f{equation*}
 \begin{pmatrix}

--- a/examples/step-42/doc/intro.dox
+++ b/examples/step-42/doc/intro.dox
@@ -146,7 +146,7 @@ V^+$ so that
 @f}
 where the projector $P_\Pi$ is defined as
 @f{align*}
- P_{\Pi}(\tau):=\begin{cases}
+ P_{\Pi}(\tau) \dealcoloneq \begin{cases}
     \tau, & \text{if }\vert\tau^D\vert \leq \sigma_0,\\
     \left[
       \dfrac{\gamma^{\text{iso}}}{2\mu + \gamma^{\text{iso}}} +
@@ -275,11 +275,11 @@ method for the contact. It works as follows:
  \mathcal{F}_i = \emptyset$ and set $i = 1$. Here, $\mathcal{S}$ is the set of
  all degrees of freedom located at the surface of the domain where contact
  may happen.
- The start value $\hat U^0 :=
+ The start value $\hat U^0 \dealcoloneq
  P_{\mathcal{A}_k}(0)$ fulfills our obstacle condition, i.e., we project an
  initial zero displacement onto the set of feasible displacements.
 
- <li> Assemble the Newton matrix $A_{pq} := a'(
+ <li> Assemble the Newton matrix $A_{pq} \dealcoloneq a'(
  U^{i-1};\varphi_p,\varphi_q)$ and the right-hand-side $F(\hat U^{i-1})$.
  These correspond to the linearized Newton step, ignoring for the moment
  the contact inequality.
@@ -299,8 +299,8 @@ method for the contact. It works as follows:
  <li> Damp the Newton iteration for $i>2$ by applying a line search and
  calculating a linear combination of $U^{i-1}$ and $\tilde U^i$. This
  requires finding an
- $\alpha^i_l:=2^{-l},(l=0,\ldots,10)$ so that
- @f{gather*}U^i := \alpha^i_l\bar U^i +
+ $\alpha^i_l \dealcoloneq 2^{-l},(l=0,\ldots,10)$ so that
+ @f{gather*}U^i \dealcoloneq \alpha^i_l\bar U^i +
  (1-\alpha^i_l)U^{i-1}@f}
  satisfies
  @f{gather*}
@@ -311,17 +311,17 @@ method for the contact. It works as follows:
  and (ii) elements that correspond to hanging nodes, which we eliminate in the usual manner.
 
  <li> Define the new active and inactive sets by
- @f{gather*}\mathcal{A}_{i+1}:=\lbrace p\in\mathcal{S}:\Lambda^i_p +
+ @f{gather*}\mathcal{A}_{i+1} \dealcoloneq \lbrace p\in\mathcal{S}:\Lambda^i_p +
  c\left(\left[B^TU^i\right]_p - G_p\right) > 0\rbrace,@f}
- @f{gather*}\mathcal{F}_{i+1}:=\lbrace p\in\mathcal{S}:\Lambda^i_p +
+ @f{gather*}\mathcal{F}_{i+1} \dealcoloneq \lbrace p\in\mathcal{S}:\Lambda^i_p +
  c\left(\left[B^TU^i\right]_p - G_p\right) \leq 0\rbrace.@f}
 
  <li>Project $U^i$ so that it satisfies the contact inequality,
- @f{gather*}\hat U^i := P_{\mathcal{A}_{i+1}}(U^i).@f}
+ @f{gather*}\hat U^i \dealcoloneq P_{\mathcal{A}_{i+1}}(U^i).@f}
  Here,
  $P_{\mathcal{A}}(U)$ is the projection of the active
  components in $\mathcal{A}$ to the gap
- @f{gather*}P_{\mathcal{A}}(U)_p:=\begin{cases}
+ @f{gather*}P_{\mathcal{A}}(U)_p \dealcoloneq \begin{cases}
  U_p, & \textrm{if}\quad p\notin\mathcal{A}\\
  g_{h,p}, & \textrm{if}\quad
  p\in\mathcal{A},

--- a/examples/step-44/doc/intro.dox
+++ b/examples/step-44/doc/intro.dox
@@ -99,9 +99,9 @@ The fourth-order unit tensors $\mathcal{I}$ and $\overline{\mathcal{I}}$ are def
 Note $\mathcal{I} \neq \overline{\mathcal{I}}^T$.
 Furthermore, we define the symmetric and skew-symmetric fourth-order unit tensors by
 @f[
-	\mathcal{S} := \dfrac{1}{2}[\mathcal{I} + \overline{\mathcal{I}}]
+	\mathcal{S} \dealcoloneq \dfrac{1}{2}[\mathcal{I} + \overline{\mathcal{I}}]
 		\qquad \text{and} \qquad
-	\mathcal{W} := \dfrac{1}{2}[\mathcal{I} - \overline{\mathcal{I}}] \, ,
+	\mathcal{W} \dealcoloneq \dfrac{1}{2}[\mathcal{I} - \overline{\mathcal{I}}] \, ,
 @f]
 such that
 @f[
@@ -130,12 +130,12 @@ The material description of the displacement of a particle is defined by
 The deformation gradient $\mathbf{F}$ is defined as the material gradient of the motion:
 @f[
 	\mathbf{F}(\mathbf{X},t)
-		:= \dfrac{\partial \boldsymbol{\varphi}(\mathbf{X},t)}{\partial \mathbf{X}}
+		\dealcoloneq \dfrac{\partial \boldsymbol{\varphi}(\mathbf{X},t)}{\partial \mathbf{X}}
 		= \textrm{Grad}\ \mathbf{x}(\mathbf{X},t)
 		= \mathbf{I} + \textrm{Grad}\ \mathbf{U} \, .
 @f]
 The determinant of the of the deformation gradient
-$J(\mathbf{X},t):= \textrm{det}\ \mathbf{F}(\mathbf{X},t) > 0$
+$J(\mathbf{X},t) \dealcoloneq \textrm{det}\ \mathbf{F}(\mathbf{X},t) > 0$
 maps corresponding volume elements in the reference and current configurations, denoted
 $\textrm{d}V$ and $\textrm{d}v$,
 respectively, as
@@ -143,13 +143,13 @@ respectively, as
 	\textrm{d}v = J(\mathbf{X},t)\; \textrm{d}V \, .
 @f]
 
-Two important measures of the deformation in terms of the spatial and material coordinates are the left and right Cauchy-Green tensors, respectively, 
-and denoted $\mathbf{b} := \mathbf{F}\mathbf{F}^T$ and $\mathbf{C} := \mathbf{F}^T\mathbf{F}$.
+Two important measures of the deformation in terms of the spatial and material coordinates are the left and right Cauchy-Green tensors, respectively,
+and denoted $\mathbf{b} \dealcoloneq \mathbf{F}\mathbf{F}^T$ and $\mathbf{C} \dealcoloneq \mathbf{F}^T\mathbf{F}$.
 They are both symmetric and positive definite.
 
 The Green-Lagrange strain tensor is defined by
 @f[
-	\mathbf{E}:= \frac{1}{2}[\mathbf{C} - \mathbf{I} ]
+	\mathbf{E} \dealcoloneq \frac{1}{2}[\mathbf{C} - \mathbf{I} ]
 		= \underbrace{\frac{1}{2}[\textrm{Grad}^T \mathbf{U} +	\textrm{Grad}\mathbf{U}]}_{\boldsymbol{\varepsilon}}
 			+ \frac{1}{2}[\textrm{Grad}^T\ \mathbf{U}][\textrm{Grad}\ \mathbf{U}] \, .
 @f]
@@ -175,7 +175,7 @@ The spatial velocity field is denoted $\mathbf{v}(\mathbf{x},t)$.
 The derivative of the spatial velocity field with respect to the spatial coordinates gives the spatial velocity gradient $\mathbf{l}(\mathbf{x},t)$, that is
 @f[
 	\mathbf{l}(\mathbf{x},t)
-		:= \dfrac{\partial \mathbf{v}(\mathbf{x},t)}{\partial \mathbf{x}}
+		\dealcoloneq \dfrac{\partial \mathbf{v}(\mathbf{x},t)}{\partial \mathbf{x}}
 		= \textrm{grad}\ \mathbf{v}(\mathbf{x},t) \, ,
 @f]
 where $\textrm{grad} \{\bullet \}
@@ -217,16 +217,16 @@ The stress measures used here are contravariant, while the strain measures are c
 
 The push-forward and-pull back operations for second-order covariant tensors $(\bullet)^{\text{cov}}$ are respectively given by:
 @f[
-	\chi_{*}(\bullet)^{\text{cov}}:= \mathbf{F}^{-T} (\bullet)^{\text{cov}} \mathbf{F}^{-1}
+	\chi_{*}(\bullet)^{\text{cov}} \dealcoloneq \mathbf{F}^{-T} (\bullet)^{\text{cov}} \mathbf{F}^{-1}
 	\qquad \text{and} \qquad
-	\chi^{-1}_{*}(\bullet)^{\text{cov}}:= \mathbf{F}^{T} (\bullet)^{\text{cov}} \mathbf{F} \, .
+	\chi^{-1}_{*}(\bullet)^{\text{cov}} \dealcoloneq \mathbf{F}^{T} (\bullet)^{\text{cov}} \mathbf{F} \, .
 @f]
 
 The push-forward and pull back operations for second-order contravariant tensors $(\bullet)^{\text{con}}$ are respectively given by:
 @f[
-	\chi_{*}(\bullet)^{\text{con}}:= \mathbf{F} (\bullet)^{\text{con}} \mathbf{F}^T
+	\chi_{*}(\bullet)^{\text{con}} \dealcoloneq \mathbf{F} (\bullet)^{\text{con}} \mathbf{F}^T
 	\qquad \text{and} \qquad
-	\chi^{-1}_{*}(\bullet)^{\text{con}}:= \mathbf{F}^{-1} (\bullet)^{\text{con}} \mathbf{F}^{-T} \, .
+	\chi^{-1}_{*}(\bullet)^{\text{con}} \dealcoloneq \mathbf{F}^{-1} (\bullet)^{\text{con}} \mathbf{F}^{-T} \, .
 @f]
 For example $\boldsymbol{\tau} = \chi_{*}(\mathbf{S})$.
 
@@ -263,12 +263,12 @@ Similarly, the Kirchhoff stress can be decomposed into volumetric and isochoric 
 		&= \underbrace{( \mathcal{I} - \dfrac{1}{3} \mathbf{I} \otimes \mathbf{I})}_{\mathbb{P}} : \overline{\boldsymbol{\tau}} \, ,
 @f}
 where
-$p := \dfrac{\partial \Psi_{\text{vol}}(J)}{\partial J}$ is the pressure response. 
-$\mathbb{P}$ is the projection tensor which provides the deviatoric operator in the Eulerian setting. 
+$p \dealcoloneq \dfrac{\partial \Psi_{\text{vol}}(J)}{\partial J}$ is the pressure response.
+$\mathbb{P}$ is the projection tensor which provides the deviatoric operator in the Eulerian setting.
 The fictitious Kirchhoff stress tensor $\overline{\boldsymbol{\tau}}$ is defined by
 @f[
 	\overline{\boldsymbol{\tau}}
-		:= 2 \overline{\mathbf{b}} \dfrac{\partial \Psi_{\textrm{iso}}(\overline{\mathbf{b}})}{\partial \overline{\mathbf{b}}} \, .
+		\dealcoloneq 2 \overline{\mathbf{b}} \dfrac{\partial \Psi_{\textrm{iso}}(\overline{\mathbf{b}})}{\partial \overline{\mathbf{b}}} \, .
 @f]
 
 
@@ -286,11 +286,11 @@ The Helmholtz free energy corresponding to a compressible <a href="http://en.wik
         \underbrace{\kappa [ \mathcal{G}(J) ] }_{\Psi_{\textrm{vol}}(J)}
         + \underbrace{\bigl[c_1 [ \overline{I}_1 - 3] \bigr]}_{\Psi_{\text{iso}}(\overline{\mathbf{b}})} \, ,
 @f]
-where $\kappa := \lambda + 2/3 \mu$ is the bulk modulus ($\lambda$ and $\mu$ are the Lame parameters)
-and $\overline{I}_1 := \textrm{tr}\ \overline{\mathbf{b}}$.
-The function $\mathcal{G}(J)$ is required to be strictly convex and satisfy the condition $\mathcal{G}(1) = 0$, 
+where $\kappa \dealcoloneq \lambda + 2/3 \mu$ is the bulk modulus ($\lambda$ and $\mu$ are the Lame parameters)
+and $\overline{I}_1 \dealcoloneq \textrm{tr}\ \overline{\mathbf{b}}$.
+The function $\mathcal{G}(J)$ is required to be strictly convex and satisfy the condition $\mathcal{G}(1) = 0$,
 among others, see Holzapfel (2001) for further details.
-In this work $\mathcal{G}:=\frac{1}{4} [ J^2 - 1 - 2\textrm{ln}J ]$.
+In this work $\mathcal{G} \dealcoloneq \frac{1}{4} [ J^2 - 1 - 2\textrm{ln}J ]$.
 
 Incompressibility imposes the isochoric constraint that $J=1$ for all motions $\boldsymbol{\varphi}$.
 The Helmholtz free energy corresponding to an incompressible neo-Hookean material is given by
@@ -298,7 +298,7 @@ The Helmholtz free energy corresponding to an incompressible neo-Hookean materia
     \Psi \equiv
         \underbrace{\bigl[ c_1 [ I_1 - 3] \bigr] }_{\Psi_{\textrm{iso}}(\mathbf{b})} \, ,
 @f]
-where $ I_1 := \textrm{tr}\mathbf{b} $.
+where $ I_1 \dealcoloneq \textrm{tr}\mathbf{b} $.
 Thus, the incompressible response is obtained by removing the volumetric component from the compressible free energy and enforcing $J=1$.
 
 
@@ -332,7 +332,7 @@ where
 		\\
 		&= J[\widehat{p}\, \mathbf{I} \otimes \mathbf{I} - 2p \mathcal{I}]
 			\qquad \text{where} \qquad
-		\widehat{p} := p + \dfrac{\textrm{d} p}{\textrm{d}J} \, ,
+		\widehat{p} \dealcoloneq p + \dfrac{\textrm{d} p}{\textrm{d}J} \, ,
 		\\
 	J \mathfrak{c}_{\text{iso}}
 		&=  4 \mathbf{b} \dfrac{\partial^2 \Psi_{\text{iso}}(\overline{\mathbf{b}})} {\partial \mathbf{b} \partial \mathbf{b}} \mathbf{b}
@@ -355,12 +355,12 @@ We wish to find the equilibrium configuration by minimising the potential energy
 
 As mentioned above, we adopt a three-field formulation.
 We denote the set of primary unknowns by
-$\mathbf{\Xi}:= \{ \mathbf{u}, \widetilde{p}, \widetilde{J} \}$.
+$\mathbf{\Xi} \dealcoloneq \{ \mathbf{u}, \widetilde{p}, \widetilde{J} \}$.
 The independent kinematic variable $\widetilde{J}$ enters the formulation as a constraint on $J$ enforced by the Lagrange multiplier $\widetilde{p}$ (the pressure, as we shall see).
 
 The three-field variational principle used here is given by
 @f[
-	\Pi(\mathbf{\Xi}) := \int_\Omega \bigl[
+	\Pi(\mathbf{\Xi}) \dealcoloneq \int_\Omega \bigl[
 		\Psi_{\textrm{vol}}(\widetilde{J})
 		+ \widetilde{p}\,[J(\mathbf{u}) - \widetilde{J}]
 		+ \Psi_{\textrm{iso}}(\overline{\mathbf{b}}(\mathbf{u}))
@@ -463,7 +463,7 @@ $\varDelta \{ \bullet \} = { \{ \bullet \} }^{\textrm{n}} - { \{ \bullet \} }^{\
 The value of a quantity at the current iteration $\textrm{i}$ is denoted 
 ${ \{ \bullet \} }^{\textrm{n}}_{\textrm{i}} = { \{ \bullet \} }_{\textrm{i}}$.
 The incremental change between iterations $\textrm{i}$ and $\textrm{i}+1$ is denoted
-$d \{ \bullet \} := \{ \bullet \}_{\textrm{i}+1} - \{ \bullet \}_{\textrm{i}}$.
+$d \{ \bullet \} \dealcoloneq \{ \bullet \}_{\textrm{i}+1} - \{ \bullet \}_{\textrm{i}}$.
 
 Assume that the state of the system is known for some iteration $\textrm{i}$.
 The linearised approximation to nonlinear governing equations to be solved using the  Newton-Raphson method is:
@@ -629,7 +629,7 @@ and thus
 @f]
 where
 @f[
-		\overline{\overline{\mathbf{\mathsf{K}}}} :=
+		\overline{\overline{\mathbf{\mathsf{K}}}} \dealcoloneq
 			\mathbf{\mathsf{K}}_{u\widetilde{p}} \overline{\mathbf{\mathsf{K}}} \mathbf{\mathsf{K}}_{\widetilde{p}u} \, .
 @f]
 Note that due to the choice of $\widetilde{p}$ and $\widetilde{J}$ as discontinuous at the element level, all matrices that need to be inverted are defined at the element level.
@@ -642,7 +642,7 @@ The procedure to construct the various contributions is as follows:
   That is
   @f[
         \mathbf{\mathsf{K}}_{\textrm{store}}
-:=
+\dealcoloneq
         \begin{bmatrix}
 			\mathbf{\mathsf{K}}_{\textrm{con}}	&	\mathbf{\mathsf{K}}_{u\widetilde{p}}	& \mathbf{0}
 			\\
@@ -660,10 +660,10 @@ In this tutorial we simply have one Material class named Material_Compressible_N
 Ideally this class would derive from a class HyperelasticMaterial which would derive from the base class Material.
 The three-field nature of the formulation used here also complicates the matter. 
 
-The Helmholtz free energy function for the three field formulation is $\Psi = \Psi_\text{vol}(\widetilde{J}) + \Psi_\text{iso}(\overline{\mathbf{b}})$. 
-The isochoric part of the Kirchhoff stress ${\boldsymbol{\tau}}_{\text{iso}}(\overline{\mathbf{b}})$ is identical to that obtained using a one-field formulation for a hyperelastic material. 
-However, the volumetric part of the free energy is now a function of the primary variable $\widetilde{J}$. 
-Thus, for a three field formulation the constitutive response for the volumetric part of the Kirchhoff stress ${\boldsymbol{\tau}}_{\text{vol}}$ (and the tangent) is not given by the hyperelastic constitutive law as in a one-field formulation. 
+The Helmholtz free energy function for the three field formulation is $\Psi = \Psi_\text{vol}(\widetilde{J}) + \Psi_\text{iso}(\overline{\mathbf{b}})$.
+The isochoric part of the Kirchhoff stress ${\boldsymbol{\tau}}_{\text{iso}}(\overline{\mathbf{b}})$ is identical to that obtained using a one-field formulation for a hyperelastic material.
+However, the volumetric part of the free energy is now a function of the primary variable $\widetilde{J}$.
+Thus, for a three field formulation the constitutive response for the volumetric part of the Kirchhoff stress ${\boldsymbol{\tau}}_{\text{vol}}$ (and the tangent) is not given by the hyperelastic constitutive law as in a one-field formulation.
 One can label the term
 $\boldsymbol{\tau}_{\textrm{vol}} \equiv \widetilde{p} J \mathbf{I}$
 as the volumetric Kirchhoff stress, but the pressure $\widetilde{p}$ is not derived from the free energy; it is a primary field.  

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -499,12 +499,12 @@ namespace Step44
   // \Psi_{\text{iso}}(\overline{\mathbf{b}}) = c_{1} [\overline{I}_{1} - 3] $
   // where $ c_{1} = \frac{\mu}{2} $ and $\overline{I}_{1}$ is the first
   // invariant of the left- or right-isochoric Cauchy-Green deformation tensors.
-  // That is $\overline{I}_1 :=\textrm{tr}(\overline{\mathbf{b}})$.  In this
-  // example the SEF that governs the volumetric response is defined as $
-  // \Psi_{\text{vol}}(\widetilde{J}) = \kappa \frac{1}{4} [ \widetilde{J}^2 - 1
-  // - 2\textrm{ln}\; \widetilde{J} ]$,  where $\kappa:= \lambda + 2/3 \mu$ is
-  // the <a href="http://en.wikipedia.org/wiki/Bulk_modulus">bulk modulus</a>
-  // and $\lambda$ is <a
+  // That is $\overline{I}_1 \dealcoloneq \textrm{tr}(\overline{\mathbf{b}})$.
+  // In this example the SEF that governs the volumetric response is defined as
+  // $ \Psi_{\text{vol}}(\widetilde{J}) = \kappa \frac{1}{4} [ \widetilde{J}^2 -
+  // 1 - 2\textrm{ln}\; \widetilde{J} ]$, where $\kappa \dealcoloneq \lambda +
+  // 2/3 \mu$ is the <a href="http://en.wikipedia.org/wiki/Bulk_modulus">bulk
+  // modulus</a> and $\lambda$ is <a
   // href="http://en.wikipedia.org/wiki/Lam%C3%A9_parameters">Lame's first
   // parameter</a>.
   //
@@ -1141,7 +1141,7 @@ namespace Step44
     time.increment();
 
     // We then declare the incremental solution update $\varDelta
-    // \mathbf{\Xi}:= \{\varDelta \mathbf{u},\varDelta \widetilde{p},
+    // \mathbf{\Xi} \dealcoloneq \{\varDelta \mathbf{u},\varDelta \widetilde{p},
     // \varDelta \widetilde{J} \}$ and start the loop over the time domain.
     //
     // At the beginning, we reset the solution update for this time step...
@@ -1955,10 +1955,9 @@ namespace Step44
     return vol_current;
   }
 
-  // Calculate how well the dilatation $\widetilde{J}$ agrees with $J :=
-  // \textrm{det}\ \mathbf{F}$ from the $L^2$ error $ \bigl[ \int_{\Omega_0} {[
-  // J
-  // - \widetilde{J}]}^{2}\textrm{d}V \bigr]^{1/2}$.
+  // Calculate how well the dilatation $\widetilde{J}$ agrees with $J
+  // \dealcoloneq \textrm{det}\ \mathbf{F}$ from the $L^2$ error $ \bigl[
+  // \int_{\Omega_0} {[ J - \widetilde{J}]}^{2}\textrm{d}V \bigr]^{1/2}$.
   // We also return the ratio of the current volume of the
   // domain to the reference volume. This is of interest for incompressible
   // media where we want to check how well the isochoric constraint has been
@@ -2731,8 +2730,8 @@ namespace Step44
     // with $\mathsf{\mathbf{k}}_{\textrm{con}} = \bigl[
     // \mathsf{\mathbf{k}}_{uu} +\overline{\overline{\mathsf{\mathbf{k}}}}~
     // \bigr]$ where $               \overline{\overline{\mathsf{\mathbf{k}}}}
-    // := \mathsf{\mathbf{k}}_{u\widetilde{p}} \overline{\mathsf{\mathbf{k}}}
-    // \mathsf{\mathbf{k}}_{\widetilde{p}u}
+    // \dealcoloneq \mathsf{\mathbf{k}}_{u\widetilde{p}}
+    // \overline{\mathsf{\mathbf{k}}} \mathsf{\mathbf{k}}_{\widetilde{p}u}
     // $
     // and
     // $
@@ -2891,7 +2890,7 @@ namespace Step44
         // the tangent matrix. For the following, recall that
         // @f{align*}
         //  \mathsf{\mathbf{K}}_{\textrm{store}}
-        //:=
+        //\dealcoloneq
         //  \begin{bmatrix}
         //      \mathsf{\mathbf{K}}_{\textrm{con}}      &
         //      \mathsf{\mathbf{K}}_{u\widetilde{p}}    & \mathbf{0}
@@ -2949,7 +2948,7 @@ namespace Step44
         //  @f]
         //  where
         //  @f[
-        //              \overline{\overline{\mathsf{\mathbf{K}}}} :=
+        //              \overline{\overline{\mathsf{\mathbf{K}}}} \dealcoloneq
         //                      \mathsf{\mathbf{K}}_{u\widetilde{p}}
         //                      \overline{\mathsf{\mathbf{K}}}
         //                      \mathsf{\mathbf{K}}_{\widetilde{p}u} \, .

--- a/examples/step-45/doc/intro.dox
+++ b/examples/step-45/doc/intro.dox
@@ -157,7 +157,7 @@ going to solve the Stokes problem
   -\textrm{div}\;  \textbf{u}&=&0,\\
   \textbf{u}|_{\Gamma_1}&=&{\bf 0},
 @f}
-where the boundary $\Gamma_1$ is defined as $\Gamma_1:=\{x\in \partial\Omega: \|x\|\in\{0.5,1\}\}$.
+where the boundary $\Gamma_1$ is defined as $\Gamma_1 \dealcoloneq \{x\in \partial\Omega: \|x\|\in\{0.5,1\}\}$.
 For the remaining parts of the boundary we are going to use periodic boundary conditions, i.e.
 @f{align*}
   u_x(0,\nu)&=-u_y(\nu,0)&\nu&\in[0,1]\\

--- a/examples/step-51/doc/intro.dox
+++ b/examples/step-51/doc/intro.dox
@@ -317,7 +317,7 @@ separately and uses the gradient as the main source of information.
 <h3> Problem specific data </h3>
 
 For this tutorial program, we consider almost the same test case as in
-step-7. The computational domain is $\Omega := [-1,1]^d$ and the exact
+step-7. The computational domain is $\Omega \dealcoloneq [-1,1]^d$ and the exact
 solution corresponds to the one in step-7, except for a scaling. We use the
 following source centers $x_i$ for the exponentials
 <ul>

--- a/examples/step-60/doc/intro.dox
+++ b/examples/step-60/doc/intro.dox
@@ -208,9 +208,9 @@ G
 where
 
 @f{eqnarray*}{
-K_{ij} &:=& (\nabla v_j, \nabla v_i)_\Omega   \qquad i,j=1,\dots,n \\
-C_{\alpha j} &:=& (v_j, q_\alpha)_\Gamma  \qquad j=1,\dots,n, \alpha = 1,\dots, m \\\\
-G_{\alpha} &:=& (g, q_\alpha)_\Gamma \qquad \alpha = 1,\dots, m.
+K_{ij} &\dealcoloneq& (\nabla v_j, \nabla v_i)_\Omega   \qquad i,j=1,\dots,n \\
+C_{\alpha j} &\dealcoloneq& (v_j, q_\alpha)_\Gamma  \qquad j=1,\dots,n, \alpha = 1,\dots, m \\\\
+G_{\alpha} &\dealcoloneq& (g, q_\alpha)_\Gamma \qquad \alpha = 1,\dots, m.
 @f}
 
 While the matrix $K$ is the standard stiffness matrix for the Poisson problem on
@@ -227,7 +227,7 @@ reference element $\hat K$, where $F_{K}$ is the mapping from $\hat K$ to $K$,
 and compute the integral on $\hat K$ using a quadrature formula:
 
 \f[
-C_{\alpha j} := (v_j, q_\alpha)_\Gamma  = \sum_{K\in \Gamma} \int_{\hat K}
+C_{\alpha j} \dealcoloneq (v_j, q_\alpha)_\Gamma  = \sum_{K\in \Gamma} \int_{\hat K}
 \hat q_\alpha(\hat x) (v_j \circ F_{K}) (\hat x) J_K (\hat x) \mathrm{d} \hat x =
 \sum_{K\in \Gamma} \sum_{i=1}^{n_q}  \big(\hat q_\alpha(\hat x_i)  (v_j \circ F_{K}) (\hat x_i) J_K (\hat x_i) w_i \big)
 \f]
@@ -242,7 +242,7 @@ of the matrix $C$.
 To evaluate $(v_j \circ F_{K}) (\hat x_i)$ the following steps needs to be
 taken (as shown in the picture below):
 
-- For a given cell $K$ in $\Gamma$ compute the real point $y_i := F_{K} (\hat
+- For a given cell $K$ in $\Gamma$ compute the real point $y_i \dealcoloneq F_{K} (\hat
 x_i)$, where $x_i$ is one of the quadrature points used for the integral on $K
 \subseteq \Gamma$.
 

--- a/include/deal.II/base/quadrature_lib.h
+++ b/include/deal.II/base/quadrature_lib.h
@@ -634,10 +634,10 @@ public:
    * where the matrix $B$ is given by $B_{ij} = v[j][i]-v[0][i]$.
    *
    * The weights are scaled with the absolute value of the determinant of $B$,
-   * that is $J := |\text{det}(B)|$. If $J$ is zero, an empty quadrature is
-   * returned. This may happen, in two dimensions, if the three vertices are
-   * aligned, or in three dimensions if the four vertices are on the same
-   * plane.
+   * that is $J \dealcoloneq |\text{det}(B)|$. If $J$ is zero, an empty
+   * quadrature is returned. This may happen, in two dimensions, if the three
+   * vertices are aligned, or in three dimensions if the four vertices are on
+   * the same plane.
    *
    * @param[in] vertices The vertices of the simplex you wish to integrate on
    * @return A quadrature object that can be used to integrate on the simplex
@@ -662,7 +662,7 @@ public:
  *  \frac{\hat x}{\sin(\theta)+\cos(\theta)} cos(\theta) \\
  *  \frac{\hat x}{\sin(\theta)+\cos(\theta)} sin(\theta)
  *  \end{pmatrix}
- *  \qquad \theta := \frac\pi 2 \hat y
+ *  \qquad \theta \dealcoloneq \frac\pi 2 \hat y
  * \f]
  *
  * @author Luca Heltai, 2017

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -2288,7 +2288,8 @@ inline DEAL_II_ALWAYS_INLINE Tensor<2, dim, Number>
  * The adjugate of a tensor $\left(\bullet\right)$ is defined as
  * @f[
  *  \textrm{adj}\left(\bullet\right)
- *   := \textrm{det}\left(\bullet\right) \; \left(\bullet\right)^{-1} \; .
+ *   \dealcoloneq \textrm{det}\left(\bullet\right) \; \left(\bullet\right)^{-1}
+ * \; .
  * @f]
  *
  * @note This requires that the tensor is invertible.
@@ -2309,7 +2310,7 @@ adjugate(const Tensor<2, dim, Number> &t)
  * The cofactor of a tensor $\left(\bullet\right)$ is defined as
  * @f[
  *  \textrm{cof}\left(\bullet\right)
- *   := \textrm{det}\left(\bullet\right) \; \left(\bullet\right)^{-T}
+ *   \dealcoloneq \textrm{det}\left(\bullet\right) \; \left(\bullet\right)^{-T}
  *    = \left[ \textrm{adj}\left(\bullet\right) \right]^{T} \; .
  * @f]
  *

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -847,11 +847,11 @@ namespace FEValuesViews
      * For 1d this function does not make any sense. Thus it is not
      * implemented for <code>spacedim=1</code>.  In 2d the curl is defined as
      * @f{equation*}{
-     * \operatorname{curl}(u):=\frac{du_2}{dx} -\frac{du_1}{dy},
+     * \operatorname{curl}(u) \dealcoloneq \frac{du_2}{dx} -\frac{du_1}{dy},
      * @f}
      * whereas in 3d it is given by
      * @f{equation*}{
-     * \operatorname{curl}(u):=\left( \begin{array}{c}
+     * \operatorname{curl}(u) \dealcoloneq \left( \begin{array}{c}
      * \frac{du_3}{dy}-\frac{du_2}{dz}\\ \frac{du_1}{dz}-\frac{du_3}{dx}\\
      * \frac{du_2}{dx}-\frac{du_1}{dy} \end{array} \right).
      * @f}
@@ -4542,9 +4542,9 @@ namespace FEValuesViews
         // A_{ij} = A_{ji} and there is only one (if diagonal) or two non-zero
         // entries in the tensorial representation.  define the
         // divergence as:
-        // b_i := \dfrac{\partial phi_{ij}}{\partial x_j}.
+        // b_i \dealcoloneq \dfrac{\partial phi_{ij}}{\partial x_j}.
         // (which is incidentally also
-        // b_j := \dfrac{\partial phi_{ij}}{\partial x_i}).
+        // b_j \dealcoloneq \dfrac{\partial phi_{ij}}{\partial x_i}).
         // In both cases, a sum is implied.
         //
         // Now, we know the nonzero component in unrolled form: it is indicated
@@ -4559,13 +4559,13 @@ namespace FEValuesViews
         // given the form of the divergence above, if ii=jj there is only a
         // single nonzero component of the full tensor and the gradient
         // equals
-        // b_ii := \dfrac{\partial phi_{ii,ii}}{\partial x_ii}.
+        // b_ii \dealcoloneq \dfrac{\partial phi_{ii,ii}}{\partial x_ii}.
         // all other entries of 'b' are zero
         //
         // on the other hand, if ii!=jj, then there are two nonzero entries in
         // the full tensor and
-        // b_ii := \dfrac{\partial phi_{ii,jj}}{\partial x_ii}.
-        // b_jj := \dfrac{\partial phi_{ii,jj}}{\partial x_jj}.
+        // b_ii \dealcoloneq \dfrac{\partial phi_{ii,jj}}{\partial x_ii}.
+        // b_jj \dealcoloneq \dfrac{\partial phi_{ii,jj}}{\partial x_jj}.
         // again, all other entries of 'b' are zero
         const dealii::Tensor<1, spacedim> &phi_grad =
           fe_values->finite_element_output.shape_gradients[snc][q_point];

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -360,7 +360,7 @@ public:
  * @relatesalso LinearOperator
  *
  * Addition of two linear operators @p first_op and @p second_op given by
- * $(\text{first\_op}+\text{second\_op})x := \text{first\_op}(x) +
+ * $(\text{first\_op}+\text{second\_op})x \dealcoloneq \text{first\_op}(x) +
  * \text{second\_op}(x)$
  *
  * @ingroup LAOperators
@@ -419,7 +419,7 @@ operator+(const LinearOperator<Range, Domain, Payload> &first_op,
  * @relatesalso LinearOperator
  *
  * Subtraction of two linear operators @p first_op and @p second_op given by
- * $(\text{first\_op}-\text{second\_op})x := \text{first\_op}(x) -
+ * $(\text{first\_op}-\text{second\_op})x \dealcoloneq \text{first\_op}(x) -
  * \text{second\_op}(x)$
  *
  * @ingroup LAOperators
@@ -554,7 +554,7 @@ operator*(const LinearOperator<Range, Domain, Payload> &op,
  * @relatesalso LinearOperator
  *
  * Composition of two linear operators @p first_op and @p second_op given by
- * $(\text{first\_op}*\text{second\_op})x :=
+ * $(\text{first\_op}*\text{second\_op})x \dealcoloneq
  * \text{first\_op}(\text{second\_op}(x))$
  *
  * @ingroup LAOperators

--- a/include/deal.II/lac/scalapack.templates.h
+++ b/include/deal.II/lac/scalapack.templates.h
@@ -449,10 +449,15 @@ extern "C"
 
   /**
    * Perform one of the matrix-matrix operations:
-   * sub( C ) := alpha*op( sub( A ) )*op( sub( B ) ) + beta*sub( C ),
+   * @f{align*}
+   * \mathrm{sub}(C) &\dealcoloneq \alpha op(\mathrm{sub}(A))op(\mathrm{sub}(B))
+   *                            + \beta \mathrm{sub}(C), \\
+   * \mathrm{sub}(C) &\dealcoloneq \alpha op(\mathrm{sub}(A))op(\mathrm{sub}(B))
+   *                            + beta sub(C),
+   * @f
    * where
-   * sub( C ) denotes C(IC:IC+M-1,JC:JC+N-1),  and, op( X )  is one  of
-   * op( X ) = X   or   op( X ) = X'.
+   * $\mathrm{sub}(C)$ denotes C(IC:IC+M-1,JC:JC+N-1),  and, $op(X)$ is one of
+   * $op(X) = X$ or $op(X) = X^T$.
    */
   void
   pdgemm_(const char *  transa,
@@ -574,10 +579,11 @@ extern "C"
           int *       info);
 
   /**
-   * Copy all or a part of a distributed matrix A to another
-   * distributed matrix B. No communication is performed, pdlacpy
-   * performs a local copy sub(A) := sub(B), where sub(A) denotes
-   * A(ia:ia+m-1,ja:ja+n-1) and sub(B) denotes B(ib:ib+m-1,jb:jb+n-1)
+   * Copy all or a part of a distributed matrix A to another distributed matrix
+   * B. No communication is performed, pdlacpy performs a local copy
+   * $\mathrm{sub}(A) \dealcoloneq \mathrm{sub}(B)$, where $\mathrm{sub}(A)$
+   * denotes $A(ia:ia+m-1, ja:ja+n-1)$ and $\mathrm{sub}(B)$ denotes
+   * $B(ib:ib+m-1, jb:jb+n-1)$.
    */
   void
   pdlacpy_(const char *  uplo,
@@ -801,8 +807,10 @@ extern "C"
 
   /*
    * Perform matrix sum:
-   * C := beta*C + alpha*op(A),
-   * where op(A) denotes either op(A)=A or op(A)=A^T
+   * @f{equation*}
+   * C \dealcoloneq \beta C + \alpha op(A),
+   * @f
+   * where $op(A)$ denotes either $op(A) = A$ or $op(A)=A^T$.
    */
   void
   pdgeadd_(const char *  transa,

--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -230,7 +230,7 @@ public:
   /**
    * Enables the failure check. Solving is stopped with @p ReturnState @p
    * failure if <tt>residual>failure_residual</tt> with
-   * <tt>failure_residual:=rel_failure_residual*first_residual</tt>.
+   * <tt>failure_residual := rel_failure_residual*first_residual</tt>.
    */
   void
   set_failure_criterion(const double rel_failure_residual);

--- a/include/deal.II/non_matching/coupling.h
+++ b/include/deal.II/non_matching/coupling.h
@@ -52,7 +52,8 @@ namespace NonMatching
    * \text{span}\{w_j\}_{j=0}^m$, compute the sparsity pattern that would be
    * necessary to assemble the matrix
    * \f[
-   * M_{ij} := \int_{B} v_i(x) w_j(x) dx, \quad i \in [0,n), j \in [0,m),
+   * M_{ij} \dealcoloneq \int_{B} v_i(x) w_j(x) dx,
+   *                     \quad i \in [0,n), j \in [0,m),
    * \f]
    * where $V(\Omega)$ is the finite element space associated with the
    * `space_dh` passed to this function (or part of it, if specified in
@@ -144,7 +145,8 @@ namespace NonMatching
    * $V(\Omega) = \text{span}\{v_i\}_{i=0}^n$ and $Q(B) =
    * \text{span}\{w_j\}_{j=0}^m$, compute the coupling matrix
    * \f[
-   * M_{ij} := \int_{B} v_i(x) w_j(x) dx, \quad i \in [0,n), j \in [0,m),
+   * M_{ij} \dealcoloneq \int_{B} v_i(x) w_j(x) dx,
+   *                     \quad i \in [0,n), j \in [0,m),
    * \f]
    * where $V(\Omega)$ is the finite element space associated with the
    * `space_dh` passed to this function (or part of it, if specified in

--- a/include/deal.II/non_matching/immersed_surface_quadrature.h
+++ b/include/deal.II/non_matching/immersed_surface_quadrature.h
@@ -57,7 +57,7 @@ namespace NonMatching
    * also the normalized normal for each quadrature point. This can be viewed
    * as storing a discrete surface element,
    * @f[
-   * \Delta \hat{S}_q := w_q \hat{n}_q \approx d\hat{S}(\hat{x}_q),
+   * \Delta \hat{S}_q \dealcoloneq w_q \hat{n}_q \approx d\hat{S}(\hat{x}_q),
    * @f]
    * for each quadrature point. The surface integral in real space would then be
    * approximated as

--- a/include/deal.II/physics/elasticity/kinematics.h
+++ b/include/deal.II/physics/elasticity/kinematics.h
@@ -57,7 +57,8 @@ namespace Physics
        * The result is expressed as
        * @f[
        *  \mathbf{F}
-       *    := \nabla_{0} \boldsymbol{\varphi} \left( \mathbf{X} \right)
+       *    \dealcoloneq \nabla_{0} \boldsymbol{\varphi}
+       *    \left( \mathbf{X} \right)
        *     =\mathbf{I} + \nabla_{0}\mathbf{u}
        * @f]
        * where $\mathbf{u} = \mathbf{u}\left(\mathbf{X}\right)$ is the
@@ -77,7 +78,7 @@ namespace Physics
        * tensor @p F .
        * The result is expressed as
        * @f[
-       *  \mathbf{F}^{\text{iso}} := J^{-1/\textrm{dim}} \mathbf{F}
+       *  \mathbf{F}^{\text{iso}} \dealcoloneq J^{-1/\textrm{dim}} \mathbf{F}
        * @f]
        * where $J = \text{det}\left(\mathbf{F}\right)$.
        *
@@ -93,7 +94,7 @@ namespace Physics
        * tensor @p F .
        * The result is expressed as
        * @f[
-       *  \mathbf{F}^{\text{vol}} := J^{1/\textrm{dim}} \mathbf{I}
+       *  \mathbf{F}^{\text{vol}} \dealcoloneq J^{1/\textrm{dim}} \mathbf{I}
        * @f]
        * where $J = \text{det}\left(\mathbf{F}\right)$.
        *
@@ -109,7 +110,7 @@ namespace Physics
        * as constructed from the deformation gradient tensor @p F.
        * The result is expressed as
        * @f[
-       *  \mathbf{C} := \mathbf{F}^{T}\cdot\mathbf{F} \, .
+       *  \mathbf{C} \dealcoloneq \mathbf{F}^{T}\cdot\mathbf{F} \, .
        * @f]
        *
        * @dealiiWriggersA{23,3.15}
@@ -124,7 +125,7 @@ namespace Physics
        * as constructed from the deformation gradient tensor @p F.
        * The result is expressed as
        * @f[
-       *  \mathbf{b} := \mathbf{F}\cdot\mathbf{F}^{T} \, .
+       *  \mathbf{b} \dealcoloneq \mathbf{F}\cdot\mathbf{F}^{T} \, .
        * @f]
        *
        * @dealiiWriggersA{28,3.25}
@@ -146,8 +147,8 @@ namespace Physics
        * as constructed from the deformation gradient tensor @p F.
        * The result is expressed as
        * @f[
-       *  \mathbf{E} := \frac{1}{2}[\mathbf{F}^{T}\cdot\mathbf{F} - \mathbf{I}]
-       * \, .
+       *  \mathbf{E} \dealcoloneq \frac{1}{2}
+       *  \left[ \mathbf{F}^{T}\cdot\mathbf{F} - \mathbf{I} \right] \, .
        * @f]
        *
        * @dealiiWriggersA{23,3.15}
@@ -162,8 +163,8 @@ namespace Physics
        * as constructed from the displacement gradient tensor @p Grad_u.
        * The result is expressed as
        * @f[
-       *  \boldsymbol{\varepsilon} := \frac{1}{2} \left[ \nabla_{0}\mathbf{u}
-       *   + [\nabla_{0}\mathbf{u}]^{T} \right] \, .
+       *  \boldsymbol{\varepsilon} \dealcoloneq \frac{1}{2}
+       *  \left[ \nabla_{0}\mathbf{u} + [\nabla_{0}\mathbf{u}]^{T} \right] \, .
        * @f]
        * where $\mathbf{u} = \mathbf{u}(\mathbf{X})$ is the displacement at
        * position
@@ -182,7 +183,7 @@ namespace Physics
        * as constructed from the deformation gradient tensor @p F.
        * The result is expressed as
        * @f[
-       *  \mathbf{e} := \frac{1}{2} \left[ \mathbf{I}
+       *  \mathbf{e} \dealcoloneq \frac{1}{2} \left[ \mathbf{I}
        *   - \mathbf{F}^{-T}\cdot\mathbf{F}^{-1} \right] \, .
        * @f]
        *
@@ -207,7 +208,7 @@ namespace Physics
        * gradient).
        * The result is expressed as
        * @f[
-       *  \mathbf{l} := \dot{\mathbf{F}}\cdot\mathbf{F}^{-1} \, .
+       *  \mathbf{l} \dealcoloneq \dot{\mathbf{F}}\cdot\mathbf{F}^{-1} \, .
        * @f]
        *
        * @dealiiWriggersA{32,3.47}
@@ -224,7 +225,8 @@ namespace Physics
        * gradient).
        * The result is expressed as
        * @f[
-       *  \mathbf{d} := \frac{1}{2} \left[ \mathbf{l} + \mathbf{l}^{T} \right]
+       *  \mathbf{d} \dealcoloneq \frac{1}{2}
+       *  \left[ \mathbf{l} + \mathbf{l}^{T} \right]
        * @f]
        * where
        * @f[
@@ -246,7 +248,8 @@ namespace Physics
        * gradient).
        * The result is expressed as
        * @f[
-       *  \mathbf{w} := \frac{1}{2} \left[ \mathbf{l} - \mathbf{l}^{T} \right]
+       *  \mathbf{w} \dealcoloneq \frac{1}{2}
+       *  \left[ \mathbf{l} - \mathbf{l}^{T} \right]
        * @f]
        * where
        * @f[

--- a/include/deal.II/physics/elasticity/standard_tensors.h
+++ b/include/deal.II/physics/elasticity/standard_tensors.h
@@ -77,7 +77,8 @@ namespace Physics
        * \}$ the following holds:
        * @f[
        *   \mathcal{S} : \{ \hat{\bullet} \}
-       *     := \dfrac{1}{2}[\{ \hat{\bullet} \} + \{ \hat{\bullet} \}^T] \, .
+       *   \dealcoloneq \dfrac{1}{2}
+       *   \left[ \{ \hat{\bullet} \} + \{ \hat{\bullet} \}^T \right] \, .
        * @f]
        *
        * As a corollary to this, for any second-order symmetric tensor $\{
@@ -125,8 +126,8 @@ namespace Physics
        * This is defined as
        * @f[
        *   \mathcal{P}
-       *     := \mathcal{S} - \frac{1}{\textrm{dim}} \mathbf{I} \otimes
-       * \mathbf{I}
+       *     \dealcoloneq \mathcal{S} - \frac{1}{\textrm{dim}} \mathbf{I}
+       *     \otimes \mathbf{I}
        * @f]
        * where $\mathcal{S}$ is the fourth-order unit symmetric tensor and
        * $\mathbf{I}$ is the second-order identity tensor.
@@ -134,9 +135,10 @@ namespace Physics
        * For any second-order (spatial) symmetric tensor the following holds:
        * @f[
        *  \mathcal{P} : \{ \bullet \}
-       *  := \{ \bullet \} - \frac{1}{\textrm{dim}} \left[ \{ \bullet \} :
-       * \mathbf{I} \right]\mathbf{I} = \mathcal{P}^{T} : \{ \bullet \} =
-       * \texttt{dev\_P} \left( \{ \bullet \} \right)
+       *  \dealcoloneq \{ \bullet \} - \frac{1}{\textrm{dim}}
+       *  \left[ \{ \bullet \} : \mathbf{I} \right]\mathbf{I}
+       *  = \mathcal{P}^{T} : \{ \bullet \}
+       *  = \texttt{dev\_P} \left( \{ \bullet \} \right)
        * @f]
        * and, therefore,
        * @f[
@@ -164,11 +166,11 @@ namespace Physics
        * This referential isochoric projection tensor is defined as
        * @f[
        *   \hat{\mathcal{P}}
-       *     := \frac{\partial \bar{\mathbf{C}}}{\partial \mathbf{C}}
+       *     \dealcoloneq \frac{\partial \bar{\mathbf{C}}}{\partial \mathbf{C}}
        * @f]
        * with
        * @f[
-       *  \bar{\mathbf{C}} := J^{-2/\textrm{dim}} \mathbf{C}
+       *  \bar{\mathbf{C}} \dealcoloneq J^{-2/\textrm{dim}} \mathbf{C}
        *    \qquad \text{,} \qquad
        *  \mathbf{C} = \mathbf{F}^{T}\cdot\mathbf{F}
        *    \qquad \text{and} \qquad
@@ -178,7 +180,7 @@ namespace Physics
        * the following holds:
        * @f[
        *  \{ \bullet \} : \hat{\mathcal{P}}
-       *    := J^{-2/\textrm{dim}} \left[ \{ \bullet \} -
+       *    \dealcoloneq J^{-2/\textrm{dim}} \left[ \{ \bullet \} -
        * \frac{1}{\textrm{dim}}\left[\mathbf{C} : \{ \bullet \}\right]
        * \mathbf{C}^{-1} \right] = \texttt{Dev\_P} \left( \{ \bullet \} \right)
        * \, .
@@ -272,7 +274,7 @@ namespace Physics
        * @f[
        *  \left[ \frac{\partial \mathbf{C}^{-1}}{\partial \mathbf{C}}
        * \right]_{IJKL}
-       *    := -\frac{1}{2}[ C^{-1}_{IK}C^{-1}_{JL}
+       *    \dealcoloneq -\frac{1}{2}[ C^{-1}_{IK}C^{-1}_{JL}
        *     + C^{-1}_{IL}C^{-1}_{JK}  ]
        * @f]
        *

--- a/include/deal.II/physics/notation.h
+++ b/include/deal.II/physics/notation.h
@@ -43,7 +43,7 @@ namespace Physics
      * a rank-2 symmetric tensor $\mathbf{S}$ we enumerate its tensor
      * components
      * @f[
-     * \mathbf{S} := \left[ \begin{array}{ccc}
+     * \mathbf{S} \dealcoloneq \left[ \begin{array}{ccc}
      *  S_{00}          & S_{01}          & S_{02} \\
      *  S_{10} = S_{01} & S_{11}          & S_{12} \\
      *  S_{20} = S_{02} & S_{21} = S_{12} & S_{22}
@@ -58,7 +58,7 @@ namespace Physics
      * where $n$ denotes the Kelvin index for the tensor component,
      * while for a general rank-2 tensor $\mathbf{T}$
      * @f[
-     * \mathbf{T} := \left[ \begin{array}{ccc}
+     * \mathbf{T} \dealcoloneq \left[ \begin{array}{ccc}
      *  T_{00} & T_{01} & T_{02} \\
      *  T_{10} & T_{11} & T_{12} \\
      *  T_{20} & T_{21} & T_{22}
@@ -72,7 +72,7 @@ namespace Physics
      * @f]
      * and for a rank-1 tensor $\mathbf{v}$
      * @f[
-     * \mathbf{v} := \left[ \begin{array}{c}
+     * \mathbf{v} \dealcoloneq \left[ \begin{array}{c}
      *  v_{0} \\ v_{1} \\ v_{2}
      * \end{array}\right]
      * \quad \Rightarrow \quad

--- a/include/deal.II/physics/transformations.h
+++ b/include/deal.II/physics/transformations.h
@@ -43,7 +43,7 @@ namespace Physics
       /**
        * Return the rotation matrix for 2-d Euclidean space, namely
        * @f[
-       *  \mathbf{R} := \left[ \begin{array}{cc}
+       *  \mathbf{R} \dealcoloneq \left[ \begin{array}{cc}
        *  cos(\theta) & sin(\theta) \\
        *  -sin(\theta) & cos(\theta)
        * \end{array}\right]
@@ -65,7 +65,7 @@ namespace Physics
        * stated using the Rodrigues' rotation formula, this function returns
        * the equivalent of
        * @f[
-       *  \mathbf{R} := cos(\theta)\mathbf{I} + sin(\theta)\mathbf{W}
+       *  \mathbf{R} \dealcoloneq cos(\theta)\mathbf{I} + sin(\theta)\mathbf{W}
        *              + (1-cos(\theta))\mathbf{u}\otimes\mathbf{u}
        * @f]
        * where $\mathbf{u}$ is the axial vector (an axial vector) and $\theta$
@@ -126,7 +126,7 @@ namespace Physics
        * contravariant vector, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\sharp}
-       *    := \mathbf{F} \cdot \left(\bullet\right)^{\sharp}
+       *    \dealcoloneq \mathbf{F} \cdot \left(\bullet\right)^{\sharp}
        * @f]
        *
        * @param[in] V The (referential) vector to be operated on
@@ -144,7 +144,7 @@ namespace Physics
        * contravariant tensor, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\sharp}
-       *    := \mathbf{F} \cdot \left(\bullet\right)^{\sharp} \cdot
+       *    \dealcoloneq \mathbf{F} \cdot \left(\bullet\right)^{\sharp} \cdot
        * \mathbf{F}^{T}
        * @f]
        *
@@ -163,7 +163,7 @@ namespace Physics
        * contravariant symmetric tensor, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\sharp}
-       *    := \mathbf{F} \cdot \left(\bullet\right)^{\sharp} \cdot
+       *    \dealcoloneq \mathbf{F} \cdot \left(\bullet\right)^{\sharp} \cdot
        * \mathbf{F}^{T}
        * @f]
        *
@@ -183,7 +183,8 @@ namespace Physics
        * contravariant tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi\left(\bullet\right)^{\sharp} \right]_{ijkl}
-       *    := F_{iI} F_{jJ} \left(\bullet\right)^{\sharp}_{IJKL} F_{kK} F_{lL}
+       *    \dealcoloneq F_{iI} F_{jJ}
+       *    \left(\bullet\right)^{\sharp}_{IJKL} F_{kK} F_{lL}
        * @f]
        *
        * @param[in] H The (referential) rank-4 tensor to be operated on
@@ -201,7 +202,8 @@ namespace Physics
        * contravariant symmetric tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi\left(\bullet\right)^{\sharp} \right]_{ijkl}
-       *    := F_{iI} F_{jJ} \left(\bullet\right)^{\sharp}_{IJKL} F_{kK} F_{lL}
+       *    \dealcoloneq F_{iI} F_{jJ}
+       *    \left(\bullet\right)^{\sharp}_{IJKL} F_{kK} F_{lL}
        * @f]
        *
        * @param[in] H The (referential) rank-4 symmetric tensor to be operated
@@ -227,7 +229,7 @@ namespace Physics
        * vector, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\sharp}
-       *    := \mathbf{F}^{-1} \cdot \left(\bullet\right)^{\sharp}
+       *    \dealcoloneq \mathbf{F}^{-1} \cdot \left(\bullet\right)^{\sharp}
        * @f]
        *
        * @param[in] v The (spatial) vector to be operated on
@@ -245,8 +247,8 @@ namespace Physics
        * contravariant tensor, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\sharp}
-       *    := \mathbf{F}^{-1} \cdot \left(\bullet\right)^{\sharp} \cdot
-       * \mathbf{F}^{-T}
+       *    \dealcoloneq \mathbf{F}^{-1} \cdot \left(\bullet\right)^{\sharp}
+       *    \cdot \mathbf{F}^{-T}
        * @f]
        *
        * @param[in] t The (spatial) tensor to be operated on
@@ -264,8 +266,8 @@ namespace Physics
        * contravariant symmetric tensor, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\sharp}
-       *    := \mathbf{F}^{-1} \cdot \left(\bullet\right)^{\sharp} \cdot
-       * \mathbf{F}^{-T}
+       *    \dealcoloneq \mathbf{F}^{-1} \cdot \left(\bullet\right)^{\sharp}
+       *    \cdot \mathbf{F}^{-T}
        * @f]
        *
        * @param[in] t The (spatial) symmetric tensor to be operated on
@@ -283,8 +285,8 @@ namespace Physics
        * contravariant tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi^{-1}\left(\bullet\right)^{\sharp} \right]_{IJKL}
-       *    := F^{-1}_{Ii} F^{-1}_{Jj} \left(\bullet\right)^{\sharp}_{ijkl}
-       * F^{-1}_{Kk} F^{-1}_{Ll}
+       *    \dealcoloneq F^{-1}_{Ii} F^{-1}_{Jj}
+       * \left(\bullet\right)^{\sharp}_{ijkl} F^{-1}_{Kk} F^{-1}_{Ll}
        * @f]
        *
        * @param[in] h The (spatial) tensor to be operated on
@@ -302,8 +304,8 @@ namespace Physics
        * contravariant symmetric tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi^{-1}\left(\bullet\right)^{\sharp} \right]_{IJKL}
-       *    := F^{-1}_{Ii} F^{-1}_{Jj} \left(\bullet\right)^{\sharp}_{ijkl}
-       * F^{-1}_{Kk} F^{-1}_{Ll}
+       *    \dealcoloneq F^{-1}_{Ii} F^{-1}_{Jj}
+       *    \left(\bullet\right)^{\sharp}_{ijkl} F^{-1}_{Kk} F^{-1}_{Ll}
        * @f]
        *
        * @param[in] h The (spatial) symmetric tensor to be operated on
@@ -351,7 +353,7 @@ namespace Physics
        * vector, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\flat}
-       *    := \mathbf{F}^{-T} \cdot \left(\bullet\right)^{\flat}
+       *    \dealcoloneq \mathbf{F}^{-T} \cdot \left(\bullet\right)^{\flat}
        * @f]
        *
        * @param[in] V The (referential) vector to be operated on
@@ -369,8 +371,8 @@ namespace Physics
        * covariant tensor, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\flat}
-       *    := \mathbf{F}^{-T} \cdot \left(\bullet\right)^{\flat} \cdot
-       * \mathbf{F}^{-1}
+       *    \dealcoloneq \mathbf{F}^{-T} \cdot \left(\bullet\right)^{\flat}
+       *    \cdot \mathbf{F}^{-1}
        * @f]
        *
        * @param[in] T The (referential) rank-2 tensor to be operated on
@@ -388,8 +390,8 @@ namespace Physics
        * covariant symmetric tensor, i.e.
        * @f[
        *  \chi\left(\bullet\right)^{\flat}
-       *    := \mathbf{F}^{-T} \cdot \left(\bullet\right)^{\flat} \cdot
-       * \mathbf{F}^{-1}
+       *    \dealcoloneq \mathbf{F}^{-T} \cdot \left(\bullet\right)^{\flat}
+       *    \cdot \mathbf{F}^{-1}
        * @f]
        *
        * @param[in] T The (referential) rank-2 symmetric tensor to be operated
@@ -408,8 +410,8 @@ namespace Physics
        * covariant tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi\left(\bullet\right)^{\flat} \right]_{ijkl}
-       *    := F^{-T}_{iI} F^{-T}_{jJ} \left(\bullet\right)^{\flat}_{IJKL}
-       * F^{-T}_{kK} F^{-T}_{lL}
+       *    \dealcoloneq F^{-T}_{iI} F^{-T}_{jJ}
+       *    \left(\bullet\right)^{\flat}_{IJKL} F^{-T}_{kK} F^{-T}_{lL}
        * @f]
        *
        * @param[in] H The (referential) rank-4 tensor to be operated on
@@ -427,8 +429,8 @@ namespace Physics
        * covariant symmetric tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi\left(\bullet\right)^{\flat} \right]_{ijkl}
-       *    := F^{-T}_{iI} F^{-T}_{jJ} \left(\bullet\right)^{\flat}_{IJKL}
-       * F^{-T}_{kK} F^{-T}_{lL}
+       *    \dealcoloneq F^{-T}_{iI} F^{-T}_{jJ}
+       *    \left(\bullet\right)^{\flat}_{IJKL} F^{-T}_{kK} F^{-T}_{lL}
        * @f]
        *
        * @param[in] H The (referential) rank-4 symmetric tensor to be operated
@@ -454,7 +456,7 @@ namespace Physics
        * vector, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\flat}
-       *    := \mathbf{F}^{T} \cdot \left(\bullet\right)^{\flat}
+       *    \dealcoloneq \mathbf{F}^{T} \cdot \left(\bullet\right)^{\flat}
        * @f]
        *
        * @param[in] v The (spatial) vector to be operated on
@@ -472,7 +474,7 @@ namespace Physics
        * covariant tensor, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\flat}
-       *    := \mathbf{F}^{T} \cdot \left(\bullet\right)^{\flat} \cdot
+       *    \dealcoloneq \mathbf{F}^{T} \cdot \left(\bullet\right)^{\flat} \cdot
        * \mathbf{F}
        * @f]
        *
@@ -491,8 +493,8 @@ namespace Physics
        * covariant symmetric tensor, i.e.
        * @f[
        *  \chi^{-1}\left(\bullet\right)^{\flat}
-       *    := \mathbf{F}^{T} \cdot \left(\bullet\right)^{\flat} \cdot
-       * \mathbf{F}
+       *    \dealcoloneq \mathbf{F}^{T} \cdot \left(\bullet\right)^{\flat}
+       *    \cdot \mathbf{F}
        * @f]
        *
        * @param[in] t The (spatial) symmetric tensor to be operated on
@@ -510,8 +512,8 @@ namespace Physics
        * contravariant tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi^{-1}\left(\bullet\right)^{\flat} \right]_{IJKL}
-       *    := F^{T}_{Ii} F^{T}_{Jj} \left(\bullet\right)^{\flat}_{ijkl}
-       * F^{T}_{Kk} F^{T}_{Ll}
+       *  \dealcoloneq F^{T}_{Ii} F^{T}_{Jj}
+       *  \left(\bullet\right)^{\flat}_{ijkl} F^{T}_{Kk} F^{T}_{Ll}
        * @f]
        *
        * @param[in] h The (spatial) tensor to be operated on
@@ -529,8 +531,8 @@ namespace Physics
        * contravariant symmetric tensor, i.e. (in index notation)
        * @f[
        *  \left[ \chi^{-1}\left(\bullet\right)^{\flat} \right]_{IJKL}
-       *    := F^{T}_{Ii} F^{T}_{Jj} \left(\bullet\right)^{\flat}_{ijkl}
-       * F^{T}_{Kk} F^{T}_{Ll}
+       *  \dealcoloneq F^{T}_{Ii} F^{T}_{Jj}
+       *  \left(\bullet\right)^{\flat}_{ijkl} F^{T}_{Kk} F^{T}_{Ll}
        * @f]
        *
        * @param[in] h The (spatial) symmetric tensor to be operated on
@@ -565,8 +567,8 @@ namespace Physics
        * contravariant vector, i.e.
        * @f[
        *  \textrm{det} \mathbf{F}^{-1} \; \chi\left(\bullet\right)^{\sharp}
-       *    := \frac{1}{\textrm{det} \mathbf{F}} \; \mathbf{F} \cdot
-       * \left(\bullet\right)^{\sharp}
+       *  \dealcoloneq \frac{1}{\textrm{det} \mathbf{F}} \; \mathbf{F} \cdot
+       *  \left(\bullet\right)^{\sharp}
        * @f]
        *
        * @param[in] V The (referential) vector to be operated on
@@ -585,7 +587,7 @@ namespace Physics
        * contravariant tensor, i.e.
        * @f[
        *  \textrm{det} \mathbf{F}^{-1} \; \chi\left(\bullet\right)^{\sharp}
-       *    := \frac{1}{\textrm{det} \mathbf{F}} \; \mathbf{F} \cdot
+       *    \dealcoloneq \frac{1}{\textrm{det} \mathbf{F}} \; \mathbf{F} \cdot
        * \left(\bullet\right)^{\sharp} \cdot \mathbf{F}^{T}
        * @f]
        *
@@ -605,7 +607,7 @@ namespace Physics
        * contravariant symmetric tensor, i.e.
        * @f[
        *  \textrm{det} \mathbf{F}^{-1} \; \chi\left(\bullet\right)^{\sharp}
-       *    := \frac{1}{\textrm{det} \mathbf{F}} \; \mathbf{F} \cdot
+       *    \dealcoloneq \frac{1}{\textrm{det} \mathbf{F}} \; \mathbf{F} \cdot
        * \left(\bullet\right)^{\sharp} \cdot \mathbf{F}^{T}
        * @f]
        *
@@ -627,7 +629,7 @@ namespace Physics
        * @f[
        *  \textrm{det} \mathbf{F}^{-1} \; \left[
        * \chi\left(\bullet\right)^{\sharp} \right]_{ijkl}
-       *    := \frac{1}{\textrm{det} \mathbf{F}} \; F_{iI} F_{jJ}
+       *    \dealcoloneq \frac{1}{\textrm{det} \mathbf{F}} \; F_{iI} F_{jJ}
        * \left(\bullet\right)^{\sharp}_{IJKL} F_{kK} F_{lL}
        * @f]
        *
@@ -648,7 +650,7 @@ namespace Physics
        * @f[
        *  \textrm{det} \mathbf{F}^{-1} \; \left[
        * \chi\left(\bullet\right)^{\sharp} \right]_{ijkl}
-       *    := \frac{1}{\textrm{det} \mathbf{F}} \; F_{iI} F_{jJ}
+       *    \dealcoloneq \frac{1}{\textrm{det} \mathbf{F}} \; F_{iI} F_{jJ}
        * \left(\bullet\right)^{\sharp}_{IJKL} F_{kK} F_{lL}
        * @f]
        *
@@ -676,7 +678,7 @@ namespace Physics
        * vector, i.e.
        * @f[
        *  \textrm{det} \mathbf{F} \; \chi^{-1}\left(\bullet\right)^{\sharp}
-       *    := \textrm{det} \mathbf{F} \; \mathbf{F}^{-1} \cdot
+       *    \dealcoloneq \textrm{det} \mathbf{F} \; \mathbf{F}^{-1} \cdot
        * \left(\bullet\right)^{\sharp}
        * @f]
        *
@@ -696,7 +698,7 @@ namespace Physics
        * contravariant tensor, i.e.
        * @f[
        *  \textrm{det} \mathbf{F} \; \chi^{-1}\left(\bullet\right)^{\sharp}
-       *    := \textrm{det} \mathbf{F} \; \mathbf{F}^{-1} \cdot
+       *    \dealcoloneq \textrm{det} \mathbf{F} \; \mathbf{F}^{-1} \cdot
        * \left(\bullet\right)^{\sharp} \cdot \mathbf{F}^{-T}
        * @f]
        *
@@ -716,7 +718,7 @@ namespace Physics
        * contravariant symmetric tensor, i.e.
        * @f[
        *  \textrm{det} \mathbf{F} \; \chi^{-1}\left(\bullet\right)^{\sharp}
-       *    := \textrm{det} \mathbf{F} \; \mathbf{F}^{-1} \cdot
+       *    \dealcoloneq \textrm{det} \mathbf{F} \; \mathbf{F}^{-1} \cdot
        * \left(\bullet\right)^{\sharp} \cdot \mathbf{F}^{-T}
        * @f]
        *
@@ -737,7 +739,7 @@ namespace Physics
        * @f[
        *  \textrm{det} \mathbf{F} \; \left[
        * \chi^{-1}\left(\bullet\right)^{\sharp} \right]_{IJKL}
-       *    := \textrm{det} \mathbf{F} \; F^{-1}_{Ii} F^{-1}_{Jj}
+       *    \dealcoloneq \textrm{det} \mathbf{F} \; F^{-1}_{Ii} F^{-1}_{Jj}
        * \left(\bullet\right)^{\sharp}_{ijkl} F^{-1}_{Kk} F^{-1}_{Ll}
        * @f]
        *
@@ -758,7 +760,7 @@ namespace Physics
        * @f[
        *  \textrm{det} \mathbf{F} \; \left[
        * \chi^{-1}\left(\bullet\right)^{\sharp} \right]_{IJKL}
-       *    := \textrm{det} \mathbf{F} \; F^{-1}_{Ii} F^{-1}_{Jj}
+       *    \dealcoloneq \textrm{det} \mathbf{F} \; F^{-1}_{Ii} F^{-1}_{Jj}
        * \left(\bullet\right)^{\sharp}_{ijkl} F^{-1}_{Kk} F^{-1}_{Ll}
        * @f]
        *
@@ -791,8 +793,8 @@ namespace Physics
      * between the reference and spatial surface elements, i.e.
      * @f[
      *  \mathbf{n} \frac{da}{dA}
-     *    := \textrm{det} \mathbf{F} \, \mathbf{F}^{-T} \cdot \mathbf{N}
-     *     = \textrm{cof} \mathbf{F} \cdot \mathbf{N} \, .
+     *  \dealcoloneq \textrm{det} \mathbf{F} \, \mathbf{F}^{-T} \cdot \mathbf{N}
+     *  = \textrm{cof} \mathbf{F} \cdot \mathbf{N} \, .
      * @f]
      *
      * @param[in] N The referential normal unit vector $\mathbf{N}$

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -139,17 +139,19 @@ namespace SUNDIALS
    *
    * For both DIRK and ARK methods, an implicit system of the form
    * \f[
-   *  G(z_i) := M z_i − h_n A^I_{i,i} f_I (t^I_{n,i}, z_i) − a_i = 0
+   *  G(z_i) \dealcoloneq M z_i − h_n A^I_{i,i} f_I (t^I_{n,i}, z_i) − a_i = 0
    * \f]
    * must be solved for each stage $z_i , i = 1, \ldot, s$, where
    * we have the data
    * \f[
-   *  a_i :=  M y_{n−1} + h_n \sum_{j=1}^{i−1} [ A^E_{i,j} f_E(t^E_{n,j}, z_j)
+   *  a_i \dealcoloneq
+   *  M y_{n−1} + h_n \sum_{j=1}^{i−1} [ A^E_{i,j} f_E(t^E_{n,j}, z_j)
    *  + A^I_{i,j} f_I (t^I_{n,j}, z_j)]
    * \f]
    * for the ARK methods, or
    * \f[
-   *  a_i :=  M y_{n−1} + h_n \sum_{j=1}^{i−1} A^I_{i,j} f_I (t^I_{n,j}, z_j)
+   *  a_i \dealcoloneq
+   *  M y_{n−1} + h_n \sum_{j=1}^{i−1} A^I_{i,j} f_I (t^I_{n,j}, z_j)
    * \f]
    * for the DIRK methods. Here $A^I_{i,j}$ and $A^E_{i,j}$ are the Butcher's
    * tables for the chosen solver.
@@ -172,8 +174,9 @@ namespace SUNDIALS
    * \f]
    * where
    * \f[
-   * N := M - \gamma J, \quad J := \frac{\partial f_I}{\partial y},
-   * \qquad \gamma:= h_n A^I_{i,i}.
+   * N \dealcoloneq M - \gamma J, \quad J
+   * \dealcoloneq \frac{\partial f_I}{\partial y},
+   * \qquad \gamma\dealcoloneq h_n A^I_{i,i}.
    * \f]
    *
    * As an alternate to Newton’s method, ARKode may solve for each stage $z_i ,i
@@ -264,7 +267,7 @@ namespace SUNDIALS
    * That is $y' = A y$
    * where
    * \f[
-   * A:=
+   * A \dealcoloneq
    * \begin{matrix}
    * 0 & 1 \\
    * -k^2 &0

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -237,7 +237,7 @@ ScaLAPACKMatrix<NumberType> &
 ScaLAPACKMatrix<NumberType>::operator=(const FullMatrix<NumberType> &matrix)
 {
   // FIXME: another way to copy is to use pdgeadd_ PBLAS routine.
-  // This routine computes the sum of two matrices B:=a*A+b*B.
+  // This routine computes the sum of two matrices B := a*A + b*B.
   // Matrices can have different distribution,in particular matrix A can
   // be owned by only one process, so we can set a=1 and b=0 to copy
   // non-distributed matrix A into distributed matrix B.


### PR DESCRIPTION
The MathJax `\coloneqq` command is a bit odd in that it is does not correctly center the colon and is not available in offline versions of MathJax. Fix both problems by defining our own macro for ':=', \dealcoloneq, that is correctly centered.

Here is what my browser (firefox 61) renders on master:
![old](https://user-images.githubusercontent.com/3917035/44997695-48632f80-af7e-11e8-9b7e-e3ff41dc95a0.png)

and here is what I get for this patch:
![new](https://user-images.githubusercontent.com/3917035/44997692-41d4b800-af7e-11e8-9bbc-be323d9568ce.png)

Fixes #6432.