### PR TITLE
Use canonical webpages

### DIFF
--- a/contrib/utilities/check_encoding.py
+++ b/contrib/utilities/check_encoding.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2019 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+# This script checks if the files in the deal.II repository are encoded with
+# valid UTF8.
+#
+# This script should be invoked from the root folder of the deal.ii
+# repository:
+# contrib/utilities/check_encoding.py
+
+import glob
+import itertools
+
+filenames = itertools.chain(glob.iglob('**/*.h', recursive=True),
+                            glob.iglob('**/*.cc', recursive=True),
+                            glob.iglob('**/*.html', recursive=True))
+
+for filename in filenames:
+    try:
+        with open(filename, encoding='utf-8') as file:
+            file.read()
+    except:
+        raise Exception(filename + ' is not encoded is not encoded with UTF-8')

--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -303,6 +303,10 @@ ADD_CUSTOM_TARGET(doxygen ALL
   )
 ADD_DEPENDENCIES(documentation doxygen)
 
+# Set the canonical link for the doxygen webpages
+ADD_CUSTOM_COMMAND(TARGET doxygen POST_BUILD
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/set_canonical_doxygen.py)
+
 INSTALL(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/deal.tag
   DESTINATION ${DEAL_II_DOCHTML_RELDIR}/doxygen

--- a/doc/doxygen/scripts/set_canonical_doxygen.py
+++ b/doc/doxygen/scripts/set_canonical_doxygen.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2019 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+# This script sets the canonical webpage for all the webpages of the
+# doxygen documentation. For more information see
+# https://en.wikipedia.org/wiki/Canonical_link_element
+#
+# This script is invoked by CMake. To add the canonical link to the webpages of
+# the deal.ii repository you can use the script
+# contrib/utilities/set_canonical_webpages.py
+
+import glob
+
+filenames = glob.iglob('**/*html', recursive=True)
+
+for filename in filenames:
+    file = open(filename, 'r')
+    new_text_data = str()
+    if '<link rel="canonical"' not in file.read():
+        file.seek(0)
+        for line in file.readlines():
+            # Do not add the canonical link twice
+            canonical_link_added = False
+            new_text_data += line
+            if (not canonical_link_added) and ('<head>' in line):
+                new_text_data += ('<link rel="canonical" href="https://www.dealii.org/current/doxygen/deal.II/'
+                                  + filename + '" />' + '\n')
+                canonical_link_added = True
+        file.close()
+
+        # Truncate the file and write the new text
+        file = open(filename, 'w+')
+        file.write(new_text_data)
+        file.close()


### PR DESCRIPTION
I think that it would be a good idea to set the canonical webpages for the doxygen documentation. You can find the information here:
- https://en.wikipedia.org/wiki/Canonical_link_element
- https://support.google.com/webmasters/answer/139066?hl=en

Often I search the documentation with google. A couple of times I used old and outdated documentation because I didn't check the deal.ii version of the documentation. For example I've been using an old version of PETSc. The goal of the canonical link is to solve this problem.

How about the webpages point to the canonical website: https://www.dealii.org/current/doxygen/deal.II

I wouldn't use https://www.dealii.org/developer/doxygen/deal.II/index.html because it changes too often and google gets confused

How about the script `set_canonical_webpages.py` is run for the new and the old documentation. Also the website https://www.dealii.org/current/doxygen/deal.II should be created.

Let me know what you think :)