### PR TITLE
find_active_cell_around_point now takes also an rtree of vertices.

### DIFF
--- a/doc/news/changes/minor/20181205LucaHeltai
+++ b/doc/news/changes/minor/20181205LucaHeltai
@@ -1,0 +1,9 @@
+New: GridTools::find_active_cell_around_point now allows you to specify an (optional) rtree, constructed
+from the used vertices of the triangulation. Once you have built a tree, querying for a nearest
+vertex is an O(log(N)) operation, where N is the number of used vertices. You can ask a GridTools::Cache
+object to return a tree that is compatible with the new function signature. 
+The previous version of this function had a cost that was O(N^2) when the point was not in the cell_hint
+object. 
+<br>
+(Luca Heltai, 2018/12/05)
+

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -36,6 +36,8 @@
 
 #  include <deal.II/lac/sparsity_tools.h>
 
+#  include <deal.II/numerics/rtree.h>
+
 #  include <boost/archive/binary_iarchive.hpp>
 #  include <boost/archive/binary_oarchive.hpp>
 #  include <boost/optional.hpp>
@@ -1125,8 +1127,10 @@ namespace GridTools
    * A version of the previous function that exploits an already existing
    * map between vertices and cells, constructed using the function
    * GridTools::vertex_to_cell_map, a map of vertex_to_cell_centers, obtained
-   * through GridTools::vertex_to_cell_centers_directions, and a guess
-   * `cell_hint`.
+   * through GridTools::vertex_to_cell_centers_directions, a guess
+   * `cell_hint`, and optionally an RTree constructed from the used
+   * vertices of the Triangulation. All of these structures can be queried
+   * from a GridTools::Cache object.
    *
    * @author Luca Heltai, Rene Gassmoeller, 2017
    */
@@ -1148,7 +1152,9 @@ namespace GridTools
     const std::vector<std::vector<Tensor<1, spacedim>>> &vertex_to_cell_centers,
     const typename MeshType<dim, spacedim>::active_cell_iterator &cell_hint =
       typename MeshType<dim, spacedim>::active_cell_iterator(),
-    const std::vector<bool> &marked_vertices = {});
+    const std::vector<bool> &                              marked_vertices = {},
+    const RTree<std::pair<Point<spacedim>, unsigned int>> &used_vertices_rtree =
+      {});
 
   /**
    * A version of the previous function where we use that mapping on a given

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -36,7 +36,8 @@ for (X : TRIANGULATIONS; deal_II_dimension : DIMENSIONS;
         const dealii::internal::ActiveCellIterator<deal_II_dimension,
                                                    deal_II_space_dimension,
                                                    X>::type &,
-        const std::vector<bool> &);
+        const std::vector<bool> &,
+        const RTree<std::pair<Point<deal_II_space_dimension>, unsigned int>> &);
 
       template std::vector<BoundingBox<deal_II_space_dimension>>
       compute_mesh_predicate_bounding_box<X>(


### PR DESCRIPTION
@davydden , this should fix the issue you brought up some time ago, and should finish what @GivAlz had started in his MHPC thesis. 

Now the version of `find_active_cell_around_point`  that takes a `Cache` object, uses the RTree of used vertices in order to get the closest vertex. This costs `log(N)` for each query vs the current `N^2`.