### PR TITLE
Remove unnecessary semicolons from source files.

### DIFF
--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1966,7 +1966,7 @@ ParameterHandler::print_parameters_section(
 
                 default:
                   Assert(false, ExcNotImplemented());
-              };
+              }
 
             // then the contents of the subsection
             enter_subsection(demangle(p->first));
@@ -2018,7 +2018,7 @@ ParameterHandler::print_parameters_section(
                 overall_indent_level -= 1;
                 out << std::setw(overall_indent_level * 2) << ""
                     << "end" << std::endl;
-              };
+              }
 
           break;
         }
@@ -2340,7 +2340,7 @@ MultipleParameterLoop::loop(MultipleParameterLoop::UserClass &uc)
       uc.create_new(run_no + 1);
       fill_entry_values(run_no);
       uc.run(*this);
-    };
+    }
 }
 
 
@@ -2536,7 +2536,7 @@ MultipleParameterLoop::Entry::split_different_values()
       different_values.push_back(
         prefix + std::string(multiple, 0, multiple.find('|')) + postfix);
       multiple.erase(0, multiple.find('|') + 1);
-    };
+    }
   // make up the last selection ("while" broke
   // because there was no '|' any more
   different_values.push_back(prefix + multiple + postfix);

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -554,7 +554,7 @@ namespace Patterns
           return true;
 
         tmp.erase(0, tmp.find('|') + 1);
-      };
+      }
 
     // remove whitespace at the end
     while ((tmp.length() != 0) && (std::isspace(*(tmp.end() - 1))))
@@ -1274,7 +1274,7 @@ namespace Patterns
           name.erase(name.length() - 1, 1);
 
         split_names.push_back(name);
-      };
+      }
 
 
     // check the different possibilities
@@ -1296,10 +1296,10 @@ namespace Patterns
                 // need it anymore.
                 string_found = true;
                 break;
-              };
+              }
 
             tmp.erase(0, tmp.find('|') + 1);
-          };
+          }
         // check last choice, not finished by |
         if (!string_found)
           if (*test_string == tmp)
@@ -1307,7 +1307,7 @@ namespace Patterns
 
         if (!string_found)
           return false;
-      };
+      }
 
     return true;
   }

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -210,7 +210,7 @@ namespace Polynomials
       {
         values[0] = value(x);
         return;
-      };
+      }
 
     // if there are derivatives needed, then do it properly by the full Horner
     // scheme
@@ -1124,8 +1124,8 @@ namespace Polynomials
             // coefficients array
             recursive_coefficients[k] =
               std_cxx14::make_unique<const std::vector<double>>(std::move(ck));
-          };
-      };
+          }
+      }
   }
 
 

--- a/source/base/polynomial_space.cc
+++ b/source/base/polynomial_space.cc
@@ -262,7 +262,7 @@ PolynomialSpace<dim>::compute(
       {
         v(d, i).resize(v_size, 0.);
         polynomials[i].value(p(d), v(d, i));
-      };
+      }
 
   if (update_values)
     {

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -135,7 +135,7 @@ Quadrature<dim>::Quadrature(const SubQuadrature &q1, const Quadrature<1> &q2)
         weights[present_index] = q1.weight(i1) * q2.weight(i2);
 
         ++present_index;
-      };
+      }
 
 #ifdef DEBUG
   if (size() > 0)
@@ -527,7 +527,7 @@ QProjector<2>::project_to_face(const Quadrature<1> &  quadrature,
           break;
         default:
           Assert(false, ExcInternalError());
-      };
+      }
 }
 
 
@@ -573,7 +573,7 @@ QProjector<3>::project_to_face(const Quadrature<2> &  quadrature,
 
         default:
           Assert(false, ExcInternalError());
-      };
+      }
 }
 
 
@@ -624,7 +624,7 @@ QProjector<2>::project_to_subface(const Quadrature<1> &  quadrature,
                 break;
               default:
                 Assert(false, ExcInternalError());
-            };
+            }
           break;
         case 1:
           switch (subface_no)
@@ -637,7 +637,7 @@ QProjector<2>::project_to_subface(const Quadrature<1> &  quadrature,
                 break;
               default:
                 Assert(false, ExcInternalError());
-            };
+            }
           break;
         case 2:
           switch (subface_no)
@@ -650,7 +650,7 @@ QProjector<2>::project_to_subface(const Quadrature<1> &  quadrature,
                 break;
               default:
                 Assert(false, ExcInternalError());
-            };
+            }
           break;
         case 3:
           switch (subface_no)
