### PR TITLE
Make SmartPointer+Subscriptor check for dangling pointers

### DIFF
--- a/doc/news/changes/incompatibilities/20181102DanielArndt
+++ b/doc/news/changes/incompatibilities/20181102DanielArndt
@@ -1,0 +1,5 @@
+Changed: The constructor for Subscriptor requires providing a pointer to a boolean
+that can be used to signal validity of the object pointed to by the subscribing
+object.
+<br>
+(Daniel Arndt, 2018/11/02)

--- a/doc/news/changes/minor/20181102DanielArndt
+++ b/doc/news/changes/minor/20181102DanielArndt
@@ -1,0 +1,6 @@
+Changed: The class Subscriptor and SmartPointer check for dangling pointers and
+use-after-move. The destructor of Subscriptor doesn't signal an error when there
+is still an object subscribed to it. Instead, validity is checked when
+dereferencing the SmartPointer object.
+<br>
+(Daniel Arndt, 2018/11/02)

--- a/tests/base/assign_subscriptor.cc
+++ b/tests/base/assign_subscriptor.cc
@@ -15,7 +15,8 @@
 
 
 
-// check that Subscriptor objects need to be empty before assigning.
+// Check the behavior of the SmartPointer-Subscriptor pair
+// for copy and move semantics.
 
 
 #include <deal.II/base/smartpointer.h>
@@ -36,55 +37,112 @@ main()
 
   initlog();
 
-  // should work
   {
-    Subscriptor subscriptor_1;
-    Subscriptor subscriptor_2;
+    deallog << "Checking copy assignment" << std::endl;
 
-    SmartPointer<Subscriptor> smart(&subscriptor_1);
+    Subscriptor               subscriptor_1;
+    Subscriptor               subscriptor_2;
+    SmartPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
+    SmartPointer<Subscriptor> smart_pointer_2(&subscriptor_2);
 
     subscriptor_2 = subscriptor_1;
+
+    deallog << "Checking smart_pointer_1" << std::endl;
+    try
+      {
+        const auto dummy_1 = *smart_pointer_1;
+        (void)dummy_1;
+      }
+    catch (ExceptionBase &e)
+      {
+        deallog << e.get_exc_name() << std::endl;
+      }
+
+    deallog << "Checking smart_pointer_2" << std::endl;
+    try
+      {
+        const auto dummy_2 = *smart_pointer_2;
+        (void)dummy_2;
+      }
+    catch (ExceptionBase &e)
+      {
+        deallog << e.get_exc_name() << std::endl;
+      }
+    deallog << std::endl;
   }
 
-  try
-    {
-      Subscriptor subscriptor_1;
-      Subscriptor subscriptor_2;
+  {
+    deallog << "Checking copy construction" << std::endl;
 
-      SmartPointer<Subscriptor> smart(&subscriptor_2);
+    Subscriptor               subscriptor_1;
+    SmartPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
 
-      subscriptor_2 = subscriptor_1;
-    }
-  catch (ExceptionBase &e)
-    {
-      deallog << e.get_exc_name() << std::endl;
-    }
+    Subscriptor subscriptor_2(subscriptor_1);
 
-  try
-    {
-      Subscriptor subscriptor_1;
-      Subscriptor subscriptor_2;
+    deallog << "Checking smart_pointer_1" << std::endl;
+    try
+      {
+        const auto dummy_1 = *smart_pointer_1;
+        (void)dummy_1;
+      }
+    catch (ExceptionBase &e)
+      {
+        deallog << e.get_exc_name() << std::endl;
+      }
+    deallog << std::endl;
+  }
 
-      SmartPointer<Subscriptor> smart(&subscriptor_1);
+  {
+    deallog << "Checking move assignement" << std::endl;
 
-      subscriptor_2 = std::move(subscriptor_1);
-    }
-  catch (ExceptionBase &e)
-    {
-      deallog << e.get_exc_name() << std::endl;
-    }
+    Subscriptor               subscriptor_1;
+    Subscriptor               subscriptor_2;
+    SmartPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
+    SmartPointer<Subscriptor> smart_pointer_2(&subscriptor_2);
 
-  try
-    {
-      Subscriptor subscriptor_1;
-      Subscriptor subscriptor_2;
+    subscriptor_2 = std::move(subscriptor_1);
 
-      SmartPointer<Subscriptor> smart(&subscriptor_2);
+    deallog << "Checking smart_pointer_1" << std::endl;
+    try
+      {
+        const auto dummy_1 = *smart_pointer_1;
+        (void)dummy_1;
+      }
+    catch (ExceptionBase &e)
+      {
+        deallog << e.get_exc_name() << std::endl;
+      }
 
-      subscriptor_2 = std::move(subscriptor_1);
-    }
-  catch (ExceptionBase &e)
-    {
-      deallog << e.get_exc_name() << std::endl;
-    }
+    deallog << "Checking smart_pointer_2" << std::endl;
+    try
+      {
+        const auto dummy_2 = *smart_pointer_2;
+        (void)dummy_2;
+      }
+    catch (ExceptionBase &e)
+      {
+        deallog << e.get_exc_name() << std::endl;
+      }
+    deallog << std::endl;
+  }
+
+  {
+    deallog << "Checking move construction" << std::endl;
+
+    Subscriptor               subscriptor_1;
+    SmartPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
+
+    Subscriptor subscriptor_2(std::move(subscriptor_1));
+
+    deallog << "Checking smart_pointer_1" << std::endl;
+    try
+      {
+        const auto dummy_1 = *smart_pointer_1;
+        (void)dummy_1;
+      }
+    catch (ExceptionBase &e)
+      {
+        deallog << e.get_exc_name() << std::endl;
+      }
+  }
 }

