### PR TITLE
Avoid warning about unused variable in compute_n_point_to_point_communications

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -299,14 +299,13 @@ namespace Utilities
       const MPI_Comm &                 mpi_comm,
       const std::vector<unsigned int> &destinations)
     {
-      const unsigned int myid    = Utilities::MPI::this_mpi_process(mpi_comm);
       const unsigned int n_procs = Utilities::MPI::n_mpi_processes(mpi_comm);
 
       for (unsigned int i = 0; i < destinations.size(); ++i)
         {
           Assert(destinations[i] < n_procs,
                  ExcIndexRange(destinations[i], 0, n_procs));
-          Assert(destinations[i] != myid,
+          Assert(destinations[i] != Utilities::MPI::this_mpi_process(mpi_comm),
                  ExcMessage(
                    "There is no point in communicating with ourselves."));
         }


### PR DESCRIPTION
`myid` was unused in `Release` mode.