### PR TITLE
Revert "tests: Fix mpi/periodicity_07 test"

### DIFF
--- a/tests/mpi/periodicity_07.cc
+++ b/tests/mpi/periodicity_07.cc
@@ -150,6 +150,7 @@ test(const unsigned numRefinementLevels = 2)
   AffineConstraints<double> constraints;
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);
+  DoFTools::make_hanging_node_constraints(dof_handler, constraints);
 
   std::vector<
     GridTools::PeriodicFacePair<typename DoFHandler<dim>::cell_iterator>>
@@ -163,6 +164,7 @@ test(const unsigned numRefinementLevels = 2)
 
   DoFTools::make_periodicity_constraints<DoFHandler<dim>>(periodicity_vectorDof,
                                                           constraints);
+  constraints.close();
 
   const bool consistent =
     constraints.is_consistent_in_parallel(locally_owned_dofs,
@@ -170,20 +172,8 @@ test(const unsigned numRefinementLevels = 2)
                                           mpi_communicator,
                                           /*verbose*/ true);
 
-  pcout << "Periodicity constraints are consistent in parallel: " << consistent
+  pcout << "Total constraints are consistent in parallel: " << consistent
         << std::endl;
-
-  DoFTools::make_hanging_node_constraints(dof_handler, constraints);
-
-  const bool hanging_consistent =
-    constraints.is_consistent_in_parallel(locally_owned_dofs,
-                                          locally_active_dofs,
-                                          mpi_communicator);
-
-  pcout << "Hanging nodes constraints are consistent in parallel: "
-        << hanging_consistent << std::endl;
-
-  constraints.close();
 }
 
 int

--- a/tests/mpi/periodicity_07.mpirun=13.output
+++ b/tests/mpi/periodicity_07.mpirun=13.output
@@ -1,3 +1,2 @@
 number of elements: 183
-Periodicity constraints are consistent in parallel: 1
-Hanging nodes constraints are consistent in parallel: 1
+Total constraints are consistent in parallel: 1


### PR DESCRIPTION
Actually, this is not a fix but a bug introduced in mpi/periodicity_07:
The check for consistency in parallel only works if the constraint
object had been closed beforehand.

This means that the order in which we are entering constraints into the
AffineConstraints container actually doesn't matter. This also implies
that my suggested fix of simply rearranging the order in which periodic
boundary conditions and hanging node conditions are applied actually
doesn't fix anything.

This reverts commit b037a42941ef284c20f705496c5b8b50587563b4.