### PR TITLE
Deprecate VectorSlice.

### DIFF
--- a/doc/news/changes/incompatibilities/20190121DavidWells
+++ b/doc/news/changes/incompatibilities/20190121DavidWells
@@ -1,0 +1,6 @@
+Changed: VectorSlice has been deprecated in favor of the more general ArrayView
+class. All public interfaces now take ArrayView arguments instead of VectorSlice
+arguments. Since VectorSlice now inherits from ArrayView this should be
+compatible with the overwhelming majority of use cases.
+<br>
+(David Wells, 2019/01/21)

--- a/include/deal.II/base/vector_slice.h
+++ b/include/deal.II/base/vector_slice.h
@@ -23,7 +23,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
 /**
  * Filter a range out of any object having a random access <tt>operator[]
  * (unsigned int)</tt> and a function <tt>size() const</tt>.
@@ -45,9 +44,15 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @ingroup data
  * @author Guido Kanschat, 2004
+ *
+ * @deprecated Use the more general ArrayView class instead.
  */
 template <typename VectorType>
-class VectorSlice
+class DEAL_II_DEPRECATED VectorSlice
+  : public ArrayView<
+      typename std::conditional<std::is_const<VectorType>::value,
+                                const typename VectorType::value_type,
+                                typename VectorType::value_type>::type>
 {
 public:
   /**
@@ -63,74 +68,14 @@ public:
    */
   VectorSlice(VectorType &v, unsigned int start, unsigned int length);
 
+protected:
   /**
-   * Conversion operator to an ArrayView object that represents an array of
-   * non-const elements pointing to the same location as the current object.
+   * Alias for the base class name.
    */
-  operator ArrayView<typename VectorType::value_type *>();
-
-  /**
-   * Conversion operator to an ArrayView object that represents an array of
-   * const elements pointing to the same location as the current object.
-   */
-  operator ArrayView<const typename VectorType::value_type *>() const;
-
-  /**
-   * Return the length of the slice using the same interface as
-   * <tt>std::vector</tt>.
-   */
-  unsigned int
-  size() const;
-
-  /**
-   * Return a reference to the $i$th element of the range represented by the
-   * current object.
-   */
-  typename VectorType::reference operator[](unsigned int i);
-
-  /**
-   * Return a @p const reference to the $i$th element of the range represented
-   * by the current object.
-   */
-  typename VectorType::const_reference operator[](unsigned int i) const;
-
-  /**
-   * Standard-conforming iterator function.
-   */
-  typename VectorType::iterator
-  begin();
-
-  /**
-   * Standard-conforming iterator function.
-   */
-  typename VectorType::const_iterator
-  begin() const;
-
-  /**
-   * Standard-conforming iterator function.
-   */
-  typename VectorType::iterator
-  end();
-
-  /**
-   * Standard-conforming iterator function.
-   */
-  typename VectorType::const_iterator
-  end() const;
-
-private:
-  /**
-   * The vector we extract from.
-   */
-  VectorType &v;
-  /**
-   * The start index of the slice.
-   */
-  const unsigned int start;
-  /**
-   * The length of the slice.
-   */
-  const unsigned int length;
+  using ArrayViewType =
+    ArrayView<typename std::conditional<std::is_const<VectorType>::value,
+                                        const typename VectorType::value_type,
+                                        typename VectorType::value_type>::type>;
 };
 
 
@@ -172,97 +117,20 @@ make_slice(VectorType &v, const unsigned int start, const unsigned int length)
 
 template <typename VectorType>
 inline VectorSlice<VectorType>::VectorSlice(VectorType &v)
-  : v(v)
-  , start(0)
-  , length(v.size())
+  : ArrayViewType(make_array_view(std::begin(v), std::end(v)))
 {}
+
 
 
 template <typename VectorType>
 inline VectorSlice<VectorType>::VectorSlice(VectorType & v,
                                             unsigned int start,
                                             unsigned int length)
