### PR TITLE
Fix renumbering in parallel for hp.

### DIFF
--- a/tests/mpi/hp_renumber_01.cc
+++ b/tests/mpi/hp_renumber_01.cc
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Distribute DoFs as we do in hp_unify_dof_indices_02, but then
+// renumber DoFs. In this test, we use the identity renumbering, i.e.,
+// this does not actually change any DoF indices, but it still runs
+// through the renumbering machinery to verify that things work
+// correctly.
+
+
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/intergrid_map.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/hp/dof_handler.h>
+#include <deal.II/hp/fe_collection.h>
+
+#include <numeric>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> triangulation(
+    MPI_COMM_WORLD, Triangulation<dim>::limit_level_difference_at_vertices);
+
+  std::vector<unsigned int> reps(dim, 1U);
+  reps[0] = 2;
+  reps[1] = 2;
+  Point<dim> top_right;
+  for (unsigned int d = 0; d < dim; ++d)
+    top_right[d] = (d == 0 ? 2 : 1);
+  GridGenerator::subdivided_hyper_rectangle(triangulation,
+                                            reps,
+                                            Point<dim>(),
+                                            top_right);
+  Assert(triangulation.n_global_active_cells() == 4, ExcInternalError());
+  Assert(triangulation.n_active_cells() == 4, ExcInternalError());
+
+  hp::FECollection<dim> fe;
+  fe.push_back(FE_Q<dim>(2));
+  fe.push_back(FE_Q<dim>(2));
+  fe.push_back(FE_Q<dim>(2));
+
+  hp::DoFHandler<dim> dof_handler(triangulation);
+  for (auto cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        {
+          if (cell->id().to_string() == "0_0:")
+            cell->set_active_fe_index(0);
+          if (cell->id().to_string() == "1_0:")
+            cell->set_active_fe_index(1);
+          if (cell->id().to_string() == "2_0:")
+            cell->set_active_fe_index(2);
+          if (cell->id().to_string() == "3_0:")
+            cell->set_active_fe_index(0);
+        }
+    }
+  dof_handler.distribute_dofs(fe);
+
+  // now do the identity renumbering
+  const IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
+  std::vector<types::global_dof_index> new_indices(
+    locally_owned_dofs.n_elements());
+  for (unsigned int i = 0; i < new_indices.size(); ++i)
+    new_indices[i] = locally_owned_dofs.nth_index_in_set(i);
+  dof_handler.renumber_dofs(new_indices);
+
+  deallog << "Processor: " << Utilities::MPI::this_mpi_process(MPI_COMM_WORLD)
+          << std::endl;
+  for (auto cell : dof_handler.active_cell_iterators())
+    {
+      deallog << "  Cell: " << cell << std::endl;
+
+      std::vector<types::global_dof_index> dof_indices(
+        cell->get_fe().dofs_per_cell);
+      cell->get_dof_indices(dof_indices);
+      deallog << "    ";
+      for (auto i : dof_indices)
+        deallog << i << ' ';
+      deallog << std::endl;
+    }
+  deallog << "  n_locally_owned_dofs: " << dof_handler.n_locally_owned_dofs()
+          << std::endl;
+  deallog << "  n_global_dofs: " << dof_handler.n_dofs() << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/mpi/hp_renumber_01.mpirun=2.output
+++ b/tests/mpi/hp_renumber_01.mpirun=2.output
@@ -1,0 +1,47 @@
+
+DEAL:0:2d::Processor: 0
+DEAL:0:2d::  Cell: 0.0
+DEAL:0:2d::    0 1 2 3 4 5 6 7 8 
+DEAL:0:2d::  Cell: 0.1
+DEAL:0:2d::    1 9 3 19 5 10 11 12 13 
+DEAL:0:2d::  Cell: 0.2
+DEAL:0:2d::    2 3 14 20 15 16 7 17 18 
+DEAL:0:2d::  Cell: 0.3
+DEAL:0:2d::    3 19 20 21 16 22 12 23 24 
+DEAL:0:2d::  n_locally_owned_dofs: 14
+DEAL:0:2d::  n_global_dofs: 25
+DEAL:0:3d::Processor: 0
+DEAL:0:3d::  Cell: 0.0
+DEAL:0:3d::    0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:0:3d::  Cell: 0.1
+DEAL:0:3d::    1 27 3 53 5 28 7 56 9 29 30 61 13 31 32 65 17 33 19 67 21 34 35 36 37 38 39 
+DEAL:0:3d::  Cell: 0.2
+DEAL:0:3d::    2 3 40 54 6 7 41 57 42 59 11 43 44 63 15 45 18 19 46 68 47 48 23 49 50 51 52 
+DEAL:0:3d::  Cell: 0.3
+DEAL:0:3d::    3 53 54 55 7 56 57 58 59 60 61 62 63 64 65 66 19 67 68 69 48 70 36 71 72 73 74 
+DEAL:0:3d::  n_locally_owned_dofs: 40
+DEAL:0:3d::  n_global_dofs: 75
+
+DEAL:1:2d::Processor: 1
+DEAL:1:2d::  Cell: 0.0
+DEAL:1:2d::    0 1 2 3 4 5 6 7 8 
+DEAL:1:2d::  Cell: 0.1
+DEAL:1:2d::    1 9 3 19 5 10 11 12 13 
+DEAL:1:2d::  Cell: 0.2
+DEAL:1:2d::    2 3 14 20 15 16 7 17 18 
+DEAL:1:2d::  Cell: 0.3
+DEAL:1:2d::    3 19 20 21 16 22 12 23 24 
+DEAL:1:2d::  n_locally_owned_dofs: 11
+DEAL:1:2d::  n_global_dofs: 25
+DEAL:1:3d::Processor: 1
+DEAL:1:3d::  Cell: 0.0
+DEAL:1:3d::    0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1:3d::  Cell: 0.1
+DEAL:1:3d::    1 27 3 53 5 28 7 56 9 29 30 61 13 31 32 65 17 33 19 67 21 34 35 36 37 38 39 
+DEAL:1:3d::  Cell: 0.2
+DEAL:1:3d::    2 3 40 54 6 7 41 57 42 59 11 43 44 63 15 45 18 19 46 68 47 48 23 49 50 51 52 
+DEAL:1:3d::  Cell: 0.3
+DEAL:1:3d::    3 53 54 55 7 56 57 58 59 60 61 62 63 64 65 66 19 67 68 69 48 70 36 71 72 73 74 
+DEAL:1:3d::  n_locally_owned_dofs: 35
+DEAL:1:3d::  n_global_dofs: 75
+


### PR DESCRIPTION
When renumbering in parallel, the input are the new indices for
all locally owned DoFs on the current process. This means that we
need to be careful when we set new DoFs to only touch those DoF
indices that we actually own -- not doing so yields invalid
accesses that current abort the program.

The first part of the patch is therefore to only touch DoFs for
which we really know that we have a valid new index; for all
others, we need to set the index to numbers::invalid_dof_index
for the moment.

The second part is that we need to merge/unify DoF indices for
adjacent pairs of finite elements where the DoF on one side
may be unified with one on the neighboring cell. Because the
current cell may be locally owned but the neighboring cell be
a ghost cell, the right time to do this unification is between
the two exchange phases on ghost cells. This is indeed the
same place where the unification also happens on during the
initial enumeration process in distribute_dofs().