@@ -663,12 +663,12 @@ QProjector<2>::project_to_subface(const Quadrature<1> &  quadrature,
                 break;
               default:
                 Assert(false, ExcInternalError());
-            };
+            }
           break;
 
         default:
           Assert(false, ExcInternalError());
-      };
+      }
 }
 
 
@@ -916,7 +916,7 @@ QProjector<1>::project_to_all_subfaces(const Quadrature<0> &quadrature)
       {
         project_to_subface(quadrature, face, subface, help);
         std::copy(help.begin(), help.end(), std::back_inserter(q_points));
-      };
+      }
 
   // next copy over weights
   std::vector<double> weights;
@@ -960,7 +960,7 @@ QProjector<2>::project_to_all_subfaces(const SubQuadrature &quadrature)
       {
         project_to_subface(quadrature, face, subface, help);
         std::copy(help.begin(), help.end(), std::back_inserter(q_points));
-      };
+      }
 
   // next copy over weights
   std::vector<double> weights;
@@ -1580,7 +1580,7 @@ namespace internal
 //          dst.weights[next_point]
 //            = base_quadrature.weight(q_point) / n_copies;
 //          ++next_point;
-//        };
+//        }
 //     }
 //   else
 //                                   // skip doubly available points
@@ -1602,7 +1602,7 @@ namespace internal
 //        {
 //          double_point_weight += base_quadrature.weight(i);
 //          ++n_end_points;
-//        };
+//        }
 //                                     // scale the weight correctly
 //       double_point_weight /= n_copies;
 
@@ -1639,8 +1639,8 @@ namespace internal
 //                                        n_copies;
 
 //          ++next_point;
-//        };
-//     };
+//        }
+//     }
 
 // #if DEBUG
 //   double sum_of_weights = 0;
@@ -1691,7 +1691,7 @@ QIterated<1>::QIterated(const Quadrature<1> &base_quadrature,
               base_quadrature.weight(q_point) / n_copies;
 
             ++next_point;
-          };
+          }
     }
   else
     // skip doubly available points
@@ -1713,7 +1713,7 @@ QIterated<1>::QIterated(const Quadrature<1> &base_quadrature,
           {
             double_point_weight += base_quadrature.weight(i);
             ++n_end_points;
-          };
+          }
       // scale the weight correctly
       double_point_weight /= n_copies;
 
@@ -1751,8 +1751,8 @@ QIterated<1>::QIterated(const Quadrature<1> &base_quadrature,
                 base_quadrature.weight(q_point) / n_copies;
 
             ++next_point;
-          };
-    };
+          }
+    }
 
 #if DEBUG
   double sum_of_weights = 0;

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -181,7 +181,7 @@ QTrapez<1>::QTrapez()
     {
       this->quadrature_points[i] = Point<1>(xpts[i]);
       this->weights[i]           = wts[i];
-    };
+    }
 }
 
 
@@ -197,7 +197,7 @@ QSimpson<1>::QSimpson()
     {
       this->quadrature_points[i] = Point<1>(xpts[i]);
       this->weights[i]           = wts[i];
-    };
+    }
 }
 
 
@@ -214,7 +214,7 @@ QMilne<1>::QMilne()
     {
       this->quadrature_points[i] = Point<1>(xpts[i]);
       this->weights[i]           = wts[i];
-    };
+    }
 }
 
 
@@ -237,7 +237,7 @@ QWeddle<1>::QWeddle()
     {
       this->quadrature_points[i] = Point<1>(xpts[i]);
       this->weights[i]           = wts[i];
-    };
+    }
 }
 
 

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -587,7 +587,7 @@ AnisotropicPolynomials<dim>::compute(
         {
           v[d][i].resize(n_values_and_derivatives, 0.);
           polynomials[d][i].value(p(d), v[d][i]);
-        };
+        }
     }
 
   for (unsigned int i = 0; i < n_tensor_pols; ++i)

--- a/source/base/thread_management.cc
+++ b/source/base/thread_management.cc
@@ -213,7 +213,7 @@ namespace Threads
       {
         std::abort();
         return 1;
-      };
+      }
 #  endif
   }
 
@@ -254,7 +254,7 @@ namespace Threads
           }
         else
           return_values[i].second = end;
-      };
+      }
     return return_values;
   }
 } // namespace Threads

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1537,7 +1537,7 @@ namespace DoFRenumbering
         {
           new_indices[i] = next_selected;
           ++next_selected;
-        };
+        }
     Assert(next_unselected == n_selected_dofs, ExcInternalError());
     Assert(next_selected == n_dofs, ExcInternalError());
   }
