### PR TITLE
Avoid warnings in ad_drivers.h

### DIFF
--- a/include/deal.II/differentiation/ad/ad_drivers.h
+++ b/include/deal.II/differentiation/ad/ad_drivers.h
@@ -1264,8 +1264,7 @@ namespace Differentiation
       }
 
       bool
-      is_registered_tape(
-        const typename Types<ADNumberType>::tape_index tape_index) const
+      is_registered_tape(const typename Types<ADNumberType>::tape_index) const
       {
         AssertThrow(false, ExcRequiresADOLC());
         return false;
@@ -1306,7 +1305,7 @@ namespace Differentiation
       }
 
       void
-      print(std::ostream &stream) const
+      print(std::ostream &) const
       {
         AssertThrow(false, ExcRequiresADOLC());
       }


### PR DESCRIPTION
Fixes the warnings in https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&onlydeltan&buildid=5318.