### PR TITLE
Lazily initialize VectorMemory::Pool

### DIFF
--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -438,7 +438,8 @@ private:
   /**
    * Array of allocated vectors.
    */
-  static Pool pool;
+  static Pool &
+  get_pool();
 
   /**
    * Overall number of allocations. Only used for bookkeeping and to generate

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -436,7 +436,7 @@ private:
   };
 
   /**
-   * Array of allocated vectors.
+   * Return an array of allocated vectors.
    */
   static Pool &
   get_pool();

--- a/source/base/cuda.cu
+++ b/source/base/cuda.cu
@@ -45,18 +45,6 @@ namespace Utilities
 
     Handle::~Handle()
     {
-      dealii::GrowingVectorMemory<
-        LinearAlgebra::CUDAWrappers::Vector<float>>::release_unused_memory();
-      dealii::GrowingVectorMemory<
-        LinearAlgebra::CUDAWrappers::Vector<double>>::release_unused_memory();
-
-      dealii::GrowingVectorMemory<
-        LinearAlgebra::distributed::Vector<float, dealii::MemorySpace::CUDA>>::
-        release_unused_memory();
-      dealii::GrowingVectorMemory<
-        LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::CUDA>>::
-        release_unused_memory();
-
       cusolverStatus_t cusolver_error_code =
         cusolverDnDestroy(cusolver_dn_handle);
       AssertCusolver(cusolver_error_code);

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -598,14 +598,9 @@ struct MPILogInitAll
 // cards for different processes even if only one node is used. The choice below
 // is based on the MPI proccess id.
 // MPI needs to be initialized before using this function.
-//
-// Also initialize a dummy handle that makes sure that unused memory is released
-// before the device shuts down.
 void
 init_cuda(const bool use_mpi = false)
 {
-  static Utilities::CUDA::Handle cuda_handle;
-
 #  ifndef DEAL_II_WITH_MPI
   Assert(use_mpi == false, ExcInternalError());
 #  endif


### PR DESCRIPTION
Part of #7443.
Initializing `VectorMemory::Pool` on first call, makes sure that it is destroyed before the `CUDA` driver is shut down. Hence, `Utilities::CUDA::Handle` does not need to deal with clearing the memory pool in its destructor. In particular, it is not necessary anymore to instantiate a `static` `Utilities::CUDA::Handle` in all the tests (and all the `CUDA` applications that use `VectorMemory::Pool` directly or indirectly).