### PR TITLE
Avoid C-style cast in numerics

### DIFF
--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -282,7 +282,7 @@ namespace Functions
         // Number of quadrature points on this cell
         unsigned int nq = qpoints[i].size();
         // Construct a quadrature formula
-        std::vector<double> ww(nq, 1. / ((double)nq));
+        std::vector<double> ww(nq, 1. / nq);
 
         quadrature_collection.push_back(Quadrature<dim>(qpoints[i], ww));
       }
@@ -352,7 +352,7 @@ namespace Functions
         // Number of quadrature points on this cell
         unsigned int nq = qpoints[i].size();
         // Construct a quadrature formula
-        std::vector<double> ww(nq, 1. / ((double)nq));
+        std::vector<double> ww(nq, 1. / nq);
 
         quadrature_collection.push_back(Quadrature<dim>(qpoints[i], ww));
       }
@@ -428,7 +428,7 @@ namespace Functions
         // Number of quadrature points on this cell
         unsigned int nq = qpoints[i].size();
         // Construct a quadrature formula
-        std::vector<double> ww(nq, 1. / ((double)nq));
+        std::vector<double> ww(nq, 1. / nq);
 
         quadrature_collection.push_back(Quadrature<dim>(qpoints[i], ww));
       }

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -746,7 +746,7 @@ namespace MatrixCreator
           copy_local_to_global<number, SparseMatrix<number>, Vector<number>>,
         std::placeholders::_1,
         &matrix,
-        (Vector<number> *)nullptr),
+        static_cast<Vector<number> *>(nullptr)),
       assembler_data,
       copy_data);
   }
@@ -896,7 +896,7 @@ namespace MatrixCreator
           copy_local_to_global<number, SparseMatrix<number>, Vector<number>>,
         std::placeholders::_1,
         &matrix,
-        (Vector<number> *)nullptr),
+        static_cast<Vector<number> *>(nullptr)),
       assembler_data,
       copy_data);
   }
@@ -1988,7 +1988,7 @@ namespace MatrixCreator
           copy_local_to_global<double, SparseMatrix<double>, Vector<double>>,
         std::placeholders::_1,
         &matrix,
-        (Vector<double> *)(nullptr)),
+        static_cast<Vector<double> *>(nullptr)),
       assembler_data,
       copy_data);
   }
@@ -2136,7 +2136,7 @@ namespace MatrixCreator
           copy_local_to_global<double, SparseMatrix<double>, Vector<double>>,
         std::placeholders::_1,
         &matrix,
-        (Vector<double> *)nullptr),
+        static_cast<Vector<double> *>(nullptr)),
       assembler_data,
       copy_data);
   }

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -3531,7 +3531,7 @@ namespace VectorTools
         boundary_functions,
         rhs,
         dof_to_boundary_mapping,
-        (const Function<spacedim, number> *)nullptr,
+        static_cast<const Function<spacedim, number> *>(nullptr),
         component_mapping);
 
       // For certain weird elements,

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -600,8 +600,8 @@ PointValueHistory<dim>::evaluate_field(const std::string &vector_name,
   if (n_indep != 0) // hopefully this will get optimized, can't test
                     // independent_values[0] unless n_indep > 0
     {
-      Assert(std::abs((int)dataset_key.size() -
-                      (int)independent_values[0].size()) < 2,
+      Assert(std::abs(static_cast<int>(dataset_key.size()) -
+                      static_cast<int>(independent_values[0].size())) < 2,
              ExcDataLostSync());
     }
   // Look up the field name and get an
@@ -669,8 +669,8 @@ PointValueHistory<dim>::evaluate_field(
   if (n_indep != 0) // hopefully this will get optimized, can't test
                     // independent_values[0] unless n_indep > 0
     {
-      Assert(std::abs((int)dataset_key.size() -
-                      (int)independent_values[0].size()) < 2,
+      Assert(std::abs(static_cast<int>(dataset_key.size()) -
+                      static_cast<int>(independent_values[0].size())) < 2,
              ExcDataLostSync());
     }
 
@@ -912,8 +912,8 @@ PointValueHistory<dim>::evaluate_field_at_requested_location(
   if (n_indep != 0) // hopefully this will get optimized, can't test
                     // independent_values[0] unless n_indep > 0
     {
-      Assert(std::abs((int)dataset_key.size() -
-                      (int)independent_values[0].size()) < 2,
+      Assert(std::abs(static_cast<int>(dataset_key.size()) -
+                      static_cast<int>(independent_values[0].size())) < 2,
              ExcDataLostSync());
     }
   // Look up the field name and get an
@@ -992,8 +992,8 @@ PointValueHistory<dim>::push_back_independent(
   Assert(indep_values.size() == n_indep,
          ExcDimensionMismatch(indep_values.size(), n_indep));
   Assert(n_indep != 0, ExcNoIndependent());
-  Assert(std::abs((int)dataset_key.size() - (int)independent_values[0].size()) <
-           2,
+  Assert(std::abs(static_cast<int>(dataset_key.size()) -
+                  static_cast<int>(independent_values[0].size())) < 2,
          ExcDataLostSync());
 
   for (unsigned int component = 0; component < n_indep; component++)
@@ -1482,8 +1482,8 @@ PointValueHistory<dim>::deep_check(const bool strict)
     }
   if (n_indep != 0)
     {
-      if (std::abs((int)dataset_key.size() -
-                   (int)independent_values[0].size()) >= 2)
+      if (std::abs(static_cast<int>(dataset_key.size()) -
+                   static_cast<int>(independent_values[0].size())) >= 2)
         {
           return false;
         }
@@ -1497,8 +1497,8 @@ PointValueHistory<dim>::deep_check(const bool strict)
         {
           Assert(data_store_begin->second.size() > 0, ExcInternalError());
 
-          if (std::abs((int)(data_store_begin->second)[0].size() -
-                       (int)dataset_key.size()) >= 2)
+          if (std::abs(static_cast<int>((data_store_begin->second)[0].size()) -
+                       static_cast<int>(dataset_key.size())) >= 2)
             return false;
           // this loop only tests one member
           // for each name, i.e. checks the

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -888,9 +888,9 @@ TimeStepBase_Tria<dim>::refine_grid(const RefinementData refinement_data)
           if (cell->refine_flag_set())
             previous_cells += (GeometryInfo<dim>::max_children_per_cell - 1);
           else if (cell->coarsen_flag_set())
-            previous_cells -=
-              (double)(GeometryInfo<dim>::max_children_per_cell - 1) /
-              GeometryInfo<dim>::max_children_per_cell;
+            previous_cells -= static_cast<double>(
+                                GeometryInfo<dim>::max_children_per_cell - 1) /
+                              GeometryInfo<dim>::max_children_per_cell;
 
         // @p{previous_cells} now gives the
         // number of cells which would result
@@ -915,9 +915,9 @@ TimeStepBase_Tria<dim>::refine_grid(const RefinementData refinement_data)
           if (cell->refine_flag_set())
             estimated_cells += (GeometryInfo<dim>::max_children_per_cell - 1);
           else if (cell->coarsen_flag_set())
-            estimated_cells -=
-              (double)(GeometryInfo<dim>::max_children_per_cell - 1) /
-              GeometryInfo<dim>::max_children_per_cell;
+            estimated_cells -= static_cast<double>(
+                                 GeometryInfo<dim>::max_children_per_cell - 1) /
+                               GeometryInfo<dim>::max_children_per_cell;
 
         // calculate the allowed delta in
         // cell numbers; be more lenient


### PR DESCRIPTION
Part of #7459.
This PR replaces all C-style casts in `include/deal.II/numerics` and `source/numerics`.