### PR TITLE
Fix warnings due to conversion from floats to integers in tests

### DIFF
--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1500,7 +1500,8 @@ namespace Patterns
           return std_cxx14::make_unique<Patterns::Bool>();
         else if (std::is_integral<T>::value)
           return std_cxx14::make_unique<Patterns::Integer>(
-            std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
+            static_cast<int>(std::numeric_limits<T>::min()),
+            static_cast<int>(std::numeric_limits<T>::max()));
         else if (std::is_floating_point<T>::value)
           return std_cxx14::make_unique<Patterns::Double>(
             -std::numeric_limits<T>::max(), std::numeric_limits<T>::max());

--- a/tests/ad_common_tests/step-44-helper_res_lin_01.h
+++ b/tests/ad_common_tests/step-44-helper_res_lin_01.h
@@ -1574,8 +1574,9 @@ namespace Step44
           std::cout << " SLV " << std::flush;
           if (parameters.type_lin == "CG")
             {
-              const int solver_its = tangent_matrix.block(u_dof, u_dof).m() *
-                                     parameters.max_iterations_lin;
+              const auto solver_its = static_cast<unsigned int>(
+                tangent_matrix.block(u_dof, u_dof).m() *
+                parameters.max_iterations_lin);
               const double tol_sol =
                 parameters.tol_lin * system_rhs.block(u_dof).l2_norm();
               SolverControl solver_control(solver_its, tol_sol, false, false);
@@ -1656,8 +1657,8 @@ namespace Step44
             preconditioner_K_Jp_inv.use_matrix(
               tangent_matrix.block(J_dof, p_dof));
             ReductionControl solver_control_K_Jp_inv(
-              tangent_matrix.block(J_dof, p_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(J_dof, p_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_Jp_inv;
@@ -1675,8 +1676,8 @@ namespace Step44
             preconditioner_K_con_inv.use_matrix(
               tangent_matrix.block(u_dof, u_dof));
             ReductionControl solver_control_K_con_inv(
-              tangent_matrix.block(u_dof, u_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(u_dof, u_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_con_inv;

--- a/tests/ad_common_tests/step-44-helper_var_form_01.h
+++ b/tests/ad_common_tests/step-44-helper_var_form_01.h
@@ -1500,8 +1500,9 @@ namespace Step44
           std::cout << " SLV " << std::flush;
           if (parameters.type_lin == "CG")
             {
-              const int solver_its = tangent_matrix.block(u_dof, u_dof).m() *
-                                     parameters.max_iterations_lin;
+              const auto solver_its = static_cast<unsigned int>(
+                tangent_matrix.block(u_dof, u_dof).m() *
+                parameters.max_iterations_lin);
               const double tol_sol =
                 parameters.tol_lin * system_rhs.block(u_dof).l2_norm();
               SolverControl solver_control(solver_its, tol_sol, false, false);
@@ -1582,8 +1583,8 @@ namespace Step44
             preconditioner_K_Jp_inv.use_matrix(
               tangent_matrix.block(J_dof, p_dof));
             ReductionControl solver_control_K_Jp_inv(
-              tangent_matrix.block(J_dof, p_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(J_dof, p_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_Jp_inv;
@@ -1601,8 +1602,8 @@ namespace Step44
             preconditioner_K_con_inv.use_matrix(
               tangent_matrix.block(u_dof, u_dof));
             ReductionControl solver_control_K_con_inv(
-              tangent_matrix.block(u_dof, u_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(u_dof, u_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_con_inv;

--- a/tests/arpack/parpack_advection_diffusion_petsc.cc
+++ b/tests/arpack/parpack_advection_diffusion_petsc.cc
@@ -179,7 +179,7 @@ test()
         const dealii::Point<dim> &center = cell->center();
         const double              x      = center[0];
 
-        const unsigned int id = std::floor((x - x0) / dL);
+        const auto id = static_cast<unsigned int>((x - x0) / dL);
         cell->set_subdomain_id(id);
       }
   }

--- a/tests/arpack/parpack_advection_diffusion_trilinos.cc
+++ b/tests/arpack/parpack_advection_diffusion_trilinos.cc
@@ -153,7 +153,7 @@ test()
         const Point<dim> &center = cell->center();
         const double      x      = center[0];
 
-        const unsigned int id = std::floor((x - x0) / dL);
+        const auto id = static_cast<unsigned int>((x - x0) / dL);
         cell->set_subdomain_id(id);
       }
   }

--- a/tests/arpack/step-36_parpack.cc
+++ b/tests/arpack/step-36_parpack.cc
@@ -181,7 +181,7 @@ test()
         const dealii::Point<dim> &center = cell->center();
         const double              x      = center[0];
 
-        const unsigned int id = std::floor((x - x0) / dL);
+        const auto id = static_cast<unsigned int>(std::floor((x - x0) / dL));
         cell->set_subdomain_id(id);
       }
   }

--- a/tests/arpack/step-36_parpack_trilinos.cc
+++ b/tests/arpack/step-36_parpack_trilinos.cc
@@ -155,7 +155,7 @@ test()
         const Point<dim> &center = cell->center();
         const double      x      = center[0];
 
-        const unsigned int id = std::floor((x - x0) / dL);
+        const auto id = static_cast<unsigned int>((x - x0) / dL);
         cell->set_subdomain_id(id);
       }
   }

--- a/tests/base/utilities_11.cc
+++ b/tests/base/utilities_11.cc
@@ -25,18 +25,18 @@
 void
 test()
 {
-  unsigned long long int i = std::pow(2, 33);
+  const auto i = static_cast<unsigned long long int>(std::pow(2, 33));
   Assert(Utilities::to_string(i) == "8589934592", ExcInternalError());
   Assert(Utilities::to_string(i, 11) == "08589934592", ExcInternalError());
 
-  unsigned long long j = std::pow(2, 31);
+  const auto j = static_cast<unsigned long long int>(std::pow(2, 31));
   Assert(Utilities::to_string(j) == "2147483648", ExcInternalError());
 
-  int k = -std::pow(2, 30);
+  const int k = static_cast<int>(-std::pow(2, 30));
   Assert(Utilities::to_string(k) == "-1073741824", ExcInternalError());
   Assert(Utilities::to_string(k, 12) == "-01073741824", ExcInternalError());
 
-  long long int l = -std::pow(2, 35);
+  const auto l = static_cast<long long int>(-std::pow(2, 35));
   Assert(Utilities::to_string(l) == "-34359738368", ExcInternalError());
   Assert(Utilities::to_string(l, 13) == "-034359738368", ExcInternalError());
 

--- a/tests/fe/fe_enriched_color_07.cc
+++ b/tests/fe/fe_enriched_color_07.cc
@@ -611,14 +611,14 @@ public:
                              const double &     sigma,
                              const std::string &rhs_expr,
                              const std::string &boundary_expr,
-                             const double &     refinement = 11);
+                             const unsigned int refinement = 11);
   EstimateEnrichmentFunction(const Point<1> &   center,
                              const double &     left_bound,
                              const double &     right_bound,
                              const double &     sigma,
                              const std::string &rhs_expr,
                              const std::string &boundary_expr,
-                             const double &     refinement = 11);
+                             const unsigned int refinement = 11);
   ~EstimateEnrichmentFunction();
   void
   run();
@@ -669,7 +669,7 @@ EstimateEnrichmentFunction::EstimateEnrichmentFunction(
   const double &     sigma,
   const std::string &rhs_expr,
   const std::string &boundary_expr,
-  const double &     refinement)
+  const unsigned int refinement)
   : center(center)
   , domain_size(domain_size)
   , sigma(sigma)
@@ -692,7 +692,7 @@ EstimateEnrichmentFunction::EstimateEnrichmentFunction(
   const double &     sigma,
   const std::string &rhs_expr,
   const std::string &boundary_expr,
-  const double &     refinement)
+  const unsigned int refinement)
   : center(center)
   , left_bound(left_bound)
   , right_bound(right_bound)

--- a/tests/hp/refinement_01.cc
+++ b/tests/hp/refinement_01.cc
@@ -47,7 +47,7 @@ test()
   hp::FECollection<dim> fe_collection;
 
   // prepare FECollection with arbitrary number of entries
-  const unsigned int max_degree = 1 + std::pow(2, dim);
+  const unsigned int max_degree = 1 + Utilities::pow(2, dim);
   for (unsigned int i = 0; i < max_degree; ++i)
     fe_collection.push_back(FE_Q<dim>(max_degree - i));
 

--- a/tests/integrators/mesh_worker_1d_dg.cc
+++ b/tests/integrators/mesh_worker_1d_dg.cc
@@ -216,7 +216,8 @@ namespace Advection
   AdvectionProblem<dim>::assemble_rhs(Vector<double> &solution,
                                       Vector<double> &residual)
   {
-    const unsigned int n_gauss_points = std::ceil(((2.0 * fe.degree) + 1) / 2);
+    const auto n_gauss_points =
+      static_cast<unsigned int>(std::ceil(((2.0 * fe.degree) + 1) / 2));
 
     MeshWorker::IntegrationInfoBox<dim> info_box;
 
@@ -437,8 +438,8 @@ namespace Advection
     deallog << "\tNumber of degrees of freedom: " << dof_handler.n_dofs()
             << std::endl;
 
-    const double delta_t = 0.005;
-    const double n_dt    = 10;
+    const double       delta_t = 0.005;
+    const unsigned int n_dt    = 10;
 
     double inv_cell_vol = 1.0 / std::pow(0.01, dim);
 

--- a/tests/matrix_free/cell_categorization.cc
+++ b/tests/matrix_free/cell_categorization.cc
@@ -83,7 +83,7 @@ test()
   for (const auto &cell : tria.active_cell_iterators())
     if (cell->is_locally_owned())
       data.cell_vectorization_category[cell->active_cell_index()] =
-        cell->center()[1] * 10.;
+        static_cast<unsigned int>(cell->center()[1] * 10.);
 
   data.cell_vectorization_categories_strict = false;
   mf_data.reinit(dof, constraints, QGauss<1>(2), data);

--- a/tests/mpi/cell_weights_05.cc
+++ b/tests/mpi/cell_weights_05.cc
@@ -54,7 +54,7 @@ cell_weight(
     (cell->center()[0] < 1) && (cell->center()[1] < 1) &&
         (dim == 3 ? (cell->center()[2] < 1) : true) ?
       // one cell has more weight than all others together
-      std::pow(16, dim) * 1000 :
+      Utilities::pow(16, dim) * 1000 :
       0);
 }
 

--- a/tests/mpi/hp_active_fe_indices_transfer_01.cc
+++ b/tests/mpi/hp_active_fe_indices_transfer_01.cc
@@ -47,7 +47,7 @@ test()
   hp::FECollection<dim> fe_collection;
 
   // prepare FECollection with arbitrary number of entries
-  const unsigned int max_degree = 1 + std::pow(2, dim);
+  const unsigned int max_degree = 1 + Utilities::pow(2, dim);
   for (unsigned int i = 0; i < max_degree; ++i)
     fe_collection.push_back(FE_Q<dim>(max_degree - i));
 

--- a/tests/mpi/hp_refinement_01.cc
+++ b/tests/mpi/hp_refinement_01.cc
@@ -54,7 +54,7 @@ test()
   hp::FECollection<dim> fe_collection;
 
   // prepare FECollection with arbitrary number of entries
-  const unsigned int max_degree = 1 + std::pow(2, dim);
+  const unsigned int max_degree = 1 + Utilities::pow(2, dim);
   for (unsigned int i = 0; i < max_degree; ++i)
     fe_collection.push_back(FE_Q<dim>(max_degree - i));
 

--- a/tests/mpi/hp_refinement_02.cc
+++ b/tests/mpi/hp_refinement_02.cc
@@ -54,7 +54,7 @@ test()
   hp::FECollection<dim> fe_collection;
 
   // prepare FECollection with arbitrary number of entries
-  const unsigned int max_degree = 1 + std::pow(2, dim);
+  const unsigned int max_degree = 1 + Utilities::pow(2, dim);
   for (unsigned int i = 0; i < max_degree; ++i)
     fe_collection.push_back(FE_Q<dim>(max_degree - i));
 

--- a/tests/mpi/p4est_save_06.cc
+++ b/tests/mpi/p4est_save_06.cc
@@ -78,7 +78,7 @@ test()
       hp::FECollection<dim> fe_collection;
 
       // prepare FECollection with arbitrary number of entries
-      const unsigned int max_degree = 1 + std::pow(2, dim);
+      const unsigned int max_degree = 1 + Utilities::pow(2, dim);
       for (unsigned int i = 0; i < max_degree; ++i)
         fe_collection.push_back(FE_Q<dim>(max_degree - i));
 
@@ -133,7 +133,7 @@ test()
     hp::FECollection<dim> fe_collection;
 
     // prepare FECollection with arbitrary number of entries
-    const unsigned int max_degree = 1 + std::pow(2, dim);
+    const unsigned int max_degree = 1 + Utilities::pow(2, dim);
     for (unsigned int i = 0; i < max_degree; ++i)
       fe_collection.push_back(FE_Q<dim>(max_degree - i));
 

--- a/tests/mpi/refine_and_coarsen_fixed_number_07.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_number_07.cc
@@ -65,7 +65,8 @@ test(const double max_n_cell_ratio)
         }
   }
 
