### PR TITLE
Do not use deprecated function Threads::this_thread_id().

### DIFF
--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -21,6 +21,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <thread>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -414,8 +415,8 @@ LogStream::get_prefixes() const
 void
 LogStream::print_line_head()
 {
-  const std::string &head   = get_prefix();
-  const unsigned int thread = Threads::this_thread_id();
+  const std::string &   head   = get_prefix();
+  const std::thread::id thread = std::this_thread::get_id();
 
   if (get_prefixes().size() <= std_depth)
     {


### PR DESCRIPTION
Instead use std::this_thread::get_id(). I don't know what this will do to the
output we get in the testsuite, but no better way to find out than to try out.