### PR TITLE
Fix distributed_compute_point_locations_02

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1335,10 +1335,8 @@ namespace GridTools
                       const Point<spacedim> &        p,
                       const std::vector<bool> &      marked_vertices)
   {
-    // first get the underlying
-    // triangulation from the
-    // mesh and determine vertices
-    // and used vertices
+    // first get the underlying triangulation from the mesh and determine
+    // vertices and used vertices
     const Triangulation<dim, spacedim> &tria = mesh.get_triangulation();
 
     const std::vector<Point<spacedim>> &vertices = tria.get_vertices();
@@ -1348,13 +1346,10 @@ namespace GridTools
            ExcDimensionMismatch(tria.get_vertices().size(),
                                 marked_vertices.size()));
 
-    // If p is an element of marked_vertices,
-    // and q is that of used_Vertices,
-    // the vector marked_vertices does NOT
-    // contain unused vertices if p implies q.
-    // I.e., if p is true q must be true
-    // (if p is false, q could be false or true).
-    // p implies q logic is encapsulated in ~p|q.
+    // marked_vertices is expected to be a subset of used_vertices. Thus,
+    // comparing the range marked_vertices.begin() to marked_vertices.end() with
+    // the range used_vertices.begin() to used_vertices.end() the element in the
+    // second range must be valid if the element in the first range is valid.
     Assert(
       marked_vertices.size() == 0 ||
         std::equal(marked_vertices.begin(),
@@ -1365,23 +1360,18 @@ namespace GridTools
         "marked_vertices should be a subset of used vertices in the triangulation "
         "but marked_vertices contains one or more vertices that are not used vertices!"));
 
-    // In addition, if a vector bools
-    // is specified (marked_vertices)
-    // marking all the vertices which
-    // could be the potentially closest
-    // vertex to the point, use it instead
-    // of used vertices
+    // If marked_indices is empty, consider all used_vertices for finding the
+    // closest vertex to the point. Otherwise, marked_indices is used.
     const std::vector<bool> &used = (marked_vertices.size() == 0) ?
                                       tria.get_used_vertices() :
                                       marked_vertices;
 
-    // At the beginning, the first
-    // used vertex is the closest one
+    // At the beginning, the first used vertex is considered to be the closest
+    // one.
     std::vector<bool>::const_iterator first =
       std::find(used.begin(), used.end(), true);
 
-    // Assert that at least one vertex
-    // is actually used
+    // Assert that at least one vertex is actually used
     Assert(first != used.end(), ExcInternalError());
 
     unsigned int best_vertex = std::distance(used.begin(), first);
@@ -1416,10 +1406,8 @@ namespace GridTools
     if (mapping.preserves_vertex_locations() == true)
       return find_closest_vertex(mesh, p, marked_vertices);
 
-    // first get the underlying
-    // triangulation from the
-    // mesh and determine vertices
-    // and used vertices
+    // first get the underlying triangulation from the mesh and determine
+    // vertices and used vertices
     const Triangulation<dim, spacedim> &tria = mesh.get_triangulation();
 
     auto vertices = extract_used_vertices(tria, mapping);
@@ -1429,13 +1417,11 @@ namespace GridTools
            ExcDimensionMismatch(tria.get_vertices().size(),
                                 marked_vertices.size()));
 
-    // If p is an element of marked_vertices,
-    // and q is that of used_Vertices,
-    // the vector marked_vertices does NOT
-    // contain unused vertices if p implies q.
-    // I.e., if p is true q must be true
-    // (if p is false, q could be false or true).
-    // p implies q logic is encapsulated in ~p|q.
+    // marked_vertices is expected to be a subset of used_vertices. Thus,
+    // comparing the range marked_vertices.begin() to marked_vertices.end()
+    // with the range used_vertices.begin() to used_vertices.end() the element
+    // in the second range must be valid if the element in the first range is
+    // valid.
     Assert(
       marked_vertices.size() == 0 ||
         std::equal(marked_vertices.begin(),
@@ -1447,12 +1433,12 @@ namespace GridTools
         "but marked_vertices contains one or more vertices that are not used vertices!"));
 
     // Remove from the map unwanted elements.
