### PR TITLE
Avoid C-style cast in base

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -407,8 +407,8 @@ namespace internal
       // never arrive here because they are non-trivial).
 
       if (std::is_trivial<T>::value == true)
-        std::memcpy((void *)(destination_ + begin),
-                    (void *)(source_ + begin),
+        std::memcpy(static_cast<void *>(destination_ + begin),
+                    static_cast<const void *>(source_ + begin),
                     (end - begin) * sizeof(T));
       else
         for (std::size_t i = begin; i < end; ++i)
@@ -474,8 +474,8 @@ namespace internal
       // never arrive here because they are non-trivial).
 
       if (std::is_trivial<T>::value == true)
-        std::memcpy((void *)(destination_ + begin),
-                    (void *)(source_ + begin),
+        std::memcpy(static_cast<void *>(destination_ + begin),
+                    static_cast<void *>(source_ + begin),
                     (end - begin) * sizeof(T));
       else
         for (std::size_t i = begin; i < end; ++i)
@@ -536,7 +536,9 @@ namespace internal
           // cast element to (void*) to silence compiler warning for virtual
           // classes (they will never arrive here because they are
           // non-trivial).
-          if (std::memcmp(zero, (void *)&element, sizeof(T)) == 0)
+          if (std::memcmp(zero,
+                          static_cast<const void *>(&element),
+                          sizeof(T)) == 0)
             trivial_element = true;
         }
       if (size < minimum_parallel_grain_size)
@@ -557,7 +559,7 @@ namespace internal
       // classes (they will never arrive here because they are
       // non-trivial).
       if (std::is_trivial<T>::value == true && trivial_element)
-        std::memset((void *)(destination_ + begin),
+        std::memset(static_cast<void *>(destination_ + begin),
                     0,
                     (end - begin) * sizeof(T));
       else
@@ -640,7 +642,7 @@ namespace internal
       // classes (they will never arrive here because they are
       // non-trivial).
       if (std::is_trivial<T>::value == true)
-        std::memset((void *)(destination_ + begin),
+        std::memset(static_cast<void *>(destination_ + begin),
                     0,
                     (end - begin) * sizeof(T));
       else
@@ -861,7 +863,7 @@ AlignedVector<T>::reserve(const size_type size_alloc)
       // allocate and align along 64-byte boundaries (this is enough for all
       // levels of vectorization currently supported by deal.II)
       T *new_data;
-      Utilities::System::posix_memalign((void **)&new_data,
+      Utilities::System::posix_memalign(reinterpret_cast<void **>(&new_data),
                                         64,
                                         size_actual_allocate);
 

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1518,7 +1518,7 @@ namespace Patterns
         std::stringstream str;
         if (std::is_same<T, unsigned char>::value ||
             std::is_same<T, signed char>::value || std::is_same<T, char>::value)
-          str << (int)value;
+          str << static_cast<int>(value);
         else if (std::is_same<T, bool>::value)
           str << (value ? "true" : "false");
         else

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -372,7 +372,7 @@ template <int dim, typename Number>
 inline Number
 Point<dim, Number>::operator()(const unsigned int index) const
 {
-  AssertIndexRange((int)index, dim);
+  AssertIndexRange(index, dim);
   return this->values[index];
 }
 
@@ -382,7 +382,7 @@ template <int dim, typename Number>
 inline Number &
 Point<dim, Number>::operator()(const unsigned int index)
 {
-  AssertIndexRange((int)index, dim);
+  AssertIndexRange(index, dim);
   return this->values[index];
 }
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -109,7 +109,7 @@ namespace
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
       if (value_in > 63)
         return '=';
-      return encoding[(int)value_in];
+      return encoding[static_cast<int>(value_in)];
     }
 
     int
@@ -266,9 +266,9 @@ namespace
         uLongf compressed_data_length = compressBound(data.size() * sizeof(T));
         char * compressed_data        = new char[compressed_data_length];
         int    err =
-          compress2((Bytef *)compressed_data,
+          compress2(reinterpret_cast<Bytef *>(compressed_data),
                     &compressed_data_length,
-                    (const Bytef *)data.data(),
+                    reinterpret_cast<const Bytef *>(data.data()),
                     data.size() * sizeof(T),
                     get_zlib_compression_level(flags.compression_level));
         (void)err;
@@ -276,11 +276,12 @@ namespace
 
         // now encode the compression header
         const uint32_t compression_header[4] = {
-          1,                                   /* number of blocks */
-          (uint32_t)(data.size() * sizeof(T)), /* size of block */
-          (uint32_t)(data.size() * sizeof(T)), /* size of last block */
-          (uint32_t)
-            compressed_data_length}; /* list of compressed sizes of blocks */
+          1,                                              /* number of blocks */
+          static_cast<uint32_t>(data.size() * sizeof(T)), /* size of block */
+          static_cast<uint32_t>(data.size() *
+                                sizeof(T)), /* size of last block */
+          static_cast<uint32_t>(
+            compressed_data_length)}; /* list of compressed sizes of blocks */
 
         char *encoded_header =
           encode_block(reinterpret_cast<const char *>(&compression_header[0]),
@@ -6391,25 +6392,25 @@ namespace DataOutBase
                              0,
                              n_subdivisions);
 
-                x_min = std::min(x_min, (double)projected_points[0][0]);
-                x_min = std::min(x_min, (double)projected_points[1][0]);
-                x_min = std::min(x_min, (double)projected_points[2][0]);
-                x_min = std::min(x_min, (double)projected_points[3][0]);
+                x_min = std::min(x_min, projected_points[0][0]);
+                x_min = std::min(x_min, projected_points[1][0]);
+                x_min = std::min(x_min, projected_points[2][0]);
+                x_min = std::min(x_min, projected_points[3][0]);
 
-                x_max = std::max(x_max, (double)projected_points[0][0]);
-                x_max = std::max(x_max, (double)projected_points[1][0]);
-                x_max = std::max(x_max, (double)projected_points[2][0]);
-                x_max = std::max(x_max, (double)projected_points[3][0]);
+                x_max = std::max(x_max, projected_points[0][0]);
+                x_max = std::max(x_max, projected_points[1][0]);
+                x_max = std::max(x_max, projected_points[2][0]);
+                x_max = std::max(x_max, projected_points[3][0]);
 
-                y_min = std::min(y_min, (double)projected_points[0][1]);
-                y_min = std::min(y_min, (double)projected_points[1][1]);
-                y_min = std::min(y_min, (double)projected_points[2][1]);
-                y_min = std::min(y_min, (double)projected_points[3][1]);
+                y_min = std::min(y_min, projected_points[0][1]);
+                y_min = std::min(y_min, projected_points[1][1]);
+                y_min = std::min(y_min, projected_points[2][1]);
+                y_min = std::min(y_min, projected_points[3][1]);
 
-                y_max = std::max(y_max, (double)projected_points[0][1]);
-                y_max = std::max(y_max, (double)projected_points[1][1]);
-                y_max = std::max(y_max, (double)projected_points[2][1]);
-                y_max = std::max(y_max, (double)projected_points[3][1]);
+                y_max = std::max(y_max, projected_points[0][1]);
+                y_max = std::max(y_max, projected_points[1][1]);
+                y_max = std::max(y_max, projected_points[2][1]);
+                y_max = std::max(y_max, projected_points[3][1]);
 
                 Assert((flags.height_vector < patch->data.n_rows()) ||
                          patch->data.n_rows() == 0,
@@ -6417,32 +6418,32 @@ namespace DataOutBase
                                      0,
                                      patch->data.n_rows()));
 
-                z_min = std::min(z_min,
-                                 (double)patch->data(flags.height_vector,
+                z_min = std::min<double>(z_min,
+                                         patch->data(flags.height_vector,
                                                      i1 * d1 + i2 * d2));
-                z_min = std::min(z_min,
-                                 (double)patch->data(flags.height_vector,
+                z_min = std::min<double>(z_min,
+                                         patch->data(flags.height_vector,
                                                      (i1 + 1) * d1 + i2 * d2));
-                z_min = std::min(z_min,
-                                 (double)patch->data(flags.height_vector,
+                z_min = std::min<double>(z_min,
+                                         patch->data(flags.height_vector,
                                                      i1 * d1 + (i2 + 1) * d2));
                 z_min =
-                  std::min(z_min,
-                           (double)patch->data(flags.height_vector,
+                  std::min<double>(z_min,
+                                   patch->data(flags.height_vector,
                                                (i1 + 1) * d1 + (i2 + 1) * d2));
 
-                z_max = std::max(z_max,
-                                 (double)patch->data(flags.height_vector,
+                z_max = std::max<double>(z_max,
+                                         patch->data(flags.height_vector,
                                                      i1 * d1 + i2 * d2));
-                z_max = std::max(z_max,
-                                 (double)patch->data(flags.height_vector,
+                z_max = std::max<double>(z_max,
+                                         patch->data(flags.height_vector,
                                                      (i1 + 1) * d1 + i2 * d2));
-                z_max = std::max(z_max,
-                                 (double)patch->data(flags.height_vector,
+                z_max = std::max<double>(z_max,
+                                         patch->data(flags.height_vector,
                                                      i1 * d1 + (i2 + 1) * d2));
                 z_max =
-                  std::max(z_max,
-                           (double)patch->data(flags.height_vector,
+                  std::max<double>(z_max,
+                                   patch->data(flags.height_vector,
                                                (i1 + 1) * d1 + (i2 + 1) * d2));
               }
           }
@@ -6678,55 +6679,71 @@ namespace DataOutBase
 
                 x_min_perspective =
                   std::min(x_min_perspective,
-                           (double)projection_decompositions[0][0]);
+                           static_cast<double>(
+                             projection_decompositions[0][0]));
                 x_min_perspective =
                   std::min(x_min_perspective,
-                           (double)projection_decompositions[1][0]);
+                           static_cast<double>(
+                             projection_decompositions[1][0]));
                 x_min_perspective =
                   std::min(x_min_perspective,
-                           (double)projection_decompositions[2][0]);
+                           static_cast<double>(
+                             projection_decompositions[2][0]));
                 x_min_perspective =
                   std::min(x_min_perspective,
-                           (double)projection_decompositions[3][0]);
+                           static_cast<double>(
+                             projection_decompositions[3][0]));
 
                 x_max_perspective =
                   std::max(x_max_perspective,
-                           (double)projection_decompositions[0][0]);
+                           static_cast<double>(
+                             projection_decompositions[0][0]));
                 x_max_perspective =
                   std::max(x_max_perspective,
-                           (double)projection_decompositions[1][0]);
+                           static_cast<double>(
+                             projection_decompositions[1][0]));
                 x_max_perspective =
                   std::max(x_max_perspective,
-                           (double)projection_decompositions[2][0]);
+                           static_cast<double>(
+                             projection_decompositions[2][0]));
                 x_max_perspective =
                   std::max(x_max_perspective,
-                           (double)projection_decompositions[3][0]);
+                           static_cast<double>(
+                             projection_decompositions[3][0]));
 
                 y_min_perspective =
                   std::min(y_min_perspective,
-                           (double)projection_decompositions[0][1]);
+                           static_cast<double>(
+                             projection_decompositions[0][1]));
                 y_min_perspective =
                   std::min(y_min_perspective,
-                           (double)projection_decompositions[1][1]);
+                           static_cast<double>(
+                             projection_decompositions[1][1]));
                 y_min_perspective =
                   std::min(y_min_perspective,
-                           (double)projection_decompositions[2][1]);
+                           static_cast<double>(
+                             projection_decompositions[2][1]));
                 y_min_perspective =
                   std::min(y_min_perspective,
-                           (double)projection_decompositions[3][1]);
+                           static_cast<double>(
+                             projection_decompositions[3][1]));
 
                 y_max_perspective =
                   std::max(y_max_perspective,
-                           (double)projection_decompositions[0][1]);
+                           static_cast<double>(
+                             projection_decompositions[0][1]));
                 y_max_perspective =
                   std::max(y_max_perspective,
-                           (double)projection_decompositions[1][1]);
+                           static_cast<double>(
+                             projection_decompositions[1][1]));
                 y_max_perspective =
                   std::max(y_max_perspective,
-                           (double)projection_decompositions[2][1]);
+                           static_cast<double>(
+                             projection_decompositions[2][1]));
                 y_max_perspective =
                   std::max(y_max_perspective,
-                           (double)projection_decompositions[3][1]);
+                           static_cast<double>(
+                             projection_decompositions[3][1]));
               }
           }
       }
