### PR TITLE
Use shared_ptr for Partitioner in CUDAWrappers::MatrixFree

### DIFF
--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -61,7 +61,7 @@ namespace CUDAWrappers
       setup_constraints(
         std::vector<types::global_dof_index> &                    dof_indices,
         const CellIterator &                                      cell,
-        const std::unique_ptr<const Utilities::MPI::Partitioner> &partitioner,
+        const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
         unsigned int &                                            mask) const;
 
     private:
@@ -276,7 +276,7 @@ namespace CUDAWrappers
     HangingNodes<dim>::setup_constraints(
       std::vector<types::global_dof_index> &                    dof_indices,
       const CellIterator &                                      cell,
-      const std::unique_ptr<const Utilities::MPI::Partitioner> &partitioner,
+      const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
       unsigned int &                                            mask) const
     {
       mask                         = 0;

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -428,10 +428,10 @@ namespace CUDAWrappers
     std::vector<dim3> block_dim;
 
     /**
-     * Unique pointer to a Partitioner for distributed Vectors used in
+     * Shared pointer to a Partitioner for distributed Vectors used in
      * cell_loop. When MPI is not used the pointer is null.
      */
-    std::unique_ptr<const Utilities::MPI::Partitioner> partitioner;
+    std::shared_ptr<const Utilities::MPI::Partitioner> partitioner;
 
     // Parallelization parameters
     unsigned int cells_per_block;

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -23,7 +23,6 @@
 
 #  include <deal.II/base/cuda_size.h>
 #  include <deal.II/base/graph_coloring.h>
-#  include <deal.II/base/std_cxx14/memory.h>
 
 #  include <deal.II/dofs/dof_tools.h>
 
@@ -147,7 +146,7 @@ namespace CUDAWrappers
       get_cell_data(
         const CellFilter &                                        cell,
         const unsigned int                                        cell_id,
-        const std::unique_ptr<const Utilities::MPI::Partitioner> &partitioner);
+        const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner);
 
       void
       alloc_and_copy_arrays(const unsigned int cell);
@@ -287,7 +286,7 @@ namespace CUDAWrappers
     ReinitHelper<dim, Number>::get_cell_data(
       const CellFilter &                                        cell,
       const unsigned int                                        cell_id,
-      const std::unique_ptr<const Utilities::MPI::Partitioner> &partitioner)
+      const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner)
     {
       cell->get_dof_indices(local_dof_indices);
       // When using MPI, we need to transform the local_dof_indices, which
@@ -843,7 +842,7 @@ namespace CUDAWrappers
       {
         DoFTools::extract_locally_relevant_dofs(dof_handler,
                                                 locally_relevant_dofs);
-        partitioner = std_cxx14::make_unique<Utilities::MPI::Partitioner>(
+        partitioner = std::make_shared<Utilities::MPI::Partitioner>(
           dof_handler.locally_owned_dofs(), locally_relevant_dofs, *comm);
       }
     for (unsigned int i = 0; i < n_colors; ++i)


### PR DESCRIPTION
It seems that there indeed were compelling reasons to use `shared_ptr` instead of `unique_ptr` in `CUDAWrappers::MatrixFree` for the `Partitioner` variable: https://cdash.kyomu.43-1.org/viewTest.php?onlydelta&buildid=6204
In fact, `LinearAlgebra::distributed::Vector` has a `std::shared_ptr` interface and these tests break because we try to pass a `std::unique_ptr` instead.