### PR TITLE
Fix failing Sacado tests

### DIFF
--- a/include/deal.II/differentiation/ad.h
+++ b/include/deal.II/differentiation/ad.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/differentiation/ad/ad_helpers.h>
 #include <deal.II/differentiation/ad/ad_number_traits.h>
 #include <deal.II/differentiation/ad/ad_number_types.h>
 #include <deal.II/differentiation/ad/adolc_math.h>

--- a/tests/ad_common_tests/step-44-helper_res_lin_01.h
+++ b/tests/ad_common_tests/step-44-helper_res_lin_01.h
@@ -43,11 +43,9 @@
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <deal.II/lac/block_sparse_matrix.h>
 #include <deal.II/lac/block_vector.h>
-#include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/linear_operator.h>
@@ -483,9 +481,6 @@ namespace Step44
     SymmetricTensor<2, dim, NumberType>
     get_tau_bar(const Tensor<2, dim, NumberType> &F) const
     {
-      using adtl::pow;
-      using std::pow;
-
       const NumberType                    det_F = determinant(F);
       SymmetricTensor<2, dim, NumberType> b_bar = symmetrize(F * transpose(F));
       b_bar *= std::pow(det_F, -2.0 / dim);
@@ -609,7 +604,7 @@ namespace Step44
     const QGauss<dim - 1>                qf_face;
     const unsigned int                   n_q_points;
     const unsigned int                   n_q_points_f;
-    ConstraintMatrix                     constraints;
+    AffineConstraints<double>            constraints;
     BlockSparsityPattern                 sparsity_pattern;
     BlockSparseMatrix<double>            tangent_matrix;
     BlockVector<double>                  system_rhs;
@@ -699,7 +694,7 @@ namespace Step44
     make_grid();
     system_setup();
     {
-      ConstraintMatrix constraints;
+      AffineConstraints<double> constraints;
       constraints.close();
       const ComponentSelectFunction<dim> J_mask(J_component, n_components);
       VectorTools::project(dof_handler_ref,

--- a/tests/ad_common_tests/step-44-helper_var_form_01.h
+++ b/tests/ad_common_tests/step-44-helper_var_form_01.h
@@ -43,11 +43,9 @@
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <deal.II/lac/block_sparse_matrix.h>
 #include <deal.II/lac/block_vector.h>
-#include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/linear_operator.h>
@@ -572,7 +570,7 @@ namespace Step44
     const QGauss<dim - 1>                qf_face;
     const unsigned int                   n_q_points;
     const unsigned int                   n_q_points_f;
-    ConstraintMatrix                     constraints;
+    AffineConstraints<double>            constraints;
     BlockSparsityPattern                 sparsity_pattern;
     BlockSparseMatrix<double>            tangent_matrix;
     BlockVector<double>                  system_rhs;
@@ -662,7 +660,7 @@ namespace Step44
     make_grid();
     system_setup();
     {
-      ConstraintMatrix constraints;
+      AffineConstraints<double> constraints;
       constraints.close();
       const ComponentSelectFunction<dim> J_mask(J_component, n_components);
       VectorTools::project(dof_handler_ref,

--- a/tests/sacado/physics_functions_01_1.cc
+++ b/tests/sacado/physics_functions_01_1.cc
@@ -30,16 +30,16 @@ main()
 
   deallog.push("Double");
   {
-    test_physics<2, double, AD::NumberTypes::adolc_taped>();
-    test_physics<3, double, AD::NumberTypes::adolc_taped>();
+    test_physics<2, double, AD::NumberTypes::sacado_dfad>();
+    test_physics<3, double, AD::NumberTypes::sacado_dfad>();
     deallog << "OK" << std::endl;
   }
   deallog.pop();
 
   deallog.push("Float");
   {
-    test_physics<2, float, AD::NumberTypes::adolc_taped>();
-    test_physics<3, float, AD::NumberTypes::adolc_taped>();
+    test_physics<2, float, AD::NumberTypes::sacado_dfad>();
+    test_physics<3, float, AD::NumberTypes::sacado_dfad>();
     deallog << "OK" << std::endl;
   }
   deallog.pop();

--- a/tests/sacado/physics_functions_02_1.cc
+++ b/tests/sacado/physics_functions_02_1.cc
@@ -30,16 +30,16 @@ main()
 
   deallog.push("Double");
   {
-    test_physics<2, double, AD::NumberTypes::adolc_taped>();
-    test_physics<3, double, AD::NumberTypes::adolc_taped>();
+    test_physics<2, double, AD::NumberTypes::sacado_dfad>();
+    test_physics<3, double, AD::NumberTypes::sacado_dfad>();
     deallog << "OK" << std::endl;
   }
   deallog.pop();
 
   deallog.push("Float");
   {
-    test_physics<2, float, AD::NumberTypes::adolc_taped>();
-    test_physics<3, float, AD::NumberTypes::adolc_taped>();
+    test_physics<2, float, AD::NumberTypes::sacado_dfad>();
+    test_physics<3, float, AD::NumberTypes::sacado_dfad>();
     deallog << "OK" << std::endl;
   }
   deallog.pop();

--- a/tests/sacado/physics_functions_03_1.cc
+++ b/tests/sacado/physics_functions_03_1.cc
@@ -30,16 +30,16 @@ main()
 
   deallog.push("Double");
   {
-    test_physics<2, double, AD::NumberTypes::adolc_taped>();
-    test_physics<3, double, AD::NumberTypes::adolc_taped>();
+    test_physics<2, double, AD::NumberTypes::sacado_dfad>();
+    test_physics<3, double, AD::NumberTypes::sacado_dfad>();
     deallog << "OK" << std::endl;
   }
   deallog.pop();
 
   deallog.push("Float");
   {
-    test_physics<2, float, AD::NumberTypes::adolc_taped>();
-    test_physics<3, float, AD::NumberTypes::adolc_taped>();
+    test_physics<2, float, AD::NumberTypes::sacado_dfad>();
+    test_physics<3, float, AD::NumberTypes::sacado_dfad>();
     deallog << "OK" << std::endl;
   }
   deallog.pop();


### PR DESCRIPTION
Fixes the failing tests in https://cdash.kyomu.43-1.org/viewTest.php?onlydelta&buildid=5320 (and avoids deprecated classes and include files in the fixed `Sacado` tests).