### PR TITLE
Use range-based for loop in base

### DIFF
--- a/include/deal.II/base/event.h
+++ b/include/deal.II/base/event.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -177,11 +178,7 @@ namespace Algorithms
   {
     if (all_true)
       return true;
-    for (std::vector<bool>::const_iterator i = flags.begin(); i != flags.end();
-         ++i)
-      if (*i)
-        return true;
-    return false;
+    return std::find(flags.begin(), flags.end(), true) != flags.end();
   }
 
 
@@ -209,13 +206,7 @@ namespace Algorithms
         // Test all flags separately
         // and return false if one is
         // not set
-        for (std::vector<bool>::const_iterator i = flags.begin();
-             i != flags.end();
-             ++i)
-          if (!*i)
-            return false;
-        // All flags are set
-        return true;
+        return std::find(flags.begin(), flags.end(), false) == flags.end();
       }
 
     // Finally, compare each flag
@@ -256,9 +247,7 @@ namespace Algorithms
     all_true = false;
     if (event.all_true)
       {
-        for (std::vector<bool>::iterator i = flags.begin(); i != flags.end();
-             ++i)
-          *i = false;
+        std::fill(flags.begin(), flags.end(), false);
         return *this;
       }
 

--- a/include/deal.II/base/graph_coloring.h
+++ b/include/deal.II/base/graph_coloring.h
@@ -285,8 +285,8 @@ namespace GraphColoring
               // linked to current_vertex is already using the color j, this
               // color cannot be used anymore.
               bool unused_color(true);
