### PR TITLE
Avoid C-style cast in grid

### DIFF
--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -960,7 +960,7 @@ inline FilteredIterator<BaseIterator>::FilteredIterator(
     // address of fi, GCC would not cast fi to the base class of type
     // BaseIterator but tries to go through constructing a new
     // BaseIterator with an Accessor.
-  BaseIterator(*(BaseIterator *)(&fi))
+  BaseIterator(*static_cast<const BaseIterator *>(&fi))
   , predicate(fi.predicate->clone())
 {}
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1176,22 +1176,21 @@ namespace GridGenerator
       {
         case 1:
           for (unsigned int x = 0; x <= repetitions[0]; ++x)
-            points.push_back(p1 + (double)x * delta[0]);
+            points.push_back(p1 + x * delta[0]);
           break;
 
         case 2:
           for (unsigned int y = 0; y <= repetitions[1]; ++y)
             for (unsigned int x = 0; x <= repetitions[0]; ++x)
-              points.push_back(p1 + (double)x * delta[0] +
-                               (double)y * delta[1]);
+              points.push_back(p1 + x * delta[0] + y * delta[1]);
           break;
 
         case 3:
           for (unsigned int z = 0; z <= repetitions[2]; ++z)
             for (unsigned int y = 0; y <= repetitions[1]; ++y)
               for (unsigned int x = 0; x <= repetitions[0]; ++x)
-                points.push_back(p1 + (double)x * delta[0] +
-                                 (double)y * delta[1] + (double)z * delta[2]);
+                points.push_back(p1 + x * delta[0] + y * delta[1] +
+                                 z * delta[2]);
           break;
 
         default:
@@ -1806,22 +1805,21 @@ namespace GridGenerator
       {
         case 1:
           for (unsigned int x = 0; x <= repetitions[0]; ++x)
-            points.push_back(p1 + (double)x * delta[0]);
+            points.push_back(p1 + x * delta[0]);
           break;
 
         case 2:
           for (unsigned int y = 0; y <= repetitions[1]; ++y)
             for (unsigned int x = 0; x <= repetitions[0]; ++x)
-              points.push_back(p1 + (double)x * delta[0] +
-                               (double)y * delta[1]);
+              points.push_back(p1 + x * delta[0] + y * delta[1]);
           break;
 
         case 3:
           for (unsigned int z = 0; z <= repetitions[2]; ++z)
             for (unsigned int y = 0; y <= repetitions[1]; ++y)
               for (unsigned int x = 0; x <= repetitions[0]; ++x)
-                points.push_back(p1 + (double)x * delta[0] +
-                                 (double)y * delta[1] + (double)z * delta[2]);
+                points.push_back(p1 + x * delta[0] + y * delta[1] +
+                                 z * delta[2]);
           break;
 
         default:
@@ -5040,7 +5038,7 @@ namespace GridGenerator
                       treated_vertices[vv] = true;
                       for (unsigned int i = 0; i <= Nz; ++i)
                         {
-                          double d = ((double)i) * L / ((double)Nz);
+                          double d = i * L / Nz;
                           switch (vv - i * 16)
                             {
                               case 1:

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -2961,7 +2961,7 @@ GridIn<dim, spacedim>::read_assimp(const std::string &filename,
                   cells[valid_cell].vertices[f] =
                     mFaces[i].mIndices[f] + v_offset;
                 }
-              cells[valid_cell].material_id = (types::material_id)m;
+              cells[valid_cell].material_id = m;
               ++valid_cell;
             }
           else

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -419,9 +419,9 @@ GridRefinement::refine_and_coarsen_optimize(Triangulation<dim, spacedim> &tria,
       expected_error_reduction +=
         (1 - std::pow(2., -1. * order)) * criteria(cell_indices[M]);
 
-      const double cost =
-        std::pow(((std::pow(2., dim) - 1) * (1 + M) + N), (double)order / dim) *
-        (original_error - expected_error_reduction);
+      const double cost = std::pow(((std::pow(2., dim) - 1) * (1 + M) + N),
+                                   static_cast<double>(order) / dim) *
+                          (original_error - expected_error_reduction);
       if (cost <= min_cost)
         {
           min_cost = cost;

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2812,8 +2812,8 @@ namespace GridTools
       if (cell->active())
         {
           while (current_cell_idx >=
-                 std::floor((long)n_active_cells * (current_proc_idx + 1) /
-                            n_partitions))
+                 std::floor(static_cast<long>(n_active_cells) *
+                            (current_proc_idx + 1) / n_partitions))
             ++current_proc_idx;
           cell->set_subdomain_id(current_proc_idx);
           ++current_cell_idx;
@@ -3674,12 +3674,12 @@ namespace GridTools
           if (cell->face(f)->at_boundary())
             for (unsigned int e = 0; e < GeometryInfo<dim>::lines_per_face; ++e)
               {
-                const auto bid = cell->face(f)->line(e)->boundary_id();
-                const auto ind = std::find(src_boundary_ids.begin(),
-                                           src_boundary_ids.end(),
-                                           bid) -
-                                 src_boundary_ids.begin();
-                if ((unsigned int)ind < src_boundary_ids.size())
+                const auto         bid = cell->face(f)->line(e)->boundary_id();
+                const unsigned int ind = std::find(src_boundary_ids.begin(),
+                                                   src_boundary_ids.end(),
+                                                   bid) -
+                                         src_boundary_ids.begin();
+                if (ind < src_boundary_ids.size())
                   cell->face(f)->line(e)->set_manifold_id(
                     dst_manifold_ids[ind]);
               }
@@ -3692,12 +3692,12 @@ namespace GridTools
       for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->face(f)->at_boundary())
           {
-            const auto bid = cell->face(f)->boundary_id();
-            const auto ind =
+            const auto         bid = cell->face(f)->boundary_id();
+            const unsigned int ind =
               std::find(src_boundary_ids.begin(), src_boundary_ids.end(), bid) -
               src_boundary_ids.begin();
 
-            if ((unsigned int)ind < src_boundary_ids.size())
+            if (ind < src_boundary_ids.size())
               {
                 // assign the manifold id
                 cell->face(f)->set_manifold_id(dst_manifold_ids[ind]);
@@ -3710,11 +3710,11 @@ namespace GridTools
                    ++e)
                 {
                   const auto bid = cell->face(f)->line(e)->boundary_id();
-                  const auto ind = std::find(src_boundary_ids.begin(),
-                                             src_boundary_ids.end(),
-                                             bid) -
-                                   src_boundary_ids.begin();
-                  if ((unsigned int)ind < src_boundary_ids.size())
+                  const unsigned int ind = std::find(src_boundary_ids.begin(),
+                                                     src_boundary_ids.end(),
+                                                     bid) -
+                                           src_boundary_ids.begin();
+                  if (ind < src_boundary_ids.size())
                     cell->face(f)->line(e)->set_boundary_id(
                       reset_boundary_ids[ind]);
                 }

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1195,7 +1195,8 @@ namespace internal
       types::boundary_id,
       << "The input data for creating a triangulation contained "
       << "information about a line with indices " << arg1 << " and " << arg2
-      << " that is described to have boundary indicator " << (int)arg3
+      << " that is described to have boundary indicator "
+      << static_cast<int>(arg3)
       << ". However, this is an internal line not located on the "
       << "boundary. You cannot assign a boundary indicator to it." << std::endl
       << std::endl
@@ -1228,7 +1229,8 @@ namespace internal
       << "The input data for creating a triangulation contained "
       << "information about a quad with indices " << arg1 << ", " << arg2
       << ", " << arg3 << ", and " << arg4
-      << " that is described to have boundary indicator " << (int)arg5
+      << " that is described to have boundary indicator "
+      << static_cast<int>(arg5)
       << ". However, this is an internal quad not located on the "
       << "boundary. You cannot assign a boundary indicator to it." << std::endl
       << std::endl
@@ -1493,9 +1495,10 @@ namespace internal
         // access any of these numbers, we can do this in the
         // background
         Threads::Task<void> update_lines = Threads::new_task(
-          (void (*)(const Triangulation<dim, spacedim> &,
-                    const unsigned int,
-                    internal::TriangulationImplementation::NumberCache<1> &))(
+          static_cast<
+            void (*)(const Triangulation<dim, spacedim> &,
+                     const unsigned int,
+                     internal::TriangulationImplementation::NumberCache<1> &)>(
             &compute_number_cache<dim, spacedim>),
           triangulation,
           level_objects,
@@ -1599,9 +1602,10 @@ namespace internal
         // don't access any of these numbers, we can do this in the
         // background
         Threads::Task<void> update_quads_and_lines = Threads::new_task(
-          (void (*)(const Triangulation<dim, spacedim> &,
-                    const unsigned int,
-                    internal::TriangulationImplementation::NumberCache<2> &))(
+          static_cast<
+            void (*)(const Triangulation<dim, spacedim> &,
+                     const unsigned int,
+                     internal::TriangulationImplementation::NumberCache<2> &)>(
             &compute_number_cache<dim, spacedim>),
           triangulation,
           level_objects,

--- a/source/grid/tria_levels.cc
+++ b/source/grid/tria_levels.cc
@@ -73,7 +73,7 @@ namespace internal
           else
             direction_flags.clear();
 
-          parents.reserve((int)(total_cells + 1) / 2);
+          parents.reserve((total_cells + 1) / 2);
           parents.insert(parents.end(),
                          (total_cells + 1) / 2 - parents.size(),
                          -1);
@@ -165,7 +165,7 @@ namespace internal
           else
             direction_flags.clear();
 
-          parents.reserve((int)(total_cells + 1) / 2);
+          parents.reserve((total_cells + 1) / 2);
           parents.insert(parents.end(),
                          (total_cells + 1) / 2 - parents.size(),
                          -1);


### PR DESCRIPTION
Part of #7459.
This PR replaces all C-style casts in `include/deal.II/grid` and `source/grid`.