@@ -1579,7 +1579,7 @@ namespace DoFRenumbering
         {
           new_indices[i] = next_selected;
           ++next_selected;
-        };
+        }
     Assert(next_unselected == n_selected_dofs, ExcInternalError());
     Assert(next_selected == n_dofs, ExcInternalError());
   }

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1080,7 +1080,7 @@ namespace DoFTools
           cell->get_dof_indices(local_dof_indices);
           for (unsigned int i = 0; i < dofs_per_cell; ++i)
             selected_dofs[local_dof_indices[i]] = true;
-        };
+        }
   }
 
 

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -347,7 +347,7 @@ namespace DoFTools
           if ((index != numbers::invalid_dof_index) && (index > max_element))
             max_element = index;
         AssertDimension(max_element, sparsity.n_rows() - 1);
-      };
+      }
 #endif
 
     std::vector<types::global_dof_index> dofs_on_this_face;
@@ -423,7 +423,7 @@ namespace DoFTools
               sparsity.add_entries(boundary_dof_boundary_indices[i],
                                    boundary_dof_boundary_indices.begin(),
                                    boundary_dof_boundary_indices.end());
-          };
+          }
         return;
       }
 
@@ -448,7 +448,7 @@ namespace DoFTools
           if ((index != numbers::invalid_dof_index) && (index > max_element))
             max_element = index;
         AssertDimension(max_element, sparsity.n_rows() - 1);
-      };
+      }
 #endif
 
     std::vector<types::global_dof_index> dofs_on_this_face;

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -870,7 +870,7 @@ FiniteElement<dim, spacedim>::interface_constraints_size() const
                                this->dofs_per_face);
       default:
         Assert(false, ExcNotImplemented());
-    };
+    }
   return TableIndices<2>(numbers::invalid_unsigned_int,
                          numbers::invalid_unsigned_int);
 }

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -518,12 +518,12 @@ FE_ABF<dim>::has_support_on_face(const unsigned int shape_index,
 
               default:
                 return true;
-            };
-        };
+            }
+        }
 
       default: // other rt_order
         return true;
-    };
+    }
 
   return true;
 }

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -759,7 +759,7 @@ FE_DGQ<dim, spacedim>::has_support_on_face(const unsigned int shape_index,
           // second on face 1:
           return (((shape_index == 0) && (face_index == 0)) ||
                   ((shape_index == this->degree) && (face_index == 1)));
-        };
+        }
 
       case 2:
         {
@@ -772,7 +772,7 @@ FE_DGQ<dim, spacedim>::has_support_on_face(const unsigned int shape_index,
           if (face_index == 3 && shape_index >= this->dofs_per_cell - n)
             return true;
           return false;
-        };
+        }
 
       case 3:
         {
@@ -797,7 +797,7 @@ FE_DGQ<dim, spacedim>::has_support_on_face(const unsigned int shape_index,
           if (face_index == 5 && shape_index >= this->dofs_per_cell - n2)
             return true;
           return false;
-        };
+        }
 
       default:
         Assert(false, ExcNotImplemented());

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -875,7 +875,7 @@ FE_Q_Hierarchical<dim>::initialize_generalized_support_points()
                 p(2) = .5;
             }
           this->generalized_support_points[index_map_inverse[k++]] = p;
-        };
+        }
 }
 
 
@@ -1924,7 +1924,7 @@ FE_Q_Hierarchical<dim>::initialize_generalized_face_support_points()
                 p(2) = .5;
             }
           this->generalized_face_support_points[face_renumber[k++]] = p;
-        };
+        }
 }
 
 

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -469,12 +469,12 @@ FE_RaviartThomas<dim>::has_support_on_face(const unsigned int shape_index,
 
               default:
                 return true;
-            };
-        };
+            }
+        }
 
       default: // other rt_order
         return true;
-    };
+    }
 
   return true;
 }

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1444,7 +1444,7 @@ FESystem<dim, spacedim>::build_interface_constraints()
                 // should be of size zero)
                 Assert(false, ExcInternalError());
                 break;
-              };
+              }
 
             case 2:
               {
@@ -1495,9 +1495,9 @@ FESystem<dim, spacedim>::build_interface_constraints()
                       base_element(m_index.first.first).dofs_per_line *
                         sub_line +
                       tmp2;
-                  };
+                  }
                 break;
