### PR TITLE
 Avoid C-style cast in Trilinos-related files

### DIFF
--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -1613,7 +1613,8 @@ namespace TrilinosWrappers
             {
               const int ierr = vector->ReplaceGlobalValues(
                 1,
-                (const TrilinosWrappers::types::int_type *)(&row),
+                reinterpret_cast<const TrilinosWrappers::types::int_type *>(
+                  &row),
                 &values[i]);
               AssertThrow(ierr == 0, ExcTrilinosError(ierr));
               compressed = false;
@@ -1688,7 +1689,8 @@ namespace TrilinosWrappers
             {
               const int ierr = vector->SumIntoGlobalValues(
                 1,
-                (const TrilinosWrappers::types::int_type *)(&row),
+                reinterpret_cast<const TrilinosWrappers::types::int_type *>(
+                  &row),
                 &values[i]);
               AssertThrow(ierr == 0, ExcTrilinosError(ierr));
               compressed = false;
@@ -1717,11 +1719,9 @@ namespace TrilinosWrappers
     Vector::size() const
     {
 #    ifndef DEAL_II_WITH_64BIT_INDICES
-      return (size_type)(vector->Map().MaxAllGID() + 1 -
-                         vector->Map().MinAllGID());
+      return vector->Map().MaxAllGID() + 1 - vector->Map().MinAllGID();
 #    else
-      return (size_type)(vector->Map().MaxAllGID64() + 1 -
-                         vector->Map().MinAllGID64());
+      return vector->Map().MaxAllGID64() + 1 - vector->Map().MinAllGID64();
 #    endif
     }
 
@@ -1730,7 +1730,7 @@ namespace TrilinosWrappers
     inline Vector::size_type
     Vector::local_size() const
     {
-      return (size_type)vector->Map().NumMyElements();
+      return vector->Map().NumMyElements();
     }
 
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -1604,18 +1604,14 @@ namespace TrilinosWrappers
 
       for (size_type i = 0; i < n_elements; ++i)
         {
-          const size_type                         row       = indices[i];
-          const TrilinosWrappers::types::int_type local_row = vector->Map().LID(
-            static_cast<TrilinosWrappers::types::int_type>(row));
+          const TrilinosWrappers::types::int_type row = indices[i];
+          const TrilinosWrappers::types::int_type local_row =
+            vector->Map().LID(row);
           if (local_row != -1)
             (*vector)[0][local_row] = values[i];
           else
             {
-              const int ierr = vector->ReplaceGlobalValues(
-                1,
-                reinterpret_cast<const TrilinosWrappers::types::int_type *>(
-                  &row),
-                &values[i]);
+              const int ierr = vector->ReplaceGlobalValues(1, &row, &values[i]);
               AssertThrow(ierr == 0, ExcTrilinosError(ierr));
               compressed = false;
             }

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -575,7 +575,7 @@ namespace LinearAlgebra
             (unsigned int *)vector->Map().MyGlobalElements();
 #    else
           size_type *vector_indices =
-            (size_type *)vector->Map().MyGlobalElements64();
+            reinterpret_cast<size_type *>(vector->Map().MyGlobalElements64());
 #    endif
           is.add_indices(vector_indices, vector_indices + n_indices);
         }

--- a/source/lac/trilinos_precondition.cc
+++ b/source/lac/trilinos_precondition.cc
@@ -121,7 +121,7 @@ namespace TrilinosWrappers
                       0));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -173,7 +173,7 @@ namespace TrilinosWrappers
                       additional_data.overlap));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -226,7 +226,7 @@ namespace TrilinosWrappers
                       additional_data.overlap));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -288,7 +288,7 @@ namespace TrilinosWrappers
                       0));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -356,7 +356,7 @@ namespace TrilinosWrappers
                       additional_data.overlap));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -425,7 +425,7 @@ namespace TrilinosWrappers
                       additional_data.overlap));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -484,7 +484,7 @@ namespace TrilinosWrappers
                       additional_data.overlap));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -492,7 +492,7 @@ namespace TrilinosWrappers
     int ierr;
 
     Teuchos::ParameterList parameter_list;
