### PR TITLE
Reinit blockvector only if required in matrix-free copy_to_mg

### DIFF
--- a/doc/news/changes/minor/20181219DanielJodlbauer
+++ b/doc/news/changes/minor/20181219DanielJodlbauer
@@ -1,0 +1,3 @@
+Fixed: Reinit blockvector only when necessary in MGTransferBlockMatrixFree::copy_to_mg.
+<br>
+(Daniel Jodlbauer, 2018/12/19)

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -653,6 +653,8 @@ MGTransferBlockMatrixFree<dim, Number>::copy_to_mg(
               }
             dst[level].collect_sizes();
           }
+        else
+          dst[level] = 0;
       }
   }
 

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -615,10 +615,16 @@ MGTransferBlockMatrixFree<dim, Number>::copy_to_mg(
                      &(mg_dof[0]->get_triangulation())) == tria),
                   ExcMessage("The DoFHandler use different Triangulations!"));
 
+    MGLevelObject<bool> do_reinit;
+    do_reinit.resize(min_level, max_level);
     for (unsigned int level = min_level; level <= max_level; ++level)
       {
-        dst[level].reinit(n_blocks);
-        bool collect_size = false;
+        do_reinit[level] = false;
+        if (dst[level].n_blocks() != n_blocks)
+          {
+            do_reinit[level] = true;
+            continue; // level
+          }
         for (unsigned int b = 0; b < n_blocks; ++b)
           {
             LinearAlgebra::distributed::Vector<Number> &v = dst[level].block(b);
@@ -626,16 +632,27 @@ MGTransferBlockMatrixFree<dim, Number>::copy_to_mg(
                 v.local_size() !=
                   mg_dof[b]->locally_owned_mg_dofs(level).n_elements())
               {
+                do_reinit[level] = true;
+                break; // b
+              }
+          }
+      }
+
+    for (unsigned int level = min_level; level <= max_level; ++level)
+      {
+        if (do_reinit[level])
+          {
+            dst[level].reinit(n_blocks);
+            for (unsigned int b = 0; b < n_blocks; ++b)
+              {
+                LinearAlgebra::distributed::Vector<Number> &v =
+                  dst[level].block(b);
                 v.reinit(mg_dof[b]->locally_owned_mg_dofs(level),
                          tria != nullptr ? tria->get_communicator() :
                                            MPI_COMM_SELF);
-                collect_size = true;
               }
-            else
-              v = 0.;
+            dst[level].collect_sizes();
           }
-        if (collect_size)
-          dst[level].collect_sizes();
       }
   }
 


### PR DESCRIPTION
The function MGTransferBlockMatrixFree::copy_to_mg always reinitializes a given block-vector. However, this removes any information about ghost entries, which might be required later on.
This PR changes the vectors only if it is necessary (i.e. sizes or local dofs are different), as done in the non-block version.