### PR TITLE
Fix copyright date format.

### DIFF
--- a/include/deal.II/lac/la_vector.templates.h
+++ b/include/deal.II/lac/la_vector.templates.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C)  2015 by the deal.II authors
+// Copyright (C) 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //


### PR DESCRIPTION
This is the only file that had used two spaces after '(C)'.