### PR TITLE
Fix clang-tidy complaints

### DIFF
--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -380,7 +380,7 @@ namespace Step16
   {
     MappingQ1<dim> mapping;
 
-    typedef decltype(dof_handler.begin_active()) Iterator;
+    using Iterator = decltype(this->dof_handler.begin_active());
 
     auto cell_worker = [&](const Iterator &  cell,
                            ScratchData<dim> &scratch_data,
@@ -449,7 +449,7 @@ namespace Step16
         boundary_constraints[level].close();
       }
 
-    typedef decltype(dof_handler.begin_mg()) Iterator;
+    using Iterator = decltype(this->dof_handler.begin_mg());
 
     auto cell_worker = [&](const Iterator &  cell,
                            ScratchData<dim> &scratch_data,

--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -380,13 +380,12 @@ namespace Step16
   {
     MappingQ1<dim> mapping;
 
-    using Iterator = decltype(this->dof_handler.begin_active());
-
-    auto cell_worker = [&](const Iterator &  cell,
-                           ScratchData<dim> &scratch_data,
-                           CopyData &        copy_data) {
-      this->cell_worker(cell, scratch_data, copy_data);
-    };
+    auto cell_worker =
+      [&](const typename DoFHandler<dim>::active_cell_iterator &cell,
+          ScratchData<dim> &                                    scratch_data,
+          CopyData &                                            copy_data) {
+        this->cell_worker(cell, scratch_data, copy_data);
+      };
 
     auto copier = [&](const CopyData &cd) {
       this->constraints.distribute_local_to_global(cd.cell_matrix,
@@ -449,13 +448,12 @@ namespace Step16
         boundary_constraints[level].close();
       }
 
-    using Iterator = decltype(this->dof_handler.begin_mg());
-
-    auto cell_worker = [&](const Iterator &  cell,
-                           ScratchData<dim> &scratch_data,
-                           CopyData &        copy_data) {
-      this->cell_worker(cell, scratch_data, copy_data);
-    };
+    auto cell_worker =
+      [&](const typename DoFHandler<dim>::active_cell_iterator &cell,
+          ScratchData<dim> &                                    scratch_data,
+          CopyData &                                            copy_data) {
+        this->cell_worker(cell, scratch_data, copy_data);
+      };
 
     auto copier = [&](const CopyData &cd) {
       boundary_constraints[cd.level].distribute_local_to_global(

--- a/include/deal.II/lac/cuda_kernels.h
+++ b/include/deal.II/lac/cuda_kernels.h
@@ -39,7 +39,7 @@ namespace LinearAlgebra
     {
       using ::dealii::CUDAWrappers::block_size;
       using ::dealii::CUDAWrappers::chunk_size;
-      typedef types::global_dof_index size_type;
+      using size_type = types::global_dof_index;
 
       /**
        * Multiply each entry of @p val of size @p N by @p a.

--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -70,7 +70,7 @@ namespace LinearAlgebra
       /**
        * Move constructor.
        */
-      Vector(Vector<Number> &&) = default;
+      Vector(Vector<Number> &&) noexcept = default;
 
       /**
        * Constructor. Set dimension to @p n and initialize all elements with
@@ -94,7 +94,7 @@ namespace LinearAlgebra
        * Move assignment operator.
        */
       Vector &
-      operator=(Vector<Number> &&v) = default;
+      operator=(Vector<Number> &&v) noexcept = default;
 
       /**
        * Swap the contents of this vector and the other vector @p v. One could do

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -88,10 +88,10 @@ namespace CUDAWrappers
       void
       transpose_subface_index(unsigned int &subface) const;
 
-      typedef typename DoFHandler<dim>::cell_iterator cell_iterator;
-      typedef
-        typename DoFHandler<dim>::active_cell_iterator active_cell_iterator;
-      const unsigned int                               n_raw_lines;
+      using cell_iterator = typename DoFHandler<dim>::cell_iterator;
+      using active_cell_iterator =
+        typename DoFHandler<dim>::active_cell_iterator;
+      const unsigned int n_raw_lines;
       std::vector<std::vector<std::pair<cell_iterator, unsigned int>>>
                                        line_to_cells;
       const std::vector<unsigned int> &lexicographic_mapping;


### PR DESCRIPTION
Namely, mark move assignment operators and move constructors as `noexcept` and replace `typedef` by `using`.