### PR TITLE
De-pluralize a word.

### DIFF
--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -163,7 +163,7 @@ class TriaActiveIterator;
  * but you may write your own version (non-virtual, since we use templates) to
  * add functionality.
  *
- * The accessors provided by the library consists of two groups, determined by
+ * The accessors provided by the library consist of two groups, determined by
  * whether they access the data of Triangulation objects or
  * DoFHandler/hp::DoFHandler objects. They are derived from TriaAccessor and
  * DoFAccessor, respectively. Each group also has specialized accessors for


### PR DESCRIPTION
Requested by @bangerth in #7167; I removed other edits to this file so it doesn't make sense to include that typo fix there any more.