### PR TITLE
Fix: 'iota' is not a member of 'std'

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -24,6 +24,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/vector_memory.h>
 
+#include <numeric> 
 #include <iostream>
 
 #ifdef DEAL_II_WITH_TRILINOS

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -24,8 +24,8 @@
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include <numeric> 
 #include <iostream>
+#include <numeric>
 
 #ifdef DEAL_II_WITH_TRILINOS
 #  ifdef DEAL_II_WITH_MPI


### PR DESCRIPTION
Fixes GCC compilation error:
 /source/base/mpi.cc:129:7: error: 'iota' is not a member of 'std'
That appears on newer gcc

Fixes #7155