### PR TITLE
Fix more Trilinos-related clang-tidy complains

### DIFF
--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -137,9 +137,9 @@ public:
 
 #ifdef DEAL_II_WITH_TRILINOS
   /**
-   * Constructor from a trilinos Epetra_Map.
+   * Constructor from a Trilinos Epetra_BlockMap.
    */
-  explicit IndexSet(const Epetra_Map &map);
+  explicit IndexSet(const Epetra_BlockMap &map);
 #endif
 
   /**

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -1551,7 +1551,7 @@ namespace TrilinosWrappers
   inline IndexSet
   SparsityPattern::locally_owned_domain_indices() const
   {
-    return IndexSet(static_cast<const Epetra_Map &>(graph->DomainMap()));
+    return IndexSet(graph->DomainMap());
   }
 
 
@@ -1559,7 +1559,7 @@ namespace TrilinosWrappers
   inline IndexSet
   SparsityPattern::locally_owned_range_indices() const
   {
-    return IndexSet(static_cast<const Epetra_Map &>(graph->RangeMap()));
+    return IndexSet(graph->RangeMap());
   }
 
 #    endif // DOXYGEN

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -2137,7 +2137,8 @@ namespace TrilinosWrappers
     inline const Epetra_Map &
     Vector::vector_partitioner() const
     {
-      return static_cast<const Epetra_Map &>(vector->Map());
+      // TODO A dynamic_cast fails here. This is suspicious.
+      return static_cast<const Epetra_Map &>(vector->Map()); // NOLINT
     }
 
 

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -38,14 +38,15 @@ DEAL_II_NAMESPACE_OPEN
 
 #  ifdef DEAL_II_WITH_64BIT_INDICES
 
-IndexSet::IndexSet(const Epetra_Map &map)
+IndexSet::IndexSet(const Epetra_BlockMap &map)
   : is_compressed(true)
   , index_space_size(1 + map.MaxAllGID64())
   , largest_range(numbers::invalid_unsigned_int)
 {
   Assert(map.MinAllGID64() == 0,
-         ExcMessage("The Epetra_Map does not contain the global index 0, which "
-                    "means some entries are not present on any processor."));
+         ExcMessage(
+           "The Epetra_BlockMap does not contain the global index 0, "
+           "which means some entries are not present on any processor."));
 
   // For a contiguous map, we do not need to go through the whole data...
   if (map.LinearMap())
@@ -64,14 +65,15 @@ IndexSet::IndexSet(const Epetra_Map &map)
 
 // this is the standard 32-bit implementation
 
-IndexSet::IndexSet(const Epetra_Map &map)
+IndexSet::IndexSet(const Epetra_BlockMap &map)
   : is_compressed(true)
   , index_space_size(1 + map.MaxAllGID())
   , largest_range(numbers::invalid_unsigned_int)
 {
   Assert(map.MinAllGID() == 0,
-         ExcMessage("The Epetra_Map does not contain the global index 0, which "
-                    "means some entries are not present on any processor."));
+         ExcMessage(
+           "The Epetra_BlockMap does not contain the global index 0, "
+           "which means some entries are not present on any processor."));
 
   // For a contiguous map, we do not need to go through the whole data...
   if (map.LinearMap())


### PR DESCRIPTION
For the `IndexSet(const Epetra_Map &map)` constructor only the interfaces from the base class `Epetra_BlockMap` are needed.
Using the base class in the constructor interface instead saves us from forcing a failing downcast.

Unfortunately, changing the return type for `Vector::vector_partitioner()` would not be backward-compatible (all tests would work nevertheless since the return value is only used as a temporary variable).