@@ -7283,9 +7300,10 @@ namespace DataOutBase
               out << "; font-weight:bold";
 
             out << "\">"
-                << (float)(((int)((z_min + index * (z_dimension / 4.)) *
-                                  10000)) /
-                           10000.);
+                << static_cast<float>(
+                     (static_cast<int>((z_min + index * (z_dimension / 4.)) *
+                                       10000)) /
+                     10000.);
 
             if (index == 4)
               out << " max";

--- a/source/base/function_lib.cc
+++ b/source/base/function_lib.cc
@@ -2647,8 +2647,7 @@ namespace Functions
         else if (p[d] >= interval_endpoints[d].second - delta_x)
           ix[d] = n_subintervals[d] - 1;
         else
-          ix[d] =
-            (unsigned int)((p[d] - interval_endpoints[d].first) / delta_x);
+          ix[d] = (p[d] - interval_endpoints[d].first) / delta_x;
       }
 
     // now compute the relative point within the interval/rectangle/box

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -433,7 +433,10 @@ namespace Utilities
         dealii::Utilities::MPI::n_mpi_processes(mpi_communicator);
 
       MPI_Op op;
-      int    ierr = MPI_Op_create((MPI_User_function *)&max_reduce, true, &op);
+      int    ierr =
+        MPI_Op_create(reinterpret_cast<MPI_User_function *>(&max_reduce),
+                      true,
+                      &op);
       AssertThrowMPI(ierr);
 
       MinMaxAvg in;

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -494,7 +494,7 @@ QProjector<1>::project_to_face(const Quadrature<0> &,
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
   AssertDimension(q_points.size(), 1);
 
-  q_points[0] = Point<dim>((double)face_no);
+  q_points[0] = Point<dim>(static_cast<double>(face_no));
 }
 
 
