### PR TITLE
Avoid C-style cast in sundials

### DIFF
--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -132,12 +132,15 @@ namespace SUNDIALS
       copy(*src_ypred, ypred);
       copy(*src_fpred, fpred);
 
-      int err = solver.setup_jacobian(convfail,
+      // avoid reinterpret_cast
+      bool jcurPtr_tmp = false;
+      int  err         = solver.setup_jacobian(convfail,
                                       arkode_mem->ark_tn,
                                       arkode_mem->ark_gamma,
                                       *src_ypred,
                                       *src_fpred,
-                                      (bool &)*jcurPtr);
+                                      jcurPtr_tmp);
+      *jcurPtr         = jcurPtr_tmp ? SUNTRUE : SUNFALSE;
 
       return err;
     }
@@ -424,7 +427,7 @@ namespace SUNDIALS
     status = ARKodeSetInitStep(arkode_mem, current_time_step);
     AssertARKode(status);
 
-    status = ARKodeSetUserData(arkode_mem, (void *)this);
+    status = ARKodeSetUserData(arkode_mem, this);
     AssertARKode(status);
 
     status = ARKodeSetStopTime(arkode_mem, data.final_time);
@@ -435,7 +438,7 @@ namespace SUNDIALS
     AssertARKode(status);
 
     // Initialize solver
-    ARKodeMem ARKode_mem = (ARKodeMem)arkode_mem;
+    auto ARKode_mem = static_cast<ARKodeMem>(arkode_mem);
 
     if (solve_jacobian_system)
       {

--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -362,7 +362,7 @@ namespace SUNDIALS
     status = IDASetInitStep(ida_mem, current_time_step);
     AssertIDA(status);
 
-    status = IDASetUserData(ida_mem, (void *)this);
+    status = IDASetUserData(ida_mem, this);
     AssertIDA(status);
 
     if (data.ic_type == AdditionalData::use_y_diff ||
@@ -391,8 +391,7 @@ namespace SUNDIALS
     AssertIDA(status);
 
     // Initialize solver
-    IDAMem IDA_mem;
-    IDA_mem = (IDAMem)ida_mem;
+    auto IDA_mem = static_cast<IDAMem>(ida_mem);
 
     IDA_mem->ida_lsetup = t_dae_lsetup<VectorType>;
     IDA_mem->ida_lsolve = t_dae_solve<VectorType>;

--- a/source/sundials/kinsol.cc
+++ b/source/sundials/kinsol.cc
@@ -238,7 +238,7 @@ namespace SUNDIALS
     (void)status;
     AssertKINSOL(status);
 
-    status = KINSetUserData(kinsol_mem, (void *)this);
+    status = KINSetUserData(kinsol_mem, static_cast<void *>(this));
     AssertKINSOL(status);
 
     status = KINSetNumMaxIters(kinsol_mem, data.maximum_non_linear_iterations);
@@ -253,7 +253,7 @@ namespace SUNDIALS
     status = KINSetMaxSetupCalls(kinsol_mem, data.maximum_setup_calls);
     AssertKINSOL(status);
 
-    status = KINSetNoInitSetup(kinsol_mem, (int)data.no_init_setup);
+    status = KINSetNoInitSetup(kinsol_mem, data.no_init_setup);
     AssertKINSOL(status);
 
     status = KINSetMaxNewtonStep(kinsol_mem, data.maximum_newton_step);
@@ -275,7 +275,7 @@ namespace SUNDIALS
 
     if (solve_jacobian_system)
       {
-        KINMem KIN_mem      = (KINMem)kinsol_mem;
+        auto KIN_mem        = static_cast<KINMem>(kinsol_mem);
         KIN_mem->kin_lsolve = t_kinsol_solve_jacobian<VectorType>;
         if (setup_jacobian)
           {
@@ -306,7 +306,7 @@ namespace SUNDIALS
       Assert(iteration_function, ExcFunctionNotProvided("iteration_function"));
 
     // call to KINSol
-    status = KINSol(kinsol_mem, solution, (int)data.strategy, u_scale, f_scale);
+    status = KINSol(kinsol_mem, solution, data.strategy, u_scale, f_scale);
     AssertKINSOL(status);
 
     copy(initial_guess_and_solution, solution);
@@ -337,7 +337,7 @@ namespace SUNDIALS
 #  endif
     KINFree(&kinsol_mem);
 
-    return (unsigned int)nniters;
+    return static_cast<unsigned int>(nniters);
   }
 
   template <typename VectorType>


### PR DESCRIPTION
Part of #7459.
This PR replaces all C-style casts in `include/deal.II/sundials` and `source/sundials`.