-              };
+              }
 
             case 3:
               {
@@ -1580,14 +1580,14 @@ FESystem<dim, spacedim>::build_interface_constraints()
                       base_element(m_index.first.first).dofs_per_quad *
                         sub_quad +
                       tmp2;
-                  };
+                  }
 
                 break;
-              };
+              }
 
             default:
               Assert(false, ExcNotImplemented());
-          };
+          }
 
         // now that we gathered all information: use it to build the
         // matrix. note that if n and m belong to different base elements or
@@ -1596,7 +1596,7 @@ FESystem<dim, spacedim>::build_interface_constraints()
           this->interface_constraints(m, n) =
             (base_element(n_index.first.first)
                .constraints()(m_index.second, n_index.second));
-      };
+      }
 }
 
 

--- a/source/fe/mapping_c1.cc
+++ b/source/fe/mapping_c1.cc
@@ -152,7 +152,7 @@ MappingC1<2>::MappingC1Generic::add_line_support_points(
               real_point *= h;
               real_point += line->vertex(0);
               a.push_back(real_point);
-            };
+            }
         }
       else
         // not at boundary, so just use scaled Gauss-Lobatto points (i.e., use

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -788,7 +788,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
       // vertices_indices[i] is automatically
       // created upon first usage
       vertex_indices[vertex_number] = vertex;
-    };
+    }
 
   // set up array of cells
   std::vector<CellData<dim>> cells;
@@ -906,7 +906,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
                 // no such vertex index
                 AssertThrow(false, ExcInvalidVertexIndex(cell, vertex));
                 vertex = numbers::invalid_unsigned_int;
-              };
+              }
         }
       else if ((cell_type == "quad") && (dim == 3))
         // boundary info
@@ -960,12 +960,12 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
                 // no such vertex index
                 Assert(false, ExcInvalidVertexIndex(cell, vertex));
                 vertex = numbers::invalid_unsigned_int;
-              };
+              }
         }
       else
         // cannot read this
         AssertThrow(false, ExcUnknownIdentifier(cell_type));
-    };
+    }
 
 
   // check that no forbidden arrays are used
@@ -1132,7 +1132,7 @@ GridIn<dim, spacedim>::read_dbmesh(std::istream &in)
         in >> vertices[vertex][d];
       // read Ref phi_i, whatever that may be
       in >> dummy;
-    };
+    }
   AssertThrow(in, ExcInvalidDBMeshFormat());
 
   skip_empty_lines(in);
@@ -1151,7 +1151,7 @@ GridIn<dim, spacedim>::read_dbmesh(std::istream &in)
       in >> dummy >> dummy;
       // read Ref phi_i, whatever that may be
       in >> dummy;
-    };
+    }
   AssertThrow(in, ExcInvalidDBMeshFormat());
 
   skip_empty_lines(in);
@@ -1172,7 +1172,7 @@ GridIn<dim, spacedim>::read_dbmesh(std::istream &in)
       in >> dummy >> dummy;
       // read Ref phi_i, whatever that may be
       in >> dummy;
-    };
+    }
   AssertThrow(in, ExcInvalidDBMeshFormat());
 
   skip_empty_lines(in);
@@ -1202,11 +1202,11 @@ GridIn<dim, spacedim>::read_dbmesh(std::istream &in)
                       ExcInvalidVertexIndex(cell, cells.back().vertices[i]));
 
           --cells.back().vertices[i];
-        };
+        }
 
       // read and discard Ref phi_i
       in >> dummy;
-    };
+    }
   AssertThrow(in, ExcInvalidDBMeshFormat());
 
   skip_empty_lines(in);
@@ -1290,7 +1290,7 @@ GridIn<2>::read_xda(std::istream &in)
 
       for (unsigned int &vertex : cells[cell].vertices)
         in >> vertex;
-    };
+    }
 
 
 
@@ -1306,7 +1306,7 @@ GridIn<2>::read_xda(std::istream &in)
       // store vertex
       for (unsigned int d = 0; d < 2; ++d)
         vertices[vertex](d) = x[d];
-    };
+    }
   AssertThrow(in, ExcIO());
 
   // do some clean-up on vertices...
@@ -1368,7 +1368,7 @@ GridIn<3>::read_xda(std::istream &in)
 
       for (unsigned int i = 0; i < 8; i++)
         cells[cell].vertices[i] = xda_ordered_nodes[xda_to_dealII_map[i]];
-    };
+    }
 
 
 
@@ -1384,7 +1384,7 @@ GridIn<3>::read_xda(std::istream &in)
       // store vertex
       for (unsigned int d = 0; d < 3; ++d)
         vertices[vertex](d) = x[d];
