### PR TITLE
Avoid DEAL_II_COMPILER_CUDA_AWARE inside objects

### DIFF
--- a/include/deal.II/base/cuda.h
+++ b/include/deal.II/base/cuda.h
@@ -24,9 +24,8 @@
 #  include <cusolverDn.h>
 #  include <cusolverSp.h>
 #  include <cusparse.h>
-#endif
 
-#include <vector>
+#  include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 namespace Utilities
@@ -58,7 +57,6 @@ namespace Utilities
        */
       ~Handle();
 
-#ifdef DEAL_II_COMPILER_CUDA_AWARE
       cusolverDnHandle_t cusolver_dn_handle;
 
       cusolverSpHandle_t cusolver_sp_handle;
@@ -67,7 +65,6 @@ namespace Utilities
        * Handle to the cuSPARSE library.
        */
       cusparseHandle_t cusparse_handle;
-#endif
     };
 
     /**
@@ -77,14 +74,9 @@ namespace Utilities
     inline void
     malloc(T *&pointer, const unsigned int n_elements)
     {
-#ifdef DEAL_II_COMPILER_CUDA_AWARE
       cudaError_t cuda_error_code =
         cudaMalloc(&pointer, n_elements * sizeof(T));
       AssertCuda(cuda_error_code);
-#else
-      (void)pointer;
-      (void)n_elements;
-#endif
     }
 
     /**
@@ -94,13 +86,9 @@ namespace Utilities
     inline void
     free(T *&pointer)
     {
-#ifdef DEAL_II_COMPILER_CUDA_AWARE
       cudaError_t cuda_error_code = cudaFree(pointer);
       AssertCuda(cuda_error_code);
       pointer = nullptr;
-#else
-      (void)pointer;
-#endif
     }
 
     /**
@@ -110,17 +98,9 @@ namespace Utilities
     Number *
     allocate_device_data(const std::size_t size)
     {
-#ifdef DEAL_II_COMPILER_CUDA_AWARE
       Number *device_ptr;
       Utilities::CUDA::malloc(device_ptr, size);
       return device_ptr;
-#else
-      (void)size;
-      Assert(
-        false,
-        ExcMessage(
-          "This function can only be used if deal.II is built with CUDA support!"));
-#endif
     }
 
     /**
@@ -130,16 +110,8 @@ namespace Utilities
     void
     delete_device_data(Number *device_ptr) noexcept
     {
-#ifdef DEAL_II_COMPILER_CUDA_AWARE
       const cudaError_t error_code = cudaFree(device_ptr);
       AssertNothrowCuda(error_code);
-#else
-      (void)device_ptr;
-      AssertNothrow(
-        false,
-        ExcMessage(
-          "This function can only be used if deal.II is built with CUDA support!"));
-#endif
     }
 
     /**
@@ -149,16 +121,11 @@ namespace Utilities
     inline void
     copy_to_host(const T *pointer_dev, std::vector<T> &vector_host)
     {
-#ifdef DEAL_II_COMPILER_CUDA_AWARE
       cudaError_t cuda_error_code = cudaMemcpy(vector_host.data(),
                                                pointer_dev,
                                                vector_host.size() * sizeof(T),
                                                cudaMemcpyDeviceToHost);
       AssertCuda(cuda_error_code);
-#else
-      (void)pointer_dev;
-      (void)vector_host;
-#endif
     }
 
     /**
@@ -169,20 +136,15 @@ namespace Utilities
     inline void
     copy_to_dev(const std::vector<T> &vector_host, T *pointer_dev)
     {
-#ifdef DEAL_II_COMPILER_CUDA_AWARE
       cudaError_t cuda_error_code = cudaMemcpy(pointer_dev,
                                                vector_host.data(),
                                                vector_host.size() * sizeof(T),
                                                cudaMemcpyHostToDevice);
       AssertCuda(cuda_error_code);
-#else
-      (void)vector_host;
-      (void)pointer_dev;
-#endif
     }
   } // namespace CUDA
 } // namespace Utilities
 
 DEAL_II_NAMESPACE_CLOSE
-
+#endif
 #endif

--- a/include/deal.II/base/memory_space.h
+++ b/include/deal.II/base/memory_space.h
@@ -47,24 +47,6 @@ namespace MemorySpace
 
 
 
-#ifdef DEAL_II_COMPILER_CUDA_AWARE
-  /**
-   * Deleter for unique/shared pointer pointing to an array allocated on the
-   * device.
-   */
-  template <typename Number>
-  void
-  deleter_device_array(Number *ptr) noexcept
-  {
-    const cudaError_t cuda_error_code = cudaFree(ptr);
-    (void)cuda_error_code;
-    AssertNothrow(cuda_error_code == cudaSuccess,
-                  ExcCudaError(cudaGetErrorString(cuda_error_code)));
-  }
-#endif
-
-
-
   /**
    * Data structure
    */
@@ -172,7 +154,7 @@ namespace MemorySpace
   {
     MemorySpaceData()
       : values(nullptr, &free)
-      , values_dev(nullptr, deleter_device_array<Number>)
+      , values_dev(nullptr, Utilities::CUDA::delete_device_data<Number>)
     {}
 
     void

--- a/include/deal.II/lac/cuda_precondition.h
+++ b/include/deal.II/lac/cuda_precondition.h
@@ -23,7 +23,7 @@
 
 #include <memory>
 
-#ifdef DEAL_II_WITH_CUDA
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
This is an intermediate step for #7303. We found out that using `DEAL_II_CUDA_AWARE` inside non-templated code leads potentially to difficult to understand problems.
The biggest change here is to hide everything in `cuda.h` in case `DEAL_II_CUDA_AWARE` is not defined.