### PR TITLE
Only declare FunctionParser if there is muparser support

### DIFF
--- a/examples/step-33/CMakeLists.txt
+++ b/examples/step-33/CMakeLists.txt
@@ -40,11 +40,13 @@ ENDIF()
 #
 # Are all dependencies fulfilled?
 #
-IF(NOT DEAL_II_TRILINOS_WITH_SACADO) # keep in one line
+IF(NOT DEAL_II_TRILINOS_WITH_SACADO OR NOT DEAL_II_WITH_MUPARSER) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
+    DEAL_II_WITH_MUPARSER = ON
     DEAL_II_TRILINOS_WITH_SACADO = ON
 However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_MUPARSER = ${DEAL_II_WITH_MUPARSER}
     DEAL_II_TRILINOS_WITH_SACADO = ${DEAL_II_TRILINOS_WITH_SACADO}
 which conflict with the requirements."
     )

--- a/examples/step-60/CMakeLists.txt
+++ b/examples/step-60/CMakeLists.txt
@@ -37,11 +37,13 @@ ENDIF()
 #
 # Are all dependencies fulfilled?
 #
-IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
+IF(NOT DEAL_II_WITH_UMFPACK OR NOT DEAL_II_WITH_MUPARSER) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
+    DEAL_II_WITH_MUPARSER = ON
     DEAL_II_WITH_UMFPACK = ON
 However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_MUPARSER = ${DEAL_II_WITH_MUPARSER}
     DEAL_II_WITH_UMFPACK = ${DEAL_II_WITH_UMFPACK}
 which conflict with the requirements."
     )

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -938,17 +938,6 @@ namespace StandardExceptions
     "find a valid NetCDF library.");
 
   /**
-   * This function requires support for the FunctionParser library.
-   */
-  DeclExceptionMsg(
-    ExcNeedsFunctionparser,
-    "You are attempting to use functionality that is only available "
-    "if deal.II was configured to use the function parser which "
-    "relies on the muparser library, but cmake did not "
-    "find a valid muparser library on your system and also did "
-    "not choose the one that comes bundled with deal.II.");
-
-  /**
    * This function requires support for the Assimp library.
    */
   DeclExceptionMsg(

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -16,18 +16,18 @@
 #ifndef dealii_function_parser_h
 #define dealii_function_parser_h
 
-
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/auto_derivative_function.h>
-#include <deal.II/base/exceptions.h>
-#include <deal.II/base/point.h>
-#include <deal.II/base/tensor.h>
-#include <deal.II/base/thread_local_storage.h>
+#ifdef DEAL_II_WITH_MUPARSER
+#  include <deal.II/base/auto_derivative_function.h>
+#  include <deal.II/base/exceptions.h>
+#  include <deal.II/base/point.h>
+#  include <deal.II/base/tensor.h>
+#  include <deal.II/base/thread_local_storage.h>
 
-#include <map>
-#include <memory>
-#include <vector>
+#  include <map>
+#  include <memory>
+#  include <vector>
 
 namespace mu
 {
@@ -368,7 +368,6 @@ public:
   //@}
 
 private:
-#ifdef DEAL_II_WITH_MUPARSER
   /**
    * Place for the variables for each thread
    */
@@ -410,7 +409,6 @@ private:
    */
   void
   init_muparser() const;
-#endif
 
   /**
    * An array of function expressions (one per component), required to
@@ -456,5 +454,5 @@ FunctionParser<dim>::default_variable_names()
 
 
 DEAL_II_NAMESPACE_CLOSE
-
+#endif
 #endif

--- a/include/deal.II/base/parsed_function.h
+++ b/include/deal.II/base/parsed_function.h
@@ -17,9 +17,12 @@
 #ifndef dealii_parsed_function_h
 #define dealii_parsed_function_h
 
-#include <deal.II/base/auto_derivative_function.h>
-#include <deal.II/base/function_parser.h>
-#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_MUPARSER
+#  include <deal.II/base/auto_derivative_function.h>
+#  include <deal.II/base/function_parser.h>
+#  include <deal.II/base/parameter_handler.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -215,5 +218,5 @@ namespace Functions
 } // namespace Functions
 
 DEAL_II_NAMESPACE_CLOSE
-
+#endif
 #endif

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -498,6 +498,7 @@ public:
     const Tensor<1, chartdim> &periodicity = Tensor<1, chartdim>(),
     const double               tolerance   = 1e-10);
 
+#ifdef DEAL_II_WITH_MUPARSER
   /**
    * Expressions constructor. Takes the expressions of the push_forward
    * function of spacedim components, and of the pull_back function of @p
@@ -524,6 +525,7 @@ public:
       FunctionParser<spacedim>::default_variable_names(),
     const double tolerance = 1e-10,
     const double h         = 1e-8);
+#endif
 
   /**
    * If needed, we delete the pointers we own.
@@ -576,10 +578,12 @@ public:
   pull_back(const Point<spacedim> &space_point) const override;
 
 private:
+#ifdef DEAL_II_WITH_MUPARSER
   /**
    * Constants for the FunctionParser classes.
    */
   const typename FunctionParser<spacedim>::ConstMap const_map;
+#endif
 
   /**
    * Pointer to the push_forward function.

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -13,31 +13,20 @@
 //
 // ---------------------------------------------------------------------
 
-
-#include <deal.II/base/function_parser.h>
-#include <deal.II/base/patterns.h>
-#include <deal.II/base/thread_management.h>
-#include <deal.II/base/utilities.h>
-
-#include <deal.II/lac/vector.h>
-
-#include <boost/random.hpp>
-
-#include <cmath>
-#include <map>
-
 #ifdef DEAL_II_WITH_MUPARSER
-#  include <muParser.h>
-#else
+#  include <deal.II/base/function_parser.h>
+#  include <deal.II/base/patterns.h>
+#  include <deal.II/base/thread_management.h>
+#  include <deal.II/base/utilities.h>
 
+#  include <deal.II/lac/vector.h>
 
+#  include <boost/random.hpp>
 
-namespace fparser
-{
-  class FunctionParser
-  {};
-} // namespace fparser
-#endif
+#  include <cmath>
+#  include <map>
+
+#    include <muParser.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -96,7 +85,6 @@ template <int dim>
 FunctionParser<dim>::~FunctionParser() = default;
 
 
-#ifdef DEAL_II_WITH_MUPARSER
 
 template <int dim>
 void
@@ -492,50 +480,6 @@ FunctionParser<dim>::vector_value(const Point<dim> &p,
     values(component) = fp.get()[component]->Eval();
 }
 
-#else
-
-
-template <int dim>
-void
-FunctionParser<dim>::initialize(const std::string &,
-                                const std::vector<std::string> &,
-                                const std::map<std::string, double> &,
-                                const bool)
-{
-  Assert(false, ExcNeedsFunctionparser());
-}
-
-template <int dim>
-void
-FunctionParser<dim>::initialize(const std::string &,
-                                const std::string &,
-                                const std::map<std::string, double> &,
-                                const bool)
-{
-  Assert(false, ExcNeedsFunctionparser());
-}
-
-
-
-template <int dim>
-double
-FunctionParser<dim>::value(const Point<dim> &, unsigned int) const
-{
-  Assert(false, ExcNeedsFunctionparser());
-  return 0.;
-}
-
-
-template <int dim>
-void
-FunctionParser<dim>::vector_value(const Point<dim> &, Vector<double> &) const
-{
-  Assert(false, ExcNeedsFunctionparser());
-}
-
-
-#endif
-
 // Explicit Instantiations.
 
 template class FunctionParser<1>;
@@ -543,3 +487,4 @@ template class FunctionParser<2>;
 template class FunctionParser<3>;
 
 DEAL_II_NAMESPACE_CLOSE
+#endif

--- a/source/base/parsed_function.cc
+++ b/source/base/parsed_function.cc
@@ -13,10 +13,12 @@
 //
 // ---------------------------------------------------------------------
 
-#include <deal.II/base/parsed_function.h>
-#include <deal.II/base/utilities.h>
+#ifdef DEAL_II_WITH_MUPARSER
 
-#include <cstdio>
+#  include <deal.II/base/parsed_function.h>
+#  include <deal.II/base/utilities.h>
+
+#  include <cstdio>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -196,3 +198,5 @@ namespace Functions
   template class ParsedFunction<3>;
 } // namespace Functions
 DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1170,7 +1170,7 @@ FunctionManifold<dim, spacedim, chartdim>::FunctionManifold(
 }
 
 
-
+#ifdef DEAL_II_WITH_MUPARSER
 template <int dim, int spacedim, int chartdim>
 FunctionManifold<dim, spacedim, chartdim>::FunctionManifold(
   const std::string                                 push_forward_expression,
@@ -1198,7 +1198,7 @@ FunctionManifold<dim, spacedim, chartdim>::FunctionManifold(
   push_forward_function = pf;
   pull_back_function    = pb;
 }
-
+#endif
 
 
 template <int dim, int spacedim, int chartdim>
@@ -1232,6 +1232,7 @@ FunctionManifold<dim, spacedim, chartdim>::clone() const
   // function (owns_pointers == false) or that the newly generated manifold
   // creates internally the push_forward and pull_back functions using the same
   // expressions that were used to construct this class (own_pointers == true).
+#ifdef DEAL_II_WITH_MUPARSER
   if (owns_pointers == true)
     {
       return std_cxx14::make_unique<FunctionManifold<dim, spacedim, chartdim>>(
@@ -1245,6 +1246,7 @@ FunctionManifold<dim, spacedim, chartdim>::clone() const
         finite_difference_step);
     }
   else
+#endif
     return std_cxx14::make_unique<FunctionManifold<dim, spacedim, chartdim>>(
       *push_forward_function,
       *pull_back_function,


### PR DESCRIPTION
When compiling with minimal support, I regularly find myself stumbling across some problems with the right functions and variables being defined such that the `FunctionParser` class compiles.
Of course, the class is unusable in this case. Hence, I propose that we just don't declare the class in that case in the first place.