### PR TITLE
Provide alternative output for mpi/hp_cell_weights_03

### DIFF
--- a/tests/mpi/hp_cell_weights_03.with_mpi=true.with_metis=true.mpirun=2.output.1
+++ b/tests/mpi/hp_cell_weights_03.with_mpi=true.with_metis=true.mpirun=2.output.1
@@ -1,0 +1,23 @@
+
+DEAL:0:2d::Number of cells before repartitioning: 8
+DEAL:0:2d::  Cumulative dofs per cell: 64
+DEAL:0:2d::Number of cells after repartitioning: 13
+DEAL:0:2d::  Cumulative dofs per cell: 52
+DEAL:0:2d::OK
+DEAL:0:3d::Number of cells before repartitioning: 32
+DEAL:0:3d::  Cumulative dofs per cell: 256
+DEAL:0:3d::Number of cells after repartitioning: 47
+DEAL:0:3d::  Cumulative dofs per cell: 376
+DEAL:0:3d::OK
+
+DEAL:1:2d::Number of cells before repartitioning: 8
+DEAL:1:2d::  Cumulative dofs per cell: 32
+DEAL:1:2d::Number of cells after repartitioning: 3
+DEAL:1:2d::  Cumulative dofs per cell: 44
+DEAL:1:2d::OK
+DEAL:1:3d::Number of cells before repartitioning: 32
+DEAL:1:3d::  Cumulative dofs per cell: 464
+DEAL:1:3d::Number of cells after repartitioning: 17
+DEAL:1:3d::  Cumulative dofs per cell: 344
+DEAL:1:3d::OK
+


### PR DESCRIPTION
Fixes #7355.
`METIS` strikes again with inconsistent output between different versions...
This PR adds the one I get with one of my configurations.
The diff looks the following:
```
 DEAL:0:2d::Number of cells before repartitioning: 8
-DEAL:0:2d::  Cumulative dofs per cell: 32
+DEAL:0:2d::  Cumulative dofs per cell: 64
 DEAL:0:2d::Number of cells after repartitioning: 13
 DEAL:0:2d::  Cumulative dofs per cell: 52
 DEAL:0:2d::OK
-DEAL:0:3d::Number of cells before repartitioning: 33
-DEAL:0:3d::  Cumulative dofs per cell: 264
+DEAL:0:3d::Number of cells before repartitioning: 32
+DEAL:0:3d::  Cumulative dofs per cell: 256
 DEAL:0:3d::Number of cells after repartitioning: 47
 DEAL:0:3d::  Cumulative dofs per cell: 376
 DEAL:0:3d::OK
 
 DEAL:1:2d::Number of cells before repartitioning: 8
-DEAL:1:2d::  Cumulative dofs per cell: 64
+DEAL:1:2d::  Cumulative dofs per cell: 32
 DEAL:1:2d::Number of cells after repartitioning: 3
 DEAL:1:2d::  Cumulative dofs per cell: 44
 DEAL:1:2d::OK
-DEAL:1:3d::Number of cells before repartitioning: 31
-DEAL:1:3d::  Cumulative dofs per cell: 456
+DEAL:1:3d::Number of cells before repartitioning: 32
+DEAL:1:3d::  Cumulative dofs per cell: 464
 DEAL:1:3d::Number of cells after repartitioning: 17
 DEAL:1:3d::  Cumulative dofs per cell: 344
 DEAL:1:3d::OK
```
There is an observable difference in the distribution of cells before repartitioning. After repartitioning, the number of degrees of freedom for each MPI process is the same as before.

edit: link to #7355
