### PR TITLE
Replace TrilinosWrappers::MPI:Vector::vector_partitioner

### DIFF
--- a/doc/news/changes/minor/20181222DanielArndt
+++ b/doc/news/changes/minor/20181222DanielArndt
@@ -1,0 +1,6 @@
+Replaced: TrilinosWrappers::MPI::Vector::vector_partitioner() has been
+deprecated in favor of TrilinosWrappers::MPI::Vector::trilinos_partitioner().
+The latter one returns an Epetra_BlockMap instead of an Epetra_Map avoiding an
+invalid downcast.
+<br>
+(Daniel Arndt, 2018/12/22)

--- a/doc/news/changes/minor/20181222DanielArndt
+++ b/doc/news/changes/minor/20181222DanielArndt
@@ -2,5 +2,7 @@ Replaced: TrilinosWrappers::MPI::Vector::vector_partitioner() has been
 deprecated in favor of TrilinosWrappers::MPI::Vector::trilinos_partitioner().
 The latter one returns an Epetra_BlockMap instead of an Epetra_Map avoiding an
 invalid downcast.
+The IndexSet constructor taking an Epetra_Map object has been replaced to
+accept a base class object of type Epetra_BlockMap instead.
 <br>
 (Daniel Arndt, 2018/12/22)

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -308,7 +308,7 @@ namespace LinearAlgebra
     // the argument's lifetime needs to be longer then. If we do this, we need
     // to think about whether the view should be read/write.
 
