### PR TITLE
MemorySpace template parameter for ArrayView

### DIFF
--- a/doc/news/changes/minor/20181104DanielArndt-1
+++ b/doc/news/changes/minor/20181104DanielArndt-1
@@ -1,0 +1,5 @@
+Improved: The class ArrayView checks the memory location of the data it presents
+and gained a template parameter indicating whether the data is stored in CPU or
+CUDA memory.
+<br>
+(Daniel Arndt, 2018/11/04)

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/memory_space.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
@@ -72,7 +73,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup data
  * @author Wolfgang Bangerth, 2015, David Wells, 2017
  */
-template <typename ElementType>
+template <typename ElementType, typename MemorySpaceType = MemorySpace::Host>
 class ArrayView
 {
 public:
@@ -122,7 +123,8 @@ public:
    * non-@p const view to a @p const view, akin to converting a non-@p const
    * pointer to a @p const pointer.
    */
-  ArrayView(const ArrayView<typename std::remove_cv<value_type>::type> &view);
+  ArrayView(const ArrayView<typename std::remove_cv<value_type>::type,
+                            MemorySpaceType> &view);
 
   /**
    * A constructor that automatically creates a view from a std::vector object.
@@ -163,7 +165,8 @@ public:
    * This version always compares with the const value_type.
    */
   bool
-  operator==(const ArrayView<const value_type> &other_view) const;
+  operator==(
+    const ArrayView<const value_type, MemorySpaceType> &other_view) const;
 
   /**
    * Compare two ArrayView objects of the same type. Two objects are considered
@@ -171,8 +174,8 @@ public:
    * This version always compares with the non-const value_type.
    */
   bool
-  operator==(const ArrayView<typename std::remove_cv<value_type>::type>
-               &other_view) const;
+  operator==(const ArrayView<typename std::remove_cv<value_type>::type,
+                             MemorySpaceType> &other_view) const;
 
   /**
    * Compare two ArrayView objects of the same type. Two objects are considered
@@ -180,7 +183,8 @@ public:
    * This version always compares with the const value_type.
    */
   bool
-  operator!=(const ArrayView<const value_type> &other_view) const;
+  operator!=(
+    const ArrayView<const value_type, MemorySpaceType> &other_view) const;
 
   /**
    * Compare two ArrayView objects of the same type. Two objects are considered
@@ -188,8 +192,8 @@ public:
    * This version always compares with the non-const value_type.
    */
   bool
-  operator!=(const ArrayView<typename std::remove_cv<value_type>::type>
-               &other_view) const;
+  operator!=(const ArrayView<typename std::remove_cv<value_type>::type,
+                             MemorySpaceType> &other_view) const;
 
   /**
    * Return the size (in elements) of the view of memory this object
@@ -252,7 +256,7 @@ private:
    */
   const std::size_t n_elements;
 
-  friend class ArrayView<const ElementType>;
+  friend class ArrayView<const ElementType, MemorySpaceType>;
 };
 
 
@@ -261,26 +265,28 @@ private:
 
 
 
-template <typename ElementType>
-inline ArrayView<ElementType>::ArrayView(value_type *      starting_element,
-                                         const std::size_t n_elements)
+template <typename ElementType, typename MemorySpaceType>
+inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
+  value_type *      starting_element,
+  const std::size_t n_elements)
   : starting_element(starting_element)
   , n_elements(n_elements)
 {}
 
 
 
-template <typename ElementType>
-inline ArrayView<ElementType>::ArrayView(
-  const ArrayView<typename std::remove_cv<value_type>::type> &view)
+template <typename ElementType, typename MemorySpaceType>
+inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
+  const ArrayView<typename std::remove_cv<value_type>::type, MemorySpaceType>
+    &view)
   : starting_element(view.starting_element)
   , n_elements(view.n_elements)
 {}
 
 
 
-template <typename ElementType>
-inline ArrayView<ElementType>::ArrayView(
+template <typename ElementType, typename MemorySpaceType>
+inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
   const std::vector<typename std::remove_cv<value_type>::type> &vector)
   : // use delegating constructor
   ArrayView(vector.data(), vector.size())
