### PR TITLE
Avoid integer overflow in Utilities::pack_integers

### DIFF
--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -278,7 +278,7 @@ namespace Utilities
     AssertIndexRange(bits_per_dim * dim, 65);
     Assert(bits_per_dim > 0, ExcMessage("bits_per_dim should be positive"));
 
-    const Integer mask = (1 << bits_per_dim) - 1;
+    const Integer mask = (Integer(1) << bits_per_dim) - 1;
 
     Integer res = 0;
     for (unsigned int i = 0; i < dim; ++i)


### PR DESCRIPTION
Coverity detected that
```
1 << bits_per_dim
```
may overflow in `Utillities::pack_integers`. Simply start with a large enough type to begin with.