### PR TITLE
Tests: base/utilities_13.cc - workaround for clang

### DIFF
--- a/tests/base/utilities_13.cc
+++ b/tests/base/utilities_13.cc
@@ -113,12 +113,17 @@ test3()
                             ((Integer)1 << min_bits) - 1);
 
   // make sure conversion is within bounds:
-  const std::vector<Number> points = {0.2, 0.7};
-  for (const auto &v : points)
-    {
-      const Integer i = (Integer)(v * (Number)max);
-      Assert(i > 0 && i < max, ExcInternalError());
-    }
+  {
+    const Number  v = 0.2;
+    const Integer i = (Integer)(v * (Number)max);
+    Assert(i > 0 && i < max, ExcInternalError());
+  }
+
+  {
+    const Number  v = 0.7;
+    const Integer i = (Integer)(v * (Number)max);
+    Assert(i > 0 && i < max, ExcInternalError());
+  }
 
   {
     const Number  v = 0.;


### PR DESCRIPTION
Clang issues a spurious arithmetic exception if this code snippet is
called with a reference long double pointing into the vector. Work
around this issue by explicitly writing out the long double twice.

Supersedes #7312