### PR TITLE
Don't use semicolons at end of lines in python files

### DIFF
--- a/contrib/python-bindings/tests/point_wrapper.py
+++ b/contrib/python-bindings/tests/point_wrapper.py
@@ -30,7 +30,7 @@ class TestPointWrapper(unittest.TestCase):
         self.assertEqual(p1.y, 2.)
         p2 = Point([0., 2.])
         self.assertEqual(p1.distance(p2), 1.)
-        self.assertEqual(p2.norm(), 2.) 
+        self.assertEqual(p2.norm(), 2.)
         self.assertEqual(p2.norm_square(), 4.)
         self.assertEqual(p1 != p2, True)
         self.assertEqual(p1 == p2, False)
@@ -41,25 +41,25 @@ class TestPointWrapper(unittest.TestCase):
         p3 = p1 - p2
         self.assertEqual(p3.x, p1.x - p2.x)
         self.assertEqual(p3.y, p1.y - p2.y)
-        p3 = -p2;
+        p3 = -p2
         self.assertEqual(p3.x, -p2.x)
         self.assertEqual(p3.y, -p2.y)
-        p3 = p2 / 2.; 
+        p3 = p2 / 2.
         self.assertEqual(p3.x, p2.x / 2.)
         self.assertEqual(p3.y, p2.y / 2.)
-        p3 = p2 * 2.;
+        p3 = p2 * 2.
         self.assertEqual(p3.x, p2.x * 2.)
         self.assertEqual(p3.y, p2.y * 2.)
-        p2 += p1 
+        p2 += p1
         self.assertEqual(p2.x, 1.)
         self.assertEqual(p2.y, 4.)
-        p2 -= p1 
+        p2 -= p1
         self.assertEqual(p2.x, 0.)
         self.assertEqual(p2.y, 2.)
-        p2 /= 2.; 
+        p2 /= 2.
         self.assertEqual(p2.x, 0.)
         self.assertEqual(p2.y, 1.)
-        p2 *= 2.;
+        p2 *= 2.
         self.assertEqual(p2.x, 0.)
         self.assertEqual(p2.y, 2.)
 
@@ -90,15 +90,15 @@ class TestPointWrapper(unittest.TestCase):
         self.assertEqual(p3.x, p1.x - p2.x)
         self.assertEqual(p3.y, p1.y - p2.y)
         self.assertEqual(p3.z, p1.z - p2.z)
-        p3 = -p2;
+        p3 = -p2
         self.assertEqual(p3.x, -p2.x)
         self.assertEqual(p3.y, -p2.y)
         self.assertEqual(p3.z, -p2.z)
-        p3 = p2 / 2.; 
+        p3 = p2 / 2.
         self.assertEqual(p3.x, p2.x / 2.)
         self.assertEqual(p3.y, p2.y / 2.)
         self.assertEqual(p3.z, p2.z / 2.)
-        p3 = p2 * 2.;
+        p3 = p2 * 2.
         self.assertEqual(p3.x, p2.x * 2.)
         self.assertEqual(p3.y, p2.y * 2.)
         self.assertEqual(p3.z, p2.z * 2.)

--- a/contrib/utilities/checkdoxygen.py
+++ b/contrib/utilities/checkdoxygen.py
@@ -23,8 +23,8 @@ for l in lines:
     elif "@}" in l:
              count = count -1
              if (count < 0):
-                 sys.exit("Error in file '%s' in line %d"%(args[0],lineno));
+                 sys.exit("Error in file '%s' in line %d"%(args[0],lineno))
     lineno = lineno + 1
 
 if (count != 0):
-    sys.exit("Error: missing closing braces in file '%s'"%(args[0]));
+    sys.exit("Error: missing closing braces in file '%s'"%(args[0]))

--- a/contrib/utilities/parse_ctest_output.py
+++ b/contrib/utilities/parse_ctest_output.py
@@ -60,7 +60,7 @@ def parse_revision(dirname):
         rev.number = number[1:]
     else:
         return None
-        
+
     print dirname, "BUILD: ", rev.name
 
     #now Test.xml:
@@ -82,32 +82,32 @@ def parse_revision(dirname):
             failstatustxt = failtextlines[0].split(' ')[-1]
             for i in range(0,len(failtextlines)):
                 failtextlines[i] = failtextlines[i][0:80]
-                if failtextlines[i].startswith('FAILED: '): failtextlines[i]='FAILED: ...';
+                if failtextlines[i].startswith('FAILED: '): failtextlines[i]='FAILED: ...'
             failtext = '\n'.join(failtextlines[4:min(25,len(failtext))])
             statuslist=['CONFIGURE','BUILD','RUN','DIFF']
             if failstatustxt in statuslist:
                 status = statuslist.index(failstatustxt)
             else:
                 print "unknown status '%s' in test %s "% (failstatustxt,name)
-                status=0           
+                status=0
 
         if not group in rev.groups:
             rev.groups[group]= Group(group)
-            
+
         rev.groups[group].n_tests += 1
         rev.n_tests += 1
         rev.groups[group].n_status[status] += 1