@@ -590,7 +590,7 @@ QProjector<1>::project_to_subface(const Quadrature<0> &,
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
   AssertDimension(q_points.size(), 1);
 
-  q_points[0] = Point<dim>((double)face_no);
+  q_points[0] = Point<dim>(static_cast<double>(face_no));
 }
 
 
@@ -726,7 +726,7 @@ QProjector<3>::project_to_subface(const Quadrature<2> &    quadrature,
     }
   // set the scale and translation parameter
   // for individual subfaces
-  switch ((unsigned char)ref_case)
+  switch (ref_case)
     {
       case RefinementCase<dim - 1>::cut_x:
         xi_scale       = 0.5;

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -438,7 +438,8 @@ TableHandler::write_text(std::ostream &out, const TextOutputFormat format) const
             {
               const std::string &key = sel_columns[j];
               column_widths[j] =
-                std::max(column_widths[j], (unsigned int)key.length());
+                std::max(column_widths[j],
+                         static_cast<unsigned int>(key.length()));
               out << std::setw(column_widths[j]);
               out << key << " | ";
             }

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -553,10 +553,11 @@ TimerOutput::print_summary() const
   // get the maximum width among all sections
   unsigned int max_width = 0;
   for (const auto &i : sections)
-    max_width = std::max(max_width, (unsigned int)i.first.length());
+    max_width =
+      std::max(max_width, static_cast<unsigned int>(i.first.length()));
 
   // 32 is the default width until | character
-  max_width                     = std::max(max_width + 1, (unsigned int)32);
+  max_width = std::max(max_width + 1, static_cast<unsigned int>(32));
   const std::string extra_dash  = std::string(max_width - 32, '-');
   const std::string extra_space = std::string(max_width - 32, ' ');
 

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -1051,7 +1051,7 @@ namespace Utilities
     unsigned int
     get_this_mpi_process(const Epetra_Comm &mpi_communicator)
     {
-      return (unsigned int)mpi_communicator.MyPID();
+      return static_cast<unsigned int>(mpi_communicator.MyPID());
     }
 
 


### PR DESCRIPTION
Part of #7459.
This PR replaces all C-style casts in `include-deal.II/base` and `source/base`.