### PR TITLE
Fix warnings in Release mode

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1596,6 +1596,7 @@ namespace deal_II_exceptions
   AssertDimension(VEC.size(), DIM1);                 \
   for (const auto &subvector : VEC)                  \
     {                                                \
+      (void)subvector;                               \
       AssertDimension(subvector.size(), DIM2);       \
     }
 


### PR DESCRIPTION
Fixes the warnings in https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=7298.