### PR TITLE
Allow TrilinosWrappers::SparseMatrix::mmult for 64-bit indices

### DIFF
--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -2240,10 +2240,7 @@ namespace TrilinosWrappers
                   const MPI::Vector & V,
                   const bool          transpose_left)
     {
-#  ifdef DEAL_II_WITH_64BIT_INDICES
-      Assert(false, ExcNotImplemented())
-#  endif
-        const bool use_vector = (V.size() == inputright.m() ? true : false);
+      const bool use_vector = (V.size() == inputright.m() ? true : false);
       if (transpose_left == false)
         {
           Assert(inputleft.n() == inputright.m(),
@@ -2329,10 +2326,7 @@ namespace TrilinosWrappers
                       const SparseMatrix &B,
                       const MPI::Vector & V) const
   {
-#  ifdef DEAL_II_WITH_64BIT_INDICES
-    Assert(false, ExcNotImplemented())
-#  endif
-      internals::perform_mmult(*this, B, C, V, false);
+    internals::perform_mmult(*this, B, C, V, false);
   }
 
 
@@ -2342,10 +2336,7 @@ namespace TrilinosWrappers
                        const SparseMatrix &B,
                        const MPI::Vector & V) const
   {
-#  ifdef DEAL_II_WITH_64BIT_INDICES
-    Assert(false, ExcNotImplemented())
-#  endif
-      internals::perform_mmult(*this, B, C, V, true);
+    internals::perform_mmult(*this, B, C, V, true);
   }
 
 


### PR DESCRIPTION
Currently, `epetraext/sparse_matrix_mmult_02` is failing in `Debug` mode in case we only we use 64-bit indices because we prevent the function to be called in that case.
I see no reason why this restriction is (still?) necessary.  The test is working correctly without it.
Hence, this PR just removes the `Assert`s.