-  const unsigned int max_n_cell = max_n_cell_ratio * tr.n_global_active_cells();
+  const auto max_n_cell =
+    static_cast<unsigned int>(max_n_cell_ratio * tr.n_global_active_cells());
 
   parallel::distributed::GridRefinement ::refine_and_coarsen_fixed_number(
     tr, indicators, 0.2, 0.2, max_n_cell);

--- a/tests/mpi/solution_transfer_04.cc
+++ b/tests/mpi/solution_transfer_04.cc
@@ -52,7 +52,7 @@ test()
   hp::FECollection<dim> fe_collection;
 
   // prepare FECollection with arbitrary number of entries
-  const unsigned int max_degree = 1 + std::pow(2, dim);
+  const unsigned int max_degree = 1 + Utilities::pow(2, dim);
   for (unsigned int i = 0; i < max_degree; ++i)
     fe_collection.push_back(FE_Q<dim>(max_degree - i));
 

--- a/tests/optimization/step-44.h
+++ b/tests/optimization/step-44.h
@@ -1402,13 +1402,13 @@ namespace Step44
 
           // The values for eta, mu are chosen such that
           // more strict convergence conditions are enforced.
-          const double a1               = 1.0;
-          const double eta              = 0.5;
-          const double mu               = 0.49;
-          const double a_max            = 1.25;
-          const double max_evals        = 20;
-          const bool   debug_linesearch = false;
-          const auto   res = (use_ptrb ? LineMinimization::line_search<double>(
+          const double       a1               = 1.0;
+          const double       eta              = 0.5;
+          const double       mu               = 0.49;
+          const double       a_max            = 1.25;
+          const unsigned int max_evals        = 20;
+          const bool         debug_linesearch = false;
+          const auto res = (use_ptrb ? LineMinimization::line_search<double>(
                                          ls_minimization_function_ptrb,
                                          res_0.first,
                                          res_0.second,
@@ -2072,8 +2072,9 @@ namespace Step44
           std::cout << " SLV " << std::flush;
           if (parameters.type_lin == "CG")
             {
-              const int solver_its = tangent_matrix.block(u_dof, u_dof).m() *
-                                     parameters.max_iterations_lin;
+              const auto solver_its = static_cast<unsigned int>(
+                tangent_matrix.block(u_dof, u_dof).m() *
+                parameters.max_iterations_lin);
               const double tol_sol =
                 parameters.tol_lin * system_rhs.block(u_dof).l2_norm();
               SolverControl solver_control(solver_its, tol_sol, false, false);
@@ -2154,8 +2155,8 @@ namespace Step44
             preconditioner_K_Jp_inv.use_matrix(
               tangent_matrix.block(J_dof, p_dof));
             ReductionControl solver_control_K_Jp_inv(
-              tangent_matrix.block(J_dof, p_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(J_dof, p_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_Jp_inv;
@@ -2173,8 +2174,8 @@ namespace Step44
             preconditioner_K_con_inv.use_matrix(
               tangent_matrix.block(u_dof, u_dof));
             ReductionControl solver_control_K_con_inv(
-              tangent_matrix.block(u_dof, u_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(u_dof, u_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_con_inv;

--- a/tests/physics/step-44-standard_tensors-material_push_forward.cc
+++ b/tests/physics/step-44-standard_tensors-material_push_forward.cc
@@ -2099,8 +2099,9 @@ namespace Step44
           pcout << " SLV " << std::flush;
           if (parameters.type_lin == "CG")
             {
-              const int solver_its = tangent_matrix.block(u_dof, u_dof).m() *
-                                     parameters.max_iterations_lin;
+              const auto solver_its = static_cast<unsigned int>(
+                tangent_matrix.block(u_dof, u_dof).m() *
+                parameters.max_iterations_lin);
               const double tol_sol =
                 parameters.tol_lin * system_rhs.block(u_dof).l2_norm();
               SolverControl solver_control(solver_its, tol_sol, false, false);
@@ -2181,8 +2182,8 @@ namespace Step44
             preconditioner_K_Jp_inv.use_matrix(
               tangent_matrix.block(J_dof, p_dof));
             ReductionControl solver_control_K_Jp_inv(
-              tangent_matrix.block(J_dof, p_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(J_dof, p_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_Jp_inv;
@@ -2200,8 +2201,8 @@ namespace Step44
             preconditioner_K_con_inv.use_matrix(
               tangent_matrix.block(u_dof, u_dof));
             ReductionControl solver_control_K_con_inv(
-              tangent_matrix.block(u_dof, u_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(u_dof, u_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_con_inv;

--- a/tests/physics/step-44-standard_tensors-spatial.cc
+++ b/tests/physics/step-44-standard_tensors-spatial.cc
@@ -1899,8 +1899,9 @@ namespace Step44
           pcout << " SLV " << std::flush;
           if (parameters.type_lin == "CG")
             {
-              const int solver_its = tangent_matrix.block(u_dof, u_dof).m() *
-                                     parameters.max_iterations_lin;
+              const auto solver_its = static_cast<unsigned int>(
+                tangent_matrix.block(u_dof, u_dof).m() *
+                parameters.max_iterations_lin);
               const double tol_sol =
                 parameters.tol_lin * system_rhs.block(u_dof).l2_norm();
               SolverControl solver_control(solver_its, tol_sol, false, false);
@@ -1981,8 +1982,8 @@ namespace Step44
             preconditioner_K_Jp_inv.use_matrix(
               tangent_matrix.block(J_dof, p_dof));
             ReductionControl solver_control_K_Jp_inv(
-              tangent_matrix.block(J_dof, p_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(J_dof, p_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_Jp_inv;
@@ -2000,8 +2001,8 @@ namespace Step44
             preconditioner_K_con_inv.use_matrix(
               tangent_matrix.block(u_dof, u_dof));
             ReductionControl solver_control_K_con_inv(
-              tangent_matrix.block(u_dof, u_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(u_dof, u_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_con_inv;

--- a/tests/physics/step-44.cc
+++ b/tests/physics/step-44.cc
@@ -1910,8 +1910,9 @@ namespace Step44
           pcout << " SLV " << std::flush;
           if (parameters.type_lin == "CG")
             {
-              const int solver_its = tangent_matrix.block(u_dof, u_dof).m() *
-                                     parameters.max_iterations_lin;
+              const auto solver_its = static_cast<unsigned int>(
+                tangent_matrix.block(u_dof, u_dof).m() *
+                parameters.max_iterations_lin);
               const double tol_sol =
                 parameters.tol_lin * system_rhs.block(u_dof).l2_norm();
               SolverControl solver_control(solver_its, tol_sol, false, false);
@@ -1992,8 +1993,8 @@ namespace Step44
             preconditioner_K_Jp_inv.use_matrix(
               tangent_matrix.block(J_dof, p_dof));
             ReductionControl solver_control_K_Jp_inv(
-              tangent_matrix.block(J_dof, p_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(J_dof, p_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_Jp_inv;
@@ -2011,8 +2012,8 @@ namespace Step44
             preconditioner_K_con_inv.use_matrix(
               tangent_matrix.block(u_dof, u_dof));
             ReductionControl solver_control_K_con_inv(
-              tangent_matrix.block(u_dof, u_dof).m() *
-                parameters.max_iterations_lin,
+              static_cast<unsigned int>(tangent_matrix.block(u_dof, u_dof).m() *
+                                        parameters.max_iterations_lin),
               1.0e-30,
               parameters.tol_lin);
             SolverSelector<Vector<double>> solver_K_con_inv;

--- a/tests/sharedtria/mg_dof_01.cc
+++ b/tests/sharedtria/mg_dof_01.cc
@@ -131,7 +131,7 @@ test()
         if (cell->center()[0] < 0.5 && cell->center()[1] < 0.5)
           cell->set_refine_flag();
       if (dim == 3)
-        if (cell->center()[0] < 0.5 && cell->center()[1] &&
+        if (cell->center()[0] < 0.5 && cell->center()[1] < 0.5 &&
             cell->center()[2] < 0.5)
           cell->set_refine_flag();
     }
@@ -153,7 +153,7 @@ test()
           cell->set_refine_flag();
       if (dim == 3)
         if (cell->is_locally_owned() && cell->center()[0] < 0.5 &&
-            cell->center()[1] && cell->center()[2] < 0.5)
+            cell->center()[1] < 0.5 && cell->center()[2] < 0.5)
           cell->set_refine_flag();
     }
   distributed_tria.execute_coarsening_and_refinement();

--- a/tests/slepc/step-36_parallel.cc
+++ b/tests/slepc/step-36_parallel.cc
@@ -94,7 +94,7 @@ test(std::string solver_name, std::string preconditioner_name)
         const dealii::Point<dim> &center = cell->center();
         const double              x      = center[0];
 
-        const unsigned int id = std::floor((x - x0) / dL);
+        const auto id = static_cast<unsigned int>((x - x0) / dL);
         cell->set_subdomain_id(id);
       }
   }

--- a/tests/slepc/step-36_parallel_03.cc
+++ b/tests/slepc/step-36_parallel_03.cc
@@ -94,7 +94,7 @@ test(std::string solver_name, std::string preconditioner_name)
         const dealii::Point<dim> &center = cell->center();
         const double              x      = center[0];
 
-        const unsigned int id = std::floor((x - x0) / dL);
+        const auto id = static_cast<unsigned int>((x - x0) / dL);
         cell->set_subdomain_id(id);
       }
   }


### PR DESCRIPTION
A follow-up to #7499. I need these changes to be able to run the tests with `-Werror` again.