### PR TITLE
Fix 64bit compilation with CUDA.

### DIFF
--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -406,11 +406,10 @@ namespace CUDAWrappers
                          n_cells * dim * dim * padding_length);
         }
 
-      alloc_and_copy(
-        &data->constraint_mask[color],
-        ArrayView<const types::global_dof_index>(constraint_mask_host.data(),
-                                                 constraint_mask_host.size()),
-        n_cells);
+      alloc_and_copy(&data->constraint_mask[color],
+                     ArrayView<const unsigned int>(constraint_mask_host.data(),
+                                                   constraint_mask_host.size()),
+                     n_cells);
     }
 
 


### PR DESCRIPTION
Fixes #7540. I do not use the CUDA code but this is similar to other 64 bit compilation issues (some of which I have introduced).

The `ReinitHelper::constraint_mask_host` array should always contain unsigned integers since it is only used to provide arguments for `HangingNodes::setup_constraints`, which expects an unsigned integer.