### PR TITLE
Replace SparsityPattern::Iterator with LinearIndexIterator.

### DIFF
--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -929,7 +929,7 @@ namespace ChunkSparsityPatternIterators
   {
     Assert(is_valid_entry() == true, ExcInvalidIterator());
 
-    return reduced_accessor.index_within_sparsity;
+    return reduced_accessor.linear_index;
   }
 
 
@@ -953,11 +953,11 @@ namespace ChunkSparsityPatternIterators
 
     if (chunk_row != other.chunk_row)
       {
-        if (reduced_accessor.index_within_sparsity ==
-            reduced_accessor.sparsity_pattern->n_nonzero_elements())
+        if (reduced_accessor.linear_index ==
+            reduced_accessor.container->n_nonzero_elements())
           return false;
-        if (other.reduced_accessor.index_within_sparsity ==
-            reduced_accessor.sparsity_pattern->n_nonzero_elements())
+        if (other.reduced_accessor.linear_index ==
+            reduced_accessor.container->n_nonzero_elements())
           return true;
 
         const unsigned int global_row = sparsity_pattern->get_chunk_size() *
@@ -973,11 +973,10 @@ namespace ChunkSparsityPatternIterators
           return false;
       }
 
-    return (reduced_accessor.index_within_sparsity <
-              other.reduced_accessor.index_within_sparsity ||
-            (reduced_accessor.index_within_sparsity ==
-               other.reduced_accessor.index_within_sparsity &&
-             chunk_col < other.chunk_col));
+    return (
+      reduced_accessor.linear_index < other.reduced_accessor.linear_index ||
+      (reduced_accessor.linear_index == other.reduced_accessor.linear_index &&
+       chunk_col < other.chunk_col));
   }
 
 
@@ -1007,8 +1006,8 @@ namespace ChunkSparsityPatternIterators
       {
         const unsigned int reduced_row = reduced_accessor.row();
         // end of row
-        if (reduced_accessor.index_within_sparsity + 1 ==
-            reduced_accessor.sparsity_pattern->rowstart[reduced_row + 1])
+        if (reduced_accessor.linear_index + 1 ==
+            reduced_accessor.container->rowstart[reduced_row + 1])
           {
             ++chunk_row;
 
@@ -1025,8 +1024,8 @@ namespace ChunkSparsityPatternIterators
             // go back to the beginning of the same reduced row but with
             // chunk_row increased by one
             else
-              reduced_accessor.index_within_sparsity =
-                reduced_accessor.sparsity_pattern->rowstart[reduced_row];
+              reduced_accessor.linear_index =
+                reduced_accessor.container->rowstart[reduced_row];
           }
         // advance within chunk
         else

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -2112,8 +2112,8 @@ namespace SparseMatrixIterators
   inline number
   Accessor<number, true>::value() const
   {
-    AssertIndexRange(index_within_sparsity, matrix->n_nonzero_elements());
-    return matrix->val[index_within_sparsity];
+    AssertIndexRange(linear_index, matrix->n_nonzero_elements());
+    return matrix->val[linear_index];
   }
 
 
@@ -2137,9 +2137,9 @@ namespace SparseMatrixIterators
   template <typename number>
   inline Accessor<number, false>::Reference::operator number() const
   {
-    AssertIndexRange(accessor->index_within_sparsity,
+    AssertIndexRange(accessor->linear_index,
                      accessor->matrix->n_nonzero_elements());
-    return accessor->matrix->val[accessor->index_within_sparsity];
+    return accessor->matrix->val[accessor->linear_index];
   }
 
 
@@ -2148,9 +2148,9 @@ namespace SparseMatrixIterators
   inline const typename Accessor<number, false>::Reference &
   Accessor<number, false>::Reference::operator=(const number n) const
   {
-    AssertIndexRange(accessor->index_within_sparsity,
+    AssertIndexRange(accessor->linear_index,
                      accessor->matrix->n_nonzero_elements());
-    accessor->matrix->val[accessor->index_within_sparsity] = n;
+    accessor->matrix->val[accessor->linear_index] = n;
     return *this;
   }
 
@@ -2160,9 +2160,9 @@ namespace SparseMatrixIterators
   inline const typename Accessor<number, false>::Reference &
   Accessor<number, false>::Reference::operator+=(const number n) const
   {
-    AssertIndexRange(accessor->index_within_sparsity,
+    AssertIndexRange(accessor->linear_index,
                      accessor->matrix->n_nonzero_elements());
-    accessor->matrix->val[accessor->index_within_sparsity] += n;
+    accessor->matrix->val[accessor->linear_index] += n;
     return *this;
   }
 
@@ -2172,9 +2172,9 @@ namespace SparseMatrixIterators
   inline const typename Accessor<number, false>::Reference &
   Accessor<number, false>::Reference::operator-=(const number n) const
   {
-    AssertIndexRange(accessor->index_within_sparsity,
+    AssertIndexRange(accessor->linear_index,
                      accessor->matrix->n_nonzero_elements());
-    accessor->matrix->val[accessor->index_within_sparsity] -= n;
+    accessor->matrix->val[accessor->linear_index] -= n;
     return *this;
   }
 
@@ -2184,9 +2184,9 @@ namespace SparseMatrixIterators
   inline const typename Accessor<number, false>::Reference &
   Accessor<number, false>::Reference::operator*=(const number n) const
   {
-    AssertIndexRange(accessor->index_within_sparsity,
+    AssertIndexRange(accessor->linear_index,
                      accessor->matrix->n_nonzero_elements());
-    accessor->matrix->val[accessor->index_within_sparsity] *= n;
+    accessor->matrix->val[accessor->linear_index] *= n;
     return *this;
   }
 
@@ -2196,9 +2196,9 @@ namespace SparseMatrixIterators
   inline const typename Accessor<number, false>::Reference &
   Accessor<number, false>::Reference::operator/=(const number n) const
   {
-    AssertIndexRange(accessor->index_within_sparsity,
+    AssertIndexRange(accessor->linear_index,
                      accessor->matrix->n_nonzero_elements());
-    accessor->matrix->val[accessor->index_within_sparsity] /= n;
+    accessor->matrix->val[accessor->linear_index] /= n;
     return *this;
   }
 
@@ -2339,7 +2339,7 @@ namespace SparseMatrixIterators
     Assert(&accessor.get_matrix() == &other.accessor.get_matrix(),
            ExcInternalError());
 
-    return (*this)->index_within_sparsity - other->index_within_sparsity;
+    return (*this)->linear_index - other->linear_index;
   }
 
 


### PR DESCRIPTION
This class already defines an Accessor class that is compatible with what `LinearIndexIterator` expects, so we can get rid of another custom iterator implementation by renaming a few protected variables and inheriting from `LinearIndexIterator` instead.