### PR TITLE
Add tests to check compilation of functions / classes with AD numbers

### DIFF
--- a/tests/ad_common_tests/physics_functions_01.h
+++ b/tests/ad_common_tests/physics_functions_01.h
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Header file:
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Kinematics
+
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/differentiation/ad.h>
+
+#include <deal.II/physics/elasticity/kinematics.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+using namespace dealii;
+namespace AD = dealii::Differentiation::AD;
+
+template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+void
+test_physics()
+{
+  typedef
+    typename AD::NumberTraits<number_t, ad_type_code>::ad_type ADNumberType;
+
+  std::cout << "*** Test physics functions: Kinematics, "
+            << "dim = " << Utilities::to_string(dim) << ", "
+            << "Type code: " << static_cast<int>(ad_type_code) << std::endl;
+
+  Tensor<2, dim, ADNumberType>       grad_u;
+  const Tensor<2, dim, ADNumberType> F =
+    Physics::Elasticity::Kinematics::F(grad_u);
+  const Tensor<2, dim, ADNumberType> F_inv =
+    invert(F); // Test, since this can be a problem too.
+
+  const Tensor<2, dim, ADNumberType> F_iso =
+    Physics::Elasticity::Kinematics::F_iso(F);
+  const SymmetricTensor<2, dim, ADNumberType> F_vol =
+    Physics::Elasticity::Kinematics::F_vol(F);
+  const SymmetricTensor<2, dim, ADNumberType> C =
+    Physics::Elasticity::Kinematics::C(F);
+  const SymmetricTensor<2, dim, ADNumberType> b =
+    Physics::Elasticity::Kinematics::b(F);
+
+  const SymmetricTensor<2, dim, ADNumberType> E =
+    Physics::Elasticity::Kinematics::E(F);
+  const SymmetricTensor<2, dim, ADNumberType> epsilon =
+    Physics::Elasticity::Kinematics::epsilon(grad_u);
+  const SymmetricTensor<2, dim, ADNumberType> e =
+    Physics::Elasticity::Kinematics::e(F);
+
+  Tensor<2, dim, ADNumberType>       dF_dt;
+  const Tensor<2, dim, ADNumberType> l =
+    Physics::Elasticity::Kinematics::l(F, dF_dt);
+  const SymmetricTensor<2, dim, ADNumberType> d =
+    Physics::Elasticity::Kinematics::d(F, dF_dt);
+  const Tensor<2, dim, ADNumberType> w =
+    Physics::Elasticity::Kinematics::w(F, dF_dt);
+}

--- a/tests/ad_common_tests/physics_functions_02.h
+++ b/tests/ad_common_tests/physics_functions_02.h
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Header file:
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// StandardTensors
+
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/differentiation/ad.h>
+
+#include <deal.II/physics/elasticity/kinematics.h>
+#include <deal.II/physics/elasticity/standard_tensors.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+using namespace dealii;
+namespace AD = dealii::Differentiation::AD;
+
+template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+void
+test_physics()
+{
+  typedef
+    typename AD::NumberTraits<number_t, ad_type_code>::ad_type ADNumberType;
+
+  std::cout << "*** Test physics functions: Standard tensors, "
+            << "dim = " << Utilities::to_string(dim) << ", "
+            << "Type code: " << static_cast<int>(ad_type_code) << std::endl;
+
+  Tensor<2, dim, ADNumberType>       grad_u;
+  const Tensor<2, dim, ADNumberType> F =
+    Physics::Elasticity::Kinematics::F(grad_u);
+
+  const SymmetricTensor<2, dim, ADNumberType> ddet_F_dC =
+    Physics::Elasticity::StandardTensors<dim>::ddet_F_dC(F);
+  const SymmetricTensor<4, dim, ADNumberType> dC_inv_dC =
+    Physics::Elasticity::StandardTensors<dim>::dC_inv_dC(F);
+
+  const SymmetricTensor<4, dim, ADNumberType> Dev_P =
+    Physics::Elasticity::StandardTensors<dim>::Dev_P(F);
+  const SymmetricTensor<4, dim, ADNumberType> Dev_P_T =
+    Physics::Elasticity::StandardTensors<dim>::Dev_P_T(F);
+}

