### PR TITLE
Use ranged-based for loops in hp

### DIFF
--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -595,7 +595,7 @@ namespace hp
     // this collection. Inlining the definition of fe_pointers causes internal
     // compiler errors on GCC 7.1.1 so we define it separately:
     const auto fe_pointers = {&fes...};
-    for (auto p : fe_pointers)
+    for (const auto p : fe_pointers)
       push_back(*p);
   }
 

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -157,7 +157,7 @@ namespace hp
     // this collection. Inlining the definition of q_pointers causes internal
     // compiler errors on GCC 7.1.1 so we define it separately:
     const auto q_pointers = {&quadrature_objects...};
-    for (auto p : q_pointers)
+    for (const auto p : q_pointers)
       push_back(*p);
   }
 

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -980,7 +980,7 @@ namespace internal
               // non-locally_owned cells. so we have to work around the
               // issue a little bit by accessing the underlying data
               // structures directly
-              for (auto cell : dof_handler.active_cell_iterators())
+              for (const auto &cell : dof_handler.active_cell_iterators())
                 if (cell->is_ghost())
                   dof_handler.levels[cell->level()]->set_active_fe_index(
                     cell->index(),
@@ -1579,8 +1579,8 @@ namespace hp
           Assert(*p == i, ExcNewNumbersNotConsecutive(i));
       }
     else
-      for (types::global_dof_index i = 0; i < new_numbers.size(); ++i)
-        Assert(new_numbers[i] < n_dofs(),
+      for (const auto new_number : new_numbers)
+        Assert(new_number < n_dofs(),
                ExcMessage(
                  "New DoF index is not less than the total number of dofs."));
 #endif
@@ -1754,7 +1754,7 @@ namespace hp
             const std::vector<types::subdomain_id> &true_subdomain_ids =
               shared_tria->get_true_subdomain_ids_of_cells();
 
-            for (auto &cell : active_cell_iterators())
+            for (const auto &cell : active_cell_iterators())
               {
                 const unsigned int index   = cell->active_cell_index();
                 saved_subdomain_ids[index] = cell->subdomain_id();
@@ -1815,7 +1815,7 @@ namespace hp
 
         // Finally, restore current subdomain_ids.
         if (shared_tria != nullptr && shared_tria->with_artificial_cells())
-          for (auto &cell : active_cell_iterators())
+          for (const auto &cell : active_cell_iterators())
             {
               if (cell->is_artificial())
                 cell->set_subdomain_id(numbers::invalid_subdomain_id);

--- a/source/hp/dof_level.cc
+++ b/source/hp/dof_level.cc
@@ -256,10 +256,9 @@ namespace internal
     void
     DoFLevel::normalize_active_fe_indices()
     {
-      for (unsigned int i = 0; i < active_fe_indices.size(); ++i)
-        if (is_compressed_entry(active_fe_indices[i]))
-          active_fe_indices[i] =
-            get_toggled_compression_state(active_fe_indices[i]);
+      for (auto &active_fe_index : active_fe_indices)
+        if (is_compressed_entry(active_fe_index))
+          active_fe_index = get_toggled_compression_state(active_fe_index);
     }
 
 

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -40,8 +40,11 @@ namespace hp
   {
     Assert(codim <= dim, ExcImpossibleInDim(dim));
 
-    for (auto it = fes.cbegin(); it != fes.cend(); ++it)
-      AssertIndexRange(*it, finite_elements.size());
+    for (const unsigned int fe_index : fes)
+      {
+        (void)fe_index;
+        AssertIndexRange(fe_index, finite_elements.size());
+      }
 
     // If the set of elements to be dominated contains only a single element X,
     // then by definition the dominating set contains this single element X
@@ -114,8 +117,11 @@ namespace hp
   {
     Assert(codim <= dim, ExcImpossibleInDim(dim));
 
-    for (auto it = fes.cbegin(); it != fes.cend(); ++it)
-      AssertIndexRange(*it, finite_elements.size());
+    for (const unsigned int fe_index : fes)
+      {
+        (void)fe_index;
+        AssertIndexRange(fe_index, finite_elements.size());
+      }
 
     // If the set of elements to be dominated contains only a single element X,
     // then by definition the dominating set contains this single element


### PR DESCRIPTION
The third patch applying `modernize-loop-convert`.