### PR TITLE
Deprecate the NetCDF bindings.

### DIFF
--- a/doc/news/changes/incompatibilities/20181027DavidWells
+++ b/doc/news/changes/incompatibilities/20181027DavidWells
@@ -1,0 +1,7 @@
+Deprecated: deal.II's NetCDF bindings have been deprecated. The present set of
+bindings are incompatible with recent releases of NetCDF and, at the present
+time, no one has volunteered to either maintain or upgrade our interface. The
+bindings will be removed in a future version if no one steps forward to update
+the bindings.
+<br>
+(David Wells, 2018/10/27)

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -498,10 +498,12 @@
 
             <dt><a name="netcdf"></a><a href="http://www.unidata.ucar.edu/software/netcdf/" target="_top">NetCDF</a></dt>
             <dd>
+                <p>
                 <a href="http://www.unidata.ucar.edu/software/netcdf/" target="_top">NetCDF</a> is a library that provides services for reading and writing mesh data (and many other things). <acronym>deal.II</acronym> can use it to read meshes via one
                 of the functions of the <code>GridIn</code> class.
                 <a href="http://www.unidata.ucar.edu/software/netcdf/" target="_top">NetCDF</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
                 <code>-DNETCDF_DIR=/path/to/netcdf</code> to <code>cmake</code>.
+                <em>The deal.II NetCDF bindings are only compatible with an obsolete version of NetCDF and will be removed in a future release of the library unless newer bindings are contributed.</em>
                 </p>
             </dd>
 

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -930,6 +930,8 @@ namespace StandardExceptions
 
   /**
    * This function requires support for the NetCDF library.
+   *
+   * @deprecated Support for NetCDF in deal.II is deprecated.
    */
   DeclExceptionMsg(
     ExcNeedsNetCDF,

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -462,8 +462,10 @@ public:
    * supported is the <tt>TAU grid format</tt>.
    *
    * This function requires the library to be linked with the NetCDF library.
+   *
+   * @deprecated Support for NetCDF in deal.II is deprecated.
    */
-  void
+  DEAL_II_DEPRECATED void
   read_netcdf(const std::string &filename);
 
   /**


### PR DESCRIPTION
Fixes #5570: we are only compatible with the sparsely-supported `netcdf-cxx-legacy` package and no one seems interested enough in this format to fix that, so I have deprecated the bindings.