### PR TITLE
Use more flags in [[fallthrough]] checks

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -569,8 +569,11 @@ UNSET_IF_CHANGED(CHECK_CXX_FEATURES_FLAGS_SAVED
 # but a compiler extension in earlier language versions: check both
 # possibilities here.
 #
+ADD_FLAGS(CMAKE_REQUIRED_FLAGS "${DEAL_II_CXX_FLAGS}")
+ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-Werror -Wno-unused-command-line-argument")
+#
 # first try the attribute [[fallthrough]]
-ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-Werror -Wextra ${DEAL_II_CXX_VERSION_FLAG}")
+#
 CHECK_CXX_SOURCE_COMPILES(
   "
   int main()
@@ -593,8 +596,10 @@ CHECK_CXX_SOURCE_COMPILES(
    DEAL_II_HAVE_CXX17_ATTRIBUTE_FALLTHROUGH
    )
 
+#
 # see if the current compiler configuration supports the GCC extension
 # __attribute__((fallthrough)) syntax instead
+#
 CHECK_CXX_SOURCE_COMPILES(
   "
   int main()


### PR DESCRIPTION
It turned out that `clang-4.0.1` at least needs `-pedantic` to treat using `[[fallthrough]]` as an error instead of a warning when compiling without `C++17` support (also see https://cdash.kyomu.43-1.org/viewBuildError.php?onlydeltap&buildid=6949).
Since `-pedantic` is enabled in `DEAL_II_CXX_FLAGS` we should disable `[[fallthrough]]` support then.
In the end, the best idea seems to be to follow what we do for `[[deprecated]]` with respect to compiler flags and simply take `DEAL_II_CXX_FLAGS`. That is what this PR does.

I am still not sure why the build in the `CDash` report above fails, though. The output only lists warnings, no errors, and I can't reproduce a build failure locally. Hopefully, the output is at least more telling after this patch.