### PR TITLE
Improve the MatrixFree doxygen formatting

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -2129,7 +2129,7 @@ protected:
  * way cells are looped by MatrixFree::cell_loop() can be different for
  * different DoFHandler or AffineConstraints arguments. More precisely, even
  * though the layout is going to be the same in serial, there is no guarantee
- * about the ordering for different DoFHandler/Constraints in the MPI
+ * about the ordering for different DoFHandler/AffineConstraints in the MPI
  * case. The reason is that the algorithm detects cells that need data
  * exchange with MPI and those can change for different elements &mdash; FE_Q
  * with hanging node constraints connects to more neighbors than a FE_DGQ

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -53,15 +53,18 @@ namespace internal
        * The cell or face is Cartesian.
        */
       cartesian = 0,
+
       /**
        * The cell or face can be described with an affine mapping.
        */
       affine = 1,
+
       /**
        * The face is flat, i.e., the normal factor on a face is the same on
        * all quadrature points. This type is not assigned for cells.
        */
       flat_faces = 2,
+
       /**
        * There is no special information available for compressing the
        * representation of the object under consideration.

--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -35,6 +35,8 @@ namespace internal
      * An enum that encodes the type of element detected during
      * initialization. FEEvaluation will select the most efficient algorithm
      * based on the given element type.
+     *
+     * @ingroup matrixfree
      */
     enum ElementType
     {
@@ -47,27 +49,32 @@ namespace internal
        * integration in the Gauss-Lobatto quadrature points of the same order.
        */
       tensor_symmetric_collocation = 0,
+
       /**
        * Symmetric tensor product shape functions fulfilling a Hermite
        * identity with values and first derivatives zero at the element end
        * points in 1D.
        */
       tensor_symmetric_hermite = 1,
+
       /**
        * Usual tensor product shape functions whose shape values and
        * quadrature points are symmetric about the midpoint of the unit
        * interval 0.5
        */
       tensor_symmetric = 2,
+
       /**
        * Tensor product shape functions without further particular properties
        */
       tensor_general = 3,
+
       /**
        * Polynomials of complete degree rather than tensor degree which can be
        * described by a truncated tensor product
        */
       truncated_tensor = 4,
+
       /**
        * Tensor product shape functions that are symmetric about the midpoint
        * of the unit interval 0.5 that additionally add a constant shape


### PR DESCRIPTION
This is a followup to #7129: I added name qualifications and a few other minor things to make it easier to read the matrix free module header.