### PR TITLE
Avoid C-style cast in distributed

### DIFF
--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -84,11 +84,11 @@ namespace internal
         typename dealii::internal::p4est::iter<dim>::corner_info *info,
         void *                                                    user_data)
       {
-        int i, j;
-        int nsides = info->sides.elem_count;
-        typename dealii::internal::p4est::iter<dim>::corner_side *sides =
-          (typename dealii::internal::p4est::iter<dim>::corner_side
-             *)(info->sides.array);
+        int   i, j;
+        int   nsides = info->sides.elem_count;
+        auto *sides  = reinterpret_cast<
+          typename dealii::internal::p4est::iter<dim>::corner_side *>(
+          info->sides.array);
         FindGhosts<dim, spacedim> *fg =
           static_cast<FindGhosts<dim, spacedim> *>(user_data);
         sc_array_t *subids = fg->subids;
@@ -123,8 +123,9 @@ namespace internal
             return;
           }
 
-        nsubs         = (int)subids->elem_count;
-        subdomain_ids = (dealii::types::subdomain_id *)(subids->array);
+        nsubs = static_cast<int>(subids->elem_count);
+        subdomain_ids =
+          reinterpret_cast<dealii::types::subdomain_id *>(subids->array);
 
         for (i = 0; i < nsides; i++)
           {
@@ -160,13 +161,12 @@ namespace internal
         typename dealii::internal::p4est::iter<dim>::edge_info *info,
         void *                                                  user_data)
       {
-        int i, j, k;
-        int nsides = info->sides.elem_count;
-        typename dealii::internal::p4est::iter<dim>::edge_side *sides =
-          (typename dealii::internal::p4est::iter<dim>::edge_side *)(info->sides
-                                                                       .array);
-        FindGhosts<dim, spacedim> *fg =
-          static_cast<FindGhosts<dim, spacedim> *>(user_data);
+        int   i, j, k;
+        int   nsides = info->sides.elem_count;
+        auto *sides  = reinterpret_cast<
+          typename dealii::internal::p4est::iter<dim>::edge_side *>(
+          info->sides.array);
+        auto *      fg = static_cast<FindGhosts<dim, spacedim> *>(user_data);
         sc_array_t *subids = fg->subids;
         const dealii::parallel::distributed::Triangulation<dim, spacedim>
           *                          triangulation = fg->triangulation;
@@ -203,8 +203,9 @@ namespace internal
             return;
           }
 
-        nsubs         = (int)subids->elem_count;
-        subdomain_ids = (dealii::types::subdomain_id *)(subids->array);
+        nsubs = static_cast<int>(subids->elem_count);
+        subdomain_ids =
+          reinterpret_cast<dealii::types::subdomain_id *>(subids->array);
 
         for (i = 0; i < nsides; i++)
           {
@@ -244,11 +245,11 @@ namespace internal
         typename dealii::internal::p4est::iter<dim>::face_info *info,
         void *                                                  user_data)
       {
-        int i, j, k;
-        int nsides = info->sides.elem_count;
-        typename dealii::internal::p4est::iter<dim>::face_side *sides =
-          (typename dealii::internal::p4est::iter<dim>::face_side *)(info->sides
-                                                                       .array);
+        int   i, j, k;
+        int   nsides = info->sides.elem_count;
+        auto *sides  = reinterpret_cast<
+          typename dealii::internal::p4est::iter<dim>::face_side *>(
+          info->sides.array);
         FindGhosts<dim, spacedim> *fg =
           static_cast<FindGhosts<dim, spacedim> *>(user_data);
         sc_array_t *subids = fg->subids;
@@ -288,8 +289,9 @@ namespace internal
             return;
           }
 
-        nsubs         = (int)subids->elem_count;
-        subdomain_ids = (dealii::types::subdomain_id *)(subids->array);
+        nsubs = static_cast<int>(subids->elem_count);
+        subdomain_ids =
+          reinterpret_cast<dealii::types::subdomain_id *>(subids->array);
 
         for (i = 0; i < nsides; i++)
           {

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3594,16 +3594,13 @@ namespace parallel
           types::subdomain_id                                  ghost_owner = 0;
           typename dealii::internal::p4est::types<dim>::topidx ghost_tree  = 0;
 
-          for (unsigned int g_idx = 0;
-               g_idx < parallel_ghost->ghosts.elem_count;
+          for (int g_idx = 0; static_cast<unsigned int>(g_idx) <
+                              parallel_ghost->ghosts.elem_count;
                ++g_idx)
             {
-              while (
-                g_idx >=
-                (unsigned int)parallel_ghost->proc_offsets[ghost_owner + 1])
+              while (g_idx >= parallel_ghost->proc_offsets[ghost_owner + 1])
                 ++ghost_owner;
-              while (g_idx >=
-                     (unsigned int)parallel_ghost->tree_offsets[ghost_tree + 1])
+              while (g_idx >= parallel_ghost->tree_offsets[ghost_tree + 1])
                 ++ghost_tree;
 
               quadr = static_cast<

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3594,13 +3594,15 @@ namespace parallel
           types::subdomain_id                                  ghost_owner = 0;
           typename dealii::internal::p4est::types<dim>::topidx ghost_tree  = 0;
 
-          for (int g_idx = 0; static_cast<unsigned int>(g_idx) <
-                              parallel_ghost->ghosts.elem_count;
+          for (unsigned int g_idx = 0;
+               g_idx < parallel_ghost->ghosts.elem_count;
                ++g_idx)
             {
-              while (g_idx >= parallel_ghost->proc_offsets[ghost_owner + 1])
+              while (g_idx >= static_cast<unsigned int>(
+                                parallel_ghost->proc_offsets[ghost_owner + 1]))
                 ++ghost_owner;
-              while (g_idx >= parallel_ghost->tree_offsets[ghost_tree + 1])
+              while (g_idx >= static_cast<unsigned int>(
+                                parallel_ghost->tree_offsets[ghost_tree + 1]))
                 ++ghost_tree;
 
               quadr = static_cast<


### PR DESCRIPTION
Part of #7459.
This PR replaces all C-style casts in `include/deal.II/distributed` and `source/distributed`.
