### PR TITLE
Introduced FECollection::find_most_face_dominating_fe_in_subset().

### DIFF
--- a/doc/news/changes/minor/20181005MarcFehling
+++ b/doc/news/changes/minor/20181005MarcFehling
@@ -1,0 +1,5 @@
+New: Member function hp::FECollection::find_face_dominating_fe_in_subset()
+returns the index of the most dominating finite element out of a given
+set of indices.
+<br>
+(Marc Fehling, 2018/10/05)

--- a/doc/news/changes/minor/20181008MarcFehling
+++ b/doc/news/changes/minor/20181008MarcFehling
@@ -1,0 +1,5 @@
+New: Functions DoFAccessor::get_active_fe_indices() and
+internal::DoFAccessorImplementation::get_active_vertex_fe_indices()
+return all active finite element indices on the corresponding object.
+<br>
+(Marc Fehling, 2018/10/08)

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -556,6 +556,15 @@ public:
   nth_active_fe_index(const unsigned int n) const;
 
   /**
+   * Returns all active fe indices on this object.
+   *
+   * The size of the returned set equals the number of finite elements that
+   * are active on this object.
+   */
+  std::set<unsigned int>
+  get_active_fe_indices() const;
+
+  /**
    * Return true if the finite element with given index is active on the
    * present object. For non-hp DoF accessors, this is of course the case only
    * if @p fe_index equals zero. For cells, it is the case if @p fe_index

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1324,6 +1324,29 @@ namespace internal
 
 
       /**
+       * Returns all active fe indices on a given vertex.
+       *
+       * The size of the returned set equals the number of finite elements that
+       * are active on this vertex.
+       */
+      template <int dim, int spacedim>
+      static std::set<unsigned int>
+      get_active_vertex_fe_indices(
+        const dealii::hp::DoFHandler<dim, spacedim> &dof_handler,
+        const unsigned int                           vertex_index)
+      {
+        std::set<unsigned int> active_fe_indices;
+        for (unsigned int i = 0;
+             i < n_active_vertex_fe_indices(dof_handler, vertex_index);
+             ++i)
+          active_fe_indices.insert(
+            nth_active_vertex_fe_index(dof_handler, vertex_index, i));
+        return active_fe_indices;
+      }
+
+
+
+      /**
        * Return whether a particular finite element index is active on the
        * specified vertex.
        */
@@ -1616,6 +1639,19 @@ DoFAccessor<dim, DoFHandlerType, level_dof_access>::nth_active_fe_index(
                         this->present_index,
                         n,
                         std::integral_constant<int, dim>());
+}
+
+
+
+template <int dim, typename DoFHandlerType, bool level_dof_access>
+inline std::set<unsigned int>
+DoFAccessor<dim, DoFHandlerType, level_dof_access>::get_active_fe_indices()
+  const
+{
+  std::set<unsigned int> active_fe_indices;
+  for (unsigned int i = 0; i < n_active_fe_indices(); ++i)
+    active_fe_indices.insert(nth_active_fe_index(i));
+  return active_fe_indices;
 }
 
 

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -302,6 +302,33 @@ namespace hp
     find_least_face_dominating_fe(const std::set<unsigned int> &fes) const;
 
     /**
+     * Try to find a most face dominating finite element inside the subset of
+     * fe_indices @p fes as part of this FECollection. For example, if an
+     * FECollection consists of `{FE_Q(1),FE_Q(2),FE_Q(3),FE_Q(4)}` elements
+     * and we are looking for the most face dominating finite element among the
+     * last two elements of this collection (i.e., @p fes is `{2,3}`), then the
+     * answer is FE_Q(3) and therefore this function will return its index in
+     * the FECollection, namely `2`.
+     *
+     * This function differs from find_least_face_dominating_fe() in such a way
+     * that it looks for the most dominating finite element within the given
+     * subset @p fes, instead of finding a finite element in the whole
+     * FECollection that dominates all elements of the subset @p fes.
+     *
+     * For the purpose of this function by domination we consider either
+     * FiniteElementDomination::Domination::this_element_dominates or
+     * FiniteElementDomination::Domination::either_element_can_dominate;
+     * therefore the element can dominate itself. Thus, if an FECollection
+     * contains `{FE_Q(1),FE_Q(2),FE_Q(3),FE_Q(4)}` and @p fes only has
+     * a single element `{3}`, then the function returns 3.
+     *
+     * If the function is not able to find a finite element, the function
+     * returns numbers::invalid_unsigned_int.
+     */
+    unsigned int
+    find_face_dominating_fe_in_subset(const std::set<unsigned int> &fes) const;
+
+    /**
      * Return a component mask with as many elements as this object has vector
      * components and of which exactly the one component is true that
      * corresponds to the given argument.

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -1258,14 +1258,14 @@ namespace ColorEnriched
        * Each time we build constraints at the
        * interface between two different FE_Enriched, we look for the least
        * dominating FE via
-       * hp::FECollection< dim, spacedim
-       * >::find_least_face_dominating_fe_in_collection(). If we don't take
-       * further actions, we may find a dominating FE that is too restrictive,
-       * i.e. enriched FE consisting of only FE_Nothing. New elements needs to
-       * be added to FECollection object to help find the correct enriched FE
-       * underlying the spaces in the adjacent cells. This is done by creating
-       * an appropriate set in fe_sets and a call to the function
-       * make_fe_collection_from_colored_enrichments at a later stage.
+       * hp::FECollection<dim,
+       * spacedim>::find_least_face_dominating_fe_in_collection(). If we don't
+       * take further actions, we may find a dominating FE that is too
+       * restrictive, i.e. enriched FE consisting of only FE_Nothing. New
+       * elements needs to be added to FECollection object to help find the
+       * correct enriched FE underlying the spaces in the adjacent cells. This
+       * is done by creating an appropriate set in fe_sets and a call to the
+       * function make_fe_collection_from_colored_enrichments at a later stage.
        *
        * Consider a domain with three predicates and hence with three different
        * enrichment functions. Let the enriched finite element of a cell with


### PR DESCRIPTION
This is meant as a predecessor to #7272.

Replaces the `get_most_dominating_fe_index()` function of the `internal::hp::DoFHandlerImplementation` namespace by a function `hp::FECollection::find_most_face_dominating_fe_in_subset()` that takes a set of `fe_indices` instead of a reference to a `internal::Triangulation::TriaObject`.