### PR TITLE
Fix nvcc warnings

### DIFF
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -602,9 +602,9 @@ namespace internal
 
     // Type T is constructible from F.
     template <typename F>
-    static T
-    value(const F &f,
-          typename std::enable_if<
+    static DEAL_II_CUDA_HOST_DEV T
+                                 value(const F &f,
+                                       typename std::enable_if<
             !std::is_same<typename std::decay<T>::type,
                           typename std::decay<F>::type>::value &&
             std::is_constructible<T, F>::value>::type * = nullptr)

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1138,6 +1138,8 @@ namespace Utilities
     // the data is never compressed when we can't use zlib.
     (void)allow_compression;
 
+    size_t size = 0;
+
     // see if the object is small and copyable via memcpy. if so, use
     // this fast path. otherwise, we have to go through the BOOST
     // serialization machinery
@@ -1160,7 +1162,7 @@ namespace Utilities
 
         std::memcpy(dest_buffer.data() + previous_size, &object, sizeof(T));
 
-        return sizeof(T);
+        size = sizeof(T);
       }
     else
       {
@@ -1192,12 +1194,10 @@ namespace Utilities
             std::move(s.begin(), s.end(), std::back_inserter(dest_buffer));
           }
 
-        return (dest_buffer.size() - previous_size);
+        size = dest_buffer.size() - previous_size;
       }
 
-    // We should never get here
-    Assert(false, ExcInternalError());
-    return 0;
+    return size;
   }
 
 


### PR DESCRIPTION
Fix some of the errors `nvcc` reports.
- We already marked `internal::NumberType<T>::value(const T &t)` with `DEAL_II_CUDA_HOST_DEV` but need to do the same with `internal::NumberType<T>::value(const U &u)` where `T` is constructible from `U`. This happens for example when initializing a `Tensor<0, float>::value` with `internal::NumberType<float>::value(0.0)`.
- In `Utilities::pack` the compiler complains about unreachable code. It seems that we really need to declare a variable to satisfy a maximum of compilers.