### PR TITLE
Avoid C-style cast in lac (excluding Trilinos)

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -1938,7 +1938,8 @@ public:
    * derived from BlockMatrixBase<T>).
    */
   static const bool value =
-    (sizeof(check_for_block_matrix((MatrixType *)nullptr)) == sizeof(yes_type));
+    (sizeof(check_for_block_matrix(static_cast<MatrixType *>(nullptr))) ==
+     sizeof(yes_type));
 };
 
 // instantiation of the static member

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -96,7 +96,8 @@ public:
    * derived from BlockVectorBase<T>).
    */
   static const bool value =
-    (sizeof(check_for_block_vector((VectorType *)nullptr)) == sizeof(yes_type));
+    (sizeof(check_for_block_vector(static_cast<VectorType *>(nullptr))) ==
+     sizeof(yes_type));
 };
 
 

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -588,7 +588,8 @@ FullMatrix<number>::mmult(FullMatrix<number2> &      dst,
       {
         number2 add_value = adding ? dst(i, j) : 0.;
         for (size_type k = 0; k < l; k++)
-          add_value += (number2)(*this)(i, k) * (number2)(src(k, j));
+          add_value += static_cast<number2>((*this)(i, k)) *
+                       static_cast<number2>((src(k, j)));
         dst(i, j) = add_value;
       }
 }