-    parameter_list.set("fact: level-of-fill", (int)additional_data.ic_fill);
+    parameter_list.set("fact: level-of-fill", additional_data.ic_fill);
     parameter_list.set("fact: absolute threshold", additional_data.ic_atol);
     parameter_list.set("fact: relative threshold", additional_data.ic_rtol);
     parameter_list.set("schwarz: combine mode", "Add");
@@ -534,7 +534,7 @@ namespace TrilinosWrappers
                       additional_data.overlap));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -587,7 +587,7 @@ namespace TrilinosWrappers
                       additional_data.overlap));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -596,7 +596,8 @@ namespace TrilinosWrappers
 
     Teuchos::ParameterList parameter_list;
     parameter_list.set("fact: drop value", additional_data.ilut_drop);
-    parameter_list.set("fact: level-of-fill", (int)additional_data.ilut_fill);
+    parameter_list.set("fact: level-of-fill",
+                       static_cast<int>(additional_data.ilut_fill));
     parameter_list.set("fact: absolute threshold", additional_data.ilut_atol);
     parameter_list.set("fact: relative threshold", additional_data.ilut_rtol);
     parameter_list.set("schwarz: combine mode", "Add");
@@ -633,7 +634,7 @@ namespace TrilinosWrappers
                       additional_data.overlap));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -683,7 +684,7 @@ namespace TrilinosWrappers
       std::make_shared<Ifpack_Chebyshev>(&matrix.trilinos_matrix());
 
     Ifpack_Chebyshev *ifpack =
-      static_cast<Ifpack_Chebyshev *>(preconditioner.get());
+      dynamic_cast<Ifpack_Chebyshev *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));
@@ -697,7 +698,8 @@ namespace TrilinosWrappers
                        additional_data.min_eigenvalue);
     parameter_list.set("chebyshev: max eigenvalue",
                        additional_data.max_eigenvalue);
-    parameter_list.set("chebyshev: degree", (int)additional_data.degree);
+    parameter_list.set("chebyshev: degree",
+                       static_cast<int>(additional_data.degree));
     parameter_list.set("chebyshev: min diagonal value",
                        additional_data.min_diagonal);
     parameter_list.set("chebyshev: zero starting solution",
@@ -738,7 +740,7 @@ namespace TrilinosWrappers
                       0));
 
     Ifpack_Preconditioner *ifpack =
-      static_cast<Ifpack_Preconditioner *>(preconditioner.get());
+      dynamic_cast<Ifpack_Preconditioner *>(preconditioner.get());
     Assert(ifpack != nullptr,
            ExcMessage("Trilinos could not create this "
                       "preconditioner"));

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -143,7 +143,7 @@ namespace TrilinosWrappers
         }
 
       int ierr = matrix->trilinos_matrix().ExtractGlobalRowCopy(
-        (TrilinosWrappers::types::int_type)this->a_row,
+        static_cast<TrilinosWrappers::types::int_type>(this->a_row),
         colnums,
         ncols,
         &((*value_cache)[0]),
@@ -205,8 +205,9 @@ namespace TrilinosWrappers
     : column_space_map(new Epetra_Map(input_map))
     , matrix(new Epetra_FECrsMatrix(Copy,
                                     *column_space_map,
-                                    (int *)const_cast<unsigned int *>(
-                                      &(n_entries_per_row[0])),
+                                    reinterpret_cast<int *>(
+                                      const_cast<unsigned int *>(
+                                        &(n_entries_per_row[0]))),
                                     false))
     , last_action(Zero)
     , compressed(false)
@@ -235,8 +236,9 @@ namespace TrilinosWrappers
     : column_space_map(new Epetra_Map(input_col_map))
     , matrix(new Epetra_FECrsMatrix(Copy,
                                     input_row_map,
-                                    (int *)const_cast<unsigned int *>(
-                                      &(n_entries_per_row[0])),
+                                    reinterpret_cast<int *>(
+                                      const_cast<unsigned int *>(
+                                        &(n_entries_per_row[0]))),
                                     false))
     , last_action(Zero)
     , compressed(false)
@@ -288,7 +290,8 @@ namespace TrilinosWrappers
                    0,
                    Utilities::Trilinos::comm_self()),
         *column_space_map,