-    if (marked_vertices.size())
+    if (marked_vertices.size() != 0)
       for (auto it = vertices.begin(); it != vertices.end();)
         {
           if (marked_vertices[it->first] == false)
             {
-              vertices.erase(it++);
+              it = vertices.erase(it);
             }
           else
             {

--- a/tests/grid/distributed_compute_point_locations_02.cc
+++ b/tests/grid/distributed_compute_point_locations_02.cc
@@ -93,34 +93,42 @@ test_compute_pt_loc(unsigned int ref_cube, unsigned int ref_sphere)
       // Store the point only if it is inside a locally owned sphere cell
       if (cell->subdomain_id() == my_rank)
         loc_owned_points.emplace_back(center_pt);
-      // Find the cube cell where center pt lies
-      auto my_pair = GridTools::find_active_cell_around_point(cache, center_pt);
-      // If it is inside a locally owned cell it shall be returned
-      // from distributed compute point locations
-      if (my_pair.first->is_locally_owned())
+      try
         {
-          computed_pts++;
-          auto cells_it = std::find(computed_cells.begin(),
-                                    computed_cells.end(),
-                                    my_pair.first);
+          // Find the cube cell where center pt lies
+          auto my_pair =
+            GridTools::find_active_cell_around_point(cache, center_pt);
+          // If it is inside a locally owned cell it shall be returned
+          // from distributed compute point locations
+          if (my_pair.first->is_locally_owned())
+            {
+              computed_pts++;
+              auto cells_it = std::find(computed_cells.begin(),
+                                        computed_cells.end(),
+                                        my_pair.first);
 
-          if (cells_it == computed_cells.end())
-            {
-              // Cell not found: adding a new cell
-              computed_cells.emplace_back(my_pair.first);
-              computed_qpoints.emplace_back(1, my_pair.second);
-              computed_points.emplace_back(1, center_pt);
-              computed_ranks.emplace_back(1, cell->subdomain_id());
-            }
-          else
-            {
-              // Cell found: just adding the point index and qpoint to the list
-              unsigned int current_cell = cells_it - computed_cells.begin();
-              computed_qpoints[current_cell].emplace_back(my_pair.second);
-              computed_points[current_cell].emplace_back(center_pt);
-              computed_ranks[current_cell].emplace_back(cell->subdomain_id());
+              if (cells_it == computed_cells.end())
+                {
+                  // Cell not found: adding a new cell
+                  computed_cells.emplace_back(my_pair.first);
+                  computed_qpoints.emplace_back(1, my_pair.second);
+                  computed_points.emplace_back(1, center_pt);
+                  computed_ranks.emplace_back(1, cell->subdomain_id());
+                }
+              else
+                {
+                  // Cell found: just adding the point index and qpoint to the
+                  // list
+                  unsigned int current_cell = cells_it - computed_cells.begin();
+                  computed_qpoints[current_cell].emplace_back(my_pair.second);
+                  computed_points[current_cell].emplace_back(center_pt);
+                  computed_ranks[current_cell].emplace_back(
+                    cell->subdomain_id());
+                }
             }
         }
+      catch (const GridTools::ExcPointNotFound<dim> &)
+        {}
     }
 
   // Computing bounding boxes describing the locally owned part of the mesh


### PR DESCRIPTION
Fixes the failing tests in https://cdash.kyomu.43-1.org/viewTest.php?onlyfailed&buildid=6736.
Opposed to `GridTools::find_closest_vertex` (that uses all vertices of the Triangulation) the RTree branch in `GridTools::find_active_cell_around_point` only considers used vertices (returned by `GridTools::extract_used_vertices`). Hence, the previous implementation (before #7505) always returned a cell containing the given point (if it is contained in the domain described by the triangulation) even if the cell is artificial. The new implementation searches for the given point only in cells that contain the nearest vertex with respect to locally owned and ghosted cells. Hence, it might fail for points not contained inside the locally owned or ghosted part of the triangulation.
With respect to the test (that searches for cell midpoints of the shared triangulation within the distributed triangulation), these cells are not interesting anyway. Hence, it should be safe to ignore them and this makes the test pass.

Of course, we could also provide an empty `used_vertices_rtree` in `GridTools::extract_used_vertices` and restore the previous behavior not testing the new implementation.
Another possibility would be to only use shared triangulations in the test. This, however, seems to contradict the purpose (or at least the description) of the test.
A fourth possibility would be to change the implementation of `GridTools::find_active_cell_around_point` to always consider all vertices in its first step. This would require to construct the RTree with all the vertices and not only the used ones. In practice, this seems not to be advisable to do. It only really makes sense to call the function (not preparing for dealing with an exception) if a ghosted or locally owned is expected to be returned.

Therefore, I only consider the second possibility to be a viable alternative to the fix in this PR.
