### PR TITLE
Only declare VectorizedArray::n_array_elements externally if vectorization is enabled

### DIFF
--- a/source/base/vectorization.cc
+++ b/source/base/vectorization.cc
@@ -17,7 +17,9 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1
 const unsigned int VectorizedArray<double>::n_array_elements;
 const unsigned int VectorizedArray<float>::n_array_elements;
+#endif
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
We don't have specializations for `VectorizedArray<double>` and `VectorizedArray<float>` if vectorization is disabled, i.e. `DEAL_II_COMPILER_VECTORIZATION_LEVEL==0`. Hence, we must not provide an external declaration for `n_array_elements` in this case.