### PR TITLE
Replace remaining C-style casts

### DIFF
--- a/cmake/checks/check_01_cpu_features.cmake
+++ b/cmake/checks/check_01_cpu_features.cmake
@@ -87,14 +87,14 @@ IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
     __m128d * data =
       reinterpret_cast<__m128d*>(_mm_malloc (2*vector_bytes, vector_bytes));
     double * ptr = reinterpret_cast<double*>(&a);
-    ptr[0] = (volatile double)(1.0);
+    ptr[0] = static_cast<volatile double>(1.0);
     for (int i=1; i<n_vectors; ++i)
       ptr[i] = 0.0;
-    b = _mm_set1_pd ((volatile double)(2.25));
+    b = _mm_set1_pd (static_cast<volatile double>(2.25));
     data[0] = _mm_add_pd (a, b);
     data[1] = _mm_mul_pd (b, data[0]);
     ptr = reinterpret_cast<double*>(&data[1]);
-    unsigned int return_value = 0;
+    int return_value = 0;
     if (ptr[0] != 7.3125)
       return_value = 1;
     for (int i=1; i<n_vectors; ++i)
@@ -143,14 +143,14 @@ IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
       __m256d * data =
         reinterpret_cast<__m256d*>(_mm_malloc (2*vector_bytes, vector_bytes));
       double * ptr = reinterpret_cast<double*>(&a);
-      ptr[0] = (volatile double)(1.0);
+      ptr[0] = static_cast<volatile double>(1.0);
       for (int i=1; i<n_vectors; ++i)
         ptr[i] = 0.0;
-      b = _mm256_set1_pd ((volatile double)(2.25));
+      b = _mm256_set1_pd (static_cast<volatile double>(2.25));
       data[0] = _mm256_add_pd (a, b);
       data[1] = _mm256_mul_pd (b, data[0]);
       ptr = reinterpret_cast<double*>(&data[1]);
-      unsigned int return_value = 0;
+      int return_value = 0;
       if (ptr[0] != 7.3125)
         return_value = 1;
       for (int i=1; i<n_vectors; ++i)
@@ -184,7 +184,7 @@ IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
       __m512d * data =
         reinterpret_cast<__m512d*>(_mm_malloc (2*vector_bytes, vector_bytes));
       double * ptr = reinterpret_cast<double*>(&a);
-      ptr[0] = (volatile double)(1.0);
+      ptr[0] = static_cast<volatile double>(1.0);
       for (int i=1; i<n_vectors; ++i)
         ptr[i] = 0.0;
       const volatile double x = 2.25;
@@ -192,7 +192,7 @@ IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
       data[0] = _mm512_add_pd (a, b);
       data[1] = _mm512_mul_pd (b, data[0]);
       ptr = reinterpret_cast<double*>(&data[1]);
-      unsigned int return_value = 0;
+      int return_value = 0;
       if (ptr[0] != 7.3125)
         return_value = 1;
       for (int i=1; i<n_vectors; ++i)
@@ -218,20 +218,20 @@ IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
     __vector double a, b, data1, data2;
     const int n_vectors = sizeof(a)/sizeof(double);
     double * ptr = reinterpret_cast<double*>(&a);
-    ptr[0] = (volatile double)(1.0);
+    ptr[0] = static_cast<volatile double>(1.0);
     for (int i=1; i<n_vectors; ++i)
       ptr[i] = 0.0;
-    b = vec_splats ((volatile double)(2.25));
+    b = vec_splats (static_cast<volatile double>(2.25));
     data1 = vec_add (a, b);
     data2 = vec_mul (b, data1);
     ptr = reinterpret_cast<double*>(&data2);
-    unsigned int return_value = 0;
+    int return_value = 0;
     if (ptr[0] != 7.3125)
       return_value += 1;
     for (int i=1; i<n_vectors; ++i)
       if (ptr[i] != 5.0625)
         return_value += 2;
-    b = vec_splats ((volatile double)(-1.0));
+    b = vec_splats (static_cast<volatile double>(-1.0));
     data1 = vec_abs(vec_mul (b, data2));
     vec_vsx_st(data1, 0, ptr);
     b = vec_vsx_ld(0, ptr);