-  : v(v)
-  , start(start)
-  , length(length)
+  : ArrayViewType(
+      make_array_view(std::begin(v) + start, std::begin(v) + start + length))
 {
   Assert((start + length <= v.size()),
          ExcIndexRange(length, 0, v.size() - start + 1));
-}
-
-
-template <typename VectorType>
-inline unsigned int
-VectorSlice<VectorType>::size() const
-{
-  return length;
-}
-
-
-template <typename VectorType>
-VectorSlice<VectorType>::operator ArrayView<typename VectorType::value_type *>()
-{
-  return ArrayView<typename VectorType::value_type *>(&v[start], length);
-}
-
-
-template <typename VectorType>
-VectorSlice<VectorType>::
-operator ArrayView<const typename VectorType::value_type *>() const
-{
-  return ArrayView<const typename VectorType::value_type *>(&v[start], length);
-}
-
-
-template <typename VectorType>
-inline typename VectorType::reference VectorSlice<VectorType>::
-                                      operator[](unsigned int i)
-{
-  Assert((i < length), ExcIndexRange(i, 0, length));
-
-  return v[start + i];
-}
-
-
-template <typename VectorType>
-inline typename VectorType::const_reference VectorSlice<VectorType>::
-                                            operator[](unsigned int i) const
-{
-  Assert((i < length), ExcIndexRange(i, 0, length));
-
-  return v[start + i];
-}
-
-
-template <typename VectorType>
-inline typename VectorType::const_iterator
-VectorSlice<VectorType>::begin() const
-{
-  return v.begin() + start;
-}
-
-
-template <typename VectorType>
-inline typename VectorType::iterator
-VectorSlice<VectorType>::begin()
-{
-  return v.begin() + start;
-}
-
-
-template <typename VectorType>
-inline typename VectorType::const_iterator
-VectorSlice<VectorType>::end() const
-{
-  return v.begin() + start + length;
-}
-
-
-template <typename VectorType>
-inline typename VectorType::iterator
-VectorSlice<VectorType>::end()
-{
-  return v.begin() + start + length;
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2331,9 +2331,9 @@ public:
   template <class InputVector>
   void
   get_function_values(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-    std::vector<typename InputVector::value_type> &values) const;
+    const InputVector &                             fe_function,
+    const ArrayView<const types::global_dof_index> &indices,
+    std::vector<typename InputVector::value_type> & values) const;
 
   /**
    * Generate vector function values from an arbitrary vector.
@@ -2359,8 +2359,8 @@ public:
   template <class InputVector>
   void
   get_function_values(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
+    const InputVector &                                    fe_function,
+    const ArrayView<const types::global_dof_index> &       indices,
     std::vector<Vector<typename InputVector::value_type>> &values) const;
 
 
@@ -2397,10 +2397,9 @@ public:
   template <class InputVector>
   void
   get_function_values(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-    VectorSlice<std::vector<std::vector<typename InputVector::value_type>>>
-               values,
+    const InputVector &                                      fe_function,
+    const ArrayView<const types::global_dof_index> &         indices,
+    ArrayView<std::vector<typename InputVector::value_type>> values,
     const bool quadrature_points_fastest) const;
 
   //@}
@@ -2485,8 +2484,8 @@ public:
   template <class InputVector>
   void
   get_function_gradients(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
+    const InputVector &                             fe_function,
+    const ArrayView<const types::global_dof_index> &indices,
     std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
       &gradients) const;
 
@@ -2499,10 +2498,10 @@ public:
   template <class InputVector>
   void
   get_function_gradients(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-    VectorSlice<std::vector<
-      std::vector<Tensor<1, spacedim, typename InputVector::value_type>>>>
+    const InputVector &                             fe_function,
+    const ArrayView<const types::global_dof_index> &indices,
+    ArrayView<
+      std::vector<Tensor<1, spacedim, typename InputVector::value_type>>>
          gradients,
     bool quadrature_points_fastest = false) const;
 
@@ -2590,8 +2589,8 @@ public:
   template <class InputVector>
   void
   get_function_hessians(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
+    const InputVector &                             fe_function,
+    const ArrayView<const types::global_dof_index> &indices,
     std::vector<Tensor<2, spacedim, typename InputVector::value_type>>
       &hessians) const;
 
@@ -2604,10 +2603,10 @@ public:
   template <class InputVector>
   void
   get_function_hessians(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-    VectorSlice<std::vector<
-      std::vector<Tensor<2, spacedim, typename InputVector::value_type>>>>
+    const InputVector &                             fe_function,
+    const ArrayView<const types::global_dof_index> &indices,
+    ArrayView<
+      std::vector<Tensor<2, spacedim, typename InputVector::value_type>>>
          hessians,
     bool quadrature_points_fastest = false) const;
 
@@ -2693,9 +2692,9 @@ public:
   template <class InputVector>
   void
   get_function_laplacians(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-    std::vector<typename InputVector::value_type> &laplacians) const;
+    const InputVector &                             fe_function,
+    const ArrayView<const types::global_dof_index> &indices,
+    std::vector<typename InputVector::value_type> & laplacians) const;
 
   /**
    * Access to the second derivatives of a function with more flexibility. See
@@ -2706,8 +2705,8 @@ public:
   template <class InputVector>
   void
   get_function_laplacians(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
+    const InputVector &                                    fe_function,
+    const ArrayView<const types::global_dof_index> &       indices,
     std::vector<Vector<typename InputVector::value_type>> &laplacians) const;
 
   /**
@@ -2719,9 +2718,9 @@ public:
   template <class InputVector>
   void
   get_function_laplacians(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-    std::vector<std::vector<typename InputVector::value_type>> &   laplacians,
+    const InputVector &                                         fe_function,
+    const ArrayView<const types::global_dof_index> &            indices,
+    std::vector<std::vector<typename InputVector::value_type>> &laplacians,
     bool quadrature_points_fastest = false) const;
 
   //@}
@@ -2809,8 +2808,8 @@ public:
   template <class InputVector>
   void
   get_function_third_derivatives(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
+    const InputVector &                             fe_function,
+    const ArrayView<const types::global_dof_index> &indices,
     std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
       &third_derivatives) const;
 
@@ -2823,10 +2822,10 @@ public:
   template <class InputVector>
   void
   get_function_third_derivatives(
-    const InputVector &                                            fe_function,
-    const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-    VectorSlice<std::vector<
-      std::vector<Tensor<3, spacedim, typename InputVector::value_type>>>>
+    const InputVector &                             fe_function,
+    const ArrayView<const types::global_dof_index> &indices,
+    ArrayView<
+      std::vector<Tensor<3, spacedim, typename InputVector::value_type>>>
          third_derivatives,
     bool quadrature_points_fastest = false) const;
   //@}

--- a/include/deal.II/integrators/advection.h
+++ b/include/deal.II/integrators/advection.h
@@ -77,12 +77,11 @@ namespace LocalIntegrators
      */
     template <int dim>
     void