-        (int *)const_cast<unsigned int *>(&(n_entries_per_row[0])),
+        reinterpret_cast<int *>(
+          const_cast<unsigned int *>(&(n_entries_per_row[0]))),
         false))
     , last_action(Zero)
     , compressed(false)
@@ -318,8 +321,9 @@ namespace TrilinosWrappers
         parallel_partitioning.make_trilinos_map(communicator, false)))
     , matrix(new Epetra_FECrsMatrix(Copy,
                                     *column_space_map,
-                                    (int *)const_cast<unsigned int *>(
-                                      &(n_entries_per_row[0])),
+                                    reinterpret_cast<int *>(
+                                      const_cast<unsigned int *>(
+                                        &(n_entries_per_row[0]))),
                                     false))
     , last_action(Zero)
     , compressed(false)
@@ -353,7 +357,8 @@ namespace TrilinosWrappers
     , matrix(new Epetra_FECrsMatrix(
         Copy,
         row_parallel_partitioning.make_trilinos_map(communicator, false),
-        (int *)const_cast<unsigned int *>(&(n_entries_per_row[0])),
+        reinterpret_cast<int *>(
+          const_cast<unsigned int *>(&(n_entries_per_row[0]))),
         false))
     , last_action(Zero)
     , compressed(false)
@@ -1243,7 +1248,7 @@ namespace TrilinosWrappers
 
         int *diag_find =
           std::find(col_indices, col_indices + num_entries, local_row);
-        int diag_index = (int)(diag_find - col_indices);
+        int diag_index = static_cast<int>(diag_find - col_indices);
 
         for (TrilinosWrappers::types::int_type j = 0; j < num_entries; ++j)
           if (diag_index != j || new_diag_value == 0)
@@ -1325,7 +1330,7 @@ namespace TrilinosWrappers
         int *el_find =
           std::find(col_indices, col_indices + nnz_present, trilinos_j);
 
-        int local_col_index = (int)(el_find - col_indices);
+        int local_col_index = static_cast<int>(el_find - col_indices);
 
         // This is actually the only
         // difference to the el(i,j)
@@ -1401,7 +1406,7 @@ namespace TrilinosWrappers
         int *el_find =
           std::find(col_indices, col_indices + nnz_present, trilinos_j);
 
-        int local_col_index = (int)(el_find - col_indices);
+        int local_col_index = static_cast<int>(el_find - col_indices);
 
 
         // This is actually the only
@@ -1542,7 +1547,8 @@ namespace TrilinosWrappers
     // we will not modify const data)
     if (elide_zero_values == false)
       {
-        col_index_ptr = (TrilinosWrappers::types::int_type *)col_indices;
+        col_index_ptr = reinterpret_cast<TrilinosWrappers::types::int_type *>(
+          const_cast<size_type *>(col_indices));
         col_value_ptr = const_cast<TrilinosScalar *>(values);
         n_columns     = n_cols;
       }
@@ -1566,8 +1572,7 @@ namespace TrilinosWrappers
               }
           }
 
-        Assert(n_columns <= (TrilinosWrappers::types::int_type)n_cols,
-               ExcInternalError());
+        AssertIndexRange(n_columns, n_cols + 1);
       }
 
 
