### PR TITLE
Cast variables in AssertDimension

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1365,8 +1365,14 @@ namespace deal_II_exceptions
  * @ingroup Exceptions
  * @author Guido Kanschat 2007
  */
-#define AssertDimension(dim1, dim2) \
-  Assert((dim1) == (dim2), dealii::ExcDimensionMismatch((dim1), (dim2)))
+#define AssertDimension(dim1, dim2)                                            \
+  Assert(static_cast<typename ::dealii::internal::argument_type<void(          \
+             typename std::common_type<decltype(dim1),                         \
+                                       decltype(dim2)>::type)>::type>(dim1) == \
+           static_cast<typename ::dealii::internal::argument_type<void(        \
+             typename std::common_type<decltype(dim1),                         \
+                                       decltype(dim2)>::type)>::type>(dim2),   \
+         dealii::ExcDimensionMismatch((dim1), (dim2)))
 
 
 /**

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -2015,9 +2015,9 @@ namespace TrilinosWrappers
   PreconditionBase::vmult(dealii::Vector<double> &      dst,
                           const dealii::Vector<double> &src) const
   {
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(dst.size()),
+    AssertDimension(dst.size(),
                     preconditioner->OperatorDomainMap().NumMyElements());
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(src.size()),
+    AssertDimension(src.size(),
                     preconditioner->OperatorRangeMap().NumMyElements());
     Epetra_Vector tril_dst(View,
                            preconditioner->OperatorDomainMap(),
@@ -2035,9 +2035,9 @@ namespace TrilinosWrappers
   PreconditionBase::Tvmult(dealii::Vector<double> &      dst,
                            const dealii::Vector<double> &src) const
   {
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(dst.size()),
+    AssertDimension(dst.size(),
                     preconditioner->OperatorDomainMap().NumMyElements());
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(src.size()),
+    AssertDimension(src.size(),
                     preconditioner->OperatorRangeMap().NumMyElements());
     Epetra_Vector tril_dst(View,
                            preconditioner->OperatorDomainMap(),
@@ -2059,11 +2059,9 @@ namespace TrilinosWrappers
     LinearAlgebra::distributed::Vector<double> &      dst,
     const LinearAlgebra::distributed::Vector<double> &src) const
   {
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(
-                      dst.local_size()),
+    AssertDimension(dst.local_size(),
                     preconditioner->OperatorDomainMap().NumMyElements());
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(
-                      src.local_size()),
+    AssertDimension(src.local_size(),
                     preconditioner->OperatorRangeMap().NumMyElements());
     Epetra_Vector tril_dst(View,
                            preconditioner->OperatorDomainMap(),
@@ -2081,11 +2079,9 @@ namespace TrilinosWrappers
     LinearAlgebra::distributed::Vector<double> &      dst,
     const LinearAlgebra::distributed::Vector<double> &src) const
   {
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(
-                      dst.local_size()),
+    AssertDimension(dst.local_size(),
                     preconditioner->OperatorDomainMap().NumMyElements());
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(
-                      src.local_size()),
+    AssertDimension(src.local_size(),
                     preconditioner->OperatorRangeMap().NumMyElements());
     Epetra_Vector tril_dst(View,
                            preconditioner->OperatorDomainMap(),

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1275,8 +1275,7 @@ namespace MatrixFreeOperators
       {
         if (data_->n_macro_cells() > 0)
           {
-            AssertDimension(static_cast<int>(level),
-                            data_->get_cell_iterator(0, 0, j)->level());
+            AssertDimension(level, data_->get_cell_iterator(0, 0, j)->level());
           }
 
         // setup edge_constrained indices

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -229,12 +229,8 @@ namespace TrilinosWrappers
   {
     // In case we call the solver with deal.II vectors, we create views of the
     // vectors in Epetra format.
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(
-                      x.local_size()),
-                    A.domain_partitioner().NumMyElements());
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(
-                      b.local_size()),
-                    A.range_partitioner().NumMyElements());
+    AssertDimension(x.local_size(), A.domain_partitioner().NumMyElements());
+    AssertDimension(b.local_size(), A.range_partitioner().NumMyElements());
 
     Epetra_Vector ep_x(View, A.domain_partitioner(), x.begin());
     Epetra_Vector ep_b(View,
@@ -257,12 +253,8 @@ namespace TrilinosWrappers
                     const dealii::LinearAlgebra::distributed::Vector<double> &b,
                     const PreconditionBase &preconditioner)
   {
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(
-                      x.local_size()),
-                    A.OperatorDomainMap().NumMyElements());
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(
-                      b.local_size()),
-                    A.OperatorRangeMap().NumMyElements());
+    AssertDimension(x.local_size(), A.OperatorDomainMap().NumMyElements());
+    AssertDimension(b.local_size(), A.OperatorRangeMap().NumMyElements());
 
     Epetra_Vector ep_x(View, A.OperatorDomainMap(), x.begin());
     Epetra_Vector ep_b(View,
@@ -913,12 +905,8 @@ namespace TrilinosWrappers
     dealii::LinearAlgebra::distributed::Vector<double> &      x,
     const dealii::LinearAlgebra::distributed::Vector<double> &b)
   {
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(
-                      x.local_size()),
-                    A.domain_partitioner().NumMyElements());
-    AssertDimension(static_cast<TrilinosWrappers::types::int_type>(
-                      b.local_size()),
-                    A.range_partitioner().NumMyElements());
+    AssertDimension(x.local_size(), A.domain_partitioner().NumMyElements());
+    AssertDimension(b.local_size(), A.range_partitioner().NumMyElements());
     Epetra_Vector ep_x(View, A.domain_partitioner(), x.begin());
     Epetra_Vector ep_b(View,
                        A.range_partitioner(),

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -492,13 +492,9 @@ namespace TrilinosWrappers
       if (input_row_map.Comm().MyPID() == 0)
         {
           AssertDimension(sparsity_pattern.n_rows(),
-                          static_cast<size_type>(
-                            TrilinosWrappers::n_global_elements(
-                              input_row_map)));
+                          TrilinosWrappers::n_global_elements(input_row_map));
           AssertDimension(sparsity_pattern.n_cols(),
-                          static_cast<size_type>(
-                            TrilinosWrappers::n_global_elements(
-                              input_col_map)));
+                          TrilinosWrappers::n_global_elements(input_col_map));
         }
 
       column_space_map = std_cxx14::make_unique<Epetra_Map>(input_col_map);
@@ -584,8 +580,7 @@ namespace TrilinosWrappers
 
       // check whether we got the number of columns right.
       AssertDimension(sparsity_pattern.n_cols(),
-                      static_cast<size_type>(
-                        TrilinosWrappers::n_global_cols(*graph)));
+                      TrilinosWrappers::n_global_cols(*graph));
       (void)n_global_cols;
 
       // And now finally generate the matrix.
@@ -634,11 +629,9 @@ namespace TrilinosWrappers
       nonlocal_matrix_exporter.reset();
 
       AssertDimension(sparsity_pattern.n_rows(),
-                      static_cast<size_type>(
-                        TrilinosWrappers::n_global_elements(input_row_map)));
+                      TrilinosWrappers::n_global_elements(input_row_map));
       AssertDimension(sparsity_pattern.n_cols(),
-                      static_cast<size_type>(
-                        TrilinosWrappers::n_global_elements(input_col_map)));
+                      TrilinosWrappers::n_global_elements(input_col_map));
 
       column_space_map = std_cxx14::make_unique<Epetra_Map>(input_col_map);
 
@@ -786,8 +779,7 @@ namespace TrilinosWrappers
       graph->OptimizeStorage();
 
       AssertDimension(sparsity_pattern.n_cols(),
-                      static_cast<size_type>(
-                        TrilinosWrappers::n_global_cols(*graph)));
+                      TrilinosWrappers::n_global_cols(*graph));
 
       matrix = std_cxx14::make_unique<Epetra_FECrsMatrix>(Copy, *graph, false);
     }
@@ -1867,7 +1859,7 @@ namespace TrilinosWrappers
           indices.size(),
           n_indices,
           indices.data());
-        AssertDimension(static_cast<unsigned int>(n_indices), indices.size());
+        AssertDimension(n_indices, indices.size());
 
         for (TrilinosWrappers::types::int_type i = 0; i < n_indices; ++i)
           std::cout << indices[i] << " ";
@@ -2100,11 +2092,9 @@ namespace TrilinosWrappers
                                                                     src,
                                                                     dst);
     const size_type dst_local_size = internal::end(dst) - internal::begin(dst);
-    AssertDimension(dst_local_size,
-                    static_cast<size_type>(matrix->RangeMap().NumMyPoints()));
+    AssertDimension(dst_local_size, matrix->RangeMap().NumMyPoints());
     const size_type src_local_size = internal::end(src) - internal::begin(src);
-    AssertDimension(src_local_size,
-                    static_cast<size_type>(matrix->DomainMap().NumMyPoints()));
+    AssertDimension(src_local_size, matrix->DomainMap().NumMyPoints());
 
     Epetra_MultiVector tril_dst(
       View, matrix->RangeMap(), internal::begin(dst), dst_local_size, 1);
@@ -2133,11 +2123,9 @@ namespace TrilinosWrappers
                                                                     dst,
                                                                     src);
     const size_type dst_local_size = internal::end(dst) - internal::begin(dst);
-    AssertDimension(dst_local_size,
-                    static_cast<size_type>(matrix->DomainMap().NumMyPoints()));
+    AssertDimension(dst_local_size, matrix->DomainMap().NumMyPoints());
     const size_type src_local_size = internal::end(src) - internal::begin(src);
-    AssertDimension(src_local_size,
-                    static_cast<size_type>(matrix->RangeMap().NumMyPoints()));
+    AssertDimension(src_local_size, matrix->RangeMap().NumMyPoints());
 
     Epetra_MultiVector tril_dst(
       View, matrix->DomainMap(), internal::begin(dst), dst_local_size, 1);
@@ -3097,13 +3085,9 @@ namespace TrilinosWrappers
 
           // Duplicated from TrilinosWrappers::SparseMatrix::vmult
           const size_type i_local_size = i->end() - i->begin();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            first_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorDomainMap();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            second_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
           (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
@@ -3141,13 +3125,9 @@ namespace TrilinosWrappers
 
           // Duplicated from TrilinosWrappers::SparseMatrix::vmult
           const size_type i_local_size = i->end() - i->begin();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            first_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorRangeMap();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            second_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
           (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
@@ -3182,13 +3162,9 @@ namespace TrilinosWrappers
 
           // Duplicated from TrilinosWrappers::SparseMatrix::vmult
           const size_type i_local_size = i->end() - i->begin();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            first_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorRangeMap();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            second_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
           (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
@@ -3226,13 +3202,9 @@ namespace TrilinosWrappers
 
           // Duplicated from TrilinosWrappers::SparseMatrix::vmult
           const size_type i_local_size = i->end() - i->begin();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            first_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorDomainMap();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            second_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
           (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
@@ -3288,13 +3260,9 @@ namespace TrilinosWrappers
 
           // Duplicated from TrilinosWrappers::SparseMatrix::vmult
           const size_type i_local_size = i->end() - i->begin();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            first_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorRangeMap();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            second_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
           (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
@@ -3330,13 +3298,9 @@ namespace TrilinosWrappers
 
           // Duplicated from TrilinosWrappers::SparseMatrix::vmult
           const size_type i_local_size = i->end() - i->begin();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            first_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorDomainMap();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            second_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
           (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
@@ -3368,13 +3332,9 @@ namespace TrilinosWrappers
 
           // Duplicated from TrilinosWrappers::SparseMatrix::vmult
           const size_type i_local_size = i->end() - i->begin();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            first_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorDomainMap();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            second_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
           (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
@@ -3410,13 +3370,9 @@ namespace TrilinosWrappers
 
           // Duplicated from TrilinosWrappers::SparseMatrix::vmult
           const size_type i_local_size = i->end() - i->begin();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            first_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorRangeMap();
-          AssertDimension(i_local_size,
-                          static_cast<size_type>(
-                            second_op_init_map.NumMyPoints()));
+          AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
           (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -335,8 +335,7 @@ namespace TrilinosWrappers
       nonlocal_graph.reset();
       graph.reset();
       AssertDimension(n_entries_per_row.size(),
-                      static_cast<size_type>(
-                        TrilinosWrappers::n_global_elements(row_map)));
+                      TrilinosWrappers::n_global_elements(row_map));
 
       column_space_map = std_cxx14::make_unique<Epetra_Map>(col_map);
       std::vector<int> local_entries_per_row(
@@ -376,11 +375,9 @@ namespace TrilinosWrappers
       graph.reset();
 
       AssertDimension(sp.n_rows(),
-                      static_cast<size_type>(
-                        TrilinosWrappers::n_global_elements(row_map)));
+                      TrilinosWrappers::n_global_elements(row_map));
       AssertDimension(sp.n_cols(),
-                      static_cast<size_type>(
-                        TrilinosWrappers::n_global_elements(col_map)));
+                      TrilinosWrappers::n_global_elements(col_map));
 
       column_space_map = std_cxx14::make_unique<Epetra_Map>(col_map);
 
@@ -405,8 +402,7 @@ namespace TrilinosWrappers
         graph = std_cxx14::make_unique<Epetra_FECrsGraph>(
           Copy, row_map, col_map, n_entries_per_row.data(), false);
 
-      AssertDimension(sp.n_rows(),
-                      static_cast<size_type>(n_global_rows(*graph)));
+      AssertDimension(sp.n_rows(), n_global_rows(*graph));
 
       std::vector<TrilinosWrappers::types::int_type> row_indices;
 


### PR DESCRIPTION
This PR casts the variables in `AssertDimension` in a similar manner as `AssertIndexRange` already does. There should not be any harm in doing so but avoids the need to use explicit casts to avoid compiler warnings.