### PR TITLE
add a flag to ParameterHandler to skip undefined fields and subsections

### DIFF
--- a/doc/news/changes/minor/20180920DenisDavydov
+++ b/doc/news/changes/minor/20180920DenisDavydov
@@ -1,0 +1,4 @@
+New: Add optional flag to ParameterHandler to skip undefined
+sections and parameters.
+<br>
+(Denis Davydov 2018/09/20)

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -839,6 +839,7 @@ class MultipleParameterLoop;
  * @author Wolfgang Bangerth, October 1997, revised February 1998, 2010, 2011, 2017
  * @author Alberto Sartori, 2015
  * @author David Wells, 2016
+ * @author Denis Davydov, 2018
  */
 class ParameterHandler : public Subscriptor
 {
@@ -901,8 +902,14 @@ public:
 
   /**
    * Constructor.
+   *
+   * If @p skip_undefined is <code>true</code>, the parameter handler
+   * will skip undefined sections and entries. This is useful for partially
+   * parsing a parameter file, for example to obtain only the spatial dimension
+   * of the problem. By default all entries and subsections are expected to be
+   * declared.
    */
-  ParameterHandler();
+  ParameterHandler(const bool skip_undefined = false);
 
   /**
    * Destructor. Declare this only to have a virtual destructor, which is
@@ -1597,6 +1604,11 @@ private:
    * tree.
    */
   static const char path_separator = '.';
+
+  /**
+   * A flag to skip undefined entries.
+   */
+  const bool skip_undefined;
 
   /**
    * Path of presently selected subsections; empty list means top level

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -902,14 +902,8 @@ public:
 
   /**
    * Constructor.
-   *
-   * If @p skip_undefined is <code>true</code>, the parameter handler
-   * will skip undefined sections and entries. This is useful for partially
-   * parsing a parameter file, for example to obtain only the spatial dimension
-   * of the problem. By default all entries and subsections are expected to be
-   * declared.
    */
-  ParameterHandler(const bool skip_undefined = false);
+  ParameterHandler();
 
   /**
    * Destructor. Declare this only to have a virtual destructor, which is
@@ -928,6 +922,12 @@ public:
    * If non-empty @p last_line is provided, the ParameterHandler object
    * will stop parsing lines after encountering @p last_line .
    * This is handy when adding extra data that shall be parsed manually.
+   *
+   * If @p skip_undefined is <code>true</code>, the parameter handler
+   * will skip undefined sections and entries. This is useful for partially
+   * parsing a parameter file, for example to obtain only the spatial dimension
+   * of the problem. By default all entries and subsections are expected to be
+   * declared.
    *
    * The function sets the value of all parameters it encounters in the
    * input file to the provided value. Parameters not explicitly listed
@@ -948,8 +948,9 @@ public:
    */
   virtual void
   parse_input(std::istream &     input,
-              const std::string &filename  = "input file",
-              const std::string &last_line = "");
+              const std::string &filename       = "input file",
+              const std::string &last_line      = "",
+              const bool         skip_undefined = false);
 
   /**
    * Parse the given file to provide values for known parameter fields. The
@@ -995,7 +996,9 @@ public:
    * @endcode
    */
   virtual void
-  parse_input(const std::string &filename, const std::string &last_line = "");
+  parse_input(const std::string &filename,
+              const std::string &last_line      = "",
+              const bool         skip_undefined = false);
 
   /**
    * Parse input from a string to populate known parameter fields. The lines
@@ -1006,7 +1009,9 @@ public:
    * there for more information.
    */
   virtual void
-  parse_input_from_string(const char *s, const std::string &last_line = "");
+  parse_input_from_string(const char *       s,
+                          const std::string &last_line      = "",
+                          const bool         skip_undefined = false);
 
   /**
    * Parse input from an XML stream to populate known parameter fields. This
@@ -1606,11 +1611,6 @@ private:
   static const char path_separator = '.';
 
   /**
-   * A flag to skip undefined entries.
-   */
-  const bool skip_undefined;
-
-  /**
    * Path of presently selected subsections; empty list means top level
    */
   std::vector<std::string> subsection_path;
@@ -1686,11 +1686,18 @@ private:
    *
    * The function modifies its argument, but also takes it by value, so the
    * caller's variable is not changed.
