### PR TITLE
Avoid the old &vec[0] idiom when possible.

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -822,7 +822,7 @@ namespace Utilities
 
       // Exchanging the size of each buffer
       MPI_Allgather(
-        &n_local_data, 1, MPI_INT, &(size_all_data[0]), 1, MPI_INT, comm);
+        &n_local_data, 1, MPI_INT, size_all_data.data(), 1, MPI_INT, comm);
 
       // Now computing the displacement, relative to recvbuf,
       // at which to store the incoming buffer

--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -319,9 +319,9 @@ namespace Utilities
 #ifdef DEAL_II_WITH_MPI
       // makes use of the fact that the matrix stores its data in a
       // contiguous array.
-      sum(ArrayView<const Number>(&local.val[0], local.n_nonzero_elements()),
+      sum(ArrayView<const Number>(local.val.get(), local.n_nonzero_elements()),
           mpi_communicator,
-          ArrayView<Number>(&global.val[0], global.n_nonzero_elements()));
+          ArrayView<Number>(global.val.get(), global.n_nonzero_elements()));
 #else
       (void)mpi_communicator;
       if (!PointerComparison::equal(&local, &global))

--- a/include/deal.II/differentiation/ad/ad_drivers.h
+++ b/include/deal.II/differentiation/ad/ad_drivers.h
@@ -1064,7 +1064,7 @@ namespace Differentiation
         ::gradient(active_tape_index,
                    independent_variables.size(),
                    const_cast<scalar_type *>(independent_variables.data()),
-                   &gradient[0]);
+                   gradient.data());
       }
 
       static void
@@ -1086,7 +1086,7 @@ namespace Differentiation
           independent_variables.size();
         std::vector<scalar_type *> H(n_independent_variables);
         for (unsigned int i = 0; i < n_independent_variables; ++i)
-          H[i] = &(hessian[i][0]);
+          H[i] = &hessian[i][0];
 
         ::hessian(active_tape_index,
                   n_independent_variables,
@@ -1119,7 +1119,7 @@ namespace Differentiation
                    n_dependent_variables,
                    independent_variables.size(),
                    const_cast<scalar_type *>(independent_variables.data()),
-                   &values[0]);
+                   values.data());
       }
 
       static void
@@ -1141,7 +1141,7 @@ namespace Differentiation
 
         std::vector<scalar_type *> J(n_dependent_variables);
         for (unsigned int i = 0; i < n_dependent_variables; ++i)
