### PR TITLE
install summary.log

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -63,11 +63,12 @@ INSTALL(FILES
   )
 
 #
-# Install summary.log
+# Install summary.log an detailed.log
 #
 
 INSTALL(FILES
   ${CMAKE_BINARY_DIR}/summary.log
+  ${CMAKE_BINARY_DIR}/detailed.log
   DESTINATION ${DEAL_II_DOCREADME_RELDIR}
   COMPONENT library
   )

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -63,6 +63,16 @@ INSTALL(FILES
   )
 
 #
+# Install summary.log
+#
+
+INSTALL(FILES
+  ${CMAKE_BINARY_DIR}/summary.log
+  DESTINATION ${DEAL_II_DOCREADME_RELDIR}
+  COMPONENT library
+  )
+
+#
 # Add a dummy target to make documentation files known to IDEs.
 #
 


### PR DESCRIPTION
This is extremely useful to debug installation problems because one can
easily check the version and status of dependencies of an installation
instead of digging into the config.h