### PR TITLE
Add "covering rtree" to GridTools::Cache

### DIFF
--- a/doc/news/changes/minor/20190111GiovanniAlzetta
+++ b/doc/news/changes/minor/20190111GiovanniAlzetta
@@ -1,0 +1,5 @@
+New: GridTools::Cache::get_covering_rtree() automatically stores and generates
+a rtree of bounding boxes covering the whole triangulation. In a distributed setting
+it can identify which processes have locally owned cells in any part of the mesh.
+<br>
+(Giovanni Alzetta, 2019/01/11)

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -150,6 +150,33 @@ namespace GridTools
     const Mapping<dim, spacedim> &
     get_mapping() const;
 
+
+    /**
+     * This function returns an object that allows identifying
+     * which process(es) in a parallel computation may own the
+     * cell that surrounds a given point. The elements of this
+     * object -- an Rtree -- are pairs of bounding boxes denoting
+     * areas that cover all or parts of the local portion of a
+     * parallel triangulation, and an unsigned int representing
+     * the process or subdomain that owns these cells.
+     * Given a point on a parallel::Triangulation, this tree
+     * allows to identify one, or few candidate processes, for
+     * which the point lies on a locally owned cell.
+     *
+     * Constructing or updating the rtree requires a call to
+     * GridTools::build_global_description_tree(), which exchanges
+     * bounding boxes between all processes using
+     * Utilities::MPI::all_gather(), a collective operation.
+     * Therefore this function must be called by all processes
+     * at the same time.
+     *
+     * While each box may only cover part of a process's locally
+     * owned part of the triangulation, the boxes associated with
+     * each process jointly cover the entire local portion.
+     */
+    const RTree<std::pair<BoundingBox<spacedim>, unsigned int>> &
+    get_covering_rtree() const;
+
 #ifdef DEAL_II_WITH_NANOFLANN
     /**
      * Return the cached vertex_kdtree object, constructed with the vertices of
@@ -190,6 +217,12 @@ namespace GridTools
      */
     mutable std::vector<std::vector<Tensor<1, spacedim>>>
       vertex_to_cell_centers;
+
+    /**
+     * An rtree object covering the whole mesh.
+     */
+    mutable RTree<std::pair<BoundingBox<spacedim>, unsigned int>>
+      covering_rtree;
 
 #ifdef DEAL_II_WITH_NANOFLANN
     /**

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -74,6 +74,16 @@ namespace GridTools
     update_cell_bounding_boxes_rtree = 0x020,
 
     /**
+     * Update the covering rtree object, initialized with pairs
+     * of a bounding box and an unsigned int. The bounding
+     * boxes are used to describe approximately which portion
+     * of the mesh contains locally owned cells by the
+     * process of rank the second element of the pair.
+     *
+     */
+    update_covering_rtree = 0x040,
+
+    /**
      * Update all objects.
      */
     update_all = 0x0FF,
@@ -94,6 +104,8 @@ namespace GridTools
       s << "|vertex_to_cell_map";
     if (u & update_vertex_to_cell_centers_directions)
       s << "|vertex_to_cells_centers_directions";
+    if (u & update_covering_rtree)
+      s << "|covering_rtree";
 #ifdef DEAL_II_WITH_NANOFLANN
     if (u & update_vertex_kdtree)
       s << "|vertex_kdtree";

--- a/tests/grid/grid_tools_cache_04.cc
+++ b/tests/grid/grid_tools_cache_04.cc
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2001 - 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Validate grid_tools_cache for the creation of build global rtree
+
+
+#include <deal.II/distributed/grid_refinement.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_tools_cache.h>
+#include <deal.II/grid/tria.h>
+
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/vector.hpp>
+#include <boost/signals2.hpp>
+
+#include "../tests.h"
+
+using namespace dealii;
+
+namespace bg  = boost::geometry;
+namespace bgi = boost::geometry::index;
+
+
+template <int dim>
+void
+test(unsigned int n_points)
+{
+  deallog << "Testing for dim = " << dim << std::endl;
+
+  // Creating a grid in the square [0,1]x[0,1]
+  parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(std::max(8 - dim, 3));
+
+
+  GridTools::Cache<dim> cache(tria);
+
+  const auto &global_description = cache.get_covering_rtree();
+
+  // Creating the random points
+  std::vector<Point<dim>> points;
+
+  for (size_t i = 0; i < n_points; ++i)
+    points.push_back(random_point<dim>());
+
+
+
+  const auto cell_qpoint_map =
+    GridTools::compute_point_locations(cache, points);
+  const auto & cells   = std::get<0>(cell_qpoint_map);
+  const auto & maps    = std::get<2>(cell_qpoint_map);
+  unsigned int n_cells = cells.size();
+
+  for (unsigned int c = 0; c < n_cells; ++c)
+    {
+      // We know the owner as we're working on a shared triangulation
+      unsigned int cell_owner = cells[c]->subdomain_id();
+      for (unsigned int idx : maps[c])
+        {
+          std::vector<std::pair<BoundingBox<dim>, unsigned int>> test_results;
+          global_description.query(bgi::intersects(points[idx]),
+                                   std::back_inserter(test_results));
+          bool found = false;
+
+          // Printing and checking function output
+          for (const auto &ans : test_results)
+            {
+              const auto &bd_points = ans.first.get_boundary_points();
+              deallog << "Bounding box: p1 " << bd_points.first << " p2 "
+                      << bd_points.second << " rank owner: " << ans.second
+                      << std::endl;
+              // Check if the guess made from the tree contains the answer
+              if (ans.second == cell_owner)
+                found = true;
+            }
+
+          if (!found)
+            deallog << "Error point " << points[idx] << " was not found."
+                    << std::endl;
+        }
+    }
+  deallog << "Test for dim " << dim << " finished." << std::endl;
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+#ifdef DEAL_II_WITH_MPI
+  MPILogInitAll log;
+#else
+  initlog();
+  deallog.push("0");
+#endif
+
+  test<1>(50);
+  test<2>(80);
+  test<3>(101);
+
+  return 0;
+}

