### PR TITLE
Make non_matching/coupling_0[56] more robust

### DIFF
--- a/tests/non_matching/coupling_05.cc
+++ b/tests/non_matching/coupling_05.cc
@@ -149,7 +149,7 @@ test()
 
   coupling.Tvmult(Mprojected_squares, space_square);
 
-  SolverControl                     cn(100, 1e-12);
+  SolverControl                     cn(100, 1e-12, false, false);
   TrilinosWrappers::SolverCG        solver(cn);
   TrilinosWrappers::PreconditionILU prec;
   prec.initialize(mass_matrix);

--- a/tests/non_matching/coupling_05.with_p4est=true.with_trilinos=true.mpirun=2.output
+++ b/tests/non_matching/coupling_05.with_p4est=true.with_trilinos=true.mpirun=2.output
@@ -6,9 +6,8 @@ DEAL:0::Dofs      : 17
 DEAL:0::Space dofs: 289
 DEAL:0::Local dofs      : 9
 DEAL:0::Local space dofs: 153
-DEAL:0::Convergence step 9 value 4.51115e-14
 DEAL:0::Squares norm    : 0.275853
-DEAL:0::Error on squares: 1.07673e-12
+DEAL:0::Error on squares: 1.07675e-12
 DEAL:0::dim: 2, spacedim: 2
 DEAL:0::FE      : FE_Q<2>(2)
 DEAL:0::Space FE: FE_Q<2>(2)
@@ -16,7 +15,6 @@ DEAL:0::Dofs      : 289
 DEAL:0::Space dofs: 289
 DEAL:0::Local dofs      : 153
 DEAL:0::Local space dofs: 153
-DEAL:0::Convergence step 12 value 2.66570e-13
 DEAL:0::Squares norm    : 1.98578
 DEAL:0::Error on squares: 4.16199e-10
 DEAL:0::dim: 2, spacedim: 3
@@ -26,7 +24,6 @@ DEAL:0::Dofs      : 289
 DEAL:0::Space dofs: 4913
 DEAL:0::Local dofs      : 153
 DEAL:0::Local space dofs: 2601
-DEAL:0::Convergence step 12 value 2.66570e-13
 DEAL:0::Squares norm    : 1.98578
 DEAL:0::Error on squares: 4.16199e-10
 DEAL:0::dim: 3, spacedim: 3
@@ -36,7 +33,6 @@ DEAL:0::Dofs      : 4913
 DEAL:0::Space dofs: 4913
 DEAL:0::Local dofs      : 2601
 DEAL:0::Local space dofs: 2601
-DEAL:0::Convergence step 12 value 6.65914e-13
 DEAL:0::Squares norm    : 11.6248
 DEAL:0::Error on squares: 4.61425e-08
 
@@ -47,9 +43,8 @@ DEAL:1::Dofs      : 17
 DEAL:1::Space dofs: 289
 DEAL:1::Local dofs      : 8
 DEAL:1::Local space dofs: 136
-DEAL:1::Convergence step 9 value 4.51115e-14
 DEAL:1::Squares norm    : 0.275853
-DEAL:1::Error on squares: 1.07673e-12
+DEAL:1::Error on squares: 1.07675e-12
 DEAL:1::dim: 2, spacedim: 2
 DEAL:1::FE      : FE_Q<2>(2)
 DEAL:1::Space FE: FE_Q<2>(2)
@@ -57,7 +52,6 @@ DEAL:1::Dofs      : 289
 DEAL:1::Space dofs: 289
 DEAL:1::Local dofs      : 136
 DEAL:1::Local space dofs: 136
-DEAL:1::Convergence step 12 value 2.66570e-13
 DEAL:1::Squares norm    : 1.98578
 DEAL:1::Error on squares: 4.16199e-10
 DEAL:1::dim: 2, spacedim: 3
@@ -67,7 +61,6 @@ DEAL:1::Dofs      : 289
 DEAL:1::Space dofs: 4913
 DEAL:1::Local dofs      : 136
 DEAL:1::Local space dofs: 2312
-DEAL:1::Convergence step 12 value 2.66570e-13
 DEAL:1::Squares norm    : 1.98578
 DEAL:1::Error on squares: 4.16199e-10
 DEAL:1::dim: 3, spacedim: 3
@@ -77,7 +70,6 @@ DEAL:1::Dofs      : 4913
 DEAL:1::Space dofs: 4913
 DEAL:1::Local dofs      : 2312
 DEAL:1::Local space dofs: 2312
-DEAL:1::Convergence step 12 value 6.65914e-13
 DEAL:1::Squares norm    : 11.6248
 DEAL:1::Error on squares: 4.61425e-08
 

