### PR TITLE
Last modernize-loop-convert changes

### DIFF
--- a/include/deal.II/fe/block_mask.h
+++ b/include/deal.II/fe/block_mask.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
 
+#include <algorithm>
 #include <iosfwd>
 #include <vector>
 
@@ -289,11 +290,9 @@ BlockMask::n_selected_blocks(const unsigned int n) const
   else
     {
       AssertDimension(real_n, block_mask.size());
-      unsigned int c = 0;
-      for (unsigned int i = 0; i < block_mask.size(); ++i)
-        if (block_mask[i] == true)
-          ++c;
-      return c;
+      return std::count_if(block_mask.begin(),
+                           block_mask.end(),
+                           [](const bool selected) { return selected; });
     }
 }
 

--- a/include/deal.II/fe/component_mask.h
+++ b/include/deal.II/fe/component_mask.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
 
+#include <algorithm>
 #include <iosfwd>
 #include <vector>
 
@@ -319,11 +320,9 @@ ComponentMask::n_selected_components(const unsigned int n) const
   else
     {
       AssertDimension(real_n, component_mask.size());
-      unsigned int c = 0;
-      for (unsigned int i = 0; i < component_mask.size(); ++i)
-        if (component_mask[i] == true)
-          ++c;
-      return c;
+      return std::count_if(component_mask.begin(),
+                           component_mask.end(),
+                           [](const bool selected) { return selected; });
     }
 }
 

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -642,11 +642,12 @@ namespace FETools
         {
           // The base element establishing a component does not make sense in
           // this case. Set up to something meaningless:
-          for (unsigned int i = 0; i < component_to_base_table.size(); i++)
-            component_to_base_table[i] =
-              std::make_pair(std::make_pair(numbers::invalid_unsigned_int,
-                                            numbers::invalid_unsigned_int),
-                             numbers::invalid_unsigned_int);
+          std::fill(
+            component_to_base_table.begin(),
+            component_to_base_table.end(),
+            std::make_pair(std::make_pair(numbers::invalid_unsigned_int,
+                                          numbers::invalid_unsigned_int),
+                           numbers::invalid_unsigned_int));
         }
 
 
@@ -1403,16 +1404,16 @@ namespace FETools
 
     comp_start.resize(element.n_base_elements());
 