--- a/tests/ad_common_tests/physics_functions_03.h
+++ b/tests/ad_common_tests/physics_functions_03.h
@@ -1,0 +1,138 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Header file:
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// StandardTensors
+
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/differentiation/ad.h>
+
+#include <deal.II/physics/elasticity/kinematics.h>
+#include <deal.II/physics/transformations.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+using namespace dealii;
+namespace AD = dealii::Differentiation::AD;
+
+template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+void
+test_physics()
+{
+  typedef
+    typename AD::NumberTraits<number_t, ad_type_code>::ad_type ADNumberType;
+
+  std::cout << "*** Test physics functions: Standard tensors, "
+            << "dim = " << Utilities::to_string(dim) << ", "
+            << "Type code: " << static_cast<int>(ad_type_code) << std::endl;
+
+  Tensor<2, dim, ADNumberType>       grad_u;
+  const Tensor<2, dim, ADNumberType> F =
+    Physics::Elasticity::Kinematics::F(grad_u);
+  const Tensor<1, dim, ADNumberType>          N;
+  const Tensor<1, dim, ADNumberType>          V;
+  const Tensor<2, dim, ADNumberType>          T1;
+  const SymmetricTensor<2, dim, ADNumberType> T2;
+  const Tensor<4, dim, ADNumberType>          TT1;
+  const SymmetricTensor<4, dim, ADNumberType> TT2;
+
+  const Tensor<1, dim, ADNumberType> ddet_F_dC =
+    Physics::Transformations::nansons_formula(N, F);
+
+  // Contravariant
+  {
+    const Tensor<1, dim, ADNumberType> V_out =
+      Physics::Transformations::Contravariant::push_forward(V, F);
+    const Tensor<2, dim, ADNumberType> T1_out =
+      Physics::Transformations::Contravariant::push_forward(T1, F);
+    const SymmetricTensor<2, dim, ADNumberType> T2_out =
+      Physics::Transformations::Contravariant::push_forward(T2, F);
+    const Tensor<4, dim, ADNumberType> TT1_out =
+      Physics::Transformations::Contravariant::push_forward(TT1, F);
+    const SymmetricTensor<4, dim, ADNumberType> TT2_out =
+      Physics::Transformations::Contravariant::push_forward(TT2, F);
+  }
+  {
+    const Tensor<1, dim, ADNumberType> V_out =
+      Physics::Transformations::Contravariant::pull_back(V, F);
+    const Tensor<2, dim, ADNumberType> T1_out =
+      Physics::Transformations::Contravariant::pull_back(T1, F);
+    const SymmetricTensor<2, dim, ADNumberType> T2_out =
+      Physics::Transformations::Contravariant::pull_back(T2, F);
+    const Tensor<4, dim, ADNumberType> TT1_out =
+      Physics::Transformations::Contravariant::pull_back(TT1, F);
+    const SymmetricTensor<4, dim, ADNumberType> TT2_out =
+      Physics::Transformations::Contravariant::pull_back(TT2, F);
+  }
+
+  // Covariant
+  {
+    const Tensor<1, dim, ADNumberType> V_out =
+      Physics::Transformations::Covariant::push_forward(V, F);
+    const Tensor<2, dim, ADNumberType> T1_out =
+      Physics::Transformations::Covariant::push_forward(T1, F);
+    const SymmetricTensor<2, dim, ADNumberType> T2_out =
+      Physics::Transformations::Covariant::push_forward(T2, F);
+    const Tensor<4, dim, ADNumberType> TT1_out =
+      Physics::Transformations::Covariant::push_forward(TT1, F);
+    const SymmetricTensor<4, dim, ADNumberType> TT2_out =
+      Physics::Transformations::Covariant::push_forward(TT2, F);
+  }
+  {
+    const Tensor<1, dim, ADNumberType> V_out =
+      Physics::Transformations::Covariant::pull_back(V, F);
+    const Tensor<2, dim, ADNumberType> T1_out =
+      Physics::Transformations::Covariant::pull_back(T1, F);
+    const SymmetricTensor<2, dim, ADNumberType> T2_out =
+      Physics::Transformations::Covariant::pull_back(T2, F);
+    const Tensor<4, dim, ADNumberType> TT1_out =
+      Physics::Transformations::Covariant::pull_back(TT1, F);
+    const SymmetricTensor<4, dim, ADNumberType> TT2_out =
+      Physics::Transformations::Covariant::pull_back(TT2, F);
+  }
+
+  // Piola
+  {
+    const Tensor<1, dim, ADNumberType> V_out =
+      Physics::Transformations::Piola::push_forward(V, F);
+    const Tensor<2, dim, ADNumberType> T1_out =
+      Physics::Transformations::Piola::push_forward(T1, F);
+    const SymmetricTensor<2, dim, ADNumberType> T2_out =
+      Physics::Transformations::Piola::push_forward(T2, F);
+    const Tensor<4, dim, ADNumberType> TT1_out =
+      Physics::Transformations::Piola::push_forward(TT1, F);
+    const SymmetricTensor<4, dim, ADNumberType> TT2_out =
+      Physics::Transformations::Piola::push_forward(TT2, F);
+  }
+  {
+    const Tensor<1, dim, ADNumberType> V_out =
+      Physics::Transformations::Piola::pull_back(V, F);
+    const Tensor<2, dim, ADNumberType> T1_out =
+      Physics::Transformations::Piola::pull_back(T1, F);
+    const SymmetricTensor<2, dim, ADNumberType> T2_out =
+      Physics::Transformations::Piola::pull_back(T2, F);
+    const Tensor<4, dim, ADNumberType> TT1_out =
+      Physics::Transformations::Piola::pull_back(TT1, F);
+    const SymmetricTensor<4, dim, ADNumberType> TT2_out =
+      Physics::Transformations::Piola::pull_back(TT2, F);
+  }
+}

