### PR TITLE
Remove dummy threading implementation

### DIFF
--- a/doc/news/changes/minor/20180927Bangerth-4
+++ b/doc/news/changes/minor/20180927Bangerth-4
@@ -1,0 +1,9 @@
+Removed: The Threads::DummyMutex, Threads::DummyConditionVariable, and
+Threads::DummyThreadBarrier classes have been removed. These were only
+used if deal.II was compiled without thread support, in which case
+certain functionality from the TBB was not available. But the
+implementations of the underlying functionality is now unconditionally
+available via the C++11 standard library, and so we don't need the
+dummy implementations any more.
+<br>
+(Wolfgang Bangerth, 2018/09/27)

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -23,22 +23,17 @@
 #  include <deal.II/base/multithread_info.h>
 #  include <deal.II/base/template_constraints.h>
 
-#  ifdef DEAL_II_WITH_THREADS
-#    include <condition_variable>
-#    include <mutex>
-#    include <thread>
-#  endif
-
+#  include <condition_variable>
 #  include <functional>
 #  include <iterator>
 #  include <list>
 #  include <memory>
+#  include <mutex>
 #  include <tuple>
 #  include <utility>
 #  include <vector>
-
-
 #  ifdef DEAL_II_WITH_THREADS
+#    include <thread>
 #    ifdef DEAL_II_USE_MT_POSIX
 #      include <pthread.h>
 #    endif

--- a/source/base/thread_management.cc
+++ b/source/base/thread_management.cc
@@ -148,19 +148,10 @@ namespace Threads
 
 
 
-#ifndef DEAL_II_WITH_THREADS
-  DummyBarrier::DummyBarrier(const unsigned int count, const char *, void *)
-  {
-    (void)count;
-    Assert(count == 1, ExcBarrierSizeNotUseful(count));
-  }
+#ifdef DEAL_II_USE_MT_POSIX
 
 
-#else
-#  ifdef DEAL_II_USE_MT_POSIX
-
-
-#    ifndef DEAL_II_USE_MT_POSIX_NO_BARRIERS
+#  ifndef DEAL_II_USE_MT_POSIX_NO_BARRIERS
   PosixThreadBarrier::PosixThreadBarrier(const unsigned int count,
                                          const char *,
                                          void *)
@@ -168,7 +159,7 @@ namespace Threads
     pthread_barrier_init(&barrier, nullptr, count);
   }
 
-#    else
+#  else
 
   PosixThreadBarrier::PosixThreadBarrier(const unsigned int count,
                                          const char *,
@@ -187,21 +178,21 @@ namespace Threads
                            "this class, but the rest of the threading\n"
                            "functionality is available."));
   }
-#    endif
+#  endif
 
 
 
   PosixThreadBarrier::~PosixThreadBarrier()
   {
-#    ifndef DEAL_II_USE_MT_POSIX_NO_BARRIERS
+#  ifndef DEAL_II_USE_MT_POSIX_NO_BARRIERS
     pthread_barrier_destroy(&barrier);
-#    else
+#  else
     // unless the barrier is a no-op,
     // complain again (how did we get
     // here then?)
     if (count != 1)
       std::abort();
-#    endif
+#  endif
   }
 
 
@@ -209,9 +200,9 @@ namespace Threads
   int
   PosixThreadBarrier::wait()
   {
-#    ifndef DEAL_II_USE_MT_POSIX_NO_BARRIERS
+#  ifndef DEAL_II_USE_MT_POSIX_NO_BARRIERS
     return pthread_barrier_wait(&barrier);
-#    else
+#  else
     // in the special case, this
     // function is a no-op. otherwise
     // complain about the missing
@@ -223,12 +214,11 @@ namespace Threads
         std::abort();
         return 1;
       };
-#    endif
+#  endif
   }
 
 
 
-#  endif
 #endif
 
 


### PR DESCRIPTION
This is the patch mentioned in #7245. It removes the dummy implementations of the threading mutex/condition variable/... classes given that they now no longer depend on external dependencies but simply build on compiler material. In other words, the *real* classes ought to compile also in non-threading mode.

I believe that if we commit this, we can undo #7245 -- simplifying the code at the cost of a modest slow-down of the code when running in non-threading mode.

In reference to #7228.