-          J[i] = &(jacobian[i][0]);
+          J[i] = &jacobian[i][0];
 
         ::jacobian(active_tape_index,
                    n_dependent_variables,

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1158,7 +1158,7 @@ namespace FETools
           destinations.push_back(it->receiver);
 
           it->pack_data(*buffer);
-          const int ierr = MPI_Isend(&(*buffer)[0],
+          const int ierr = MPI_Isend(buffer->data(),
                                      buffer->size(),
                                      MPI_BYTE,
                                      it->receiver,

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3367,8 +3367,7 @@ namespace GridTools
               -> Point<spacedim> {
               return object->get_manifold().get_new_point(
                 make_array_view(vertices.begin(), vertices.end()),
-                make_array_view(&weights[0],
-                                &weights[n_vertices_per_cell - 1] + 1));
+                make_array_view(weights.begin_raw(), weights.end_raw()));
             };
 
             // pick the initial weights as (normalized) inverse distances from

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -3662,10 +3662,10 @@ AffineConstraints<number>::distribute_local_to_global(
       // calculate all the data that will be written into the matrix row.
       if (use_dealii_matrix == false)
         {
-          size_type *col_ptr = &cols[0];
+          size_type *col_ptr = cols.data();
           // cast is uncritical here and only used to avoid compiler
           // warnings. We never access a non-double array
-          number *val_ptr = &vals[0];
+          number *val_ptr = vals.data();
           internals::resolve_matrix_row(global_rows,
                                         global_rows,
                                         i,
@@ -3674,9 +3674,10 @@ AffineConstraints<number>::distribute_local_to_global(
                                         local_matrix,
                                         col_ptr,
                                         val_ptr);
-          const size_type n_values = col_ptr - &cols[0];
+          const size_type n_values = col_ptr - cols.data();
           if (n_values > 0)
-            global_matrix.add(row, n_values, &cols[0], &vals[0], false, true);
+            global_matrix.add(
+              row, n_values, cols.data(), vals.data(), false, true);
         }
       else
         internals::resolve_matrix_row(
@@ -3816,8 +3817,8 @@ AffineConstraints<number>::distribute_local_to_global(
                               end_block   = block_starts[block_col + 1];
               if (use_dealii_matrix == false)
                 {
-                  size_type *col_ptr = &cols[0];
-                  number *   val_ptr = &vals[0];
+                  size_type *col_ptr = cols.data();
+                  number *   val_ptr = vals.data();
                   internals::resolve_matrix_row(global_rows,
                                                 global_rows,
                                                 i,
@@ -3826,10 +3827,11 @@ AffineConstraints<number>::distribute_local_to_global(
                                                 local_matrix,
                                                 col_ptr,
                                                 val_ptr);
-                  const size_type n_values = col_ptr - &cols[0];
+                  const size_type n_values = col_ptr - cols.data();
                   if (n_values > 0)
                     global_matrix.block(block, block_col)
-                      .add(row, n_values, &cols[0], &vals[0], false, true);
+                      .add(
+                        row, n_values, cols.data(), vals.data(), false, true);
                 }
               else
                 {
@@ -3928,8 +3930,8 @@ AffineConstraints<number>::distribute_local_to_global(
       const size_type row = global_rows.global_row(i);
 
       // calculate all the data that will be written into the matrix row.
-      size_type *col_ptr = &cols[0];
-      number *   val_ptr = &vals[0];
+      size_type *col_ptr = cols.data();
+      number *   val_ptr = vals.data();
       internals::resolve_matrix_row(global_rows,
                                     global_cols,
                                     i,
@@ -3938,9 +3940,9 @@ AffineConstraints<number>::distribute_local_to_global(
                                     local_matrix,
                                     col_ptr,
                                     val_ptr);
-      const size_type n_values = col_ptr - &cols[0];
+      const size_type n_values = col_ptr - cols.data();
       if (n_values > 0)
-        global_matrix.add(row, n_values, &cols[0], &vals[0], false, true);
+        global_matrix.add(row, n_values, cols.data(), vals.data(), false, true);
     }
 }
 

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -1809,8 +1809,8 @@ BlockMatrixBase<MatrixType>::set(const size_type  row,
       block(row_index.first, block_col)
         .set(row_index.second,
              temporary_data.counter_within_block[block_col],
-             &temporary_data.column_indices[block_col][0],
-             &temporary_data.column_values[block_col][0],
+             temporary_data.column_indices[block_col].data(),
+             temporary_data.column_values[block_col].data(),
              false);
     }
 }
@@ -2065,8 +2065,8 @@ BlockMatrixBase<MatrixType>::add(const size_type  row,
       block(row_index.first, block_col)
         .add(row_index.second,
              temporary_data.counter_within_block[block_col],
-             &temporary_data.column_indices[block_col][0],
-             &temporary_data.column_values[block_col][0],
+             temporary_data.column_indices[block_col].data(),
+             temporary_data.column_values[block_col].data(),
              false,
              col_indices_are_sorted);
     }

--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -578,7 +578,7 @@ ChunkSparseMatrix<number>::add(const number                         factor,
   // add everything, including padding elements
   const size_type     chunk_size = cols->get_chunk_size();
   number *            val_ptr    = val.get();
-  const somenumber *  matrix_ptr = &matrix.val[0];
+  const somenumber *  matrix_ptr = matrix.val.get();
   const number *const end_ptr =
     val.get() +
     cols->sparsity_pattern.n_nonzero_elements() * chunk_size * chunk_size;

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -121,8 +121,8 @@ FullMatrix<number>::all_zero() const
 {
   Assert(!this->empty(), ExcEmptyMatrix());
 
-  const number *      p = &this->values[0];
-  const number *const e = &this->values[0] + this->n_elements();
+  const number *      p = this->values.data();
+  const number *const e = this->values.data() + this->n_elements();
   while (p != e)
     if (*p++ != number(0.0))
       return false;
@@ -183,7 +183,7 @@ FullMatrix<number>::vmult(Vector<number2> &      dst,
 
   Assert(&src != &dst, ExcSourceEqualsDestination());
 
-  const number *e = &this->values[0];
+  const number *e = this->values.data();
   // get access to the data in order to
   // avoid copying it when using the ()
   // operator
@@ -214,7 +214,7 @@ FullMatrix<number>::Tvmult(Vector<number2> &      dst,
 
   Assert(&src != &dst, ExcSourceEqualsDestination());
 
-  const number *  e       = &this->values[0];
+  const number *  e       = this->values.data();
   number2 *       dst_ptr = &dst(0);
   const size_type size_m = m(), size_n = n();
 
@@ -567,7 +567,7 @@ FullMatrix<number>::mmult(FullMatrix<number2> &      dst,
              &alpha,
              &src(0, 0),
              &m,
-             &this->values[0],
+             this->values.data(),
              &k,
              &beta,
              &dst(0, 0),
@@ -652,7 +652,7 @@ FullMatrix<number>::Tmmult(FullMatrix<number2> &      dst,
              &alpha,
              &src(0, 0),
              &m,
-             &this->values[0],
+             this->values.data(),
              &n,
              &beta,
              &dst(0, 0),
@@ -757,7 +757,7 @@ FullMatrix<number>::mTmult(FullMatrix<number2> &      dst,
              &alpha,
              &src(0, 0),
              &k,
-             &this->values[0],
+             this->values.data(),
              &k,
              &beta,
              &dst(0, 0),
@@ -859,7 +859,7 @@ FullMatrix<number>::TmTmult(FullMatrix<number2> &      dst,
              &alpha,
              &src(0, 0),
              &k,
-             &this->values[0],
+             this->values.data(),
              &n,
              &beta,
              &dst(0, 0),
@@ -957,7 +957,7 @@ FullMatrix<number>::matrix_norm_square(const Vector<number2> &v) const
 
   number2         sum     = 0.;
   const size_type n_rows  = m();
-  const number *  val_ptr = &this->values[0];
+  const number *  val_ptr = this->values.data();
 
   for (size_type row = 0; row < n_rows; ++row)
     {
@@ -988,7 +988,7 @@ FullMatrix<number>::matrix_scalar_product(const Vector<number2> &u,
   number2         sum     = 0.;
   const size_type n_rows  = m();
   const size_type n_cols  = n();
-  const number *  val_ptr = &this->values[0];
+  const number *  val_ptr = this->values.data();
 
   for (size_type row = 0; row < n_rows; ++row)
     {
@@ -1859,7 +1859,7 @@ FullMatrix<number>::gauss_jordan()
 
         // Use the LAPACK function getrf for
         // calculating the LU factorization.
-        getrf(&nn, &nn, &this->values[0], &nn, ipiv.data(), &info);
+        getrf(&nn, &nn, this->values.data(), &nn, ipiv.data(), &info);
 
         Assert(info >= 0, ExcInternalError());
         Assert(info == 0, LACExceptions::ExcSingular());
@@ -1870,8 +1870,13 @@ FullMatrix<number>::gauss_jordan()
         // Use the LAPACK function getri for
         // calculating the actual inverse using
         // the LU factorization.
-        getri(
-          &nn, &this->values[0], &nn, ipiv.data(), inv_work.data(), &nn, &info);
+        getri(&nn,
+              this->values.data(),
+              &nn,
+              ipiv.data(),
+              inv_work.data(),
+              &nn,
+              &info);
 
         Assert(info >= 0, ExcInternalError());
         Assert(info == 0, LACExceptions::ExcSingular());

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -1132,9 +1132,9 @@ namespace PETScWrappers
   VectorBase::extract_subvector_to(const std::vector<size_type> &indices,
                                    std::vector<PetscScalar> &    values) const
   {
-    extract_subvector_to(&(indices[0]),
-                         &(indices[0]) + indices.size(),
-                         &(values[0]));
+    Assert(indices.size() <= values.size(),
+           ExcDimensionMismatch(indices.size(), values.size()));
+    extract_subvector_to(indices.begin(), indices.end(), values.begin());
   }
 
   template <typename ForwardIterator, typename OutputIterator>

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -494,7 +494,7 @@ TensorProductMatrixSymmetricSumBase<dim, Number, size>::vmult(
          mass_matrix[0].n_rows());
   Number *      t   = tmp_array.begin();
   const Number *src = src_view.begin();
-  Number *      dst = &(dst_view[0]);
+  Number *      dst = dst_view.data();
 
   if (dim == 1)
     {
@@ -561,7 +561,7 @@ TensorProductMatrixSymmetricSumBase<dim, Number, size>::apply_inverse(
          mass_matrix[0].n_rows());
   Number *      t   = tmp_array.begin();
   const Number *src = src_view.data();
-  Number *      dst = &(dst_view[0]);
+  Number *      dst = dst_view.data();
 
   // NOTE: dof_to_quad has to be interpreted as 'dof to eigenvalue index'
   //       --> apply<.,true,.> (S,src,dst) calculates dst = S^T * src,

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -839,7 +839,7 @@ namespace CUDAWrappers
     unsigned int size_shape_values = n_dofs_1d * n_q_points_1d * sizeof(Number);
 
     cudaError_t cuda_error = cudaMemcpyToSymbol(internal::global_shape_values,
-                                                &shape_info.shape_values[0],
+                                                shape_info.shape_values.data(),
                                                 size_shape_values,
                                                 0,
                                                 cudaMemcpyHostToDevice);
@@ -848,7 +848,7 @@ namespace CUDAWrappers
     if (update_flags & update_gradients)
       {
         cuda_error = cudaMemcpyToSymbol(internal::global_shape_gradients,
-                                        &shape_info.shape_gradients[0],
+                                        shape_info.shape_gradients.data(),
                                         size_shape_values,
                                         0,
                                         cudaMemcpyHostToDevice);

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -95,15 +95,15 @@ MatrixFree<dim, Number>::create_cell_subrange_hp_by_index(
       AssertIndexRange(range.second, fe_indices.size() + 1);
 #endif
       std::pair<unsigned int, unsigned int> return_range;
-      return_range.first = std::lower_bound(&fe_indices[0] + range.first,
-                                            &fe_indices[0] + range.second,
+      return_range.first = std::lower_bound(fe_indices.begin() + range.first,
+                                            fe_indices.begin() + range.second,
                                             fe_index) -
-                           &fe_indices[0];
+                           fe_indices.begin();
       return_range.second =
-        std::lower_bound(&fe_indices[0] + return_range.first,
-                         &fe_indices[0] + range.second,
+        std::lower_bound(fe_indices.begin() + return_range.first,
+                         fe_indices.begin() + range.second,
                          fe_index + 1) -
-        &fe_indices[0];
+        fe_indices.begin();
       Assert(return_range.first >= range.first &&
                return_range.second <= range.second,
              ExcInternalError());

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -998,8 +998,9 @@ namespace MatrixFreeOperators
 
     const unsigned int shift_coefficient =
       inverse_coefficients.size() > dofs_per_component ? dofs_per_component : 0;
-    const VectorizedArray<Number> *inv_coefficient = &inverse_coefficients[0];
-    VectorizedArray<Number>        temp_data_field[dofs_per_component];
+    const VectorizedArray<Number> *inv_coefficient =
+      inverse_coefficients.data();
+    VectorizedArray<Number> temp_data_field[dofs_per_component];
     for (unsigned int d = 0; d < n_actual_components; ++d)
       {
         const VectorizedArray<Number> *in  = in_array + d * dofs_per_component;

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -556,7 +556,7 @@ namespace DataOutBase
   const double *
   DataOutFilter::get_data_set(const unsigned int set_num) const
   {
-    return &data_sets[set_num][0];
+    return data_sets[set_num].data();
   }
 
 
@@ -5110,11 +5110,11 @@ namespace DataOutBase
 
       int total = (vars_per_node * num_nodes);
 
-      ierr = TECDAT(&total, &tm.nodalData[0], &is_double);
+      ierr = TECDAT(&total, tm.nodalData.data(), &is_double);
 
       Assert(ierr == 0, ExcTecplotAPIError());
 
-      ierr = TECNOD(&tm.connData[0]);
+      ierr = TECNOD(tm.connData.data());
 
       Assert(ierr == 0, ExcTecplotAPIError());
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -209,7 +209,7 @@ namespace Utilities
       // results over all processes
       unsigned int n_recv_from;
       const int    ierr = MPI_Reduce_scatter_block(
-        &dest_vector[0], &n_recv_from, 1, MPI_UNSIGNED, MPI_SUM, mpi_comm);
+        dest_vector.data(), &n_recv_from, 1, MPI_UNSIGNED, MPI_SUM, mpi_comm);
 
       AssertThrowMPI(ierr);
 
@@ -222,7 +222,7 @@ namespace Utilities
                   el,
                   32766,
                   mpi_comm,
-                  &send_requests[&el - &destinations[0]]);
+                  send_requests.data() + (&el - destinations.data()));
 
       // if no one to receive from, return an empty vector
       if (n_recv_from == 0)
@@ -322,7 +322,7 @@ namespace Utilities
       unsigned int n_recv_from = 0;
 
       const int ierr = MPI_Reduce_scatter_block(
-        &dest_vector[0], &n_recv_from, 1, MPI_UNSIGNED, MPI_SUM, mpi_comm);
+        dest_vector.data(), &n_recv_from, 1, MPI_UNSIGNED, MPI_SUM, mpi_comm);
 
       AssertThrowMPI(ierr);
 
@@ -334,14 +334,14 @@ namespace Utilities
       std::vector<unsigned int> buffer(dest_vector.size());
       unsigned int              n_recv_from = 0;
 
-      MPI_Reduce(&dest_vector[0],
-                 &buffer[0],
+      MPI_Reduce(dest_vector.data(),
+                 buffer.data(),
                  dest_vector.size(),
                  MPI_UNSIGNED,
                  MPI_SUM,
                  0,
                  mpi_comm);
-      MPI_Scatter(&buffer[0],
+      MPI_Scatter(buffer.data(),
                   1,
                   MPI_UNSIGNED,
                   &n_recv_from,

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -301,7 +301,7 @@ TensorProductPolynomials<dim, PolynomialType>::compute(
       for (unsigned d = 0; d < dim; ++d)
         polynomials[i].value(p(d),
                              n_values_and_derivatives,
-                             &values_1d[i][d][0]);
+                             values_1d[i][d].data());
 
   unsigned int indices[3];
   unsigned int ind = 0;

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -4242,7 +4242,7 @@ namespace parallel
           // that the packet has been
           // received
           it->second.pack_data(*buffer);
-          const int ierr = MPI_Isend(&(*buffer)[0],
+          const int ierr = MPI_Isend(buffer->data(),
                                      buffer->size(),
                                      MPI_BYTE,
                                      it->first,

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -4655,7 +4655,7 @@ namespace internal
 
               // send reply
               reply_buffers[idx] = cell_data_transfer_buffer.pack_data();
-              ierr               = MPI_Isend(&(reply_buffers[idx])[0],
+              ierr               = MPI_Isend(reply_buffers[idx].data(),
                                reply_buffers[idx].size(),
                                MPI_BYTE,
                                status.MPI_SOURCE,
@@ -5381,7 +5381,7 @@ namespace internal
               &level_number_cache.n_locally_owned_dofs,
               1,
               DEAL_II_DOF_INDEX_MPI_TYPE,
-              &level_number_cache.n_locally_owned_dofs_per_processor[0],
+              level_number_cache.n_locally_owned_dofs_per_processor.data(),
               1,
               DEAL_II_DOF_INDEX_MPI_TYPE,
               triangulation->get_communicator());

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -1737,7 +1737,7 @@ namespace internal
               Assert(data.n_shape_functions > 0, ExcInternalError());
 
               const Tensor<1, spacedim> *supp_pts =
-                &data.mapping_support_points[0];
+                data.mapping_support_points.data();
 
               for (unsigned int point = 0; point < n_q_points; ++point)
                 {

--- a/source/grid/cell_id.cc
+++ b/source/grid/cell_id.cc
@@ -53,7 +53,7 @@ CellId::CellId(const unsigned int  coarse_cell_id,
   , n_child_indices(n_child_indices)
 {
   Assert(n_child_indices < child_indices.size(), ExcInternalError());
-  memcpy(&(child_indices[0]), id, n_child_indices);
+  memcpy(child_indices.data(), id, n_child_indices);
 }
 
 

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -2103,9 +2103,9 @@ GridIn<2>::read_netcdf(const std::string &filename)
               ExcIO());
   std::vector<std::vector<double>> point_values(
     3, std::vector<double>(n_vertices));
-  points_xc->get(&*point_values[0].begin(), n_vertices);
-  points_yc->get(&*point_values[1].begin(), n_vertices);
-  points_zc->get(&*point_values[2].begin(), n_vertices);
+  points_xc->get(point_values[0].data(), n_vertices);
+  points_yc->get(point_values[1].data(), n_vertices);
+  points_zc->get(point_values[2].data(), n_vertices);
 
   // and fill the vertices
   std::vector<Point<spacedim>> vertices(n_vertices);
@@ -2265,9 +2265,9 @@ GridIn<3>::read_netcdf(const std::string &filename)
               ExcIO());
   std::vector<std::vector<double>> point_values(
     3, std::vector<double>(n_vertices));
-  points_xc->get(&*point_values[0].begin(), n_vertices);
-  points_yc->get(&*point_values[1].begin(), n_vertices);
-  points_zc->get(&*point_values[2].begin(), n_vertices);
+  points_xc->get(point_values[0].data(), n_vertices);
+  points_yc->get(point_values[1].data(), n_vertices);
+  points_zc->get(point_values[2].data(), n_vertices);
 
   // and fill the vertices
   std::vector<Point<spacedim>> vertices(n_vertices);

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2364,7 +2364,7 @@ namespace GridTools
           }
 
         // Send the message
-        ierr = MPI_Isend(&vertices_send_buffers[i][0],
+        ierr = MPI_Isend(vertices_send_buffers[i].data(),
                          buffer_size,
                          DEAL_II_VERTEX_INDEX_MPI_TYPE,
                          destination,
@@ -2389,7 +2389,7 @@ namespace GridTools
         vertices_recv_buffers[i].resize(buffer_size);
 
         // Receive the message
-        ierr = MPI_Recv(&vertices_recv_buffers[i][0],
+        ierr = MPI_Recv(vertices_recv_buffers[i].data(),
                         buffer_size,
                         DEAL_II_VERTEX_INDEX_MPI_TYPE,
                         source,
@@ -2430,7 +2430,7 @@ namespace GridTools
           }
 
         // Send the message
-        ierr = MPI_Isend(&cellids_send_buffers[i][0],
+        ierr = MPI_Isend(cellids_send_buffers[i].data(),
                          buffer_size,
                          MPI_CHAR,
                          destination,
@@ -2453,7 +2453,7 @@ namespace GridTools
         cellids_recv_buffers[i].resize(buffer_size);
 
         // Receive the message
-        ierr = MPI_Recv(&cellids_recv_buffers[i][0],
+        ierr = MPI_Recv(cellids_recv_buffers[i].data(),
                         buffer_size,
                         MPI_CHAR,
                         source,
@@ -5029,7 +5029,7 @@ namespace GridTools
     int ierr = MPI_Allgather(&n_local_data,
                              1,
                              MPI_INT,
-                             &(size_all_data[0]),
+                             size_all_data.data(),
                              1,
                              MPI_INT,
                              mpi_communicator);
@@ -5046,12 +5046,12 @@ namespace GridTools
     // Allocating a vector to contain all the received data
     std::vector<double> data_array(rdispls.back() + size_all_data.back());
 
-    ierr = MPI_Allgatherv(&(loc_data_array[0]),
+    ierr = MPI_Allgatherv(loc_data_array.data(),
                           n_local_data,
                           MPI_DOUBLE,
-                          &(data_array[0]),
-                          &(size_all_data[0]),
-                          &(rdispls[0]),
+                          data_array.data(),
+                          size_all_data.data(),
+                          rdispls.data(),
                           MPI_DOUBLE,
                           mpi_communicator);
     AssertThrowMPI(ierr);

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2218,7 +2218,7 @@ CellAccessor<dim, spacedim>::id() const
   Assert(ptr.level() == 0, ExcInternalError());
   const unsigned int coarse_index = ptr.index();
 
-  return CellId(coarse_index, n_child_indices, &(id[0]));
+  return CellId(coarse_index, n_child_indices, id.data());
 }
 
 

--- a/source/lac/cuda_sparse_matrix.cu
+++ b/source/lac/cuda_sparse_matrix.cu
@@ -298,7 +298,7 @@ namespace CUDAWrappers
     // Copy the elements to the gpu
     val_dev.reset(Utilities::CUDA::allocate_device_data<Number>(nnz));
     cudaError_t error_code = cudaMemcpy(val_dev.get(),
-                                        &val[0],
+                                        val.data(),
                                         nnz * sizeof(Number),
                                         cudaMemcpyHostToDevice);
     AssertCuda(error_code);
@@ -307,7 +307,7 @@ namespace CUDAWrappers
     column_index_dev.reset(Utilities::CUDA::allocate_device_data<int>(nnz));
     AssertCuda(error_code);
     error_code = cudaMemcpy(column_index_dev.get(),
-                            &column_index[0],
+                            column_index.data(),
                             nnz * sizeof(int),
                             cudaMemcpyHostToDevice);
     AssertCuda(error_code);
@@ -316,7 +316,7 @@ namespace CUDAWrappers
     row_ptr_dev.reset(Utilities::CUDA::allocate_device_data<int>(row_ptr_size));
     AssertCuda(error_code);
     error_code = cudaMemcpy(row_ptr_dev.get(),
-                            &row_ptr[0],
+                            row_ptr.data(),
                             row_ptr_size * sizeof(int),
                             cudaMemcpyHostToDevice);
     AssertCuda(error_code);

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -82,7 +82,7 @@ namespace internal
       geev(&vl,
            &vr,
            &n_rows,
-           &matrix[0],
+           matrix.data(),
            &n_rows,
            real_part_eigenvalues.data(),
            imag_part_eigenvalues.data(),
@@ -134,7 +134,7 @@ namespace internal
       geev(&vl,
            &vr,
            &n_rows,
-           &matrix[0],
+           matrix.data(),
            &n_rows,
            eigenvalues.data(),
            left_eigenvectors.data(),
@@ -178,12 +178,12 @@ namespace internal
       gesdd(&job,
             &n_rows,
             &n_cols,
-            &matrix[0],
+            matrix.data(),
             &n_rows,
             singular_values.data(),
-            &left_vectors[0],
+            left_vectors.data(),
             &n_rows,
-            &right_vectors[0],
+            right_vectors.data(),
             &n_cols,
             real_work.data(),
             &work_flag,
@@ -224,12 +224,12 @@ namespace internal
       gesdd(&job,
             &n_rows,
             &n_cols,
-            &matrix[0],
+            matrix.data(),
             &n_rows,
             singular_values.data(),
-            &left_vectors[0],
+            left_vectors.data(),
             &n_rows,
-            &right_vectors[0],
+            right_vectors.data(),
             &n_cols,
             work.data(),
             &work_flag,
@@ -436,7 +436,7 @@ LAPACKFullMatrix<number>::operator*=(const number factor)
   types::blas_int       info  = 0;
   // kl and ku will not be referenced for type = G (dense matrices).
   const types::blas_int kl     = 0;
-  number *              values = &this->values[0];
+  number *              values = this->values.data();
 
   lascl(&type, &kl, &kl, &cfrom, &factor, &m, &n, values, &lda, &info);
 
@@ -466,7 +466,7 @@ LAPACKFullMatrix<number>::operator/=(const number factor)
   types::blas_int       info = 0;
   // kl and ku will not be referenced for type = G (dense matrices).
   const types::blas_int kl     = 0;
-  number *              values = &this->values[0];
+  number *              values = this->values.data();
 
   lascl(&type, &kl, &kl, &factor, &cto, &m, &n, values, &lda, &info);
 
@@ -496,8 +496,8 @@ LAPACKFullMatrix<number>::add(const number a, const LAPACKFullMatrix<number> &A)
   // ==> use BLAS 1 for adding vectors
   const types::blas_int n        = this->m() * this->n();
   const types::blas_int inc      = 1;
-  number *              values   = &this->values[0];
-  const number *        values_A = &A.values[0];
+  number *              values   = this->values.data();
+  const number *        values_A = A.values.data();
 
   axpy(&n, &a, values_A, &inc, values, &inc);
 }
@@ -677,7 +677,8 @@ LAPACKFullMatrix<number>::vmult(Vector<number> &      w,
       const types::blas_int lda  = N;
       const types::blas_int incx = 1;
 
-      trmv(&uplo, &trans, &diag, &N, &this->values[0], &lda, &w[0], &incx);
+      trmv(
+        &uplo, &trans, &diag, &N, this->values.data(), &lda, w.data(), &incx);
 
       return;
     }
@@ -694,12 +695,12 @@ LAPACKFullMatrix<number>::vmult(Vector<number> &      w,
                &mm,
                &nn,
                &alpha,
-               &this->values[0],
+               this->values.data(),
                &mm,
-               v.values.get(),
+               v.data(),
                &one,
                &beta,
-               w.values.get(),
+               w.data(),
                &one);
           break;
         }
@@ -714,9 +715,9 @@ LAPACKFullMatrix<number>::vmult(Vector<number> &      w,
                &nn,
                &nn,
                &alpha,
-               &svd_vt->values[0],
+               svd_vt->values.data(),
                &nn,
-               v.values.get(),
+               v.data(),
                &one,
                &null,
                work.data(),
@@ -729,12 +730,12 @@ LAPACKFullMatrix<number>::vmult(Vector<number> &      w,
                &mm,
                &mm,
                &alpha,
-               &svd_u->values[0],
+               svd_u->values.data(),
                &mm,
                work.data(),
                &one,
                &beta,
-               w.values.get(),
+               w.data(),
                &one);
           break;
         }
@@ -749,9 +750,9 @@ LAPACKFullMatrix<number>::vmult(Vector<number> &      w,
                &mm,
                &mm,
                &alpha,
-               &svd_u->values[0],
+               svd_u->values.data(),
                &mm,
-               v.values.get(),
+               v.data(),
                &one,
                &null,
                work.data(),
@@ -764,12 +765,12 @@ LAPACKFullMatrix<number>::vmult(Vector<number> &      w,
                &nn,
                &nn,
                &alpha,
-               &svd_vt->values[0],
+               svd_vt->values.data(),
                &nn,
                work.data(),
                &one,
                &beta,
-               w.values.get(),
+               w.data(),
                &one);
           break;
         }
@@ -811,7 +812,8 @@ LAPACKFullMatrix<number>::Tvmult(Vector<number> &      w,
       const types::blas_int lda  = N;
       const types::blas_int incx = 1;
 
-      trmv(&uplo, &trans, &diag, &N, &this->values[0], &lda, &w[0], &incx);
+      trmv(
+        &uplo, &trans, &diag, &N, this->values.data(), &lda, w.data(), &incx);
 
       return;
     }
@@ -829,12 +831,12 @@ LAPACKFullMatrix<number>::Tvmult(Vector<number> &      w,
                &mm,
                &nn,
                &alpha,
-               &this->values[0],
+               this->values.data(),
                &mm,
-               v.values.get(),
+               v.data(),
                &one,
                &beta,
-               w.values.get(),
+               w.data(),
                &one);
           break;
         }
@@ -850,9 +852,9 @@ LAPACKFullMatrix<number>::Tvmult(Vector<number> &      w,
                &mm,
                &mm,
                &alpha,
-               &svd_u->values[0],
+               svd_u->values.data(),
                &mm,
-               v.values.get(),
+               v.data(),
                &one,
                &null,
                work.data(),
@@ -865,12 +867,12 @@ LAPACKFullMatrix<number>::Tvmult(Vector<number> &      w,
                &nn,
                &nn,
                &alpha,
-               &svd_vt->values[0],
+               svd_vt->values.data(),
                &nn,
                work.data(),
                &one,
                &beta,
-               w.values.get(),
+               w.data(),
                &one);
           break;
         }
@@ -886,9 +888,9 @@ LAPACKFullMatrix<number>::Tvmult(Vector<number> &      w,
                &nn,
                &nn,
                &alpha,
-               &svd_vt->values[0],
+               svd_vt->values.data(),
                &nn,
-               v.values.get(),
+               v.data(),
                &one,
                &null,
                work.data(),
@@ -901,12 +903,12 @@ LAPACKFullMatrix<number>::Tvmult(Vector<number> &      w,
                &mm,
                &mm,
                &alpha,
-               &svd_u->values[0],
+               svd_u->values.data(),
                &mm,
                work.data(),
                &one,
                &beta,
-               w.values.get(),
+               w.data(),
                &one);
           break;
         }
@@ -958,12 +960,12 @@ LAPACKFullMatrix<number>::mmult(LAPACKFullMatrix<number> &      C,
        &nn,
        &kk,
        &alpha,
-       &this->values[0],
+       this->values.data(),
        &mm,
-       &B.values[0],
+       B.values.data(),
        &kk,
        &beta,
-       &C.values[0],
+       C.values.data(),
        &mm);
 }
 
@@ -993,9 +995,9 @@ LAPACKFullMatrix<number>::mmult(FullMatrix<number> &            C,
        &mm,
        &kk,
        &alpha,
-       &B.values[0],
+       B.values.data(),
        &kk,
-       &this->values[0],
+       this->values.data(),
        &mm,
        &beta,
        &C(0, 0),
@@ -1055,12 +1057,12 @@ LAPACKFullMatrix<number>::Tmmult(LAPACKFullMatrix<number> &      C,
        &nn,
        &kk,
        &alpha,
-       &this->values[0],
+       this->values.data(),
        &kk,
-       &work[0],
+       work.data(),
        &kk,
        &beta,
-       &C.values[0],
+       C.values.data(),
        &mm);
 }
 
@@ -1077,7 +1079,7 @@ LAPACKFullMatrix<number>::transpose(LAPACKFullMatrix<number> &B) const
   const types::blas_int n = B.n();
 #ifdef DEAL_II_LAPACK_WITH_MKL
   const number one = 1.;
-  omatcopy('C', 'C', n, m, one, &A.values[0], n, &B.values[0], m);
+  omatcopy('C', 'C', n, m, one, A.values.data(), n, B.values.data(), m);
 #else
   for (types::blas_int i = 0; i < m; ++i)
     for (types::blas_int j = 0; j < n; ++j)
@@ -1128,10 +1130,10 @@ LAPACKFullMatrix<number>::Tmmult(LAPACKFullMatrix<number> &      C,
            &nn,
            &kk,
            &alpha,
-           &this->values[0],
+           this->values.data(),
            &kk,
            &beta,
-           &C.values[0],
+           C.values.data(),
            &nn);
 
       // fill-in lower triangular part
@@ -1149,12 +1151,12 @@ LAPACKFullMatrix<number>::Tmmult(LAPACKFullMatrix<number> &      C,
            &nn,
            &kk,
            &alpha,
-           &this->values[0],
+           this->values.data(),
            &kk,
-           &B.values[0],
+           B.values.data(),
            &kk,
            &beta,
-           &C.values[0],
+           C.values.data(),
            &mm);
     }
 }
@@ -1185,9 +1187,9 @@ LAPACKFullMatrix<number>::Tmmult(FullMatrix<number> &            C,
        &mm,
        &kk,
        &alpha,
-       &B.values[0],
+       B.values.data(),
        &kk,
-       &this->values[0],
+       this->values.data(),
        &kk,
        &beta,
        &C(0, 0),
@@ -1220,10 +1222,10 @@ LAPACKFullMatrix<number>::mTmult(LAPACKFullMatrix<number> &      C,
            &nn,
            &kk,
            &alpha,
-           &this->values[0],
+           this->values.data(),
            &nn,
            &beta,
-           &C.values[0],
+           C.values.data(),
            &nn);
 
       // fill-in lower triangular part
@@ -1241,12 +1243,12 @@ LAPACKFullMatrix<number>::mTmult(LAPACKFullMatrix<number> &      C,
            &nn,
            &kk,
            &alpha,
-           &this->values[0],
+           this->values.data(),
            &mm,
-           &B.values[0],
+           B.values.data(),
            &nn,
            &beta,
-           &C.values[0],
+           C.values.data(),
            &mm);
     }
 }
@@ -1278,9 +1280,9 @@ LAPACKFullMatrix<number>::mTmult(FullMatrix<number> &            C,
        &mm,
        &kk,
        &alpha,
-       &B.values[0],
+       B.values.data(),
        &nn,
-       &this->values[0],
+       this->values.data(),
        &mm,
        &beta,
        &C(0, 0),
@@ -1312,12 +1314,12 @@ LAPACKFullMatrix<number>::TmTmult(LAPACKFullMatrix<number> &      C,
        &nn,
        &kk,
        &alpha,
-       &this->values[0],
+       this->values.data(),
        &kk,
-       &B.values[0],
+       B.values.data(),
        &nn,
        &beta,
-       &C.values[0],
+       C.values.data(),
        &mm);
 }
 
@@ -1347,9 +1349,9 @@ LAPACKFullMatrix<number>::TmTmult(FullMatrix<number> &            C,
        &mm,
        &kk,
        &alpha,
-       &B.values[0],
+       B.values.data(),
        &nn,
-       &this->values[0],
+       this->values.data(),
        &kk,
        &beta,
        &C(0, 0),
@@ -1366,7 +1368,7 @@ LAPACKFullMatrix<number>::compute_lu_factorization()
 
   const types::blas_int mm     = this->m();
   const types::blas_int nn     = this->n();
-  number *const         values = &this->values[0];
+  number *const         values = this->values.data();
   ipiv.resize(mm);
   types::blas_int info = 0;
   getrf(&mm, &nn, values, &mm, ipiv.data(), &info);
@@ -1432,7 +1434,7 @@ LAPACKFullMatrix<number>::norm(const char type) const
 
   const types::blas_int N      = this->n();
   const types::blas_int M      = this->m();
-  const number *const   values = &this->values[0];
+  const number *const   values = this->values.data();
   if (property == symmetric)
     {
       const types::blas_int lda = std::max<types::blas_int>(1, N);
@@ -1484,7 +1486,7 @@ LAPACKFullMatrix<number>::compute_cholesky_factorization()
   (void)mm;
   Assert(mm == nn, ExcDimensionMismatch(mm, nn));
 
-  number *const         values = &this->values[0];
+  number *const         values = this->values.data();
   types::blas_int       info   = 0;
   const types::blas_int lda    = std::max<types::blas_int>(1, nn);
   potrf(&LAPACKSupport::L, &nn, values, &lda, &info);
@@ -1507,7 +1509,7 @@ LAPACKFullMatrix<number>::reciprocal_condition_number(const number a_norm) const
   number rcond = 0.;
 
   const types::blas_int N      = this->m();
-  const number *        values = &this->values[0];
+  const number *        values = this->values.data();
   types::blas_int       info   = 0;
   const types::blas_int lda    = std::max<types::blas_int>(1, N);
   work.resize(3 * N);
@@ -1541,7 +1543,7 @@ LAPACKFullMatrix<number>::reciprocal_condition_number() const
   number rcond = 0.;
 
   const types::blas_int N      = this->m();
-  const number *const   values = &this->values[0];
+  const number *const   values = this->values.data();
   types::blas_int       info   = 0;
   const types::blas_int lda    = std::max<types::blas_int>(1, N);
   work.resize(3 * N);
@@ -1698,7 +1700,7 @@ LAPACKFullMatrix<number>::invert()
   const types::blas_int nn = this->n();
   Assert(nn == mm, ExcNotQuadratic());
 
-  number *const   values = &this->values[0];
+  number *const   values = this->values.data();
   types::blas_int info   = 0;
 
   if (property != symmetric)
@@ -1740,7 +1742,7 @@ LAPACKFullMatrix<number>::solve(Vector<number> &v, const bool transposed) const
   AssertDimension(this->m(), v.size());
   const char *          trans  = transposed ? &T : &N;
   const types::blas_int nn     = this->n();
-  const number *const   values = &this->values[0];
+  const number *const   values = this->values.data();
   const types::blas_int n_rhs  = 1;
   types::blas_int       info   = 0;
 
@@ -1786,19 +1788,32 @@ LAPACKFullMatrix<number>::solve(LAPACKFullMatrix<number> &B,
   AssertDimension(this->m(), B.m());
   const char *          trans  = transposed ? &T : &N;
   const types::blas_int nn     = this->n();
-  const number *const   values = &this->values[0];
+  const number *const   values = this->values.data();
   const types::blas_int n_rhs  = B.n();
   types::blas_int       info   = 0;
 
   if (state == lu)
     {
-      getrs(
-        trans, &nn, &n_rhs, values, &nn, ipiv.data(), &B.values[0], &nn, &info);
+      getrs(trans,
+            &nn,
+            &n_rhs,
+            values,
+            &nn,
+            ipiv.data(),
+            B.values.data(),
+            &nn,
+            &info);
     }
   else if (state == cholesky)
     {
-      potrs(
-        &LAPACKSupport::L, &nn, &n_rhs, values, &nn, &B.values[0], &nn, &info);
+      potrs(&LAPACKSupport::L,
+            &nn,
+            &n_rhs,
+            values,
+            &nn,
+            B.values.data(),
+            &nn,
+            &info);
     }
   else if (property == upper_triangular || property == lower_triangular)
     {
@@ -1814,7 +1829,7 @@ LAPACKFullMatrix<number>::solve(LAPACKFullMatrix<number> &B,
             &n_rhs,
             values,
             &lda,
-            &B.values[0],
+            B.values.data(),
             &ldb,
             &info);
     }
@@ -1977,8 +1992,8 @@ LAPACKFullMatrix<number>::compute_eigenvalues_symmetric(
   wr.resize(nn);
   LAPACKFullMatrix<number> matrix_eigenvectors(nn, nn);
 
-  number *const values_A            = &this->values[0];
-  number *const values_eigenvectors = &matrix_eigenvectors.values[0];
+  number *const values_A            = this->values.data();
+  number *const values_eigenvectors = matrix_eigenvectors.values.data();
 
   types::blas_int              info(0), lwork(-1), n_eigenpairs(0);
   const char *const            jobz(&V);
@@ -2092,9 +2107,9 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric(
   wr.resize(nn);
   LAPACKFullMatrix<number> matrix_eigenvectors(nn, nn);
 
-  number *const values_A            = &this->values[0];
-  number *const values_B            = &B.values[0];
-  number *const values_eigenvectors = &matrix_eigenvectors.values[0];
+  number *const values_A            = this->values.data();
+  number *const values_B            = B.values.data();
+  number *const values_eigenvectors = matrix_eigenvectors.values.data();
 
   types::blas_int              info(0), lwork(-1), n_eigenpairs(0);
   const char *const            jobz(&V);
@@ -2216,8 +2231,8 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric(
   wi.resize(nn); // This is set purely for consistency reasons with the
   // eigenvalues() function.
 
-  number *const values_A = &this->values[0];
-  number *const values_B = &B.values[0];
+  number *const values_A = this->values.data();
+  number *const values_B = B.values.data();
 
   types::blas_int   info  = 0;
   types::blas_int   lwork = -1;

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -456,7 +456,7 @@ namespace PETScWrappers
           // now copy over the information
           // from the sparsity pattern.
           {
-            PetscInt *ptr = &colnums_in_window[0];
+            PetscInt *ptr = colnums_in_window.data();
             for (PetscInt i = local_row_start; i < local_row_end; ++i)
               for (typename SparsityPatternType::iterator p =
                      sparsity_pattern.begin(i);
@@ -583,7 +583,7 @@ namespace PETScWrappers
           // now copy over the information
           // from the sparsity pattern.
           {
-            PetscInt *ptr = &colnums_in_window[0];
+            PetscInt *ptr = colnums_in_window.data();
             for (size_type i = local_row_start; i < local_row_end; ++i)
               for (typename SparsityPatternType::iterator p =
                      sparsity_pattern.begin(i);

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -267,7 +267,7 @@ namespace PETScWrappers
 
       const PetscInt *ptr =
         (ghostindices.size() > 0 ?
-           reinterpret_cast<const PetscInt *>(&(ghostindices[0])) :
+           reinterpret_cast<const PetscInt *>(ghostindices.data()) :
            nullptr);
 
       PetscErrorCode ierr = VecCreateGhost(communicator,

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -994,7 +994,7 @@ namespace SparsityTools
       unsigned int idx = 0;
       for (const auto &sparsity_line : send_data)
         {
-          const int ierr = MPI_Isend(&(sparsity_line.second[0]),
+          const int ierr = MPI_Isend(sparsity_line.second.data(),
                                      sparsity_line.second.size(),
                                      DEAL_II_DOF_INDEX_MPI_TYPE,
                                      sparsity_line.first,
@@ -1138,7 +1138,7 @@ namespace SparsityTools
       unsigned int idx = 0;
       for (const auto &sparsity_line : send_data)
         {
-          const int ierr = MPI_Isend(&(sparsity_line.second[0]),
+          const int ierr = MPI_Isend(sparsity_line.second.data(),
                                      sparsity_line.second.size(),
                                      DEAL_II_DOF_INDEX_MPI_TYPE,
                                      sparsity_line.first,

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -146,9 +146,9 @@ namespace TrilinosWrappers
         this->a_row,
         colnums,
         ncols,
-        &((*value_cache)[0]),
+        value_cache->data(),
         reinterpret_cast<TrilinosWrappers::types::int_type *>(
-          &((*colnum_cache)[0])));
+          colnum_cache->data()));
       value_cache->resize(ncols);
       colnum_cache->resize(ncols);
       AssertThrow(ierr == 0, ExcTrilinosError(ierr));
@@ -207,7 +207,7 @@ namespace TrilinosWrappers
                                     *column_space_map,
                                     reinterpret_cast<int *>(
                                       const_cast<unsigned int *>(
-                                        &(n_entries_per_row[0]))),
+                                        n_entries_per_row.data())),
                                     false))
     , last_action(Zero)
     , compressed(false)
@@ -238,7 +238,7 @@ namespace TrilinosWrappers
                                     input_row_map,
                                     reinterpret_cast<int *>(
                                       const_cast<unsigned int *>(
-                                        &(n_entries_per_row[0]))),
+                                        n_entries_per_row.data())),
                                     false))
     , last_action(Zero)
     , compressed(false)
@@ -291,7 +291,7 @@ namespace TrilinosWrappers
                    Utilities::Trilinos::comm_self()),
         *column_space_map,
         reinterpret_cast<int *>(
-          const_cast<unsigned int *>(&(n_entries_per_row[0]))),
+          const_cast<unsigned int *>(n_entries_per_row.data())),
         false))
     , last_action(Zero)
     , compressed(false)
@@ -323,7 +323,7 @@ namespace TrilinosWrappers
                                     *column_space_map,
                                     reinterpret_cast<int *>(
                                       const_cast<unsigned int *>(
-                                        &(n_entries_per_row[0]))),
+                                        n_entries_per_row.data())),
                                     false))
     , last_action(Zero)
     , compressed(false)
@@ -358,7 +358,7 @@ namespace TrilinosWrappers
         Copy,
         row_parallel_partitioning.make_trilinos_map(communicator, false),
         reinterpret_cast<int *>(
-          const_cast<unsigned int *>(&(n_entries_per_row[0]))),
+          const_cast<unsigned int *>(n_entries_per_row.data())),
         false))
     , last_action(Zero)
     , compressed(false)

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -60,7 +60,7 @@ namespace TrilinosWrappers
             colnum_cache->size(),
             ncols,
             reinterpret_cast<TrilinosWrappers::types::int_type *>(
-              const_cast<size_type *>(&(*colnum_cache)[0])));
+              const_cast<size_type *>(colnum_cache->data())));
           AssertThrow(ierr == 0, ExcTrilinosError(ierr));
           AssertThrow(static_cast<std::vector<size_type>::size_type>(ncols) ==
                         colnum_cache->size(),

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -500,7 +500,7 @@ MGTransferMatrixFree<dim, Number>::do_restrict_add(
                                [(cell / vec_size) * three_to_dim],
             n_components,
             fe_degree,
-            &evaluation_data[0]);
+            evaluation_data.data());
           for (unsigned int c = 0; c < n_components; ++c)
             internal::FEEvaluationImplBasisChange<internal::evaluate_general,
                                                   dim,

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -577,8 +577,8 @@ DataOut<dim, DoFHandlerType>::build_patches(
   // now build the patches in parallel
   if (all_cells.size() > 0)
     WorkStream::run(
-      &all_cells[0],
-      &all_cells[0] + all_cells.size(),
+      all_cells.data(),
+      all_cells.data() + all_cells.size(),
       std::bind(&DataOut<dim, DoFHandlerType>::build_one_patch,
                 this,
                 std::placeholders::_1,

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -396,8 +396,8 @@ DataOutFaces<dim, DoFHandlerType>::build_patches(
     n_datasets, Utilities::fixed_power<dimension - 1>(n_subdivisions + 1));
 
   // now build the patches in parallel
-  WorkStream::run(&all_faces[0],
-                  &all_faces[0] + all_faces.size(),
+  WorkStream::run(all_faces.data(),
+                  all_faces.data() + all_faces.size(),
                   std::bind(&DataOutFaces<dim, DoFHandlerType>::build_one_patch,
                             this,
                             std::placeholders::_1,

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -533,8 +533,8 @@ DataOutRotation<dim, DoFHandlerType>::build_patches(
 
   // now build the patches in parallel
   WorkStream::run(
-    &all_cells[0],
-    &all_cells[0] + all_cells.size(),
+    all_cells.data(),
+    all_cells.data() + all_cells.size(),
     std::bind(&DataOutRotation<dim, DoFHandlerType>::build_one_patch,
               this,
               std::placeholders::_1,

--- a/source/numerics/kdtree.cc
+++ b/source/numerics/kdtree.cc
@@ -48,7 +48,7 @@ KDTree<dim>::get_points_within_ball(const Point<dim> &center,
   params.sorted = sorted;
 
   std::vector<std::pair<unsigned int, double>> matches;
-  kdtree->radiusSearch(&center[0], radius, matches, params);
+  kdtree->radiusSearch(center.begin_raw(), radius, matches, params);
 
   return matches;
 }
@@ -67,7 +67,10 @@ KDTree<dim>::get_closest_points(const Point<dim> & target,
   std::vector<unsigned int> indices(n_points);
   std::vector<double>       distances(n_points);
 
-  kdtree->knnSearch(&target[0], n_points, &indices[0], &distances[0]);
+  kdtree->knnSearch(target.begin_raw(),
+                    n_points,
+                    indices.data(),
+                    distances.data());
 
   // convert it to the format we want to return
   std::vector<std::pair<unsigned int, double>> matches(n_points);

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -904,7 +904,7 @@ namespace Particles
           AssertThrowMPI(ierr);
         }
       const int ierr =
-        MPI_Waitall(2 * n_neighbors, &n_requests[0], MPI_STATUSES_IGNORE);
+        MPI_Waitall(2 * n_neighbors, n_requests.data(), MPI_STATUSES_IGNORE);
       AssertThrowMPI(ierr);
     }
 
@@ -953,7 +953,7 @@ namespace Particles
             recv_ops++;
           }
       const int ierr =
-        MPI_Waitall(send_ops + recv_ops, &requests[0], MPI_STATUSES_IGNORE);
+        MPI_Waitall(send_ops + recv_ops, requests.data(), MPI_STATUSES_IGNORE);
       AssertThrowMPI(ierr);
     }
 


### PR DESCRIPTION
It is cleaner to just let the array decay into a pointer or use `Container::data()` when appropriate.