-    };
+    }
   AssertThrow(in, ExcIO());
 
   // do some clean-up on vertices...
@@ -1775,7 +1775,7 @@ GridIn<dim, spacedim>::read_msh(std::istream &in)
                                   ExcInvalidVertexIndex(cell_per_entity,
                                                         vertex));
                       vertex = numbers::invalid_unsigned_int;
-                    };
+                    }
               }
             else if ((cell_type == 3) && (dim == 3))
               // boundary info
@@ -3099,7 +3099,7 @@ GridIn<2>::debug_output_grid(const std::vector<CellData<2>> &cells,
             min_y = p(1);
           if (p(1) > max_y)
             max_y = p(1);
-        };
+        }
 
       out << "# cell " << i << std::endl;
       Point<2> center;
@@ -3123,7 +3123,7 @@ GridIn<2>::debug_output_grid(const std::vector<CellData<2>> &cells,
             << vertices[cells[i].vertices[f]](0) << ','
             << vertices[cells[i].vertices[f]](1) << std::endl;
       out << std::endl;
-    };
+    }
 
 
   out << std::endl
@@ -3203,7 +3203,7 @@ GridIn<3>::debug_output_grid(const std::vector<CellData<3>> &cells,
           << vertices[cell.vertices[7]] << std::endl
           << std::endl
           << std::endl;
-    };
+    }
 }
 
 

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -121,7 +121,7 @@ namespace GridTools
           if ((*pi == true) && (*pj == true) &&
               ((vertices[i] - vertices[j]).norm_square() > max_distance_sqr))
             max_distance_sqr = (vertices[i] - vertices[j]).norm_square();
-      };
+      }
 
     return std::sqrt(max_distance_sqr);
   }

--- a/source/grid/intergrid_map.cc
+++ b/source/grid/intergrid_map.cc
@@ -77,7 +77,7 @@ InterGridMap<MeshType>::make_mapping(const MeshType &source_grid,
       // zero-based index, but we need the
       // number of cells, which is one larger
       mapping[level].resize(n_cells + 1, destination_grid.end());
-    };
+    }
 
   // now make up the mapping
   // loop over all cells and set the user

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -52,7 +52,7 @@ SubCellData::check_consistency(const unsigned int dim) const
         return ((boundary_lines.size() == 0) && (boundary_quads.size() == 0));
       case 2:
         return (boundary_quads.size() == 0);
-    };
+    }
   return true;
 }
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1833,7 +1833,7 @@ CellAccessor<2>::point_inside(const Point<2> &p) const
       // outside
       if ((-face[1] * to_p[0] + face[0] * to_p[1]) < 0)
         return false;
-    };
+    }
 
   // if we arrived here, then the
   // point is inside for all four
@@ -2179,7 +2179,7 @@ CellAccessor<dim, spacedim>::set_neighbor(
       this->tria->levels[this->present_level]
         ->neighbors[this->present_index * GeometryInfo<dim>::faces_per_cell + i]
         .second = -1;
-    };
+    }
 }
 
 

--- a/source/grid/tria_levels.cc
+++ b/source/grid/tria_levels.cc
@@ -82,7 +82,7 @@ namespace internal
           neighbors.insert(neighbors.end(),
                            total_cells * (2 * dimension) - neighbors.size(),
                            std::make_pair(-1, -1));
-        };
+        }
     }
 
 
@@ -174,7 +174,7 @@ namespace internal
           neighbors.insert(neighbors.end(),
                            total_cells * (2 * dimension) - neighbors.size(),
                            std::make_pair(-1, -1));
-        };
+        }
     }
 
 

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -900,7 +900,7 @@ namespace internal
               default:
                 Assert(false, ExcNotImplemented());
                 max_couplings = 0;
-            };
+            }
           return std::min(max_couplings, dof_handler.n_dofs());
         }
 

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -88,7 +88,7 @@ BlockSparsityPatternBase<SparsityPatternBase>::reinit(
         SparsityPatternBase *sp = sub_objects[i][j];
         sub_objects[i][j]       = nullptr;
         delete sp;
-      };
+      }
   sub_objects.reinit(0, 0);
 
   // then set new sizes
@@ -201,7 +201,7 @@ BlockSparsityPatternBase<SparsityPatternBase>::max_entries_per_row() const
 
       if (this_row > max_entries)
         max_entries = this_row;
