### PR TITLE
Avoid C-style cast in matrix_free

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -2968,9 +2968,10 @@ inline FEEvaluationBase<dim, n_components_, Number, is_face>::FEEvaluationBase(
                   mapping_data->descriptor[active_quad_index].n_q_points);
   Assert(
     dof_info->start_components.back() == 1 ||
-      (int)n_components_ <=
-        (int)dof_info->start_components
-            [dof_info->component_to_base_index[first_selected_component] + 1] -
+      static_cast<int>(n_components_) <=
+        static_cast<int>(
+          dof_info->start_components
+            [dof_info->component_to_base_index[first_selected_component] + 1]) -
           first_selected_component,
     ExcMessage(
       "You tried to construct a vector-valued evaluator with " +

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -700,7 +700,7 @@ namespace internal
                        ++j)
                     if (cell_t[j] > most_general_type)
                       most_general_type = cell_t[j];
-                  AssertIndexRange((unsigned int)most_general_type, 4U);
+                  AssertIndexRange(most_general_type, 4U);
                   mapping_info.cell_type[cell] = most_general_type;
                 }
 
@@ -1859,7 +1859,7 @@ namespace internal
             tasks += Threads::new_task(
               &ExtractFaceHelper::compute_normal_times_jacobian<dim, Number>,
               work_per_chunk * i,
-              std::min(work_per_chunk * (i + 1), (unsigned int)faces.size()),
+              std::min<unsigned int>(work_per_chunk * (i + 1), faces.size()),
               face_type,
               faces,
               face_data[my_q]);

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1484,12 +1484,11 @@ MatrixFree<dim, Number>::initialize_indices(
                                        ghost_indices.end());
             compressed_set.subtract_set(
               dof_info[no].vector_partitioner->locally_owned_range());
-            const bool all_ghosts_equal = Utilities::MPI::min(
-              (int)(compressed_set.n_elements() ==
-                    dof_info[no]
-                      .vector_partitioner->ghost_indices()
-                      .n_elements()),
-              dof_info[no].vector_partitioner->get_mpi_communicator());
+            const bool all_ghosts_equal =
+              Utilities::MPI::min<int>(
+                compressed_set.n_elements() ==
+                  dof_info[no].vector_partitioner->ghost_indices().n_elements(),
+                dof_info[no].vector_partitioner->get_mpi_communicator()) != 0;
             if (all_ghosts_equal)
               dof_info[no].vector_partitioner_face_variants[0] =
                 dof_info[no].vector_partitioner;
@@ -1584,8 +1583,8 @@ MatrixFree<dim, Number>::initialize_indices(
                         has_noncontiguous_cell = true;
                     }
                 has_noncontiguous_cell =
-                  Utilities::MPI::min((int)has_noncontiguous_cell,
-                                      task_info.communicator);
+                  Utilities::MPI::min<int>(has_noncontiguous_cell,
+                                           task_info.communicator) != 0;
 
                 std::sort(ghost_indices.begin(), ghost_indices.end());
                 ghost_indices.erase(std::unique(ghost_indices.begin(),
@@ -1596,12 +1595,14 @@ MatrixFree<dim, Number>::initialize_indices(
                                            ghost_indices.end());
                 compressed_set.subtract_set(
                   dof_info[no].vector_partitioner->locally_owned_range());
-                const bool all_ghosts_equal = Utilities::MPI::min(
-                  (int)(compressed_set.n_elements() ==
-                        dof_info[no]
-                          .vector_partitioner->ghost_indices()
-                          .n_elements()),
-                  dof_info[no].vector_partitioner->get_mpi_communicator());
+                const bool all_ghosts_equal =
+                  Utilities::MPI::min<int>(
+                    compressed_set.n_elements() ==
+                      dof_info[no]
+                        .vector_partitioner->ghost_indices()
+                        .n_elements(),
+                    dof_info[no].vector_partitioner->get_mpi_communicator()) !=
+                  0;
                 if (all_ghosts_equal || has_noncontiguous_cell)
                   dof_info[no].vector_partitioner_face_variants[1] =
                     dof_info[no].vector_partitioner;
@@ -1702,12 +1703,14 @@ MatrixFree<dim, Number>::initialize_indices(
                                            ghost_indices.end());
                 compressed_set.subtract_set(
                   dof_info[no].vector_partitioner->locally_owned_range());
-                const bool all_ghosts_equal = Utilities::MPI::min(
-                  (int)(compressed_set.n_elements() ==
-                        dof_info[no]
-                          .vector_partitioner->ghost_indices()
-                          .n_elements()),
-                  dof_info[no].vector_partitioner->get_mpi_communicator());
+                const bool all_ghosts_equal =
+                  Utilities::MPI::min<int>(
+                    compressed_set.n_elements() ==
+                      dof_info[no]
+                        .vector_partitioner->ghost_indices()
+                        .n_elements(),
+                    dof_info[no].vector_partitioner->get_mpi_communicator()) !=
+                  0;
                 if (all_ghosts_equal)
                   dof_info[no].vector_partitioner_face_variants[2] =
                     dof_info[no].vector_partitioner;

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -1052,7 +1052,8 @@ namespace internal
           if (dofs_per_cell * block_size > 10000)
             block_size /= 4;
 
-          block_size = 1 << (unsigned int)(std::log2(block_size + 1));
+          block_size =
+            1 << static_cast<unsigned int>(std::log2(block_size + 1));
         }
       if (block_size > n_active_cells)
         block_size = std::max(1U, n_active_cells);


### PR DESCRIPTION
Part of #7459.
This PR replaces all C-style casts in `include/deal.II/matrix_free` and `source/matrix_free` (not necessarily the `CUDA` parts).
Also, be more explicit about conversions between `int`s and `bool`s.