### PR TITLE
Work around empty CMAKE_*_LIBRARY-*FIX

### DIFF
--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -247,6 +247,28 @@ ENDFOREACH()
 #
 
 #
+# We need to gather some variables for the regex below to work.
+#
+
+SET(_library_prefixes "")
+IF (CMAKE_SHARED_LIBRARY_PREFIX)
+  LIST(APPEND _library_prefixes ${CMAKE_SHARED_LIBRARY_PREFIX})
+ENDIF()
+IF (CMAKE_STATIC_LIBRARY_PREFIX)
+  LIST(APPEND _library_prefixes ${CMAKE_STATIC_LIBRARY_PREFIX})
+ENDIF()
+STRING(REPLACE ";" "|" _library_prefixes "${_library_prefixes}")
+
+SET(_library_suffixes "")
+IF (CMAKE_SHARED_LIBRARY_SUFFIX)
+  LIST(APPEND _library_suffixes ${CMAKE_SHARED_LIBRARY_SUFFIX})
+ENDIF()
+IF (CMAKE_STATIC_LIBRARY_SUFFIX)
+  LIST(APPEND _library_suffixes ${CMAKE_STATIC_LIBRARY_SUFFIX})
+ENDIF()
+STRING(REPLACE ";" "|" _library_suffixes "${_library_suffixes}")
+
+#
 # Build up the link line from our list of libraries:
 #
 
@@ -283,14 +305,12 @@ FOREACH(_build ${DEAL_II_BUILD_TYPES})
       ENDIF()
 
       # Recover short name:
-      STRING(REGEX REPLACE
-        "^(${CMAKE_STATIC_LIBRARY_PREFIX}|${CMAKE_SHARED_LIBRARY_PREFIX})"
-        "" _name "${_name}"
-        )
-      STRING(REGEX REPLACE
-        "(${CMAKE_STATIC_LIBRARY_SUFFIX}|${CMAKE_SHARED_LIBRARY_SUFFIX})$"
-        "" _name "${_name}"
-        )
+      IF(_library_prefixes)
+        STRING(REGEX REPLACE "^(${_library_prefixes})" "" _name "${_name}")
+      ENDIF()
+      IF(_library_suffixes)
+        STRING(REGEX REPLACE "(${_library_suffixes})$" "" _name "${_name}")
+      ENDIF()
       SET(_library_string "${_library_string}-l${_name}")
     ENDIF()
 


### PR DESCRIPTION
Fixes #7516. 
@adamqc Can you please test whether this workaround works for you?

`CMake` doesn't like  the regexes `^(|)`, `^(foo|)` and `^(|foo)` so this PR makes sure
that we don't use the regex replace in the first case and `^(foo)` in the latter cases instead.
We also take care of `(|)$`, `(foo|)$` and `(|foo)$` in the same way.