### PR TITLE
Template CUDA MatrixFree on VectorType

### DIFF
--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -79,10 +79,6 @@ namespace CUDAWrappers
     // TODO this should really be a CUDAWrappers::Point
     using point_type = Tensor<1, dim, Number>;
 
-    // Use Number2 so we don't hide the template parameter Number
-    template <typename Number2>
-    using CUDAVector = ::dealii::LinearAlgebra::CUDAWrappers::Vector<Number2>;
-
     /**
      * Parallelization scheme used: parallel_in_elem (parallelism at the level
      * of degrees of freedom) or parallel_over_elem (parallelism at the level of
@@ -183,18 +179,19 @@ namespace CUDAWrappers
      * This method runs the loop over all cells and apply the local operation on
      * each element in parallel. @p func is a functor which is appplied on each color.
      */
-    template <typename functor>
+    template <typename functor, typename VectorType>
     void
-    cell_loop(const functor &           func,
-              const CUDAVector<Number> &src,
-              CUDAVector<Number> &      dst) const;
+    cell_loop(const functor &   func,
+              const VectorType &src,
+              VectorType &      dst) const;
 
+    template <typename VectorType>
     void
-    copy_constrained_values(const CUDAVector<Number> &src,
-                            CUDAVector<Number> &      dst) const;
+    copy_constrained_values(const VectorType &src, VectorType &dst) const;
 
+    template <typename VectorType>
     void