-    };
+    }
   return max_entries;
 }
 

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -2339,7 +2339,7 @@ LAPACKFullMatrix<number>::print_formatted(std::ostream &     out,
         else
           out << std::setw(width) << zero_string << ' ';
       out << std::endl;
-    };
+    }
 
   AssertThrow(out, ExcIO());
   // reset output format

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -625,7 +625,7 @@ namespace PETScWrappers
             false,
             ExcMessage(
               "ParaSails parameter symmetric can only be equal to 0, 1, 2!"));
-      };
+      }
 
     set_option_value("-pc_hypre_parasails_sym", ssStream.str());
 

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -458,7 +458,7 @@ namespace PETScWrappers
           sum1 += *ptr++;
           sum2 += *ptr++;
           sum3 += *ptr++;
-        };
+        }
       // add up remaining elements
       while (ptr != start_ptr + size())
         sum0 += *ptr++;

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -203,7 +203,7 @@ SparsityPattern::SparsityPattern(const SparsityPattern &original,
       // row given to this constructor
       Assert(next_free_slot <= &colnums[rowstart[row + 1]],
              ExcNotEnoughSpace(0, rowstart[row + 1] - rowstart[row]));
-    };
+    }
 }
 
 
@@ -435,7 +435,7 @@ SparsityPattern::compress()
                                    &new_colnums[next_row_start]) ==
                 &new_colnums[next_row_start]),
              ExcInternalError());
-    };
+    }
 
   // assert that we have used all allocated space, no more and no less
   Assert(next_free_entry == nonzero_elements, ExcInternalError());
@@ -628,7 +628,7 @@ SparsityPattern::empty() const
       Assert(max_vec_len == 0, ExcInternalError());
 
       return true;
-    };
+    }
   return false;
 }
 
@@ -709,8 +709,8 @@ SparsityPattern::add(const size_type i, const size_type j)
         {
           colnums[k] = j;
           return;
-        };
-    };
+        }
+    }
 
   // if we came thus far, something went wrong: there was not enough space in
   // this line
@@ -858,7 +858,7 @@ SparsityPattern::symmetrize()
         // would not harm, only take time to check up)
         if (colnums[k] != row)
           add(colnums[k], row);
-      };
+      }
 }
 
 

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -364,9 +364,9 @@ MGTransferBlockBase::build_matrices(const DoFHandler<dim, spacedim> &,
                         if ((icomp == jcomp) && selected[icomp])
                           prolongation_sparsities[level]->add(
                             dof_indices_child[i], dof_indices_parent[j]);
-                      };
-              };
-          };
+                      }
+              }
+          }
       prolongation_sparsities[level]->compress();
 
       prolongation_matrices[level]->reinit(*prolongation_sparsities[level]);

--- a/source/multigrid/mg_transfer_component.cc
+++ b/source/multigrid/mg_transfer_component.cc
@@ -452,9 +452,9 @@ MGTransferComponentBase::build_matrices(const DoFHandler<dim, spacedim> &,
                         if ((icomp == jcomp) && mg_component_mask[icomp])
                           prolongation_sparsities[level]->add(
                             dof_indices_child[i], dof_indices_parent[j]);
-                      };
-              };
-          };
+                      }
+              }
+          }
       prolongation_sparsities[level]->compress();
 
       prolongation_matrices[level]->reinit(*prolongation_sparsities[level]);

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -155,7 +155,7 @@ DataOutRotation<dim, DoFHandlerType>::build_one_patch(
               my_patches[angle].vertices[3] = r2 * angle_directions[angle + 1];
 
               break;
-            };
+            }
 
           case 2:
             {
@@ -181,14 +181,14 @@ DataOutRotation<dim, DoFHandlerType>::build_one_patch(
                     .vertices[vertex +
                               GeometryInfo<dimension>::vertices_per_cell][0] =
                     v(1);
-                };
+                }
 
               break;
-            };
+            }
 
           default:
             Assert(false, ExcNotImplemented());
-        };
+        }
 
       // then fill in data
       if (data.n_datasets > 0)

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -129,7 +129,7 @@ DataOutStack<dim, spacedim, DoFHandlerType>::declare_data_vector(
            ++data_set)
         for (unsigned int i = 0; i < data_set->names.size(); ++i)
           Assert(*name != data_set->names[i], ExcNameAlreadyUsed(*name));
-    };
+    }
 
   switch (vector_type)
     {
@@ -142,7 +142,7 @@ DataOutStack<dim, spacedim, DoFHandlerType>::declare_data_vector(
         cell_data.emplace_back();
         cell_data.back().names = names;
         break;
-    };
+    }
 }
 
 
