### PR TITLE
extend Patterns::Tools::Convert to understand ComponentMask and Funct…

### DIFF
--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -342,6 +342,13 @@ public:
   vector_value(const Point<dim> &p, Vector<double> &values) const override;
 
   /**
+   * Return an array of function expressions (one per component), used to
+   * initialize this function.
+   */
+  const std::vector<std::string> &
+  get_expressions() const;
+
+  /**
    * @addtogroup Exceptions
    * @{
    */

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -42,6 +42,14 @@ namespace fparser
 DEAL_II_NAMESPACE_OPEN
 
 
+template <int dim>
+const std::vector<std::string> &
+FunctionParser<dim>::get_expressions() const
+{
+  return expressions;
+}
+
+
 
 template <int dim>
 FunctionParser<dim>::FunctionParser(const unsigned int n_components,

--- a/tests/parameter_handler/patterns_14.cc
+++ b/tests/parameter_handler/patterns_14.cc
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2005 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// test add_parameters with ParsedFunction.
+
+#include <deal.II/base/function_parser.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/std_cxx14/memory.h>
+
+#include <memory>
+
+#include "../tests.h"
+
+using namespace Patterns;
+using namespace Patterns::Tools;
+
+int
+main()
+{
+  initlog();
+
+  typedef std::unique_ptr<FunctionParser<3>> T;
+
+  T a;
+  a = Convert<T>::to_value("x*y,y-t");
+
+  ParameterHandler prm;
+  prm.add_parameter("A function", a);
+
+  prm.log_parameters(deallog);
+
+  prm.set("A function", "x*4,y*y*x+t*24");
+
+  deallog << "After ParameterHandler::set =========================="
+          << std::endl
+          << std::endl;
+  prm.log_parameters(deallog);
+
+  deallog << "Actual variables            =========================="
+          << std::endl
+          << std::endl;
+
+  deallog << Convert<T>::to_string(a) << std::endl;
+}

--- a/tests/parameter_handler/patterns_14.output
+++ b/tests/parameter_handler/patterns_14.output
@@ -1,0 +1,8 @@
+
+DEAL:parameters::A function: x*y,y-t
+DEAL::After ParameterHandler::set ==========================
+DEAL::
+DEAL:parameters::A function: x*4,y*y*x+t*24
+DEAL::Actual variables            ==========================
+DEAL::
+DEAL::x*4,y*y*x+t*24

--- a/tests/parameter_handler/patterns_15.cc
+++ b/tests/parameter_handler/patterns_15.cc
@@ -1,0 +1,57 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2005 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// test add_parameters with ComponentMask.
+
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/std_cxx14/memory.h>
+
+#include <deal.II/fe/component_mask.h>
+
+#include <memory>
+
+#include "../tests.h"
+
+using namespace Patterns;
+using namespace Patterns::Tools;
+
+int
+main()
+{
+  initlog();
+
+  typedef ComponentMask T;
+
+  T a;
+  a = Convert<T>::to_value("true,false,true");
+
+  ParameterHandler prm;
+  prm.add_parameter("A mask", a);
+
+  prm.log_parameters(deallog);
+
+  prm.set("A mask", "false,false,true");
+
+  deallog << "After ParameterHandler::set =========================="
+          << std::endl
+          << std::endl;
+  prm.log_parameters(deallog);
+
+  deallog << "Actual variables            =========================="
+          << std::endl
+          << std::endl;
+
+  deallog << Convert<T>::to_string(a) << std::endl;
+}

--- a/tests/parameter_handler/patterns_15.output
+++ b/tests/parameter_handler/patterns_15.output
@@ -1,0 +1,8 @@
+
+DEAL:parameters::A mask: true, false, true
+DEAL::After ParameterHandler::set ==========================
+DEAL::
+DEAL:parameters::A mask: false,false,true
+DEAL::Actual variables            ==========================
+DEAL::
+DEAL::false, false, true

--- a/tests/parameter_handler/patterns_16.cc
+++ b/tests/parameter_handler/patterns_16.cc
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2005 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// test add_parameters with std::map<unsigned int,ParsedFunction>
+
+#include <deal.II/base/function_parser.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/std_cxx14/memory.h>
+
+#include <deal.II/fe/component_mask.h>
+
+#include <memory>
+
+#include "../tests.h"
+
+using namespace Patterns;
+using namespace Patterns::Tools;
+
+int
+main()
+{
+  initlog();
+
+  typedef std::map<types::boundary_id, std::unique_ptr<FunctionParser<3>>> T;
+
+  T a;
+  a = Convert<T>::to_value("0:x,y,z*t");
+
+  ParameterHandler prm;
+  prm.add_parameter("Boundary conditions", a);
+
+  prm.log_parameters(deallog);
+
+  prm.set("Boundary conditions", "0:x*x*x,y*y*y,z*z*z*t;1:0,x*y,t");
+
+  deallog << "After ParameterHandler::set =========================="
+          << std::endl
+          << std::endl;
+  prm.log_parameters(deallog);
+
+  deallog << "Actual variables            =========================="
+          << std::endl
+          << std::endl;
+
+  deallog << Convert<T>::to_string(a) << std::endl;
+}

--- a/tests/parameter_handler/patterns_16.output
+++ b/tests/parameter_handler/patterns_16.output
@@ -1,0 +1,8 @@
+
+DEAL:parameters::Boundary conditions: 0:x,y,z*t
+DEAL::After ParameterHandler::set ==========================
+DEAL::
+DEAL:parameters::Boundary conditions: 0:x*x*x,y*y*y,z*z*z*t;1:0,x*y,t
+DEAL::Actual variables            ==========================
+DEAL::
+DEAL::0:x*x*x,y*y*y,z*z*z*t; 1:0,x*y,t


### PR DESCRIPTION
…ionParser

this allows to work with types like `std::map<types::boundary_id, std::unique_ptr<FunctionParser<3>>>` which I find useful for BC.

p.s. i had to use `std::unique_ptr` to avoid a lot of compiler errors https://github.com/dealii/dealii/issues/7214#issuecomment-422921629 

@mac-a FYI