-    set_constrained_values(const Number val, CUDAVector<Number> &dst) const;
+    set_constrained_values(const Number val, VectorType &dst) const;
 
     /**
      * Free all the memory allocated.

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -724,11 +724,14 @@ namespace CUDAWrappers
 
 
   template <int dim, typename Number>
+  template <typename VectorType>
   void
-  MatrixFree<dim, Number>::copy_constrained_values(
-    const CUDAVector<Number> &src,
-    CUDAVector<Number> &      dst) const
+  MatrixFree<dim, Number>::copy_constrained_values(const VectorType &src,
+                                                   VectorType &      dst) const
   {
+    static_assert(
+      std::is_same<Number, typename VectorType::value_type>::value,
+      "VectorType::value_type and Number should be of the same type.");
     internal::copy_constrained_dofs<Number>
       <<<constraint_grid_dim, constraint_block_dim>>>(constrained_dofs,
                                                       n_constrained_dofs,
@@ -739,10 +742,14 @@ namespace CUDAWrappers
 
 
   template <int dim, typename Number>
+  template <typename VectorType>
   void
-  MatrixFree<dim, Number>::set_constrained_values(Number              val,
-                                                  CUDAVector<Number> &dst) const
+  MatrixFree<dim, Number>::set_constrained_values(Number      val,
+                                                  VectorType &dst) const
   {
+    static_assert(
+      std::is_same<Number, typename VectorType::value_type>::value,
+      "VectorType::value_type and Number should be of the same type.");
     internal::set_constrained_dofs<Number>
       <<<constraint_grid_dim, constraint_block_dim>>>(constrained_dofs,
                                                       n_constrained_dofs,
@@ -762,11 +769,11 @@ namespace CUDAWrappers
 
 
   template <int dim, typename Number>
-  template <typename functor>
+  template <typename functor, typename VectorType>
   void
-  MatrixFree<dim, Number>::cell_loop(const functor &           func,
-                                     const CUDAVector<Number> &src,
-                                     CUDAVector<Number> &      dst) const
+  MatrixFree<dim, Number>::cell_loop(const functor &   func,
+                                     const VectorType &src,
+                                     VectorType &      dst) const
   {
     for (unsigned int i = 0; i < n_colors; ++i)
       internal::apply_kernel_shmem<dim, Number, functor>

--- a/tests/cuda/matrix_free_matrix_vector_01.cu
+++ b/tests/cuda/matrix_free_matrix_vector_01.cu
@@ -41,5 +41,9 @@ test()
   AffineConstraints<double> constraints;
   constraints.close();
 
-  do_test<dim, fe_degree, double, fe_degree + 1>(dof, constraints);
+  do_test<dim,
+          fe_degree,
+          double,
+          LinearAlgebra::CUDAWrappers::Vector<double>,
+          fe_degree + 1>(dof, constraints);
 }

--- a/tests/cuda/matrix_free_matrix_vector_02.cu
+++ b/tests/cuda/matrix_free_matrix_vector_02.cu
@@ -45,5 +45,9 @@ test()
                                            constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double, fe_degree + 1>(dof, constraints);
+  do_test<dim,
+          fe_degree,
+          double,
+          LinearAlgebra::CUDAWrappers::Vector<double>,
+          fe_degree + 1>(dof, constraints);
 }

--- a/tests/cuda/matrix_free_matrix_vector_03.cu
+++ b/tests/cuda/matrix_free_matrix_vector_03.cu
@@ -68,5 +68,9 @@ test()
 
   // Skip 2D tests with even fe_degree
   if ((dim == 3) || ((fe_degree % 2) == 1))
-    do_test<dim, fe_degree, double, fe_degree + 1>(dof, constraints);
+    do_test<dim,
+            fe_degree,
+            double,
+            LinearAlgebra::CUDAWrappers::Vector<double>,
+            fe_degree + 1>(dof, constraints);
 }

--- a/tests/cuda/matrix_free_matrix_vector_04.cu
+++ b/tests/cuda/matrix_free_matrix_vector_04.cu
@@ -44,5 +44,9 @@ test()
   AffineConstraints<double> constraints;
   constraints.close();
 
-  do_test<dim, fe_degree, double, fe_degree + 1>(dof, constraints);
+  do_test<dim,
+          fe_degree,
+          double,
+          LinearAlgebra::CUDAWrappers::Vector<double>,
+          fe_degree + 1>(dof, constraints);
 }

--- a/tests/cuda/matrix_free_matrix_vector_05.cu
+++ b/tests/cuda/matrix_free_matrix_vector_05.cu
@@ -78,5 +78,9 @@ test()
 
   // Skip 2D tests with even fe_degree
   if ((dim == 3) || ((fe_degree % 2) == 1))
-    do_test<dim, fe_degree, double, fe_degree + 1>(dof, constraints);
+    do_test<dim,
+            fe_degree,
+            double,
+            LinearAlgebra::CUDAWrappers::Vector<double>,
+            fe_degree + 1>(dof, constraints);
 }

--- a/tests/cuda/matrix_free_matrix_vector_06.cu
+++ b/tests/cuda/matrix_free_matrix_vector_06.cu
@@ -74,5 +74,9 @@ test()
                                            constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double, fe_degree + 1>(dof, constraints);
+  do_test<dim,
+          fe_degree,
+          double,
+          LinearAlgebra::CUDAWrappers::Vector<double>,
+          fe_degree + 1>(dof, constraints);
 }

--- a/tests/cuda/matrix_free_matrix_vector_06a.cu
+++ b/tests/cuda/matrix_free_matrix_vector_06a.cu
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Same as matrix_free_matrix_vector_06a but uses LA::distributed::Vector
+// instead of CUDAWrappers::Vector
+
+#include <deal.II/base/function.h>
+
+#include "../tests.h"
+#include "create_mesh.h"
+
+std::ofstream logfile("output");
+
+#include "matrix_vector_common.h"
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  if (fe_degree > 1)
+    return;
+  Triangulation<dim> tria;
+  create_mesh(tria);
+  tria.begin_active()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  typename Triangulation<dim>::active_cell_iterator cell, endc;
+  cell = tria.begin_active();
+  endc = tria.end();
+  for (; cell != endc; ++cell)
+    if (cell->center().norm() < 0.5)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  tria.begin(tria.n_levels() - 1)->set_refine_flag();
+  tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  tria.refine_global(1);
+  cell = tria.begin_active();
+  for (unsigned int i = 0; i < 10 - 3 * dim; ++i)
+    {
+      cell                 = tria.begin_active();
+      endc                 = tria.end();
+      unsigned int counter = 0;
+      for (; cell != endc; ++cell, ++counter)
+        if (counter % (7 - i) == 0)
+          cell->set_refine_flag();
+      tria.execute_coarsening_and_refinement();
+    }
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  VectorTools::interpolate_boundary_values(dof,
+                                           0,
+                                           Functions::ZeroFunction<dim>(),
+                                           constraints);
+  constraints.close();
+
+  do_test<dim,
+          fe_degree,
+          double,
+          LinearAlgebra::distributed::Vector<double, MemorySpace::CUDA>,
+          fe_degree + 1>(dof, constraints);
+}

--- a/tests/cuda/matrix_free_matrix_vector_06a.output
+++ b/tests/cuda/matrix_free_matrix_vector_06a.output
@@ -1,0 +1,7 @@
+
+DEAL:2d::Testing FE_Q<2>(1)
+DEAL:2d::Norm of difference: 0
+DEAL:2d::
+DEAL:3d::Testing FE_Q<3>(1)
+DEAL:3d::Norm of difference: 0
+DEAL:3d::

--- a/tests/cuda/matrix_free_matrix_vector_09.cu
+++ b/tests/cuda/matrix_free_matrix_vector_09.cu
@@ -72,5 +72,9 @@ test()
                                            constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double, fe_degree + 1>(dof, constraints);
+  do_test<dim,
+          fe_degree,
+          double,
+          LinearAlgebra::CUDAWrappers::Vector<double>,
+          fe_degree + 1>(dof, constraints);
 }

--- a/tests/cuda/matrix_vector_common.h
+++ b/tests/cuda/matrix_vector_common.h
@@ -34,6 +34,7 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/cuda_vector.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/read_write_vector.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
@@ -53,7 +54,11 @@ test();
 
 
 
-template <int dim, int fe_degree, typename Number, int n_q_points_1d>
+template <int dim,
+          int fe_degree,
+          typename Number,
+          typename VectorType,
+          int n_q_points_1d>
 void
 do_test(const DoFHandler<dim> &          dof,
         const AffineConstraints<double> &constraints)
@@ -70,12 +75,12 @@ do_test(const DoFHandler<dim> &          dof,
   const QGauss<1> quad(n_q_points_1d);
   mf_data.reinit(mapping, dof, constraints, quad, additional_data);
 
-  const unsigned int                                    n_dofs = dof.n_dofs();
-  MatrixFreeTest<dim, fe_degree, Number, n_q_points_1d> mf(mf_data);
-  Vector<Number>                              in_host(n_dofs), out_host(n_dofs);
-  LinearAlgebra::ReadWriteVector<Number>      in(n_dofs), out(n_dofs);
-  LinearAlgebra::CUDAWrappers::Vector<Number> in_device(n_dofs);
-  LinearAlgebra::CUDAWrappers::Vector<Number> out_device(n_dofs);
+  const unsigned int n_dofs = dof.n_dofs();
+  MatrixFreeTest<dim, fe_degree, Number, VectorType, n_q_points_1d> mf(mf_data);
+  Vector<Number>                         in_host(n_dofs), out_host(n_dofs);
+  LinearAlgebra::ReadWriteVector<Number> in(n_dofs), out(n_dofs);
+  VectorType                             in_device(n_dofs);
+  VectorType                             out_device(n_dofs);
 
   for (unsigned int i = 0; i < n_dofs; ++i)
     {

--- a/tests/cuda/matrix_vector_mf.h
+++ b/tests/cuda/matrix_vector_mf.h
@@ -19,6 +19,7 @@
 // general, with and without hanging nodes).
 
 #include <deal.II/lac/cuda_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 
 #include <deal.II/matrix_free/cuda_fe_evaluation.h>
 #include <deal.II/matrix_free/cuda_matrix_free.h>
@@ -94,7 +95,8 @@ operator()(const unsigned int                                          cell,
 template <int dim,
           int fe_degree,
           typename Number,
-          int n_q_points_1d = fe_degree + 1>
+          typename VectorType = LinearAlgebra::CUDAWrappers::Vector<Number>,
+          int n_q_points_1d   = fe_degree + 1>
 class MatrixFreeTest
 {
 public:
@@ -102,8 +104,7 @@ public:
     : data(data_in){};
 
   void
-  vmult(LinearAlgebra::CUDAWrappers::Vector<Number> &      dst,
-        const LinearAlgebra::CUDAWrappers::Vector<Number> &src);
+  vmult(VectorType &dst, const VectorType &src);
 
 private:
   const CUDAWrappers::MatrixFree<dim, Number> &data;
@@ -111,11 +112,15 @@ private:
 
 
 
-template <int dim, int fe_degree, typename Number, int n_q_points_1d>
+template <int dim,
+          int fe_degree,
+          typename Number,
+          typename VectorType,
+          int n_q_points_1d>
 void
-MatrixFreeTest<dim, fe_degree, Number, n_q_points_1d>::vmult(
-  LinearAlgebra::CUDAWrappers::Vector<Number> &      dst,
-  const LinearAlgebra::CUDAWrappers::Vector<Number> &src)
+MatrixFreeTest<dim, fe_degree, Number, VectorType, n_q_points_1d>::vmult(
+  VectorType &      dst,
+  const VectorType &src)
 {
   dst = static_cast<Number>(0.);
   HelmholtzOperator<dim, fe_degree, Number, n_q_points_1d> helmholtz_operator;


### PR DESCRIPTION
Template the CUDA MatrixFree on the VectorType to be able to use both `CUDAWrappers::Vector<Number>` and `LA::d:Vector<Number, MemorySpace::CUDA>`. Right now, we can only use `CUDAWrappers::Vector<Number>`.