### PR TITLE
Replace ConstraintMatrix by AffineConstraints in tests

### DIFF
--- a/tests/cuda/matrix_free_matrix_vector_01.cu
+++ b/tests/cuda/matrix_free_matrix_vector_01.cu
@@ -38,7 +38,7 @@ test()
   FE_Q<dim>       fe(fe_degree);
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
-  ConstraintMatrix constraints;
+  AffineConstraints<double> constraints;
   constraints.close();
 
   do_test<dim, fe_degree, double, fe_degree + 1>(dof, constraints);

--- a/tests/cuda/matrix_free_matrix_vector_02.cu
+++ b/tests/cuda/matrix_free_matrix_vector_02.cu
@@ -38,7 +38,7 @@ test()
   FE_Q<dim>       fe(fe_degree);
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
-  ConstraintMatrix constraints;
+  AffineConstraints<double> constraints;
   VectorTools::interpolate_boundary_values(dof,
                                            0,
                                            Functions::ZeroFunction<dim>(),

--- a/tests/cuda/matrix_free_matrix_vector_04.cu
+++ b/tests/cuda/matrix_free_matrix_vector_04.cu
@@ -41,7 +41,7 @@ test()
   FE_Q<dim>       fe(fe_degree);
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
-  ConstraintMatrix constraints;
+  AffineConstraints<double> constraints;
   constraints.close();
 
   do_test<dim, fe_degree, double, fe_degree + 1>(dof, constraints);

--- a/tests/examples/step-56.cc
+++ b/tests/examples/step-56.cc
@@ -441,7 +441,7 @@ namespace Step56
     DoFHandler<dim>    dof_handler;
     DoFHandler<dim>    velocity_dof_handler;
 
-    ConstraintMatrix constraints;
+    AffineConstraints<double> constraints;
 
     BlockSparsityPattern      sparsity_pattern;
     BlockSparseMatrix<double> system_matrix;
@@ -746,9 +746,9 @@ namespace Step56
 
     std::vector<SymmetricTensor<2, dim>> symgrad_phi_u(dofs_per_cell);
 
-    std::vector<ConstraintMatrix> boundary_constraints(
+    std::vector<AffineConstraints<double>> boundary_constraints(
       triangulation.n_levels());
-    std::vector<ConstraintMatrix> boundary_interface_constraints(
+    std::vector<AffineConstraints<double>> boundary_interface_constraints(
       triangulation.n_levels());
     for (unsigned int level = 0; level < triangulation.n_levels(); ++level)
       {

--- a/tests/fe/br_approximation_01.cc
+++ b/tests/fe/br_approximation_01.cc
@@ -46,7 +46,6 @@ std::ofstream logfile("output");
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 
-#include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/sparse_matrix.h>
@@ -341,7 +340,7 @@ double TestProjection(Mapping<2> &mapping, DoFHandler<2> *dof_handler)
       TestPoly<2> pol(deg);
 
       // Project solution onto BR FE field
-      ConstraintMatrix hn_constraints;
+      AffineConstraints<double> hn_constraints;
       hn_constraints.clear();
       DoFTools::make_hanging_node_constraints(*dof_handler, hn_constraints);
       hn_constraints.close();
@@ -450,7 +449,7 @@ main()
   solution_q.reinit(dof_handler->n_dofs());
   deformation.reinit(dof_handler_def->n_dofs());
 
-  ConstraintMatrix hn_constraints_def;
+  AffineConstraints<double> hn_constraints_def;
   hn_constraints_def.clear();
   DoFTools::make_hanging_node_constraints(*dof_handler_def, hn_constraints_def);
   hn_constraints_def.close();

--- a/tests/fe/fe_br.cc
+++ b/tests/fe/fe_br.cc
@@ -31,7 +31,6 @@
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <deal.II/lac/vector.h>
 

--- a/tests/fe/fe_enriched_color_05.cc
+++ b/tests/fe/fe_enriched_color_05.cc
@@ -99,7 +99,7 @@ plot_shape_function(hp::DoFHandler<dim> &dof_handler, unsigned int patches = 5)
   std::cout << "n_cells: " << dof_handler.get_triangulation().n_active_cells()
             << std::endl;
 
-  ConstraintMatrix constraints;
+  AffineConstraints<double> constraints;
   constraints.clear();
   dealii::DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();

--- a/tests/fe/fe_enriched_color_07.cc
+++ b/tests/fe/fe_enriched_color_07.cc
@@ -927,7 +927,7 @@ plot_shape_function(hp::DoFHandler<dim> &dof_handler, unsigned int patches = 5)
   std::cout << "...start plotting shape function" << std::endl;
   std::cout << "Patches for output: " << patches << std::endl;
 
-  ConstraintMatrix constraints;
+  AffineConstraints<double> constraints;
   constraints.clear();
   dealii::DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();
@@ -1098,7 +1098,7 @@ protected:
   Vector<double>                   localized_solution;
   PETScWrappers::MPI::Vector       system_rhs;
 
-  ConstraintMatrix constraints;
+  AffineConstraints<double> constraints;
 
   MPI_Comm           mpi_communicator;
   const unsigned int n_mpi_processes;

--- a/tests/fe/fe_enriched_color_08.cc
+++ b/tests/fe/fe_enriched_color_08.cc
@@ -57,7 +57,7 @@ plot_shape_function(hp::DoFHandler<dim> &dof_handler, unsigned int patches = 5)
   deallog << "...start plotting shape function" << std::endl;
   deallog << "Patches for output: " << patches << std::endl;
 
-  ConstraintMatrix constraints;
+  AffineConstraints<double> constraints;
   constraints.clear();
   dealii::DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();
@@ -274,7 +274,7 @@ main(int argc, char **argv)
 
   dof_handler.distribute_dofs(fe_collection);
 
-  ConstraintMatrix constraints;
+  AffineConstraints<double> constraints;
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();
 

--- a/tests/integrators/assembler_simple_system_inhom_01.cc
+++ b/tests/integrators/assembler_simple_system_inhom_01.cc
@@ -483,11 +483,11 @@ RHSIntegrator<dim>::face(MeshWorker::DoFInfo<dim> &,
  * Main class
  */
 template <int dim>
-class MeshWorkerConstraintMatrixTest
+class MeshWorkerAffineConstraintsTest
 {
 public:
-  MeshWorkerConstraintMatrixTest(const FiniteElement<dim> &fe);
-  ~MeshWorkerConstraintMatrixTest();
+  MeshWorkerAffineConstraintsTest(const FiniteElement<dim> &fe);
+  ~MeshWorkerAffineConstraintsTest();
 
   void
   run();
@@ -523,7 +523,7 @@ private:
 
 
 template <int dim>
-MeshWorkerConstraintMatrixTest<dim>::MeshWorkerConstraintMatrixTest(
+MeshWorkerAffineConstraintsTest<dim>::MeshWorkerAffineConstraintsTest(
   const FiniteElement<dim> &fe)
   : mapping()
   , dof_handler(triangulation)
@@ -540,7 +540,7 @@ MeshWorkerConstraintMatrixTest<dim>::MeshWorkerConstraintMatrixTest(
 
 
 template <int dim>
-MeshWorkerConstraintMatrixTest<dim>::~MeshWorkerConstraintMatrixTest()
+MeshWorkerAffineConstraintsTest<dim>::~MeshWorkerAffineConstraintsTest()
 {
   dof_handler.clear();
 }
@@ -548,7 +548,7 @@ MeshWorkerConstraintMatrixTest<dim>::~MeshWorkerConstraintMatrixTest()
 
 template <int dim>
 void
-MeshWorkerConstraintMatrixTest<dim>::setup_system()
+MeshWorkerAffineConstraintsTest<dim>::setup_system()
 {
   dof_handler.distribute_dofs(fe);
 
@@ -588,7 +588,7 @@ MeshWorkerConstraintMatrixTest<dim>::setup_system()
  */
 template <int dim>
 void
-MeshWorkerConstraintMatrixTest<dim>::assemble_system_MeshWorker()
+MeshWorkerAffineConstraintsTest<dim>::assemble_system_MeshWorker()
 {
   MeshWorker::IntegrationInfoBox<dim> info_box;
 
@@ -624,7 +624,7 @@ MeshWorkerConstraintMatrixTest<dim>::assemble_system_MeshWorker()
  */
 template <int dim>
 void
-MeshWorkerConstraintMatrixTest<dim>::assemble_MeshWorker()
+MeshWorkerAffineConstraintsTest<dim>::assemble_MeshWorker()
 {
   MeshWorker::IntegrationInfoBox<dim> info_box;
 
@@ -668,7 +668,7 @@ MeshWorkerConstraintMatrixTest<dim>::assemble_MeshWorker()
 
 template <int dim>
 void
-MeshWorkerConstraintMatrixTest<dim>::createInhomConstraints()
+MeshWorkerAffineConstraintsTest<dim>::createInhomConstraints()
 {
   this->constraintsInhom.clear();
   // boundary constraints
@@ -702,7 +702,7 @@ MeshWorkerConstraintMatrixTest<dim>::createInhomConstraints()
 
 template <int dim>
 void
-MeshWorkerConstraintMatrixTest<dim>::run()
+MeshWorkerAffineConstraintsTest<dim>::run()
 {
   setup_system();
   createInhomConstraints();
@@ -743,13 +743,13 @@ main()
 
   FE_Q<2> fe(1);
   deallog.push(fe.get_name());
-  MeshWorkerConstraintMatrixTest<2> test(fe);
+  MeshWorkerAffineConstraintsTest<2> test(fe);
   test.run();
   deallog.pop();
 
   FE_DGQ<2> fe2(1);
   deallog.push(fe2.get_name());
-  MeshWorkerConstraintMatrixTest<2> test2(fe2);
+  MeshWorkerAffineConstraintsTest<2> test2(fe2);
   test2.run();
   deallog.pop();
 }

--- a/tests/matrix_free/cell_categorization_02.cc
+++ b/tests/matrix_free/cell_categorization_02.cc
@@ -86,7 +86,7 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
   dof.distribute_mg_dofs();
-  ConstraintMatrix constraints;
+  AffineConstraints<double> constraints;
   constraints.close();
 
   MGConstrainedDoFs mg_constrained_dofs;

--- a/tests/mpi/hp_unify_dof_indices_07.cc
+++ b/tests/mpi/hp_unify_dof_indices_07.cc
@@ -81,7 +81,7 @@ test()
     (++dof_handler.begin_active())->set_active_fe_index(1);
   dof_handler.distribute_dofs(fe);
 
-  ConstraintMatrix constraints;
+  AffineConstraints<double> constraints;
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();
 

--- a/tests/optimization/step-44.h
+++ b/tests/optimization/step-44.h
@@ -40,7 +40,6 @@
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/block_sparse_matrix.h>


### PR DESCRIPTION
This avoids warnings when running these tests.
Additionally, get rid off `tria_boundary_lib.h`.