### PR TITLE
Use Trilinos functions and types for preconditioners

### DIFF
--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -232,7 +232,7 @@ namespace TrilinosWrappers
      * This is a pointer to the preconditioner object that is used when
      * applying the preconditioner.
      */
-    std::shared_ptr<Epetra_Operator> preconditioner;
+    Teuchos::RCP<Epetra_Operator> preconditioner;
 
     /**
      * Internal communication pattern in case the matrix needs to be copied

--- a/source/lac/trilinos_precondition.cc
+++ b/source/lac/trilinos_precondition.cc
@@ -77,7 +77,7 @@ namespace TrilinosWrappers
   Epetra_Operator &
   PreconditionBase::trilinos_operator() const
   {
-    AssertThrow(preconditioner,
+    AssertThrow(!preconditioner.is_null(),
                 ExcMessage("Trying to dereference a null pointer."));
     return (*preconditioner);
   }
@@ -679,9 +679,8 @@ namespace TrilinosWrappers
   PreconditionChebyshev::initialize(const SparseMatrix &  matrix,
                                     const AdditionalData &additional_data)
   {
-    preconditioner.reset();
     preconditioner =
-      std::make_shared<Ifpack_Chebyshev>(&matrix.trilinos_matrix());
+      Teuchos::rcp(new Ifpack_Chebyshev(&matrix.trilinos_matrix()));
 
     Ifpack_Chebyshev *ifpack =
       dynamic_cast<Ifpack_Chebyshev *>(preconditioner.get());

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -224,10 +224,8 @@ namespace TrilinosWrappers
   PreconditionAMG::initialize(const Epetra_RowMatrix &      matrix,
                               const Teuchos::ParameterList &ml_parameters)
   {
-    preconditioner.reset();
-    preconditioner =
-      std::make_shared<ML_Epetra::MultiLevelPreconditioner>(matrix,
-                                                            ml_parameters);
+    preconditioner.reset(
+      new ML_Epetra::MultiLevelPreconditioner(matrix, ml_parameters));
   }
 
 

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -566,7 +566,7 @@ namespace TrilinosWrappers
   {
     // Introduce the preconditioner, if the identity preconditioner is used,
     // the precondioner is set to none, ...
-    if (preconditioner.preconditioner.use_count() != 0)
+    if (preconditioner.preconditioner.strong_count() != 0)
       {
         const int ierr = solver.SetPrecOperator(
           const_cast<Epetra_Operator *>(preconditioner.preconditioner.get()));


### PR DESCRIPTION
Using `MueLU::CreateEpetraPreconditioner` the setup for ` PreconditionAMGMueLu` can be simplified.
It also seems to be natural to use `Teuchos::RCP` instead of `std::shared_ptr` here.

This PR let's me move another step towards fixing #6856. The new error I get when compiling with `Trilinos` with `CUDA`-enabled `Kokkos` is 
```
 /export/home/darndt/Trilinos-dev/include/Cuda/Kokkos_Cuda_Parallel.hpp(451): error: calling a __host__ function("") from a __device__ function("Kokkos::Impl::ParallelFor< ::,  ::Kokkos::RangePolicy< ::Kokkos::Cuda,  ::Kokkos::IndexType<int>  > ,  ::Kokkos::Cuda> ::      operator ()") is not allowed
 
 /export/home/darndt/Trilinos-dev/include/Cuda/Kokkos_Cuda_Parallel.hpp(451): error: calling a __host__ function("") from a __device__ function("Kokkos::Impl::ParallelFor< ::,  ::Kokkos::RangePolicy< ::Kokkos::Cuda,  ::Kokkos::IndexType<int>  > ,  ::Kokkos::Cuda> ::      operator ()") is not allowed
 
 /export/home/darndt/Trilinos-dev/include/Cuda/Kokkos_Cuda_Parallel.hpp(2461): error: calling a __host__ function("") from a __device__ function("Kokkos::Impl::ParallelReduce< ::Kokkos::Impl::CudaFunctorAdapter< ::,  ::Kokkos::RangePolicy< ::Kokkos::Cuda > , unsigned     long, void> ,  ::Kokkos::RangePolicy< ::Kokkos::Cuda > ,  ::Kokkos::InvalidType,  ::Kokkos::Cuda> ::operator ()") is not allowed
 
 /export/home/darndt/Trilinos-dev/include/Cuda/Kokkos_Cuda_Parallel.hpp(451): error: calling a __host__ function("") from a __device__ function("Kokkos::Impl::ParallelFor< ::,  ::Kokkos::RangePolicy< ::Kokkos::Cuda,  ::Kokkos::IndexType<int>  > ,  ::Kokkos::Cuda> ::      operator ()") is not allowed
```
This error even appears if I uncomment everything except for the header files in `source/lac/trilinos_precondition.cc`. Hence, it doesn't seem to be related to anything we do here, but to be a `Trilinos` problem.