### PR TITLE
 Disallow using rvalue references for Subscriptor::(un)?subscribe 

### DIFF
--- a/doc/news/changes/incompatibilities/20181112DanielArndt
+++ b/doc/news/changes/incompatibilities/20181112DanielArndt
@@ -1,0 +1,8 @@
+Changed: Subscriptor::subscribe cannot be called with rvalue references anymore.
+In particular, temporary string literals cannot be used as argument. Storing
+string literals with the same content at the same memory location is
+implementation defined and cannot be relied upon. On the other hand, the
+subscriber strings are not compared by their memory address anymore but by their
+actual content.
+<br>
+(Daniel Arndt, 2018/11/12)

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -442,7 +442,7 @@ namespace parallel
        * Override the implementation of prepare_coarsening_and_refinement from
        * the base class. This is necessary if periodic boundaries are enabled
        * and the level difference over vertices over the periodic boundary
-       * must be not more than 2:1.
+       * must not be more than 2:1.
        */
       virtual bool
       prepare_coarsening_and_refinement() override;

--- a/tests/base/unsubscribe_subscriptor_01.cc
+++ b/tests/base/unsubscribe_subscriptor_01.cc
@@ -15,7 +15,9 @@
 
 
 
-// check that unsubscribing with a wrong id is handled correctly
+// check that unsubscribing with a wrong id is handled correctly. This time,
+// we check that unsubscribung with a different pointer with the same content
+// works as well
 
 
 #include <deal.II/base/smartpointer.h>
@@ -38,13 +40,17 @@ main()
 
   Subscriptor       subscriptor;
   std::atomic<bool> dummy_a;
-  const char *      foo_a = "a";
-  const char *      foo_b = "b";
-  subscriptor.subscribe(&dummy_a, foo_a);
-  subscriptor.unsubscribe(&dummy_a, foo_b);
-  std::atomic<bool> dummy_b;
-  subscriptor.unsubscribe(&dummy_b, foo_a);
-  subscriptor.unsubscribe(&dummy_a, foo_a);
+  const char *      foo        = "a";
+  const std::string foo_string = "a";
+  subscriptor.subscribe(&dummy_a, foo);
+  subscriptor.unsubscribe(&dummy_a, foo_string.c_str());
+
+  deallog << "OK" << std::endl;
+
+  subscriptor.subscribe(&dummy_a, foo);
+  subscriptor.unsubscribe(&dummy_a, "a");
+
+  deallog << "OK" << std::endl;
 
   return 0;
 }

--- a/tests/base/unsubscribe_subscriptor_01.output
+++ b/tests/base/unsubscribe_subscriptor_01.output
@@ -1,0 +1,3 @@
+
+DEAL::OK
+DEAL::OK


### PR DESCRIPTION
Storing string literals with the same content at the same memory location is implementation-defined and
cannot be relied upon.
Hence, it is not safe to use temporary string literals as argument to `Subscriptor::(un)?subscribe`.
This PR simply disallows doing that avoiding hard to track down errors. 