### PR TITLE
Provide the mod_header.pl.in with a copyright header and explanation.

### DIFF
--- a/doc/doxygen/scripts/mod_footer.pl.in
+++ b/doc/doxygen/scripts/mod_footer.pl.in
@@ -1,3 +1,22 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2014 - 2018 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE.md at
+## the top level directory of deal.II.
+##
+## ---------------------------------------------------------------------
+
+#
+# A PERL script that modifies the default-generated 'footer.html' file
+# that doxygen provides for us and customizes it for our needs.
+#
 
 use Sys::Hostname;
 my $host = hostname;

--- a/doc/doxygen/scripts/mod_header.pl.in
+++ b/doc/doxygen/scripts/mod_header.pl.in
@@ -1,3 +1,22 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2014 - 2018 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE.md at
+## the top level directory of deal.II.
+##
+## ---------------------------------------------------------------------
+
+#
+# A PERL script that modifies the default-generated 'header.html' file
+# that doxygen provides for us and customizes it for our needs.
+#
 
 
 # Modify these to enter the current data automatically
@@ -11,6 +30,10 @@ if (m'</head>')
     print '<meta name="author" content="The deal.II Authors <authors@dealii.org>"></meta>', "\n";
     print '<meta name="copyright" content="Copyright (C) 1998 - ', $year, ' by the deal.II authors"></meta>', "\n";
     print '<meta name="deal.II-version" content="@DEAL_II_PACKAGE_VERSION@"></meta>', "\n";
+
+    # This script is run with ${perl} -pi, so it outputs every line we don't
+    # explicitly modify. Consequently, it still outputs the '</head>' tag
+    # above.
 }
 
 s/\$projectname// unless (m/<title>/);
@@ -20,8 +43,8 @@ s/\$projectname// unless (m/<title>/);
 # disappear while MathJax works.
 if (eof)
 {
-    CORE::say '<!--Extra macros for MathJax:-->';
-    CORE::say '<div style="display:none">';
-    CORE::say '\(\newcommand{\dealcoloneq}{\mathrel{\vcenter{:}}=}\)';
-    CORE::say '</div>';
+    print '<!--Extra macros for MathJax:-->', "\n";
+    print '<div style="display:none">', "\n";
+    print '\(\newcommand{\dealcoloneq}{\mathrel{\vcenter{:}}=}\)', "\n";
+    print '</div>', "\n";
 }


### PR DESCRIPTION
While there, also clean up some idiosyncratic use of CORE::say: we use
print everywhere else in PERL scripts, so do the same here.

Put the same copyright header also into mod_footer.pl.in.