### PR TITLE
use const cast for old OpenMPI version

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -58,6 +58,33 @@ class SymmetricTensor;
 template <typename Number>
 class SparseMatrix;
 
+
+// Helper macro to remove const from the pointer arguments to some MPI_*
+// functions.
+//
+// This is needed as the input arguments of functions like MPI_Allgather() are
+// not marked as const in OpenMPI 1.6.5.
+#ifdef DEAL_II_WITH_MPI
+#  if DEAL_II_MPI_VERSION_GTE(3, 0)
+// We are good, no casts are needed.
+#    define DEAL_II_MPI_CONST_CAST(expr) (expr)
+#  else
+
+#    include <type_traits>
+
+// This monster of a macro will:
+// 1. remove *
+// 2. remove const
+// 3. add *
+// 4. const_cast the given expression to this new type.
+#    define DEAL_II_MPI_CONST_CAST(expr)                                       \
+      const_cast<                                                              \
+        std::remove_const<std::remove_pointer<decltype(expr)>::type>::type *>( \
+        expr)
+
+#  endif
+#endif
+
 namespace Utilities
 {
   /**

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -47,16 +47,6 @@ using MPI_Op       = int;
 #  endif
 #endif
 
-DEAL_II_NAMESPACE_OPEN
-
-
-// Forward type declarations to allow MPI sums over tensorial types
-template <int rank, int dim, typename Number>
-class Tensor;
-template <int rank, int dim, typename Number>
-class SymmetricTensor;
-template <typename Number>
-class SparseMatrix;
 
 
 // Helper macro to remove const from the pointer arguments to some MPI_*
@@ -84,6 +74,19 @@ class SparseMatrix;
 
 #  endif
 #endif
+
+
+
+DEAL_II_NAMESPACE_OPEN
+
+
+// Forward type declarations to allow MPI sums over tensorial types
+template <int rank, int dim, typename Number>
+class Tensor;
+template <int rank, int dim, typename Number>
+class SymmetricTensor;
+template <typename Number>
+class SparseMatrix;
 
 namespace Utilities
 {

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -49,24 +49,27 @@ using MPI_Op       = int;
 
 
 
-// Helper macro to remove const from the pointer arguments to some MPI_*
-// functions.
-//
-// This is needed as the input arguments of functions like MPI_Allgather() are
-// not marked as const in OpenMPI 1.6.5.
+/** Helper macro to remove const from the pointer arguments to some MPI_*
+ * functions.
+ *
+ * This is needed as the input arguments of functions like MPI_Allgather() are
+ * not marked as const in OpenMPI 1.6.5. If using MPI 3 or newer, this macro
+ * is a NOOP, while we do the following otherwise:
+ *
+ * 1. remove * from type of @p expr
+ * 2. remove const from resulting type
+ * 3. add * to resulting type
+ * 4. const_cast the given expression @p expr to this new type.
+ */
 #ifdef DEAL_II_WITH_MPI
 #  if DEAL_II_MPI_VERSION_GTE(3, 0)
-// We are good, no casts are needed.
+
 #    define DEAL_II_MPI_CONST_CAST(expr) (expr)
+
 #  else
 
 #    include <type_traits>
 
-// This monster of a macro will:
-// 1. remove *
-// 2. remove const
-// 3. add *
-// 4. const_cast the given expression to this new type.
 #    define DEAL_II_MPI_CONST_CAST(expr)                                       \
       const_cast<                                                              \
         std::remove_const<std::remove_pointer<decltype(expr)>::type>::type *>( \

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -5079,7 +5079,7 @@ namespace internal
           n_locally_owned_dofs_per_processor(n_cpus);
 
         const int ierr =
-          MPI_Allgather(&n_locally_owned_dofs,
+          MPI_Allgather(DEAL_II_MPI_CONST_CAST(&n_locally_owned_dofs),
                         1,
                         DEAL_II_DOF_INDEX_MPI_TYPE,
                         n_locally_owned_dofs_per_processor.data(),


### PR DESCRIPTION
Old versions of OpenMPI are missing const specifiers for input arguments in functions like MPI_Allgather. Introduce a macro to cast away const in these cases.

The compiler chokes at some of the casts if they are complicated types, so I had to introduce local variables for some of them. Don't ask me why.

fixes #7225