### PR TITLE
Fix parallel quick tests

### DIFF
--- a/doc/news/changes/minor/20180913DavidWells
+++ b/doc/news/changes/minor/20180913DavidWells
@@ -1,0 +1,8 @@
+Fixed: <code>make test</code> now runs in parallel automatically (i.e., it uses
+a CMake command to determine the number of cores available). Since <code>make
+test</code> just immediately invokes <code>ctest</code> as a subprocess, it is
+currently not possible to link the number of globally available
+<code>make</code> processes with the number of concurrently run tests; i.e.,
+the number of cores <code>make test</code> uses is not changeable by users.
+<br>
+(David Wells, 2018/09/13)

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -183,8 +183,8 @@
         </li>
 
         <li> If your machine has multiple processors, use <code>make
-	  -jN</code> in the last step, where <code>N</code> is the number of simultaneous build processes you want <code>make</code> to use at any given time. Allowing <code>make</code> to use more simultaneous build processes (assuming you have that many processor
-            cores) will greatly lower the build time.
+	  -jN install</code> in the second to last step instead, where <code>N</code> is the number of simultaneous build processes you want <code>make</code> to use at any given time. Allowing <code>make</code> to use more simultaneous build processes (assuming you have that many processor
+            cores) will greatly lower the build time. <code>make test</code> automatically runs in parallel and no <code>-jN</code> flag should be supplied to it.
         </li>
 
         <li> If you do not intend to modify the <acronym>deal.II</acronym> sources and recompile things, then you can remove the <code>build/</code> directory after the last step.

--- a/tests/quick_tests/run.cmake
+++ b/tests/quick_tests/run.cmake
@@ -13,13 +13,22 @@
 ##
 ## ---------------------------------------------------------------------
 
-# This file is run when "make test" is executed by the user and is 
+# This file is run when "make test" is executed by the user and is
 # responsible for running the tests and printing some helpful
 # error messages.
+include(ProcessorCount)
+PROCESSORCOUNT(_n_processors)
+IF(_n_processors EQUAL 0)
+  SET(_n_processors "1")
+ENDIF()
 
 SEPARATE_ARGUMENTS(ALL_TESTS)
 
-EXECUTE_PROCESS(COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -O quicktests.log RESULT_VARIABLE res_var)
+EXECUTE_PROCESS(COMMAND ${CMAKE_CTEST_COMMAND} -j${_n_processors}
+  --force-new-ctest-process
+  --output-on-failure
+  -O quicktests.log
+  RESULT_VARIABLE res_var)
 
 IF(NOT "${res_var}" STREQUAL "0")
   MESSAGE("


### PR DESCRIPTION
In-progress fix for #6589.

There are two separate issues here: I have fixed just one so far.
1. CMake essentially generates the rule
```make
test:
    ctest quick_tests
```

so the number of processes we start `make` (or `ninja`) with is irrelevant: there is no way AFAICT to pass along the number of available jobs to `ctest`. The first commit just uses the number of CPUs, which is nearly always what we want (we could divide this by 2 if we wanted to be more conservative).

2. For reasons I do not fully understand, we cannot do `make -j2 test` when we link the example programs against `deal_II.g` (`deal_II` doesn't work either). Linking against other libraries seems fine. Its irrelevant whether or not we need the libraries; just adding `deal_II.g` to the link line makes cmake misbehave. 