### PR TITLE
Added empty destructor to la::p::BlockVector.

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -180,6 +180,16 @@ namespace LinearAlgebra
                   const MPI_Comm               communicator);
 
       /**
+       * Destructor.
+       *
+       * @note We need to explicitly provide a destructor, otherwise the
+       *   linker may think it is unused and discards it, although required
+       *   in a different section. The Intel compiler is prone to this
+       *   behavior.
+       */
+      virtual ~BlockVector() override = default;
+
+      /**
        * Copy operator: fill all components of the vector with the given
        * scalar value.
        */


### PR DESCRIPTION
Intel compilers complain about discarded destructors of `la::p::BlockVector` instantiations.
```
lac/CMakeFiles/obj_lac_debug.dir/la_parallel_block_vector.cc.o:la_parallel_block_vector.cc:vtable for dealii::LinearAlgebra::distributed::BlockVector<double>: error: relocation refers to global symbol "non-virtual thunk to dealii::LinearAlgebra::distributed::BlockVector<double>::~BlockVector()", which is defined in a discarded section
  section group signature: "_ZN6dealii13LinearAlgebra11distributed11BlockVectorIdED1Ev"
  prevailing definition is from numerics/CMakeFiles/obj_numerics_debug.dir/vector_tools_interpolate.cc.o
```
I added that missing destructor similarly to the `la::p::Vector` class.

Closes #6705. See for further information.

@bangerth's guess was right: It was a `virtual` member function that was not flagged as `inline`.