@@ -217,7 +217,7 @@ DataOutStack<dim, spacedim, DoFHandlerType>::add_data_vector(
             data_vector->data.reinit(vec.size());
             std::copy(vec.begin(), vec.end(), data_vector->data.begin());
             return;
-          };
+          }
 
       // ok. not found. there is a
       // slight chance that
@@ -242,9 +242,9 @@ DataOutStack<dim, spacedim, DoFHandlerType>::add_data_vector(
             data_vector->data.reinit(vec.size());
             std::copy(vec.begin(), vec.end(), data_vector->data.begin());
             return;
-          };
+          }
       Assert(false, ExcVectorNotDeclared(names[0]));
-    };
+    }
 
   // we have either return or Assert
   // statements above, so shouldn't
@@ -383,7 +383,7 @@ DataOutStack<dim, spacedim, DoFHandlerType>::build_patches(
 
           default:
             Assert(false, ExcNotImplemented());
-        };
+        }
 
 
       // now fill in the data values.

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -273,7 +273,7 @@ namespace DerivativeApproximation
                 fe_values.get_fe().n_components()));
           fe_values.get_function_gradients(solution, values);
           return ProjectedDerivative(values[0][component]);
-        };
+        }
     }
 
 
@@ -476,8 +476,8 @@ namespace DerivativeApproximation
               EE[0]              = am + R * std::cos(theta);
               EE[1] = am + R * std::cos(theta + 2. / 3. * numbers::PI);
               EE[2] = am + R * std::cos(theta + 4. / 3. * numbers::PI);
-            };
-        };
+            }
+        }
 
       return std::max(std::fabs(EE[0]),
                       std::max(std::fabs(EE[1]), std::fabs(EE[2])));
@@ -518,7 +518,7 @@ namespace DerivativeApproximation
           {
             const double s = (d[i][j] + d[j][i]) / 2;
             d[i][j] = d[j][i] = s;
-          };
+          }
     }
 
 
@@ -610,7 +610,7 @@ namespace DerivativeApproximation
                 fe_values.get_fe().n_components()));
           fe_values.get_function_hessians(solution, values);
           return ProjectedDerivative(values[0][component]);
-        };
+        }
     }
 
 
@@ -884,7 +884,7 @@ namespace DerivativeApproximation
           projected_finite_difference /= distance;
 
           projected_derivative += outer_product(y, projected_finite_difference);
-        };
+        }
 
       // can we determine an
       // approximation of the

--- a/source/numerics/histogram.cc
+++ b/source/numerics/histogram.cc
@@ -89,10 +89,10 @@ Histogram::evaluate(const std::vector<Vector<number>> &values,
               max_value =
                 std::max(max_value,
                          *std::max_element(values[i].begin(), values[i].end()));
-            };
+            }
 
           break;
-        };
+        }
 
       case logarithmic:
         {
@@ -159,7 +159,7 @@ Histogram::evaluate(const std::vector<Vector<number>> &values,
                                       min_value + (n + 1) * delta);
 
           break;
-        };
+        }
 
       case logarithmic:
         {
@@ -172,11 +172,11 @@ Histogram::evaluate(const std::vector<Vector<number>> &values,
                                                (n + 1) * delta));
 
           break;
-        };
+        }
 
       default:
         Assert(false, ExcInternalError());
-    };
+    }
 
   // fill the other lists of intervals
   for (unsigned int i = 1; i < values.size(); ++i)
@@ -200,8 +200,8 @@ Histogram::evaluate(const std::vector<Vector<number>> &values,
             {
               ++intervals[i][n].content;
               break;
-            };
-      };
+            }
+      }
 }
 
 
@@ -270,7 +270,7 @@ Histogram::write_gnuplot(std::ostream &out) const
               << intervals[i][n].content << std::endl;
 
         out << std::endl;
-      };
+      }
 
   AssertThrow(out, ExcIO());
 }
@@ -297,7 +297,7 @@ Histogram::parse_interval_spacing(const std::string &name)
       AssertThrow(false, ExcInvalidName(name));
 
       return linear;
-    };
+    }
 }
 
 

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -216,7 +216,7 @@ TimeDependent::start_sweep(const unsigned int s)
     {
       timesteps[step]->set_timestep_no(step);
       timesteps[step]->set_sweep_no(sweep_no);
-    };
+    }
 
   for (unsigned int step = 0; step < timesteps.size(); ++step)
     timesteps[step]->start_sweep();
@@ -545,10 +545,10 @@ TimeStepBase_Tria<dim>::restore_grid()
       //          if (static_cast<unsigned int>(cell->level()) >=
       //              flags.max_refinement_level)
       //            cell->clear_refine_flag();
