### PR TITLE
Introduce init_cuda in tests.h

### DIFF
--- a/tests/cuda/cuda_evaluate_1d_shape.cu
+++ b/tests/cuda/cuda_evaluate_1d_shape.cu
@@ -159,6 +159,8 @@ main()
   std::ofstream logfile("output");
   deallog.attach(logfile);
 
+  init_cuda();
+
   deallog.push("values");
   test<4, 4, 0, false>();
   test<3, 3, 0, false>();

--- a/tests/cuda/cuda_evaluate_2d_shape.cu
+++ b/tests/cuda/cuda_evaluate_2d_shape.cu
@@ -184,6 +184,8 @@ main()
   std::ofstream logfile("output");
   deallog.attach(logfile);
 
+  init_cuda();
+
   deallog.push("values");
   test<4, 4, 0, false>();
   test<3, 3, 0, false>();

--- a/tests/cuda/cuda_tensor_01.cu
+++ b/tests/cuda/cuda_tensor_01.cu
@@ -101,6 +101,8 @@ main()
   deallog << std::setprecision(5);
   deallog.attach(logfile);
 
+  init_cuda();
+
   test_cpu();
 
   test_gpu();

--- a/tests/cuda/cuda_vector_01.cu
+++ b/tests/cuda/cuda_vector_01.cu
@@ -115,6 +115,8 @@ main(int argc, char **argv)
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   test();
 
   deallog << "OK" << std::endl;

--- a/tests/cuda/cuda_vector_02.cu
+++ b/tests/cuda/cuda_vector_02.cu
@@ -111,6 +111,8 @@ main(int argc, char **argv)
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   test();
 
   deallog << "OK" << std::endl;

--- a/tests/cuda/cuda_vector_03.cu
+++ b/tests/cuda/cuda_vector_03.cu
@@ -41,6 +41,8 @@ main(int argc, char **argv)
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   test();
 
   deallog << "OK" << std::endl;

--- a/tests/cuda/cuda_vector_04.cu
+++ b/tests/cuda/cuda_vector_04.cu
@@ -49,6 +49,8 @@ main(int argc, char **argv)
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   test();
 
   deallog << "OK" << std::endl;

--- a/tests/cuda/matrix_vector_common.h
+++ b/tests/cuda/matrix_vector_common.h
@@ -159,6 +159,8 @@ main()
 
   deallog << std::setprecision(3);
 
