### PR TITLE
[9.0] redo 7156

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -23,6 +23,7 @@
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/base/multithread_info.h>
 
+#include <numeric> 
 #include <iostream>
 
 #ifdef DEAL_II_WITH_TRILINOS


### PR DESCRIPTION
The call to `std::iota` is in 9.0, so I think we should include this patch.

I will continue to look through the logs and see if there are any other simple fixes we should include.