### PR TITLE
Fix the installation path for a script.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ ADD_SUBDIRECTORY(cmake/config) # has to be included after source
 ADD_SUBDIRECTORY(examples)
 
 ADD_SUBDIRECTORY(contrib/python-bindings)
+ADD_SUBDIRECTORY(contrib/utilities)
 
 IF(DEAL_II_HAVE_TESTS_DIRECTORY)
   ADD_SUBDIRECTORY(tests)

--- a/cmake/scripts/CMakeLists.txt
+++ b/cmake/scripts/CMakeLists.txt
@@ -51,7 +51,6 @@ SET(_scripts
   ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
   ${CMAKE_CURRENT_SOURCE_DIR}/get_closest_tag.sh
   ${CMAKE_CURRENT_SOURCE_DIR}/get_latest_tag.sh
-  ${CMAKE_CURRENT_SOURCE_DIR}/../contrib/utilities/indent.py
   )
 FILE(COPY ${_scripts}
   DESTINATION ${CMAKE_BINARY_DIR}/${DEAL_II_SHARE_RELDIR}/scripts

--- a/contrib/utilities/CMakeLists.txt
+++ b/contrib/utilities/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2018 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE.md at
+## the top level directory of deal.II.
+##
+## ---------------------------------------------------------------------
+
+#
+# At the present time we only install one script from this directory.
+#
+
+SET(_scripts
+  ${CMAKE_CURRENT_SOURCE_DIR}/indent.py
+  )
+FILE(COPY ${_scripts}
+  DESTINATION ${CMAKE_BINARY_DIR}/${DEAL_II_SHARE_RELDIR}/scripts
+  )
+INSTALL(FILES ${_scripts}
+  DESTINATION ${DEAL_II_SHARE_RELDIR}/scripts
+  COMPONENT library
+  )


### PR DESCRIPTION
CMake rightfully complains that
```
CMake Error at cmake/scripts/CMakeLists.txt:56 (FILE):
  FILE COPY cannot find
  "/home/drwells/Documents/Code/CPP/dealii-dev/cmake/scripts/../contrib/utilities/indent.py".
```
doesn't exist: the script is in `contrib/utilities`, not `cmake/contrib/utilities`.

This path needs to be correct to run `make indent` so we should merge this asap.