-        if fail: 
+        if fail:
             rev.groups[group].n_fail += 1
             rev.n_fail += 1
             rev.groups[group].fail.append(name)
             rev.groups[group].fail_text[name]=failtext
             rev.groups[group].fail_status[name]=status
-        
+
     for g in sorted(rev.groups):
         g = rev.groups[g]
         #print g.name, g.n_tests, g.n_fail, g.fail
-        
+
     return rev
 
 
@@ -134,7 +134,7 @@ for f in n:
             allgroups.add(gr)
 
 revs.sort(key=lambda x: x.number, reverse=True)
-    
+
 allgroups = sorted(allgroups)
 
 f = open('tests.html', 'w')
@@ -200,7 +200,7 @@ else
 f.write('<table>')
 
 f.write('<colgroup span="1" class="colgroup""/>')
-for rev in revs:    
+for rev in revs:
     f.write('<colgroup span="5" class="colgroup"/>')
 f.write('\n')
 
@@ -226,7 +226,7 @@ f.write('<tbody><tr style="border-bottom: 2px solid">')
 f.write('<td></td>')
 for rev in revs:
     for c in range(0,5):
-        
+
         titles=['Configure','Build','Run','Diff','Pass']
         caption=['C','B','R','D','P']
         f.write('<td title="%s" class="test%d">%s</td>'%(titles[c],c,caption[c]))
@@ -265,7 +265,7 @@ for group in allgroups:
 
     f.write('</tr></tbody>\n')
 
-                
+
     #failing tests in group:
     if len(failing)>0:
         f.write('<tbody class="togglebody" style="display:none" id="group:%s">'%group)
@@ -288,7 +288,7 @@ for group in allgroups:
 
             f.write('</tr>\n')
         f.write('</tbody>\n')
-                
+
     f.write('\n\n')
 
 

--- a/examples/step-55/reference.py
+++ b/examples/step-55/reference.py
@@ -3,35 +3,35 @@ from sympy.printing import print_ccode
 from sympy.physics.vector import ReferenceFrame, gradient, divergence
 from sympy.vector import CoordSysCartesian
 
-R = ReferenceFrame('R');
-x = R[0]; y = R[1];
+R = ReferenceFrame('R')
+x = R[0]; y = R[1]
 
-a=-0.5; b=1.5;
-visc=1e-1;
-lambda_=(1/(2*visc)-sqrt(1/(4*visc**2)+4*pi**2));
+a=-0.5; b=1.5
+visc=1e-1
+lambda_=(1/(2*visc)-sqrt(1/(4*visc**2)+4*pi**2))
 print(" visc=%f" % visc)
 
 u=[0,0]
-u[0]=1-exp(lambda_*x)*cos(2*pi*y);
-u[1]=lambda_/(2*pi)*exp(lambda_*x)*sin(2*pi*y);
-p=(exp(3*lambda_)-exp(-lambda_))/(8*lambda_)-exp(2*lambda_*x)/2;
-p=p - integrate(p, (x,a,b));
+u[0]=1-exp(lambda_*x)*cos(2*pi*y)
+u[1]=lambda_/(2*pi)*exp(lambda_*x)*sin(2*pi*y)
+p=(exp(3*lambda_)-exp(-lambda_))/(8*lambda_)-exp(2*lambda_*x)/2
+p=p - integrate(p, (x,a,b))
 
 grad_p = gradient(p, R).to_matrix(R)
-f0 = -divergence(visc*gradient(u[0], R), R) + grad_p[0];
-f1 = -divergence(visc*gradient(u[1], R), R) + grad_p[1];
-f2 = divergence(u[0]*R.x + u[1]*R.y, R);
+f0 = -divergence(visc*gradient(u[0], R), R) + grad_p[0]
+f1 = -divergence(visc*gradient(u[1], R), R) + grad_p[1]
+f2 = divergence(u[0]*R.x + u[1]*R.y, R)
 
 print("\n * RHS:")
-print(ccode(f0, assign_to = "values[0]"));
-print(ccode(f1, assign_to = "values[1]"));
-print(ccode(f2, assign_to = "values[2]"));
+print(ccode(f0, assign_to = "values[0]"))
+print(ccode(f1, assign_to = "values[1]"))
+print(ccode(f2, assign_to = "values[2]"))
 
 
 print("\n * ExactSolution:")
-print(ccode(u[0], assign_to = "values[0]"));
-print(ccode(u[1], assign_to = "values[1]"));
-print(ccode(p, assign_to = "values[2]"));
+print(ccode(u[0], assign_to = "values[0]"))
+print(ccode(u[1], assign_to = "values[1]"))
+print(ccode(p, assign_to = "values[2]"))
 
 print("")
 print("pressure mean:", N(integrate(p,(x,a,b))))


### PR DESCRIPTION
As requested on slack, this PR removes the superfluous semicolons in `python` files. Fixes the issues in https://www.codefactor.io/repository/github/dealii/dealii/issues?category=Maintainability&groupId=459.