### PR TITLE
Fix read with FEEvaluation and AVX-512 support

### DIFF
--- a/doc/news/changes/minor/20181110MartinKronbichler
+++ b/doc/news/changes/minor/20181110MartinKronbichler
@@ -1,0 +1,5 @@
+Fixed: The operation FEEvaluation::read_dof_values performed invalid array
+accesses with AVX512 vectorization in rare circumstances of particular 1d
+meshes. This is now fixed.
+<br>
+(Martin Kronbichler, 2018/11/10)

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -817,8 +817,11 @@ namespace internal
                       dof_indices[j * ndofs + 1] - dof_indices[j * ndofs];
                   for (unsigned int k = 0; k < ndofs; ++k)
                     for (unsigned int j = 0; j < n_comp; ++j)
-                      if (dof_indices[j * ndofs + k] !=
-                          dof_indices[j * ndofs] + k * offsets[j])
+                      // the first if case is to avoid negative offsets
+                      // (invalid)
+                      if (dof_indices[j * ndofs + 1] < dof_indices[j * ndofs] ||
+                          dof_indices[j * ndofs + k] !=
+                            dof_indices[j * ndofs] + k * offsets[j])
                         {
                           indices_are_interleaved_and_mixed = 0;
                           break;


### PR DESCRIPTION
Fixes #7433.

It turned out that we did not check for negative indices (where offsets do not work).