### PR TITLE
Replace size_t by std::size_t

### DIFF
--- a/include/deal.II/base/std_cxx14/utility.h
+++ b/include/deal.II/base/std_cxx14/utility.h
@@ -57,7 +57,7 @@ namespace std_cxx14
   } // namespace internal
   // --------------------------------------------------------------
 
-  template <size_t N>
+  template <std::size_t N>
   struct make_index_sequence : internal::merge_and_renumber<
                                  typename make_index_sequence<N / 2>::type,
                                  typename make_index_sequence<N - N / 2>::type>

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -855,7 +855,7 @@ namespace Utilities
      * leaving this task to the calling site.
      */
     void
-    posix_memalign(void **memptr, size_t alignment, size_t size);
+    posix_memalign(void **memptr, std::size_t alignment, std::size_t size);
   } // namespace System
 
 
@@ -1138,7 +1138,7 @@ namespace Utilities
     // the data is never compressed when we can't use zlib.
     (void)allow_compression;
 
-    size_t size = 0;
+    std::size_t size = 0;
 
     // see if the object is small and copyable via memcpy. if so, use
     // this fast path. otherwise, we have to go through the BOOST
@@ -1157,7 +1157,7 @@ namespace Utilities
 #  endif
 #endif
       {
-        const size_t previous_size = dest_buffer.size();
+        const std::size_t previous_size = dest_buffer.size();
         dest_buffer.resize(previous_size + sizeof(T));
 
         std::memcpy(dest_buffer.data() + previous_size, &object, sizeof(T));
@@ -1168,7 +1168,7 @@ namespace Utilities
       {
         // use buffer as the target of a compressing
         // stream into which we serialize the current object
-        const size_t previous_size = dest_buffer.size();
+        const std::size_t previous_size = dest_buffer.size();
 #ifdef DEAL_II_WITH_ZLIB
         if (allow_compression)
           {

--- a/include/deal.II/boost_adaptors/bounding_box.h
+++ b/include/deal.II/boost_adaptors/bounding_box.h
@@ -50,7 +50,7 @@ namespace boost
        * Access to the D-th coordinate of the lower left  corner of a
        * dealii::BoundingBox.
        */
-      template <int dim, class Number, size_t D>
+      template <int dim, class Number, std::size_t D>
       struct indexed_access<dealii::BoundingBox<dim, Number>, min_corner, D>
       {
         /**
@@ -78,7 +78,7 @@ namespace boost
        * Access to the D-th coordinate of the upper right corner of a
        * dealii::BoundingBox.
        */
-      template <int dim, class Number, size_t D>
+      template <int dim, class Number, std::size_t D>
       struct indexed_access<dealii::BoundingBox<dim, Number>, max_corner, D>
       {
         /**

--- a/include/deal.II/boost_adaptors/point.h
+++ b/include/deal.II/boost_adaptors/point.h
@@ -65,7 +65,7 @@ namespace boost
       /**
        * Getter function for D-th coordinate of a dealii Point.
        */
-      template <size_t D, int dim, class Number>
+      template <std::size_t D, int dim, class Number>
       struct access<dealii::Point<dim, Number>, D>
       {
         static inline double

--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -158,7 +158,7 @@ namespace internal
         types<2>::locidx        min_quadrants,
         int                     min_level,
         int                     fill_uniform,
-        size_t                  data_size,
+        std::size_t             data_size,
         p4est_init_t            init_fn,
         void *                  user_pointer);
 
@@ -188,7 +188,7 @@ namespace internal
 
       static types<2>::forest *(&load_ext)(const char *filename,
                                            MPI_Comm    mpicomm,
-                                           size_t      data_size,
+                                           std::size_t data_size,
                                            int         load_data,
                                            int         autopartition,
                                            int         broadcasthead,
@@ -200,8 +200,8 @@ namespace internal
 
       static int (&connectivity_is_valid)(types<2>::connectivity *connectivity);
 
-      static types<2>::connectivity *(&connectivity_load)(const char *filename,
-                                                          size_t *    length);
+      static types<2>::connectivity *(&connectivity_load)(const char * filename,
+                                                          std::size_t *length);
 
       static unsigned int (&checksum)(types<2>::forest *p4est);
 
@@ -215,13 +215,14 @@ namespace internal
       static void (&ghost_destroy)(types<2>::ghost *ghost);
 
       static void (&reset_data)(types<2>::forest *p4est,
-                                size_t            data_size,
+                                std::size_t       data_size,
                                 p4est_init_t      init_fn,
                                 void *            user_pointer);
 
-      static size_t (&forest_memory_used)(types<2>::forest *p4est);
+      static std::size_t (&forest_memory_used)(types<2>::forest *p4est);
 
-      static size_t (&connectivity_memory_used)(types<2>::connectivity *p4est);
+      static std::size_t (&connectivity_memory_used)(
+        types<2>::connectivity *p4est);
 
       template <int spacedim>
       static void
@@ -237,7 +238,7 @@ namespace internal
                                     int                     tag,
                                     void *                  dest_data,
                                     const void *            src_data,
-                                    size_t                  data_size);
+                                    std::size_t             data_size);
 
       static types<2>::transfer_context *(&transfer_fixed_begin)(
         const types<2>::gloidx *dest_gfq,
@@ -246,7 +247,7 @@ namespace internal
         int                     tag,
         void *                  dest_data,
         const void *            src_data,
-        size_t                  data_size);
+        std::size_t             data_size);
 
       static void (&transfer_fixed_end)(types<2>::transfer_context *tc);
 
@@ -327,7 +328,7 @@ namespace internal
         types<3>::locidx        min_quadrants,
         int                     min_level,
         int                     fill_uniform,
-        size_t                  data_size,
+        std::size_t             data_size,
         p8est_init_t            init_fn,
         void *                  user_pointer);
 
@@ -369,8 +370,8 @@ namespace internal
 
       static int (&connectivity_is_valid)(types<3>::connectivity *connectivity);
 
-      static types<3>::connectivity *(&connectivity_load)(const char *filename,
-                                                          size_t *    length);
+      static types<3>::connectivity *(&connectivity_load)(const char * filename,
+                                                          std::size_t *length);
 
       static unsigned int (&checksum)(types<3>::forest *p8est);
 
@@ -383,13 +384,14 @@ namespace internal
       static void (&ghost_destroy)(types<3>::ghost *ghost);
 
       static void (&reset_data)(types<3>::forest *p4est,
-                                size_t            data_size,
+                                std::size_t       data_size,
                                 p8est_init_t      init_fn,
                                 void *            user_pointer);
 
-      static size_t (&forest_memory_used)(types<3>::forest *p4est);
+      static std::size_t (&forest_memory_used)(types<3>::forest *p4est);
 
-      static size_t (&connectivity_memory_used)(types<3>::connectivity *p4est);
+      static std::size_t (&connectivity_memory_used)(
+        types<3>::connectivity *p4est);
 
       static constexpr unsigned int max_level = P8EST_MAXLEVEL;
 
@@ -399,7 +401,7 @@ namespace internal
                                     int                     tag,
                                     void *                  dest_data,
                                     const void *            src_data,
-                                    size_t                  data_size);
+                                    std::size_t             data_size);
 
       static types<3>::transfer_context *(&transfer_fixed_begin)(
         const types<3>::gloidx *dest_gfq,
@@ -408,7 +410,7 @@ namespace internal
         int                     tag,
         void *                  dest_data,
         const void *            src_data,
-        size_t                  data_size);
+        std::size_t             data_size);
 
       static void (&transfer_fixed_end)(types<3>::transfer_context *tc);
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3571,8 +3571,8 @@ namespace GridTools
     Assert(cell_ids.size() == data.size(),
            ExcDimensionMismatch(cell_ids.size(), data.size()));
     // archive the cellids in an efficient binary format
