### PR TITLE
Static initialization

### DIFF
--- a/cmake/scripts/expand_instantiations.cc
+++ b/cmake/scripts/expand_instantiations.cc
@@ -52,11 +52,16 @@
 #include <map>
 #include <string>
 
-// a map from the keys in the expansion lists to the list itself. For
+// Returns a map from the keys in the expansion lists to the list itself. For
 // instance, the example above will lead to the entry
-//      expansion_lists[REAL_SCALARS] = (double, float)
+//      get_expansion_lists()[REAL_SCALARS] = (double, float)
 // in this map, among others
-std::map<std::string, std::list<std::string>> expansion_lists;
+std::map<std::string, std::list<std::string>> &
+get_expansion_lists()
+{
+  static std::map<std::string, std::list<std::string>> expansion_lists;
+  return expansion_lists;
+}
 
 
 
@@ -281,7 +286,7 @@ substitute_tokens(const std::string &text,
 
 // read and parse the expansion lists like
 //   REAL_SCALARS    := { double; float}
-// as specified at the top of the file and store them in the global
+// as specified at the top of the file and store them in the static
 // expansion_lists variable
 void
 read_expansion_lists(const std::string &filename)
@@ -338,7 +343,7 @@ read_expansion_lists(const std::string &filename)
       // happen if, for example, we have "Vector<double>; TRILINOS_VECTOR;"
       // and if TRILINOS_VECTOR is an empty expansion after running
       // ./configure)
-      expansion_lists[name] =
+      get_expansion_lists()[name] =
         delete_empty_entries(split_string_list(expansion, ';'));
     }
 }