--- a/tests/ad_common_tests/symmetric_tensor_functions_01.h
+++ b/tests/ad_common_tests/symmetric_tensor_functions_01.h
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Header file:
+// Test to check that the various SymmetricTensor functions compile
+// with the various auto-differentiable number types
+
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/differentiation/ad.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+using namespace dealii;
+namespace AD = dealii::Differentiation::AD;
+
+template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+void
+test_symmetric_tensor()
+{
+  typedef
+    typename AD::NumberTraits<number_t, ad_type_code>::ad_type ADNumberType;
+
+  std::cout << "*** Test SymmetricTensor functions, "
+            << "dim = " << Utilities::to_string(dim) << ", "
+            << "Type code: " << static_cast<int>(ad_type_code) << std::endl;
+
+  const ADNumberType                          a = 1.0;
+  const Tensor<1, dim, ADNumberType>          v;
+  const SymmetricTensor<2, dim, ADNumberType> A(
+    unit_symmetric_tensor<dim, ADNumberType>());
+  const SymmetricTensor<2, dim, ADNumberType> B(
+    unit_symmetric_tensor<dim, ADNumberType>());
+  const Tensor<2, dim, ADNumberType> A_ns(
+    unit_symmetric_tensor<dim, ADNumberType>());
+  const SymmetricTensor<4, dim, ADNumberType> HH(
+    identity_tensor<dim, ADNumberType>());
+
+  const SymmetricTensor<2, dim, ADNumberType> C1 = A + B;
+  const SymmetricTensor<2, dim, ADNumberType> C2 = A - B;
+  const SymmetricTensor<2, dim, ADNumberType> C4 = a * A;
+  const SymmetricTensor<2, dim, ADNumberType> C5 = A * a;
+  const SymmetricTensor<2, dim, ADNumberType> C6 = A / a;
+
+  const ADNumberType det_A = determinant(A);
+  const ADNumberType tr_A  = trace(A);
+  const ADNumberType I1_A  = first_invariant(A);
+  const ADNumberType I2_A  = second_invariant(A);
+  const ADNumberType I3_A  = third_invariant(A);
+
+  const SymmetricTensor<2, dim, ADNumberType> A_inv  = invert(A);
+  const SymmetricTensor<2, dim, ADNumberType> A_T    = transpose(A);
+  const SymmetricTensor<2, dim, ADNumberType> A_dev  = deviator(A);
+  const SymmetricTensor<2, dim, ADNumberType> A_symm = symmetrize(A_ns);
+  // const ADNumberType A_l1_norm = l1_norm(A);
+  // const ADNumberType A_linf_norm = linfty_norm(A);
+
+  const ADNumberType                 A_ddot_B_1 = A * B;
+  const ADNumberType                 sp_A_B     = scalar_product(A, B);
+  const Tensor<4, dim, ADNumberType> op_A_B     = outer_product(A, B);
+
+
+  SymmetricTensor<2, dim, ADNumberType> C_dc;
+  double_contract(C_dc, A, HH);
+  double_contract(C_dc, HH, A);
+
+  const Tensor<1, dim, ADNumberType> v3 = A * v;
+  const Tensor<1, dim, ADNumberType> v4 = v * A;
+  const Tensor<2, dim, ADNumberType> C7 = A * A_ns;
+  const Tensor<2, dim, ADNumberType> C8 = A_ns * A;
+}