-    const size_t n_cells = cell_ids.size();
-    ar &         n_cells;
+    const std::size_t n_cells = cell_ids.size();
+    ar &              n_cells;
     for (auto &it : cell_ids)
       {
         CellId::binary_type binary_cell_id = it.template to_binary<dim>();
@@ -3590,8 +3590,8 @@ namespace GridTools
   CellDataTransferBuffer<dim, T>::load(Archive &ar,
                                        const unsigned int /*version*/)
   {
-    size_t n_cells;
-    ar &   n_cells;
+    std::size_t n_cells;
+    ar &        n_cells;
     cell_ids.clear();
     cell_ids.reserve(n_cells);
     for (unsigned int c = 0; c < n_cells; ++c)

--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -54,8 +54,8 @@ template <typename Range  = BlockVector<double>,
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_operator(const BlockMatrixType &matrix);
 
-template <size_t m,
-          size_t n,
+template <std::size_t m,
+          std::size_t n,
           typename Range  = BlockVector<double>,
           typename Domain = Range,
           typename BlockPayload =
@@ -68,7 +68,7 @@ block_operator(
                               n>,
                    m> &);
 
-template <size_t m,
+template <std::size_t m,
           typename Range  = BlockVector<double>,
           typename Domain = Range,
           typename BlockPayload =
@@ -80,7 +80,7 @@ block_diagonal_operator(
                                   typename BlockPayload::BlockType>,
                    m> &);
 
-template <size_t m,
+template <std::size_t m,
           typename Range  = BlockVector<double>,
           typename Domain = Range,
           typename BlockPayload =
@@ -264,7 +264,7 @@ public:
    * LinearOperator. This constructor calls the corresponding block_operator()
    * specialization.
    */
-  template <size_t m, size_t n>
+  template <std::size_t m, std::size_t n>
   BlockLinearOperator(const std::array<std::array<BlockType, n>, m> &ops)
   {
     *this = block_operator<m, n, Range, Domain, BlockPayload>(ops);
@@ -275,7 +275,7 @@ public:
    * @p ops of LinearOperator. This constructor calls the corresponding
    * block_operator() specialization.
    */
-  template <size_t m>
+  template <std::size_t m>
   BlockLinearOperator(const std::array<BlockType, m> &ops)
   {
     *this = block_diagonal_operator<m, Range, Domain, BlockPayload>(ops);
@@ -304,7 +304,7 @@ public:
    * This assignment operator calls the corresponding block_operator()
    * specialization.
    */
-  template <size_t m, size_t n>
+  template <std::size_t m, std::size_t n>
   BlockLinearOperator<Range, Domain, BlockPayload> &
   operator=(const std::array<std::array<BlockType, n>, m> &ops)
   {
@@ -317,7 +317,7 @@ public:
    * that creates a block-diagonal BlockLinearOperator. This assignment
    * operator calls the corresponding block_operator() specialization.
    */
-  template <size_t m>
+  template <std::size_t m>
   BlockLinearOperator<Range, Domain, BlockPayload> &
   operator=(const std::array<BlockType, m> &ops)
   {
@@ -679,8 +679,8 @@ block_operator(const BlockMatrixType &block_matrix)
  *
  * @ingroup LAOperators
  */
-template <size_t m,
-          size_t n,
+template <std::size_t m,
+          std::size_t n,
           typename Range,
           typename Domain,
           typename BlockPayload>
@@ -793,7 +793,7 @@ block_diagonal_operator(const BlockMatrixType &block_matrix)
  *
  * @ingroup LAOperators
  */
-template <size_t m, typename Range, typename Domain, typename BlockPayload>
+template <std::size_t m, typename Range, typename Domain, typename BlockPayload>
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_diagonal_operator(
   const std::array<LinearOperator<typename Range::BlockType,
@@ -842,7 +842,7 @@ block_diagonal_operator(
  *
  * @ingroup LAOperators
  */
-template <size_t m, typename Range, typename Domain, typename BlockPayload>
+template <std::size_t m, typename Range, typename Domain, typename BlockPayload>
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_diagonal_operator(
   const LinearOperator<typename Range::BlockType,

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -409,7 +409,7 @@ FullMatrix<number>::add_col(const size_type i,
 {
   Assert(!this->empty(), ExcEmptyMatrix());
 
-  for (size_t l = 0; l < m(); ++l)
+  for (std::size_t l = 0; l < m(); ++l)
     (*this)(l, i) += s * (*this)(l, j) + t * (*this)(l, k);
 }
 
@@ -1751,7 +1751,7 @@ FullMatrix<number>::precondition_Jacobi(Vector<somenumber> &      dst,
   Assert(dst.size() == n(), ExcDimensionMismatch(dst.size(), n()));
   Assert(src.size() == n(), ExcDimensionMismatch(src.size(), n()));
 
-  const size_t      n       = src.size();
+  const std::size_t n       = src.size();
   somenumber *      dst_ptr = dst.begin();
   const somenumber *src_ptr = src.begin();
 

--- a/include/deal.II/lac/trilinos_linear_operator.h
+++ b/include/deal.II/lac/trilinos_linear_operator.h
@@ -168,7 +168,10 @@ namespace TrilinosWrappers
    *
    * @ingroup TrilinosWrappers
    */
-  template <size_t m, size_t n, typename Range, typename Domain = Range>
+  template <std::size_t m,
+            std::size_t n,
+            typename Range,
+            typename Domain = Range>
   inline BlockLinearOperator<
     Range,
     Domain,
@@ -246,7 +249,7 @@ namespace TrilinosWrappers
    *
    * @ingroup TrilinosWrappers
    */
-  template <size_t m, typename Range, typename Domain = Range>
+  template <std::size_t m, typename Range, typename Domain = Range>
   inline BlockLinearOperator<
     Range,
     Domain,

--- a/include/deal.II/numerics/kdtree.h
+++ b/include/deal.II/numerics/kdtree.h
@@ -126,16 +126,16 @@ public:
      * Return the L2 distance between points
      */
     coord_t
-    kdtree_distance(const coord_t *p1,
-                    const size_t   idx_p2,
-                    const size_t   size) const;
+    kdtree_distance(const coord_t *   p1,
+                    const std::size_t idx_p2,
+                    const std::size_t size) const;
 
 
     /**
      * Return the d-th component of the idx-th point in the class.
      */
     coord_t
-    kdtree_get_pt(const size_t idx, const int d) const;
+    kdtree_get_pt(const std::size_t idx, const int d) const;
 
 
     /**
@@ -289,7 +289,8 @@ KDTree<dim>::PointCloudAdaptor::kdtree_get_point_count() const
 
 template <int dim>
 inline double
-KDTree<dim>::PointCloudAdaptor::kdtree_get_pt(const size_t idx, int d) const
+KDTree<dim>::PointCloudAdaptor::kdtree_get_pt(const std::size_t idx,
+                                              int               d) const
 {
   AssertIndexRange(d, dim);
   return points[idx][d];
@@ -309,13 +310,13 @@ KDTree<dim>::PointCloudAdaptor::kdtree_get_bbox(BBOX &) const
 
 template <int dim>
 inline double
-KDTree<dim>::PointCloudAdaptor::kdtree_distance(const double *p1,
-                                                const size_t  idx_p2,
-                                                const size_t  size) const
+KDTree<dim>::PointCloudAdaptor::kdtree_distance(const double *    p1,
+                                                const std::size_t idx_p2,
+                                                const std::size_t size) const
 {
   AssertDimension(size, dim);
   double res = 0.0;
-  for (size_t d = 0; d < size; ++d)
+  for (std::size_t d = 0; d < size; ++d)
     res += (p1[d] - points[idx_p2][d]) * (p1[d] - points[idx_p2][d]);
   return std::sqrt(res);
 }

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -473,7 +473,7 @@ IndexSet::block_write(std::ostream &out) const
   AssertThrow(out, ExcIO());
   out.write(reinterpret_cast<const char *>(&index_space_size),
             sizeof(index_space_size));
-  size_t n_ranges = ranges.size();
+  std::size_t n_ranges = ranges.size();
   out.write(reinterpret_cast<const char *>(&n_ranges), sizeof(n_ranges));
   if (ranges.empty() == false)
     out.write(reinterpret_cast<const char *>(&*ranges.begin()),
@@ -484,8 +484,8 @@ IndexSet::block_write(std::ostream &out) const
 void
 IndexSet::block_read(std::istream &in)
 {
-  size_type size;
-  size_t    n_ranges;
+  size_type   size;
+  std::size_t n_ranges;
   in.read(reinterpret_cast<char *>(&size), sizeof(size));
   in.read(reinterpret_cast<char *>(&n_ranges), sizeof(n_ranges));
   // we have to clear ranges first

--- a/source/base/multithread_info.cc
+++ b/source/base/multithread_info.cc
@@ -61,9 +61,9 @@ MultithreadInfo::get_n_cpus()
 unsigned int
 MultithreadInfo::get_n_cpus()
 {
-  int    mib[2];
-  int    n_cpus;
-  size_t len;
+  int         mib[2];
+  int         n_cpus;
+  std::size_t len;
 
   mib[0] = CTL_HW;
   mib[1] = HW_NCPU;

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -933,7 +933,7 @@ namespace Utilities
 
 
     void
-    posix_memalign(void **memptr, size_t alignment, size_t size)
+    posix_memalign(void **memptr, std::size_t alignment, std::size_t size)
     {
 #ifndef DEAL_II_MSVC
       const int ierr = ::posix_memalign(memptr, alignment, size);

--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -397,7 +397,7 @@ namespace internal
       types<2>::locidx        min_quadrants,
       int                     min_level,
       int                     fill_uniform,
-      size_t                  data_size,
+      std::size_t             data_size,
       p4est_init_t            init_fn,
       void *                  user_pointer) = p4est_new_ext;
 
@@ -444,8 +444,8 @@ namespace internal
       types<2>::connectivity *connectivity) = p4est_connectivity_is_valid;
 
     types<2>::connectivity *(&functions<2>::connectivity_load)(
-      const char *filename,
-      size_t *    length) = p4est_connectivity_load;
+      const char * filename,
+      std::size_t *length) = p4est_connectivity_load;
 
     unsigned int (&functions<2>::checksum)(types<2>::forest *p4est) =
       p4est_checksum;
@@ -463,14 +463,14 @@ namespace internal
       p4est_ghost_destroy;
 
     void (&functions<2>::reset_data)(types<2>::forest *p4est,
-                                     size_t            data_size,
+                                     std::size_t       data_size,
                                      p4est_init_t      init_fn,
                                      void *user_pointer) = p4est_reset_data;
 
-    size_t (&functions<2>::forest_memory_used)(types<2>::forest *p4est) =
+    std::size_t (&functions<2>::forest_memory_used)(types<2>::forest *p4est) =
       p4est_memory_used;
 
-    size_t (&functions<2>::connectivity_memory_used)(
+    std::size_t (&functions<2>::connectivity_memory_used)(
       types<2>::connectivity *p4est) = p4est_connectivity_memory_used;
 
     template <int dim, int spacedim>
@@ -533,7 +533,7 @@ namespace internal
                                          int                     tag,
                                          void *                  dest_data,
                                          const void *            src_data,
-                                         size_t                  data_size) =
+                                         std::size_t             data_size) =
       p4est_transfer_fixed;
 
     types<2>::transfer_context *(&functions<2>::transfer_fixed_begin)(
@@ -543,7 +543,7 @@ namespace internal
       int                     tag,
       void *                  dest_data,
       const void *            src_data,
-      size_t                  data_size) = p4est_transfer_fixed_begin;
+      std::size_t             data_size) = p4est_transfer_fixed_begin;
 
     void (&functions<2>::transfer_fixed_end)(types<2>::transfer_context *tc) =
       p4est_transfer_fixed_end;
@@ -636,7 +636,7 @@ namespace internal
       types<3>::locidx        min_quadrants,
       int                     min_level,
       int                     fill_uniform,
-      size_t                  data_size,
+      std::size_t             data_size,
       p8est_init_t            init_fn,
       void *                  user_pointer) = p8est_new_ext;
 
@@ -683,8 +683,8 @@ namespace internal
       types<3>::connectivity *connectivity) = p8est_connectivity_is_valid;
 
     types<3>::connectivity *(&functions<3>::connectivity_load)(
-      const char *filename,
-      size_t *    length) = p8est_connectivity_load;
+      const char * filename,
+      std::size_t *length) = p8est_connectivity_load;
 
     unsigned int (&functions<3>::checksum)(types<3>::forest *p8est) =
       p8est_checksum;
@@ -702,14 +702,14 @@ namespace internal
       p8est_ghost_destroy;
 
     void (&functions<3>::reset_data)(types<3>::forest *p4est,
-                                     size_t            data_size,
+                                     std::size_t       data_size,
                                      p8est_init_t      init_fn,
                                      void *user_pointer) = p8est_reset_data;
 
-    size_t (&functions<3>::forest_memory_used)(types<3>::forest *p4est) =
+    std::size_t (&functions<3>::forest_memory_used)(types<3>::forest *p4est) =
       p8est_memory_used;
 
-    size_t (&functions<3>::connectivity_memory_used)(
+    std::size_t (&functions<3>::connectivity_memory_used)(
       types<3>::connectivity *p4est) = p8est_connectivity_memory_used;
 
     constexpr unsigned int functions<3>::max_level;
@@ -720,7 +720,7 @@ namespace internal
                                          int                     tag,
                                          void *                  dest_data,
                                          const void *            src_data,
-                                         size_t                  data_size) =
+                                         std::size_t             data_size) =
       p8est_transfer_fixed;
 
     types<3>::transfer_context *(&functions<3>::transfer_fixed_begin)(
@@ -730,7 +730,7 @@ namespace internal
       int                     tag,
       void *                  dest_data,
       const void *            src_data,
-      size_t                  data_size) = p8est_transfer_fixed_begin;
+      std::size_t             data_size) = p8est_transfer_fixed_begin;
 
     void (&functions<3>::transfer_fixed_end)(types<3>::transfer_context *tc) =
       p8est_transfer_fixed_end;

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2878,7 +2878,8 @@ namespace DoFTools
         copy_data.global_parameter_representation.resize(n_interesting_dofs);
 
         bool is_called_in_parallel = false;
-        for (size_t i = 0; i < copy_data.global_parameter_representation.size();
+        for (std::size_t i = 0;
+             i < copy_data.global_parameter_representation.size();
              ++i)
           {
 #ifdef DEAL_II_WITH_MPI
@@ -2936,7 +2937,8 @@ namespace DoFTools
                         copy_data);
 
 #ifdef DEAL_II_WITH_MPI
-        for (size_t i = 0; i < copy_data.global_parameter_representation.size();
+        for (std::size_t i = 0;
+             i < copy_data.global_parameter_representation.size();
              ++i)
           copy_data.global_parameter_representation[i].update_ghost_values();
 #endif

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -289,7 +289,7 @@ MGTransferPrebuilt<VectorType>::build_matrices(
             n_locally_owned_mg_dofs_per_processor(
               locally_owned_mg_dofs_per_processor.size(), 0);
 
-          for (size_t index = 0;
+          for (std::size_t index = 0;
                index < n_locally_owned_mg_dofs_per_processor.size();
                ++index)
             {

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -286,8 +286,8 @@ namespace SUNDIALS
 #  ifdef DEAL_II_WITH_MPI
     if (is_serial_vector<VectorType>::value == false)
       {
-        const IndexSet is                = solution.locally_owned_elements();
-        const size_t   local_system_size = is.n_elements();
+        const IndexSet    is                = solution.locally_owned_elements();
+        const std::size_t local_system_size = is.n_elements();
 
         yy = N_VNew_Parallel(communicator, local_system_size, system_size);
 
@@ -385,8 +385,8 @@ namespace SUNDIALS
 #  ifdef DEAL_II_WITH_MPI
     if (is_serial_vector<VectorType>::value == false)
       {
-        const IndexSet is                = solution.locally_owned_elements();
-        const size_t   local_system_size = is.n_elements();
+        const IndexSet    is                = solution.locally_owned_elements();
+        const std::size_t local_system_size = is.n_elements();
 
         yy = N_VNew_Parallel(communicator, local_system_size, system_size);
 

--- a/source/sundials/copy.cc
+++ b/source/sundials/copy.cc
@@ -64,10 +64,10 @@ namespace SUNDIALS
     void
     copy(TrilinosWrappers::MPI::Vector &dst, const N_Vector &src)
     {
-      const IndexSet is = dst.locally_owned_elements();
-      const size_t   N  = is.n_elements();
+      const IndexSet    is = dst.locally_owned_elements();
+      const std::size_t N  = is.n_elements();
       AssertDimension(N, N_Vector_length(src));
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           dst[is.nth_index_in_set(i)] = NV_Ith_P(src, i);
         }
@@ -77,10 +77,10 @@ namespace SUNDIALS
     void
     copy(N_Vector &dst, const TrilinosWrappers::MPI::Vector &src)
     {
-      const IndexSet is = src.locally_owned_elements();
-      const size_t   N  = is.n_elements();
+      const IndexSet    is = src.locally_owned_elements();
+      const std::size_t N  = is.n_elements();
       AssertDimension(N, N_Vector_length(dst));
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           NV_Ith_P(dst, i) = src[is.nth_index_in_set(i)];
         }
@@ -89,10 +89,10 @@ namespace SUNDIALS
     void
     copy(TrilinosWrappers::MPI::BlockVector &dst, const N_Vector &src)
     {
-      const IndexSet is = dst.locally_owned_elements();
-      const size_t   N  = is.n_elements();
+      const IndexSet    is = dst.locally_owned_elements();
+      const std::size_t N  = is.n_elements();
       AssertDimension(N, N_Vector_length(src));
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           dst[is.nth_index_in_set(i)] = NV_Ith_P(src, i);
         }
@@ -102,10 +102,10 @@ namespace SUNDIALS
     void
     copy(N_Vector &dst, const TrilinosWrappers::MPI::BlockVector &src)
     {
-      IndexSet     is = src.locally_owned_elements();
-      const size_t N  = is.n_elements();
+      IndexSet          is = src.locally_owned_elements();
+      const std::size_t N  = is.n_elements();
       AssertDimension(N, N_Vector_length(dst));
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           NV_Ith_P(dst, i) = src[is.nth_index_in_set(i)];
         }
@@ -119,10 +119,10 @@ namespace SUNDIALS
     void
     copy(PETScWrappers::MPI::Vector &dst, const N_Vector &src)
     {
-      const IndexSet is = dst.locally_owned_elements();
-      const size_t   N  = is.n_elements();
+      const IndexSet    is = dst.locally_owned_elements();
+      const std::size_t N  = is.n_elements();
       AssertDimension(N, N_Vector_length(src));
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           dst[is.nth_index_in_set(i)] = NV_Ith_P(src, i);
         }
@@ -132,10 +132,10 @@ namespace SUNDIALS
     void
     copy(N_Vector &dst, const PETScWrappers::MPI::Vector &src)
     {
-      const IndexSet is = src.locally_owned_elements();
-      const size_t   N  = is.n_elements();
+      const IndexSet    is = src.locally_owned_elements();
+      const std::size_t N  = is.n_elements();
       AssertDimension(N, N_Vector_length(dst));
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           NV_Ith_P(dst, i) = src[is.nth_index_in_set(i)];
         }
@@ -144,10 +144,10 @@ namespace SUNDIALS
     void
     copy(PETScWrappers::MPI::BlockVector &dst, const N_Vector &src)
     {
-      const IndexSet is = dst.locally_owned_elements();
-      const size_t   N  = is.n_elements();
+      const IndexSet    is = dst.locally_owned_elements();
+      const std::size_t N  = is.n_elements();
       AssertDimension(N, N_Vector_length(src));
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           dst[is.nth_index_in_set(i)] = NV_Ith_P(src, i);
         }
@@ -157,10 +157,10 @@ namespace SUNDIALS
     void
     copy(N_Vector &dst, const PETScWrappers::MPI::BlockVector &src)
     {
-      const IndexSet is = src.locally_owned_elements();
-      const size_t   N  = is.n_elements();
+      const IndexSet    is = src.locally_owned_elements();
+      const std::size_t N  = is.n_elements();
       AssertDimension(N, N_Vector_length(dst));
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           NV_Ith_P(dst, i) = src[is.nth_index_in_set(i)];
         }
@@ -174,9 +174,9 @@ namespace SUNDIALS
     void
     copy(BlockVector<double> &dst, const N_Vector &src)
     {
-      const size_t N = dst.size();
+      const std::size_t N = dst.size();
       AssertDimension(N_Vector_length(src), N);
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           dst[i] = NV_Ith_S(src, i);
         }
@@ -185,9 +185,9 @@ namespace SUNDIALS
     void
     copy(N_Vector &dst, const BlockVector<double> &src)
     {
-      const size_t N = src.size();
+      const std::size_t N = src.size();
       AssertDimension(N_Vector_length(dst), N);
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           NV_Ith_S(dst, i) = src[i];
         }
@@ -196,9 +196,9 @@ namespace SUNDIALS
     void
     copy(Vector<double> &dst, const N_Vector &src)
     {
-      const size_t N = dst.size();
+      const std::size_t N = dst.size();
       AssertDimension(N_Vector_length(src), N);
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           dst[i] = NV_Ith_S(src, i);
         }
@@ -207,9 +207,9 @@ namespace SUNDIALS
     void
     copy(N_Vector &dst, const Vector<double> &src)
     {
-      const size_t N = src.size();
+      const std::size_t N = src.size();
       AssertDimension(N_Vector_length(dst), N);
-      for (size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
         {
           NV_Ith_S(dst, i) = src[i];
         }

--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -204,8 +204,8 @@ namespace SUNDIALS
 #  ifdef DEAL_II_WITH_MPI
     if (is_serial_vector<VectorType>::value == false)
       {
-        const IndexSet is                = solution.locally_owned_elements();
-        const size_t   local_system_size = is.n_elements();
+        const IndexSet    is                = solution.locally_owned_elements();
+        const std::size_t local_system_size = is.n_elements();
 
         yy = N_VNew_Parallel(communicator, local_system_size, system_size);
 
@@ -318,8 +318,8 @@ namespace SUNDIALS
 #  ifdef DEAL_II_WITH_MPI
     if (is_serial_vector<VectorType>::value == false)
       {
-        const IndexSet is                = solution.locally_owned_elements();
-        const size_t   local_system_size = is.n_elements();
+        const IndexSet    is                = solution.locally_owned_elements();
+        const std::size_t local_system_size = is.n_elements();
 
         yy = N_VNew_Parallel(communicator, local_system_size, system_size);
 

--- a/tests/base/utilities_pack_unpack_05.cc
+++ b/tests/base/utilities_pack_unpack_05.cc
@@ -36,7 +36,7 @@ check(const double (&array)[N], const Point<dim>(&point))
 
   // PACK BUFFER
   // add first object to buffer and store buffer size for later separation
-  const size_t buffer_separator = Utilities::pack(array, buffer);
+  const std::size_t buffer_separator = Utilities::pack(array, buffer);
   // add second object to buffer
   Utilities::pack(point, buffer);
 

--- a/tests/distributed_grids/intergrid_transfer_representation_parallel.cc
+++ b/tests/distributed_grids/intergrid_transfer_representation_parallel.cc
@@ -97,7 +97,7 @@ test(unsigned n_refinements)
   // For this test case, all weights are one and their sum
   // should be equal to number of degrees of freedom
   unsigned local_sum = 0.;
-  for (size_t i = 0; i < transfer_representation.size(); ++i)
+  for (std::size_t i = 0; i < transfer_representation.size(); ++i)
     {
       TransferRep::value_type m = transfer_representation[i];
       for (TransferRep::value_type::const_iterator it = m.begin();

--- a/tests/fe/fe_compute_point_locations_01.cc
+++ b/tests/fe/fe_compute_point_locations_01.cc
@@ -57,7 +57,7 @@ test_compute_pt_loc(unsigned int n_points)
   // Creating the random points
   std::vector<Point<dim>> points;
 
-  for (size_t i = 0; i < n_points; ++i)
+  for (std::size_t i = 0; i < n_points; ++i)
     points.push_back(random_point<dim>());
 
   std::vector<typename DoFHandler<dim>::active_cell_iterator> cells;
@@ -68,7 +68,7 @@ test_compute_pt_loc(unsigned int n_points)
   Vector<double>                  dummy;
   Functions::FEFieldFunction<dim> fe_function(
     dof_handler, dummy, StaticMappingQ1<dim, dim>::mapping);
-  size_t n_cells =
+  std::size_t n_cells =
     fe_function.compute_point_locations(points, cells, qpoints, maps);
 
   deallog << "Points found in " << n_cells << " cells" << std::endl;

--- a/tests/full_matrix/full_matrix_move.cc
+++ b/tests/full_matrix/full_matrix_move.cc
@@ -25,10 +25,10 @@ main()
 {
   initlog();
 
-  size_t             m = 2, n = 3;
+  std::size_t        m = 2, n = 3;
   FullMatrix<double> A(m, n);
-  for (size_t i = 0; i < m; ++i)
-    for (size_t j = 0; j < n; ++j)
+  for (std::size_t i = 0; i < m; ++i)
+    for (std::size_t j = 0; j < n; ++j)
       A(i, j) = n * i + j;
 
   deallog << "Size of A:" << std::endl << A.m() << " " << A.n() << std::endl;

--- a/tests/grid/compute_point_locations_01.cc
+++ b/tests/grid/compute_point_locations_01.cc
@@ -58,14 +58,14 @@ test_compute_pt_loc(unsigned int n_points)
   // Creating the random points
   std::vector<Point<dim>> points;
 
-  for (size_t i = 0; i < n_points; ++i)
+  for (std::size_t i = 0; i < n_points; ++i)
     points.push_back(random_point<dim>());
 
   // Initializing the cache
   GridTools::Cache<dim, dim> cache(tria);
 
-  auto   cell_qpoint_map = GridTools::compute_point_locations(cache, points);
-  size_t n_cells         = std::get<0>(cell_qpoint_map).size();
+  auto cell_qpoint_map = GridTools::compute_point_locations(cache, points);
+  std::size_t n_cells  = std::get<0>(cell_qpoint_map).size();
 
   deallog << "Points found in " << n_cells << " cells" << std::endl;
 

--- a/tests/grid/compute_point_locations_02.cc
+++ b/tests/grid/compute_point_locations_02.cc
@@ -58,7 +58,7 @@ test_compute_pt_loc(unsigned int n_points)
   // Creating the random points
   std::vector<Point<dim>> points;
 
-  for (size_t i = 0; i < n_points; ++i)
+  for (std::size_t i = 0; i < n_points; ++i)
     {
       Point<dim> p;
       for (unsigned int d = 0; d < dim; ++d)
@@ -72,7 +72,7 @@ test_compute_pt_loc(unsigned int n_points)
   auto my_pair = GridTools::find_active_cell_around_point(cache, points[0]);
   auto cell_qpoint_map =
     GridTools::compute_point_locations(cache, points, my_pair.first);
-  size_t n_cells = std::get<0>(cell_qpoint_map).size();
+  std::size_t n_cells = std::get<0>(cell_qpoint_map).size();
 
   deallog << "Points found in " << n_cells << " cells" << std::endl;
 

--- a/tests/grid/distributed_compute_point_locations_01.cc
+++ b/tests/grid/distributed_compute_point_locations_01.cc
@@ -50,7 +50,7 @@ test_compute_pt_loc(unsigned int n_points)
   // Creating the random points
   std::vector<Point<dim>> points;
 
-  for (size_t i = 0; i < n_points; ++i)
+  for (std::size_t i = 0; i < n_points; ++i)
     points.push_back(random_point<dim>());
 
   // Initializing the cache
@@ -78,9 +78,9 @@ test_compute_pt_loc(unsigned int n_points)
   // Testing in serial against the serial version
   auto cell_qpoint_map = GridTools::compute_point_locations(cache, points);
 
-  auto & serial_cells   = std::get<0>(cell_qpoint_map);
-  auto & serial_qpoints = std::get<1>(cell_qpoint_map);
-  size_t n_cells        = std::get<0>(output_tuple).size();
+  auto &      serial_cells   = std::get<0>(cell_qpoint_map);
+  auto &      serial_qpoints = std::get<1>(cell_qpoint_map);
+  std::size_t n_cells        = std::get<0>(output_tuple).size();
 
   deallog << "Points found in " << n_cells << " cells" << std::endl;
 

--- a/tests/grid/find_active_cell_around_point_01.cc
+++ b/tests/grid/find_active_cell_around_point_01.cc
@@ -54,7 +54,7 @@ test(unsigned int n_ref, unsigned int n_points)
   std::vector<Point<spacedim>> points;
 
   deallog << "Points in study: " << n_points << std::endl;
-  for (size_t i = 0; i < n_points; ++i)
+  for (std::size_t i = 0; i < n_points; ++i)
     points.push_back(random_point<spacedim>());
 
   auto v_to_c   = GridTools::vertex_to_cell_map(tria);

--- a/tests/grid/find_active_cell_around_point_02.cc
+++ b/tests/grid/find_active_cell_around_point_02.cc
@@ -53,7 +53,7 @@ test(unsigned int n_ref, unsigned int n_points)
   std::vector<Point<spacedim>> points;
 
   deallog << "Points in study: " << n_points << std::endl;
-  for (size_t i = 0; i < n_points; ++i)
+  for (std::size_t i = 0; i < n_points; ++i)
     points.push_back(random_point<spacedim>());
 
   auto &mapping = StaticMappingQ1<dim, spacedim>::mapping;

--- a/tests/grid/grid_tools_guess_pt_owner_1.cc
+++ b/tests/grid/grid_tools_guess_pt_owner_1.cc
@@ -102,7 +102,7 @@ test_point_owner(unsigned int n_procs)
   points.clear();
 
   unsigned int n_points = 2 * tot_bbox;
-  for (size_t i = 0; i < n_points; ++i)
+  for (std::size_t i = 0; i < n_points; ++i)
     {
       Point<spacedim> p;
       p[0] = tot_bbox * double(Testing::rand()) / RAND_MAX;

--- a/tests/numerics/project_bv_curl_conf_02.cc
+++ b/tests/numerics/project_bv_curl_conf_02.cc
@@ -108,7 +108,7 @@ test(unsigned order)
           const std::vector<std::pair<types::global_dof_index, double>> &c2 =
             *constraints_fe.get_constraint_entries(lines.nth_index_in_set(i));
 
-          for (size_t j = 0; j < c1.size(); ++j)
+          for (std::size_t j = 0; j < c1.size(); ++j)
             if ((c1[j].first != c2[j].first) ||
                 (fabs(c1[j].second - c2[j].second) > 1e-14))
               {


### PR DESCRIPTION
One of @drwells comments in #7570 motivated me to look for more places where we use `C`'s `size_t` instead of `std::size_t`.

Theis PR is the result of a simple
```
 find cmake examples/ tests/ source/ include/ \( -name "*.cc" -o -name "*.h" \) -exec sed -i "s/\([<( ]\)size_t /\1std::size_t /g" {} \;
```

A subsequent
```
grep -r "size_t " examples/ tests/ source/ include/ | grep -v "std::size_t"
```
doesn't show any more occurences afterwards.