### PR TITLE
Replace default function parameter in find_active_cell_around_point

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1154,7 +1154,7 @@ namespace GridTools
       typename MeshType<dim, spacedim>::active_cell_iterator(),
     const std::vector<bool> &                              marked_vertices = {},
     const RTree<std::pair<Point<spacedim>, unsigned int>> &used_vertices_rtree =
-      {});
+      RTree<std::pair<Point<spacedim>, unsigned int>>{});
 
   /**
    * A version of the previous function where we use that mapping on a given


### PR DESCRIPTION
Apparently (and sadly), using 
```
const RTree<std::pair<Point<spacedim>, unsigned int>> &used_vertices_rtree = {}
```
is insufficient since the copy constructor is explicit. Fixes one of the failing tests in https://cdash.kyomu.43-1.org/viewTest.php?onlydelta&buildid=6390.