### PR TITLE
Mark EpetraExt as optional

### DIFF
--- a/doc/external-libs/trilinos.html
+++ b/doc/external-libs/trilinos.html
@@ -60,7 +60,7 @@
         <li> Amesos,
         <li> AztecOO,
         <li> Epetra,
-        <li> EpetraExt,
+        <li> EpetraExt (optional),
         <li> Ifpack,
         <li> ML,
         <li> MueLu,


### PR DESCRIPTION
In #7100 we decided to use `EpetraExt` and make it an optional `Trilinos` dependency.
We forgot to mark `EpetraExt` as optional in the documentation. This PR fixes this.