### PR TITLE
Use one statement per line in python files

### DIFF
--- a/contrib/utilities/parse_ctest_output.py
+++ b/contrib/utilities/parse_ctest_output.py
@@ -70,19 +70,22 @@ def parse_revision(dirname):
 
     for test in testing.findall("Test"):
         fail=False
-        if test.attrib['Status']=="failed": fail=True
+        if test.attrib['Status']=="failed":
+            fail=True
         name = test.find('Name').text
         group = name.split('/')[0]
         status = 4
         if fail:
             text = test.find('Results').find('Measurement').find('Value').text
-            if text == None: text=""
+            if text == None:
+                text=""
             failtext = text.encode('utf-8')
             failtextlines = failtext.replace('"','').split('\n')
             failstatustxt = failtextlines[0].split(' ')[-1]
             for i in range(0,len(failtextlines)):
                 failtextlines[i] = failtextlines[i][0:80]
-                if failtextlines[i].startswith('FAILED: '): failtextlines[i]='FAILED: ...'
+                if failtextlines[i].startswith('FAILED: '):
+                    failtextlines[i]='FAILED: ...'
             failtext = '\n'.join(failtextlines[4:min(25,len(failtext))])
             statuslist=['CONFIGURE','BUILD','RUN','DIFF']
             if failstatustxt in statuslist:

--- a/examples/step-55/reference.py
+++ b/examples/step-55/reference.py
@@ -4,9 +4,11 @@ from sympy.physics.vector import ReferenceFrame, gradient, divergence
 from sympy.vector import CoordSysCartesian
 
 R = ReferenceFrame('R')
-x = R[0]; y = R[1]
+x = R[0]
+y = R[1]
 
-a=-0.5; b=1.5
+a=-0.5
+b=1.5
 visc=1e-1
 lambda_=(1/(2*visc)-sqrt(1/(4*visc**2)+4*pi**2))
 print(" visc=%f" % visc)


### PR DESCRIPTION
As requested in #7523, this PR makes sure that there is only one statement per line in `python` files. Fixes the issues in https://www.codefactor.io/repository/github/dealii/dealii/issues?category=Maintainability&groupId=418.