### PR TITLE
Make the internals of class Vector 'private:'.

### DIFF
--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1024,6 +1024,14 @@ private:
     thread_loop_partitioner;
 
   /**
+   * Allocate and align @p values along 64-byte boundaries. The size of the
+   * allocated memory is determined by @p max_vec_size . Copy first
+   * @p copy_n_el from the old values.
+   */
+  void
+  allocate(const size_type copy_n_el = 0);
+
+  /**
    * Make all other vector types friends.
    */
   template <typename Number2>
@@ -1034,15 +1042,6 @@ private:
    */
   template <typename Number2>
   friend class LAPACKFullMatrix;
-
-private:
-  /**
-   * Allocate and align @p values along 64-byte boundaries. The size of the
-   * allocated memory is determined by @p max_vec_size . Copy first
-   * @p copy_n_el from the old values.
-   */
-  void
-  allocate(const size_type copy_n_el = 0);
 };
 
 /*@}*/

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -992,9 +992,9 @@ public:
   memory_consumption() const;
   //@}
 
-protected:
+private:
   /**
-   * Dimension. Actual number of components contained in the vector.  Get this
+   * Dimension. Actual number of components contained in the vector. Get this
    * number by calling <tt>size()</tt>.
    */
   size_type vec_size;


### PR DESCRIPTION
Maybe surprisingly, they were 'protected:'. This was because we had that odd class that
was derived from class Vector and that subverted the whole memory management of the
base class -- it's probably some Freudian thing that I can't remember the class's
name, nor when we removed it. Either way, it's apparently gone because we can make
these members private without breaking compilation (at least on my laptop).