### PR TITLE
Fix a few warnings from the bundled boost package

### DIFF
--- a/bundled/boost-1.62.0/include/boost/geometry/algorithms/centroid.hpp
+++ b/bundled/boost-1.62.0/include/boost/geometry/algorithms/centroid.hpp
@@ -92,7 +92,7 @@ public:
     \brief Returns the explanatory string.
     \return Pointer to a null-terminated string with explanatory information.
     */
-    virtual char const* what() const throw()
+    virtual char const* what() const throw() override
     {
         return "Boost.Geometry Centroid calculation exception";
     }

--- a/bundled/boost-1.62.0/include/boost/geometry/algorithms/detail/has_self_intersections.hpp
+++ b/bundled/boost-1.62.0/include/boost/geometry/algorithms/detail/has_self_intersections.hpp
@@ -45,7 +45,7 @@ public:
 
     inline overlay_invalid_input_exception() {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const throw () override
     {
         return "Boost.Geometry Overlay invalid input exception";
     }

--- a/bundled/boost-1.62.0/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/bundled/boost-1.62.0/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -56,7 +56,7 @@ public:
     virtual ~turn_info_exception() throw()
     {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const throw() override
     {
         return message.c_str();
     }

--- a/bundled/boost-1.62.0/include/boost/geometry/algorithms/detail/overlay/inconsistent_turns_exception.hpp
+++ b/bundled/boost-1.62.0/include/boost/geometry/algorithms/detail/overlay/inconsistent_turns_exception.hpp
@@ -25,7 +25,7 @@ public:
     virtual ~inconsistent_turns_exception() throw()
     {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const throw() override
     {
         return "Boost.Geometry Inconsistent Turns exception";
     }

--- a/bundled/boost-1.62.0/include/boost/geometry/core/exception.hpp
+++ b/bundled/boost-1.62.0/include/boost/geometry/core/exception.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace geometry
 class exception : public std::exception
 {
 public:
-    virtual char const* what() const throw()
+    virtual char const* what() const throw() override
     {
         return "Boost.Geometry exception";
     }
@@ -52,7 +52,7 @@ public:
 
     inline invalid_input_exception() {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const throw() override
     {
         return "Boost.Geometry Invalid-Input exception";
     }
@@ -77,7 +77,7 @@ public:
 
     inline empty_input_exception() {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const throw() override
     {
         return "Boost.Geometry Empty-Input exception";
     }

--- a/bundled/boost-1.62.0/include/boost/geometry/io/wkt/read.hpp
+++ b/bundled/boost-1.62.0/include/boost/geometry/io/wkt/read.hpp
@@ -91,7 +91,7 @@ struct read_wkt_exception : public geometry::exception
 
     virtual ~read_wkt_exception() throw() {}
 
-    virtual const char* what() const throw()
+    virtual const char* what() const throw() override
     {
         return complete.c_str();
     }

--- a/bundled/boost-1.62.0/include/boost/numeric/ublas/matrix_expression.hpp
+++ b/bundled/boost-1.62.0/include/boost/numeric/ublas/matrix_expression.hpp
@@ -2221,10 +2221,10 @@ namespace boost { namespace numeric { namespace ublas {
                         index1 = it1_.index1 ();
                 }
                 size_type index2 = (*this) ().size1 ();
-                if (it2_ != it2_end_)
+                if (it2_ != it2_end_) {
                     if (it2_.index1 () <= i_)
                         ++ it2_;
-                    if (it2_ != it2_end_) {
+                    if (it2_ != it2_end_)
                         index2 = it2_.index1 ();
                 }
                 i_ = (std::min) (index1, index2);


### PR DESCRIPTION
This fixes most of the warnings in https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&onlydeltap&buildid=6350 and https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&onlydeltap&buildid=6358.

The ones that are left for me compiling with `gcc-8` look like
```
[...]
 ../include/deal.II/numerics/rtree.h:171:10:   required from ‘dealii::RTree<typename LeafTypeIterator::value_type, IndexType> dealii::pack_rtree(const LeafTypeIterator&, const LeafTypeIterator&) [with IndexType = boost::       geometry::index::linear<16>; LeafTypeIterator = __gnu_cxx::__normal_iterator<const std::pair<dealii::Point<3, double>, unsigned int>*, std::vector<std::pair<dealii::Point<3, double>, unsigned int>, std::allocator<std::        pair<dealii::Point<3, double>, unsigned int> > > >; dealii::RTree<typename LeafTypeIterator::value_type, IndexType> = boost::geometry::index::rtree<std::pair<dealii::Point<3, double>, unsigned int>, boost::geometry::index::   linear<16>, boost::geometry::index::indexable<std::pair<dealii::Point<3, double>, unsigned int> >, boost::geometry::index::equal_to<std::pair<dealii::Point<3, double>, unsigned int> >, std::allocator<std::pair<dealii::        Point<3, double>, unsigned int> > >; typename LeafTypeIterator::value_type = std::pair<dealii::Point<3, double>, unsigned int>]’
 ../include/deal.II/numerics/rtree.h:180:31:   required from ‘dealii::RTree<typename LeafTypeIterator::value_type, IndexType> dealii::pack_rtree(const ContainerType&) [with IndexType = boost::geometry::index::linear<16>;       ContainerType = std::vector<std::pair<dealii::Point<3, double>, unsigned int>, std::allocator<std::pair<dealii::Point<3, double>, unsigned int> > >; dealii::RTree<typename LeafTypeIterator::value_type, IndexType> = boost::    geometry::index::rtree<std::pair<dealii::Point<3, double>, unsigned int>, boost::geometry::index::linear<16>, boost::geometry::index::indexable<std::pair<dealii::Point<3, double>, unsigned int> >, boost::geometry::index::     equal_to<std::pair<dealii::Point<3, double>, unsigned int> >, std::allocator<std::pair<dealii::Point<3, double>, unsigned int> > >; typename LeafTypeIterator::value_type = std::pair<dealii::Point<3, double>, unsigned int>]’
 ../source/grid/grid_tools_cache.cc:110:41:   required from ‘dealii::RTree<std::pair<dealii::Point<spacedim>, unsigned int> >& dealii::GridTools::Cache<dim, spacedim>::get_used_vertices_rtree() const [with int dim = 1; int     spacedim = 3; dealii::RTree<std::pair<dealii::Point<spacedim>, unsigned int> > = boost::geometry::index::rtree<std::pair<dealii::Point<3, double>, unsigned int>, boost::geometry::index::linear<16>, boost::geometry::index::    indexable<std::pair<dealii::Point<3, double>, unsigned int> >, boost::geometry::index::equal_to<std::pair<dealii::Point<3, double>, unsigned int> >, std::allocator<std::pair<dealii::Point<3, double>, unsigned int> > >]’
 source/grid/grid_tools_cache.inst:23:17:   required from here
 ../bundled/boost-1.62.0/include/boost/geometry/index/detail/varray_detail.hpp:237:13: error: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of type ‘struct std::pair<dealii::Point<3, double>, unsigned int>’   with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Werror=class-memaccess]
      ::memcpy(boost::addressof(*dst), boost::addressof(*first), sizeof(value_type) * d);
```

I am not sure if we can do anything about these. Clearly, `gcc-8` is following the words of the standard implying that a `std::pair` is not required to be trivially copyable. In fact, it doesn't fulfill the requirements in the usual implementations. On the other hand, using `std::memcpy` will likely still succeed (even if not guaranteed by the standard). In our own codebase, we are checking if the type in question is in fact trivially copyable and fall back to `std::copy` otherwise, but we can't easily do anything like that here.