### PR TITLE
Improve the message for 'make strip_comments'.

### DIFF
--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -214,7 +214,7 @@ ${_switch_targets}#
   IF(PERL_FOUND)
     FILE(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/print_usage.cmake
 "#      ${_make_command} strip_comments - to strip the source files in this
-#                               directory off the documentation comments
+#                               directory off their comments; this is irreversible
 ")
   ENDIF()
   FILE(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/print_usage.cmake


### PR DESCRIPTION
It is remarkable how often I find myself asked how one can get the
comments back after calling 'make strip_comments'. Document that one can't.