### PR TITLE
Enhanced compatibility with Intel 19.

### DIFF
--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1213,6 +1213,8 @@ namespace Utilities
          const std::vector<char>::const_iterator &cend,
          const bool                               allow_compression)
   {
+    T object;
+
     // the data is never compressed when we can't use zlib.
     (void)allow_compression;
 
@@ -1234,14 +1236,11 @@ namespace Utilities
 #endif
       {
         Assert(std::distance(cbegin, cend) == sizeof(T), ExcInternalError());
-        T object;
         std::memcpy(&object, &*cbegin, sizeof(T));
-        return object;
       }
     else
       {
         std::string decompressed_buffer;
-        T           object;
 
         // first decompress the buffer
 #ifdef DEAL_II_WITH_ZLIB
@@ -1264,8 +1263,9 @@ namespace Utilities
         boost::archive::binary_iarchive archive(in);
 
         archive >> object;
-        return object;
       }
+
+    return object;
   }
 
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1385,7 +1385,7 @@ namespace DoFTools
          &dof_handler.get_triangulation()) == nullptr ?
          [&dof_handler]() {
            unsigned int max_subdomain_id = 0;
-           for (auto cell : dof_handler.active_cell_iterators())
+           for (const auto &cell : dof_handler.active_cell_iterators())
              max_subdomain_id =
                std::max(max_subdomain_id, cell->subdomain_id());
            return max_subdomain_id + 1;


### PR DESCRIPTION
Compiling deal.II with `Intel 19` yields to some issues. This pull request covers some of them.

- `Intel` has problems with non-literals in lambda functions:
  ```
  .../dealii/source/dofs/dof_tools.cc(1388): error: variable type "dealii::TriaActiveIterator<dealii::DoFCellAccessor<dealii::DoFHandler<1, 1>, false>>" in constexpr function is not a literal type
               for (auto cell : dof_handler.active_cell_iterators())
                         ^
   ```
- There are clumsily placed return statements that I added this spring. Sorry for that.
   ```
  .../dealii/include/deal.II/base/utilities.h(1269): warning #1011: missing return statement at end of non-void function "dealii::Utilities::unpack<T>(const std::vector<char, std::allocator<char>>::const_iterator &, const std::vector<char, std::allocator<char>>::const_iterator &, bool) [with T=dealii::GridTools::CellDataTransferBuffer<2, std::vector<unsigned int, std::allocator<unsigned int>>>]"
      }
      ^
   ```