### PR TITLE
Prefer std::string over const char * in public interfaces

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2963,7 +2963,7 @@ public:
    * DataOutInterface::write_vtu().
    */
   void
-  write_vtu_in_parallel(const char *filename, MPI_Comm comm) const;
+  write_vtu_in_parallel(const std::string &filename, MPI_Comm comm) const;
 
   /**
    * Some visualization programs, such as ParaView, can read several separate

--- a/include/deal.II/base/event.h
+++ b/include/deal.II/base/event.h
@@ -54,7 +54,7 @@ namespace Algorithms
      * later use.
      */
     static Event
-    assign(const char *name);
+    assign(const std::string &name);
 
     /**
      * If you forgot to store the result of assign, here is how to retrieve it

--- a/include/deal.II/base/job_identifier.h
+++ b/include/deal.II/base/job_identifier.h
@@ -58,7 +58,7 @@ public:
    * identifier for the program being run.
    */
   static std::string
-  base_name(const char *filename);
+  base_name(const std::string &filename);
 
   /**
    * Return the value of <tt>id</tt>.

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1009,7 +1009,7 @@ public:
    * there for more information.
    */
   virtual void
-  parse_input_from_string(const char *       s,
+  parse_input_from_string(const std::string &s,
                           const std::string &last_line      = "",
                           const bool         skip_undefined = false);
 

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -587,7 +587,7 @@ namespace parallel
        * interface between deal.II and p4est.
        */
       void
-      write_mesh_vtk(const char *file_basename) const;
+      write_mesh_vtk(const std::string &file_basename) const;
 
       /**
        * Produce a check sum of the triangulation.  This is a collective
@@ -604,7 +604,7 @@ namespace parallel
        * cell-based data can be saved using register_data_attach().
        */
       void
-      save(const char *filename) const;
+      save(const std::string &filename) const;
 
       /**
        * Load the refinement information saved with save() back in. The mesh
@@ -625,7 +625,7 @@ namespace parallel
        * if a different number of MPI processes is encountered).
        */
       void
-      load(const char *filename, const bool autopartition = true);
+      load(const std::string &filename, const bool autopartition = true);
 
       /**
        * Register a function that can be used to attach data of fixed size
@@ -1043,8 +1043,8 @@ namespace parallel
          */
         void
         save(const typename dealii::internal::p4est::types<dim>::forest
-               *         parallel_forest,
-             const char *filename) const;
+               *                parallel_forest,
+             const std::string &filename) const;
 
         /**
          * Transfer data from file system.
@@ -1067,7 +1067,7 @@ namespace parallel
         void
         load(const typename dealii::internal::p4est::types<dim>::forest
                *                parallel_forest,
-             const char *       filename,
+             const std::string &filename,
              const unsigned int n_attached_deserialize_fixed,
              const unsigned int n_attached_deserialize_variable);
 
@@ -1302,14 +1302,14 @@ namespace parallel
        * compiler.
        */
       void
-      load(const char *filename, const bool autopartition = true);
+      load(const std::string &filename, const bool autopartition = true);
 
       /**
        * This function is not implemented, but needs to be present for the
        * compiler.
        */
       void
-      save(const char *filename) const;
+      save(const std::string &filename) const;
 
       /**
        * This function is not implemented, but needs to be present for the

--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -463,17 +463,6 @@ public:
                         numbers::invalid_unsigned_int)) const;
 
   /**
-   * Same as above but takes a filename as a <code>char</code> pointer.
-   *
-   * @deprecated This function is deprecated. Use the one taking <code>std::string</code> instead.
-   */
-  DEAL_II_DEPRECATED void
-  save(const char *                                 filename,
-       const std::pair<unsigned int, unsigned int> &chunk_size =
-         std::make_pair(numbers::invalid_unsigned_int,
-                        numbers::invalid_unsigned_int)) const;
-
-  /**
    * Loads the distributed matrix from file @p filename using HDF5.
    * In case that deal.II was built without HDF5
    * a call to this function will cause an exception to be thrown.
@@ -486,14 +475,6 @@ public:
    */
   void
   load(const std::string &filename);