--- a/tests/ad_common_tests/tensor_functions_01.h
+++ b/tests/ad_common_tests/tensor_functions_01.h
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Header file:
+// Test to check that the various Tensor functions compile
+// with the various auto-differentiable number types
+
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/differentiation/ad.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+using namespace dealii;
+namespace AD = dealii::Differentiation::AD;
+
+template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>
+void
+test_tensor()
+{
+  typedef
+    typename AD::NumberTraits<number_t, ad_type_code>::ad_type ADNumberType;
+
+  std::cout << "*** Test Tensor functions, "
+            << "dim = " << Utilities::to_string(dim) << ", "
+            << "Type code: " << static_cast<int>(ad_type_code) << std::endl;
+
+  const ADNumberType                 a = 1.0;
+  const Tensor<1, dim, ADNumberType> v1;
+  const Tensor<1, dim, ADNumberType> v2;
+  const Tensor<2, dim, ADNumberType> A(
+    unit_symmetric_tensor<dim, ADNumberType>());
+  const Tensor<2, dim, ADNumberType> B(
+    unit_symmetric_tensor<dim, ADNumberType>());
+
+  const Tensor<2, dim, ADNumberType> C1 = A + B;
+  const Tensor<2, dim, ADNumberType> C2 = A - B;
+  const Tensor<2, dim, ADNumberType> C3 = A * B;
+  const Tensor<2, dim, ADNumberType> C4 = a * A;
+  const Tensor<2, dim, ADNumberType> C5 = A * a;
+  const Tensor<2, dim, ADNumberType> C6 = A / a;
+
+  const ADNumberType                 det_A       = determinant(A);
+  const ADNumberType                 tr_A        = trace(A);
+  const Tensor<2, dim, ADNumberType> A_inv       = invert(A);
+  const Tensor<2, dim, ADNumberType> A_T         = transpose(A);
+  const Tensor<2, dim, ADNumberType> A_adj       = adjugate(A);
+  const Tensor<2, dim, ADNumberType> A_cof       = cofactor(A);
+  const ADNumberType                 A_l1_norm   = l1_norm(A);
+  const ADNumberType                 A_linf_norm = linfty_norm(A);
+
+  const ADNumberType                 A_ddot_B = double_contract(A, B);
+  const Tensor<2, dim, ADNumberType> A_dot_B  = contract<1, 0>(A, B);
+  const ADNumberType                 sp_A_B   = scalar_product(A, B);
+  const Tensor<4, dim, ADNumberType> op_A_B   = outer_product(A, B);
+
+  if (dim == 2)
+    const Tensor<1, dim, ADNumberType> v3 = cross_product_2d(v1);
+  if (dim == 3)
+    const Tensor<1, dim, ADNumberType> v3 = cross_product_3d(v1, v2);
+}

