### PR TITLE
Fix failing SCALAPCK tests

### DIFF
--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -2617,8 +2617,12 @@ ScaLAPACKMatrix<NumberType>::save(
       chunks_size_.first  = n_rows;
       chunks_size_.second = 1;
     }
-  AssertIndexRange(chunks_size_.first - 1, n_rows);
-  AssertIndexRange(chunks_size_.second - 1, n_columns);
+  Assert(chunks_size_.first > 0,
+         ExcMessage("The row chunk size must be larger than 0."));
+  AssertIndexRange(chunks_size_.first, n_rows + 1);
+  Assert(chunks_size_.second > 0,
+         ExcMessage("The column chunk size must be larger than 0."));
+  AssertIndexRange(chunks_size_.second, n_columns + 1);
 
 #    ifdef H5_HAVE_PARALLEL
   // implementation for configurations equipped with a parallel file system


### PR DESCRIPTION
This ought to fix the currently failing SCALAPACK tests (https://cdash.kyomu.43-1.org/viewTest.php?onlydelta&buildid=6454), but I don't have a working `SCALAPACK` package at the moment, unfortunately.
The previously working `Asserts` were
```
Assert((chunks_size_.first <= (unsigned int)n_rows) && (chunks_size_.first > 0),
       ExcIndexRange(chunks_size_.first, 1, n_rows + 1));
Assert((chunks_size_.second <= (unsigned int)n_columns) && (chunks_size_.second > 0),
       ExcIndexRange(chunks_size_.second, 1, n_columns + 1));
```