### PR TITLE
Provide a dummy return value to satisfy ICC

### DIFF
--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1194,6 +1194,10 @@ namespace Utilities
 
         return (dest_buffer.size() - previous_size);
       }
+
+    // We should never get here
+    Assert(false, ExcInternalError());
+    return 0;
   }
 
 


### PR DESCRIPTION
Similar to #7545 ICC is also complaining about a missing return value in `Utilities::pack`.