-    stored_elements = IndexSet(trilinos_vec.vector_partitioner());
+    stored_elements = IndexSet(trilinos_vec.trilinos_partitioner());
 
     resize_val(stored_elements.n_elements());
 

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -1976,9 +1976,11 @@ namespace TrilinosWrappers
   inline void
   PreconditionBase::vmult(MPI::Vector &dst, const MPI::Vector &src) const
   {
-    Assert(dst.vector_partitioner().SameAs(preconditioner->OperatorRangeMap()),
+    Assert(dst.trilinos_partitioner().SameAs(
+             preconditioner->OperatorRangeMap()),
            ExcNonMatchingMaps("dst"));
-    Assert(src.vector_partitioner().SameAs(preconditioner->OperatorDomainMap()),
+    Assert(src.trilinos_partitioner().SameAs(
+             preconditioner->OperatorDomainMap()),
            ExcNonMatchingMaps("src"));
 
     const int ierr = preconditioner->ApplyInverse(src.trilinos_vector(),
@@ -1989,9 +1991,11 @@ namespace TrilinosWrappers
   inline void
   PreconditionBase::Tvmult(MPI::Vector &dst, const MPI::Vector &src) const
   {
-    Assert(dst.vector_partitioner().SameAs(preconditioner->OperatorRangeMap()),
+    Assert(dst.trilinos_partitioner().SameAs(
+             preconditioner->OperatorRangeMap()),
            ExcNonMatchingMaps("dst"));
-    Assert(src.vector_partitioner().SameAs(preconditioner->OperatorDomainMap()),
+    Assert(src.trilinos_partitioner().SameAs(
+             preconditioner->OperatorDomainMap()),
            ExcNonMatchingMaps("src"));
 
     preconditioner->SetUseTranspose(true);

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -1201,9 +1201,19 @@ namespace TrilinosWrappers
       /**
        * Return a const reference to the underlying Trilinos Epetra_Map that
        * sets the parallel partitioning of the vector.
+       *
+       * @deprecated Use trilinos_partitioner() instead.
        */
+      DEAL_II_DEPRECATED
       const Epetra_Map &
       vector_partitioner() const;
+
+      /**
+       * Return a const reference to the underlying Trilinos Epetra_BlockMap
+       * that sets the parallel partitioning of the vector.
+       */
+      const Epetra_BlockMap &
+      trilinos_partitioner() const;
 
       /**
        * Print to a stream. @p precision denotes the desired precision with
@@ -2139,6 +2149,14 @@ namespace TrilinosWrappers
     {
       // TODO A dynamic_cast fails here. This is suspicious.
       return static_cast<const Epetra_Map &>(vector->Map()); // NOLINT
+    }
+
+
+
+    inline const Epetra_BlockMap &
+    Vector::trilinos_partitioner() const
+    {
+      return vector->Map();
     }
 
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -2068,10 +2068,10 @@ namespace TrilinosWrappers
                                 const TrilinosWrappers::MPI::Vector &in,
                                 const TrilinosWrappers::MPI::Vector &out)
       {
-        Assert(in.vector_partitioner().SameAs(m.DomainMap()) == true,
+        Assert(in.trilinos_partitioner().SameAs(m.DomainMap()) == true,
                ExcMessage(
                  "Column map of matrix does not fit with vector map!"));
-        Assert(out.vector_partitioner().SameAs(m.RangeMap()) == true,
+        Assert(out.trilinos_partitioner().SameAs(m.RangeMap()) == true,
                ExcMessage("Row map of matrix does not fit with vector map!"));
         (void)m;
         (void)in;

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -300,7 +300,7 @@ namespace TrilinosWrappers
         {
           TrilinosWrappers::types::int_type *glob_elements =
             TrilinosWrappers::my_global_elements(
-              v.block(block).vector_partitioner());
+              v.block(block).trilinos_partitioner());
           for (size_type i = 0; i < v.block(block).local_size(); ++i)
             global_ids[added_elements++] = glob_elements[i] + block_offset;
           owned_elements.add_indices(v.block(block).owned_elements,
@@ -313,7 +313,7 @@ namespace TrilinosWrappers
                          n_elements,
                          global_ids.data(),
                          0,
-                         v.block(0).vector_partitioner().Comm());
+                         v.block(0).trilinos_partitioner().Comm());
 
       auto actual_vec = std_cxx14::make_unique<Epetra_FEVector>(new_map);
 
@@ -616,7 +616,7 @@ namespace TrilinosWrappers
       // GlobalAssemble().
       double                double_mode = mode;
       const Epetra_MpiComm *comm_ptr =
-        dynamic_cast<const Epetra_MpiComm *>(&(vector_partitioner().Comm()));
+        dynamic_cast<const Epetra_MpiComm *>(&(trilinos_partitioner().Comm()));
       Assert(comm_ptr != nullptr, ExcInternalError());
       Utilities::MPI::MinMaxAvg result =
         Utilities::MPI::min_max_avg(double_mode, comm_ptr->GetMpiComm());

--- a/tests/mpi/trilinos_compress_bug.cc
+++ b/tests/mpi/trilinos_compress_bug.cc
@@ -63,7 +63,7 @@ test()
 
   test1.compress(VectorOperation::add);
 
-  // TrilinosWrappers::MPI::Vector test(test1.vector_partitioner()); // works
+  // TrilinosWrappers::MPI::Vector test(test1.trilinos_partitioner()); // works
   // TrilinosWrappers::MPI::Vector test(locally_owned); // works
   TrilinosWrappers::MPI::Vector test(test1); // fails
 

--- a/tests/mpi/trilinos_vector_reinit.cc
+++ b/tests/mpi/trilinos_vector_reinit.cc
@@ -40,7 +40,7 @@ test()
 
   TrilinosWrappers::MPI::Vector test1, test2;
 
-  AssertThrow(test1.vector_partitioner().SameAs(test2.vector_partitioner()),
+  AssertThrow(test1.trilinos_partitioner().SameAs(test2.trilinos_partitioner()),
               ExcInternalError());
 
   // first processor owns 2 indices, second
@@ -54,7 +54,7 @@ test()
   // reinit Trilinos vector from other vector
   test2.reinit(test1, true);
 
-  AssertThrow(test1.vector_partitioner().SameAs(test2.vector_partitioner()),
+  AssertThrow(test1.trilinos_partitioner().SameAs(test2.trilinos_partitioner()),
               ExcInternalError());
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)

--- a/tests/trilinos/index_set_02.cc
+++ b/tests/trilinos/index_set_02.cc
@@ -66,7 +66,7 @@ test()
   TrilinosWrappers::MPI::Vector v;
 
   v.reinit(set_my, set_ghost, MPI_COMM_WORLD);
-  IndexSet from_partitioner(v.vector_partitioner());
+  IndexSet from_partitioner(v.trilinos_partitioner());
   deallog << "vec size: " << v.size()
           << " from_partitioner: " << from_partitioner.size() << std::endl;
 

--- a/tests/trilinos/readwritevector_02.cc
+++ b/tests/trilinos/readwritevector_02.cc
@@ -60,7 +60,7 @@ test()
   tril_vector_ghosted.print(deallog.get_file_stream());
 
 
-  IndexSet readwrite_is(tril_vector_ghosted.vector_partitioner());
+  IndexSet readwrite_is(tril_vector_ghosted.trilinos_partitioner());
   deallog << "ghosted IS: ";
   readwrite_is.print(deallog);
 

--- a/tests/trilinos/readwritevector_03.cc
+++ b/tests/trilinos/readwritevector_03.cc
@@ -60,7 +60,7 @@ test()
   tril_vector_ghosted.print(deallog.get_file_stream());
 
 
-  IndexSet readwrite_is(tril_vector_ghosted.vector_partitioner());
+  IndexSet readwrite_is(tril_vector_ghosted.trilinos_partitioner());
   deallog << "ghosted IS: ";
   readwrite_is.print(deallog);
 


### PR DESCRIPTION
Part of #7512.
This PR deprecates `TrilinosWrappers::MPI::Vector::vector_partitioner()` in favor of `TrilinosWrappers::MPI::Vector::trilinos_partitioner()`. The latter one returns an `Epetra_BlockMap` instead of an `Epetra_Map` avoiding an invalid downcast.