### PR TITLE
Fixed indices in FESeries::Fourier::set_k_vectors().

### DIFF
--- a/doc/news/changes/minor/20190108Fehling
+++ b/doc/news/changes/minor/20190108Fehling
@@ -1,0 +1,5 @@
+Fixed: Tensor indices of set_k_vectors() in FESeries::Fourier.
+Coefficients will now be distributed in every
+coordinate direction correctly.
+<br>
+(Marc Fehling, 2019/01/08)

--- a/source/fe/fe_series_fourier.cc
+++ b/source/fe/fe_series_fourier.cc
@@ -54,8 +54,8 @@ namespace
         for (unsigned int k = 0; k < N; ++k)
           {
             k_vectors(i, j, k)[0] = 2. * numbers::PI * i;
-            k_vectors(i, j, k)[0] = 2. * numbers::PI * j;
-            k_vectors(i, j, k)[0] = 2. * numbers::PI * k;
+            k_vectors(i, j, k)[1] = 2. * numbers::PI * j;
+            k_vectors(i, j, k)[2] = 2. * numbers::PI * k;
           }
   }
 


### PR DESCRIPTION
Comparing to the 2D specialization above, these indices need to be adjusted.