-    cell_matrix(
-      FullMatrix<double> &                                       M,
-      const FEValuesBase<dim> &                                  fe,
-      const FEValuesBase<dim> &                                  fetest,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      const double                                               factor = 1.)
+    cell_matrix(FullMatrix<double> &                        M,
+                const FEValuesBase<dim> &                   fe,
+                const FEValuesBase<dim> &                   fetest,
+                const ArrayView<const std::vector<double>> &velocity,
+                const double                                factor = 1.)
     {
       const unsigned int n_dofs       = fe.dofs_per_cell;
       const unsigned int t_dofs       = fetest.dofs_per_cell;
@@ -134,12 +133,11 @@ namespace LocalIntegrators
      */
     template <int dim>
     inline void
-    cell_residual(
-      Vector<double> &                                           result,
-      const FEValuesBase<dim> &                                  fe,
-      const std::vector<Tensor<1, dim>> &                        input,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      double                                                     factor = 1.)
+    cell_residual(Vector<double> &                            result,
+                  const FEValuesBase<dim> &                   fe,
+                  const std::vector<Tensor<1, dim>> &         input,
+                  const ArrayView<const std::vector<double>> &velocity,
+                  double                                      factor = 1.)
     {
       const unsigned int nq     = fe.n_quadrature_points;
       const unsigned int n_dofs = fe.dofs_per_cell;
@@ -178,12 +176,11 @@ namespace LocalIntegrators
      */
     template <int dim>
     inline void
-    cell_residual(
-      Vector<double> &                                                   result,
-      const FEValuesBase<dim> &                                          fe,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &input,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      double                                                     factor = 1.)
+    cell_residual(Vector<double> &                                    result,
+                  const FEValuesBase<dim> &                           fe,
+                  const ArrayView<const std::vector<Tensor<1, dim>>> &input,
+                  const ArrayView<const std::vector<double>> &        velocity,
+                  double factor = 1.)
     {
       const unsigned int nq     = fe.n_quadrature_points;
       const unsigned int n_dofs = fe.dofs_per_cell;
@@ -221,12 +218,11 @@ namespace LocalIntegrators
      */
     template <int dim>
     inline void
-    cell_residual(
-      Vector<double> &                                           result,
-      const FEValuesBase<dim> &                                  fe,
-      const std::vector<double> &                                input,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      double                                                     factor = 1.)
+    cell_residual(Vector<double> &                            result,
+                  const FEValuesBase<dim> &                   fe,
+                  const std::vector<double> &                 input,
+                  const ArrayView<const std::vector<double>> &velocity,
+                  double                                      factor = 1.)
     {
       const unsigned int nq     = fe.n_quadrature_points;
       const unsigned int n_dofs = fe.dofs_per_cell;
@@ -262,12 +258,11 @@ namespace LocalIntegrators
      */
     template <int dim>
     inline void
-    cell_residual(
-      Vector<double> &                                           result,
-      const FEValuesBase<dim> &                                  fe,
-      const VectorSlice<const std::vector<std::vector<double>>> &input,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      double                                                     factor = 1.)
+    cell_residual(Vector<double> &                            result,
+                  const FEValuesBase<dim> &                   fe,
+                  const ArrayView<const std::vector<double>> &input,
+                  const ArrayView<const std::vector<double>> &velocity,
+                  double                                      factor = 1.)
     {
       const unsigned int nq     = fe.n_quadrature_points;
       const unsigned int n_dofs = fe.dofs_per_cell;
@@ -307,7 +302,7 @@ namespace LocalIntegrators
      * u_i v_j \, ds
      * @f]
      *
-     * The <tt>velocity</tt> is provided as a VectorSlice, having <tt>dim</tt>
+     * The <tt>velocity</tt> is provided as an ArrayView, having <tt>dim</tt>
      * vectors, one for each velocity component. Each of the vectors must
      * either have only a single entry, if the advection velocity is constant,
      * or have an entry for each quadrature point.
@@ -317,12 +312,11 @@ namespace LocalIntegrators
      */
     template <int dim>
     void
-    upwind_value_matrix(
-      FullMatrix<double> &                                       M,
-      const FEValuesBase<dim> &                                  fe,
-      const FEValuesBase<dim> &                                  fetest,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      double                                                     factor = 1.)
+    upwind_value_matrix(FullMatrix<double> &                        M,
+                        const FEValuesBase<dim> &                   fe,
+                        const FEValuesBase<dim> &                   fetest,
+                        const ArrayView<const std::vector<double>> &velocity,
+                        double                                      factor = 1.)
     {
       const unsigned int n_dofs       = fe.dofs_per_cell;
       const unsigned int t_dofs       = fetest.dofs_per_cell;
@@ -381,7 +375,7 @@ namespace LocalIntegrators
      * argument `input` on the outflow boundary. On the inflow boundary, it is
      * the inhomogenous boundary value in the argument `data`.
      *
-     * The <tt>velocity</tt> is provided as a VectorSlice, having <tt>dim</tt>
+     * The <tt>velocity</tt> is provided as an ArrayView, having <tt>dim</tt>
      * vectors, one for each velocity component. Each of the vectors must
      * either have only a single entry, if the advection velocity is constant,
      * or have an entry for each quadrature point.
@@ -391,13 +385,12 @@ namespace LocalIntegrators
      */
     template <int dim>
     inline void
-    upwind_value_residual(
-      Vector<double> &                                           result,
-      const FEValuesBase<dim> &                                  fe,
-      const std::vector<double> &                                input,
-      const std::vector<double> &                                data,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      double                                                     factor = 1.)
+    upwind_value_residual(Vector<double> &                            result,
+                          const FEValuesBase<dim> &                   fe,
+                          const std::vector<double> &                 input,
+                          const std::vector<double> &                 data,
+                          const ArrayView<const std::vector<double>> &velocity,
+                          double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
 
@@ -449,7 +442,7 @@ namespace LocalIntegrators
      * argument `input` on the outflow boundary. On the inflow boundary, it is
      * the inhomogenous boundary value in the argument `data`.
      *
-     * The <tt>velocity</tt> is provided as a VectorSlice, having <tt>dim</tt>
+     * The <tt>velocity</tt> is provided as an ArrayView, having <tt>dim</tt>
      * vectors, one for each velocity component. Each of the vectors must
      * either have only a single entry, if the advection velocity is constant,
      * or have an entry for each quadrature point.
@@ -459,13 +452,12 @@ namespace LocalIntegrators
      */
     template <int dim>
     inline void
-    upwind_value_residual(
-      Vector<double> &                                           result,
-      const FEValuesBase<dim> &                                  fe,
-      const VectorSlice<const std::vector<std::vector<double>>> &input,
-      const VectorSlice<const std::vector<std::vector<double>>> &data,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      double                                                     factor = 1.)
+    upwind_value_residual(Vector<double> &                            result,
+                          const FEValuesBase<dim> &                   fe,
+                          const ArrayView<const std::vector<double>> &input,
+                          const ArrayView<const std::vector<double>> &data,
+                          const ArrayView<const std::vector<double>> &velocity,
+                          double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       const unsigned int n_comp = fe.get_fe().n_components();
@@ -517,7 +509,7 @@ namespace LocalIntegrators
      * \,ds
      * @f]
      *
-     * The <tt>velocity</tt> is provided as a VectorSlice, having <tt>dim</tt>
+     * The <tt>velocity</tt> is provided as an ArrayView, having <tt>dim</tt>
      * vectors, one for each velocity component. Each of the vectors must
      * either have only a single entry, if the advection velocity is constant,
      * or have an entry for each quadrature point.
@@ -527,17 +519,16 @@ namespace LocalIntegrators
      */
     template <int dim>
     void
-    upwind_value_matrix(
-      FullMatrix<double> &                                       M11,
-      FullMatrix<double> &                                       M12,
-      FullMatrix<double> &                                       M21,
-      FullMatrix<double> &                                       M22,
-      const FEValuesBase<dim> &                                  fe1,
-      const FEValuesBase<dim> &                                  fe2,
-      const FEValuesBase<dim> &                                  fetest1,
-      const FEValuesBase<dim> &                                  fetest2,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      const double                                               factor = 1.)
+    upwind_value_matrix(FullMatrix<double> &                        M11,
+                        FullMatrix<double> &                        M12,
+                        FullMatrix<double> &                        M21,
+                        FullMatrix<double> &                        M22,
+                        const FEValuesBase<dim> &                   fe1,
+                        const FEValuesBase<dim> &                   fe2,
+                        const FEValuesBase<dim> &                   fetest1,
+                        const FEValuesBase<dim> &                   fetest2,
+                        const ArrayView<const std::vector<double>> &velocity,
+                        const double                                factor = 1.)
     {
       const unsigned int n1 = fe1.dofs_per_cell;
       // Multiply the quadrature point
@@ -603,7 +594,7 @@ namespace LocalIntegrators
      * \,ds
      * @f]
      *
-     * The <tt>velocity</tt> is provided as a VectorSlice, having <tt>dim</tt>
+     * The <tt>velocity</tt> is provided as an ArrayView, having <tt>dim</tt>
      * vectors, one for each velocity component. Each of the vectors must
      * either have only a single entry, if the advection velocity is constant,
      * or have an entry for each quadrature point.
@@ -613,15 +604,14 @@ namespace LocalIntegrators
      */
     template <int dim>
     void
-    upwind_face_residual(
-      Vector<double> &                                           result1,
-      Vector<double> &                                           result2,
-      const FEValuesBase<dim> &                                  fe1,
-      const FEValuesBase<dim> &                                  fe2,
-      const std::vector<double> &                                input1,
-      const std::vector<double> &                                input2,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      const double                                               factor = 1.)
+    upwind_face_residual(Vector<double> &                            result1,
+                         Vector<double> &                            result2,
+                         const FEValuesBase<dim> &                   fe1,
+                         const FEValuesBase<dim> &                   fe2,
+                         const std::vector<double> &                 input1,
+                         const std::vector<double> &                 input2,
+                         const ArrayView<const std::vector<double>> &velocity,
+                         const double factor = 1.)
     {
       Assert(fe1.get_fe().n_components() == 1,
              ExcDimensionMismatch(fe1.get_fe().n_components(), 1));
@@ -681,7 +671,7 @@ namespace LocalIntegrators
      * \,ds
      * @f]
      *
-     * The <tt>velocity</tt> is provided as a VectorSlice, having <tt>dim</tt>
+     * The <tt>velocity</tt> is provided as an ArrayView, having <tt>dim</tt>
      * vectors, one for each velocity component. Each of the vectors must
      * either have only a single entry, if the advection velocity is constant,
      * or have an entry for each quadrature point.
@@ -691,15 +681,14 @@ namespace LocalIntegrators
      */
     template <int dim>
     void
-    upwind_face_residual(
-      Vector<double> &                                           result1,
-      Vector<double> &                                           result2,
-      const FEValuesBase<dim> &                                  fe1,
-      const FEValuesBase<dim> &                                  fe2,
-      const VectorSlice<const std::vector<std::vector<double>>> &input1,
-      const VectorSlice<const std::vector<std::vector<double>>> &input2,
-      const VectorSlice<const std::vector<std::vector<double>>> &velocity,
-      const double                                               factor = 1.)
+    upwind_face_residual(Vector<double> &                            result1,
+                         Vector<double> &                            result2,
+                         const FEValuesBase<dim> &                   fe1,
+                         const FEValuesBase<dim> &                   fe2,
+                         const ArrayView<const std::vector<double>> &input1,
+                         const ArrayView<const std::vector<double>> &input2,
+                         const ArrayView<const std::vector<double>> &velocity,
+                         const double factor = 1.)
     {
       const unsigned int n_comp = fe1.get_fe().n_components();
       const unsigned int n1     = fe1.dofs_per_cell;

--- a/include/deal.II/integrators/divergence.h
+++ b/include/deal.II/integrators/divergence.h
@@ -98,11 +98,10 @@ namespace LocalIntegrators
      */
     template <int dim, typename number>
     void
-    cell_residual(
-      Vector<number> &                                                   result,
-      const FEValuesBase<dim> &                                          fetest,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &input,
-      const double factor = 1.)
+    cell_residual(Vector<number> &                                    result,
+                  const FEValuesBase<dim> &                           fetest,
+                  const ArrayView<const std::vector<Tensor<1, dim>>> &input,
+                  const double factor = 1.)
     {
       AssertDimension(fetest.get_fe().n_components(), 1);
       AssertVectorVectorDimension(input, dim, fetest.n_quadrature_points);
@@ -135,11 +134,10 @@ namespace LocalIntegrators
      */
     template <int dim, typename number>
     void
-    cell_residual(
-      Vector<number> &                                           result,
-      const FEValuesBase<dim> &                                  fetest,
-      const VectorSlice<const std::vector<std::vector<double>>> &input,
-      const double                                               factor = 1.)
+    cell_residual(Vector<number> &                            result,
+                  const FEValuesBase<dim> &                   fetest,
+                  const ArrayView<const std::vector<double>> &input,
+                  const double                                factor = 1.)
     {
       AssertDimension(fetest.get_fe().n_components(), 1);
       AssertVectorVectorDimension(input, dim, fetest.n_quadrature_points);
@@ -317,12 +315,11 @@ namespace LocalIntegrators
      */
     template <int dim, typename number>
     void
-    u_dot_n_residual(
-      Vector<number> &                                           result,
-      const FEValuesBase<dim> &                                  fe,
-      const FEValuesBase<dim> &                                  fetest,
-      const VectorSlice<const std::vector<std::vector<double>>> &data,
-      double                                                     factor = 1.)
+    u_dot_n_residual(Vector<number> &                            result,
+                     const FEValuesBase<dim> &                   fe,
+                     const FEValuesBase<dim> &                   fetest,
+                     const ArrayView<const std::vector<double>> &data,
+                     double                                      factor = 1.)
     {
       const unsigned int t_dofs = fetest.dofs_per_cell;
 
@@ -461,19 +458,17 @@ namespace LocalIntegrators
      */
     template <int dim, typename number>
     DEAL_II_DEPRECATED void
-    grad_div_residual(
-      Vector<number> &                                                   result,
-      const FEValuesBase<dim> &                                          fetest,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &input,
-      const double factor = 1.);
+    grad_div_residual(Vector<number> &         result,
+                      const FEValuesBase<dim> &fetest,
+                      const ArrayView<const std::vector<Tensor<1, dim>>> &input,
+                      const double factor = 1.);
 
     template <int dim, typename number>
     void
-    grad_div_residual(
-      Vector<number> &                                                   result,
-      const FEValuesBase<dim> &                                          fetest,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &input,
-      const double                                                       factor)
+    grad_div_residual(Vector<number> &         result,
+                      const FEValuesBase<dim> &fetest,
+                      const ArrayView<const std::vector<Tensor<1, dim>>> &input,
+                      const double factor)
     {
       GradDiv::cell_residual(result, fetest, input, factor);
     }
@@ -550,8 +545,8 @@ namespace LocalIntegrators
      */
     template <int dim>
     double
-    norm(const FEValuesBase<dim> &                                          fe,
-         const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &Du)
+    norm(const FEValuesBase<dim> &                           fe,
+         const ArrayView<const std::vector<Tensor<1, dim>>> &Du)
     {
       AssertDimension(fe.get_fe().n_components(), dim);
       AssertVectorVectorDimension(Du, dim, fe.n_quadrature_points);

--- a/include/deal.II/integrators/elasticity.h
+++ b/include/deal.II/integrators/elasticity.h
@@ -83,11 +83,10 @@ namespace LocalIntegrators
      */
     template <int dim, typename number>
     inline void
-    cell_residual(
-      Vector<number> &                                                   result,
-      const FEValuesBase<dim> &                                          fe,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &input,
-      double factor = 1.)
+    cell_residual(Vector<number> &                                    result,
+                  const FEValuesBase<dim> &                           fe,
+                  const ArrayView<const std::vector<Tensor<1, dim>>> &input,
+                  double factor = 1.)
     {
       const unsigned int nq     = fe.n_quadrature_points;
       const unsigned int n_dofs = fe.dofs_per_cell;
@@ -260,14 +259,13 @@ namespace LocalIntegrators
      */
     template <int dim, typename number>
     void
-    nitsche_residual(
-      Vector<number> &                                                   result,
-      const FEValuesBase<dim> &                                          fe,
-      const VectorSlice<const std::vector<std::vector<double>>> &        input,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &Dinput,
-      const VectorSlice<const std::vector<std::vector<double>>> &        data,
-      double penalty,
-      double factor = 1.)
+    nitsche_residual(Vector<number> &                                    result,
+                     const FEValuesBase<dim> &                           fe,
+                     const ArrayView<const std::vector<double>> &        input,
+                     const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput,
+                     const ArrayView<const std::vector<double>> &        data,
+                     double penalty,
+                     double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       AssertVectorVectorDimension(input, dim, fe.n_quadrature_points);
@@ -314,13 +312,13 @@ namespace LocalIntegrators
     template <int dim, typename number>
     inline void
     nitsche_tangential_residual(
-      Vector<number> &                                                   result,
-      const FEValuesBase<dim> &                                          fe,
-      const VectorSlice<const std::vector<std::vector<double>>> &        input,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &Dinput,
-      const VectorSlice<const std::vector<std::vector<double>>> &        data,
-      double penalty,
-      double factor = 1.)
+      Vector<number> &                                    result,
+      const FEValuesBase<dim> &                           fe,
+      const ArrayView<const std::vector<double>> &        input,
+      const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput,
+      const ArrayView<const std::vector<double>> &        data,
+      double                                              penalty,
+      double                                              factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       AssertVectorVectorDimension(input, dim, fe.n_quadrature_points);
@@ -395,12 +393,12 @@ namespace LocalIntegrators
     template <int dim, typename number>
     void
     nitsche_residual_homogeneous(
-      Vector<number> &                                                   result,
-      const FEValuesBase<dim> &                                          fe,
-      const VectorSlice<const std::vector<std::vector<double>>> &        input,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &Dinput,
-      double penalty,
-      double factor = 1.)
+      Vector<number> &                                    result,
+      const FEValuesBase<dim> &                           fe,
+      const ArrayView<const std::vector<double>> &        input,
+      const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput,
+      double                                              penalty,
+      double                                              factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       AssertVectorVectorDimension(input, dim, fe.n_quadrature_points);
@@ -550,20 +548,17 @@ namespace LocalIntegrators
      */
     template <int dim, typename number>
     void
-    ip_residual(
-      Vector<number> &                                           result1,
-      Vector<number> &                                           result2,
-      const FEValuesBase<dim> &                                  fe1,
-      const FEValuesBase<dim> &                                  fe2,
-      const VectorSlice<const std::vector<std::vector<double>>> &input1,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>>
-        &                                                        Dinput1,
-      const VectorSlice<const std::vector<std::vector<double>>> &input2,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>>
-        &    Dinput2,
-      double pen,
-      double int_factor = 1.,
-      double ext_factor = -1.)
+    ip_residual(Vector<number> &                                    result1,
+                Vector<number> &                                    result2,
+                const FEValuesBase<dim> &                           fe1,
+                const FEValuesBase<dim> &                           fe2,
+                const ArrayView<const std::vector<double>> &        input1,
+                const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput1,
+                const ArrayView<const std::vector<double>> &        input2,
+                const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput2,
+                double                                              pen,
+                double int_factor = 1.,
+                double ext_factor = -1.)
     {
       const unsigned int n1 = fe1.dofs_per_cell;
 

--- a/include/deal.II/integrators/grad_div.h
+++ b/include/deal.II/integrators/grad_div.h
@@ -91,11 +91,10 @@ namespace LocalIntegrators
      */
     template <int dim, typename number>
     void
-    cell_residual(
-      Vector<number> &                                                   result,
-      const FEValuesBase<dim> &                                          fetest,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &input,
-      const double factor = 1.)
+    cell_residual(Vector<number> &                                    result,
+                  const FEValuesBase<dim> &                           fetest,
+                  const ArrayView<const std::vector<Tensor<1, dim>>> &input,
+                  const double factor = 1.)
     {
       const unsigned int n_dofs = fetest.dofs_per_cell;
 
@@ -183,14 +182,13 @@ namespace LocalIntegrators
      */
     template <int dim>
     void
-    nitsche_residual(
-      Vector<double> &                                                   result,
-      const FEValuesBase<dim> &                                          fe,
-      const VectorSlice<const std::vector<std::vector<double>>> &        input,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &Dinput,
-      const VectorSlice<const std::vector<std::vector<double>>> &        data,
-      double penalty,
-      double factor = 1.)
+    nitsche_residual(Vector<double> &                                    result,
+                     const FEValuesBase<dim> &                           fe,
+                     const ArrayView<const std::vector<double>> &        input,
+                     const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput,
+                     const ArrayView<const std::vector<double>> &        data,
+                     double penalty,
+                     double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       AssertDimension(fe.get_fe().n_components(), dim)
@@ -318,20 +316,17 @@ namespace LocalIntegrators
      */
     template <int dim>
     void
-    ip_residual(
-      Vector<double> &                                           result1,
-      Vector<double> &                                           result2,
-      const FEValuesBase<dim> &                                  fe1,
-      const FEValuesBase<dim> &                                  fe2,
-      const VectorSlice<const std::vector<std::vector<double>>> &input1,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>>
-        &                                                        Dinput1,
-      const VectorSlice<const std::vector<std::vector<double>>> &input2,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>>
-        &    Dinput2,
-      double pen,
-      double int_factor = 1.,
-      double ext_factor = -1.)
+    ip_residual(Vector<double> &                                    result1,
+                Vector<double> &                                    result2,
+                const FEValuesBase<dim> &                           fe1,
+                const FEValuesBase<dim> &                           fe2,
+                const ArrayView<const std::vector<double>> &        input1,
+                const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput1,
+                const ArrayView<const std::vector<double>> &        input2,
+                const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput2,
+                double                                              pen,
+                double int_factor = 1.,
+                double ext_factor = -1.)
     {
       const unsigned int n1 = fe1.dofs_per_cell;
 

--- a/include/deal.II/integrators/l2.h
+++ b/include/deal.II/integrators/l2.h
@@ -176,10 +176,10 @@ namespace LocalIntegrators
      */
     template <int dim, typename number>
     void
-    L2(Vector<number> &                                           result,
-       const FEValuesBase<dim> &                                  fe,
-       const VectorSlice<const std::vector<std::vector<double>>> &input,
-       const double                                               factor = 1.)
+    L2(Vector<number> &                            result,
+       const FEValuesBase<dim> &                   fe,
+       const ArrayView<const std::vector<double>> &input,
+       const double                                factor = 1.)
     {
       const unsigned int n_dofs       = fe.dofs_per_cell;
       const unsigned int n_components = input.size();

--- a/include/deal.II/integrators/laplace.h
+++ b/include/deal.II/integrators/laplace.h
@@ -121,11 +121,10 @@ namespace LocalIntegrators
      */
     template <int dim>
     inline void
-    cell_residual(
-      Vector<double> &                                                   result,
-      const FEValuesBase<dim> &                                          fe,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &input,
-      double factor = 1.)
+    cell_residual(Vector<double> &                                    result,
+                  const FEValuesBase<dim> &                           fe,
+                  const ArrayView<const std::vector<Tensor<1, dim>>> &input,
+                  double factor = 1.)
     {
       const unsigned int nq     = fe.n_quadrature_points;
       const unsigned int n_dofs = fe.dofs_per_cell;
@@ -323,14 +322,13 @@ namespace LocalIntegrators
      */
     template <int dim>
     void
-    nitsche_residual(
-      Vector<double> &                                                   result,
-      const FEValuesBase<dim> &                                          fe,
-      const VectorSlice<const std::vector<std::vector<double>>> &        input,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>> &Dinput,
-      const VectorSlice<const std::vector<std::vector<double>>> &        data,
-      double penalty,
-      double factor = 1.)
+    nitsche_residual(Vector<double> &                                    result,
+                     const FEValuesBase<dim> &                           fe,
+                     const ArrayView<const std::vector<double>> &        input,
+                     const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput,
+                     const ArrayView<const std::vector<double>> &        data,
+                     double penalty,
+                     double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       const unsigned int n_comp = fe.get_fe().n_components();
@@ -639,20 +637,17 @@ namespace LocalIntegrators
      */
     template <int dim>
     void
-    ip_residual(
-      Vector<double> &                                           result1,
-      Vector<double> &                                           result2,
-      const FEValuesBase<dim> &                                  fe1,
-      const FEValuesBase<dim> &                                  fe2,
-      const VectorSlice<const std::vector<std::vector<double>>> &input1,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>>
-        &                                                        Dinput1,
-      const VectorSlice<const std::vector<std::vector<double>>> &input2,
-      const VectorSlice<const std::vector<std::vector<Tensor<1, dim>>>>
-        &    Dinput2,
-      double pen,
-      double int_factor = 1.,
-      double ext_factor = -1.)
+    ip_residual(Vector<double> &                                    result1,
+                Vector<double> &                                    result2,
+                const FEValuesBase<dim> &                           fe1,
+                const FEValuesBase<dim> &                           fe2,
+                const ArrayView<const std::vector<double>> &        input1,
+                const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput1,
+                const ArrayView<const std::vector<double>> &        input2,
+                const ArrayView<const std::vector<Tensor<1, dim>>> &Dinput2,
+                double                                              pen,
+                double int_factor = 1.,
+                double ext_factor = -1.)
     {
       const unsigned int n_comp = fe1.get_fe().n_components();
       const unsigned int n1     = fe1.dofs_per_cell;

--- a/include/deal.II/integrators/patches.h
+++ b/include/deal.II/integrators/patches.h
@@ -40,10 +40,10 @@ namespace LocalIntegrators
   namespace Patches
   {
     template <int dim>
-    inline void points_and_values(
-      Table<2, double> &                                         result,
-      const FEValuesBase<dim> &                                  fe,
-      const VectorSlice<const std::vector<std::vector<double>>> &input)
+    inline void
+      points_and_values(Table<2, double> &                          result,
+                        const FEValuesBase<dim> &                   fe,
+                        const ArrayView<const std::vector<double>> &input)
     {
       const unsigned int n_comp = fe.get_fe().n_components();
       AssertVectorVectorDimension(input, n_comp, fe.n_quadrature_points);

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -391,13 +391,13 @@ public:
          const size_type               chunk_size);
 
   /**
-   * Same as above, but with a VectorSlice argument instead.
+   * Same as above, but with an ArrayView argument instead.
    */
   void
-  reinit(const size_type                                  m,
-         const size_type                                  n,
-         const VectorSlice<const std::vector<size_type>> &row_lengths,
-         const size_type                                  chunk_size);
+  reinit(const size_type                   m,
+         const size_type                   n,
+         const ArrayView<const size_type> &row_lengths,
+         const size_type                   chunk_size);
 
   /**
    * This function compresses the sparsity structure that this object

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/array_view.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/linear_index_iterator.h>
 #include <deal.II/base/std_cxx14/memory.h>
@@ -51,8 +52,6 @@ template <typename number>
 class SparseLUDecomposition;
 template <typename number>
 class SparseILU;
-template <typename VectorType>
-class VectorSlice;
 
 namespace ChunkSparsityPatternIterators
 {
@@ -510,12 +509,12 @@ public:
 
 
   /**
-   * Same as above, but with a VectorSlice argument instead.
+   * Same as above, but with an ArrayView argument instead.
    */
   void
-  reinit(const size_type                                     m,
-         const size_type                                     n,
-         const VectorSlice<const std::vector<unsigned int>> &row_lengths);
+  reinit(const size_type                      m,
+         const size_type                      n,
+         const ArrayView<const unsigned int> &row_lengths);
 
   /**
    * This function compresses the sparsity structure that this object

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3680,9 +3680,9 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_values(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-  std::vector<typename InputVector::value_type> &                values) const
+  const InputVector &                             fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
+  std::vector<typename InputVector::value_type> & values) const
 {
   using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_values,
@@ -3732,9 +3732,9 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_values(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-  std::vector<Vector<typename InputVector::value_type>> &        values) const
+  const InputVector &                                    fe_function,
+  const ArrayView<const types::global_dof_index> &       indices,
+  std::vector<Vector<typename InputVector::value_type>> &values) const
 {
   using Number = typename InputVector::value_type;
   // Size of indices must be a multiple of dofs_per_cell such that an integer
@@ -3763,10 +3763,9 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_values(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-  VectorSlice<std::vector<std::vector<typename InputVector::value_type>>>
-       values,
+  const InputVector &                                      fe_function,
+  const ArrayView<const types::global_dof_index> &         indices,
+  ArrayView<std::vector<typename InputVector::value_type>> values,
   bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
@@ -3823,8 +3822,8 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_gradients(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
+  const InputVector &                             fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
   std::vector<Tensor<1, spacedim, typename InputVector::value_type>> &gradients)
   const
 {
@@ -3877,10 +3876,9 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_gradients(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-  VectorSlice<std::vector<
-    std::vector<Tensor<1, spacedim, typename InputVector::value_type>>>>
+  const InputVector &                             fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
+  ArrayView<std::vector<Tensor<1, spacedim, typename InputVector::value_type>>>
        gradients,
   bool quadrature_points_fastest) const
 {
@@ -3937,8 +3935,8 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_hessians(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
+  const InputVector &                             fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
   std::vector<Tensor<2, spacedim, typename InputVector::value_type>> &hessians)
   const
 {
@@ -3993,10 +3991,9 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_hessians(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-  VectorSlice<std::vector<
-    std::vector<Tensor<2, spacedim, typename InputVector::value_type>>>>
+  const InputVector &                             fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
+  ArrayView<std::vector<Tensor<2, spacedim, typename InputVector::value_type>>>
        hessians,
   bool quadrature_points_fastest) const
 {
@@ -4050,9 +4047,9 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_laplacians(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-  std::vector<typename InputVector::value_type> &laplacians) const
+  const InputVector &                             fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
+  std::vector<typename InputVector::value_type> & laplacians) const
 {
   using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_hessians,
@@ -4101,8 +4098,8 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_laplacians(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
+  const InputVector &                                    fe_function,
+  const ArrayView<const types::global_dof_index> &       indices,
   std::vector<Vector<typename InputVector::value_type>> &laplacians) const
 {
   using Number = typename InputVector::value_type;
@@ -4132,9 +4129,9 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_laplacians(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-  std::vector<std::vector<typename InputVector::value_type>> &   laplacians,
+  const InputVector &                                         fe_function,
+  const ArrayView<const types::global_dof_index> &            indices,
+  std::vector<std::vector<typename InputVector::value_type>> &laplacians,
   bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
@@ -4189,8 +4186,8 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_third_derivatives(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
+  const InputVector &                             fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
   std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
     &third_derivatives) const
 {
@@ -4246,10 +4243,9 @@ template <int dim, int spacedim>
 template <class InputVector>
 void
 FEValuesBase<dim, spacedim>::get_function_third_derivatives(
-  const InputVector &                                            fe_function,
-  const VectorSlice<const std::vector<types::global_dof_index>> &indices,
-  VectorSlice<std::vector<
-    std::vector<Tensor<3, spacedim, typename InputVector::value_type>>>>
+  const InputVector &                             fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
+  ArrayView<std::vector<Tensor<3, spacedim, typename InputVector::value_type>>>
        third_derivatives,
   bool quadrature_points_fastest) const
 {

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -359,27 +359,24 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
       get_function_values<VEC>(const VEC &, std::vector<VEC::value_type> &)
         const;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<VEC>(
-        const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
-        std::vector<VEC::value_type> &) const;
+      get_function_values<VEC>(const VEC &,
+                               const ArrayView<const types::global_dof_index> &,
+                               std::vector<VEC::value_type> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_values<VEC>(const VEC &,
                                std::vector<Vector<VEC::value_type>> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<VEC>(
-        const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
-        std::vector<Vector<VEC::value_type>> &) const;
+      get_function_values<VEC>(const VEC &,
+                               const ArrayView<const types::global_dof_index> &,
+                               std::vector<Vector<VEC::value_type>> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<VEC>(
-        const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
-        VectorSlice<std::vector<std::vector<VEC::value_type>>>,
-        bool) const;
+      get_function_values<VEC>(const VEC &,
+                               const ArrayView<const types::global_dof_index> &,
+                               ArrayView<std::vector<VEC::value_type>>,
+                               bool) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients<VEC>(
@@ -389,7 +386,7 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients<VEC>(
         const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>
           &) const;
 
@@ -402,9 +399,9 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients<VEC>(
         const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
-        VectorSlice<std::vector<std::vector<
-          dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>>>,
+        const ArrayView<const types::global_dof_index> &,
+        ArrayView<std::vector<
+          dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>>,
         bool) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
@@ -415,7 +412,7 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_hessians<VEC>(
         const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>
           &) const;
 
@@ -428,9 +425,9 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_hessians<VEC>(
         const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
-        VectorSlice<std::vector<std::vector<
-          dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>>>,
+        const ArrayView<const types::global_dof_index> &,
+        ArrayView<std::vector<
+          dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>>,
         bool) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
@@ -439,7 +436,7 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_laplacians<VEC>(
         const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<VEC::value_type> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
@@ -450,13 +447,13 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_laplacians<VEC>(
         const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<Vector<VEC::value_type>> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_laplacians<VEC>(
         const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<std::vector<VEC::value_type>> &,
         bool) const;
 
@@ -468,7 +465,7 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_third_derivatives<VEC>(
         const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>
           &) const;
 
@@ -481,9 +478,9 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_third_derivatives<VEC>(
         const VEC &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
-        VectorSlice<std::vector<std::vector<
-          dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>>>,
+        const ArrayView<const types::global_dof_index> &,
+        ArrayView<std::vector<
+          dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>>,
         bool) const;
 
 #endif
@@ -647,7 +644,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_values<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<IndexSet::value_type> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
@@ -658,14 +655,14 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_values<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<Vector<IndexSet::value_type>> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_values<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
-        VectorSlice<std::vector<std::vector<IndexSet::value_type>>>,
+        const ArrayView<const types::global_dof_index> &,
+        ArrayView<std::vector<IndexSet::value_type>>,
         bool) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
@@ -677,7 +674,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<
           dealii::Tensor<1, deal_II_space_dimension, IndexSet::value_type>> &)
         const;
@@ -691,9 +688,9 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
-        VectorSlice<std::vector<std::vector<
-          dealii::Tensor<1, deal_II_space_dimension, IndexSet::value_type>>>>,
+        const ArrayView<const types::global_dof_index> &,
+        ArrayView<std::vector<
+          dealii::Tensor<1, deal_II_space_dimension, IndexSet::value_type>>>,
         bool) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
@@ -705,7 +702,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_hessians<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<
           dealii::Tensor<2, deal_II_space_dimension, IndexSet::value_type>> &)
         const;
@@ -719,9 +716,9 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_hessians<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
-        VectorSlice<std::vector<std::vector<
-          dealii::Tensor<2, deal_II_space_dimension, IndexSet::value_type>>>>,
+        const ArrayView<const types::global_dof_index> &,
+        ArrayView<std::vector<
+          dealii::Tensor<2, deal_II_space_dimension, IndexSet::value_type>>>,
         bool) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
@@ -731,7 +728,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_laplacians<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<IndexSet::value_type> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
@@ -741,13 +738,13 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_laplacians<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<Vector<IndexSet::value_type>> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_laplacians<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<std::vector<IndexSet::value_type>> &,
         bool) const;
 
@@ -760,7 +757,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_third_derivatives<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
+        const ArrayView<const types::global_dof_index> &,
         std::vector<
           dealii::Tensor<3, deal_II_space_dimension, IndexSet::value_type>> &)
         const;
@@ -774,9 +771,9 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_third_derivatives<IndexSet>(
         const IndexSet &,
-        const VectorSlice<const std::vector<types::global_dof_index>> &,
-        VectorSlice<std::vector<std::vector<
-          dealii::Tensor<3, deal_II_space_dimension, IndexSet::value_type>>>>,
+        const ArrayView<const types::global_dof_index> &,
+        ArrayView<std::vector<
+          dealii::Tensor<3, deal_II_space_dimension, IndexSet::value_type>>>,
         bool) const;
 #endif
   }

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -356,8 +356,12 @@ BlockSparsityPattern::reinit(
                              row_lengths[j][0]);
         else
           {
-            VectorSlice<const std::vector<unsigned int>> block_rows(
-              row_lengths[j], start, length);
+            Assert(row_lengths[j].begin() + start + length <=
+                     row_lengths[j].end(),
+                   ExcInternalError());
+            ArrayView<const unsigned int> block_rows(row_lengths[j].data() +
+                                                       start,
+                                                     length);
             block(i, j).reinit(rows.block_size(i),
                                cols.block_size(j),
                                block_rows);

--- a/source/lac/chunk_sparsity_pattern.cc
+++ b/source/lac/chunk_sparsity_pattern.cc
@@ -128,11 +128,10 @@ ChunkSparsityPattern::reinit(const size_type m,
 
 
 void
-ChunkSparsityPattern::reinit(
-  const size_type                                  m,
-  const size_type                                  n,
-  const VectorSlice<const std::vector<size_type>> &row_lengths,
-  const size_type                                  chunk_size)
+ChunkSparsityPattern::reinit(const size_type                   m,
+                             const size_type                   n,
+                             const ArrayView<const size_type> &row_lengths,
+                             const size_type                   chunk_size)
 {
   Assert(row_lengths.size() == m, ExcInvalidNumber(m));
   Assert(chunk_size > 0, ExcInvalidNumber(chunk_size));

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -240,10 +240,9 @@ SparsityPattern::reinit(const size_type    m,
 
 
 void
-SparsityPattern::reinit(
-  const size_type                                     m,
-  const size_type                                     n,
-  const VectorSlice<const std::vector<unsigned int>> &row_lengths)
+SparsityPattern::reinit(const size_type                      m,
+                        const size_type                      n,
+                        const ArrayView<const unsigned int> &row_lengths)
 {
   AssertDimension(row_lengths.size(), m);
 


### PR DESCRIPTION
ArrayView offers the same functionality but in a more general way. We discussed doing this in the past but never quite pulled the trigger on deprecating this class.

This PR reimplements VectorSlice as a class inheriting from ArrayView, which automatically gives us all of the right conversions (i.e., references work correctly and passing by value slices correctly). I believe that this should be backwards compatible with the overwhelming majority of usages (i.e., everything except possible type trickery).