--- a/tests/adolc/physics_functions_01_1.cc
+++ b/tests/adolc/physics_functions_01_1.cc
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Kinematics
+//
+// AD number type: ADOL-C taped
+
+#include "../ad_common_tests/physics_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::adolc_taped>();
+    test_physics<3, double, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/physics_functions_01_1.output
+++ b/tests/adolc/physics_functions_01_1.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/adolc/physics_functions_01_2.cc
+++ b/tests/adolc/physics_functions_01_2.cc
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Kinematics
+//
+// AD number type: ADOL-C tapeless
+
+#include "../ad_common_tests/physics_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::adolc_tapeless>();
+    test_physics<3, double, AD::NumberTypes::adolc_tapeless>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/physics_functions_01_2.output
+++ b/tests/adolc/physics_functions_01_2.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/adolc/physics_functions_02_1.cc
+++ b/tests/adolc/physics_functions_02_1.cc
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Standard tensors
+//
+// AD number type: ADOL-C taped
+
+#include "../ad_common_tests/physics_functions_02.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::adolc_taped>();
+    test_physics<3, double, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/physics_functions_02_1.output
+++ b/tests/adolc/physics_functions_02_1.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/adolc/physics_functions_02_2.cc
+++ b/tests/adolc/physics_functions_02_2.cc
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Standard tensors
+//
+// AD number type: ADOL-C tapeless
+
+#include "../ad_common_tests/physics_functions_02.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::adolc_tapeless>();
+    test_physics<3, double, AD::NumberTypes::adolc_tapeless>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/physics_functions_02_2.output
+++ b/tests/adolc/physics_functions_02_2.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/adolc/physics_functions_03_1.cc
+++ b/tests/adolc/physics_functions_03_1.cc
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Transformations
+//
+// AD number type: ADOL-C taped
+
+#include "../ad_common_tests/physics_functions_03.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::adolc_taped>();
+    test_physics<3, double, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/physics_functions_03_1.output
+++ b/tests/adolc/physics_functions_03_1.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/adolc/physics_functions_03_2.cc
+++ b/tests/adolc/physics_functions_03_2.cc
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Transformations
+//
+// AD number type: ADOL-C tapeless
+
+#include "../ad_common_tests/physics_functions_03.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::adolc_tapeless>();
+    test_physics<3, double, AD::NumberTypes::adolc_tapeless>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/physics_functions_03_2.output
+++ b/tests/adolc/physics_functions_03_2.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/adolc/symmetric_tensor_functions_01_1.cc
+++ b/tests/adolc/symmetric_tensor_functions_01_1.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various SymmetricTensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: ADOL-C taped
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_symmetric_tensor<2, double, AD::NumberTypes::adolc_taped>();
+    test_symmetric_tensor<3, double, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/symmetric_tensor_functions_01_1.output
+++ b/tests/adolc/symmetric_tensor_functions_01_1.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/adolc/symmetric_tensor_functions_01_2.cc
+++ b/tests/adolc/symmetric_tensor_functions_01_2.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various SymmetricTensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: ADOL-C tapeless
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_symmetric_tensor<2, double, AD::NumberTypes::adolc_tapeless>();
+    test_symmetric_tensor<3, double, AD::NumberTypes::adolc_tapeless>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/symmetric_tensor_functions_01_2.output
+++ b/tests/adolc/symmetric_tensor_functions_01_2.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/adolc/tensor_functions_01_1.cc
+++ b/tests/adolc/tensor_functions_01_1.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various Tensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: ADOL-C taped
+
+#include "../ad_common_tests/tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_tensor<2, double, AD::NumberTypes::adolc_taped>();
+    test_tensor<3, double, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/tensor_functions_01_1.output
+++ b/tests/adolc/tensor_functions_01_1.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/adolc/tensor_functions_01_2.cc
+++ b/tests/adolc/tensor_functions_01_2.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various Tensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: ADOL-C tapeless
+
+#include "../ad_common_tests/tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_tensor<2, double, AD::NumberTypes::adolc_tapeless>();
+    test_tensor<3, double, AD::NumberTypes::adolc_tapeless>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/adolc/tensor_functions_01_2.output
+++ b/tests/adolc/tensor_functions_01_2.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_01_1.cc
+++ b/tests/sacado/physics_functions_01_1.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Kinematics
+//
+// AD number type: Sacado DFad
+
+#include "../ad_common_tests/physics_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::adolc_taped>();
+    test_physics<3, double, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::adolc_taped>();
+    test_physics<3, float, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_01_1.output
+++ b/tests/sacado/physics_functions_01_1.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_01_2.cc
+++ b/tests/sacado/physics_functions_01_2.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Kinematics
+//
+// AD number type: Sacado DFad-DFad
+
+#include "../ad_common_tests/physics_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::sacado_dfad_dfad>();
+    test_physics<3, double, AD::NumberTypes::sacado_dfad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::sacado_dfad_dfad>();
+    test_physics<3, float, AD::NumberTypes::sacado_dfad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_01_2.output
+++ b/tests/sacado/physics_functions_01_2.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_01_3.cc
+++ b/tests/sacado/physics_functions_01_3.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Kinematics
+//
+// AD number type: Sacado Rad
+
+#include "../ad_common_tests/physics_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::sacado_rad>();
+    test_physics<3, double, AD::NumberTypes::sacado_rad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::sacado_rad>();
+    test_physics<3, float, AD::NumberTypes::sacado_rad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_01_3.output
+++ b/tests/sacado/physics_functions_01_3.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_01_4.cc
+++ b/tests/sacado/physics_functions_01_4.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Kinematics
+//
+// AD number type: Sacado Rad-DFad
+
+#include "../ad_common_tests/physics_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::sacado_rad_dfad>();
+    test_physics<3, double, AD::NumberTypes::sacado_rad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::sacado_rad_dfad>();
+    test_physics<3, float, AD::NumberTypes::sacado_rad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_01_4.output
+++ b/tests/sacado/physics_functions_01_4.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_02_1.cc
+++ b/tests/sacado/physics_functions_02_1.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Standard tensors
+//
+// AD number type: Sacado DFad
+
+#include "../ad_common_tests/physics_functions_02.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::adolc_taped>();
+    test_physics<3, double, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::adolc_taped>();
+    test_physics<3, float, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_02_1.output
+++ b/tests/sacado/physics_functions_02_1.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_02_2.cc
+++ b/tests/sacado/physics_functions_02_2.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Standard tensors
+//
+// AD number type: Sacado DFad-DFad
+
+#include "../ad_common_tests/physics_functions_02.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::sacado_dfad_dfad>();
+    test_physics<3, double, AD::NumberTypes::sacado_dfad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::sacado_dfad_dfad>();
+    test_physics<3, float, AD::NumberTypes::sacado_dfad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_02_2.output
+++ b/tests/sacado/physics_functions_02_2.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_02_3.cc
+++ b/tests/sacado/physics_functions_02_3.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Standard tensors
+//
+// AD number type: Sacado Rad
+
+#include "../ad_common_tests/physics_functions_02.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::sacado_rad>();
+    test_physics<3, double, AD::NumberTypes::sacado_rad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::sacado_rad>();
+    test_physics<3, float, AD::NumberTypes::sacado_rad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_02_3.output
+++ b/tests/sacado/physics_functions_02_3.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_02_4.cc
+++ b/tests/sacado/physics_functions_02_4.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Standard tensors
+//
+// AD number type: Sacado Rad-DFad
+
+#include "../ad_common_tests/physics_functions_02.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::sacado_rad_dfad>();
+    test_physics<3, double, AD::NumberTypes::sacado_rad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::sacado_rad_dfad>();
+    test_physics<3, float, AD::NumberTypes::sacado_rad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_02_4.output
+++ b/tests/sacado/physics_functions_02_4.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_03_1.cc
+++ b/tests/sacado/physics_functions_03_1.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Transformations
+//
+// AD number type: Sacado DFad
+
+#include "../ad_common_tests/physics_functions_03.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::adolc_taped>();
+    test_physics<3, double, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::adolc_taped>();
+    test_physics<3, float, AD::NumberTypes::adolc_taped>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_03_1.output
+++ b/tests/sacado/physics_functions_03_1.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_03_2.cc
+++ b/tests/sacado/physics_functions_03_2.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Transformations
+//
+// AD number type: Sacado DFad-DFad
+
+#include "../ad_common_tests/physics_functions_03.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::sacado_dfad_dfad>();
+    test_physics<3, double, AD::NumberTypes::sacado_dfad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::sacado_dfad_dfad>();
+    test_physics<3, float, AD::NumberTypes::sacado_dfad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_03_2.output
+++ b/tests/sacado/physics_functions_03_2.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_03_3.cc
+++ b/tests/sacado/physics_functions_03_3.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Transformations
+//
+// AD number type: Sacado Rad
+
+#include "../ad_common_tests/physics_functions_03.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::sacado_rad>();
+    test_physics<3, double, AD::NumberTypes::sacado_rad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::sacado_rad>();
+    test_physics<3, float, AD::NumberTypes::sacado_rad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_03_3.output
+++ b/tests/sacado/physics_functions_03_3.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/physics_functions_03_4.cc
+++ b/tests/sacado/physics_functions_03_4.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the functions in the Physics namespace compile
+// with the various auto-differentiable number types:
+// Transformations
+//
+// AD number type: Sacado Rad-DFad
+
+#include "../ad_common_tests/physics_functions_03.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_physics<2, double, AD::NumberTypes::sacado_rad_dfad>();
+    test_physics<3, double, AD::NumberTypes::sacado_rad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Float");
+  {
+    test_physics<2, float, AD::NumberTypes::sacado_rad_dfad>();
+    test_physics<3, float, AD::NumberTypes::sacado_rad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/physics_functions_03_4.output
+++ b/tests/sacado/physics_functions_03_4.output
@@ -1,0 +1,4 @@
+
+DEAL::Double:OK
+DEAL::Float:OK
+DEAL::OK

--- a/tests/sacado/symmetric_tensor_functions_01_1.cc
+++ b/tests/sacado/symmetric_tensor_functions_01_1.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various SymmetricTensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: Sacado DFad
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_symmetric_tensor<2, double, AD::NumberTypes::sacado_dfad>();
+    test_symmetric_tensor<3, double, AD::NumberTypes::sacado_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/symmetric_tensor_functions_01_1.output
+++ b/tests/sacado/symmetric_tensor_functions_01_1.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/sacado/symmetric_tensor_functions_01_2.cc
+++ b/tests/sacado/symmetric_tensor_functions_01_2.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various SymmetricTensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: Sacado DFad-DFad
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_symmetric_tensor<2, double, AD::NumberTypes::sacado_dfad_dfad>();
+    test_symmetric_tensor<3, double, AD::NumberTypes::sacado_dfad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/symmetric_tensor_functions_01_2.output
+++ b/tests/sacado/symmetric_tensor_functions_01_2.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/sacado/symmetric_tensor_functions_01_3.cc
+++ b/tests/sacado/symmetric_tensor_functions_01_3.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various SymmetricTensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: Sacado Rad
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_symmetric_tensor<2, double, AD::NumberTypes::sacado_rad>();
+    test_symmetric_tensor<3, double, AD::NumberTypes::sacado_rad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/symmetric_tensor_functions_01_3.output
+++ b/tests/sacado/symmetric_tensor_functions_01_3.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/sacado/symmetric_tensor_functions_01_4.cc
+++ b/tests/sacado/symmetric_tensor_functions_01_4.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various SymmetricTensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: Sacado Rad-DFad
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_symmetric_tensor<2, double, AD::NumberTypes::sacado_rad_dfad>();
+    test_symmetric_tensor<3, double, AD::NumberTypes::sacado_rad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/symmetric_tensor_functions_01_4.output
+++ b/tests/sacado/symmetric_tensor_functions_01_4.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/sacado/tensor_functions_01_1.cc
+++ b/tests/sacado/tensor_functions_01_1.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various Tensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: Sacado DFad
+
+#include "../ad_common_tests/tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_tensor<2, double, AD::NumberTypes::sacado_dfad>();
+    test_tensor<3, double, AD::NumberTypes::sacado_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/tensor_functions_01_1.output
+++ b/tests/sacado/tensor_functions_01_1.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/sacado/tensor_functions_01_2.cc
+++ b/tests/sacado/tensor_functions_01_2.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various Tensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: Sacado DFad-DFad
+
+#include "../ad_common_tests/tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_tensor<2, double, AD::NumberTypes::sacado_dfad_dfad>();
+    test_tensor<3, double, AD::NumberTypes::sacado_dfad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/tensor_functions_01_2.output
+++ b/tests/sacado/tensor_functions_01_2.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/sacado/tensor_functions_01_3.cc
+++ b/tests/sacado/tensor_functions_01_3.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various Tensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: Sacado Rad
+
+#include "../ad_common_tests/tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_tensor<2, double, AD::NumberTypes::sacado_rad>();
+    test_tensor<3, double, AD::NumberTypes::sacado_rad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/tensor_functions_01_3.output
+++ b/tests/sacado/tensor_functions_01_3.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK

--- a/tests/sacado/tensor_functions_01_4.cc
+++ b/tests/sacado/tensor_functions_01_4.cc
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test to check that the various Tensor functions compile
+// with the various auto-differentiable number types
+//
+// AD number type: Sacado Rad-DFad
+
+#include "../ad_common_tests/tensor_functions_01.h"
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("Double");
+  {
+    test_tensor<2, double, AD::NumberTypes::sacado_rad_dfad>();
+    test_tensor<3, double, AD::NumberTypes::sacado_rad_dfad>();
+    deallog << "OK" << std::endl;
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/sacado/tensor_functions_01_4.output
+++ b/tests/sacado/tensor_functions_01_4.output
@@ -1,0 +1,3 @@
+
+DEAL::Double:OK
+DEAL::OK


### PR DESCRIPTION
- Tensor class
- SymmetricTensor class
- Physics::Elasticity::Kinematics functions
- Physics::Elasticity::StandardTensors class
- Physics::Transformations (functions inside nested namespaces)