@@ -303,8 +309,8 @@ inline ArrayView<ElementType>::ArrayView(
 
 
 
-template <typename ElementType>
-inline ArrayView<ElementType>::ArrayView(
+template <typename ElementType, typename MemorySpaceType>
+inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
   std::vector<typename std::remove_cv<value_type>::type> &vector)
   : // use delegating constructor
   ArrayView(vector.data(), vector.size())
@@ -312,10 +318,10 @@ inline ArrayView<ElementType>::ArrayView(
 
 
 
-template <typename ElementType>
+template <typename ElementType, typename MemorySpaceType>
 inline bool
-ArrayView<ElementType>::
-operator==(const ArrayView<const value_type> &other_view) const
+ArrayView<ElementType, MemorySpaceType>::
+operator==(const ArrayView<const value_type, MemorySpaceType> &other_view) const
 {
   return (other_view.data() == starting_element) &&
          (other_view.size() == n_elements);
@@ -323,10 +329,11 @@ operator==(const ArrayView<const value_type> &other_view) const
 
 
 
-template <typename ElementType>
+template <typename ElementType, typename MemorySpaceType>
 inline bool
-ArrayView<ElementType>::operator==(
-  const ArrayView<typename std::remove_cv<value_type>::type> &other_view) const
+ArrayView<ElementType, MemorySpaceType>::
+operator==(const ArrayView<typename std::remove_cv<value_type>::type,
+                           MemorySpaceType> &other_view) const
 {
   return (other_view.data() == starting_element) &&
          (other_view.size() == n_elements);
@@ -334,19 +341,19 @@ ArrayView<ElementType>::operator==(
 
 
 
-template <typename ElementType>
+template <typename ElementType, typename MemorySpaceType>
 inline bool
-ArrayView<ElementType>::
-operator!=(const ArrayView<const value_type> &other_view) const
+ArrayView<ElementType, MemorySpaceType>::
+operator!=(const ArrayView<const value_type, MemorySpaceType> &other_view) const
 {
   return !(*this == other_view);
 }
 
 
 
-template <typename ElementType>
-inline typename ArrayView<ElementType>::value_type *
-ArrayView<ElementType>::data() const noexcept
+template <typename ElementType, typename MemorySpaceType>
+inline typename ArrayView<ElementType, MemorySpaceType>::value_type *
+ArrayView<ElementType, MemorySpaceType>::data() const noexcept
 {
   if (n_elements == 0)
     return nullptr;
@@ -356,62 +363,63 @@ ArrayView<ElementType>::data() const noexcept
 
 
 
-template <typename ElementType>
+template <typename ElementType, typename MemorySpaceType>
 inline bool
-ArrayView<ElementType>::operator!=(
-  const ArrayView<typename std::remove_cv<value_type>::type> &other_view) const
+ArrayView<ElementType, MemorySpaceType>::
+operator!=(const ArrayView<typename std::remove_cv<value_type>::type,
+                           MemorySpaceType> &other_view) const
 {
   return !(*this == other_view);
 }
 
 
 
-template <typename ElementType>
+template <typename ElementType, typename MemorySpaceType>
 inline std::size_t
-ArrayView<ElementType>::size() const
+ArrayView<ElementType, MemorySpaceType>::size() const
 {
   return n_elements;
 }
 
-template <typename ElementType>
-inline typename ArrayView<ElementType>::iterator
-ArrayView<ElementType>::begin() const
+template <typename ElementType, typename MemorySpaceType>
+inline typename ArrayView<ElementType, MemorySpaceType>::iterator
+ArrayView<ElementType, MemorySpaceType>::begin() const
 {
   return starting_element;
 }
 
 
 
-template <typename ElementType>
-inline typename ArrayView<ElementType>::iterator
-ArrayView<ElementType>::end() const
+template <typename ElementType, typename MemorySpaceType>
+inline typename ArrayView<ElementType, MemorySpaceType>::iterator
+ArrayView<ElementType, MemorySpaceType>::end() const
 {
   return starting_element + n_elements;
 }
 
 
 
-template <typename ElementType>
-inline typename ArrayView<ElementType>::const_iterator
-ArrayView<ElementType>::cbegin() const
+template <typename ElementType, typename MemorySpaceType>
+inline typename ArrayView<ElementType, MemorySpaceType>::const_iterator
+ArrayView<ElementType, MemorySpaceType>::cbegin() const
 {
   return starting_element;
 }
 
 
 
-template <typename ElementType>
-inline typename ArrayView<ElementType>::const_iterator
-ArrayView<ElementType>::cend() const
+template <typename ElementType, typename MemorySpaceType>
+inline typename ArrayView<ElementType, MemorySpaceType>::const_iterator
+ArrayView<ElementType, MemorySpaceType>::cend() const
 {
   return starting_element + n_elements;
 }
 
 
 
-template <typename ElementType>
-inline typename ArrayView<ElementType>::value_type &ArrayView<ElementType>::
-                                                    operator[](const std::size_t i) const
+template <typename ElementType, typename MemorySpaceType>
+inline typename ArrayView<ElementType, MemorySpaceType>::value_type &
+  ArrayView<ElementType, MemorySpaceType>::operator[](const std::size_t i) const
 {
   Assert(i < n_elements, ExcIndexRange(i, 0, n_elements));
 
@@ -481,9 +489,10 @@ namespace internal
  *
  * @relatesalso ArrayView
  */
-template <typename Iterator>
+template <typename Iterator, typename MemorySpaceType = MemorySpace::Host>
 ArrayView<typename std::remove_reference<
-  typename std::iterator_traits<Iterator>::reference>::type>
+            typename std::iterator_traits<Iterator>::reference>::type,
+          MemorySpaceType>
 make_array_view(const Iterator begin, const Iterator end)
 {
   static_assert(
@@ -497,8 +506,8 @@ make_array_view(const Iterator begin, const Iterator end)
          ExcMessage("The provided range isn't contiguous in memory!"));
   // the reference type, not the value type, knows the constness of the iterator
   return ArrayView<typename std::remove_reference<
-    typename std::iterator_traits<Iterator>::reference>::type>(
-    std::addressof(*begin), end - begin);
+                     typename std::iterator_traits<Iterator>::reference>::type,
+                   MemorySpaceType>(std::addressof(*begin), end - begin);
 }
 
 
@@ -512,14 +521,14 @@ make_array_view(const Iterator begin, const Iterator end)
  *
  * @relatesalso ArrayView
  */
-template <typename ElementType>
-ArrayView<ElementType>
+template <typename ElementType, typename MemorySpaceType = MemorySpace::Host>
+ArrayView<ElementType, MemorySpaceType>
 make_array_view(ElementType *const begin, ElementType *const end)
 {
   Assert(begin <= end,
          ExcMessage(
            "The beginning of the array view should be before the end."));
-  return ArrayView<ElementType>(begin, end - begin);
+  return ArrayView<ElementType, MemorySpaceType>(begin, end - begin);
 }
 
 
@@ -534,9 +543,9 @@ make_array_view(ElementType *const begin, ElementType *const end)
  *
  * @relatesalso ArrayView
  */
-template <typename Number>
-inline ArrayView<const Number>
-make_array_view(const ArrayView<Number> &array_view)
+template <typename Number, typename MemorySpaceType>
+inline ArrayView<const Number, MemorySpaceType>
+make_array_view(const ArrayView<Number, MemorySpaceType> &array_view)
 {
   return make_array_view(array_view.cbegin(), array_view.cend());
 }
@@ -553,9 +562,9 @@ make_array_view(const ArrayView<Number> &array_view)
  *
  * @relatesalso ArrayView
  */
-template <typename Number>
-inline ArrayView<Number>
-make_array_view(ArrayView<Number> &array_view)
+template <typename Number, typename MemorySpaceType>
+inline ArrayView<Number, MemorySpaceType>
+make_array_view(ArrayView<Number, MemorySpaceType> &array_view)
 {
   return make_array_view(array_view.begin(), array_view.end());
 }

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -34,15 +34,15 @@ DEAL_II_NAMESPACE_OPEN
 
 /**
  * A class that represents a window of memory locations of type @p ElementType
- * and presents it as if it was an array that can be accessed via an
- * <code>operator[]</code>. In essence, this class is nothing more than just a
- * pointer to the first location and an integer that represents the length of
- * the array in elements. The memory remains owned by whoever allocated it, as
- * this class does not take over ownership.
+ * and presents it as if it was an array. In essence, this class is nothing more
+ * than just a pointer to the first location and an integer that represents the
+ * length of the array in elements. The memory remains owned by whoever
+ * allocated it, as this class does not take over ownership.
  *
  * The advantage of using this class is that you don't have to pass around
  * pairs of pointers and that <code>operator[]</code> checks for the validity
- * of the index with which you subscript this array view.
+ * of the index with which you subscript this array view. Note that accessing
+ * elements is only allowed if the underlying data is stored in CPU memory.
  *
  * This class can handle views to both non-constant and constant memory
  * locations. If you want to represent a view of a constant array, then the
@@ -241,6 +241,9 @@ public:
    * <em>view object</em>. It may however return a reference to a non-@p const
    * memory location depending on whether the template type of the class is @p
    * const or not.
+   *
+   * This function is only allowed to be called if the underlying data is indeed
+   * stored in CPU memory.
    */
   value_type &operator[](const std::size_t i) const;
 
@@ -488,6 +491,10 @@ template <typename ElementType, typename MemorySpaceType>
 inline typename ArrayView<ElementType, MemorySpaceType>::value_type &
   ArrayView<ElementType, MemorySpaceType>::operator[](const std::size_t i) const
 {
+  Assert(
+    (std::is_same<MemorySpaceType, MemorySpace::Host>::value),
+    ExcMessage(
+      "Accessing elements is only allowed if the data is stored in CPU memory!"));
   Assert(i < n_elements, ExcIndexRange(i, 0, n_elements));
 
   return *(starting_element + i);

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -31,7 +31,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <typename ElementType>
+template <typename ElementType, typename MemorySpaceType>
 class ArrayView;
 template <int dim>
 class Quadrature;

--- a/tests/cuda/array_view_access_data.cu
+++ b/tests/cuda/array_view_access_data.cu
@@ -28,6 +28,8 @@ main(int argc, char **argv)
 
   initlog();
 
+  init_cuda();
+
   std::unique_ptr<unsigned int[], void (*)(unsigned int *)> dummy_cuda(
     Utilities::CUDA::allocate_device_data<unsigned int>(2),
     Utilities::CUDA::delete_device_data<unsigned int>);

--- a/tests/cuda/array_view_access_data.cu
+++ b/tests/cuda/array_view_access_data.cu
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// check that we detect that accessing CUDA memory in an ArrayView object
+// is not allowed.
+
+#include <deal.II/base/array_view.h>
+
+#include "../tests.h"
+
+int
+main(int argc, char **argv)
+{
+  deal_II_exceptions::disable_abort_on_exception();
+
+  initlog();
+
+  std::unique_ptr<unsigned int[], void (*)(unsigned int *)> dummy_cuda(
+    Utilities::CUDA::allocate_device_data<unsigned int>(2),
+    Utilities::CUDA::delete_device_data<unsigned int>);
+
+  try
+    {
+      ArrayView<unsigned int, MemorySpace::CUDA> view(dummy_cuda.get(), 2);
+      const auto                                 dummy = view[0];
+    }
+  catch (const ExceptionBase &exc)
+    {
+      deallog << exc.what() << std::endl;
+    }
+
+  return 0;
+}

--- a/tests/cuda/array_view_access_data.debug.output
+++ b/tests/cuda/array_view_access_data.debug.output
@@ -1,0 +1,11 @@
+
+DEAL::
+--------------------------------------------------------
+An error occurred in file <array_view.h> in function
+    dealii::ArrayView<ElementType, MemorySpaceType>::value_type& dealii::ArrayView<ElementType, MemorySpaceType>::operator[](std::size_t) const [with ElementType = unsigned int; MemorySpaceType = dealii::MemorySpace::CUDA; dealii::ArrayView<ElementType, MemorySpaceType>::value_type = unsigned int; std::size_t = long unsigned int]
+The violated condition was: 
+    (std::is_same<MemorySpaceType, MemorySpace::Host>::value)
+Additional information: 
+    Accessing elements is only allowed if the data is stored in CPU memory!
+--------------------------------------------------------
+

--- a/tests/cuda/array_view_wrong_memory.cu
+++ b/tests/cuda/array_view_wrong_memory.cu
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// check that we detect creating ArrayView objects wit the wrong memory space.
+
+#include <deal.II/base/array_view.h>
+
+#include "../tests.h"
+
+int
+main(int argc, char **argv)
+{
+  deal_II_exceptions::disable_abort_on_exception();
+
+  initlog();
+
+  std::vector<unsigned int>                                 dummy_host(2);
+  std::unique_ptr<unsigned int[], void (*)(unsigned int *)> dummy_cuda(
+    Utilities::CUDA::allocate_device_data<unsigned int>(2),
+    Utilities::CUDA::delete_device_data<unsigned int>);
+
+  deallog << "Testing host ArrayView with host memory" << std::endl;
+  ArrayView<unsigned int, MemorySpace::Host> view_1(dummy_host);
+
+  deallog << "Testing device ArrayView with host memory" << std::endl;
+  try
+    {
+      ArrayView<unsigned int, MemorySpace::CUDA> view_2(dummy_host);
+    }
+  catch (const ExceptionBase &exc)
+    {
+      deallog << exc.what() << std::endl;
+    }
+
+  deallog << "Testing host ArrayView with device memory" << std::endl;
+  try
+    {
+      ArrayView<unsigned int, MemorySpace::Host> view_3(dummy_cuda.get(), 2);
+    }
+  catch (const ExceptionBase &exc)
+    {
+      deallog << exc.what() << std::endl;
+    }
+
+  deallog << "Testing device ArrayView with device memory" << std::endl;
+  ArrayView<unsigned int, MemorySpace::CUDA> view_4(dummy_cuda.get(), 2);
+
+  return 0;
+}

--- a/tests/cuda/array_view_wrong_memory.cu
+++ b/tests/cuda/array_view_wrong_memory.cu
@@ -27,6 +27,8 @@ main(int argc, char **argv)
 
   initlog();
 
+  init_cuda();
+
   std::vector<unsigned int>                                 dummy_host(2);
   std::unique_ptr<unsigned int[], void (*)(unsigned int *)> dummy_cuda(
     Utilities::CUDA::allocate_device_data<unsigned int>(2),

--- a/tests/cuda/array_view_wrong_memory.debug.output
+++ b/tests/cuda/array_view_wrong_memory.debug.output
@@ -1,0 +1,25 @@
+
+DEAL::Testing host ArrayView with host memory
+DEAL::Testing device ArrayView with host memory
+DEAL::
+--------------------------------------------------------
+An error occurred in file <array_view.h> in function
+    dealii::ArrayView<ElementType, MemorySpaceType>::ArrayView(dealii::ArrayView<ElementType, MemorySpaceType>::value_type*, std::size_t) [with ElementType = unsigned int; MemorySpaceType = dealii::MemorySpace::CUDA; dealii::ArrayView<ElementType, MemorySpaceType>::value_type = unsigned int; std::size_t = long unsigned int]
+The violated condition was: 
+    internal::ArrayViewHelper::correct_memory_space<MemorySpaceType>( starting_element)
+Additional information: 
+    The memory space indicated by the template parameter and the one derived from the pointer value do not match!
+--------------------------------------------------------
+
+DEAL::Testing host ArrayView with device memory
+DEAL::
+--------------------------------------------------------
+An error occurred in file <array_view.h> in function
+    dealii::ArrayView<ElementType, MemorySpaceType>::ArrayView(dealii::ArrayView<ElementType, MemorySpaceType>::value_type*, std::size_t) [with ElementType = unsigned int; MemorySpaceType = dealii::MemorySpace::Host; dealii::ArrayView<ElementType, MemorySpaceType>::value_type = unsigned int; std::size_t = long unsigned int]
+The violated condition was: 
+    internal::ArrayViewHelper::correct_memory_space<MemorySpaceType>( starting_element)
+Additional information: 
+    The memory space indicated by the template parameter and the one derived from the pointer value do not match!
+--------------------------------------------------------
+
+DEAL::Testing device ArrayView with device memory

--- a/tests/cuda/array_view_wrong_memory.debug.output
+++ b/tests/cuda/array_view_wrong_memory.debug.output
@@ -6,7 +6,7 @@ DEAL::
 An error occurred in file <array_view.h> in function
     dealii::ArrayView<ElementType, MemorySpaceType>::ArrayView(dealii::ArrayView<ElementType, MemorySpaceType>::value_type*, std::size_t) [with ElementType = unsigned int; MemorySpaceType = dealii::MemorySpace::CUDA; dealii::ArrayView<ElementType, MemorySpaceType>::value_type = unsigned int; std::size_t = long unsigned int]
 The violated condition was: 
-    internal::ArrayViewHelper::correct_memory_space<MemorySpaceType>( starting_element)
+    internal::ArrayViewHelper::is_in_correct_memory_space<MemorySpaceType>( starting_element)
 Additional information: 
     The memory space indicated by the template parameter and the one derived from the pointer value do not match!
 --------------------------------------------------------
@@ -17,7 +17,7 @@ DEAL::
 An error occurred in file <array_view.h> in function
     dealii::ArrayView<ElementType, MemorySpaceType>::ArrayView(dealii::ArrayView<ElementType, MemorySpaceType>::value_type*, std::size_t) [with ElementType = unsigned int; MemorySpaceType = dealii::MemorySpace::Host; dealii::ArrayView<ElementType, MemorySpaceType>::value_type = unsigned int; std::size_t = long unsigned int]
 The violated condition was: 
-    internal::ArrayViewHelper::correct_memory_space<MemorySpaceType>( starting_element)
+    internal::ArrayViewHelper::is_in_correct_memory_space<MemorySpaceType>( starting_element)
 Additional information: 
     The memory space indicated by the template parameter and the one derived from the pointer value do not match!
 --------------------------------------------------------


### PR DESCRIPTION
Part of #7303. Having a template parameter indicating whether the data represented resides in `CPU` or `CUDA` memory space helps in choosing the correct algorithm for classes that can deal with both.
Additionally, `CUDA` functionality checks in the constructor that the template parameter is indeed correct chosen.
In case the data is stored on the `GPU`, data access is fobidden and guarded by an `Assert`.