### PR TITLE
Fix various MSVC issues

### DIFF
--- a/bundled/boost-1.62.0/include/boost/config/compiler/visualc.hpp
+++ b/bundled/boost-1.62.0/include/boost/config/compiler/visualc.hpp
@@ -294,10 +294,10 @@
 #endif
 
 //
-// tjhei: upgrade supported MSVC version to 19.13 (last checked 19.13.26131.1)
+// masterleinad: upgrade supported MSVC version to 19.16 (last checked 19.16.27024.1)
 // Boost repo has only 19.10:
 // last known and checked version is 19.10.24629 (VC++ 2017 RC):
-#if (_MSC_VER > 1913)
+#if (_MSC_VER > 1916)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"
 #  else

--- a/bundled/boost-1.62.0/include/boost/graph/named_function_params.hpp
+++ b/bundled/boost-1.62.0/include/boost/graph/named_function_params.hpp
@@ -228,6 +228,7 @@ BOOST_BGL_DECLARE_NAMED_PARAMS
   };
 
   struct param_not_found {};
+  static param_not_found g_param_not_found;
 
   template <typename Tag, typename Args>
   struct get_param_type: 
@@ -237,7 +238,7 @@ BOOST_BGL_DECLARE_NAMED_PARAMS
   inline
   const typename lookup_named_param_def<Tag, Args, param_not_found>::type&
   get_param(const Args& p, Tag) {
-    return lookup_named_param_def<Tag, Args, param_not_found>::get(p, param_not_found());
+    return lookup_named_param_def<Tag, Args, param_not_found>::get(p, g_param_not_found);
   }
 
   template <class P, class Default> 

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1500,11 +1500,11 @@ namespace Patterns
           return std_cxx14::make_unique<Patterns::Bool>();
         else if (std::is_integral<T>::value)
           return std_cxx14::make_unique<Patterns::Integer>(
-            static_cast<int>(std::numeric_limits<T>::min()),
+            static_cast<int>(std::numeric_limits<T>::lowest()),
             static_cast<int>(std::numeric_limits<T>::max()));
         else if (std::is_floating_point<T>::value)
           return std_cxx14::make_unique<Patterns::Double>(
-            -std::numeric_limits<T>::max(), std::numeric_limits<T>::max());
+            std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
 
         Assert(false, ExcNotImplemented());
         // the following line should never be invoked

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -35,6 +35,7 @@ Mapping<dim, spacedim>::get_vertices(
 }
 
 
+
 template <int dim, int spacedim>
 Point<dim - 1>
 Mapping<dim, spacedim>::project_real_point_to_unit_point_on_face(
@@ -49,26 +50,29 @@ Mapping<dim, spacedim>::project_real_point_to_unit_point_on_face(
 
   Point<dim> unit_cell_pt = transform_real_to_unit_cell(cell, p);
 
-  Point<dim - 1> unit_face_pt;
+  const unsigned int unit_normal_direction =
+    GeometryInfo<dim>::unit_normal_direction[face_no];
 
   if (dim == 2)
     {
-      if (GeometryInfo<dim>::unit_normal_direction[face_no] == 0)
-        unit_face_pt = Point<dim - 1>(unit_cell_pt(1));
-      else if (GeometryInfo<dim>::unit_normal_direction[face_no] == 1)
-        unit_face_pt = Point<dim - 1>(unit_cell_pt(0));
+      if (unit_normal_direction == 0)
+        return Point<dim - 1>{unit_cell_pt(1)};
+      else if (unit_normal_direction == 1)
+        return Point<dim - 1>{unit_cell_pt(0)};
     }
   else if (dim == 3)
     {
-      if (GeometryInfo<dim>::unit_normal_direction[face_no] == 0)
-        unit_face_pt = Point<dim - 1>(unit_cell_pt(1), unit_cell_pt(2));
-      else if (GeometryInfo<dim>::unit_normal_direction[face_no] == 1)
-        unit_face_pt = Point<dim - 1>(unit_cell_pt(0), unit_cell_pt(2));
-      else if (GeometryInfo<dim>::unit_normal_direction[face_no] == 2)
-        unit_face_pt = Point<dim - 1>(unit_cell_pt(0), unit_cell_pt(1));
+      if (unit_normal_direction == 0)
+        return Point<dim - 1>{unit_cell_pt(1), unit_cell_pt(2)};
+      else if (unit_normal_direction == 1)
+        return Point<dim - 1>{unit_cell_pt(0), unit_cell_pt(2)};
+      else if (unit_normal_direction == 2)
+        return Point<dim - 1>{unit_cell_pt(0), unit_cell_pt(1)};
     }
 
-  return unit_face_pt;
+  // We should never get here
+  Assert(false, ExcInternalError());
+  return {};
 }
 
 /* ---------------------------- InternalDataBase --------------------------- */

--- a/source/matrix_free/matrix_free.inst.in
+++ b/source/matrix_free/matrix_free.inst.in
@@ -82,7 +82,6 @@ for (deal_II_dimension : DIMENSIONS)
       const std::vector<hp::QCollection<1>> &,
       const AdditionalData &);
 
-#ifndef DEAL_II_MSVC
     template void
     internal::MatrixFreeFunctions::ShapeInfo<double>::reinit<deal_II_dimension>(
       const Quadrature<1> &,
@@ -106,7 +105,6 @@ for (deal_II_dimension : DIMENSIONS)
         const Quadrature<1> &,
         const FiniteElement<deal_II_dimension, deal_II_dimension> &,
         const unsigned int);
-#endif
   }
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)


### PR DESCRIPTION
Fixes almost everything in #7516. 
- The ICE seems to be related to NRVO since removing the variable to return fixes the issue. The same code worked in a previous MSVC version (same major version).
- I tested that removing the restriction in the instantiation file `source/matrix_free/matrix_free.inst.in` really works and `step-16` can be linked.
- I fixed various warnings, most noticeably the "Unkown compiler version" one. For some strange reason MSVC didn't like `-std::numeric_limits<T>::max()` but is fine with `std::numeric_limits<T>::lowest()`. In the context used, they should really be the same according to the standard. Finally, there was another `boost` warning regarding returning local variables that is already fixed upstream in the same way as in this PR.

I tested that all the `step` tests at least run.