--- a/tests/non_matching/coupling_06.cc
+++ b/tests/non_matching/coupling_06.cc
@@ -152,7 +152,7 @@ test()
 
   coupling.Tvmult(Mprojected_squares, space_square);
 
-  SolverControl                     cn(100, 1e-12);
+  SolverControl                     cn(100, 1e-12, false, false);
   TrilinosWrappers::SolverCG        solver(cn);
   TrilinosWrappers::PreconditionILU prec;
   prec.initialize(mass_matrix);

--- a/tests/non_matching/coupling_06.with_trilinos=true.with_p4est=true.mpirun=2.output
+++ b/tests/non_matching/coupling_06.with_trilinos=true.with_p4est=true.mpirun=2.output
@@ -6,9 +6,8 @@ DEAL:0::Dofs      : 17
 DEAL:0::Space dofs: 289
 DEAL:0::Local dofs      : 9
 DEAL:0::Local space dofs: 153
-DEAL:0::Convergence step 9 value 4.51115e-14
 DEAL:0::Squares norm    : 0.275853
-DEAL:0::Error on squares: 1.07673e-12
+DEAL:0::Error on squares: 1.07675e-12
 DEAL:0::dim: 2, spacedim: 2
 DEAL:0::FE      : FE_Q<2>(2)
 DEAL:0::Space FE: FE_Q<2>(2)
@@ -16,7 +15,6 @@ DEAL:0::Dofs      : 289
 DEAL:0::Space dofs: 289
 DEAL:0::Local dofs      : 153
 DEAL:0::Local space dofs: 153
-DEAL:0::Convergence step 12 value 2.66570e-13
 DEAL:0::Squares norm    : 1.98578
 DEAL:0::Error on squares: 4.16199e-10
 DEAL:0::dim: 2, spacedim: 3
@@ -26,7 +24,6 @@ DEAL:0::Dofs      : 289
 DEAL:0::Space dofs: 4913
 DEAL:0::Local dofs      : 153
 DEAL:0::Local space dofs: 2601
-DEAL:0::Convergence step 12 value 2.66570e-13
 DEAL:0::Squares norm    : 1.98578
 DEAL:0::Error on squares: 4.16199e-10
 DEAL:0::dim: 3, spacedim: 3
@@ -36,7 +33,6 @@ DEAL:0::Dofs      : 4913
 DEAL:0::Space dofs: 4913
 DEAL:0::Local dofs      : 2601
 DEAL:0::Local space dofs: 2601
-DEAL:0::Convergence step 12 value 6.65914e-13
 DEAL:0::Squares norm    : 11.6248
 DEAL:0::Error on squares: 4.61425e-08
 
@@ -47,9 +43,8 @@ DEAL:1::Dofs      : 17
 DEAL:1::Space dofs: 289
 DEAL:1::Local dofs      : 8
 DEAL:1::Local space dofs: 136
-DEAL:1::Convergence step 9 value 4.51115e-14
 DEAL:1::Squares norm    : 0.275853
-DEAL:1::Error on squares: 1.07673e-12
+DEAL:1::Error on squares: 1.07675e-12
 DEAL:1::dim: 2, spacedim: 2
 DEAL:1::FE      : FE_Q<2>(2)
 DEAL:1::Space FE: FE_Q<2>(2)
@@ -57,7 +52,6 @@ DEAL:1::Dofs      : 289
 DEAL:1::Space dofs: 289
 DEAL:1::Local dofs      : 136
 DEAL:1::Local space dofs: 136
-DEAL:1::Convergence step 12 value 2.66570e-13
 DEAL:1::Squares norm    : 1.98578
 DEAL:1::Error on squares: 4.16199e-10
 DEAL:1::dim: 2, spacedim: 3
@@ -67,7 +61,6 @@ DEAL:1::Dofs      : 289
 DEAL:1::Space dofs: 4913
 DEAL:1::Local dofs      : 136
 DEAL:1::Local space dofs: 2312
-DEAL:1::Convergence step 12 value 2.66570e-13
 DEAL:1::Squares norm    : 1.98578
 DEAL:1::Error on squares: 4.16199e-10
 DEAL:1::dim: 3, spacedim: 3
@@ -77,7 +70,6 @@ DEAL:1::Dofs      : 4913
 DEAL:1::Space dofs: 4913
 DEAL:1::Local dofs      : 2312
 DEAL:1::Local space dofs: 2312
-DEAL:1::Convergence step 12 value 6.65914e-13
 DEAL:1::Squares norm    : 11.6248
 DEAL:1::Error on squares: 4.61425e-08
 


### PR DESCRIPTION
These tests fail, e.g. in https://cdash.kyomu.43-1.org/viewTest.php?onlyfailed&buildid=6156.
In fact, the point of these tests is not at all to check the number of iterations needed for the solver to convergence. Hence, just remove this information from the test cases.