### PR TITLE
Fix compiling with older SUNDIALS

### DIFF
--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -140,7 +140,11 @@ namespace SUNDIALS
                                       *src_ypred,
                                       *src_fpred,
                                       jcurPtr_tmp);
-      *jcurPtr         = jcurPtr_tmp ? SUNTRUE : SUNFALSE;
+#  if DEAL_II_SUNDIALS_VERSION_GTE(2, 0, 0)
+      *jcurPtr = jcurPtr_tmp ? SUNTRUE : SUNFALSE;
+#  else
+      *jcurPtr = jcurPtr_tmp ? TRUE : FALSE;
+#  endif
 
       return err;
     }


### PR DESCRIPTION
Fixes the failing build https://cdash.kyomu.43-1.org/viewBuildError.php?buildid=6266.
Reading their changelog at https://computation.llnl.gov/projects/sundials/arkode it seems that versions prior to 2.0.0 are using `TRUE` and `FALSE` instead of `SUNTRUE` and `SUNFALSE`.