--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -118,8 +118,8 @@ CHECK_CXX_COMPILER_BUG(
 #
 CHECK_CXX_SOURCE_COMPILES(
   "
-  bool f() {}
-  int main(){ if (__builtin_expect(f(),false)) ; }
+  bool f() { return true; }
+  int main(){ if (__builtin_expect(f(),false)) {} }
   "
   DEAL_II_HAVE_BUILTIN_EXPECT)
 

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -47,12 +47,14 @@ ARGS="-D DEAL_II_WITH_MUPARSER=OFF -D DEAL_II_WITH_MPI=ON -D CMAKE_EXPORT_COMPIL
 
 # disable performance-inefficient-string-concatenation because we don't care about "a"+to_string(5)+...
 CHECKS="-*,
-        mpi-*,
-        performance-*,
-        -performance-inefficient-string-concatenation,
+        cppcoreguidelines-pro-type-static-cast-downcast,
+        google-readability-casting,
         modernize-use-emplace,
         modernize-deprecated-headers,
-        modernize-use-using"
+        modernize-use-using,
+        mpi-*,
+        performance-*,
+        -performance-inefficient-string-concatenation"
 
 CHECKS="$(echo "${CHECKS}" | tr -d '[:space:]')"
 echo "$CHECKS"

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -509,8 +509,8 @@ namespace Step42
     template <int dim>
     double BitmapFile<dim>::get_value(const double x, const double y) const
     {
-      const int ix = std::min(std::max((int)(x / hx), 0), nx - 2);
-      const int iy = std::min(std::max((int)(y / hy), 0), ny - 2);
+      const int ix = std::min(std::max(static_cast<int>(x / hx), 0), nx - 2);
+      const int iy = std::min(std::max(static_cast<int>(y / hy), 0), ny - 2);
 
       const double xi  = std::min(std::max((x - ix * hx) / hx, 1.), 0.);
       const double eta = std::min(std::max((y - iy * hy) / hy, 1.), 0.);

--- a/examples/step-60/step-60.cc
+++ b/examples/step-60/step-60.cc
@@ -927,12 +927,12 @@ namespace Step60
       TimerOutput::Scope timer_section(monitor, "Assemble system");
 
       // Embedding stiffness matrix $K$, and the right hand side $G$.
-      MatrixTools::create_laplace_matrix(*space_dh,
-                                         QGauss<spacedim>(2 * space_fe->degree +
-                                                          1),
-                                         stiffness_matrix,
-                                         (const Function<spacedim> *)nullptr,
-                                         constraints);
+      MatrixTools::create_laplace_matrix(
+        *space_dh,
+        QGauss<spacedim>(2 * space_fe->degree + 1),
+        stiffness_matrix,
+        static_cast<const Function<spacedim> *>(nullptr),
+        constraints);
 
       VectorTools::create_right_hand_side(*embedded_mapping,
                                           *embedded_dh,

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -47,7 +47,8 @@ FE_Poly<TensorProductPolynomials<1>, 1, 2>::fill_fe_values(
   // exception if that is not possible
   Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
          ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
+  const InternalData &fe_data =
+    static_cast<const InternalData &>(fe_internal); // NOLINT
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
@@ -115,7 +116,8 @@ FE_Poly<TensorProductPolynomials<2>, 2, 3>::fill_fe_values(
   // exception if that is not possible
   Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
          ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
+  const InternalData &fe_data =
+    static_cast<const InternalData &>(fe_internal); // NOLINT
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
@@ -182,7 +184,8 @@ FE_Poly<PolynomialSpace<1>, 1, 2>::fill_fe_values(
   // exception if that is not possible
   Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
          ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
+  const InternalData &fe_data =
+    static_cast<const InternalData &>(fe_internal); // NOLINT
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
@@ -249,7 +252,8 @@ FE_Poly<PolynomialSpace<2>, 2, 3>::fill_fe_values(
   // exception if that is not possible
   Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
          ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &>(fe_internal);
+  const InternalData &fe_data =
+    static_cast<const InternalData &>(fe_internal); // NOLINT
 
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -462,7 +462,7 @@ namespace TrilinosWrappers
 
       // TODO A dynamic_cast fails here, this is suspicious.
       const auto &range_map =
-        static_cast<const Epetra_Map &>(graph->RangeMap());
+        static_cast<const Epetra_Map &>(graph->RangeMap()); // NOLINT
       int ierr = graph->GlobalAssemble(*column_space_map, range_map, true);
       AssertThrow(ierr == 0, ExcTrilinosError(ierr));
 
@@ -814,7 +814,7 @@ namespace TrilinosWrappers
       {
         // TODO A dynamic_cast fails here, this is suspicious.
         const auto &range_map =
-          static_cast<const Epetra_Map &>(graph->RangeMap());
+          static_cast<const Epetra_Map &>(graph->RangeMap()); // NOLINT
         ierr = graph->GlobalAssemble(*column_space_map, range_map, true);
         AssertThrow(ierr == 0, ExcTrilinosError(ierr));
       }
@@ -1035,7 +1035,7 @@ namespace TrilinosWrappers
   {
     // TODO A dynamic_cast fails here, this is suspicious.
     const auto &domain_map =
-      static_cast<const Epetra_Map &>(graph->DomainMap());
+      static_cast<const Epetra_Map &>(graph->DomainMap()); // NOLINT
     return domain_map;
   }
 
@@ -1045,7 +1045,8 @@ namespace TrilinosWrappers
   SparsityPattern::range_partitioner() const
   {
     // TODO A dynamic_cast fails here, this is suspicious.
-    const auto &range_map = static_cast<const Epetra_Map &>(graph->RangeMap());
+    const auto &range_map =
+      static_cast<const Epetra_Map &>(graph->RangeMap()); // NOLINT
     return range_map;
   }
 
@@ -1055,7 +1056,8 @@ namespace TrilinosWrappers
   SparsityPattern::row_partitioner() const
   {
     // TODO A dynamic_cast fails here, this is suspicious.
-    const auto &row_map = static_cast<const Epetra_Map &>(graph->RowMap());
+    const auto &row_map =
+      static_cast<const Epetra_Map &>(graph->RowMap()); // NOLINT
     return row_map;
   }
 
@@ -1065,7 +1067,8 @@ namespace TrilinosWrappers
   SparsityPattern::col_partitioner() const
   {
     // TODO A dynamic_cast fails here, this is suspicious.
-    const auto &col_map = static_cast<const Epetra_Map &>(graph->ColMap());
+    const auto &col_map =
+      static_cast<const Epetra_Map &>(graph->ColMap()); // NOLINT
     return col_map;
   }
 

--- a/tests/quick_tests/affinity.cc
+++ b/tests/quick_tests/affinity.cc
@@ -50,7 +50,7 @@ getaffinity(unsigned int &bits_set, unsigned int &mask)
   for (int i = 0; i < CPU_SETSIZE; ++i)
     bits_set += CPU_ISSET(i, &my_set);
 
-  mask = *(int *)(&my_set);
+  mask = *reinterpret_cast<int *>(&my_set);
 #else
   // sadly we don't have an implementation
   // for mac/windows

--- a/tests/quick_tests/lapack.cc
+++ b/tests/quick_tests/lapack.cc
@@ -112,7 +112,7 @@ main()
   for (unsigned int i = 0; i < A.m(); ++i)
     {
       std::complex<double> lambda = LA.eigenvalue(i);
-      deallog << "Eigenvalues " << (int)(lambda.real() + .0001) << '\t'
-              << (int)(lambda.imag() + .0001) << std::endl;
+      deallog << "Eigenvalues " << static_cast<int>(lambda.real() + .0001)
+              << '\t' << static_cast<int>(lambda.imag() + .0001) << std::endl;
     }
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -222,7 +222,7 @@ namespace Testing
     r[k % 32] = nonoverflow_add(r[(k + 32 - 31) % 32], r[(k + 32 - 3) % 32]);
     int ret   = r[k % 32];
     k         = (k + 1) % 32;
-    return (unsigned int)ret >> 1;
+    return static_cast<unsigned int>(ret) >> 1;
   }
 
   // reseed our random number generator
@@ -315,7 +315,7 @@ checksum(const IT &begin, const IT &end)
 
   while (it != end)
     {
-      a = (a + (unsigned char)*it) % 65521;
+      a = (a + static_cast<unsigned char>(*it)) % 65521;
       b = (a + b) % 65521;
       ++it;
     }


### PR DESCRIPTION
Fixes #7459. Adding `-Wold-style-casts` would be too noisy, but adding the respective `clang-tidy` checks should be sufficient for maintaining the policy.