@@ -671,7 +672,8 @@ FullMatrix<number>::Tmmult(FullMatrix<number2> &      dst,
         {
           number2 add_value = 0.;
           for (size_type k = 0; k < l; ++k)
-            add_value += (number2)(*this)(k, i) * (number2)(*this)(k, j);
+            add_value += static_cast<number2>((*this)(k, i)) *
+                         static_cast<number2>((*this)(k, j));
           if (adding)
             {
               dst(i, j) += add_value;
@@ -692,7 +694,8 @@ FullMatrix<number>::Tmmult(FullMatrix<number2> &      dst,
         {
           number2 add_value = adding ? dst(i, j) : 0.;
           for (size_type k = 0; k < l; k++)
-            add_value += (number2)(*this)(k, i) * (number2)(src(k, j));
+            add_value += static_cast<number2>((*this)(k, i)) *
+                         static_cast<number2>((src(k, j)));
           dst(i, j) = add_value;
         }
 }
@@ -774,7 +777,8 @@ FullMatrix<number>::mTmult(FullMatrix<number2> &      dst,
         {
           number2 add_value = 0.;
           for (size_type k = 0; k < l; ++k)
-            add_value += (number2)(*this)(i, k) * (number2)(*this)(j, k);
+            add_value += static_cast<number2>((*this)(i, k)) *
+                         static_cast<number2>((*this)(j, k));
           if (adding)
             {
               dst(i, j) += add_value;
@@ -792,7 +796,8 @@ FullMatrix<number>::mTmult(FullMatrix<number2> &      dst,
         {
           number2 add_value = adding ? dst(i, j) : 0.;
           for (size_type k = 0; k < l; k++)
-            add_value += (number2)(*this)(i, k) * (number2)(src(j, k));
+            add_value += static_cast<number2>((*this)(i, k)) *
+                         static_cast<number2>(src(j, k));
           dst(i, j) = add_value;
         }
 }
@@ -877,7 +882,8 @@ FullMatrix<number>::TmTmult(FullMatrix<number2> &      dst,
       {
         number2 add_value = adding ? dst(i, j) : 0.;
         for (size_type k = 0; k < l; k++)
-          add_value += (number2)(*this)(k, i) * (number2)(src(j, k));
+          add_value += static_cast<number2>((*this)(k, i)) *
+                       static_cast<number2>(src(j, k));
         dst(i, j) = add_value;
       }
 }

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -618,15 +618,16 @@ namespace LinearAlgebra
 
       Number local_result = Number();
       for (unsigned int i = 0; i < this->n_blocks(); ++i)
-        local_result += this->block(i).mean_value_local() *
-                        (real_type)this->block(i).partitioner->local_size();
+        local_result +=
+          this->block(i).mean_value_local() *
+          static_cast<real_type>(this->block(i).partitioner->local_size());
 
       if (this->block(0).partitioner->n_mpi_processes() > 1)
         return Utilities::MPI::sum(
                  local_result, this->block(0).partitioner->get_communicator()) /
-               (real_type)this->size();
+               static_cast<real_type>(this->size());
       else
-        return local_result / (real_type)this->size();
+        return local_result / static_cast<real_type>(this->size());
     }
 
 

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -137,7 +137,9 @@ namespace LinearAlgebra
 
               Number *new_val;
               Utilities::System::posix_memalign(
-                (void **)&new_val, 64, sizeof(Number) * new_alloc_size);
+                reinterpret_cast<void **>(&new_val),
+                64,
+                sizeof(Number) * new_alloc_size);
               data.values.reset(new_val);
 
               allocated_size = new_alloc_size;
@@ -1678,10 +1680,10 @@ namespace LinearAlgebra
     {
       Number local_result = mean_value_local();
       if (partitioner->n_mpi_processes() > 1)
-        return Utilities::MPI::sum(local_result *
-                                     (real_type)partitioner->local_size(),
+        return Utilities::MPI::sum(local_result * static_cast<real_type>(
+                                                    partitioner->local_size()),
                                    partitioner->get_mpi_communicator()) /
-               (real_type)partitioner->size();
+               static_cast<real_type>(partitioner->size());
       else
         return local_result;
     }

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -743,7 +743,7 @@ PArpackSolver<VectorType>::internal_reinit(const IndexSet &locally_owned_dofs)
   nloc = locally_owned_dofs.n_elements();
   ncv  = additional_data.number_of_arnoldi_vectors;
 
-  Assert((int)local_indices.size() == nloc, ExcInternalError());
+  AssertDimension(local_indices.size(), nloc);
 
   // vectors
   ldv = nloc;
@@ -1016,9 +1016,11 @@ PArpackSolver<VectorType>::solve(const MatrixType1 &system_matrix,
       const int shift_x = ipntr[0] - 1;
       const int shift_y = ipntr[1] - 1;
       Assert(shift_x >= 0, dealii::ExcInternalError());
-      Assert(shift_x + nloc <= (int)workd.size(), dealii::ExcInternalError());
+      Assert(shift_x + nloc <= static_cast<int>(workd.size()),
+             dealii::ExcInternalError());
       Assert(shift_y >= 0, dealii::ExcInternalError());
-      Assert(shift_y + nloc <= (int)workd.size(), dealii::ExcInternalError());
+      Assert(shift_y + nloc <= static_cast<int>(workd.size()),
+             dealii::ExcInternalError());
 
       src = 0.;
 
@@ -1058,7 +1060,7 @@ PArpackSolver<VectorType>::solve(const MatrixType1 &system_matrix,
         {
           const int shift_b_x = ipntr[2] - 1;
           Assert(shift_b_x >= 0, dealii::ExcInternalError());
-          Assert(shift_b_x + nloc <= (int)workd.size(),
+          Assert(shift_b_x + nloc <= static_cast<int>(workd.size()),
                  dealii::ExcInternalError());
 
           // B*X
@@ -1176,7 +1178,7 @@ PArpackSolver<VectorType>::solve(const MatrixType1 &system_matrix,
   for (int i = 0; i < nev; ++i)
     {
       (*eigenvectors[i]) = 0.0;
-      Assert(i * nloc + nloc <= (int)v.size(), dealii::ExcInternalError());
+      AssertIndexRange(i * nloc + nloc, v.size() + 1);
 
       eigenvectors[i]->add(nloc, local_indices.data(), &v[i * nloc]);
       eigenvectors[i]->compress(VectorOperation::add);
@@ -1187,7 +1189,7 @@ PArpackSolver<VectorType>::solve(const MatrixType1 &system_matrix,
       std::complex<double>(eigenvalues_real[i], eigenvalues_im[i]);
 
   // Throw an error if the solver did not converge.
-  AssertThrow(iparam[4] >= (int)n_eigenvalues,
+  AssertThrow(iparam[4] >= static_cast<int>(n_eigenvalues),
               PArpackExcConvergedEigenvectors(n_eigenvalues, iparam[4]));
 
   // both PDNAUPD and PDSAUPD compute eigenpairs of inv[A - sigma*M]*M

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -1327,7 +1327,7 @@ namespace PETScWrappers
                 n_columns++;
               }
           }
-        Assert(n_columns <= (int)n_cols, ExcInternalError());
+        AssertIndexRange(n_columns, n_cols + 1);
 
         col_index_ptr = column_indices.data();
         col_value_ptr = column_values.data();
@@ -1471,7 +1471,7 @@ namespace PETScWrappers
                 n_columns++;
               }
           }
-        Assert(n_columns <= (int)n_cols, ExcInternalError());
+        AssertIndexRange(n_columns, n_cols + 1);
 
         col_index_ptr = column_indices.data();
         col_value_ptr = column_values.data();

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -1124,7 +1124,7 @@ namespace PETScWrappers
   VectorBase::get_mpi_communicator() const
   {
     static MPI_Comm comm;
-    PetscObjectGetComm((PetscObject)vector, &comm);
+    PetscObjectGetComm(reinterpret_cast<PetscObject>(vector), &comm);
     return comm;
   }
 
@@ -1199,8 +1199,7 @@ namespace PETScWrappers
                 const unsigned int ghostidx =
                   ghost_indices.index_within_set(index);
 
-                Assert(ghostidx + end - begin < (unsigned int)lsize,
-                       ExcInternalError());
+                AssertIndexRange(ghostidx + end - begin, lsize);
                 *(values_begin + i) = *(ptr + ghostidx + end - begin);
               }
           }

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -219,7 +219,8 @@ namespace LinearAlgebra
     else
       {
         Number *new_values;
-        Utilities::System::posix_memalign((void **)&new_values,
+        Utilities::System::posix_memalign(reinterpret_cast<void **>(
+                                            &new_values),
                                           64,
                                           sizeof(Number) * new_alloc_size);
         values.reset(new_values);

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -1118,7 +1118,7 @@ Vector<Number>::allocate(const size_type copy_n_el)
 {
   // allocate memory with the proper alignment requirements of 64 bytes
   Number *new_values;
-  Utilities::System::posix_memalign((void **)&new_values,
+  Utilities::System::posix_memalign(reinterpret_cast<void **>(&new_values),
                                     64,
                                     sizeof(Number) * max_vec_size);
   // copy:

--- a/source/lac/dynamic_sparsity_pattern.cc
+++ b/source/lac/dynamic_sparsity_pattern.cc
@@ -98,7 +98,7 @@ DynamicSparsityPattern::Line::add_entries(ForwardIterator begin,
       Assert(pos1 <= entries.size(), ExcInternalError());
       entries.insert(it, my_it, end);
       it = entries.begin() + pos1;
-      Assert(entries.size() >= (size_type)(it - entries.begin()),
+      Assert(entries.size() >= static_cast<size_type>(it - entries.begin()),
              ExcInternalError());
 
       // now merge the two lists.

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -1881,7 +1881,7 @@ LAPACKFullMatrix<number>::compute_eigenvalues(const bool right, const bool left)
   lwork = static_cast<types::blas_int>(std::abs(work[0]) + 1);
 
   // resize workspace array
-  work.resize((size_type)lwork);
+  work.resize(lwork);
 
   // Finally compute the eigenvalues.
   internal::LAPACKFullMatrixImplementation::geev_helper(jobvl,

--- a/source/lac/petsc_matrix_free.cc
+++ b/source/lac/petsc_matrix_free.cc
@@ -227,15 +227,21 @@ namespace PETScWrappers
     // create a PETSc MatShell matrix-type
     // object of dimension m x n and local size
     // local_rows x local_columns
-    PetscErrorCode ierr = MatCreateShell(
-      communicator, local_rows, local_columns, m, n, (void *)this, &matrix);
+    PetscErrorCode ierr = MatCreateShell(communicator,
+                                         local_rows,
+                                         local_columns,
+                                         m,
+                                         n,
+                                         static_cast<void *>(this),
+                                         &matrix);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
     // register the MatrixFree::matrix_free_mult function
     // as the matrix multiplication used by this matrix
     ierr = MatShellSetOperation(
       matrix,
       MATOP_MULT,
-      (void (*)(void)) & dealii::PETScWrappers::MatrixFree::matrix_free_mult);
+      reinterpret_cast<void (*)(void)>(
+        &dealii::PETScWrappers::MatrixFree::matrix_free_mult));
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     ierr = MatSetFromOptions(matrix);

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -266,8 +266,9 @@ namespace PETScWrappers
       ghostnodes.fill_index_vector(ghostindices);
 
       const PetscInt *ptr =
-        (ghostindices.size() > 0 ? (const PetscInt *)(&(ghostindices[0])) :
-                                   nullptr);
+        (ghostindices.size() > 0 ?
+           reinterpret_cast<const PetscInt *>(&(ghostindices[0])) :
+           nullptr);
 
       PetscErrorCode ierr = VecCreateGhost(communicator,
                                            local_size,
@@ -287,7 +288,7 @@ namespace PETScWrappers
         ierr = VecGetOwnershipRange(vector, &begin, &end);
         AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-        Assert(local_size == (size_type)(end - begin), ExcInternalError());
+        AssertDimension(local_size, static_cast<size_type>(end - begin));
 
         Vec l;
         ierr = VecGhostGetLocalForm(vector, &l);
@@ -300,8 +301,9 @@ namespace PETScWrappers
         ierr = VecGhostRestoreLocalForm(vector, &l);
         AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-        Assert(lsize == end - begin + (PetscInt)ghost_indices.n_elements(),
-               ExcInternalError());
+        AssertDimension(lsize,
+                        end - begin +
+                          static_cast<PetscInt>(ghost_indices.n_elements()));
       }
 #  endif
 

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -419,9 +419,9 @@ namespace PETScWrappers
     // and do some equally nasty stuff that at
     // least doesn't yield warnings...
     int (*fun_ptr)(KSP, int);
-    ierr = PetscObjectQueryFunction((PetscObject)(ksp),
+    ierr = PetscObjectQueryFunction(reinterpret_cast<PetscObject>(ksp),
                                     "KSPGMRESSetRestart_C",
-                                    (void (**)()) & fun_ptr);
+                                    reinterpret_cast<void (**)()>(&fun_ptr));
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     ierr = (*fun_ptr)(ksp, additional_data.restart_parameter);

--- a/source/lac/petsc_sparse_matrix.cc
+++ b/source/lac/petsc_sparse_matrix.cc
@@ -126,7 +126,8 @@ namespace PETScWrappers
   SparseMatrix::get_mpi_communicator() const
   {
     static MPI_Comm      comm;
-    const PetscErrorCode ierr = PetscObjectGetComm((PetscObject)matrix, &comm);
+    const PetscErrorCode ierr =
+      PetscObjectGetComm(reinterpret_cast<PetscObject>(matrix), &comm);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
     return comm;
   }

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -75,8 +75,7 @@ namespace PETScWrappers
               const size_type ghostidx =
                 vector.ghost_indices.index_within_set(index);
 
-              Assert(ghostidx + end - begin < (size_type)lsize,
-                     ExcInternalError());
+              AssertIndexRange(ghostidx + end - begin, lsize);
               value = *(ptr + ghostidx + end - begin);
             }
 

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -725,18 +725,12 @@ ScaLAPACKMatrix<NumberType>::copy_to(
     return;
 
   // range checking for matrix A
-  Assert(offset_A.first < (unsigned int)(n_rows - submatrix_size.first + 1),
-         ExcIndexRange(offset_A.first, 0, n_rows - submatrix_size.first + 1));
-  Assert(
-    offset_A.second < (unsigned int)(n_columns - submatrix_size.second + 1),
-    ExcIndexRange(offset_A.second, 0, n_columns - submatrix_size.second + 1));
+  AssertIndexRange(offset_A.first, n_rows - submatrix_size.first + 1);
+  AssertIndexRange(offset_A.second, n_columns - submatrix_size.second + 1);
 
   // range checking for matrix B
-  Assert(offset_B.first < (unsigned int)(B.n_rows - submatrix_size.first + 1),
-         ExcIndexRange(offset_B.first, 0, B.n_rows - submatrix_size.first + 1));
-  Assert(
-    offset_B.second < (unsigned int)(B.n_columns - submatrix_size.second + 1),
-    ExcIndexRange(offset_B.second, 0, B.n_columns - submatrix_size.second + 1));
+  AssertIndexRange(offset_B.first, B.n_rows - submatrix_size.first + 1);
+  AssertIndexRange(offset_B.second, B.n_columns - submatrix_size.second + 1);
 
   // Currently, copying of matrices will only be supported if A and B share the
   // same MPI communicator
@@ -1431,17 +1425,15 @@ ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric_by_index(
   const bool                                   compute_eigenvectors)
 {
   // check validity of index limits
-  Assert(index_limits.first < (unsigned int)n_rows,
-         ExcIndexRange(index_limits.first, 0, n_rows));
-  Assert(index_limits.second < (unsigned int)n_rows,
-         ExcIndexRange(index_limits.second, 0, n_rows));
+  AssertIndexRange(index_limits.first, n_rows);
+  AssertIndexRange(index_limits.second, n_rows);
 
   std::pair<unsigned int, unsigned int> idx =
     std::make_pair(std::min(index_limits.first, index_limits.second),
                    std::max(index_limits.first, index_limits.second));
 
   // compute all eigenvalues/eigenvectors
-  if (idx.first == 0 && idx.second == (unsigned int)n_rows - 1)
+  if (idx.first == 0 && idx.second == static_cast<unsigned int>(n_rows - 1))
     return eigenpairs_symmetric(compute_eigenvectors);
   else
     return eigenpairs_symmetric(compute_eigenvectors, idx);
@@ -1723,7 +1715,7 @@ ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric(
         this->values.swap(eigenvectors->values);
 
       // adapt the size of ev to fit m upon return
-      while ((int)ev.size() > m)
+      while (ev.size() > static_cast<size_type>(m))
         ev.pop_back();
     }
   /*
@@ -1974,7 +1966,7 @@ ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric_MRRR(
         this->values.swap(eigenvectors->values);
 
       // Adapt the size of ev to fit m upon return.
-      while ((int)ev.size() > m)
+      while (ev.size() > static_cast<size_type>(m))
         ev.pop_back();
     }
   /*
@@ -2549,28 +2541,28 @@ namespace internal
       LAPACKSupport::State val;
       state_enum_id = H5Tcreate(H5T_ENUM, sizeof(LAPACKSupport::State));
       val           = LAPACKSupport::State::cholesky;
-      herr_t status = H5Tenum_insert(state_enum_id, "cholesky", (int *)&val);
+      herr_t status = H5Tenum_insert(state_enum_id, "cholesky", &val);
       AssertThrow(status >= 0, ExcInternalError());
       val    = LAPACKSupport::State::eigenvalues;
-      status = H5Tenum_insert(state_enum_id, "eigenvalues", (int *)&val);
+      status = H5Tenum_insert(state_enum_id, "eigenvalues", &val);
       AssertThrow(status >= 0, ExcInternalError());
       val    = LAPACKSupport::State::inverse_matrix;
-      status = H5Tenum_insert(state_enum_id, "inverse_matrix", (int *)&val);
+      status = H5Tenum_insert(state_enum_id, "inverse_matrix", &val);
       AssertThrow(status >= 0, ExcInternalError());
       val    = LAPACKSupport::State::inverse_svd;
-      status = H5Tenum_insert(state_enum_id, "inverse_svd", (int *)&val);
+      status = H5Tenum_insert(state_enum_id, "inverse_svd", &val);
       AssertThrow(status >= 0, ExcInternalError());
       val    = LAPACKSupport::State::lu;
-      status = H5Tenum_insert(state_enum_id, "lu", (int *)&val);
+      status = H5Tenum_insert(state_enum_id, "lu", &val);
       AssertThrow(status >= 0, ExcInternalError());
       val    = LAPACKSupport::State::matrix;
-      status = H5Tenum_insert(state_enum_id, "matrix", (int *)&val);
+      status = H5Tenum_insert(state_enum_id, "matrix", &val);
       AssertThrow(status >= 0, ExcInternalError());
       val    = LAPACKSupport::State::svd;
-      status = H5Tenum_insert(state_enum_id, "svd", (int *)&val);
+      status = H5Tenum_insert(state_enum_id, "svd", &val);
       AssertThrow(status >= 0, ExcInternalError());
       val    = LAPACKSupport::State::unusable;
-      status = H5Tenum_insert(state_enum_id, "unusable", (int *)&val);
+      status = H5Tenum_insert(state_enum_id, "unusable", &val);
       AssertThrow(status >= 0, ExcInternalError());
     }
 
@@ -2580,25 +2572,22 @@ namespace internal
       // create HDF5 enum type for LAPACKSupport::Property
       property_enum_id = H5Tcreate(H5T_ENUM, sizeof(LAPACKSupport::Property));
       LAPACKSupport::Property prop = LAPACKSupport::Property::diagonal;
-      herr_t                  status =
-        H5Tenum_insert(property_enum_id, "diagonal", (int *)&prop);
+      herr_t status = H5Tenum_insert(property_enum_id, "diagonal", &prop);
       AssertThrow(status >= 0, ExcInternalError());
       prop   = LAPACKSupport::Property::general;
-      status = H5Tenum_insert(property_enum_id, "general", (int *)&prop);
+      status = H5Tenum_insert(property_enum_id, "general", &prop);
       AssertThrow(status >= 0, ExcInternalError());
       prop   = LAPACKSupport::Property::hessenberg;
-      status = H5Tenum_insert(property_enum_id, "hessenberg", (int *)&prop);
+      status = H5Tenum_insert(property_enum_id, "hessenberg", &prop);
       AssertThrow(status >= 0, ExcInternalError());
-      prop = LAPACKSupport::Property::lower_triangular;
-      status =
-        H5Tenum_insert(property_enum_id, "lower_triangular", (int *)&prop);
+      prop   = LAPACKSupport::Property::lower_triangular;
+      status = H5Tenum_insert(property_enum_id, "lower_triangular", &prop);
       AssertThrow(status >= 0, ExcInternalError());
       prop   = LAPACKSupport::Property::symmetric;
-      status = H5Tenum_insert(property_enum_id, "symmetric", (int *)&prop);
+      status = H5Tenum_insert(property_enum_id, "symmetric", &prop);
       AssertThrow(status >= 0, ExcInternalError());
-      prop = LAPACKSupport::Property::upper_triangular;
-      status =
-        H5Tenum_insert(property_enum_id, "upper_triangular", (int *)&prop);
+      prop   = LAPACKSupport::Property::upper_triangular;
+      status = H5Tenum_insert(property_enum_id, "upper_triangular", &prop);
       AssertThrow(status >= 0, ExcInternalError());
     }
   } // namespace
@@ -2628,12 +2617,8 @@ ScaLAPACKMatrix<NumberType>::save(
       chunks_size_.first  = n_rows;
       chunks_size_.second = 1;
     }
-  Assert((chunks_size_.first <= (unsigned int)n_rows) &&
-           (chunks_size_.first > 0),
-         ExcIndexRange(chunks_size_.first, 1, n_rows + 1));
-  Assert((chunks_size_.second <= (unsigned int)n_columns) &&
-           (chunks_size_.second > 0),
-         ExcIndexRange(chunks_size_.second, 1, n_columns + 1));
+  AssertIndexRange(chunks_size_.first + 1, n_rows);
+  AssertIndexRange(chunks_size_.second + 1, n_columns);
 
 #    ifdef H5_HAVE_PARALLEL
   // implementation for configurations equipped with a parallel file system
@@ -3122,11 +3107,11 @@ ScaLAPACKMatrix<NumberType>::load_serial(const std::string &filename)
       hsize_t dims[2];
       H5Sget_simple_extent_dims(dataspace_id, dims, nullptr);
       AssertThrow(
-        (int)dims[0] == n_columns,
+        static_cast<int>(dims[0]) == n_columns,
         ExcMessage(
           "The number of columns of the matrix does not match the content of the archive"));
       AssertThrow(
-        (int)dims[1] == n_rows,
+        static_cast<int>(dims[1]) == n_rows,
         ExcMessage(
           "The number of rows of the matrix does not match the content of the archive"));
 
@@ -3167,10 +3152,10 @@ ScaLAPACKMatrix<NumberType>::load_serial(const std::string &filename)
       // get every dimension
       hsize_t dims_state[1];
       H5Sget_simple_extent_dims(dataspace_state, dims_state, nullptr);
-      AssertThrow((int)dims_state[0] == 1, ExcIO());
+      AssertThrow(static_cast<int>(dims_state[0]) == 1, ExcIO());
       hsize_t dims_property[1];
       H5Sget_simple_extent_dims(dataspace_property, dims_property, nullptr);
-      AssertThrow((int)dims_property[0] == 1, ExcIO());
+      AssertThrow(static_cast<int>(dims_property[0]) == 1, ExcIO());
 
       // read data
       status = H5Dread(dataset_state_id,
@@ -3318,11 +3303,11 @@ ScaLAPACKMatrix<NumberType>::load_parallel(const std::string &filename)
   status = H5Sget_simple_extent_dims(dataspace_id, dims, nullptr);
   AssertThrow(status >= 0, ExcIO());
   AssertThrow(
-    (int)dims[0] == n_columns,
+    static_cast<int>(dims[0]) == n_columns,
     ExcMessage(
       "The number of columns of the matrix does not match the content of the archive"));
   AssertThrow(
-    (int)dims[1] == n_rows,
+    static_cast<int>(dims[1]) == n_rows,
     ExcMessage(
       "The number of rows of the matrix does not match the content of the archive"));
 
@@ -3400,10 +3385,10 @@ ScaLAPACKMatrix<NumberType>::load_parallel(const std::string &filename)
   // get every dimension
   hsize_t dims_state[1];
   H5Sget_simple_extent_dims(dataspace_state, dims_state, nullptr);
-  AssertThrow((int)dims_state[0] == 1, ExcIO());
+  AssertThrow(static_cast<int>(dims_state[0]) == 1, ExcIO());
   hsize_t dims_property[1];
   H5Sget_simple_extent_dims(dataspace_property, dims_property, nullptr);
-  AssertThrow((int)dims_property[0] == 1, ExcIO());
+  AssertThrow(static_cast<int>(dims_property[0]) == 1, ExcIO());
 
   // read data
   status = H5Dread(


### PR DESCRIPTION
Part of #7459.
This PR replaces all C-style casts in `include/deal.II/lac` and `source/lac` excluding `Trilinos`-related headers and source files.
`PETSc` requires us to use `reinterpret_cast` in quite a lot of places.