### PR TITLE
Restrict examples that require a working FunctionParser class

### DIFF
--- a/examples/step-33/CMakeLists.txt
+++ b/examples/step-33/CMakeLists.txt
@@ -40,11 +40,13 @@ ENDIF()
 #
 # Are all dependencies fulfilled?
 #
-IF(NOT DEAL_II_TRILINOS_WITH_SACADO) # keep in one line
+IF(NOT DEAL_II_TRILINOS_WITH_SACADO OR NOT DEAL_II_WITH_MUPARSER) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
+    DEAL_II_WITH_MUPARSER = ON
     DEAL_II_TRILINOS_WITH_SACADO = ON
 However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_MUPARSER = ${DEAL_II_WITH_MUPARSER}
     DEAL_II_TRILINOS_WITH_SACADO = ${DEAL_II_TRILINOS_WITH_SACADO}
 which conflict with the requirements."
     )

--- a/examples/step-60/CMakeLists.txt
+++ b/examples/step-60/CMakeLists.txt
@@ -37,11 +37,13 @@ ENDIF()
 #
 # Are all dependencies fulfilled?
 #
-IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
+IF(NOT DEAL_II_WITH_UMFPACK OR NOT DEAL_II_WITH_MUPARSER) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
+    DEAL_II_WITH_MUPARSER = ON
     DEAL_II_WITH_UMFPACK = ON
 However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_MUPARSER = ${DEAL_II_WITH_MUPARSER}
     DEAL_II_WITH_UMFPACK = ${DEAL_II_WITH_UMFPACK}
 which conflict with the requirements."
     )


### PR DESCRIPTION
In fact, these tutorials use `FunctionParser`. For this class to work properly, deal.II must be built with `muparser` support.