### PR TITLE
Fix TrilinosWrappers::PreconditionMueLu

### DIFF
--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -1783,7 +1783,7 @@ namespace TrilinosWrappers
     /**
      * Destructor.
      */
-    ~PreconditionAMGMueLu() override;
+    virtual ~PreconditionAMGMueLu() override = default;
 
     /**
      * Let Trilinos compute a multilevel hierarchy for the solution of a

--- a/source/lac/trilinos_precondition_muelu.cc
+++ b/source/lac/trilinos_precondition_muelu.cc
@@ -55,19 +55,16 @@ namespace TrilinosWrappers
 
   PreconditionAMGMueLu::PreconditionAMGMueLu()
   {
+    // clang-tidy wants to default the constructor if we disable the check
+    // in case we compile without 64-bit indices
 #    ifdef DEAL_II_WITH_64BIT_INDICES
-    AssertThrow(false,
+    constexpr bool enabled = false;
+#    else
+    constexpr bool enabled = true;
+#    endif
+    AssertThrow(enabled,
                 ExcMessage(
                   "PreconditionAMGMueLu does not support 64bit-indices!"));
-#    endif
-  }
-
-
-
-  PreconditionAMGMueLu::~PreconditionAMGMueLu()
-  {
-    preconditioner.reset();
-    trilinos_matrix.reset();
   }
 
 

--- a/source/lac/trilinos_precondition_muelu.cc
+++ b/source/lac/trilinos_precondition_muelu.cc
@@ -18,21 +18,11 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 #  if DEAL_II_TRILINOS_VERSION_GTE(11, 14, 0)
-
 #    include <deal.II/lac/sparse_matrix.h>
-#    include <deal.II/lac/trilinos_index_access.h>
 #    include <deal.II/lac/trilinos_sparse_matrix.h>
-#    include <deal.II/lac/vector.h>
 
-#    include <Epetra_MultiVector.h>
-#    include <MueLu.hpp>
 #    include <MueLu_CreateEpetraPreconditioner.hpp>
-#    include <MueLu_EpetraOperator.hpp>
-#    include <MueLu_MLParameterListInterpreter.hpp>
-#    include <Teuchos_ParameterList.hpp>
-#    include <Teuchos_RCP.hpp>
 #    include <ml_MultiLevelPreconditioner.h>
-#    include <ml_include.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -97,6 +87,8 @@ namespace TrilinosWrappers
   {
     // Build the AMG preconditioner.
     Teuchos::ParameterList parameter_list;
+
+    parameter_list.set("parameterlist: syntax", "ml");
 
     if (additional_data.elliptic == true)
       ML_Epetra::SetDefaults("SA", parameter_list);


### PR DESCRIPTION
Fixes the failing tests in https://cdash.kyomu.43-1.org/viewTest.php?onlyfailed&buildid=7398.
I missed in the previous commit that the parameters need to be converted from `ML` to `MueLu`.
Previously, `MueLu::CreateEpetraPreconditioner` interpreted the parameters as `MueLu` parameters since it didn't find an entry `"parameterlist: syntax"` with value `"ml"`. Adding this entry lets `MueLu::CreateEpetraPreconditioner` call the correct interpreter.

Also, remove some include files we apparently don't need anymore.