+  init_cuda();
+
   {
     deallog.push("2d");
     test<2, 1>();

--- a/tests/cuda/parallel_vector_01.cu
+++ b/tests/cuda/parallel_vector_01.cu
@@ -85,18 +85,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
-
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_02.cu
+++ b/tests/cuda/parallel_vector_02.cu
@@ -97,17 +97,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_03.cu
+++ b/tests/cuda/parallel_vector_03.cu
@@ -102,17 +102,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_03a.cu
+++ b/tests/cuda/parallel_vector_03a.cu
@@ -155,17 +155,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_04.cu
+++ b/tests/cuda/parallel_vector_04.cu
@@ -153,21 +153,10 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
+  init_cuda(true);
+
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
-
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
-
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_05.cu
+++ b/tests/cuda/parallel_vector_05.cu
@@ -98,17 +98,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_06.cu
+++ b/tests/cuda/parallel_vector_06.cu
@@ -143,18 +143,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
-
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_08.cu
+++ b/tests/cuda/parallel_vector_08.cu
@@ -126,17 +126,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_10.cu
+++ b/tests/cuda/parallel_vector_10.cu
@@ -92,17 +92,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
+  init_cuda();
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_11.cu
+++ b/tests/cuda/parallel_vector_11.cu
@@ -233,18 +233,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
-
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_12.cu
+++ b/tests/cuda/parallel_vector_12.cu
@@ -216,18 +216,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
-
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_13.cu
+++ b/tests/cuda/parallel_vector_13.cu
@@ -113,17 +113,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_14.cu
+++ b/tests/cuda/parallel_vector_14.cu
@@ -161,17 +161,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_15.cu
+++ b/tests/cuda/parallel_vector_15.cu
@@ -111,17 +111,7 @@ main(int argc, char **argv)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
 
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = myid % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
+  init_cuda(true);
 
   if (myid == 0)
     {

--- a/tests/cuda/parallel_vector_21.cu
+++ b/tests/cuda/parallel_vector_21.cu
@@ -86,18 +86,7 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  unsigned int my_id = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
-  Utilities::CUDA::Handle cuda_handle;
-  // By default, all the ranks will try to access the device 0. This is fine if
-  // we have one rank per node _and_ one gpu per node. If we have multiple GPUs
-  // on one node, we need each process to access a different GPU. We assume that
-  // each node has the same number of GPUs.
-  int         n_devices       = 0;
-  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
-  AssertCuda(cuda_error_code);
-  int device_id   = my_id % n_devices;
-  cuda_error_code = cudaSetDevice(device_id);
-  AssertCuda(cuda_error_code);
+  init_cuda(true);
 
   MPILogInitAll log;
   test();

--- a/tests/cuda/precondition_01.cu
+++ b/tests/cuda/precondition_01.cu
@@ -74,6 +74,8 @@ main()
   deallog << std::setprecision(10);
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   deallog << "Testing float" << std::endl;
   test<float>(cuda_handle);

--- a/tests/cuda/precondition_02.cu
+++ b/tests/cuda/precondition_02.cu
@@ -74,6 +74,8 @@ main()
   deallog << std::setprecision(10);
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   deallog << "Testing float" << std::endl;
   test<float>(cuda_handle);

--- a/tests/cuda/solver_01.cu
+++ b/tests/cuda/solver_01.cu
@@ -76,6 +76,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 

--- a/tests/cuda/solver_02.cu
+++ b/tests/cuda/solver_02.cu
@@ -107,6 +107,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 

--- a/tests/cuda/solver_03.cu
+++ b/tests/cuda/solver_03.cu
@@ -76,6 +76,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 

--- a/tests/cuda/solver_04.cu
+++ b/tests/cuda/solver_04.cu
@@ -77,6 +77,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 

--- a/tests/cuda/solver_05.cu
+++ b/tests/cuda/solver_05.cu
@@ -76,6 +76,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 

--- a/tests/cuda/solver_06.cu
+++ b/tests/cuda/solver_06.cu
@@ -76,6 +76,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 

--- a/tests/cuda/solver_07.cu
+++ b/tests/cuda/solver_07.cu
@@ -76,6 +76,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 

--- a/tests/cuda/solver_08.cu
+++ b/tests/cuda/solver_08.cu
@@ -76,6 +76,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 

--- a/tests/cuda/solver_09.cu
+++ b/tests/cuda/solver_09.cu
@@ -105,6 +105,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 

--- a/tests/cuda/solver_10.cu
+++ b/tests/cuda/solver_10.cu
@@ -125,6 +125,8 @@ main()
   initlog();
   deallog.depth_console(10);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
   test(cuda_handle);
 

--- a/tests/cuda/sparse_matrix_01.cu
+++ b/tests/cuda/sparse_matrix_01.cu
@@ -213,6 +213,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
 
   test(cuda_handle);

--- a/tests/cuda/sparse_matrix_02.cu
+++ b/tests/cuda/sparse_matrix_02.cu
@@ -52,6 +52,8 @@ main()
   initlog();
   deallog.depth_console(0);
 
+  init_cuda();
+
   Utilities::CUDA::Handle cuda_handle;
 
   test(cuda_handle);

--- a/tests/cuda/vector_reinit_01.cu
+++ b/tests/cuda/vector_reinit_01.cu
@@ -110,9 +110,9 @@ main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
-  Utilities::CUDA::Handle cuda_handle;
 
   initlog();
+  init_cuda();
 
   do_test<
     LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::CUDA>>();

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -20,6 +20,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/cuda.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/job_identifier.h>
 #include <deal.II/base/logstream.h>
@@ -589,6 +590,42 @@ struct MPILogInitAll
 #endif
   }
 };
+
+
+#ifdef DEAL_II_COMPILER_CUDA_AWARE
+// By default, all the ranks will try to access the device 0. We can distribute
+// the load better by using a random device which is done in this function. In
+// case tests use MPI, we make sure to set subsequent devices. MPI needs to be
+// initialized before using this function.
+// Also initialize a dummy handle that makes sure that unused memory is released
+// before the device shuts down.
+void
+init_cuda(bool use_mpi = false)
+{
+  static Utilities::CUDA::Handle cuda_handle;
+#  ifndef DEAL_II_WITH_MPI
+  Assert(use_mpi == false, ExcInternalError());
+#  endif
+  const unsigned int my_id =
+    use_mpi ? Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) : 0;
+  int         device_id       = 0;
+  int         n_devices       = 0;
+  cudaError_t cuda_error_code = cudaGetDeviceCount(&n_devices);
+  if (my_id == 0)
+    {
+      Testing::srand(std::time(nullptr));
+      AssertCuda(cuda_error_code);
+      device_id = Testing::rand() % n_devices;
+    }
+#  ifdef DEAL_II_WITH_MPI
+  if (use_mpi)
+    MPI_Bcast(&device_id, 1, MPI_INT, 0, MPI_COMM_WORLD);
+#  endif
+  device_id       = (device_id + my_id) % n_devices;
+  cuda_error_code = cudaSetDevice(device_id);
+  AssertCuda(cuda_error_code);
+}
+#endif
 
 
 


### PR DESCRIPTION
Currently, we are always using the `CUDA` device with number 0 in all the tests.
For load-balancing, we should use all the devices we have access to instead.
This is what `init_cuda()` does: It make sure that a random device is used.
In case we are using `MPI` we just choose a random device for the process and assign subsequent devices to the other processes. This is in accordance with what we are currently doing.

Furthermore, `init_cuda` provides a way to hide the `Utilities::CUDA::Handle` we need to make sure that unused memory is freed before the device shuts down.