### PR TITLE
DofTools: Sort dofs when applying periodic boundary conditions

### DIFF
--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2442,18 +2442,11 @@ namespace DoFTools
     const ComponentMask &            component_mask,
     const std::vector<unsigned int> &first_vector_components)
   {
-    using FaceVector = std::vector<
-      GridTools::PeriodicFacePair<typename DoFHandlerType::cell_iterator>>;
-    typename FaceVector::const_iterator it, end_periodic;
-    it           = periodic_faces.begin();
-    end_periodic = periodic_faces.end();
-
     // Loop over all periodic faces...
-    for (; it != end_periodic; ++it)
+    for (const auto &pair : periodic_faces)
       {
-        using FaceIterator        = typename DoFHandlerType::face_iterator;
-        const FaceIterator face_1 = it->cell[0]->face(it->face_idx[0]);
-        const FaceIterator face_2 = it->cell[1]->face(it->face_idx[1]);
+        const auto &face_1 = pair.cell[0]->face(pair.face_idx[0]);
+        const auto &face_2 = pair.cell[1]->face(pair.face_idx[1]);
 
         Assert(face_1->at_boundary() && face_2->at_boundary(),
                ExcInternalError());
@@ -2466,10 +2459,10 @@ namespace DoFTools
                                      face_2,
                                      constraints,
                                      component_mask,
-                                     it->orientation[0],
-                                     it->orientation[1],
-                                     it->orientation[2],
-                                     it->matrix,
+                                     pair.orientation[0],
+                                     pair.orientation[1],
+                                     pair.orientation[2],
+                                     pair.matrix,
                                      first_vector_components);
       }
   }


### PR DESCRIPTION
This commit restructures the actual implementation of
 make_periodicity_constraints to always sort dofs prior to entering them
 into an AffineConstraints object.

In reference to #7487