-    unsigned int k = 0;
+    unsigned int index = 0;
     for (unsigned int i = 0; i < comp_start.size(); ++i)
       {
         comp_start[i].resize(element.element_multiplicity(i));
         const unsigned int increment = element.base_element(i).dofs_per_cell;
 
-        for (unsigned int j = 0; j < comp_start[i].size(); ++j)
+        for (unsigned int &first_index_of_component : comp_start[i])
           {
-            comp_start[i][j] = k;
-            k += increment;
+            first_index_of_component = index;
+            index += increment;
           }
       }
 

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -166,7 +166,7 @@ AffineConstraints<number>::is_consistent_in_parallel(
   for (const auto &kv : received)
     {
       // for each incoming line:
-      for (auto &lineit : kv.second)
+      for (const auto &lineit : kv.second)
         {
           const ConstraintLine reference = get_line(lineit.index);
 

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -911,7 +911,7 @@ namespace LinearAlgebra
             {
               Number *new_val;
               Utilities::System::posix_memalign(
-                (void **)&new_val,
+                reinterpret_cast<void **>(&new_val),
                 64,
                 sizeof(Number) * partitioner->n_import_indices());
               import_data.values.reset(new_val);
@@ -926,7 +926,7 @@ namespace LinearAlgebra
       // uses a view of the array and thus we need the data on the host to
       // outlive the scope of the function.
       Number *new_val;
-      Utilities::System::posix_memalign((void **)&new_val,
+      Utilities::System::posix_memalign(reinterpret_cast<void **>(&new_val),
                                         64,
                                         sizeof(Number) * allocated_size);
 
@@ -1071,7 +1071,7 @@ namespace LinearAlgebra
             {
               Number *new_val;
               Utilities::System::posix_memalign(
-                (void **)&new_val,
+                reinterpret_cast<void **>(&new_val),
                 64,
                 sizeof(Number) * partitioner->n_import_indices());
               import_data.values.reset(new_val);
@@ -1086,7 +1086,7 @@ namespace LinearAlgebra
       // uses a view of the array and thus we need the data on the host to
       // outlive the scope of the function.
       Number *new_val;
-      Utilities::System::posix_memalign((void **)&new_val,
+      Utilities::System::posix_memalign(reinterpret_cast<void **>(&new_val),
                                         64,
                                         sizeof(Number) * allocated_size);
 

--- a/include/deal.II/lac/matrix_out.h
+++ b/include/deal.II/lac/matrix_out.h
@@ -350,40 +350,27 @@ MatrixOut::build_patches(const Matrix &     matrix,
   for (size_type i = 0; i < gridpoints_y; ++i)
     for (size_type j = 0; j < gridpoints_x; ++j, ++index)
       {
-        // within each patch, order
-        // the points in such a way
-        // that if some graphical
-        // output program (such as
-        // gnuplot) plots the
-        // quadrilaterals as two
-        // triangles, then the
-        // diagonal of the
-        // quadrilateral which cuts
-        // it into the two printed
-        // triangles is parallel to
-        // the diagonal of the
-        // matrix, rather than
-        // perpendicular to it. this
-        // has the advantage that,
-        // for example, the unit
-        // matrix is plotted as a
-        // straight rim, rather than
-        // as a series of bumps and
-        // valleys along the diagonal
+        // within each patch, order the points in such a way that if some
+        // graphical output program (such as gnuplot) plots the quadrilaterals
+        // as two triangles, then the diagonal of the quadrilateral which cuts
+        // it into the two printed triangles is parallel to the diagonal of the
+        // matrix, rather than perpendicular to it. this has the advantage that,
+        // for example, the unit matrix is plotted as a straight rim, rather
+        // than as a series of bumps and valleys along the diagonal
         patches[index].vertices[0](0) = j;
-        patches[index].vertices[0](1) = static_cast<signed int>(-i);
+        patches[index].vertices[0](1) = -static_cast<signed int>(i);
         patches[index].vertices[1](0) = j;
-        patches[index].vertices[1](1) = static_cast<signed int>(-i - 1);
+        patches[index].vertices[1](1) = -static_cast<signed int>(i + 1);
         patches[index].vertices[2](0) = j + 1;
-        patches[index].vertices[2](1) = static_cast<signed int>(-i);
+        patches[index].vertices[2](1) = -static_cast<signed int>(i);
         patches[index].vertices[3](0) = j + 1;
-        patches[index].vertices[3](1) = static_cast<signed int>(-i - 1);
+        patches[index].vertices[3](1) = -static_cast<signed int>(i + 1);
         // next scale all the patch
         // coordinates by the block
         // size, to get original
         // coordinates
-        for (unsigned int v = 0; v < 4; ++v)
-          patches[index].vertices[v] *= options.block_size;
+        for (auto &vertex : patches[index].vertices)
+          vertex *= options.block_size;
 
         patches[index].n_subdivisions = 1;
 

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -224,7 +224,7 @@ namespace CUDAWrappers
         line_to_inactive_cells(n_raw_lines);
 
       // First add active and inactive cells to their lines:
-      for (auto cell : dof_handler.cell_iterators())
+      for (const auto &cell : dof_handler.cell_iterators())
         {
           for (unsigned int line = 0; line < GeometryInfo<3>::lines_per_cell;
                ++line)
@@ -261,7 +261,7 @@ namespace CUDAWrappers
                     child->line(neighbor_line)->index();
 
                   // Now add all active cells
-                  for (auto cl : line_to_cells[line_idx])
+                  for (const auto cl : line_to_cells[line_idx])
                     line_to_cells[child_line_idx].push_back(cl);
                 }
             }
@@ -514,7 +514,7 @@ namespace CUDAWrappers
                 {
                   // For each cell which share that edge
                   const unsigned int line = cell->line(local_line)->index();
-                  for (auto edge_neighbor : line_to_cells[line])
+                  for (const auto edge_neighbor : line_to_cells[line])
                     {
                       // If one of them is coarser than us
                       const cell_iterator neighbor_cell = edge_neighbor.first;

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -365,10 +365,8 @@ namespace internal
                                     vector_partitioner->local_range().first);
       const std::size_t  n_ghosts = ghost_dofs.size();
 #ifdef DEBUG
-      for (std::vector<unsigned int>::iterator dof = dof_indices.begin();
-           dof != dof_indices.end();
-           ++dof)
-        AssertIndexRange(*dof, n_owned + n_ghosts);
+      for (const auto dof_index : dof_indices)
+        AssertIndexRange(dof_index, n_owned + n_ghosts);
 #endif
 
       const unsigned int        n_components = start_components.back();
@@ -631,8 +629,8 @@ namespace internal
         (vector_partitioner->local_range().second -
          vector_partitioner->local_range().first) +
         vector_partitioner->ghost_indices().n_elements();
-      for (std::size_t i = 0; i < dof_indices.size(); ++i)
-        AssertIndexRange(dof_indices[i], index_range);
+      for (const auto dof_index : dof_indices)
+        AssertIndexRange(dof_index, index_range);
 
       // sanity check 2: for the constraint indicators, the first index should
       // be smaller than the number of indices in the row, and the second
@@ -1201,9 +1199,9 @@ namespace internal
                   }
           }
       // ensure that all indices are touched at least during the last round
-      for (auto &i : touched_by)
-        if (i == numbers::invalid_unsigned_int)
-          i = task_info.cell_partition_data.back() - 1;
+      for (auto &index : touched_by)
+        if (index == numbers::invalid_unsigned_int)
+          index = task_info.cell_partition_data.back() - 1;
 
       vector_zero_range_list_index.resize(
         1 + task_info
@@ -1221,7 +1219,7 @@ namespace internal
           auto it = chunk_must_zero_vector.find(chunk);
           if (it != chunk_must_zero_vector.end())
             {
-              for (unsigned int i : it->second)
+              for (const auto i : it->second)
                 vector_zero_range_list.push_back(i);
               vector_zero_range_list_index[chunk + 1] =
                 vector_zero_range_list.size();
@@ -1519,13 +1517,13 @@ namespace internal
         }
 
       AssertIndexRange(counter, local_size + 1);
-      for (std::size_t i = 0; i < renumbering.size(); ++i)
-        if (renumbering[i] == numbers::invalid_dof_index)
-          renumbering[i] = counter++;
+      for (types::global_dof_index &dof_index : renumbering)
+        if (dof_index == numbers::invalid_dof_index)
+          dof_index = counter++;
 
       // transform indices to global index space
-      for (std::size_t i = 0; i < renumbering.size(); ++i)
-        renumbering[i] = vector_partitioner->local_to_global(renumbering[i]);
+      for (types::global_dof_index &dof_index : renumbering)
+        dof_index = vector_partitioner->local_to_global(dof_index);
 
       AssertDimension(counter, renumbering.size());
     }

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1133,7 +1133,7 @@ namespace internal
           // other tasks can already start copying the non-constant data)
           if (my_q == 0)
             {
-              for (auto &it : data_cells_local[0].second.data)
+              for (const auto &it : data_cells_local[0].second.data)
                 {
                   Tensor<2, dim, VectorizedArray<Number>> jac;
                   for (unsigned int d = 0; d < dim; ++d)
@@ -1809,7 +1809,7 @@ namespace internal
             {
               const Number jac_size =
                 ExtractCellHelper::get_jacobian_size(tria);
-              for (auto &it : data_faces_local[0].second.data)
+              for (const auto &it : data_faces_local[0].second.data)
                 {
                   // JxW values; invert previously applied scaling
                   for (unsigned int v = 0;

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1038,8 +1038,8 @@ MatrixFree<dim, Number>::initialize_indices(
                             .dofs_per_cell);
                         cell->neighbor_or_periodic_neighbor(f)
                           ->get_mg_dof_indices(dof_indices);
-                        for (unsigned int i = 0; i < dof_indices.size(); ++i)
-                          dof_info[no].ghost_dofs.push_back(dof_indices[i]);
+                        for (const auto dof_index : dof_indices)
+                          dof_info[no].ghost_dofs.push_back(dof_index);
                       }
           }
         dof_info[no].assign_ghosts(cells_with_ghosts);
@@ -1138,9 +1138,8 @@ MatrixFree<dim, Number>::initialize_indices(
               counter = 0;
               for (unsigned int j = 0; j < dof_info[0].max_fe_index; j++)
                 {
-                  for (unsigned int jj = 0; jj < renumbering_fe_index[j].size();
-                       jj++)
-                    renumbering[counter++] = renumbering_fe_index[j][jj];
+                  for (const auto jj : renumbering_fe_index[j])
+                    renumbering[counter++] = jj;
                   irregular_cells[renumbering_fe_index[j].size() /
                                     vectorization_length +
                                   n_macro_cells_before] =
@@ -1164,9 +1163,8 @@ MatrixFree<dim, Number>::initialize_indices(
               counter = start_nonboundary * vectorization_length;
               for (unsigned int j = 0; j < dof_info[0].max_fe_index; j++)
                 {
-                  for (unsigned int jj = 0; jj < renumbering_fe_index[j].size();
-                       jj++)
-                    renumbering[counter++] = renumbering_fe_index[j][jj];
+                  for (const auto jj : renumbering_fe_index[j])
+                    renumbering[counter++] = jj;
                   irregular_cells[renumbering_fe_index[j].size() /
                                     vectorization_length +
                                   n_macro_cells_before] =
@@ -1302,12 +1300,12 @@ MatrixFree<dim, Number>::initialize_indices(
   constraint_pool_data.reserve(length);
   constraint_pool_row_index.reserve(constraint_values.constraints.size() + 1);
   constraint_pool_row_index.resize(1, 0);
-  for (unsigned int i = 0; i < constraints.size(); ++i)
+  for (const auto &constraint : constraints)
     {
-      Assert(constraints[i] != nullptr, ExcInternalError());
+      Assert(constraint != nullptr, ExcInternalError());
       constraint_pool_data.insert(constraint_pool_data.end(),
-                                  constraints[i]->begin(),
-                                  constraints[i]->end());
+                                  constraint->begin(),
+                                  constraint->end());
       constraint_pool_row_index.push_back(constraint_pool_data.size());
     }
 
@@ -1337,8 +1335,9 @@ MatrixFree<dim, Number>::initialize_indices(
             task_info.face_partition_data.size())
         hard_vectorization_boundary[task_info.partition_row_index[2]] = true;
       else
-        for (unsigned int i = 0; i < hard_vectorization_boundary.size(); ++i)
-          hard_vectorization_boundary[i] = true;
+        std::fill(hard_vectorization_boundary.begin(),
+                  hard_vectorization_boundary.end(),
+                  true);
 
       internal::MatrixFreeFunctions::collect_faces_vectorization(
         face_setup.inner_faces,

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1288,10 +1288,10 @@ namespace MatrixFreeOperators
         edge_constrained_values[j].resize(interface_indices.size());
         const IndexSet &locally_owned =
           data->get_dof_handler(selected_rows[j]).locally_owned_mg_dofs(level);
-        for (unsigned int i = 0; i < interface_indices.size(); ++i)
-          if (locally_owned.is_element(interface_indices[i]))
+        for (const auto interface_index : interface_indices)
+          if (locally_owned.is_element(interface_index))
             edge_constrained_indices[j].push_back(
-              locally_owned.index_within_set(interface_indices[i]));
+              locally_owned.index_within_set(interface_index));
         have_interface_matrices |=
           Utilities::MPI::max(
             static_cast<unsigned int>(edge_constrained_indices[j].size()),
@@ -1309,8 +1309,8 @@ namespace MatrixFreeOperators
       {
         const std::vector<unsigned int> &constrained_dofs =
           data->get_constrained_dofs(selected_rows[j]);
-        for (unsigned int i = 0; i < constrained_dofs.size(); ++i)
-          BlockHelper::subblock(dst, j).local_element(constrained_dofs[i]) = 1.;
+        for (const auto constrained_dof : constrained_dofs)
+          BlockHelper::subblock(dst, j).local_element(constrained_dof) = 1.;
         for (unsigned int i = 0; i < edge_constrained_indices[j].size(); ++i)
           BlockHelper::subblock(dst, j).local_element(
             edge_constrained_indices[j][i]) = 1.;
@@ -1442,9 +1442,9 @@ namespace MatrixFreeOperators
       {
         const std::vector<unsigned int> &constrained_dofs =
           data->get_constrained_dofs(selected_rows[j]);
-        for (unsigned int i = 0; i < constrained_dofs.size(); ++i)
-          BlockHelper::subblock(dst, j).local_element(constrained_dofs[i]) +=
-            BlockHelper::subblock(src, j).local_element(constrained_dofs[i]);
+        for (const auto constrained_dof : constrained_dofs)
+          BlockHelper::subblock(dst, j).local_element(constrained_dof) +=
+            BlockHelper::subblock(src, j).local_element(constrained_dof);
       }
 
     // reset edge constrained values, multiply by unit matrix and add into

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -100,11 +100,11 @@ FE_ABF<dim>::FE_ABF(const unsigned int deg)
   this->interface_constraints.reinit((1 << (dim - 1)) * this->dofs_per_face,
                                      this->dofs_per_face);
   unsigned int target_row = 0;
-  for (unsigned int d = 0; d < face_embeddings.size(); ++d)
-    for (unsigned int i = 0; i < face_embeddings[d].m(); ++i)
+  for (const auto &face_embedding : face_embeddings)
+    for (unsigned int i = 0; i < face_embedding.m(); ++i)
       {
-        for (unsigned int j = 0; j < face_embeddings[d].n(); ++j)
-          this->interface_constraints(target_row, j) = face_embeddings[d](i, j);
+        for (unsigned int j = 0; j < face_embedding.n(); ++j)
+          this->interface_constraints(target_row, j) = face_embedding(i, j);
         ++target_row;
       }
 }

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -1072,14 +1072,14 @@ namespace ColorEnriched
         dof_handler.get_triangulation().n_vertices(), false);
 
       // Mark vertices that belong to cells in subdomain 1
-      for (auto cell : dof_handler.active_cell_iterators())
+      for (const auto &cell : dof_handler.active_cell_iterators())
         if (predicate_1(cell)) // True ==> part of subdomain 1
           for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
                ++v)
             vertices_subdomain_1[cell->vertex_index(v)] = true;
 
       // Find if cells in subdomain 2 and subdomain 1 share vertices.
-      for (auto cell : dof_handler.active_cell_iterators())
+      for (const auto &cell : dof_handler.active_cell_iterators())
         if (predicate_2(cell)) // True ==> part of subdomain 2
           for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
                ++v)
@@ -1173,7 +1173,7 @@ namespace ColorEnriched
        * of predicates active in the given cell.
        */
       unsigned int map_index = 0;
-      for (auto cell : dof_handler.active_cell_iterators())
+      for (const auto &cell : dof_handler.active_cell_iterators())
         {
           // set default FE index ==> no enrichment and no active predicates
           cell->set_active_fe_index(0);
@@ -1289,7 +1289,7 @@ namespace ColorEnriched
        */
 
       // loop through faces
-      for (auto cell : dof_handler.active_cell_iterators())
+      for (const auto &cell : dof_handler.active_cell_iterators())
         {
           const unsigned int           fe_index = cell->active_fe_index();
           const std::set<unsigned int> fe_set   = fe_sets.at(fe_index);
@@ -1413,8 +1413,7 @@ namespace ColorEnriched
       // loop through color sets and create FE_enriched element for each
       // of them provided before calling this function, we have color
       // enrichment function associated with each color.
-      for (unsigned int color_set_id = 0; color_set_id < fe_sets.size();
-           ++color_set_id)
+      for (const auto &fe_set : fe_sets)
         {
           std::vector<const FiniteElement<dim, spacedim> *> vec_fe_enriched(
             n_colors, &fe_nothing);
@@ -1422,12 +1421,12 @@ namespace ColorEnriched
             const typename Triangulation<dim, spacedim>::cell_iterator &)>>>
             functions(n_colors, {dummy_function});
 
-          for (const auto it : fe_sets[color_set_id])
+          for (const unsigned int color_id : fe_set)
             {
-              // Given a color id ( = it), corresponding color enrichment
+              // Given a color id, corresponding color enrichment
               // function is at index id-1 because color_enrichments are
               // indexed from zero and colors are indexed from 1.
-              const unsigned int ind = it - 1;
+              const unsigned int ind = color_id - 1;
 
               AssertIndexRange(ind, vec_fe_enriched.size());
               AssertIndexRange(ind, functions.size());

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -329,9 +329,9 @@ struct FE_Q_Base<PolynomialType, xdim, xspacedim>::Implementation
         for (unsigned int child = 0;
              child < GeometryInfo<dim - 1>::max_children_per_cell;
              ++child)
-          for (unsigned int i = 0; i < inner_points.size(); ++i)
+          for (const auto &inner_point : inner_points)
             constraint_points.push_back(
-              GeometryInfo<dim - 1>::child_to_cell_coordinates(inner_points[i],
+              GeometryInfo<dim - 1>::child_to_cell_coordinates(inner_point,
                                                                child));
       }
 

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -2162,10 +2162,9 @@ FESystem<dim, spacedim>::hp_object_dof_identities(
                 Assert(false, ExcNotImplemented());
             }
 
-          for (unsigned int i = 0; i < base_identities.size(); ++i)
-            identities.emplace_back(base_identities[i].first + dof_offset,
-                                    base_identities[i].second +
-                                      dof_offset_other);
+          for (const auto &base_identity : base_identities)
+            identities.emplace_back(base_identity.first + dof_offset,
+                                    base_identity.second + dof_offset_other);
 
           // record the dofs treated above as already taken care of
           dof_offset += base.template n_dofs_per_object<structdim>();
@@ -2407,10 +2406,9 @@ FESystem<dim, spacedim>::get_constant_modes() const
                              k) = base_table.first(c, ind.second);
         }
       for (unsigned int r = 0; r < element_multiplicity; ++r)
-        for (unsigned int c = 0; c < base_table.second.size(); ++c)
+        for (const unsigned int c : base_table.second)
           components.push_back(
-            comp + r * this->base_elements[i].first->n_components() +
-            base_table.second[c]);
+            comp + r * this->base_elements[i].first->n_components() + c);
     }
   AssertDimension(components.size(), constant_modes.n_rows());
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(constant_modes,

--- a/source/fe/mapping_c1.cc
+++ b/source/fe/mapping_c1.cc
@@ -143,12 +143,12 @@ MappingC1<2>::MappingC1Generic::add_line_support_points(
                                                Point<2>(t2, s_t2)};
           // then transform these points to real coordinates by rotating,
           // scaling and shifting
-          for (unsigned int i = 0; i < 2; ++i)
+          for (const auto &new_unit_point : new_unit_points)
             {
-              Point<2> real_point(std::cos(alpha) * new_unit_points[i][0] -
-                                    std::sin(alpha) * new_unit_points[i][1],
-                                  std::sin(alpha) * new_unit_points[i][0] +
-                                    std::cos(alpha) * new_unit_points[i][1]);
+              Point<2> real_point(std::cos(alpha) * new_unit_point[0] -
+                                    std::sin(alpha) * new_unit_point[1],
+                                  std::sin(alpha) * new_unit_point[0] +
+                                    std::cos(alpha) * new_unit_point[1]);
               real_point *= h;
               real_point += line->vertex(0);
               a.push_back(real_point);

--- a/source/lac/dynamic_sparsity_pattern.cc
+++ b/source/lac/dynamic_sparsity_pattern.cc
@@ -342,9 +342,9 @@ DynamicSparsityPattern::max_entries_per_row() const
     return 0;
 
   size_type m = 0;
-  for (size_type i = 0; i < lines.size(); ++i)
+  for (const auto &line : lines)
     {
-      m = std::max(m, static_cast<size_type>(lines[i].entries.size()));
+      m = std::max(m, static_cast<size_type>(line.entries.size()));
     }
 
   return m;
@@ -484,11 +484,8 @@ DynamicSparsityPattern::print(std::ostream &out) const
     {
       out << '[' << (rowset.size() == 0 ? row : rowset.nth_index_in_set(row));
 
-      for (std::vector<size_type>::const_iterator j =
-             lines[row].entries.begin();
-           j != lines[row].entries.end();
-           ++j)
-        out << ',' << *j;
+      for (const auto entry : lines[row].entries)
+        out << ',' << entry;
 
       out << ']' << std::endl;
     }
@@ -506,16 +503,13 @@ DynamicSparsityPattern::print_gnuplot(std::ostream &out) const
       const size_type rowindex =
         rowset.size() == 0 ? row : rowset.nth_index_in_set(row);
 
-      for (std::vector<size_type>::const_iterator j =
-             lines[row].entries.begin();
-           j != lines[row].entries.end();
-           ++j)
+      for (const auto entry : lines[row].entries)
         // while matrix entries are usually
         // written (i,j), with i vertical and
         // j horizontal, gnuplot output is
         // x-y, that is we have to exchange
         // the order of output
-        out << *j << " " << -static_cast<signed int>(rowindex) << std::endl;
+        out << entry << " " << -static_cast<signed int>(rowindex) << std::endl;
     }
 
 
@@ -533,13 +527,10 @@ DynamicSparsityPattern::bandwidth() const
       const size_type rowindex =
         rowset.size() == 0 ? row : rowset.nth_index_in_set(row);
 
-      for (std::vector<size_type>::const_iterator j =
-             lines[row].entries.begin();
-           j != lines[row].entries.end();
-           ++j)
-        if (static_cast<size_type>(std::abs(static_cast<int>(rowindex - *j))) >
-            b)
-          b = std::abs(static_cast<signed int>(rowindex - *j));
+      for (const auto entry : lines[row].entries)
+        if (static_cast<size_type>(
+              std::abs(static_cast<int>(rowindex - entry))) > b)
+          b = std::abs(static_cast<signed int>(rowindex - entry));
     }
 
   return b;
@@ -554,9 +545,9 @@ DynamicSparsityPattern::n_nonzero_elements() const
     return 0;
 
   size_type n = 0;
-  for (size_type i = 0; i < lines.size(); ++i)
+  for (const auto &line : lines)
     {
-      n += lines[i].entries.size();
+      n += line.entries.size();
     }
 
   return n;
@@ -570,8 +561,8 @@ DynamicSparsityPattern::memory_consumption() const
                   MemoryConsumption::memory_consumption(rowset) -
                   sizeof(rowset);
 
-  for (size_type i = 0; i < lines.size(); ++i)
-    mem += MemoryConsumption::memory_consumption(lines[i]);
+  for (const auto &line : lines)
+    mem += MemoryConsumption::memory_consumption(line);
 
   return mem;
 }

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -291,15 +291,15 @@ namespace PETScWrappers
       Assert(row_lengths.size() == m,
              ExcDimensionMismatch(row_lengths.size(), m));
 
-      // For the case that
-      // local_columns is smaller
-      // than one of the row lengths
-      // MatCreateMPIAIJ throws an
-      // error. In this case use a
+      // For the case that local_columns is smaller than one of the row lengths
+      // MatCreateMPIAIJ throws an error. In this case use a
       // PETScWrappers::SparseMatrix
-      for (size_type i = 0; i < row_lengths.size(); ++i)
-        Assert(row_lengths[i] <= local_columns,
-               ExcIndexRange(row_lengths[i], 1, local_columns + 1));
+      for (const size_type row_length : row_lengths)
+        {
+          (void)row_length;
+          Assert(row_length <= local_columns,
+                 ExcIndexRange(row_length, 1, local_columns + 1));
+        }
 
       // use the call sequence indicating a
       // maximal number of elements for each

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -278,8 +278,7 @@ ScaLAPACKMatrix<NumberType>::reinit(
       // set process-local variables to something telling:
       n_local_rows    = -1;
       n_local_columns = -1;
-      for (unsigned int i = 0; i < 9; ++i)
-        descriptor[i] = -1;
+      std::fill(std::begin(descriptor), std::end(descriptor), -1);
     }
 }
 

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -592,11 +592,14 @@ namespace SparsityTools
              sparsity.row_index_set().size() == sparsity.n_rows(),
            ExcMessage(
              "Only valid for sparsity patterns which store all rows."));
-    for (SparsityPattern::size_type i = 0; i < starting_indices.size(); ++i)
-      Assert(starting_indices[i] < sparsity.n_rows(),
-             ExcMessage("Invalid starting index: All starting indices need "
-                        "to be between zero and the number of rows in the "
-                        "sparsity pattern."));
+    for (const auto starting_index : starting_indices)
+      {
+        (void)starting_index;
+        Assert(starting_index < sparsity.n_rows(),
+               ExcMessage("Invalid starting index: All starting indices need "
+                          "to be between zero and the number of rows in the "
+                          "sparsity pattern."));
+      }
 
     // store the indices of the dofs renumbered in the last round. Default to
     // starting points
@@ -629,12 +632,9 @@ namespace SparsityTools
         std::vector<DynamicSparsityPattern::size_type> next_round_dofs;
 
         // find all neighbors of the dofs numbered in the last round
-        for (DynamicSparsityPattern::size_type i = 0;
-             i < last_round_dofs.size();
-             ++i)
-          for (DynamicSparsityPattern::iterator j =
-                 sparsity.begin(last_round_dofs[i]);
-               j < sparsity.end(last_round_dofs[i]);
+        for (const auto dof : last_round_dofs)
+          for (DynamicSparsityPattern::iterator j = sparsity.begin(dof);
+               j < sparsity.end(dof);
                ++j)
             next_round_dofs.push_back(j->column());
 
@@ -689,17 +689,14 @@ namespace SparsityTools
           dofs_by_coordination;
 
         // find coordination number for each of these dofs
-        for (std::vector<DynamicSparsityPattern::size_type>::iterator s =
-               next_round_dofs.begin();
-             s != next_round_dofs.end();
-             ++s)
+        for (const types::global_dof_index next_round_dof : next_round_dofs)
           {
             const DynamicSparsityPattern::size_type coordination =
-              sparsity.row_length(*s);
+              sparsity.row_length(next_round_dof);
 
             // insert this dof at its coordination number
             const std::pair<const DynamicSparsityPattern::size_type, int>
-              new_entry(coordination, *s);
+              new_entry(coordination, next_round_dof);
             dofs_by_coordination.insert(new_entry);
           }
 
@@ -793,16 +790,16 @@ namespace SparsityTools
               // next set of possible neighbors
               min_neighbors = std::make_pair(numbers::invalid_dof_index,
                                              numbers::invalid_dof_index);
-              for (std::set<types::global_dof_index>::iterator it =
-                     current_neighbors.begin();
-                   it != current_neighbors.end();
-                   ++it)
+              for (const auto current_neighbor : current_neighbors)
                 {
-                  Assert(touched_nodes[*it] == numbers::invalid_dof_index,
+                  Assert(touched_nodes[current_neighbor] ==
+                           numbers::invalid_dof_index,
                          ExcInternalError());
-                  if (n_remaining_neighbors[*it] < min_neighbors.second)
+                  if (n_remaining_neighbors[current_neighbor] <
+                      min_neighbors.second)
                     min_neighbors =
-                      std::make_pair(*it, n_remaining_neighbors[*it]);
+                      std::make_pair(current_neighbor,
+                                     n_remaining_neighbors[current_neighbor]);
                 }
 
               // Among the set of nodes with the minimal number of neighbors,
@@ -810,13 +807,12 @@ namespace SparsityTools
               // i.e., the one with the largest row length
               const types::global_dof_index best_row_length =
                 min_neighbors.second;
-              for (std::set<types::global_dof_index>::iterator it =
-                     current_neighbors.begin();
-                   it != current_neighbors.end();
-                   ++it)
-                if (n_remaining_neighbors[*it] == best_row_length)
-                  if (row_lengths[*it] > min_neighbors.second)
-                    min_neighbors = std::make_pair(*it, row_lengths[*it]);
+              for (const auto current_neighbor : current_neighbors)
+                if (n_remaining_neighbors[current_neighbor] == best_row_length)
+                  if (row_lengths[current_neighbor] > min_neighbors.second)
+                    min_neighbors =
+                      std::make_pair(current_neighbor,
+                                     row_lengths[current_neighbor]);
 
               // Add the pivot and all direct neighbors of the pivot node not
               // yet touched to the list of new entries.
@@ -840,11 +836,11 @@ namespace SparsityTools
               // valid neighbor (here we assume symmetry of the
               // connectivity). Delete the entries of the current list from
               // the set of possible next pivots.
-              for (unsigned int i = 0; i < next_group.size(); ++i)
+              for (const auto index : next_group)
                 {
                   for (DynamicSparsityPattern::iterator it =
-                         connectivity.begin(next_group[i]);
-                       it != connectivity.end(next_group[i]);
+                         connectivity.begin(index);
+                       it != connectivity.end(index);
                        ++it)
                     {
                       if (touched_nodes[it->column()] ==
@@ -852,7 +848,7 @@ namespace SparsityTools
                         current_neighbors.insert(it->column());
                       n_remaining_neighbors[it->column()]--;
                     }
-                  current_neighbors.erase(next_group[i]);
+                  current_neighbors.erase(index);
                 }
             }
         }
@@ -982,9 +978,8 @@ namespace SparsityTools
     {
       std::vector<unsigned int> send_to;
       send_to.reserve(send_data.size());
-      for (map_vec_t::iterator it = send_data.begin(); it != send_data.end();
-           ++it)
-        send_to.push_back(it->first);
+      for (const auto &sparsity_line : send_data)
+        send_to.push_back(sparsity_line.first);
 
       num_receive =
         Utilities::MPI::compute_n_point_to_point_communications(mpi_comm,
@@ -997,16 +992,15 @@ namespace SparsityTools
     // send data
     {
       unsigned int idx = 0;
-      for (map_vec_t::iterator it = send_data.begin(); it != send_data.end();
-           ++it, ++idx)
+      for (const auto &sparsity_line : send_data)
         {
-          const int ierr = MPI_Isend(&(it->second[0]),
-                                     it->second.size(),
+          const int ierr = MPI_Isend(&(sparsity_line.second[0]),
+                                     sparsity_line.second.size(),
                                      DEAL_II_DOF_INDEX_MPI_TYPE,
-                                     it->first,
+                                     sparsity_line.first,
                                      124,
                                      mpi_comm,
-                                     &requests[idx]);
+                                     &requests[idx++]);
           AssertThrowMPI(ierr);
         }
     }
@@ -1128,9 +1122,8 @@ namespace SparsityTools
     {
       std::vector<unsigned int> send_to;
       send_to.reserve(send_data.size());
-      for (map_vec_t::iterator it = send_data.begin(); it != send_data.end();
-           ++it)
-        send_to.push_back(it->first);
+      for (const auto &sparsity_line : send_data)
+        send_to.push_back(sparsity_line.first);
 
       num_receive =
         Utilities::MPI::compute_n_point_to_point_communications(mpi_comm,
@@ -1143,16 +1136,15 @@ namespace SparsityTools
     // send data
     {
       unsigned int idx = 0;
-      for (map_vec_t::iterator it = send_data.begin(); it != send_data.end();
-           ++it, ++idx)
+      for (const auto &sparsity_line : send_data)
         {
-          const int ierr = MPI_Isend(&(it->second[0]),
-                                     it->second.size(),
+          const int ierr = MPI_Isend(&(sparsity_line.second[0]),
+                                     sparsity_line.second.size(),
                                      DEAL_II_DOF_INDEX_MPI_TYPE,
-                                     it->first,
+                                     sparsity_line.first,
                                      124,
                                      mpi_comm,
-                                     &requests[idx]);
+                                     &requests[idx++]);
           AssertThrowMPI(ierr);
         }
     }

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -572,7 +572,7 @@ namespace LinearAlgebra
           const size_type n_indices = vector->Map().NumMyElements();
 #    ifndef DEAL_II_WITH_64BIT_INDICES
           unsigned int *vector_indices =
-            (unsigned int *)vector->Map().MyGlobalElements();
+            reinterpret_cast<unsigned int *>(vector->Map().MyGlobalElements());
 #    else
           size_type *vector_indices =
             reinterpret_cast<size_type *>(vector->Map().MyGlobalElements64());

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1266,8 +1266,8 @@ namespace TrilinosWrappers
   SparseMatrix::clear_rows(const std::vector<size_type> &rows,
                            const TrilinosScalar          new_diag_value)
   {
-    for (size_type row = 0; row < rows.size(); ++row)
-      clear_row(rows[row], new_diag_value);
+    for (const auto row : rows)
+      clear_row(row, new_diag_value);
   }
 
 

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -811,11 +811,10 @@ namespace internal
             ((n_active_cells - n_boundary_cells) / 2 / vectorization_length) *
             vectorization_length;
           unsigned int count = 0;
-          for (unsigned int i = 0; i < cells_close_to_boundary.size(); ++i)
-            if (cell_marked[cells_close_to_boundary[i]] == 0)
+          for (const unsigned int cell : cells_close_to_boundary)
+            if (cell_marked[cell] == 0)
               {
-                cell_marked[cells_close_to_boundary[i]] =
-                  count < n_second_slot ? 1 : 3;
+                cell_marked[cell] = count < n_second_slot ? 1 : 3;
                 ++count;
               }
 
@@ -836,8 +835,11 @@ namespace internal
       else
         std::fill(cell_marked.begin(), cell_marked.end(), 1);
 
-      for (unsigned int i = 0; i < cell_marked.size(); ++i)
-        Assert(cell_marked[i] != 0, ExcInternalError());
+      for (const unsigned char marker : cell_marked)
+        {
+          (void)marker;
+          Assert(marker != 0, ExcInternalError());
+        }
 
       unsigned int              n_categories = 1;
       std::vector<unsigned int> tight_category_map;
@@ -856,7 +858,7 @@ namespace internal
           std::vector<unsigned int> used_categories_vector(
             used_categories.size());
           n_categories = 0;
-          for (auto &it : used_categories)
+          for (const auto &it : used_categories)
             used_categories_vector[n_categories++] = it;
           for (unsigned int i = 0; i < n_active_cells + n_ghost_cells; ++i)
             {
@@ -879,8 +881,8 @@ namespace internal
         {
           n_categories = 2;
           tight_category_map.resize(n_active_cells + n_ghost_cells, 1);
-          for (unsigned int i = 0; i < cells_close_to_boundary.size(); ++i)
-            tight_category_map[cells_close_to_boundary[i]] = 0;
+          for (const unsigned int cell : cells_close_to_boundary)
+            tight_category_map[cell] = 0;
         }
 
       cell_partition_data.clear();
@@ -921,9 +923,8 @@ namespace internal
           // step 3: append cells according to categories
           for (unsigned int j = 0; j < n_categories; ++j)
             {
-              for (unsigned int jj = 0; jj < renumbering_category[j].size();
-                   jj++)
-                renumbering[counter++] = renumbering_category[j][jj];
+              for (const unsigned int cell : renumbering_category[j])
+                renumbering[counter++] = cell;
               unsigned int remainder =
                 renumbering_category[j].size() % vectorization_length;
               if (remainder)
@@ -1544,8 +1545,9 @@ namespace internal
       irregular_cells.resize(n_active_cells + n_ghost_slots);
 
       unsigned int max_fe_index = 0;
-      for (unsigned int i = 0; i < cell_active_fe_index.size(); ++i)
-        max_fe_index = std::max(cell_active_fe_index[i], max_fe_index);
+      for (const unsigned int fe_index : cell_active_fe_index)
+        max_fe_index = std::max(fe_index, max_fe_index);
+
       Assert(!hp_bool || cell_active_fe_index.size() == n_active_cells,
              ExcInternalError());
 
@@ -1604,30 +1606,26 @@ namespace internal
                 else
                   {
                     partition_counter = 0;
-                    for (unsigned int j = 0; j < neighbor_list.size(); ++j)
+                    for (const unsigned int neighbor : neighbor_list)
                       {
-                        Assert(cell_partition[neighbor_list[j]] == part,
+                        Assert(cell_partition[neighbor] == part,
                                ExcInternalError());
-                        Assert(cell_partition_l2[neighbor_list[j]] ==
-                                 partition_l2 - 1,
+                        Assert(cell_partition_l2[neighbor] == partition_l2 - 1,
                                ExcInternalError());
-                        DynamicSparsityPattern::iterator neighbor =
-                                                           connectivity.begin(
-                                                             neighbor_list[j]),
-                                                         end = connectivity.end(
-                                                           neighbor_list[j]);
-                        for (; neighbor != end; ++neighbor)
+                        auto       neighbor_it = connectivity.begin(neighbor);
+                        const auto end_it      = connectivity.end(neighbor);
+                        for (; neighbor_it != end_it; ++neighbor_it)
                           {
-                            if (cell_partition[neighbor->column()] == part &&
-                                cell_partition_l2[neighbor->column()] ==
+                            if (cell_partition[neighbor_it->column()] == part &&
+                                cell_partition_l2[neighbor_it->column()] ==
                                   numbers::invalid_unsigned_int)
                               {
-                                cell_partition_l2[neighbor->column()] =
+                                cell_partition_l2[neighbor_it->column()] =
                                   partition_l2;
                                 neighbor_neighbor_list.push_back(
-                                  neighbor->column());
+                                  neighbor_it->column());
                                 partition_partition_list[counter++] =
-                                  neighbor->column();
+                                  neighbor_it->column();
                                 partition_counter++;
                               }
                           }
@@ -1789,11 +1787,9 @@ namespace internal
                           cell = counter - partition_counter;
                           for (unsigned int j = 0; j < max_fe_index + 1; j++)
                             {
-                              for (unsigned int jj = 0;
-                                   jj < renumbering_fe_index[j].size();
-                                   jj++)
-                                renumbering[cell++] =
-                                  renumbering_fe_index[j][jj];
+                              for (const unsigned int jj :
+                                   renumbering_fe_index[j])
+                                renumbering[cell++] = jj;
                               if (renumbering_fe_index[j].size() %
                                     vectorization_length !=
                                   0)
@@ -2058,15 +2054,12 @@ namespace internal
 
               // Loop through the list of cells in previous partition and put
               // all their neighbors in current partition
-              for (unsigned int j = 0; j < neighbor_list.size(); ++j)
+              for (const unsigned int cell : neighbor_list)
                 {
-                  Assert(cell_partition[neighbor_list[j]] == partition - 1,
+                  Assert(cell_partition[cell] == partition - 1,
                          ExcInternalError());
-                  DynamicSparsityPattern::iterator neighbor =
-                                                     connectivity.begin(
-                                                       neighbor_list[j]),
-                                                   end = connectivity.end(
-                                                     neighbor_list[j]);
+                  auto       neighbor = connectivity.begin(cell);
+                  const auto end      = connectivity.end(cell);
                   for (; neighbor != end; ++neighbor)
                     {
                       if (cell_partition[neighbor->column()] ==


### PR DESCRIPTION
This is the last patch with changes suggested by `modernize-loop-convert` (and some manual improvements/fixes). After merging #7589, #7604 and this PR, we should be good to add `modernize-loop-convert` to the `clang-tidy` checks. After #7603 we might also just use all `clang-tidy` `modernize` checks with a few disabled instead.