### PR TITLE
Avoid C-style cast in dofs

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -4119,9 +4119,10 @@ namespace internal
                   displacements[i] = shift;
                   shift += rcounts[i];
                 }
-              Assert(((int)new_numbers_copy.size()) ==
-                       rcounts[Utilities::MPI::this_mpi_process(
-                         tr->get_communicator())],
+              Assert(new_numbers_copy.size() ==
+                       static_cast<unsigned int>(
+                         rcounts[Utilities::MPI::this_mpi_process(
+                           tr->get_communicator())]),
                      ExcInternalError());
               ierr = MPI_Allgatherv(new_numbers_copy.data(),
                                     new_numbers_copy.size(),

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1722,14 +1722,11 @@ namespace DoFRenumbering
 
     unsigned int global_index = 0;
 
-    typename std::vector<
-      typename DoFHandlerType::level_cell_iterator>::const_iterator cell;
-
-    for (cell = cells.begin(); cell != cells.end(); ++cell)
+    for (const auto &cell : cells)
       {
-        Assert((*cell)->level() == (int)level, ExcInternalError());
+        Assert(cell->level() == static_cast<int>(level), ExcInternalError());
 
-        (*cell)->get_active_or_mg_dof_indices(cell_dofs);
+        cell->get_active_or_mg_dof_indices(cell_dofs);
         std::sort(cell_dofs.begin(), cell_dofs.end());
 
         for (unsigned int i = 0; i < n_cell_dofs; ++i)

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -129,7 +129,7 @@ namespace DoFTools
                                     const ComponentMask &component_mask)
     {
       std::vector<unsigned char> local_component_association(
-        fe.dofs_per_cell, (unsigned char)(-1));
+        fe.dofs_per_cell, static_cast<unsigned char>(-1));
 
       // compute the component each local dof belongs to.
       // if the shape function is primitive, then this
@@ -170,7 +170,7 @@ namespace DoFTools
 
       Assert(std::find(local_component_association.begin(),
                        local_component_association.end(),
-                       (unsigned char)(-1)) ==
+                       static_cast<unsigned char>(-1)) ==
                local_component_association.end(),
              ExcInternalError());
 
@@ -280,13 +280,13 @@ namespace DoFTools
                               DoFHandlerType::space_dimension> &fe =
             fe_collection[f];
           local_block_association[f].resize(fe.dofs_per_cell,
-                                            (unsigned char)(-1));
+                                            static_cast<unsigned char>(-1));
           for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
             local_block_association[f][i] = fe.system_to_block_index(i).first;
 
           Assert(std::find(local_block_association[f].begin(),
                            local_block_association[f].end(),
-                           (unsigned char)(-1)) ==
+                           static_cast<unsigned char>(-1)) ==
                    local_block_association[f].end(),
                  ExcInternalError());
         }
@@ -2649,7 +2649,8 @@ namespace DoFTools
               if (cell->at_boundary(face))
                 vertex_boundary[vg] = true;
               else if ((!level_boundary_patches) &&
-                       (cell->neighbor(face)->level() != (int)level))
+                       (cell->neighbor(face)->level() !=
+                        static_cast<int>(level)))
                 vertex_boundary[vg] = true;
             }
         }

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2245,7 +2245,7 @@ namespace DoFTools
       // matrix, we assume that for a 0* rotation we would have to build the
       // identity matrix
 
-      Assert(matrix.m() == (int)spacedim, ExcInternalError())
+      Assert(matrix.m() == spacedim, ExcInternalError())
 
         Quadrature<dim - 1>
           quadrature(fe.get_unit_face_support_points());
@@ -2351,7 +2351,7 @@ namespace DoFTools
            ExcMessage("The supplied (rotation or interpolation) matrix must "
                       "be a square matrix"));
 
-    Assert(first_vector_components.empty() || matrix.m() == (int)spacedim,
+    Assert(first_vector_components.empty() || matrix.m() == spacedim,
            ExcMessage("first_vector_components is nonempty, so matrix must "
                       "be a rotation matrix exactly of size spacedim"));
 
@@ -2362,15 +2362,15 @@ namespace DoFTools
         const unsigned int n_dofs_per_face =
           face_1->get_fe(face_1->nth_active_fe_index(0)).dofs_per_face;
 
-        Assert(
-          matrix.m() == 0 ||
-            (first_vector_components.empty() &&
-             matrix.m() == n_dofs_per_face) ||
-            (!first_vector_components.empty() && matrix.m() == (int)spacedim),
-          ExcMessage("The matrix must have either size 0 or spacedim "
-                     "(if first_vector_components is nonempty) "
-                     "or the size must be equal to the # of DoFs on the face "
-                     "(if first_vector_components is empty)."));
+        Assert(matrix.m() == 0 ||
+                 (first_vector_components.empty() &&
+                  matrix.m() == n_dofs_per_face) ||
+                 (!first_vector_components.empty() && matrix.m() == spacedim),
+               ExcMessage(
+                 "The matrix must have either size 0 or spacedim "
+                 "(if first_vector_components is nonempty) "
+                 "or the size must be equal to the # of DoFs on the face "
+                 "(if first_vector_components is empty)."));
       }
 
     if (!face_2->has_children())
@@ -2379,15 +2379,15 @@ namespace DoFTools
         const unsigned int n_dofs_per_face =
           face_2->get_fe(face_2->nth_active_fe_index(0)).dofs_per_face;
 
-        Assert(
-          matrix.m() == 0 ||
-            (first_vector_components.empty() &&
-             matrix.m() == n_dofs_per_face) ||
-            (!first_vector_components.empty() && matrix.m() == (int)spacedim),
-          ExcMessage("The matrix must have either size 0 or spacedim "
-                     "(if first_vector_components is nonempty) "
-                     "or the size must be equal to the # of DoFs on the face "
-                     "(if first_vector_components is empty)."));
+        Assert(matrix.m() == 0 ||
+                 (first_vector_components.empty() &&
+                  matrix.m() == n_dofs_per_face) ||
+                 (!first_vector_components.empty() && matrix.m() == spacedim),
+               ExcMessage(
+                 "The matrix must have either size 0 or spacedim "
+                 "(if first_vector_components is nonempty) "
+                 "or the size must be equal to the # of DoFs on the face "
+                 "(if first_vector_components is empty)."));
       }
 #endif
 


### PR DESCRIPTION
Part of #7459.
This PR replaces all C-style casts in `include/deal.II/dofs` and `source/dofs`.