### PR TITLE
Deprecate Threads::ConditionVariable.

### DIFF
--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -331,9 +331,11 @@ namespace Threads
    * Class implementing a condition variable. The semantics of this class and
    * its member functions are the same as those of the POSIX functions.
    *
+   * @deprecated Use std::condition_variable instead.
+   *
    * @author Wolfgang Bangerth, 2003
    */
-  class ConditionVariable
+  class DEAL_II_DEPRECATED ConditionVariable
   {
   public:
     /**


### PR DESCRIPTION
It turns out that this class wasn't even used anywhere. See #7228.