### PR TITLE
Replace uses of Threads::Mutex::ScopedLock by std::lock_guard.

### DIFF
--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -97,7 +97,7 @@ public:
    * <code>throw</code>, or by simply reaching the closing brace. In all of
    * these cases, it is not necessary to remember to pop the prefix manually
    * using LogStream::pop(). In this, it works just like the better known
-   * std::unique_ptr and Threads::Mutex::ScopedLock classes.
+   * std::unique_ptr and std::lock_guard classes.
    */
   class Prefix
   {

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -267,20 +267,26 @@ namespace Threads
   {
   public:
     /**
-     * Scoped lock class. When you declare an object of this type, you have to
-     * pass it a mutex, which is locked in the constructor of this class and
-     * unlocked in the destructor. The lock is thus held during the entire
-     * lifetime of this object, i.e. until the end of the present scope, which
-     * explains where the name comes from. This pattern of using locks with
-     * mutexes follows the resource-acquisition-is-initialization pattern, and
-     * was used first for mutexes by Doug Schmidt. It has the advantage that
-     * locking a mutex this way is thread-safe, i.e. when an exception is
-     * thrown between the locking and unlocking point, the destructor makes
-     * sure that the mutex is unlocked; this would not automatically be the
-     * case when you lock and unlock the mutex "by hand", i.e. using
-     * Mutex::acquire() and Mutex::release().
+     * This declaration introduces a scoped lock class. It is
+     * deprecated: use `std::lock_guard<std::mutex>` or any of the
+     * other, related classes offered by C++ instead.
+     *
+     * When you declare an object of this type, you have to pass it a
+     * mutex, which is locked in the constructor of this class and
+     * unlocked in the destructor. The lock is thus held during the
+     * entire lifetime of this object, i.e. until the end of the
+     * present scope, which explains where the name comes from. This
+     * pattern of using locks with mutexes follows the
+     * resource-acquisition-is-initialization pattern, and was used
+     * first for mutexes by Doug Schmidt. It has the advantage that
+     * locking a mutex this way is thread-safe, i.e. when an exception
+     * is thrown between the locking and unlocking point, the
+     * destructor makes sure that the mutex is unlocked; this would
+     * not automatically be the case when you lock and unlock the
+     * mutex "by hand", i.e. using Mutex::acquire() and
+     * Mutex::release().
      */
-    using ScopedLock = std::lock_guard<std::mutex>;
+    using ScopedLock DEAL_II_DEPRECATED = std::lock_guard<std::mutex>;
 
     /**
      * Default constructor.

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2409,7 +2409,7 @@ namespace FETools
     // operation of this function;
     // for this, acquire the lock
     // until we quit this function
-    Threads::Mutex::ScopedLock lock(
+    std::lock_guard<std::mutex> lock(
       internal::FEToolsAddFENameHelper::fe_name_map_lock);
 
     Assert(
@@ -2566,7 +2566,7 @@ namespace FETools
           {
             // Make sure no other thread
             // is just adding an element
-            Threads::Mutex::ScopedLock lock(
+            std::lock_guard<std::mutex> lock(
               internal::FEToolsAddFENameHelper::fe_name_map_lock);
             AssertThrow(fe_name_map.find(name_part) != fe_name_map.end(),
                         FETools::ExcInvalidFEName(name));

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -1724,7 +1724,7 @@ BlockMatrixBase<MatrixType>::set(const size_type  row,
 
   // lock access to the temporary data structure to
   // allow multiple threads to call this function concurrently
-  Threads::Mutex::ScopedLock lock(temporary_data.mutex);
+  std::lock_guard<std::mutex> lock(temporary_data.mutex);
 
   // Resize scratch arrays
   if (temporary_data.column_indices.size() < this->n_block_cols())
@@ -1981,7 +1981,7 @@ BlockMatrixBase<MatrixType>::add(const size_type  row,
     }
 
   // Lock scratch arrays, then resize them
-  Threads::Mutex::ScopedLock lock(temporary_data.mutex);
+  std::lock_guard<std::mutex> lock(temporary_data.mutex);
 
   if (temporary_data.column_indices.size() < this->n_block_cols())
     {

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -875,7 +875,7 @@ namespace LinearAlgebra
 
 #ifdef DEAL_II_WITH_MPI
       // make this function thread safe
-      Threads::Mutex::ScopedLock lock(mutex);
+      std::lock_guard<std::mutex> lock(mutex);
 
       // allocate import_data in case it is not set up yet
       if (import_data == nullptr && partitioner->n_import_indices() > 0)
@@ -928,7 +928,7 @@ namespace LinearAlgebra
       // compress_requests.size() == 0
 
       // make this function thread safe
-      Threads::Mutex::ScopedLock lock(mutex);
+      std::lock_guard<std::mutex> lock(mutex);
 
       Assert(partitioner->n_import_indices() == 0 || import_data != nullptr,
              ExcNotInitialized());
@@ -975,7 +975,7 @@ namespace LinearAlgebra
         return;
 
       // make this function thread safe
-      Threads::Mutex::ScopedLock lock(mutex);
+      std::lock_guard<std::mutex> lock(mutex);
 
       // allocate import_data in case it is not set up yet
       if (import_data == nullptr && partitioner->n_import_indices() > 0)
@@ -1033,7 +1033,7 @@ namespace LinearAlgebra
       if (update_ghost_values_requests.size() > 0)
         {
           // make this function thread safe
-          Threads::Mutex::ScopedLock lock(mutex);
+          std::lock_guard<std::mutex> lock(mutex);
 
           partitioner->export_to_ghosted_array_finish(
             ArrayView<Number>(data.values.get() + partitioner->local_size(),

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -2308,7 +2308,7 @@ PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::vmult(
   VectorType &      dst,
   const VectorType &src) const
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   if (eigenvalues_are_initialized == false)
     estimate_eigenvalues(src);
 
@@ -2334,7 +2334,7 @@ PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::Tvmult(
   VectorType &      dst,
   const VectorType &src) const
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   if (eigenvalues_are_initialized == false)
     estimate_eigenvalues(src);
 
@@ -2360,7 +2360,7 @@ PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::step(
   VectorType &      dst,
   const VectorType &src) const
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   if (eigenvalues_are_initialized == false)
     estimate_eigenvalues(src);
 
@@ -2387,7 +2387,7 @@ PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::Tstep(
   VectorType &      dst,
   const VectorType &src) const
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   if (eigenvalues_are_initialized == false)
     estimate_eigenvalues(src);
 

--- a/include/deal.II/lac/swappable_vector.templates.h
+++ b/include/deal.II/lac/swappable_vector.templates.h
@@ -78,7 +78,7 @@ SwappableVector<number>::operator=(const SwappableVector<number> &v)
   // if in MT mode, block all other
   // operations. if not in MT mode,
   // this is a no-op
-  Threads::Mutex::ScopedLock lock(this->lock);
+  std::lock_guard<std::mutex> lock(this->lock);
 
   Vector<number>::operator=(v);
   data_is_preloaded       = false;
@@ -107,7 +107,7 @@ SwappableVector<number>::swap_out(const std::string &name)
   // if in MT mode, block all other
   // operations. if not in MT mode,
   // this is a no-op
-  Threads::Mutex::ScopedLock lock(this->lock);
+  std::lock_guard<std::mutex> lock(this->lock);
 
   //  check that we have not called
   //  @p alert without the respective
@@ -225,7 +225,7 @@ SwappableVector<number>::kill_file()
   // (there should be none, but who
   // knows). if not in MT mode,
   // this is a no-op
-  Threads::Mutex::ScopedLock lock(this->lock);
+  std::lock_guard<std::mutex> lock(this->lock);
 
   // this is too bad: someone
   // requested the vector in advance,

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -477,8 +477,8 @@ TensorProductMatrixSymmetricSumBase<dim, Number, size>::vmult(
 {
   AssertDimension(dst_view.size(), this->m());
   AssertDimension(src_view.size(), this->n());
-  Threads::Mutex::ScopedLock lock(this->mutex);
-  const unsigned int         n =
+  std::lock_guard<std::mutex> lock(this->mutex);
+  const unsigned int          n =
     Utilities::fixed_power<dim>(size > 0 ? size : eigenvalues[0].size());
   tmp_array.resize_fast(n * 2);
   constexpr int kernel_size = size > 0 ? size : 0;
@@ -545,8 +545,8 @@ TensorProductMatrixSymmetricSumBase<dim, Number, size>::apply_inverse(
 {
   AssertDimension(dst_view.size(), this->n());
   AssertDimension(src_view.size(), this->m());
-  Threads::Mutex::ScopedLock lock(this->mutex);
-  const unsigned int         n = size > 0 ? size : eigenvalues[0].size();
+  std::lock_guard<std::mutex> lock(this->mutex);
+  const unsigned int          n = size > 0 ? size : eigenvalues[0].size();
   tmp_array.resize_fast(Utilities::fixed_power<dim>(n));
   constexpr int kernel_size = size > 0 ? size : 0;
   internal::EvaluatorTensorProduct<internal::evaluate_general,

--- a/include/deal.II/lac/vector_memory.templates.h
+++ b/include/deal.II/lac/vector_memory.templates.h
@@ -81,7 +81,7 @@ inline GrowingVectorMemory<VectorType>::GrowingVectorMemory(
   , current_alloc(0)
   , log_statistics(log_statistics)
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   pool.initialize(initial_size);
 }
 
@@ -106,7 +106,7 @@ template <typename VectorType>
 inline VectorType *
 GrowingVectorMemory<VectorType>::alloc()
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   ++total_alloc;
   ++current_alloc;
@@ -136,7 +136,7 @@ template <typename VectorType>
 inline void
 GrowingVectorMemory<VectorType>::free(const VectorType *const v)
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   for (typename std::vector<entry_type>::iterator i = pool.data->begin();
        i != pool.data->end();
@@ -158,7 +158,7 @@ template <typename VectorType>
 inline void
 GrowingVectorMemory<VectorType>::release_unused_memory()
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   if (pool.data != nullptr)
     pool.data->clear();
@@ -170,7 +170,7 @@ template <typename VectorType>
 inline std::size_t
 GrowingVectorMemory<VectorType>::memory_consumption() const
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   std::size_t                                            result = sizeof(*this);
   const typename std::vector<entry_type>::const_iterator end = pool.data->end();

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -1313,7 +1313,7 @@ namespace internal
                 // that are within the range of one lock at once
                 const unsigned int next_bucket =
                   (*it / bucket_size_threading + 1) * bucket_size_threading;
-                Threads::Mutex::ScopedLock lock(
+                std::lock_guard<std::mutex> lock(
                   mutexes[*it / bucket_size_threading]);
                 for (; it != end_unique && *it < next_bucket; ++it)
                   {
@@ -1351,7 +1351,7 @@ namespace internal
               {
                 const unsigned int next_bucket =
                   (*it / bucket_size_threading + 1) * bucket_size_threading;
-                Threads::Mutex::ScopedLock lock(
+                std::lock_guard<std::mutex> lock(
                   mutexes[*it / bucket_size_threading]);
                 for (; it != end_unique && *it < next_bucket; ++it)
                   if (row_lengths[*it] > 0)

--- a/source/base/flow_function.cc
+++ b/source/base/flow_function.cc
@@ -57,7 +57,7 @@ namespace Functions
 
     // guard access to the aux_*
     // variables in multithread mode
-    Threads::Mutex::ScopedLock lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     for (unsigned int d = 0; d < dim + 1; ++d)
       aux_values[d].resize(n_points);
@@ -87,7 +87,7 @@ namespace Functions
 
     // guard access to the aux_*
     // variables in multithread mode
-    Threads::Mutex::ScopedLock lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     for (unsigned int d = 0; d < dim + 1; ++d)
       aux_values[d].resize(n_points);
@@ -110,7 +110,7 @@ namespace Functions
 
     // guard access to the aux_*
     // variables in multithread mode
-    Threads::Mutex::ScopedLock lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     for (unsigned int d = 0; d < dim + 1; ++d)
       aux_values[d].resize(n_points);
@@ -132,7 +132,7 @@ namespace Functions
 
     // guard access to the aux_*
     // variables in multithread mode
-    Threads::Mutex::ScopedLock lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     for (unsigned int d = 0; d < dim + 1; ++d)
       aux_gradients[d].resize(n_points);
@@ -160,7 +160,7 @@ namespace Functions
 
     // guard access to the aux_*
     // variables in multithread mode
-    Threads::Mutex::ScopedLock lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     for (unsigned int d = 0; d < dim + 1; ++d)
       aux_values[d].resize(n_points);

--- a/source/base/function_cspline.cc
+++ b/source/base/function_cspline.cc
@@ -73,7 +73,7 @@ namespace Functions
     // GSL functions may modify gsl_interp_accel *acc object (last argument).
     // This can only work in multithreaded applications if we lock the data
     // structures via a mutex.
-    Threads::Mutex::ScopedLock lock(acc_mutex);
+    std::lock_guard<std::mutex> lock(acc_mutex);
 
     const double x = p[0];
     Assert(x >= interpolation_points.front() &&
@@ -94,7 +94,7 @@ namespace Functions
     // GSL functions may modify gsl_interp_accel *acc object (last argument).
     // This can only work in multithreaded applications if we lock the data
     // structures via a mutex.
-    Threads::Mutex::ScopedLock lock(acc_mutex);
+    std::lock_guard<std::mutex> lock(acc_mutex);
 
     const double x = p[0];
     Assert(x >= interpolation_points.front() &&
@@ -118,7 +118,7 @@ namespace Functions
     // GSL functions may modify gsl_interp_accel *acc object (last argument).
     // This can only work in multithreaded applications if we lock the data
     // structures via a mutex.
-    Threads::Mutex::ScopedLock lock(acc_mutex);
+    std::lock_guard<std::mutex> lock(acc_mutex);
 
     const double x = p[0];
     Assert(x >= interpolation_points.front() &&

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -241,8 +241,8 @@ namespace internal
   double
   mu_rand_seed(double seed)
   {
-    static Threads::Mutex      rand_mutex;
-    Threads::Mutex::ScopedLock lock(rand_mutex);
+    static Threads::Mutex       rand_mutex;
+    std::lock_guard<std::mutex> lock(rand_mutex);
 
     static boost::random::uniform_real_distribution<> uniform_distribution(0,
                                                                            1);
@@ -262,7 +262,7 @@ namespace internal
   mu_rand()
   {
     static Threads::Mutex                             rand_mutex;
-    Threads::Mutex::ScopedLock                        lock(rand_mutex);
+    std::lock_guard<std::mutex>                       lock(rand_mutex);
     static boost::random::uniform_real_distribution<> uniform_distribution(0,
                                                                            1);
     static boost::random::mt19937                     rng(

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -129,7 +129,7 @@ IndexSet::do_compress() const
   // via a mutex, so that users can call 'const' functions from threads
   // in parallel (and these 'const' functions can then call compress()
   // which itself calls the current function)
-  Threads::Mutex::ScopedLock lock(compress_mutex);
+  std::lock_guard<std::mutex> lock(compress_mutex);
 
   // see if any of the contiguous ranges can be merged. do not use
   // std::vector::erase in-place as it is quadratic in the number of

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -191,7 +191,7 @@ LogStream::operator<<(std::ostream &(*p)(std::ostream &))
 
   if (query_streambuf.flushed())
     {
-      Threads::Mutex::ScopedLock lock(write_lock);
+      std::lock_guard<std::mutex> lock(write_lock);
 
       // Print the line head in case of a previous newline:
       if (at_newline)
@@ -218,7 +218,7 @@ LogStream::attach(std::ostream &                o,
                   const bool                    print_job_id,
                   const std::ios_base::fmtflags flags)
 {
-  Threads::Mutex::ScopedLock lock(log_lock);
+  std::lock_guard<std::mutex> lock(log_lock);
   file = &o;
   o.setf(flags);
   if (print_job_id)
@@ -229,7 +229,7 @@ LogStream::attach(std::ostream &                o,
 void
 LogStream::detach()
 {
-  Threads::Mutex::ScopedLock lock(log_lock);
+  std::lock_guard<std::mutex> lock(log_lock);
   file = nullptr;
 }
 
@@ -347,9 +347,9 @@ LogStream::width(const std::streamsize wide)
 unsigned int
 LogStream::depth_console(const unsigned int n)
 {
-  Threads::Mutex::ScopedLock lock(log_lock);
-  const unsigned int         h = std_depth;
-  std_depth                    = n;
+  std::lock_guard<std::mutex> lock(log_lock);
+  const unsigned int          h = std_depth;
+  std_depth                     = n;
   return h;
 }
 
@@ -358,9 +358,9 @@ LogStream::depth_console(const unsigned int n)
 unsigned int
 LogStream::depth_file(const unsigned int n)
 {
-  Threads::Mutex::ScopedLock lock(log_lock);
-  const unsigned int         h = file_depth;
-  file_depth                   = n;
+  std::lock_guard<std::mutex> lock(log_lock);
+  const unsigned int          h = file_depth;
+  file_depth                    = n;
   return h;
 }
 
@@ -369,9 +369,9 @@ LogStream::depth_file(const unsigned int n)
 bool
 LogStream::log_thread_id(const bool flag)
 {
-  Threads::Mutex::ScopedLock lock(log_lock);
-  const bool                 h = print_thread_id;
-  print_thread_id              = flag;
+  std::lock_guard<std::mutex> lock(log_lock);
+  const bool                  h = print_thread_id;
+  print_thread_id               = flag;
   return h;
 }
 

--- a/source/base/parallel.cc
+++ b/source/base/parallel.cc
@@ -74,7 +74,7 @@ namespace parallel
     std::shared_ptr<tbb::affinity_partitioner>
     TBBPartitioner::acquire_one_partitioner()
     {
-      dealii::Threads::Mutex::ScopedLock lock(mutex);
+      std::lock_guard<std::mutex> lock(mutex);
       if (in_use)
         return std::make_shared<tbb::affinity_partitioner>();
 
@@ -90,7 +90,7 @@ namespace parallel
     {
       if (p.get() == my_partitioner.get())
         {
-          dealii::Threads::Mutex::ScopedLock lock(mutex);
+          std::lock_guard<std::mutex> lock(mutex);
           in_use = false;
         }
     }

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -1006,7 +1006,7 @@ namespace Polynomials
     // of this function
     // for this, acquire the lock
     // until we quit this function
-    Threads::Mutex::ScopedLock lock(coefficients_lock);
+    std::lock_guard<std::mutex> lock(coefficients_lock);
 
     // The first 2 coefficients
     // are hard-coded
@@ -1140,7 +1140,7 @@ namespace Polynomials
     // then get a pointer to the array
     // of coefficients. do that in a MT
     // safe way
-    Threads::Mutex::ScopedLock lock(coefficients_lock);
+    std::lock_guard<std::mutex> lock(coefficients_lock);
     return *recursive_coefficients[k];
   }
 

--- a/source/base/polynomials_abf.cc
+++ b/source/base/polynomials_abf.cc
@@ -86,7 +86,7 @@ PolynomialsABF<dim>::compute(
   // using a mutex to make sure they
   // are not used by multiple threads
   // at once
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   p_values.resize((values.size() == 0) ? 0 : n_sub);
   p_grads.resize((grads.size() == 0) ? 0 : n_sub);

--- a/source/base/polynomials_bdm.cc
+++ b/source/base/polynomials_bdm.cc
@@ -85,7 +85,7 @@ PolynomialsBDM<dim>::compute(
   // are not used by multiple threads
   // at once
   {
-    Threads::Mutex::ScopedLock lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     p_values.resize((values.size() == 0) ? 0 : n_sub);
     p_grads.resize((grads.size() == 0) ? 0 : n_sub);

--- a/source/base/polynomials_raviart_thomas.cc
+++ b/source/base/polynomials_raviart_thomas.cc
@@ -93,8 +93,8 @@ PolynomialsRaviartThomas<dim>::compute(
   // deal.II/create_mass_matrix_05)
   // will start to produce random
   // results in multithread mode
-  static Threads::Mutex      mutex;
-  Threads::Mutex::ScopedLock lock(mutex);
+  static Threads::Mutex       mutex;
+  std::lock_guard<std::mutex> lock(mutex);
 
   static std::vector<double>         p_values;
   static std::vector<Tensor<1, dim>> p_grads;

--- a/source/base/polynomials_rt_bubbles.cc
+++ b/source/base/polynomials_rt_bubbles.cc
@@ -73,8 +73,8 @@ PolynomialsRT_Bubbles<dim>::compute(
   // using a mutex to make sure they are not used by multiple threads
   // at once
   {
-    static Threads::Mutex      mutex;
-    Threads::Mutex::ScopedLock lock(mutex);
+    static Threads::Mutex       mutex;
+    std::lock_guard<std::mutex> lock(mutex);
 
     static std::vector<Tensor<1, dim>> p_values;
     static std::vector<Tensor<2, dim>> p_grads;

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -412,7 +412,7 @@ TimerOutput::~TimerOutput()
 void
 TimerOutput::enter_subsection(const std::string &section_name)
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   Assert(section_name.empty() == false, ExcMessage("Section string is empty."));
 
@@ -457,7 +457,7 @@ TimerOutput::leave_subsection(const std::string &section_name)
   Assert(!active_sections.empty(),
          ExcMessage("Cannot exit any section because none has been entered!"));
 
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   if (section_name != "")
     {
@@ -873,7 +873,7 @@ TimerOutput::enable_output()
 void
 TimerOutput::reset()
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   sections.clear();
   active_sections.clear();
   timer_all.restart();

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -408,7 +408,7 @@ FE_DGQ<dim, spacedim>::get_prolongation_matrix(
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      Threads::Mutex::ScopedLock lock(this->mutex);
+      std::lock_guard<std::mutex> lock(this->mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->prolongation[refinement_case - 1][child].n() ==
@@ -488,7 +488,7 @@ FE_DGQ<dim, spacedim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      Threads::Mutex::ScopedLock lock(this->mutex);
+      std::lock_guard<std::mutex> lock(this->mutex);
 
       // if matrix got updated while waiting for the lock...
       if (this->restriction[refinement_case - 1][child].n() ==

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -2985,7 +2985,7 @@ FE_Nedelec<dim>::get_prolongation_matrix(
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      Threads::Mutex::ScopedLock lock(this->mutex);
+      std::lock_guard<std::mutex> lock(this->mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->prolongation[refinement_case - 1][child].n() ==
@@ -3047,7 +3047,7 @@ FE_Nedelec<dim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      Threads::Mutex::ScopedLock lock(this->mutex);
+      std::lock_guard<std::mutex> lock(this->mutex);
 
       // if matrix got updated while waiting for the lock...
       if (this->restriction[refinement_case - 1][child].n() ==

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -201,7 +201,7 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::shape_value_component(
   Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
   Assert(component < dim, ExcIndexRange(component, 0, dim));
 
-  Threads::Mutex::ScopedLock lock(cache_mutex);
+  std::lock_guard<std::mutex> lock(cache_mutex);
 
   if (cached_point != p || cached_values.size() == 0)
     {
@@ -247,7 +247,7 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::shape_grad_component(
   Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
   Assert(component < dim, ExcIndexRange(component, 0, dim));
 
-  Threads::Mutex::ScopedLock lock(cache_mutex);
+  std::lock_guard<std::mutex> lock(cache_mutex);
 
   if (cached_point != p || cached_grads.size() == 0)
     {
@@ -294,7 +294,7 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::shape_grad_grad_component(
   Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
   Assert(component < dim, ExcIndexRange(component, 0, dim));
 
-  Threads::Mutex::ScopedLock lock(cache_mutex);
+  std::lock_guard<std::mutex> lock(cache_mutex);
 
   if (cached_point != p || cached_grad_grads.size() == 0)
     {

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -1232,7 +1232,7 @@ FE_Q_Base<PolynomialType, dim, spacedim>::get_prolongation_matrix(
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      Threads::Mutex::ScopedLock lock(this->mutex);
+      std::lock_guard<std::mutex> lock(this->mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->prolongation[refinement_case - 1][child].n() ==
@@ -1434,7 +1434,7 @@ FE_Q_Base<PolynomialType, dim, spacedim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      Threads::Mutex::ScopedLock lock(this->mutex);
+      std::lock_guard<std::mutex> lock(this->mutex);
 
       // if matrix got updated while waiting for the lock...
       if (this->restriction[refinement_case - 1][child].n() ==

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -718,7 +718,7 @@ FESystem<dim, spacedim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      Threads::Mutex::ScopedLock lock(this->mutex);
+      std::lock_guard<std::mutex> lock(this->mutex);
 
       // check if updated while waiting for lock
       if (this->restriction[refinement_case - 1][child].n() ==
@@ -815,7 +815,7 @@ FESystem<dim, spacedim>::get_prolongation_matrix(
   // restriction matrix
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      Threads::Mutex::ScopedLock lock(this->mutex);
+      std::lock_guard<std::mutex> lock(this->mutex);
 
       if (this->prolongation[refinement_case - 1][child].n() ==
           this->dofs_per_cell)

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -321,7 +321,7 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::get_vertices(
       euler_dof_handler->get_fe().n_components()));
 
   {
-    Threads::Mutex::ScopedLock lock(fe_values_mutex);
+    std::lock_guard<std::mutex> lock(fe_values_mutex);
     fe_values.reinit(dof_cell);
     fe_values.get_function_values(*euler_vector, values);
   }

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -221,7 +221,7 @@ MappingQEulerian<dim, VectorType, spacedim>::MappingQEulerianGeneric::
   // fill shift vector for each support point using an fe_values object. make
   // sure that the fe_values variable isn't used simultaneously from different
   // threads
-  Threads::Mutex::ScopedLock lock(fe_values_mutex);
+  std::lock_guard<std::mutex> lock(fe_values_mutex);
   fe_values.reinit(dof_cell);
   if (mg_vector)
     {

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -670,7 +670,7 @@ LAPACKFullMatrix<number>::vmult(Vector<number> &      w,
         }
       case svd:
         {
-          Threads::Mutex::ScopedLock lock(mutex);
+          std::lock_guard<std::mutex> lock(mutex);
           AssertDimension(v.size(), this->n());
           AssertDimension(w.size(), this->m());
           // Compute V^T v
@@ -705,7 +705,7 @@ LAPACKFullMatrix<number>::vmult(Vector<number> &      w,
         }
       case inverse_svd:
         {
-          Threads::Mutex::ScopedLock lock(mutex);
+          std::lock_guard<std::mutex> lock(mutex);
           AssertDimension(w.size(), this->n());
           AssertDimension(v.size(), this->m());
           // Compute U^T v
@@ -805,7 +805,7 @@ LAPACKFullMatrix<number>::Tvmult(Vector<number> &      w,
         }
       case svd:
         {
-          Threads::Mutex::ScopedLock lock(mutex);
+          std::lock_guard<std::mutex> lock(mutex);
           AssertDimension(w.size(), this->n());
           AssertDimension(v.size(), this->m());
 
@@ -841,7 +841,7 @@ LAPACKFullMatrix<number>::Tvmult(Vector<number> &      w,
         }
       case inverse_svd:
         {
-          Threads::Mutex::ScopedLock lock(mutex);
+          std::lock_guard<std::mutex> lock(mutex);
           AssertDimension(v.size(), this->n());
           AssertDimension(w.size(), this->m());
 
@@ -996,7 +996,7 @@ LAPACKFullMatrix<number>::Tmmult(LAPACKFullMatrix<number> &      C,
   // https://stackoverflow.com/questions/3548069/multiplying-three-matrices-in-blas-with-the-middle-one-being-diagonal
   // http://mathforum.org/kb/message.jspa?messageID=3546564
 
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   // First, get V*B into "work" array
   work.resize(kk * nn);
   // following http://icl.cs.utk.edu/lapack-forum/viewtopic.php?f=2&t=768#p2577
@@ -1369,7 +1369,7 @@ template <typename number>
 number
 LAPACKFullMatrix<number>::norm(const char type) const
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   Assert(state == LAPACKSupport::matrix ||
            state == LAPACKSupport::inverse_matrix,
@@ -1447,7 +1447,7 @@ template <typename number>
 number
 LAPACKFullMatrix<number>::reciprocal_condition_number(const number a_norm) const
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   Assert(state == cholesky, ExcState(state));
   number rcond = 0.;
 
@@ -1480,7 +1480,7 @@ template <typename number>
 number
 LAPACKFullMatrix<number>::reciprocal_condition_number() const
 {
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   Assert(property == upper_triangular || property == lower_triangular,
          ExcProperty(property));
   number rcond = 0.;

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -1388,7 +1388,7 @@ ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric(
   Assert(property == LAPACKSupport::symmetric,
          ExcMessage("Matrix has to be symmetric for this operation."));
 
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   const bool use_values = (std::isnan(eigenvalue_limits.first) ||
                            std::isnan(eigenvalue_limits.second)) ?
@@ -1719,7 +1719,7 @@ ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric_MRRR(
   Assert(property == LAPACKSupport::symmetric,
          ExcMessage("Matrix has to be symmetric for this operation."));
 
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   const bool use_values = (std::isnan(eigenvalue_limits.first) ||
                            std::isnan(eigenvalue_limits.second)) ?
@@ -1956,7 +1956,7 @@ ScaLAPACKMatrix<NumberType>::compute_SVD(ScaLAPACKMatrix<NumberType> *U,
              ExcDimensionMismatch(grid->blacs_context,
                                   VT->grid->blacs_context));
     }
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   std::vector<NumberType> sv(std::min(n_rows, n_columns));
 
@@ -2071,7 +2071,7 @@ ScaLAPACKMatrix<NumberType>::least_squares(ScaLAPACKMatrix<NumberType> &B,
          ExcMessage(
            "Use identical block-cyclic distribution for matrices A and B"));
 
-  Threads::Mutex::ScopedLock lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
 
   if (grid->mpi_process_is_active)
     {
@@ -2223,8 +2223,8 @@ ScaLAPACKMatrix<NumberType>::reciprocal_condition_number(
   Assert(state == LAPACKSupport::cholesky,
          ExcMessage(
            "Matrix has to be in Cholesky state before calling this function."));
-  Threads::Mutex::ScopedLock lock(mutex);
-  NumberType                 rcond = 0.;
+  std::lock_guard<std::mutex> lock(mutex);
+  NumberType                  rcond = 0.;
 
   if (grid->mpi_process_is_active)
     {
@@ -2326,8 +2326,8 @@ ScaLAPACKMatrix<NumberType>::norm_general(const char type) const
   Assert(state == LAPACKSupport::matrix ||
            state == LAPACKSupport::inverse_matrix,
          ExcMessage("norms can be called in matrix state only."));
-  Threads::Mutex::ScopedLock lock(mutex);
-  NumberType                 res = 0.;
+  std::lock_guard<std::mutex> lock(mutex);
+  NumberType                  res = 0.;
 
   if (grid->mpi_process_is_active)
     {
@@ -2387,8 +2387,8 @@ ScaLAPACKMatrix<NumberType>::norm_symmetric(const char type) const
          ExcMessage("norms can be called in matrix state only."));
   Assert(property == LAPACKSupport::symmetric,
          ExcMessage("Matrix has to be symmetric for this operation."));
-  Threads::Mutex::ScopedLock lock(mutex);
-  NumberType                 res = 0.;
+  std::lock_guard<std::mutex> lock(mutex);
+  NumberType                  res = 0.;
 
   if (grid->mpi_process_is_active)
     {

--- a/tests/base/thread_local_storage_01.cc
+++ b/tests/base/thread_local_storage_01.cc
@@ -50,7 +50,7 @@ execute(int i)
   // accessed
   static Threads::Mutex m;
   {
-    Threads::Mutex::ScopedLock l(m);
+    std::lock_guard<std::mutex> l(m);
     ++counter;
   }
 

--- a/tests/base/thread_local_storage_02.cc
+++ b/tests/base/thread_local_storage_02.cc
@@ -60,7 +60,7 @@ execute(int i)
   // accessed
   static Threads::Mutex m;
   {
-    Threads::Mutex::ScopedLock l(m);
+    std::lock_guard<std::mutex> l(m);
     ++counter;
   }
 

--- a/tests/bits/step-13.cc
+++ b/tests/bits/step-13.cc
@@ -430,7 +430,7 @@ namespace LaplaceSolver
 
         cell->get_dof_indices(local_dof_indices);
 
-        Threads::Mutex::ScopedLock lock(mutex);
+        std::lock_guard<std::mutex> lock(mutex);
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           for (unsigned int j = 0; j < dofs_per_cell; ++j)
             linear_system.matrix.add(local_dof_indices[i],

--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -512,7 +512,7 @@ namespace LaplaceSolver
 
 
         cell->get_dof_indices(local_dof_indices);
-        Threads::Mutex::ScopedLock lock(mutex);
+        std::lock_guard<std::mutex> lock(mutex);
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           for (unsigned int j = 0; j < dofs_per_cell; ++j)
             linear_system.matrix.add(local_dof_indices[i],

--- a/tests/fail/hp-step-14.cc
+++ b/tests/fail/hp-step-14.cc
@@ -517,7 +517,7 @@ namespace LaplaceSolver
 
 
         cell->get_dof_indices(local_dof_indices);
-        Threads::Mutex::ScopedLock lock(mutex);
+        std::lock_guard<std::mutex> lock(mutex);
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           for (unsigned int j = 0; j < dofs_per_cell; ++j)
             linear_system.matrix.add(local_dof_indices[i],

--- a/tests/hp/step-13.cc
+++ b/tests/hp/step-13.cc
@@ -429,7 +429,7 @@ namespace LaplaceSolver
 
         cell->get_dof_indices(local_dof_indices);
 
-        Threads::Mutex::ScopedLock lock(mutex);
+        std::lock_guard<std::mutex> lock(mutex);
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           for (unsigned int j = 0; j < dofs_per_cell; ++j)
             linear_system.matrix.add(local_dof_indices[i],

--- a/tests/numerics/time_dependent_01.cc
+++ b/tests/numerics/time_dependent_01.cc
@@ -39,8 +39,8 @@ public:
   virtual void
   end_sweep()
   {
-    static Threads::Mutex      mutex;
-    Threads::Mutex::ScopedLock lock(mutex);
+    static Threads::Mutex       mutex;
+    std::lock_guard<std::mutex> lock(mutex);
     end_sweep_flags[time_step_number] = true;
   }
 


### PR DESCRIPTION
This is a follow-up to #7232. In reference to #7228.