@@ -361,7 +366,7 @@ substitute(const std::string &                                   text,
       const std::string name    = substitutions.front().first,
                         pattern = substitutions.front().second;
 
-      if (expansion_lists.find(pattern) == expansion_lists.end())
+      if (get_expansion_lists().find(pattern) == get_expansion_lists().end())
         {
           std::cerr << "could not find pattern '" << pattern << "'"
                     << std::endl;
@@ -373,8 +378,8 @@ substitute(const std::string &                                   text,
         rest_of_substitutions(++substitutions.begin(), substitutions.end());
 
       for (std::list<std::string>::const_iterator expansion =
-             expansion_lists[pattern].begin();
-           expansion != expansion_lists[pattern].end();
+             get_expansion_lists()[pattern].begin();
+           expansion != get_expansion_lists()[pattern].end();
            ++expansion)
         {
           std::string new_text = substitute_tokens(text, name, *expansion);
@@ -388,7 +393,7 @@ substitute(const std::string &                                   text,
       const std::string name    = substitutions.front().first,
                         pattern = substitutions.front().second;
 
-      if (expansion_lists.find(pattern) == expansion_lists.end())
+      if (get_expansion_lists().find(pattern) == get_expansion_lists().end())
         {
           std::cerr << "could not find pattern '" << pattern << "'"
                     << std::endl;
@@ -396,8 +401,8 @@ substitute(const std::string &                                   text,
         }
 
       for (std::list<std::string>::const_iterator expansion =
-             expansion_lists[pattern].begin();
-           expansion != expansion_lists[pattern].end();
+             get_expansion_lists()[pattern].begin();
+           expansion != get_expansion_lists()[pattern].end();
            ++expansion)
         {
           // surround each block in the for loop with an if-def hack

--- a/include/deal.II/base/job_identifier.h
+++ b/include/deal.II/base/job_identifier.h
@@ -66,6 +66,12 @@ public:
   const std::string
   operator()() const;
 
+  /**
+   * Function to identify the presently running program.
+   */
+  static const JobIdentifier &
+  get_dealjobid();
+
 private:
   /**
    * String holding the identifier of the presently running program.
@@ -73,14 +79,6 @@ private:
   std::string id;
 };
 
-
-/*----------------------------- Inline functions ----------------------------*/
-
-
-/**
- * Global object to identify the presently running program.
- */
-extern JobIdentifier dealjobid;
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1568,9 +1568,9 @@ namespace Patterns
 
     namespace internal
     {
-      const std::array<std::string, 4> default_list_separator{
+      constexpr std::array<const char *, 4> default_list_separator{
         {",", ";", "|", "%"}};
-      const std::array<std::string, 4> default_map_separator{
+      constexpr std::array<const char *, 4> default_map_separator{
         {":", "=", "@", "#"}};
 
       // specialize a type for all of the STL containers and maps

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1303,11 +1303,19 @@ namespace FETools
       // running, there are no thread-safety issues here. since this is
       // compiled for all dimensions at once, need to create objects for
       // each dimension and then separate between them further down
-      static std::array<
+      std::array<
         std::array<std::map<std::string, std::unique_ptr<const Subscriptor>>,
                    4>,
-        4>
-        fe_name_map = fill_default_map();
+        4> &
+      get_fe_name_map()
+      {
+        static std::array<
+          std::array<std::map<std::string, std::unique_ptr<const Subscriptor>>,
+                     4>,
+          4>
+          fe_name_map = fill_default_map();
+        return fe_name_map;
+      }
     } // namespace FEToolsAddFENameHelper
 
     namespace FEToolsGetInterpolationMatrixHelper
@@ -2413,13 +2421,15 @@ namespace FETools
       internal::FEToolsAddFENameHelper::fe_name_map_lock);
 
     Assert(
-      internal::FEToolsAddFENameHelper::fe_name_map[dim][spacedim].find(name) ==
-        internal::FEToolsAddFENameHelper::fe_name_map[dim][spacedim].end(),
+      internal::FEToolsAddFENameHelper::get_fe_name_map()[dim][spacedim].find(
+        name) ==
+        internal::FEToolsAddFENameHelper::get_fe_name_map()[dim][spacedim]
+          .end(),
       ExcMessage("Cannot change existing element in finite element name list"));
 
     // Insert the normalized name into
     // the map
-    internal::FEToolsAddFENameHelper::fe_name_map[dim][spacedim][name] =
+    internal::FEToolsAddFENameHelper::get_fe_name_map()[dim][spacedim][name] =
       std::unique_ptr<const Subscriptor>(factory);
   }
 
@@ -2669,7 +2679,7 @@ namespace FETools
       get_fe_by_name(std::string &name)
       {
         return get_fe_by_name_ext<dim, spacedim>(
-          name, FEToolsAddFENameHelper::fe_name_map[dim][spacedim]);
+          name, FEToolsAddFENameHelper::get_fe_name_map()[dim][spacedim]);
       }
     } // namespace FEToolsGetFEHelper
   }   // namespace internal

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1303,7 +1303,7 @@ namespace FETools
       // running, there are no thread-safety issues here. since this is
       // compiled for all dimensions at once, need to create objects for
       // each dimension and then separate between them further down
-      std::array<
+      inline std::array<
         std::array<std::map<std::string, std::unique_ptr<const Subscriptor>>,
                    4>,
         4> &

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -43,7 +43,12 @@ namespace deal_II_exceptions
 {
   namespace internals
   {
-    std::string additional_assert_output;
+    std::string &
+    get_additional_assert_output()
+    {
+      static std::string additional_assert_output;
+      return additional_assert_output;
+    }
 
     bool show_stacktrace = true;
 
@@ -51,9 +56,9 @@ namespace deal_II_exceptions
   } // namespace internals
 
   void
-  set_additional_assert_output(const char *const p)
+  set_additional_assert_output(const std::string &p)
   {
-    internals::additional_assert_output = p;
+    internals::get_additional_assert_output() = p;
   }
 
   void
@@ -324,12 +329,13 @@ ExceptionBase::generate_message() const
       print_info(converter);
       print_stack_trace(converter);
 
-      if (!deal_II_exceptions::internals::additional_assert_output.empty())
+      if (!deal_II_exceptions::internals::get_additional_assert_output()
+             .empty())
         {
           converter
             << "--------------------------------------------------------"
             << std::endl
-            << deal_II_exceptions::internals::additional_assert_output
+            << deal_II_exceptions::internals::get_additional_assert_output()
             << std::endl;
         }
 

--- a/source/base/job_identifier.cc
+++ b/source/base/job_identifier.cc
@@ -24,7 +24,13 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-JobIdentifier dealjobid;
+const JobIdentifier &
+JobIdentifier::get_dealjobid()
+{
+  static JobIdentifier dealjobid;
+  return dealjobid;
+}
+
 
 
 JobIdentifier::JobIdentifier()

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -223,7 +223,7 @@ LogStream::attach(std::ostream &                o,
   file = &o;
   o.setf(flags);
   if (print_job_id)
-    o << dealjobid();
+    o << JobIdentifier::get_dealjobid()();
 }
 
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -35,26 +35,6 @@ namespace GridGenerator
 {
   namespace
   {
-    // Corner points of the cube [-1,1]^3
-    const Point<3> hexahedron[8] = {Point<3>(-1, -1, -1),
-                                    Point<3>(+1, -1, -1),
-                                    Point<3>(-1, +1, -1),
-                                    Point<3>(+1, +1, -1),
-                                    Point<3>(-1, -1, +1),
-                                    Point<3>(+1, -1, +1),
-                                    Point<3>(-1, +1, +1),
-                                    Point<3>(+1, +1, +1)};
-
-    // Octahedron inscribed in the cube
-    // [-1,1]^3
-    const Point<3> octahedron[6] = {Point<3>(-1, 0, 0),
-                                    Point<3>(1, 0, 0),
-                                    Point<3>(0, -1, 0),
-                                    Point<3>(0, 1, 0),
-                                    Point<3>(0, 0, -1),
-                                    Point<3>(0, 0, 1)};
-
-
     /**
      * Perform the action specified by the @p colorize flag of the
      * hyper_rectangle() function of this class.
@@ -3919,6 +3899,16 @@ namespace GridGenerator
     std::vector<Point<3>>    vertices;
     std::vector<CellData<3>> cells;
 
+    // Corner points of the cube [-1,1]^3
+    static const std::array<Point<3>, 8> hexahedron = {{{-1, -1, -1}, //
+                                                        {+1, -1, -1}, //
+                                                        {-1, +1, -1}, //
+                                                        {+1, +1, -1}, //
+                                                        {-1, -1, +1}, //
+                                                        {+1, -1, +1}, //
+                                                        {-1, +1, +1}, //
+                                                        {+1, +1, +1}}};
+
     // Start with the shell bounded by
     // two nested cubes
     if (n == 6)
@@ -3952,8 +3942,17 @@ namespace GridGenerator
     // A more regular subdivision can
     // be obtained by two nested
     // rhombic dodecahedra
+
     else if (n == 12)
       {
+        // Octahedron inscribed in the cube [-1,1]^3
+        static const std::array<Point<3>, 6> octahedron = {{{-1, 0, 0}, //
+                                                            {1, 0, 0},  //
+                                                            {0, -1, 0}, //
+                                                            {0, 1, 0},  //
+                                                            {0, 0, -1}, //
+                                                            {0, 0, 1}}};
+
         for (unsigned int i = 0; i < 8; ++i)
           vertices.push_back(p + hexahedron[i] * irad);
         for (unsigned int i = 0; i < 6; ++i)

--- a/tests/base/base_name.cc
+++ b/tests/base/base_name.cc
@@ -22,9 +22,10 @@ main()
 {
   initlog();
 
-  deallog << dealjobid.base_name("mypath/test.cc") << std::endl;
-  ;
-  deallog << dealjobid.base_name("/foo.bar/mypath/test.cc") << std::endl;
+  deallog << JobIdentifier::get_dealjobid().base_name("mypath/test.cc")
+          << std::endl;
+  deallog << JobIdentifier::get_dealjobid().base_name("/foo.bar/mypath/test.cc")
+          << std::endl;
 
   return 0;
 }


### PR DESCRIPTION
This PR attempts to avoid problems with the initialization order of global variables as much as possible by deferring initialization upon first use or initializing the variables as compile time constants.
This PR does not change any of the static public variables (although that would probably be even more beneficial).

Apart from that:
- `clang-tidy` is run on `expand_instantiations` and
- `Points` can be created as compile-time constants.