--- a/tests/base/assign_subscriptor.debug.output
+++ b/tests/base/assign_subscriptor.debug.output
@@ -1,49 +1,16 @@
 
-DEAL::Exception: ExcInUse (counter.load(), object_info->name(), infostring)
+DEAL::Checking copy assignment
+DEAL::Checking smart_pointer_1
+DEAL::Checking smart_pointer_2
 DEAL::
---------------------------------------------------------
-An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::check_no_subscribers() const
-The violated condition was: 
-    counter == 0
-Additional information: 
-    Object of class N6dealii11SubscriptorE is still used by 1 other objects.
-
-(Additional information: 
-  from Subscriber v)
-
-See the entry in the Frequently Asked Questions of deal.II (linked to from http://www.dealii.org/) for a lot more information on what this error means and how to fix programs in which it happens.
---------------------------------------------------------
-
-DEAL::Exception: ExcInUse (counter.load(), object_info->name(), infostring)
+DEAL::Checking copy construction
+DEAL::Checking smart_pointer_1
 DEAL::
---------------------------------------------------------
-An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::check_no_subscribers() const
-The violated condition was: 
-    counter == 0
-Additional information: 
-    Object of class N6dealii11SubscriptorE is still used by 1 other objects.
-
-(Additional information: 
-  from Subscriber v)
-
-See the entry in the Frequently Asked Questions of deal.II (linked to from http://www.dealii.org/) for a lot more information on what this error means and how to fix programs in which it happens.
---------------------------------------------------------
-
-DEAL::Exception: ExcInUse (counter.load(), object_info->name(), infostring)
+DEAL::Checking move assignement
+DEAL::Checking smart_pointer_1
+DEAL::ExcMessage("The object pointed to is not valid anymore.")
+DEAL::Checking smart_pointer_2
 DEAL::
---------------------------------------------------------
-An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::check_no_subscribers() const
-The violated condition was: 
-    counter == 0
-Additional information: 
-    Object of class N6dealii11SubscriptorE is still used by 1 other objects.
-
-(Additional information: 
-  from Subscriber v)
-
-See the entry in the Frequently Asked Questions of deal.II (linked to from http://www.dealii.org/) for a lot more information on what this error means and how to fix programs in which it happens.
---------------------------------------------------------
-
+DEAL::Checking move construction
+DEAL::Checking smart_pointer_1
+DEAL::ExcMessage("The object pointed to is not valid anymore.")

--- a/tests/base/reference.debug.output
+++ b/tests/base/reference.debug.output
@@ -10,22 +10,7 @@ DEAL::u const
 DEAL::Construct C
 DEAL::Construct D
 DEAL::Destruct D
-DEAL::Exception: ExcInUse (counter.load(), object_info->name(), infostring)
-DEAL::
---------------------------------------------------------
-An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::check_no_subscribers() const
-The violated condition was: 
-    counter == 0
-Additional information: 
-    Object of class 4Test is still used by 1 other objects.
-
-(Additional information: 
-  from Subscriber Test R)
-
-See the entry in the Frequently Asked Questions of deal.II (linked to from http://www.dealii.org/) for a lot more information on what this error means and how to fix programs in which it happens.
---------------------------------------------------------
-
+DEAL::ExcMessage("The object pointed to is not valid anymore.")
 DEAL::Destruct C
 DEAL::Destruct B
 DEAL::Destruct A

--- a/tests/base/unsubscribe_subscriptor.cc
+++ b/tests/base/unsubscribe_subscriptor.cc
@@ -37,9 +37,10 @@ main()
   initlog();
 
   Subscriptor subscriptor;
-  subscriptor.subscribe("a");
-  subscriptor.unsubscribe("b");
-  subscriptor.unsubscribe("a");
+  bool        dummy_a;
+  subscriptor.subscribe(&dummy_a, "a");
+  subscriptor.unsubscribe(&dummy_a, "b");
+  subscriptor.unsubscribe(&dummy_a, "a");
 
   return 0;
 }

--- a/tests/base/unsubscribe_subscriptor.debug.output
+++ b/tests/base/unsubscribe_subscriptor.debug.output
@@ -3,10 +3,21 @@ DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
 DEAL::
 --------------------------------------------------------
 An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::unsubscribe(const char*) const
+    void dealii::Subscriptor::unsubscribe(bool*, const char*) const
 The violated condition was: 
     it != counter_map.end()
 Additional information: 
     No subscriber with identifier <b> subscribes to this object of class N6dealii11SubscriptorE. Consequently, it cannot be unsubscribed.
+--------------------------------------------------------
+
+DEAL::Exception: ExcMessage( "This Subscriptor object does not know anything about the supplied pointer!")
+DEAL::
+--------------------------------------------------------
+An error occurred in file <subscriptor.cc> in function
+    void dealii::Subscriptor::unsubscribe(bool*, const char*) const
+The violated condition was: 
+    validity_ptr_it != validity_pointers.end()
+Additional information: 
+    This Subscriptor object does not know anything about the supplied pointer!
 --------------------------------------------------------
 


### PR DESCRIPTION
This is an initial version of what I had in mind in #7240 inspired by `clang`'s new `-Wlifetime` warning (https://stackoverflow.com/questions/52662135/the-purpose-of-the-wlifetime-flag, https://youtu.be/80BZxujhY38 20:36).
The idea is to be less restrictive when using `SmartPointer` and checking for the use of invalidated memory when accessing the object pointing to instead of already complaining when the memory pointed to is invalidated (but not accessed). With this change, e.g. #7361, would not be necessary and we would avoid false-positives and allow a less strict order on construction of objects.

Before I clean this up, I would want to know what others think. Is this a good idea, should we use a different class or just discard the idea?