-      //      };
+      //      }
 
       tria->execute_coarsening_and_refinement();
-    };
+    }
 }
 
 
@@ -592,10 +592,10 @@ namespace
               old_cell->clear_coarsen_flag();
 
             old_cell->set_refine_flag();
-          };
+          }
 
         return;
-      };
+      }
 
     if (old_cell->has_children() && new_cell->has_children())
       {
@@ -623,7 +623,7 @@ namespace
           grids_changed |=
             dealii::adapt_grid_cells<dim>(cell1->child(c), cell2->child(c));
         return grids_changed;
-      };
+      }
 
 
     if (!cell1->has_children() && !cell2->has_children())
@@ -641,10 +641,10 @@ namespace
           {
             cell1->clear_coarsen_flag();
             return true;
-          };
+          }
 
         return false;
-      };
+      }
 
 
     if (cell1->has_children() && !cell2->has_children())
@@ -671,7 +671,7 @@ namespace
           {
             cell2->clear_coarsen_flag();
             changed_grid = true;
-          };
+          }
 
         if (!cell2->refine_flag_set())
           for (unsigned int c = 0; c < cell1->n_children(); ++c)
@@ -681,9 +681,9 @@ namespace
                 cell2->set_refine_flag();
                 changed_grid = true;
                 break;
-              };
+              }
         return changed_grid;
-      };
+      }
 
     if (!cell1->has_children() && cell2->has_children())
       // same thing, other way round...
@@ -693,7 +693,7 @@ namespace
           {
             cell1->clear_coarsen_flag();
             changed_grid = true;
-          };
+          }
 
         if (!cell1->refine_flag_set())
           for (unsigned int c = 0; c < cell2->n_children(); ++c)
@@ -703,9 +703,9 @@ namespace
                 cell1->set_refine_flag();
                 changed_grid = true;
                 break;
-              };
+              }
         return changed_grid;
-      };
+      }
 
     Assert(false, ExcInternalError());
     return false;
@@ -789,7 +789,7 @@ TimeStepBase_Tria<dim>::refine_grid(const RefinementData refinement_data)
         std::upper_bound(sorted_criteria.begin(),
                          sorted_criteria.end(),
                          static_cast<float>(coarsening_threshold));
-    };
+    }
 
 
   // actually flag cells the first time
@@ -935,7 +935,7 @@ TimeStepBase_Tria<dim>::refine_grid(const RefinementData refinement_data)
               delta_up *= relaxations[r].second;
               delta_down *= relaxations[r].second;
               break;
-            };
+            }
 
         // now, if the number of estimated
         // cells exceeds the number of cells
@@ -1061,7 +1061,7 @@ TimeStepBase_Tria<dim>::refine_grid(const RefinementData refinement_data)
             Assert(p_coarsening_threshold != p_refinement_threshold,
                    ExcInternalError());
             --p_refinement_threshold;
-          };
+          }
 
         coarsening_threshold = *p_coarsening_threshold;
         refinement_threshold = *p_refinement_threshold;
@@ -1079,13 +1079,13 @@ TimeStepBase_Tria<dim>::refine_grid(const RefinementData refinement_data)
           {
             cell->clear_refine_flag();
             cell->clear_coarsen_flag();
-          };
+          }
 
 
         // flag cells finally
         GridRefinement::refine(*tria, criteria, refinement_threshold);
         GridRefinement::coarsen(*tria, criteria, coarsening_threshold);
-      };
+      }
 
   // if step number is greater than
   // one: adapt this and the previous
@@ -1121,7 +1121,7 @@ TimeStepBase_Tria<dim>::refine_grid(const RefinementData refinement_data)
           endc     = tria->end(0);
           for (; new_cell != endc; ++new_cell, ++old_cell)
             dealii::mirror_refinement_flags<dim>(new_cell, old_cell);
-        };
+        }
 
       tria->prepare_coarsening_and_refinement();
       previous_tria->prepare_coarsening_and_refinement();
@@ -1132,7 +1132,7 @@ TimeStepBase_Tria<dim>::refine_grid(const RefinementData refinement_data)
       // to have cells refined twice more
       // than the present one and vica versa.
       dealii::adapt_grids<dim>(*previous_tria, *tria);
-    };
+    }
 }
 
 


### PR DESCRIPTION
This is something cosmetic that has bugged me for awhile: we don't need semicolons after closing braces in most contexts (e.g., `if` statements).