### PR TITLE
Use std::mutex functions instead of the names in Threads::Mutex.

### DIFF
--- a/doc/news/changes/minor/20180927Bangerth
+++ b/doc/news/changes/minor/20180927Bangerth
@@ -1,0 +1,9 @@
+Deprecated: The Threads::Mutex class is now derived from
+std::mutex. As a consequence, the Threads::Mutex::ScopedLock class is
+now no longer necessary and is deprecated in favor of std::lock_guard
+or any of the other similar classes provided by C++11 and
+later. Similarly, the Threads::Mutex::acquire() and
+Threads::Mutex::release() functions are deprecated in favor of the
+corresponding functions in the std::mutex base class.
+<br>
+(Wolfgang Bangerth, 2018/09/27)

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -309,7 +309,11 @@ namespace Threads
 
     /**
      * Acquire a mutex.
+     *
+     * @deprecated This function is deprecated. Use the
+     * std::mutex::lock() function of the base class instead.
      */
+    DEAL_II_DEPRECATED
     inline void
     acquire()
     {
@@ -318,7 +322,11 @@ namespace Threads
 
     /**
      * Release the mutex again.
+     *
+     * @deprecated This function is deprecated. Use the
+     * std::mutex::unlock() function of the base class instead.
      */
+    DEAL_II_DEPRECATED
     inline void
     release()
     {

--- a/include/deal.II/lac/swappable_vector.templates.h
+++ b/include/deal.II/lac/swappable_vector.templates.h
@@ -131,7 +131,7 @@ SwappableVector<number>::reload()
   // possibly existing @p alert
   // calls. if not in MT mode, this
   // is a no-op
-  lock.acquire();
+  lock.lock();
 
   // if data was already preloaded,
   // then there is no more need to
@@ -150,8 +150,8 @@ SwappableVector<number>::reload()
       // release lock. the lock is
       // also released in the other
       // branch of the if-clause
-      lock.release();
-    };
+      lock.unlock();
+    }
 }
 
 
@@ -169,7 +169,7 @@ SwappableVector<number>::alert()
   // synchronize with possible other
   // invocations of this function and
   // other functions in this class
-  lock.acquire();
+  lock.lock();
 
   // calling this function multiple
   // times does no harm:
@@ -178,7 +178,7 @@ SwappableVector<number>::alert()
       // vector is active does no harm
       // either
       (this->size() != 0))
-    lock.release();
+    lock.unlock();
   else
     // data has not been preloaded so
     // far, so go on! For this, start
@@ -210,7 +210,7 @@ SwappableVector<number>::reload_vector(const bool set_flag)
   // set the flag if so required
   if (set_flag)
     data_is_preloaded = true;
-  lock.release();
+  lock.unlock();
 #endif
 }
 

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -1066,9 +1066,9 @@ namespace Polynomials
           }
         else if (k == 2)
           {
-            coefficients_lock.release();
+            coefficients_lock.unlock();
             compute_coefficients(1);
-            coefficients_lock.acquire();
+            coefficients_lock.lock();
 
             std::vector<double> c2(3);
 
@@ -1091,9 +1091,9 @@ namespace Polynomials
             // allow the called
             // function to acquire it
             // itself
-            coefficients_lock.release();
+            coefficients_lock.unlock();
             compute_coefficients(k - 1);
-            coefficients_lock.acquire();
+            coefficients_lock.lock();
 
             std::vector<double> ck(k + 1);
 


### PR DESCRIPTION
This then allows the deprecation of the Threads::Mutex member functions, as done in
the second commit.

In reference to #7228. See also #7232, #7235.