### PR TITLE
doxygen: scale plate_with_hole images

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -331,13 +331,10 @@ namespace GridGenerator
    * allowed to be zero.
    *
    * Here is the non-symmetric grid (after one global refinement, colored
-   * according to manifold id) in 2D:
+   * according to manifold id) in 2D and 3D, respectively:
    *
-   * @image html plate_with_a_hole.png
-   *
-   * and in 3D:
-   *
-   * @image html plate_with_a_hole_3D.png
+   * <img src="plate_with_a_hole.png" title="2d plate" width="600px">
+   * <img src="plate_with_a_hole_3D.png" title="3d plate" width="600px">
    *
    * In 3D, triangulation will be extruded in the z-direction by the total
    * height of @p L using @p n_slices slices (minimum is 2).


### PR DESCRIPTION
the .pngs are about 1500px wide so the display is quite ugly. 600px is
in line with most of the other images on the page.