-              for (unsigned int k = 0; k < graph[current_vertex].size(); ++k)
-                if (colors_used[j].count(graph[current_vertex][k]) == 1)
+              for (const auto adjacent_vertex : graph[current_vertex])
+                if (colors_used[j].count(adjacent_vertex) == 1)
                   {
                     unused_color = false;
                     break;

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -318,7 +318,7 @@ namespace HDF5
      * Constructor. @p string_name is the name of the HDF5 Object. If @p mpi is
      * True then MPI I/O is used.
      */
-    HDF5Object(const std::string name, const bool mpi);
+    HDF5Object(const std::string &name, const bool mpi);
 
   public:
     /**
@@ -404,11 +404,11 @@ namespace HDF5
      * Create dataset. This is an internal constructor. The function
      * Group::create_dataset() should be used to create a dataset.
      */
-    DataSet(const std::string &         name,
-            const hid_t &               parent_group_id,
-            const std::vector<hsize_t> &dimensions,
-            std::shared_ptr<hid_t>      t_type,
-            const bool                  mpi);
+    DataSet(const std::string &           name,
+            const hid_t &                 parent_group_id,
+            const std::vector<hsize_t> &  dimensions,
+            const std::shared_ptr<hid_t> &t_type,
+            const bool                    mpi);
 
   public:
     /**

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -318,7 +318,7 @@ namespace HDF5
      * Constructor. @p string_name is the name of the HDF5 Object. If @p mpi is
      * True then MPI I/O is used.
      */
-    HDF5Object(const std::string &name, const bool mpi);
+    HDF5Object(const std::string name, const bool mpi);
 
   public:
     /**
@@ -404,11 +404,11 @@ namespace HDF5
      * Create dataset. This is an internal constructor. The function
      * Group::create_dataset() should be used to create a dataset.
      */
-    DataSet(const std::string &           name,
-            const hid_t &                 parent_group_id,
-            const std::vector<hsize_t> &  dimensions,
-            const std::shared_ptr<hid_t> &t_type,
-            const bool                    mpi);
+    DataSet(const std::string &         name,
+            const hid_t &               parent_group_id,
+            const std::vector<hsize_t> &dimensions,
+            std::shared_ptr<hid_t>      t_type,
+            const bool                  mpi);
 
   public:
     /**

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -1754,10 +1754,8 @@ IndexSet::n_elements() const
 
 #ifdef DEBUG
   size_type s = 0;
-  for (std::vector<Range>::iterator range = ranges.begin();
-       range != ranges.end();
-       ++range)
-    s += (range->end - range->begin);
+  for (const auto &range : ranges)
+    s += (range.end - range.begin);
   Assert(s == v, ExcInternalError());
 #endif
 
@@ -1916,9 +1914,8 @@ IndexSet::fill_binary_vector(Vector &vector) const
 
   // then write ones into the elements whose indices are contained in the
   // index set
-  for (std::vector<Range>::iterator it = ranges.begin(); it != ranges.end();
-       ++it)
-    for (size_type i = it->begin; i < it->end; ++i)
+  for (const auto &range : ranges)
+    for (size_type i = range.begin; i < range.end; ++i)
       vector[i] = 1;
 }
 

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -2155,8 +2155,8 @@ ParameterHandler::save(Archive &ar, const unsigned int) const
 
   std::vector<std::string> descriptions;
 
-  for (unsigned int j = 0; j < patterns.size(); ++j)
-    descriptions.push_back(patterns[j]->description());
+  for (const auto &pattern : patterns)
+    descriptions.push_back(pattern->description());
 
   ar &descriptions;
 }
@@ -2176,8 +2176,8 @@ ParameterHandler::load(Archive &ar, const unsigned int)
   ar &                     descriptions;
 
   patterns.clear();
-  for (unsigned int j = 0; j < descriptions.size(); ++j)
-    patterns.push_back(Patterns::pattern_factory(descriptions[j]));
+  for (const auto &description : descriptions)
+    patterns.push_back(Patterns::pattern_factory(description));
 }
 
 

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -238,7 +238,7 @@ namespace Utilities
           unsigned int offset =
             n_ghost_indices_in_larger_set - n_ghost_indices();
           // must copy ghost data into extended ghost array
-          for (const auto ghost_range : ghost_indices_subset_data)
+          for (const auto &ghost_range : ghost_indices_subset_data)
             {
               if (offset > ghost_range.first)
                 {

--- a/include/deal.II/base/path_search.h
+++ b/include/deal.II/base/path_search.h
@@ -265,20 +265,16 @@ PathSearch::show(StreamType &out) const
 {
   out << "DEAL_II_" << cls << "PATH=\"";
   bool first = true;
-  for (std::vector<std::string>::iterator p = my_path_list.begin();
-       p != my_path_list.end();
-       ++p)
+  for (const auto &p : my_path_list)
     {
       if (!first)
         out << ':';
-      out << *p;
+      out << p;
       first = false;
     }
   out << '"' << std::endl << " Suffixes";
-  for (std::vector<std::string>::iterator s = my_suffix_list.begin();
-       s != my_suffix_list.end();
-       ++s)
-    out << " \"" << *s << '"';
+  for (const auto &s : my_suffix_list)
+    out << " \"" << s << '"';
   out << std::endl;
 }
 

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1436,7 +1436,7 @@ namespace Patterns
     static_assert(sizeof...(ps) > 0,
                   "The number of PatternTypes must be greater than zero!");
     auto pattern_pointers = {(static_cast<const PatternBase *>(&ps))...};
-    for (auto p : pattern_pointers)
+    for (const auto p : pattern_pointers)
       patterns.push_back(p->clone());
   }
 
@@ -1787,8 +1787,8 @@ namespace Patterns
         std::vector<std::string> vec(t.size());
 
         unsigned int i = 0;
-        for (const auto &ti : t)
-          vec[i++] = Convert<typename T::value_type>::to_string(ti, base_p);
+        for (const auto entry : t)
+          vec[i++] = Convert<typename T::value_type>::to_string(entry, base_p);
 
         std::string s;
         if (vec.size() > 0)

--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -304,9 +304,9 @@ Subscriptor::list_subscribers(StreamType &stream) const
 {
   std::lock_guard<std::mutex> lock(mutex);
 
-  for (map_iterator it = counter_map.begin(); it != counter_map.end(); ++it)
-    stream << it->second << '/' << counter << " subscriptions from \""
-           << it->first << '\"' << std::endl;
+  for (const auto &it : counter_map)
+    stream << it.second << '/' << counter << " subscriptions from \""
+           << it.first << '\"' << std::endl;
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -912,12 +912,10 @@ TableHandler::add_value(const std::string &key, const T value)
       // follow the algorithm given in the introduction to this class
       // of padding columns as necessary
       unsigned int max_col_length = 0;
-      for (std::map<std::string, Column>::iterator p = columns.begin();
-           p != columns.end();
-           ++p)
+      for (const auto &column : columns)
         max_col_length =
           std::max(max_col_length,
-                   static_cast<unsigned int>(p->second.entries.size()));
+                   static_cast<unsigned int>(column.second.entries.size()));
 
       while (columns[key].entries.size() + 1 < max_col_length)
         {

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -87,10 +87,7 @@ ExceptionBase::ExceptionBase()
   , what_str("")
 {
 #ifdef DEAL_II_HAVE_GLIBC_STACKTRACE
-  for (unsigned int i = 0;
-       i < sizeof(raw_stacktrace) / sizeof(raw_stacktrace[0]);
-       ++i)
-    raw_stacktrace[i] = nullptr;
+  std::fill(std::begin(raw_stacktrace), std::end(raw_stacktrace), nullptr);
 #endif
 }
 
@@ -109,10 +106,7 @@ ExceptionBase::ExceptionBase(const ExceptionBase &exc)
                  // by what()
 {
 #ifdef DEAL_II_HAVE_GLIBC_STACKTRACE
-  for (unsigned int i = 0;
-       i < sizeof(raw_stacktrace) / sizeof(raw_stacktrace[0]);
-       ++i)
-    raw_stacktrace[i] = nullptr;
+  std::fill(std::begin(raw_stacktrace), std::end(raw_stacktrace), nullptr);
 #endif
 }
 

--- a/source/base/flow_function.cc
+++ b/source/base/flow_function.cc
@@ -281,9 +281,8 @@ namespace Functions
     for (unsigned int d = 0; d < dim + 1; ++d)
       Assert(values[d].size() == n, ExcDimensionMismatch(values[d].size(), n));
 
-    for (unsigned int d = 0; d < values.size(); ++d)
-      for (unsigned int k = 0; k < values[d].size(); ++k)
-        values[d][k] = 0.;
+    for (auto &point_values : values)
+      std::fill(point_values.begin(), point_values.end(), 0.);
   }
 
   //----------------------------------------------------------------------//
@@ -437,14 +436,13 @@ namespace Functions
       {
         vector_values(points, values);
         for (unsigned int d = 0; d < dim; ++d)
-          for (unsigned int k = 0; k < values[d].size(); ++k)
-            values[d][k] *= -reaction;
+          for (double &point_value : values[d])
+            point_value *= -reaction;
       }
     else
       {
         for (unsigned int d = 0; d < dim; ++d)
-          for (unsigned int k = 0; k < values[d].size(); ++k)
-            values[d][k] = 0.;
+          std::fill(values[d].begin(), values[d].end(), 0.);
       }
 
 
@@ -658,9 +656,8 @@ namespace Functions
     for (unsigned int d = 0; d < 2 + 1; ++d)
       Assert(values[d].size() == n, ExcDimensionMismatch(values[d].size(), n));
 
-    for (unsigned int d = 0; d < values.size(); ++d)
-      for (unsigned int k = 0; k < values[d].size(); ++k)
-        values[d][k] = 0.;
+    for (auto &point_values : values)
+      std::fill(point_values.begin(), point_values.end(), 0.);
   }
 
 
@@ -771,9 +768,8 @@ namespace Functions
       }
     else
       {
-        for (unsigned int d = 0; d < values.size(); ++d)
-          for (unsigned int k = 0; k < values[d].size(); ++k)
-            values[d][k] = 0.;
+        for (auto &point_values : values)
+          std::fill(point_values.begin(), point_values.end(), 0.);
       }
   }
 

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -367,11 +367,9 @@ FunctionParser<dim>::init_muparser() const
                                           "erfc",
                                           "rand",
                                           "rand_seed"};
-          for (unsigned int f = 0;
-               f < sizeof(function_names) / sizeof(function_names[0]);
-               ++f)
+          for (const auto &function_name_c_string : function_names)
             {
-              const std::string  function_name        = function_names[f];
+              const std::string  function_name        = function_name_c_string;
               const unsigned int function_name_length = function_name.size();
 
               std::string::size_type pos = 0;

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -509,10 +509,9 @@ IndexSet::fill_index_vector(std::vector<size_type> &indices) const
   indices.clear();
   indices.reserve(n_elements());
 
-  for (std::vector<Range>::iterator it = ranges.begin(); it != ranges.end();
-       ++it)
-    for (size_type i = it->begin; i < it->end; ++i)
-      indices.push_back(i);
+  for (const auto &range : ranges)
+    for (size_type entry = range.begin; entry < range.end; ++entry)
+      indices.push_back(entry);
 
   Assert(indices.size() == n_elements(), ExcInternalError());
 }

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -189,11 +189,11 @@ namespace Utilities
       const unsigned int myid    = Utilities::MPI::this_mpi_process(mpi_comm);
       const unsigned int n_procs = Utilities::MPI::n_mpi_processes(mpi_comm);
 
-      for (unsigned int i = 0; i < destinations.size(); ++i)
+      for (const unsigned int destination : destinations)
         {
-          Assert(destinations[i] < n_procs,
-                 ExcIndexRange(destinations[i], 0, n_procs));
-          Assert(destinations[i] != myid,
+          (void)destination;
+          Assert(destination < n_procs, ExcIndexRange(destination, 0, n_procs));
+          Assert(destination != myid,
                  ExcMessage(
                    "There is no point in communicating with ourselves."));
         }
@@ -302,11 +302,11 @@ namespace Utilities
     {
       const unsigned int n_procs = Utilities::MPI::n_mpi_processes(mpi_comm);
 
-      for (unsigned int i = 0; i < destinations.size(); ++i)
+      for (const unsigned int destination : destinations)
         {
-          Assert(destinations[i] < n_procs,
-                 ExcIndexRange(destinations[i], 0, n_procs));
-          Assert(destinations[i] != Utilities::MPI::this_mpi_process(mpi_comm),
+          (void)destination;
+          Assert(destination < n_procs, ExcIndexRange(destination, 0, n_procs));
+          Assert(destination != Utilities::MPI::this_mpi_process(mpi_comm),
                  ExcMessage(
                    "There is no point in communicating with ourselves."));
         }

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -173,26 +173,26 @@ ParameterAcceptor::parse_parameters(ParameterHandler &)
 void
 ParameterAcceptor::parse_all_parameters(ParameterHandler &prm)
 {
-  for (unsigned int i = 0; i < class_list.size(); ++i)
-    if (class_list[i] != nullptr)
+  for (const auto &instance : class_list)
+    if (instance != nullptr)
       {
-        class_list[i]->enter_my_subsection(prm);
-        class_list[i]->parse_parameters(prm);
-        class_list[i]->parse_parameters_call_back();
-        class_list[i]->leave_my_subsection(prm);
+        instance->enter_my_subsection(prm);
+        instance->parse_parameters(prm);
+        instance->parse_parameters_call_back();
+        instance->leave_my_subsection(prm);
       }
 }
 
 void
 ParameterAcceptor::declare_all_parameters(ParameterHandler &prm)
 {
-  for (unsigned int i = 0; i < class_list.size(); ++i)
-    if (class_list[i] != nullptr)
+  for (const auto &instance : class_list)
+    if (instance != nullptr)
       {
-        class_list[i]->enter_my_subsection(prm);
-        class_list[i]->declare_parameters(prm);
-        class_list[i]->declare_parameters_call_back();
-        class_list[i]->leave_my_subsection(prm);
+        instance->enter_my_subsection(prm);
+        instance->declare_parameters(prm);
+        instance->declare_parameters_call_back();
+        instance->leave_my_subsection(prm);
       }
 }
 

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -58,17 +58,15 @@ namespace
     // see if the name is special and if so mangle the whole thing
     const bool mangle_whole_string = (s == "value");
 
-    // for all parts of the string, see
-    // if it is an allowed character or
-    // not
-    for (unsigned int i = 0; i < s.size(); ++i)
+    // for all parts of the string, see if it is an allowed character or not
+    for (const char c : s)
       {
         static const std::string allowed_characters(
           "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
 
         if ((!mangle_whole_string) &&
-            (allowed_characters.find(s[i]) != std::string::npos))
-          u.push_back(s[i]);
+            (allowed_characters.find(c) != std::string::npos))
+          u.push_back(c);
         else
           {
             u.push_back('_');
@@ -88,8 +86,8 @@ namespace
                                          'd',
                                          'e',
                                          'f'};
-            u.push_back(hex[static_cast<unsigned char>(s[i]) / 16]);
-            u.push_back(hex[static_cast<unsigned char>(s[i]) % 16]);
+            u.push_back(hex[static_cast<unsigned char>(c) / 16]);
+            u.push_back(hex[static_cast<unsigned char>(c) % 16]);
           }
       }
 
@@ -986,7 +984,7 @@ ParameterHandler::set(const std::string &entry_string,
         {
           std::vector<int> action_indices = Utilities::string_to_int(
             Utilities::split_string_list(action_indices_as_string.get()));
-          for (unsigned int index : action_indices)
+          for (const unsigned int index : action_indices)
             if (actions.size() >= index + 1)
               actions[index](new_value);
         }
@@ -1195,9 +1193,9 @@ ParameterHandler::recursively_print_parameters(
                         p->second.get<std::string>("documentation"),
                         78 - overall_indent_level * 2 - 2);
 
-                    for (unsigned int i = 0; i < doc_lines.size(); ++i)
+                    for (const auto &doc_line : doc_lines)
                       out << std::setw(overall_indent_level * 2) << ""
-                          << "# " << doc_lines[i] << '\n';
+                          << "# " << doc_line << '\n';
                   }
 
 
@@ -1269,11 +1267,9 @@ ParameterHandler::recursively_print_parameters(
                     {
                       // create label: labels are not to be escaped but mangled
                       std::string label = "parameters:";
-                      for (unsigned int i = 0;
-                           i < target_subsection_path.size();
-                           ++i)
+                      for (const auto &path : target_subsection_path)
                         {
-                          label.append(mangle(target_subsection_path[i]));
+                          label.append(mangle(path));
                           label.append("/");
                         }
                       label.append(p->first);
@@ -1290,9 +1286,8 @@ ParameterHandler::recursively_print_parameters(
                     out << "\\index[prmindex]{" << escape(demangle(p->first))
                         << "}\n";
                     out << "\\index[prmindexfull]{";
-                    for (unsigned int i = 0; i < target_subsection_path.size();
-                         ++i)
-                      out << escape(target_subsection_path[i]) << "!";
+                    for (const auto &path : target_subsection_path)
+                      out << escape(path) << "!";
                     out << escape(demangle(p->first)) << "}\n";
 
                     // finally print value and default
@@ -1332,11 +1327,9 @@ ParameterHandler::recursively_print_parameters(
                     {
                       // create label: labels are not to be escaped but mangled
                       std::string label = "parameters:";
-                      for (unsigned int i = 0;
-                           i < target_subsection_path.size();
-                           ++i)
+                      for (const auto &path : target_subsection_path)
                         {
-                          label.append(mangle(target_subsection_path[i]));
+                          label.append(mangle(path));
                           label.append("/");
                         }
                       label.append(p->first);
@@ -1353,9 +1346,8 @@ ParameterHandler::recursively_print_parameters(
                     out << "\\index[prmindex]{" << escape(demangle(p->first))
                         << "}\n";
                     out << "\\index[prmindexfull]{";
-                    for (unsigned int i = 0; i < target_subsection_path.size();
-                         ++i)
-                      out << escape(target_subsection_path[i]) << "!";
+                    for (const auto &path : target_subsection_path)
+                      out << escape(path) << "!";
                     out << escape(demangle(p->first)) << "}\n";
 
                     // finally print alias and indicate if it is deprecated
@@ -1415,9 +1407,9 @@ ParameterHandler::recursively_print_parameters(
                 if (description_str.size() > 1)
                   {
                     out << '\n';
-                    for (unsigned int i = 0; i < description_str.size(); ++i)
+                    for (const auto &description : description_str)
                       out << std::setw(overall_indent_level * 2 + 6) << ""
-                          << description_str[i] << '\n';
+                          << description << '\n';
                   }
                 else if (description_str.empty() == false)
                   out << "  " << description_str[0] << '\n';
@@ -1488,14 +1480,14 @@ ParameterHandler::recursively_print_parameters(
 
                 // find the path to the current section so that we can
                 // print it in the \subsection{...} heading
-                for (unsigned int i = 0; i < target_subsection_path.size(); ++i)
-                  out << escape(target_subsection_path[i]) << "/";
+                for (const auto &path : target_subsection_path)
+                  out << escape(path) << "/";
                 out << escape(demangle(p->first));
 
                 out << "}" << '\n';
                 out << "\\label{parameters:";
-                for (unsigned int i = 0; i < target_subsection_path.size(); ++i)
-                  out << mangle(target_subsection_path[i]) << "/";
+                for (const auto &path : target_subsection_path)
+                  out << mangle(path) << "/";
                 out << p->first << "}";
                 out << '\n';
 
@@ -1619,11 +1611,10 @@ ParameterHandler::print_parameters_section(
         {
           // if there are top level elements to print, do it
           if (include_top_level_elements && (subsection_path.size() > 0))
-            for (unsigned int i = 0; i < subsection_path.size(); ++i)
+            for (const auto &path : subsection_path)
               {
                 out << std::setw(overall_indent_level * 2) << ""
-                    << "subsection " << demangle(subsection_path[i])
-                    << std::endl;
+                    << "subsection " << demangle(path) << std::endl;
                 overall_indent_level += 1;
               }
 
@@ -1682,9 +1673,9 @@ ParameterHandler::print_parameters_section(
                         p->second.get<std::string>("documentation"),
                         78 - overall_indent_level * 2 - 2);
 
-                    for (unsigned int i = 0; i < doc_lines.size(); ++i)
+                    for (const auto &doc_line : doc_lines)
                       out << std::setw(overall_indent_level * 2) << ""
-                          << "# " << doc_lines[i] << std::endl;
+                          << "# " << doc_line << std::endl;
                   }
 
 
@@ -1753,16 +1744,16 @@ ParameterHandler::print_parameters_section(
                     out << "\\item {\\it Parameter name:} {\\tt "
                         << escape(demangle(p->first)) << "}\n"
                         << "\\phantomsection\\label{parameters:";
-                    for (unsigned int i = 0; i < subsection_path.size(); ++i)
-                      out << mangle(subsection_path[i]) << "/";
+                    for (const auto &path : subsection_path)
+                      out << mangle(path) << "/";
                     out << p->first;
                     out << "}\n\n" << std::endl;
 
                     out << "\\index[prmindex]{" << escape(demangle(p->first))
                         << "}\n";
                     out << "\\index[prmindexfull]{";
-                    for (unsigned int i = 0; i < subsection_path.size(); ++i)
-                      out << escape(subsection_path[i]) << "!";
+                    for (const auto &path : subsection_path)
+                      out << escape(path) << "!";
                     out << escape(demangle(p->first)) << "}\n";
 
                     // finally print value and default
@@ -1797,16 +1788,16 @@ ParameterHandler::print_parameters_section(
                     out << "\\item {\\it Parameter name:} {\\tt "
                         << escape(demangle(p->first)) << "}\n"
                         << "\\phantomsection\\label{parameters:";
-                    for (unsigned int i = 0; i < subsection_path.size(); ++i)
-                      out << mangle(subsection_path[i]) << "/";
+                    for (const auto &path : subsection_path)
+                      out << mangle(path) << "/";
                     out << p->first;
                     out << "}\n\n" << std::endl;
 
                     out << "\\index[prmindex]{" << escape(demangle(p->first))
                         << "}\n";
                     out << "\\index[prmindexfull]{";
-                    for (unsigned int i = 0; i < subsection_path.size(); ++i)
-                      out << escape(subsection_path[i]) << "!";
+                    for (const auto &path : subsection_path)
+                      out << escape(path) << "!";
                     out << escape(demangle(p->first)) << "}\n";
 
                     // finally print alias and indicate if it is deprecated
@@ -1830,11 +1821,10 @@ ParameterHandler::print_parameters_section(
         {
           // if there are top level elements to print, do it
           if (include_top_level_elements && (subsection_path.size() > 0))
-            for (unsigned int i = 0; i < subsection_path.size(); ++i)
+            for (const auto &path : subsection_path)
               {
                 out << std::setw(overall_indent_level * 2) << ""
-                    << "subsection " << demangle(subsection_path[i])
-                    << std::endl;
+                    << "subsection " << demangle(path) << std::endl;
                 overall_indent_level += 1;
               };
 
@@ -1876,9 +1866,9 @@ ParameterHandler::print_parameters_section(
                 if (description_str.size() > 1)
                   {
                     out << std::endl;
-                    for (unsigned int i = 0; i < description_str.size(); ++i)
+                    for (const auto &description : description_str)
                       out << std::setw(overall_indent_level * 2 + 6) << ""
-                          << description_str[i] << std::endl;
+                          << description << std::endl;
                   }
                 else if (description_str.empty() == false)
                   out << "  " << description_str[0] << std::endl;
@@ -1949,14 +1939,14 @@ ParameterHandler::print_parameters_section(
 
                     // find the path to the current section so that we can
                     // print it in the \subsection{...} heading
-                    for (unsigned int i = 0; i < subsection_path.size(); ++i)
-                      out << escape(subsection_path[i]) << "/";
+                    for (const auto &path : subsection_path)
+                      out << escape(path) << "/";
                     out << escape(demangle(p->first));
 
                     out << "}" << std::endl;
                     out << "\\label{parameters:";
-                    for (unsigned int i = 0; i < subsection_path.size(); ++i)
-                      out << mangle(subsection_path[i]) << "/";
+                    for (const auto &path : subsection_path)
+                      out << mangle(path) << "/";
                     out << p->first << "}";
                     out << std::endl;
 
@@ -2212,7 +2202,7 @@ ParameterHandler::scan_line(std::string        line,
                   std::vector<int> action_indices =
                     Utilities::string_to_int(Utilities::split_string_list(
                       action_indices_as_string.get()));
-                  for (unsigned int index : action_indices)
+                  for (const unsigned int index : action_indices)
                     if (actions.size() >= index + 1)
                       actions[index](entry_value);
                 }
@@ -2352,24 +2342,24 @@ MultipleParameterLoop::init_branches()
   init_branches_current_section();
 
   // split up different values
-  for (unsigned int i = 0; i < multiple_choices.size(); ++i)
-    multiple_choices[i].split_different_values();
+  for (auto &multiple_choice : multiple_choices)
+    multiple_choice.split_different_values();
 
   // finally calculate number of branches
   n_branches = 1;
-  for (unsigned int i = 0; i < multiple_choices.size(); ++i)
-    if (multiple_choices[i].type == Entry::variant)
-      n_branches *= multiple_choices[i].different_values.size();
+  for (const auto &multiple_choice : multiple_choices)
+    if (multiple_choice.type == Entry::variant)
+      n_branches *= multiple_choice.different_values.size();
 
   // check whether array entries have the correct
   // number of entries
-  for (unsigned int i = 0; i < multiple_choices.size(); ++i)
-    if (multiple_choices[i].type == Entry::array)
-      if (multiple_choices[i].different_values.size() != n_branches)
+  for (const auto &multiple_choice : multiple_choices)
+    if (multiple_choice.type == Entry::array)
+      if (multiple_choice.different_values.size() != n_branches)
         std::cerr << "    The entry value" << std::endl
-                  << "        " << multiple_choices[i].entry_value << std::endl
+                  << "        " << multiple_choice.entry_value << std::endl
                   << "    for the entry named" << std::endl
-                  << "        " << multiple_choices[i].entry_name << std::endl
+                  << "        " << multiple_choice.entry_name << std::endl
                   << "    does not have the right number of entries for the "
                   << std::endl
                   << "        " << n_branches
@@ -2479,8 +2469,8 @@ std::size_t
 MultipleParameterLoop::memory_consumption() const
 {
   std::size_t mem = ParameterHandler::memory_consumption();
-  for (unsigned int i = 0; i < multiple_choices.size(); ++i)
-    mem += multiple_choices[i].memory_consumption();
+  for (const auto &multiple_choice : multiple_choices)
+    mem += multiple_choice.memory_consumption();
 
   return mem;
 }

--- a/source/base/parsed_function.cc
+++ b/source/base/parsed_function.cc
@@ -121,10 +121,10 @@ namespace Functions
     std::vector<std::string> const_list =
       Utilities::split_string_list(constants_list, ',');
     std::map<std::string, double> constants;
-    for (unsigned int i = 0; i < const_list.size(); ++i)
+    for (const auto &constant : const_list)
       {
         std::vector<std::string> this_c =
-          Utilities::split_string_list(const_list[i], '=');
+          Utilities::split_string_list(constant, '=');
         AssertThrow(this_c.size() == 2, ExcMessage("Invalid format"));
         double tmp;
         AssertThrow(std::sscanf(this_c[1].c_str(), "%lf", &tmp),

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -413,10 +413,10 @@ namespace Utilities
 #  ifdef DEBUG
           const types::global_dof_index n_local_dofs =
             local_range_data.second - local_range_data.first;
-          for (unsigned int i = 0; i < import_indices_data.size(); ++i)
+          for (const auto &range : import_indices_data)
             {
-              AssertIndexRange(import_indices_data[i].first, n_local_dofs);
-              AssertIndexRange(import_indices_data[i].second - 1, n_local_dofs);
+              AssertIndexRange(range.first, n_local_dofs);
+              AssertIndexRange(range.second - 1, n_local_dofs);
             }
 #  endif
         }
@@ -449,21 +449,19 @@ namespace Utilities
           // first translate tight ghost indices into indices within the large
           // set:
           std::vector<unsigned int> expanded_numbering;
-          for (IndexSet::ElementIterator it = ghost_indices_data.begin();
-               it != ghost_indices_data.end();
-               ++it)
+          for (dealii::IndexSet::size_type index : ghost_indices_data)
             {
-              Assert(larger_ghost_index_set.is_element(*it),
+              Assert(larger_ghost_index_set.is_element(index),
                      ExcMessage("The given larger ghost index set must contain"
                                 "all indices in the actual index set."));
               Assert(
-                larger_ghost_index_set.index_within_set(*it) <
+                larger_ghost_index_set.index_within_set(index) <
                   static_cast<types::global_dof_index>(
                     std::numeric_limits<unsigned int>::max()),
                 ExcMessage(
                   "Index overflow: This class supports at most 2^32-1 ghost elements"));
               expanded_numbering.push_back(
-                larger_ghost_index_set.index_within_set(*it));
+                larger_ghost_index_set.index_within_set(index));
             }
 
           // now rework expanded_numbering into ranges and store in:

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -59,7 +59,7 @@ namespace Patterns
             {
               std::string u;
               u.reserve(input.size());
-              for (auto c : input)
+              for (const auto c : input)
                 {
                   switch (c)
                     {
@@ -866,7 +866,7 @@ namespace Patterns
         (split_list.size() > max_elements))
       return false;
 
-    for (auto &key_value_pair : split_list)
+    for (const auto &key_value_pair : split_list)
       {
         std::vector<std::string> pair =
           Utilities::split_string_list(key_value_pair, key_value_separator);

--- a/source/base/polynomials_integrated_legendre_sz.cc
+++ b/source/base/polynomials_integrated_legendre_sz.cc
@@ -62,9 +62,9 @@ IntegratedLegendreSZ::get_coefficients(const unsigned int k)
   coefficients[k]     = b * coefficients_km1[k - 1];
   coefficients[k - 1] = b * coefficients_km1[k - 2];
 
-  for (unsigned int i = 0; i < coefficients.size(); i++)
+  for (double &coefficient : coefficients)
     {
-      coefficients[i] *= a;
+      coefficient *= a;
     }
 
   return coefficients;

--- a/source/base/polynomials_piecewise.cc
+++ b/source/base/polynomials_piecewise.cc
@@ -124,8 +124,8 @@ namespace Polynomials
   {
     std::vector<Polynomial<double>> p_base =
       LagrangeEquidistant::generate_complete_basis(base_degree);
-    for (unsigned int i = 0; i < p_base.size(); ++i)
-      p_base[i].scale(n_subdivisions);
+    for (auto &polynomial : p_base)
+      polynomial.scale(n_subdivisions);
 
     std::vector<PiecewisePolynomial<double>> p;
     p.reserve(n_subdivisions * base_degree + 1);

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -868,20 +868,20 @@ QProjector<3>::project_to_all_faces(const SubQuadrature &quadrature)
   // mutations of a face (mutation==0
   // corresponds to a face with standard
   // orientation, no flip and no rotation)
-  for (unsigned int mutation = 0; mutation < 8; ++mutation)
+  for (const auto &mutation : q)
     {
       // project to each face and append
       // results
       for (unsigned int face = 0; face < n_faces; ++face)
         {
-          project_to_face(q[mutation], face, help);
+          project_to_face(mutation, face, help);
           std::copy(help.begin(), help.end(), std::back_inserter(q_points));
         }
 
       // next copy over weights
       for (unsigned int face = 0; face < n_faces; ++face)
-        std::copy(q[mutation].get_weights().begin(),
-                  q[mutation].get_weights().end(),
+        std::copy(mutation.get_weights().begin(),
+                  mutation.get_weights().end(),
                   std::back_inserter(weights));
     }
 
@@ -1012,7 +1012,7 @@ QProjector<3>::project_to_all_subfaces(const SubQuadrature &quadrature)
   // mutations of a face (mutation==0
   // corresponds to a face with standard
   // orientation, no flip and no rotation)
-  for (unsigned int mutation = 0; mutation < 8; ++mutation)
+  for (const auto &mutation : q)
     {
       // project to each face and copy
       // results
@@ -1025,7 +1025,7 @@ QProjector<3>::project_to_all_subfaces(const SubQuadrature &quadrature)
                            RefinementCase<dim - 1>(ref_case));
                ++subface)
             {
-              project_to_subface(q[mutation],
+              project_to_subface(mutation,
                                  face,
                                  subface,
                                  help,
@@ -1042,8 +1042,8 @@ QProjector<3>::project_to_all_subfaces(const SubQuadrature &quadrature)
                subface < GeometryInfo<dim - 1>::n_children(
                            RefinementCase<dim - 1>(ref_case));
                ++subface)
-            std::copy(q[mutation].get_weights().begin(),
-                      q[mutation].get_weights().end(),
+            std::copy(mutation.get_weights().begin(),
+                      mutation.get_weights().end(),
                       std::back_inserter(weights));
     }
 

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -52,7 +52,7 @@ Subscriptor::Subscriptor(Subscriptor &&subscriptor) noexcept
   : counter(0)
   , object_info(subscriptor.object_info)
 {
-  for (auto validity_ptr : subscriptor.validity_pointers)
+  for (const auto validity_ptr : subscriptor.validity_pointers)
     *validity_ptr = false;
 }
 
@@ -60,7 +60,7 @@ Subscriptor::Subscriptor(Subscriptor &&subscriptor) noexcept
 
 Subscriptor::~Subscriptor()
 {
-  for (auto validity_ptr : validity_pointers)
+  for (const auto validity_ptr : validity_pointers)
     *validity_ptr = false;
   object_info = nullptr;
 }
@@ -94,12 +94,11 @@ Subscriptor::check_no_subscribers() const noexcept
       if (std::uncaught_exception() == false)
         {
           std::string infostring;
-          for (map_iterator it = counter_map.begin(); it != counter_map.end();
-               ++it)
+          for (const auto &map_entry : counter_map)
             {
-              if (it->second > 0)
-                infostring +=
-                  std::string("\n  from Subscriber ") + std::string(it->first);
+              if (map_entry.second > 0)
+                infostring += std::string("\n  from Subscriber ") +
+                              std::string(map_entry.first);
             }
 
           if (infostring == "")
@@ -145,7 +144,7 @@ Subscriptor::operator=(const Subscriptor &s)
 Subscriptor &
 Subscriptor::operator=(Subscriptor &&s) noexcept
 {
-  for (auto validity_ptr : s.validity_pointers)
+  for (const auto validity_ptr : s.validity_pointers)
     *validity_ptr = false;
   object_info = s.object_info;
   return *this;


### PR DESCRIPTION
This is probably the largest towards `modenize-loop-convert` and fixes everything in `source/base` and `include/deal.II/base` excluding the `hdf5` files (see #7589).