### PR TITLE
Also test enumerators in deprecation compiler checks

### DIFF
--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -310,6 +310,11 @@ CHECK_CXX_SOURCE_COMPILES(
             [[deprecated]] void test();
           };
 
+          enum color
+          {
+            red [[deprecated]]
+          };
+
           template <int dim>
           struct foo {};
           using bar [[deprecated]] = foo<2>;
@@ -328,6 +333,11 @@ CHECK_CXX_SOURCE_COMPILES(
           {
             __attribute__((deprecated)) bob(int i);
             __attribute__((deprecated)) void test();
+          };
+
+          enum color
+          {
+            red __attribute__((deprecated))
           };
 
           template <int dim>


### PR DESCRIPTION
Fixes the build failures in https://cdash.kyomu.43-1.org/viewBuildError.php?onlydeltap&buildid=6758.
Behavior for different compilers (in particular `gcc-4.9.4`) can be observed in https://godbolt.org/z/qsDry1.