### PR TITLE
FESeries::calculate accepts different VectorType for local dof values.

### DIFF
--- a/doc/news/changes/minor/20181204Fehling
+++ b/doc/news/changes/minor/20181204Fehling
@@ -1,0 +1,6 @@
+Changed: FESeries::Fourier::calculate and FESeries::Legendre::calculate
+accept both Vector<float> and Vector<double> as input parameters for
+local dof values.
+<br>
+(Marc Fehling, 2018/12/04)
+

--- a/source/fe/fe_series_fourier.cc
+++ b/source/fe/fe_series_fourier.cc
@@ -182,11 +182,12 @@ namespace FESeries
 
 
   template <int dim, int spacedim>
+  template <typename Number>
   void
   Fourier<dim, spacedim>::calculate(
-    const Vector<double> &            local_dof_values,
-    const unsigned int                cell_active_fe_index,
-    Table<dim, std::complex<double>> &fourier_coefficients)
+    const Vector<Number> &       local_dof_values,
+    const unsigned int           cell_active_fe_index,
+    Table<dim, CoefficientType> &fourier_coefficients)
   {
     ensure_existence(*fe_collection,
                      *q_collection,
@@ -194,12 +195,12 @@ namespace FESeries
                      cell_active_fe_index,
                      fourier_transform_matrices);
 
-    const FullMatrix<std::complex<double>> &matrix =
+    const FullMatrix<CoefficientType> &matrix =
       fourier_transform_matrices[cell_active_fe_index];
 
     std::fill(unrolled_coefficients.begin(),
               unrolled_coefficients.end(),
-              std::complex<double>(0.));
+              CoefficientType(0.));
 
     Assert(unrolled_coefficients.size() == matrix.m(), ExcInternalError());
 

--- a/source/fe/fe_series_fourier.inst.in
+++ b/source/fe/fe_series_fourier.inst.in
@@ -22,3 +22,17 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
                                      deal_II_space_dimension>;
 #endif
   }
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     SCALAR : REAL_SCALARS)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+    template void
+    FESeries::Fourier<deal_II_dimension, deal_II_space_dimension>::calculate(
+      const Vector<SCALAR> &,
+      const unsigned int,
+      Table<deal_II_dimension,
+            FESeries::Fourier<deal_II_dimension,
+                              deal_II_space_dimension>::CoefficientType> &);
+#endif
+  }

--- a/source/fe/fe_series_legendre.cc
+++ b/source/fe/fe_series_legendre.cc
@@ -202,11 +202,12 @@ namespace FESeries
 
 
   template <int dim, int spacedim>
+  template <typename Number>
   void
   Legendre<dim, spacedim>::calculate(
-    const dealii::Vector<double> &local_dof_values,
+    const dealii::Vector<Number> &local_dof_values,
     const unsigned int            cell_active_fe_index,
-    Table<dim, double> &          legendre_coefficients)
+    Table<dim, CoefficientType> & legendre_coefficients)
   {
     ensure_existence(*fe_collection,
                      *q_collection,
@@ -214,10 +215,12 @@ namespace FESeries
                      cell_active_fe_index,
                      legendre_transform_matrices);
 
-    const FullMatrix<double> &matrix =
+    const FullMatrix<CoefficientType> &matrix =
       legendre_transform_matrices[cell_active_fe_index];
 
-    std::fill(unrolled_coefficients.begin(), unrolled_coefficients.end(), 0.);
+    std::fill(unrolled_coefficients.begin(),
+              unrolled_coefficients.end(),
+              CoefficientType(0.));
 
     Assert(unrolled_coefficients.size() == matrix.m(), ExcInternalError());
 

--- a/source/fe/fe_series_legendre.inst.in
+++ b/source/fe/fe_series_legendre.inst.in
@@ -22,3 +22,17 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
                                       deal_II_space_dimension>;
 #endif
   }
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     SCALAR : REAL_SCALARS)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+    template void
+    FESeries::Legendre<deal_II_dimension, deal_II_space_dimension>::calculate(
+      const Vector<SCALAR> &,
+      const unsigned int,
+      Table<deal_II_dimension,
+            FESeries::Legendre<deal_II_dimension,
+                               deal_II_space_dimension>::CoefficientType> &);
+#endif
+  }


### PR DESCRIPTION
We introduce a new template parameter for the member functions `FESeries::Fourier::calculate` and `FESeries::Legendre::calculate` to calculate expansion coefficients independent of the type of local dof values provided.

Further, `CoefficientType` has been introduced, for a future generalization of smoothness estimators. 