### PR TITLE
Avoid C-style cast in fe

### DIFF
--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1259,9 +1259,9 @@ namespace FETools
         std::lower_bound(cells_list.begin(), cells_list.end(), cell_data);
 
       if ((bound != cells_list.end()) && !(cell_data < *bound))
-        return (int)(bound - cells_list.begin());
+        return static_cast<int>(bound - cells_list.begin());
 
-      return (-1);
+      return -1;
     }
 
 

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -584,8 +584,7 @@ FE_ABF<dim>::convert_generalized_support_point_values_to_dof_values(
   // Face integral of ABF terms
   for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
     {
-      double n_orient =
-        (double)GeometryInfo<dim>::unit_normal_orientation[face];
+      const double n_orient = GeometryInfo<dim>::unit_normal_orientation[face];
       for (unsigned int fp = 0; fp < n_face_points; ++fp)
         {
           // TODO: Check what the face_orientation, face_flip and face_rotation

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -861,7 +861,7 @@ FE_DGQArbitraryNodes<dim, spacedim>::get_name() const
 
   // Check whether the support points are equidistant.
   for (unsigned int j = 0; j <= this->degree; j++)
-    if (std::abs(points[j] - (double)j / this->degree) > 1e-15)
+    if (std::abs(points[j] - static_cast<double>(j) / this->degree) > 1e-15)
       {
         equidistant = false;
         break;

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -2475,7 +2475,7 @@ FE_Nedelec<dim>::get_face_interpolation_matrix(
 
       for (unsigned int i = 0; i < q; ++i)
         {
-          for (int j = 1; j < (int)GeometryInfo<dim>::lines_per_face; ++j)
+          for (unsigned int j = 1; j < GeometryInfo<dim>::lines_per_face; ++j)
             interpolation_matrix(j * p + i, j * q + i) = 1.0;
 
           for (unsigned int j = 0; j < q - 1; ++j)
@@ -3609,8 +3609,8 @@ FE_Nedelec<dim>::convert_generalized_support_point_values_to_dof_values(
                                                n_edge_points]
                                             [face_coordinates[face][1]];
 
-                      for (int i = 2;
-                           i < (int)GeometryInfo<dim>::lines_per_face;
+                      for (unsigned int i = 2;
+                           i < GeometryInfo<dim>::lines_per_face;
                            ++i)
                         for (unsigned int j = 0; j <= deg; ++j)
                           tmp -=

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -256,7 +256,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // component given: Note some i,j combinations will be
                   // incorrect, but only on invalid edges.
                   data->sigma_imj_grads[i][j][sigma_imj_component[i][j]] =
-                    2.0 * (double)sigma_imj_sign[i][j];
+                    2.0 * sigma_imj_sign[i][j];
                 }
             }
 
@@ -643,7 +643,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // component given: Note some i,j combinations will be
                   // incorrect, but only on invalid edges.
                   data->sigma_imj_grads[i][j][sigma_imj_component[i][j]] =
-                    2.0 * (double)sigma_imj_sign[i][j];
+                    2.0 * sigma_imj_sign[i][j];
                 }
             }
           // Now compute the edge parameterisations for a single element
@@ -753,10 +753,10 @@ FE_NedelecSZ<dim, spacedim>::get_data(
             {
               data->edge_lambda_gradgrads_3d[m][edge_lambda_directions[m][0]]
                                             [edge_lambda_directions[m][1]] =
-                (double)edge_lambda_sign[m] * 1.0;
+                edge_lambda_sign[m];
               data->edge_lambda_gradgrads_3d[m][edge_lambda_directions[m][1]]
                                             [edge_lambda_directions[m][0]] =
-                (double)edge_lambda_sign[m] * 1.0;
+                edge_lambda_sign[m];
             }
           // Precomputation for higher order shape functions,
           // and the face parameterisation.

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -43,13 +43,9 @@ FE_Poly<TensorProductPolynomials<1>, 1, 2>::fill_fe_values(
   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, 2>
     &output_data) const
 {
-  // convert data object to internal
-  // data for this class. fails with
-  // an exception if that is not
-  // possible
-  Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
-         ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
+  // convert data object to internal data for this class. fails with an
+  // exception if that is not possible
+  const InternalData &fe_data = dynamic_cast<const InternalData &>(fe_internal);
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
@@ -113,11 +109,9 @@ FE_Poly<TensorProductPolynomials<2>, 2, 3>::fill_fe_values(
   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2, 3>
     &output_data) const
 {
-  // assert that the following dynamics
-  // cast is really well-defined.
-  Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
-         ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
+  // convert data object to internal data for this class. fails with an
+  // exception if that is not possible
+  const InternalData &fe_data = dynamic_cast<const InternalData &>(fe_internal);
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
@@ -180,14 +174,9 @@ FE_Poly<PolynomialSpace<1>, 1, 2>::fill_fe_values(
   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<1, 2>
     &output_data) const
 {
-  // convert data object to internal
-  // data for this class. fails with
-  // an exception if that is not
-  // possible
-
-  Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
-         ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
+  // convert data object to internal data for this class. fails with an
+  // exception if that is not possible
+  const InternalData &fe_data = dynamic_cast<const InternalData &>(fe_internal);
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
@@ -250,9 +239,9 @@ FE_Poly<PolynomialSpace<2>, 2, 3>::fill_fe_values(
   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2, 3>
     &output_data) const
 {
-  Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
-         ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
+  // convert data object to internal data for this class. fails with an
+  // exception if that is not possible
+  const InternalData &fe_data = dynamic_cast<const InternalData &>(fe_internal);
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -45,7 +45,9 @@ FE_Poly<TensorProductPolynomials<1>, 1, 2>::fill_fe_values(
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
-  const InternalData &fe_data = dynamic_cast<const InternalData &>(fe_internal);
+  Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
+         ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
@@ -111,7 +113,9 @@ FE_Poly<TensorProductPolynomials<2>, 2, 3>::fill_fe_values(
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
-  const InternalData &fe_data = dynamic_cast<const InternalData &>(fe_internal);
+  Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
+         ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
@@ -176,7 +180,9 @@ FE_Poly<PolynomialSpace<1>, 1, 2>::fill_fe_values(
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
-  const InternalData &fe_data = dynamic_cast<const InternalData &>(fe_internal);
+  Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
+         ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
@@ -241,7 +247,9 @@ FE_Poly<PolynomialSpace<2>, 2, 3>::fill_fe_values(
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
-  const InternalData &fe_data = dynamic_cast<const InternalData &>(fe_internal);
+  Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
+         ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when

--- a/source/fe/fe_q.cc
+++ b/source/fe/fe_q.cc
@@ -106,7 +106,7 @@ FE_Q<dim, spacedim>::get_name() const
 
   // Check whether the support points are equidistant.
   for (unsigned int j = 0; j <= this->degree; j++)
-    if (std::fabs(points[j] - (double)j / this->degree) > 1e-15)
+    if (std::fabs(points[j] - static_cast<double>(j) / this->degree) > 1e-15)
       {
         equidistant = false;
         break;

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -356,7 +356,7 @@ struct FE_Q_Base<PolynomialType, xdim, xspacedim>::Implementation
 
     for (unsigned int i = 0; i < constraint_points.size(); ++i)
       {
-        const double interval = (double)(q_deg * 2);
+        const double interval = static_cast<double>(q_deg * 2);
         bool         mirror[dim - 1];
         Point<dim>   constraint_point;
 

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -301,7 +301,8 @@ FE_Q_Bubbles<dim, spacedim>::get_name() const
 
   // Check whether the support points are equidistant.
   for (unsigned int j = 0; j < n_points; j++)
-    if (std::fabs(points[j] - (double)j / (this->degree - 1)) > 1e-15)
+    if (std::fabs(points[j] - static_cast<double>(j) / (this->degree - 1)) >
+        1e-15)
       {
         type = false;
         break;

--- a/source/fe/fe_q_dg0.cc
+++ b/source/fe/fe_q_dg0.cc
@@ -131,7 +131,7 @@ FE_Q_DG0<dim, spacedim>::get_name() const
 
   // Check whether the support points are equidistant.
   for (unsigned int j = 0; j < n_points; j++)
-    if (std::fabs(points[j] - (double)j / this->degree) > 1e-15)
+    if (std::fabs(points[j] - static_cast<double>(j) / this->degree) > 1e-15)
       {
         type = false;
         break;

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -471,7 +471,8 @@ FE_Q_Hierarchical<dim>::build_dofs_cell(
             {
               double factor = 1.;
               for (unsigned int i = 1; i <= j; ++i)
-                factor *= ((double)(k - i + 1)) / ((double)i);
+                factor *=
+                  (static_cast<double>(k - i + 1)) / (static_cast<double>(i));
               // factor == k * (k-1) * ... * (k-j+1) / j! = k! / (k-j)! / j!
               if (c == 0)
                 {
@@ -1056,14 +1057,14 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
 
                   int factorial_i = 1;
 
-                  for (int i = 2; i < (int)this->dofs_per_face; ++i)
+                  for (unsigned int i = 2; i < this->dofs_per_face; ++i)
                     {
                       interpolation_matrix(i, i) = std::pow(0.5, i);
                       factorial_i *= i;
                       int factorial_j  = factorial_i;
                       int factorial_ij = 1;
 
-                      for (int j = i + 1; j < (int)this->dofs_per_face; ++j)
+                      for (unsigned int j = i + 1; j < this->dofs_per_face; ++j)
                         {
                           factorial_ij *= j - i;
                           factorial_j *= j;
@@ -1098,14 +1099,14 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
 
                   int factorial_i = 1;
 
-                  for (int i = 2; i < (int)this->dofs_per_face; ++i)
+                  for (unsigned int i = 2; i < this->dofs_per_face; ++i)
                     {
                       interpolation_matrix(i, i) = std::pow(0.5, i);
                       factorial_i *= i;
                       int factorial_j  = factorial_i;
                       int factorial_ij = 1;
 
-                      for (int j = i + 1; j < (int)this->dofs_per_face; ++j)
+                      for (unsigned int j = i + 1; j < this->dofs_per_face; ++j)
                         {
                           factorial_ij *= j - i;
                           factorial_j *= j;
@@ -1162,7 +1163,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
 
                   int factorial_i = 1;
 
-                  for (int i = 2; i <= (int)this->degree; ++i)
+                  for (unsigned int i = 2; i <= this->degree; ++i)
                     {
                       double tmp                         = std::pow(0.5, i);
                       interpolation_matrix(i + 2, i + 2) = tmp;
@@ -1192,7 +1193,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
 
                       int factorial_k = 1;
 
-                      for (int j = 2; j <= (int)this->degree; ++j)
+                      for (unsigned int j = 2; j <= this->degree; ++j)
                         {
                           interpolation_matrix(i + (j + 2) * source_fe.degree -
                                                  j,
@@ -1202,7 +1203,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                           int factorial_kl = 1;
                           int factorial_l  = factorial_k;
 
-                          for (int k = j + 1; k < (int)this->degree; ++k)
+                          for (unsigned int k = j + 1; k < this->degree; ++k)
                             {
                               factorial_kl *= k - j;
                               factorial_l *= k;
@@ -1227,7 +1228,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                       int factorial_j  = factorial_i;
                       int factorial_ij = 1;
 
-                      for (int j = i + 1; j <= (int)this->degree; ++j)
+                      for (unsigned int j = i + 1; j <= this->degree; ++j)
                         {
                           factorial_ij *= j - i;
                           factorial_j *= j;
@@ -1241,7 +1242,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                                                    j + 2 * this->degree) = tmp;
                               factorial_k                                = 1;
 
-                              for (int k = 2; k <= (int)this->degree; ++k)
+                              for (unsigned int k = 2; k <= this->degree; ++k)
                                 {
                                   interpolation_matrix(
                                     i + (k + 2) * source_fe.degree - k,
@@ -1251,7 +1252,8 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                                   int factorial_l  = factorial_k;
                                   int factorial_kl = 1;
 
-                                  for (int l = k + 1; l <= (int)this->degree;
+                                  for (unsigned int l = k + 1;
+                                       l <= this->degree;
                                        ++l)
                                     {
                                       factorial_kl *= l - k;
@@ -1306,7 +1308,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                                                    j + 2 * this->degree) = tmp;
                               factorial_k                                = 1;
 
-                              for (int k = 2; k <= (int)this->degree; ++k)
+                              for (unsigned int k = 2; k <= this->degree; ++k)
                                 {
                                   interpolation_matrix(
                                     i + (k + 2) * source_fe.degree - k,
@@ -1316,7 +1318,8 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                                   int factorial_l  = factorial_k;
                                   int factorial_kl = 1;
 
-                                  for (int l = k + 1; l <= (int)this->degree;
+                                  for (unsigned int l = k + 1;
+                                       l <= this->degree;
                                        ++l)
                                     {
                                       factorial_kl *= l - k;
@@ -1406,7 +1409,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
 
                   int factorial_i = 1;
 
-                  for (int i = 2; i <= (int)this->degree; ++i)
+                  for (unsigned int i = 2; i <= this->degree; ++i)
                     {
                       double tmp                         = std::pow(0.5, i + 1);
                       interpolation_matrix(i + 2, i + 2) = tmp;
@@ -1437,7 +1440,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                       int factorial_j  = factorial_i;
                       int factorial_ij = 1;
 
-                      for (int j = i + 1; j <= (int)this->degree; ++j)
+                      for (unsigned int j = i + 1; j <= this->degree; ++j)
                         {
                           factorial_ij *= j - i;
                           factorial_j *= j;
@@ -1447,7 +1450,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                                                j + 2 * this->degree) = tmp;
                           int factorial_k                            = 1;
 
-                          for (int k = 2; k <= (int)this->degree; ++k)
+                          for (unsigned int k = 2; k <= this->degree; ++k)
                             {
                               interpolation_matrix(
                                 i + (k + 2) * source_fe.degree - k,
@@ -1457,7 +1460,8 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                               int factorial_l  = factorial_k;
                               int factorial_kl = 1;
 
-                              for (int l = k + 1; l <= (int)this->degree; ++l)
+                              for (unsigned int l = k + 1; l <= this->degree;
+                                   ++l)
                                 {
                                   factorial_kl *= l - k;
                                   factorial_l *= l;
@@ -1517,7 +1521,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
 
                       int factorial_k = 1;
 
-                      for (int j = 2; j <= (int)this->degree; ++j)
+                      for (unsigned int j = 2; j <= this->degree; ++j)
                         {
                           interpolation_matrix(i + (j + 2) * source_fe.degree -
                                                  j,
@@ -1527,7 +1531,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                           int factorial_l  = factorial_k;
                           int factorial_kl = 1;
 
-                          for (int k = j + 1; k <= (int)this->degree; ++k)
+                          for (unsigned int k = j + 1; k <= this->degree; ++k)
                             {
                               factorial_kl *= k - j;
                               factorial_l *= k;
@@ -1589,7 +1593,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
 
                   int factorial_i = 1;
 
-                  for (int i = 2; i <= (int)this->degree; ++i)
+                  for (unsigned int i = 2; i <= this->degree; ++i)
                     {
                       double tmp                         = std::pow(0.5, i);
                       interpolation_matrix(i + 2, i + 2) = tmp;
@@ -1619,7 +1623,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
 
                       int factorial_k = 1;
 
-                      for (int j = 2; j <= (int)this->degree; ++j)
+                      for (unsigned int j = 2; j <= this->degree; ++j)
                         {
                           interpolation_matrix(i + (j + 2) * source_fe.degree -
                                                  j,
@@ -1629,7 +1633,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                           int factorial_kl = 1;
                           int factorial_l  = factorial_k;
 
-                          for (int k = j + 1; k <= (int)this->degree; ++k)
+                          for (unsigned int k = j + 1; k <= this->degree; ++k)
                             {
                               factorial_kl *= k - j;
                               factorial_l *= k;
@@ -1645,7 +1649,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                       int factorial_j  = factorial_i;
                       int factorial_ij = 1;
 
-                      for (int j = i + 1; j <= (int)this->degree; ++j)
+                      for (unsigned int j = i + 1; j <= this->degree; ++j)
                         {
                           factorial_ij *= j - i;
                           factorial_j *= j;
@@ -1680,7 +1684,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                                                j + 3 * this->degree - 1) = tmp;
                           int factorial_k                                = 1;
 
-                          for (int k = 2; k <= (int)this->degree; ++k)
+                          for (unsigned int k = 2; k <= this->degree; ++k)
                             {
                               interpolation_matrix(
                                 i + (k + 2) * source_fe.degree - k,
@@ -1690,7 +1694,8 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                               int factorial_l  = factorial_k;
                               int factorial_kl = 1;
 
-                              for (int l = k + 1; l <= (int)this->degree; ++l)
+                              for (unsigned int l = k + 1; l <= this->degree;
+                                   ++l)
                                 {
                                   factorial_kl *= l - k;
                                   factorial_l *= l;
@@ -1754,7 +1759,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
 
                   int factorial_i = 1;
 
-                  for (int i = 2; i <= (int)this->degree; ++i)
+                  for (unsigned int i = 2; i <= this->degree; ++i)
                     {
                       double tmp                         = std::pow(0.5, i + 1);
                       interpolation_matrix(i + 2, i + 2) = tmp;
@@ -1783,7 +1788,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                                            i + 3 * this->degree - 1) = tmp;
                       int factorial_k                                = 1;
 
-                      for (int j = 2; j <= (int)this->degree; ++j)
+                      for (unsigned int j = 2; j <= this->degree; ++j)
                         {
                           interpolation_matrix(i + (j + 2) * source_fe.degree -
                                                  j,
@@ -1793,7 +1798,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                           int factorial_l  = factorial_k;
                           int factorial_kl = 1;
 
-                          for (int k = j + 1; k <= (int)this->degree; ++k)
+                          for (unsigned int k = j + 1; k <= this->degree; ++k)
                             {
                               factorial_kl *= k - j;
                               factorial_l *= k;
@@ -1809,7 +1814,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                       int factorial_j  = factorial_i;
                       int factorial_ij = 1;
 
-                      for (int j = i + 1; j <= (int)this->degree; ++j)
+                      for (unsigned int j = i + 1; j <= this->degree; ++j)
                         {
                           factorial_ij *= j - i;
                           factorial_j *= j;
@@ -1829,7 +1834,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                                                j + 3 * this->degree - 1) = tmp;
                           int factorial_k                                = 1;
 
-                          for (int k = 2; k <= (int)this->degree; ++k)
+                          for (unsigned int k = 2; k <= this->degree; ++k)
                             {
                               interpolation_matrix(
                                 i + (k + 2) * source_fe.degree - k,
@@ -1839,7 +1844,8 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
                               int factorial_l  = factorial_k;
                               int factorial_kl = 1;
 
-                              for (int l = k + 1; l <= (int)this->degree; ++l)
+                              for (unsigned int l = k + 1; l <= this->degree;
+                                   ++l)
                                 {
                                   factorial_kl *= l - k;
                                   factorial_l *= l;


### PR DESCRIPTION
Part of #7459. 
This PR replaces all C-style casts in `include/deal.II/fe` and `source/fe`.