+   *
+   * If @p skip_undefined is <code>true</code>, the parser
+   * will skip undefined sections and entries. This is useful for partially
+   * parsing a parameter file, for example to obtain only the spatial dimension
+   * of the problem. By default all entries and subsections are expected to be
+   * declared.
    */
   void
   scan_line(std::string        line,
             const std::string &input_filename,
-            const unsigned int current_line_n);
+            const unsigned int current_line_n,
+            const bool         skip_undefined);
 
   /**
    * Print out the parameters of the subsection given by the
@@ -1982,6 +1989,12 @@ public:
    * will stop parsing lines after encountering @p last_line .
    * This is handy when adding extra data that shall be parsed manually.
    *
+   * If @p skip_undefined is <code>true</code>, the parameter handler
+   * will skip undefined sections and entries. This is useful for partially
+   * parsing a parameter file, for example to obtain only the spatial dimension
+   * of the problem. By default all entries and subsections are expected to be
+   * declared.
+   *
    * @note This is the only overload of the three <tt>parse_input</tt>
    * functions implemented by ParameterHandler overridden with new behavior by
    * this class. This is because the other two <tt>parse_input</tt> functions
@@ -1989,8 +2002,9 @@ public:
    */
   virtual void
   parse_input(std::istream &     input,
-              const std::string &filename  = "input file",
-              const std::string &last_line = "") override;
+              const std::string &filename       = "input file",
+              const std::string &last_line      = "",
+              const bool         skip_undefined = false) override;
 
   /**
    * Overriding virtual functions which are overloaded (like

--- a/tests/parameter_handler/parameter_handler_24.cc
+++ b/tests/parameter_handler/parameter_handler_24.cc
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2002 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check skip_undefined settings in parameter handler.
+
+#include <deal.II/base/parameter_handler.h>
+
+#include "../tests.h"
+
+void
+check()
+{
+  ParameterHandler prm(true);
+  prm.enter_subsection("Geometry");
+  prm.declare_entry("dim", "1", Patterns::Integer(1, 3));
+  prm.leave_subsection();
+
+  prm.declare_entry("Dimension", "1", Patterns::Integer(1, 3));
+
+  std::ifstream in(SOURCE_DIR "/parameter_handler_24.prm");
+  prm.parse_input(in, "input file");
+
+  prm.print_parameters(deallog.get_file_stream(), ParameterHandler::Text);
+}
+
+
+int
+main()
+{
+  initlog();
+  check();
+  return 0;
+}

--- a/tests/parameter_handler/parameter_handler_24.cc
+++ b/tests/parameter_handler/parameter_handler_24.cc
@@ -24,7 +24,7 @@
 void
 check()
 {
-  ParameterHandler prm(true);
+  ParameterHandler prm;
   prm.enter_subsection("Geometry");
   prm.declare_entry("dim", "1", Patterns::Integer(1, 3));
   prm.leave_subsection();
@@ -32,7 +32,7 @@ check()
   prm.declare_entry("Dimension", "1", Patterns::Integer(1, 3));
 
   std::ifstream in(SOURCE_DIR "/parameter_handler_24.prm");
-  prm.parse_input(in, "input file");
+  prm.parse_input(in, "input file", "", true);
 
   prm.print_parameters(deallog.get_file_stream(), ParameterHandler::Text);
 }

--- a/tests/parameter_handler/parameter_handler_24.output
+++ b/tests/parameter_handler/parameter_handler_24.output
@@ -1,0 +1,11 @@
+
+# Listing of Parameters
+# ---------------------
+set Dimension = 3 # default: 1
+
+
+subsection Geometry
+  set dim = 2 # default: 1
+end
+
+

--- a/tests/parameter_handler/parameter_handler_24.prm
+++ b/tests/parameter_handler/parameter_handler_24.prm
@@ -1,0 +1,20 @@
+
+subsection Boundary conditions
+  # dimension-dependent
+  set Function expressions = 0:0,0,x*t
+end
+
+set Some other dimension dependent parameter = 1.
+
+subsection Geometry
+  set dim = 2
+  set Some unrelevant field = 22
+end
+
+subsection Linear solver
+  set Tolerance = 1e-9
+end
+
+set Dimension = 3
+
+set That = this

--- a/tests/parameter_handler/parameter_handler_24.prm
+++ b/tests/parameter_handler/parameter_handler_24.prm
@@ -17,4 +17,8 @@ end
 
 set Dimension = 3
 
+subsection Simple approaches will fail here
+  set Dimension = 3333
+end
+
 set That = this


### PR DESCRIPTION
the idea is to pre-process a subset of parameters (i.e. dimension) from the file and then process the whole thing using dim-templated parameter class (i.e. BC functions will be dimension dependent).