@@ -1585,7 +1590,7 @@ namespace TrilinosWrappers
         if (matrix->Filled() == false)
           {
             ierr = matrix->Epetra_CrsMatrix::InsertGlobalValues(
-              static_cast<TrilinosWrappers::types::int_type>(row),
+              row,
               static_cast<int>(n_columns),
               const_cast<double *>(col_value_ptr),
               col_index_ptr);
@@ -1616,7 +1621,8 @@ namespace TrilinosWrappers
           {
             ierr = matrix->InsertGlobalValues(
               1,
-              (TrilinosWrappers::types::int_type *)&row,
+              reinterpret_cast<TrilinosWrappers::types::int_type *>(
+                const_cast<size_type *>(&row)),
               n_columns,
               col_index_ptr,
               &col_value_ptr,
@@ -1627,7 +1633,8 @@ namespace TrilinosWrappers
         else
           ierr = matrix->ReplaceGlobalValues(
             1,
-            (TrilinosWrappers::types::int_type *)&row,
+            reinterpret_cast<TrilinosWrappers::types::int_type *>(
+              const_cast<size_type *>(&row)),
             n_columns,
             col_index_ptr,
             &col_value_ptr,
@@ -1739,7 +1746,8 @@ namespace TrilinosWrappers
     // we will not modify const data)
     if (elide_zero_values == false)
       {
-        col_index_ptr = (TrilinosWrappers::types::int_type *)col_indices;
+        col_index_ptr = reinterpret_cast<TrilinosWrappers::types::int_type *>(
+          const_cast<size_type *>(col_indices));
         col_value_ptr = const_cast<TrilinosScalar *>(values);
         n_columns     = n_cols;
 #  ifdef DEBUG
@@ -1768,8 +1776,7 @@ namespace TrilinosWrappers
               }
           }
 
-        Assert(n_columns <= (TrilinosWrappers::types::int_type)n_cols,
-               ExcInternalError());
+        AssertIndexRange(n_columns, n_cols + 1);
       }
     // Exit early if there is nothing to do
     if (n_columns == 0)
@@ -1816,13 +1823,14 @@ namespace TrilinosWrappers
         // a time).
         compressed = false;
 
-        ierr =
-          matrix->SumIntoGlobalValues(1,
-                                      (TrilinosWrappers::types::int_type *)&row,
-                                      n_columns,
-                                      col_index_ptr,
-                                      &col_value_ptr,
-                                      Epetra_FECrsMatrix::ROW_MAJOR);
+        ierr = matrix->SumIntoGlobalValues(
+          1,
+          reinterpret_cast<TrilinosWrappers::types::int_type *>(
+            const_cast<size_type *>(&row)),
+          n_columns,
+          col_index_ptr,
+          &col_value_ptr,
+          Epetra_FECrsMatrix::ROW_MAJOR);
         AssertThrow(ierr == 0, ExcTrilinosError(ierr));
       }
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1535,6 +1535,7 @@ namespace TrilinosWrappers
 
     TrilinosWrappers::types::int_type *col_index_ptr;
     TrilinosScalar *                   col_value_ptr;
+    TrilinosWrappers::types::int_type  trilinos_row = row;
     TrilinosWrappers::types::int_type  n_columns;
 
     boost::container::small_vector<TrilinosScalar, 200> local_value_array(
@@ -1619,26 +1620,22 @@ namespace TrilinosWrappers
 
         if (matrix->Filled() == false)
           {
-            ierr = matrix->InsertGlobalValues(
-              1,
-              reinterpret_cast<TrilinosWrappers::types::int_type *>(
-                const_cast<size_type *>(&row)),
-              n_columns,
-              col_index_ptr,
-              &col_value_ptr,
-              Epetra_FECrsMatrix::ROW_MAJOR);
+            ierr = matrix->InsertGlobalValues(1,
+                                              &trilinos_row,
+                                              n_columns,
+                                              col_index_ptr,
+                                              &col_value_ptr,
+                                              Epetra_FECrsMatrix::ROW_MAJOR);
             if (ierr > 0)
               ierr = 0;
           }
         else
-          ierr = matrix->ReplaceGlobalValues(
-            1,
-            reinterpret_cast<TrilinosWrappers::types::int_type *>(
-              const_cast<size_type *>(&row)),
-            n_columns,
-            col_index_ptr,
-            &col_value_ptr,
-            Epetra_FECrsMatrix::ROW_MAJOR);
+          ierr = matrix->ReplaceGlobalValues(1,
+                                             &trilinos_row,
+                                             n_columns,
+                                             col_index_ptr,
+                                             &col_value_ptr,
+                                             Epetra_FECrsMatrix::ROW_MAJOR);
         // use the FECrsMatrix facilities for set even in the case when we
         // have explicitly set the off-processor rows because that only works
         // properly when adding elements, not when setting them (since we want
@@ -1734,6 +1731,7 @@ namespace TrilinosWrappers
 
     TrilinosWrappers::types::int_type *col_index_ptr;
     TrilinosScalar *                   col_value_ptr;
+    TrilinosWrappers::types::int_type  trilinos_row = row;
     TrilinosWrappers::types::int_type  n_columns;
 
     boost::container::small_vector<TrilinosScalar, 100> local_value_array(
@@ -1823,14 +1821,12 @@ namespace TrilinosWrappers
         // a time).
         compressed = false;
 
-        ierr = matrix->SumIntoGlobalValues(
-          1,
-          reinterpret_cast<TrilinosWrappers::types::int_type *>(
-            const_cast<size_type *>(&row)),
-          n_columns,
-          col_index_ptr,
-          &col_value_ptr,
-          Epetra_FECrsMatrix::ROW_MAJOR);
+        ierr = matrix->SumIntoGlobalValues(1,
+                                           &trilinos_row,
+                                           n_columns,
+                                           col_index_ptr,
+                                           &col_value_ptr,
+                                           Epetra_FECrsMatrix::ROW_MAJOR);
         AssertThrow(ierr == 0, ExcTrilinosError(ierr));
       }
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -143,7 +143,7 @@ namespace TrilinosWrappers
         }
 
       int ierr = matrix->trilinos_matrix().ExtractGlobalRowCopy(
-        static_cast<TrilinosWrappers::types::int_type>(this->a_row),
+        this->a_row,
         colnums,
         ncols,
         &((*value_cache)[0]),
@@ -1859,14 +1859,12 @@ namespace TrilinosWrappers
             &nonlocal_matrix->Graph() :
             &matrix->Graph();
 
-        indices.resize(graph->NumGlobalIndices(
-          static_cast<TrilinosWrappers::types::int_type>(row)));
+        indices.resize(graph->NumGlobalIndices(row));
         int n_indices = 0;
-        graph->ExtractGlobalRowCopy(
-          static_cast<TrilinosWrappers::types::int_type>(row),
-          indices.size(),
-          n_indices,
-          indices.data());
+        graph->ExtractGlobalRowCopy(row,
+                                    indices.size(),
+                                    n_indices,
+                                    indices.data());
         AssertDimension(n_indices, indices.size());
 
         for (TrilinosWrappers::types::int_type i = 0; i < n_indices; ++i)

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -453,11 +453,11 @@ namespace TrilinosWrappers
                     ++p;
                 }
             }
