### PR TITLE
Avoid C-style cast in hp

### DIFF
--- a/include/deal.II/hp/dof_level.h
+++ b/include/deal.II/hp/dof_level.h
@@ -338,7 +338,7 @@ namespace internal
     inline bool
     DoFLevel::is_compressed_entry(const active_fe_index_type active_fe_index)
     {
-      return ((signed_active_fe_index_type)active_fe_index < 0);
+      return (static_cast<signed_active_fe_index_type>(active_fe_index) < 0);
     }
 
 
@@ -349,8 +349,7 @@ namespace internal
     {
       // convert the active_fe_index into a signed type, flip all
       // bits, and get the unsigned representation back
-      return (active_fe_index_type) ~(
-        signed_active_fe_index_type)active_fe_index;
+      return ~(static_cast<signed_active_fe_index_type>(active_fe_index));
     }
 
 
@@ -366,7 +365,7 @@ namespace internal
 
       // make sure we are on an object for which DoFs have been
       // allocated at all
-      Assert(dof_offsets[obj_index] != (offset_type)(-1),
+      Assert(dof_offsets[obj_index] != static_cast<offset_type>(-1),
              ExcMessage("You are trying to access degree of freedom "
                         "information for an object on which no such "
                         "information is available"));
@@ -400,7 +399,7 @@ namespace internal
       // make sure we are on an
       // object for which DoFs have
       // been allocated at all
-      Assert(dof_offsets[obj_index] != (offset_type)(-1),
+      Assert(dof_offsets[obj_index] != static_cast<offset_type>(-1),
              ExcMessage("You are trying to access degree of freedom "
                         "information for an object on which no such "
                         "information is available"));

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -260,11 +260,11 @@ namespace internal
               dof_handler.levels[level]->dof_offsets =
                 std::vector<DoFLevel::offset_type>(
                   dof_handler.tria->n_raw_cells(level),
-                  (DoFLevel::offset_type)(-1));
+                  static_cast<DoFLevel::offset_type>(-1));
               dof_handler.levels[level]->cell_cache_offsets =
                 std::vector<DoFLevel::offset_type>(
                   dof_handler.tria->n_raw_cells(level),
-                  (DoFLevel::offset_type)(-1));
+                  static_cast<DoFLevel::offset_type>(-1));
 
               types::global_dof_index next_free_dof = 0;
               types::global_dof_index cache_size    = 0;
@@ -323,7 +323,7 @@ namespace internal
               Assert(static_cast<unsigned int>(std::count(
                        dof_handler.levels[level]->dof_offsets.begin(),
                        dof_handler.levels[level]->dof_offsets.end(),
-                       (DoFLevel::offset_type)(-1))) ==
+                       static_cast<DoFLevel::offset_type>(-1))) ==
                        dof_handler.tria->n_raw_cells(level) -
                          n_active_non_artificial_cells,
                      ExcInternalError());
@@ -964,7 +964,7 @@ namespace internal
               // up, and because every vector entry has exactly one processor
               // that owns it, the sum is correct
               std::vector<unsigned int> active_fe_indices(tr->n_active_cells(),
-                                                          (unsigned int)0);
+                                                          0u);
               for (const auto &cell : dof_handler.active_cell_iterators())
                 if (cell->is_locally_owned())
                   active_fe_indices[cell->active_cell_index()] =

--- a/source/hp/dof_level.cc
+++ b/source/hp/dof_level.cc
@@ -42,12 +42,12 @@ namespace internal
       unsigned int new_size = 0;
       for (unsigned int cell = 0; cell < dof_offsets.size();)
         // see if this cell is active on the current level
-        if (dof_offsets[cell] != (offset_type)(-1))
+        if (dof_offsets[cell] != static_cast<offset_type>(-1))
           {
             // find the next cell active on this level
             unsigned int next_cell = cell + 1;
             while ((next_cell < dof_offsets.size()) &&
-                   (dof_offsets[next_cell] == (offset_type)(-1)))
+                   (dof_offsets[next_cell] == static_cast<offset_type>(-1)))
               ++next_cell;
 
             const unsigned int next_offset =
@@ -87,15 +87,15 @@ namespace internal
       std::vector<types::global_dof_index> new_dof_indices;
       new_dof_indices.reserve(new_size);
       std::vector<offset_type> new_dof_offsets(dof_offsets.size(),
-                                               (offset_type)(-1));
+                                               static_cast<offset_type>(-1));
       for (unsigned int cell = 0; cell < dof_offsets.size();)
         // see if this cell is active on the current level
-        if (dof_offsets[cell] != (offset_type)(-1))
+        if (dof_offsets[cell] != static_cast<offset_type>(-1))
           {
             // find the next cell active on this level
             unsigned int next_cell = cell + 1;
             while ((next_cell < dof_offsets.size()) &&
-                   (dof_offsets[next_cell] == (offset_type)(-1)))
+                   (dof_offsets[next_cell] == static_cast<offset_type>(-1)))
               ++next_cell;
 
             const unsigned int next_offset =
@@ -169,7 +169,7 @@ namespace internal
       // dof_indices array after uncompression.
       unsigned int new_size = 0;
       for (unsigned int cell = 0; cell < dof_offsets.size(); ++cell)
-        if (dof_offsets[cell] != (offset_type)(-1))
+        if (dof_offsets[cell] != static_cast<offset_type>(-1))
           {
             // we know now that the slot for this cell is used. extract the
             // active_fe_index for it and see how many entries we need
@@ -181,15 +181,15 @@ namespace internal
       std::vector<types::global_dof_index> new_dof_indices;
       new_dof_indices.reserve(new_size);
       std::vector<offset_type> new_dof_offsets(dof_offsets.size(),
-                                               (offset_type)(-1));
+                                               static_cast<offset_type>(-1));
       for (unsigned int cell = 0; cell < dof_offsets.size();)
         // see if this cell is active on the current level
-        if (dof_offsets[cell] != (offset_type)(-1))
+        if (dof_offsets[cell] != static_cast<offset_type>(-1))
           {
             // find the next cell active on this level
             unsigned int next_cell = cell + 1;
             while ((next_cell < dof_offsets.size()) &&
-                   (dof_offsets[next_cell] == (offset_type)(-1)))
+                   (dof_offsets[next_cell] == static_cast<offset_type>(-1)))
               ++next_cell;
 
             const unsigned int next_offset =


### PR DESCRIPTION
Part of #7459.
This PR replaces all C-style casts in `include-deal.II/hp` and `source/hp`.