### PR TITLE
Tests: base/utilities_13 - avoid an arithmetic exception with clang

### DIFF
--- a/tests/base/utilities_13.cc
+++ b/tests/base/utilities_13.cc
@@ -141,5 +141,5 @@ main()
   test1();
   test2();
 
-  test3<std::uint64_t, long double>();
+  test3<std::int64_t, long double>();
 }


### PR DESCRIPTION
clang does not like the conversion back to an uint_64 type. Using int_64
here avoids the arithmetic exception.

@davydden *ping*