### PR TITLE
Use range-based for loops in examples and expand_instantiations

### DIFF
--- a/cmake/scripts/expand_instantiations.cc
+++ b/cmake/scripts/expand_instantiations.cc
@@ -166,12 +166,12 @@ read_whole_file(std::istream &in)
       whole_file += remove_comments(line);
       whole_file += '\n';
     }
-  // substitute tabs by spaces, multiple spaces by single ones
-  for (unsigned int i = 0; i < whole_file.size(); ++i)
-    if (whole_file[i] == '\t')
-      whole_file[i] = ' ';
-  while (whole_file.find("  ") != std::string::npos)
-    whole_file.replace(whole_file.find("  "), 2, " ");
+  // substitute tabs by spaces
+  std::replace(whole_file.begin(), whole_file.end(), '\t', ' ');
+  // substitute multiple spaces by single ones
+  std::size_t position = 0;
+  while ((position = whole_file.find("  ", position)) != std::string::npos)
+    whole_file.replace(position, 2, 1, ' ');
 
   return whole_file;
 }
@@ -219,10 +219,9 @@ std::list<std::string>
 delete_empty_entries(const std::list<std::string> &list)
 {
   std::list<std::string> return_list;
-  for (std::list<std::string>::const_iterator i = list.begin(); i != list.end();
-       ++i)
-    if (*i != "")
-      return_list.push_back(*i);
+  for (const auto &entry : list)
+    if (!entry.empty())
+      return_list.push_back(entry);
 
   return return_list;
 }
@@ -469,27 +468,22 @@ process_instantiations()
       // process the header
       std::list<std::pair<std::string, std::string>> substitutions;
 
-      for (std::list<std::string>::const_iterator s =
-             substitutions_list.begin();
-           s != substitutions_list.end();
-           ++s)
+      for (const auto &substitution : substitutions_list)
         {
           const std::list<std::string> names_and_type =
-            split_string_list(*s, ':');
+            split_string_list(substitution, ':');
           if (names_and_type.size() != 2)
             {
-              std::cerr << "Invalid instantiation header: '" << *s << "'"
-                        << std::endl;
+              std::cerr << "Invalid instantiation header: '" << substitution
+                        << "'" << std::endl;
               std::exit(1);
             }
 
           const std::list<std::string> names =
             split_string_list(names_and_type.front(), ',');
 
-          for (std::list<std::string>::const_iterator x = names.begin();
-               x != names.end();
-               ++x)
-            substitutions.emplace_back(*x, names_and_type.back());
+          for (const auto &name : names)
+            substitutions.emplace_back(name, names_and_type.back());
         }
 
       // now read the part in {...}

--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -96,8 +96,7 @@ namespace Step30
     Assert(values.size() == points.size(),
            ExcDimensionMismatch(values.size(), points.size()));
 
-    for (unsigned int i = 0; i < values.size(); ++i)
-      values[i] = 0;
+    std::fill(values.begin(), values.end(), 0.);
   }
 
 


### PR DESCRIPTION
First of a series of PRs to add `modernize-loop-convert` to the `clang-tidy` checks.
Also, use more STL algorithms.