-
-  /**
-   * Same as above but takes a filename as a <code>char</code> pointer.
-   *
-   * @deprecated This function is deprecated. Use the one taking <code>std::string</code> instead.
-   */
-  DEAL_II_DEPRECATED void
-  load(const char *filename);
 
   /**
    * Compute the Cholesky factorization of the matrix using ScaLAPACK

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7552,8 +7552,9 @@ DataOutInterface<dim, spacedim>::write_svg(std::ostream &out) const
 
 template <int dim, int spacedim>
 void
-DataOutInterface<dim, spacedim>::write_vtu_in_parallel(const char *filename,
-                                                       MPI_Comm    comm) const
+DataOutInterface<dim, spacedim>::write_vtu_in_parallel(
+  const std::string &filename,
+  MPI_Comm           comm) const
 {
 #ifndef DEAL_II_WITH_MPI
   // without MPI fall back to the normal way to write a vtu file:
@@ -7570,7 +7571,7 @@ DataOutInterface<dim, spacedim>::write_vtu_in_parallel(const char *filename,
   AssertThrowMPI(ierr);
   MPI_File fh;
   ierr = MPI_File_open(comm,
-                       const_cast<char *>(filename),
+                       DEAL_II_MPI_CONST_CAST(filename.c_str()),
                        MPI_MODE_CREATE | MPI_MODE_WRONLY,
                        info,
                        &fh);
@@ -7594,7 +7595,7 @@ DataOutInterface<dim, spacedim>::write_vtu_in_parallel(const char *filename,
       DataOutBase::write_vtu_header(ss, vtk_flags);
       header_size = ss.str().size();
       ierr = MPI_File_write(fh,
-                            const_cast<char *>(ss.str().c_str()),
+                            DEAL_II_MPI_CONST_CAST(ss.str().c_str()),
                             header_size,
                             MPI_CHAR,
                             MPI_STATUS_IGNORE);
@@ -7614,7 +7615,7 @@ DataOutInterface<dim, spacedim>::write_vtu_in_parallel(const char *filename,
                                 vtk_flags,
                                 ss);
     ierr = MPI_File_write_ordered(fh,
-                                  const_cast<char *>(ss.str().c_str()),
+                                  DEAL_II_MPI_CONST_CAST(ss.str().c_str()),
                                   ss.str().size(),
                                   MPI_CHAR,
                                   MPI_STATUS_IGNORE);
@@ -7628,7 +7629,7 @@ DataOutInterface<dim, spacedim>::write_vtu_in_parallel(const char *filename,
       DataOutBase::write_vtu_footer(ss);
       unsigned int footer_size = ss.str().size();
       ierr = MPI_File_write_shared(fh,
-                                   const_cast<char *>(ss.str().c_str()),
+                                   DEAL_II_MPI_CONST_CAST(ss.str().c_str()),
                                    footer_size,
                                    MPI_CHAR,
                                    MPI_STATUS_IGNORE);

--- a/source/base/event.cc
+++ b/source/base/event.cc
@@ -25,7 +25,7 @@ namespace Algorithms
   std::vector<std::string> Event::names;
 
   Event
-  Event::assign(const char *name)
+  Event::assign(const std::string &name)
   {
     unsigned int index = names.size();
     names.emplace_back(name);

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -296,12 +296,11 @@ FunctionParser<dim>::init_muparser() const
            constant != constants.end();
            ++constant)
         {
-          fp.get()[component]->DefineConst(constant->first.c_str(),
-                                           constant->second);
+          fp.get()[component]->DefineConst(constant->first, constant->second);
         }
 
       for (unsigned int iv = 0; iv < var_names.size(); ++iv)
-        fp.get()[component]->DefineVar(var_names[iv].c_str(), &vars.get()[iv]);
+        fp.get()[component]->DefineVar(var_names[iv], &vars.get()[iv]);
 
       // define some compatibility functions:
       fp.get()[component]->DefineFun("if", internal::mu_if, true);
@@ -411,7 +410,7 @@ FunctionParser<dim>::init_muparser() const
           std::cerr << "Token:    <" << e.GetToken() << ">\n";
           std::cerr << "Position: <" << e.GetPos() << ">\n";
           std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
-          AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg().c_str()));
+          AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
         }
     }
 }
@@ -462,7 +461,7 @@ FunctionParser<dim>::value(const Point<dim> & p,
       std::cerr << "Token:    <" << e.GetToken() << ">\n";
       std::cerr << "Position: <" << e.GetPos() << ">\n";
       std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
-      AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg().c_str()));
+      AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
       return 0.0;
     }
 }

--- a/source/base/job_identifier.cc
+++ b/source/base/job_identifier.cc
@@ -52,7 +52,7 @@ JobIdentifier::operator()() const
 
 
 std::string
-JobIdentifier::base_name(const char *filename)
+JobIdentifier::base_name(const std::string &filename)
 {
   std::string            name(filename);
   std::string::size_type pos;

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -461,7 +461,7 @@ ParameterHandler::parse_input(const std::string &filename,
 
 
 void
-ParameterHandler::parse_input_from_string(const char *       s,
+ParameterHandler::parse_input_from_string(const std::string &s,
                                           const std::string &last_line,
                                           const bool         skip_undefined)
 {

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1788,8 +1788,8 @@ namespace parallel
     void
     Triangulation<dim, spacedim>::DataTransfer::save(
       const typename dealii::internal::p4est::types<dim>::forest
-        *         parallel_forest,
-      const char *filename) const
+        *                parallel_forest,
+      const std::string &filename) const
     {
       // Large fractions of this function have been copied from
       // DataOutInterface::write_vtu_in_parallel.
@@ -1964,7 +1964,7 @@ namespace parallel
     Triangulation<dim, spacedim>::DataTransfer::load(
       const typename dealii::internal::p4est::types<dim>::forest
         *                parallel_forest,
-      const char *       filename,
+      const std::string &filename,
       const unsigned int n_attached_deserialize_fixed,
       const unsigned int n_attached_deserialize_variable)
     {
@@ -2689,20 +2689,19 @@ namespace parallel
     template <int dim, int spacedim>
     void
     Triangulation<dim, spacedim>::write_mesh_vtk(
-      const char *file_basename) const
+      const std::string &file_basename) const
     {
       Assert(parallel_forest != nullptr,
              ExcMessage("Can't produce output when no forest is created yet."));
-      dealii::internal::p4est::functions<dim>::vtk_write_file(parallel_forest,
-                                                              nullptr,
-                                                              file_basename);
+      dealii::internal::p4est::functions<dim>::vtk_write_file(
+        parallel_forest, nullptr, file_basename.c_str());
     }
 
 
 
     template <int dim, int spacedim>
     void
-    Triangulation<dim, spacedim>::save(const char *filename) const
+    Triangulation<dim, spacedim>::save(const std::string &filename) const
     {
       Assert(
         cell_attached_data.n_attached_deserialize == 0,
@@ -2757,7 +2756,7 @@ namespace parallel
           tria->data_transfer.clear();
         }
 
-      dealii::internal::p4est::functions<dim>::save(filename,
+      dealii::internal::p4est::functions<dim>::save(filename.c_str(),
                                                     parallel_forest,
                                                     false);
 
@@ -2778,8 +2777,8 @@ namespace parallel
 
     template <int dim, int spacedim>
     void
-    Triangulation<dim, spacedim>::load(const char *filename,
-                                       const bool  autopartition)
+    Triangulation<dim, spacedim>::load(const std::string &filename,
+                                       const bool         autopartition)
     {
       Assert(
         this->n_cells() > 0,
@@ -2827,7 +2826,7 @@ namespace parallel
         attached_count_fixed + attached_count_variable;
 
       parallel_forest = dealii::internal::p4est::functions<dim>::load_ext(
-        filename,
+        filename.c_str(),
         this->mpi_communicator,
         0,
         false,
@@ -5070,7 +5069,7 @@ namespace parallel
 
     template <int spacedim>
     void
-    Triangulation<1, spacedim>::load(const char *, const bool)
+    Triangulation<1, spacedim>::load(const std::string &, const bool)
     {
       Assert(false, ExcNotImplemented());
     }
@@ -5079,7 +5078,7 @@ namespace parallel
 
     template <int spacedim>
     void
-    Triangulation<1, spacedim>::save(const char *) const
+    Triangulation<1, spacedim>::save(const std::string &) const
     {
       Assert(false, ExcNotImplemented());
     }

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -2651,17 +2651,6 @@ ScaLAPACKMatrix<NumberType>::save(
 
 template <typename NumberType>
 void
-ScaLAPACKMatrix<NumberType>::save(
-  const char *                                 filename,
-  const std::pair<unsigned int, unsigned int> &chunk_size) const
-{
-  save(std::string(filename), chunk_size);
-}
-
-
-
-template <typename NumberType>
-void
 ScaLAPACKMatrix<NumberType>::save_serial(
   const std::string &                          filename,
   const std::pair<unsigned int, unsigned int> &chunk_size) const
@@ -3069,15 +3058,6 @@ ScaLAPACKMatrix<NumberType>::load(const std::string &filename)
   load_serial(filename);
 #    endif
 #  endif
-}
-
-
-
-template <typename NumberType>
-void
-ScaLAPACKMatrix<NumberType>::load(const char *filename)
-{
-  load(std::string(filename));
 }
 
 


### PR DESCRIPTION
Fixes #7309.
I went through the public interfaces of all classes to replace `const char*`by `std::string` interfaces where applicable and sensible. I didn't touch deprecated classes (e.g. `PointerMatrix`, `DataOutBase::tecplot_binary`(#7434)), `ExceptionBase` and `SmartPointer`, `Subscriptor`.
These latter classes store `const char *` member variables so can't be assigned from `std::string` safely.

The `SCALAPCK` overloads can go directly since the implementation dies not do more than the implicit cobversion does.

Also, fix some unnecessary calls to `c_str()` and use `DEAL_II_MPI_CONST_CAST` instead of `const_cast`.