--- a/tests/grid/grid_tools_cache_04.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/grid/grid_tools_cache_04.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,0 +1,238 @@
+
+DEAL:0::Testing for dim = 1
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 1.00000 rank owner: 0
+DEAL:0::Test for dim 1 finished.
+DEAL:0::Testing for dim = 2
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 1.00000 1.00000 rank owner: 0
+DEAL:0::Test for dim 2 finished.
+DEAL:0::Testing for dim = 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 0
+DEAL:0::Test for dim 3 finished.

--- a/tests/grid/grid_tools_cache_04.with_mpi=true.with_p4est=true.mpirun=4.output
+++ b/tests/grid/grid_tools_cache_04.with_mpi=true.with_p4est=true.mpirun=4.output
@@ -1,0 +1,1007 @@
+
+DEAL:0::Testing for dim = 1
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:0::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:0::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:0::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:0::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:0::Test for dim 1 finished.
+DEAL:0::Testing for dim = 2
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:0::Test for dim 2 finished.
+DEAL:0::Testing for dim = 3
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:0::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:0::Test for dim 3 finished.
+
+DEAL:1::Testing for dim = 1
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:1::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:1::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:1::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:1::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:1::Test for dim 1 finished.
+DEAL:1::Testing for dim = 2
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:1::Test for dim 2 finished.
+DEAL:1::Testing for dim = 3
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:1::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:1::Test for dim 3 finished.
+
+
+DEAL:2::Testing for dim = 1
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:2::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:2::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:2::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:2::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:2::Test for dim 1 finished.
+DEAL:2::Testing for dim = 2
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:2::Test for dim 2 finished.
+DEAL:2::Testing for dim = 3
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:2::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:2::Test for dim 3 finished.
+
+
+DEAL:3::Testing for dim = 1
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:3::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:3::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:3::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:3::Bounding box: p1 0.531250 p2 0.765625 rank owner: 3
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.257812 p2 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.765625 p2 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 p2 0.257812 rank owner: 1
+DEAL:3::Test for dim 1 finished.
+DEAL:3::Testing for dim = 2
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.00000 p2 0.515625 0.531250 rank owner: 0
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.421875 0.531250 p2 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.531250 p2 0.421875 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.515625 0.00000 p2 1.00000 0.531250 rank owner: 1
+DEAL:3::Test for dim 2 finished.
+DEAL:3::Testing for dim = 3
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.468750 0.00000 0.00000 p2 1.00000 0.531250 1.00000 rank owner: 3
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.00000 0.00000 p2 0.562500 0.531250 1.00000 rank owner: 1
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Bounding box: p1 0.531250 0.531250 0.00000 p2 1.00000 1.00000 1.00000 rank owner: 2
+DEAL:3::Bounding box: p1 0.00000 0.468750 0.00000 p2 0.562500 1.00000 1.00000 rank owner: 0
+DEAL:3::Test for dim 3 finished.
+


### PR DESCRIPTION
Hi everyone,
  as stated in https://github.com/dealii/dealii/issues/7536 , I wanted to add a new rtree in the GridTools::Cache which handles a covering of the whole mesh, with the purpose of knowing/guessing who the owner is of each portion of the mesh. This is working code, with a test. If there are suggestions (also about the name) I am here :)

Currently I am using a "safe" option: a single bounding box per process.
@luca-heltai : I have an idea, using the local rtree of Cache, to make GridTools::compute_mesh_predicate_bounding_box work properly and fast, but that's for another day.

Best,
Giovanni