-            graph->InsertGlobalIndices(
-              1,
-              reinterpret_cast<TrilinosWrappers::types::int_type *>(&row),
-              row_length,
-              row_indices.data());
+            const TrilinosWrappers::types::int_type trilinos_row = row;
+            graph->InsertGlobalIndices(1,
+                                       &trilinos_row,
+                                       row_length,
+                                       row_indices.data());
           }
 
       // TODO A dynamic_cast fails here, this is suspicious.
@@ -802,15 +802,12 @@ namespace TrilinosWrappers
                  nonlocal_graph->IndicesAreGlobal() == true,
                ExcInternalError());
 
-        // TODO A dynamic_cast fails here, this is suspicious.
-        const auto &range_map =
-          static_cast<const Epetra_Map &>(graph->RangeMap());
-        nonlocal_graph->FillComplete(*column_space_map, range_map);
+        nonlocal_graph->FillComplete(*column_space_map, graph->RangeMap());
         nonlocal_graph->OptimizeStorage();
         Epetra_Export exporter(nonlocal_graph->RowMap(), graph->RowMap());
         ierr = graph->Export(*nonlocal_graph, exporter, Add);
         AssertThrow(ierr == 0, ExcTrilinosError(ierr));
-        ierr = graph->FillComplete(*column_space_map, range_map);
+        ierr = graph->FillComplete(*column_space_map, graph->RangeMap());
         AssertThrow(ierr == 0, ExcTrilinosError(ierr));
       }
     else

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -56,7 +56,7 @@ namespace TrilinosWrappers
           // get a representation of the present row
           int       ncols;
           const int ierr = sparsity_pattern->graph->ExtractGlobalRowCopy(
-            static_cast<TrilinosWrappers::types::int_type>(this->a_row),
+            this->a_row,
             colnum_cache->size(),
             ncols,
             reinterpret_cast<TrilinosWrappers::types::int_type *>(
@@ -795,8 +795,7 @@ namespace TrilinosWrappers
           {
             // insert dummy element
             TrilinosWrappers::types::int_type row =
-              nonlocal_graph->RowMap().MyGID(
-                static_cast<TrilinosWrappers::types::int_type>(0));
+              nonlocal_graph->RowMap().MyGID(0);
             nonlocal_graph->InsertGlobalIndices(row, 1, &row);
           }
         Assert(nonlocal_graph->RowMap().NumMyElements() == 0 ||
@@ -869,10 +868,9 @@ namespace TrilinosWrappers
             // TODO: trilinos_i is the local row index -> it is an int but
             // ExtractGlobalRowView requires trilinos_i to be the global row
             // index and thus it should be a long long int
-            int ierr = graph->ExtractGlobalRowView(
-              static_cast<TrilinosWrappers::types::int_type>(trilinos_i),
-              nnz_extracted,
-              col_indices);
+            int ierr = graph->ExtractGlobalRowView(trilinos_i,
+                                                   nnz_extracted,
+                                                   col_indices);
             (void)ierr;
             Assert(ierr == 0, ExcTrilinosError(ierr));
             Assert(nnz_present == nnz_extracted,
@@ -882,9 +880,8 @@ namespace TrilinosWrappers
             TrilinosWrappers::types::int_type *el_find =
               std::find(col_indices, col_indices + nnz_present, trilinos_j);
 
-            const auto &local_col_index =
-              static_cast<TrilinosWrappers::types::int_type>(el_find -
-                                                             col_indices);
+            const TrilinosWrappers::types::int_type local_col_index =
+              el_find - col_indices;
 
             if (local_col_index == nnz_present)
               return false;
@@ -893,8 +890,7 @@ namespace TrilinosWrappers
           {
             // Prepare pointers for extraction
             // of a view of the row.
-            int nnz_present = graph->NumGlobalIndices(
-              static_cast<TrilinosWrappers::types::int_type>(i));
+            int  nnz_present = graph->NumGlobalIndices(i);
             int  nnz_extracted;
             int *col_indices;
 
@@ -939,11 +935,8 @@ namespace TrilinosWrappers
         for (unsigned int j = 0; j < static_cast<unsigned int>(num_entries);
              ++j)
           {
-            if (static_cast<size_type>(
-                  std::abs(static_cast<TrilinosWrappers::types::int_type>(
-                    i - indices[j]))) > local_b)
-              local_b = std::abs(
-                static_cast<TrilinosWrappers::types::int_type>(i - indices[j]));
+            if (static_cast<size_type>(std::abs(i - indices[j])) > local_b)
+              local_b = std::abs(i - indices[j]);
           }
       }
     graph->Comm().MaxAll(reinterpret_cast<TrilinosWrappers::types::int_type *>(

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -827,8 +827,7 @@ namespace TrilinosWrappers
       if (size() != local_size())
         {
           auto global_id = [&](const size_type index) {
-            return gid(vector->Map(),
-                       static_cast<TrilinosWrappers::types::int_type>(index));
+            return gid(vector->Map(), index);
           };
           out << "size:" << size() << " local_size:" << local_size() << " :"
               << std::endl;


### PR DESCRIPTION
Part of #7459.
This PR replaces all C-style casts in all `Trilinos`-related headers and source files.
In a lot of places, we need to use `static_cast`s instead of `dynamic_cast`s for the code to work. This is clearly suspicious. As for the `PETSc`-related code, we are using a lot of `reinterpret_cast`s. This also appears to be fragile.
This PR already incorporates the relevant changes form #7494 and removes `static_cast`s where they are not necessary to improve readability.