### PR TITLE
Actually delete copy constructors for FEValues*

### DIFF
--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -261,10 +261,10 @@ namespace FEValuesViews
 
     /**
      * Copy operator. This is not a lightweight object so we don't allow
-     * copying and generate an exception if this function is called.
+     * copying and generate a compile-time error if this function is called.
      */
     Scalar &
-    operator=(const Scalar<dim, spacedim> &);
+    operator=(const Scalar<dim, spacedim> &) = delete;
 
     /**
      * Return the value of the vector component selected by this view, for the
@@ -767,10 +767,10 @@ namespace FEValuesViews
 
     /**
      * Copy operator. This is not a lightweight object so we don't allow
-     * copying and generate an exception if this function is called.
+     * copying and generate a compile-time error if this function is called.
      */
     Vector &
-    operator=(const Vector<dim, spacedim> &);
+    operator=(const Vector<dim, spacedim> &) = delete;
 
     /**
      * Return the value of the vector components selected by this view, for
@@ -1363,10 +1363,10 @@ namespace FEValuesViews
 
     /**
      * Copy operator. This is not a lightweight object so we don't allow
-     * copying and generate an exception if this function is called.
+     * copying and generate a compile-time error if this function is called.
      */
     SymmetricTensor &
-    operator=(const SymmetricTensor<2, dim, spacedim> &);
+    operator=(const SymmetricTensor<2, dim, spacedim> &) = delete;
 
     /**
      * Return the value of the vector components selected by this view, for
@@ -1659,10 +1659,10 @@ namespace FEValuesViews
 
     /**
      * Copy operator. This is not a lightweight object so we don't allow
-     * copying and generate an exception if this function is called.
+     * copying and generate a compile-time error if this function is called.
      */
     Tensor &
-    operator=(const Tensor<2, dim, spacedim> &);
+    operator=(const Tensor<2, dim, spacedim> &) = delete;
 
     /**
      * Return the value of the vector components selected by this view, for
@@ -2045,6 +2045,11 @@ public:
                const Mapping<dim, spacedim> &      mapping,
                const FiniteElement<dim, spacedim> &fe);
 
+  /**
+   * The copy operator is deleted since objects of this class are not copyable.
+   */
+  FEValuesBase &
+  operator=(const FEValuesBase &) = delete;
 
   /**
    * Destructor.
@@ -3391,13 +3396,6 @@ private:
    * it private, and also do not implement it.
    */
   FEValuesBase(const FEValuesBase &);
-
-  /**
-   * Copy operator. Since objects of this class are not copyable, we make it
-   * private, and also do not implement it.
-   */
-  FEValuesBase &
-  operator=(const FEValuesBase &);
 
   /**
    * A cache for all possible FEValuesViews objects.

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -184,17 +184,6 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  Scalar<dim, spacedim> &
-  Scalar<dim, spacedim>::operator=(const Scalar<dim, spacedim> &)
-  {
-    // we shouldn't be copying these objects
-    Assert(false, ExcInternalError());
-    return *this;
-  }
-
-
-
-  template <int dim, int spacedim>
   Vector<dim, spacedim>::Vector(const FEValuesBase<dim, spacedim> &fe_values,
                                 const unsigned int first_vector_component)
     : fe_values(&fe_values)
@@ -272,17 +261,6 @@ namespace FEValuesViews
     : fe_values(nullptr)
     , first_vector_component(numbers::invalid_unsigned_int)
   {}
-
-
-
-  template <int dim, int spacedim>
-  Vector<dim, spacedim> &
-  Vector<dim, spacedim>::operator=(const Vector<dim, spacedim> &)
-  {
-    // we shouldn't be copying these objects
-    Assert(false, ExcInternalError());
-    return *this;
-  }
 
 
 
@@ -377,18 +355,6 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  SymmetricTensor<2, dim, spacedim> &
-  SymmetricTensor<2, dim, spacedim>::
-  operator=(const SymmetricTensor<2, dim, spacedim> &)
-  {
-    // we shouldn't be copying these objects
-    Assert(false, ExcInternalError());
-    return *this;
-  }
-
-
-
-  template <int dim, int spacedim>
   Tensor<2, dim, spacedim>::Tensor(const FEValuesBase<dim, spacedim> &fe_values,
                                    const unsigned int first_tensor_component)
     : fe_values(&fe_values)
@@ -465,17 +431,6 @@ namespace FEValuesViews
     : fe_values(nullptr)
     , first_tensor_component(numbers::invalid_unsigned_int)
   {}
-
-
-
-  template <int dim, int spacedim>
-  Tensor<2, dim, spacedim> &
-  Tensor<2, dim, spacedim>::operator=(const Tensor<2, dim, spacedim> &)
-  {
-    // we shouldn't be copying these objects
-    Assert(false, ExcInternalError());
-    return *this;
-  }
 
 
 


### PR DESCRIPTION
Looking at #7594, I realized that the copy constructors for the `FEValues*` classes are meant to be deleted but aren't properly. Use the more C++11 way.