### PR TITLE
Update author list of hp::DoFHandler.

### DIFF
--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -163,7 +163,9 @@ namespace hp
    * @ingroup dofs
    * @ingroup hp
    *
-   * @author Wolfgang Bangerth, Oliver Kayser-Herold, 2003, 2004, 2017
+   * @author Wolfgang Bangerth, 2003, 2004, 2017, 2018
+   * @author Oliver Kayser-Herold, 2003, 2004
+   * @author Marc Fehling, 2018
    */
   template <int dim, int spacedim = dim>
   class DoFHandler : public Subscriptor


### PR DESCRIPTION
We have not been consistent in annotating classes with their authors. I have
found myself tempted, on occasion, to just remove all of the doxygen
'@author' annotations because they short-change a lot of people. We also
have better ways now to give credit where credit is due, such as in
the release papers.

Regardless, the current author list of the hp::DoFHandler class is
badly outdated and should include @marcfehling. If we want to keep
the author list for this class, then we should merge this.