### PR TITLE
Explicitly use Zoltan in two tests.

### DIFF
--- a/tests/fe/fe_enriched_color_05.cc
+++ b/tests/fe/fe_enriched_color_05.cc
@@ -254,8 +254,10 @@ main(int argc, char **argv)
     }
 
 #ifdef DATA_OUT_FE_ENRICHED
-  GridTools::partition_triangulation(
-    Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD), triangulation);
+  GridTools::partition_triangulation(Utilities::MPI::n_mpi_processes(
+                                       MPI_COMM_WORLD),
+                                     triangulation,
+                                     SparsityTools::Partitioner::zoltan);
   dof_handler.distribute_dofs(*fe_collection);
 
   plot_shape_function<dim>(dof_handler, 5);

--- a/tests/fe/fe_enriched_color_07.cc
+++ b/tests/fe/fe_enriched_color_07.cc
@@ -1424,7 +1424,9 @@ LaplaceProblem<dim>::setup_system()
 {
   pcout << "...start setup system" << std::endl;
 
-  GridTools::partition_triangulation(n_mpi_processes, triangulation);
+  GridTools::partition_triangulation(n_mpi_processes,
+                                     triangulation,
+                                     SparsityTools::Partitioner::zoltan);
 
   dof_handler.distribute_dofs(*fe_collection);
 


### PR DESCRIPTION
I found this when running the test suite for #7633 on my workstation.

This doesn't matter in 05 (since that test only uses one processor) but the output file states that we use Zoltan, so we should be consistent.

This is needed in 07 since the default third argument to partition_triangulation is metis, but the output file states that we use Zoltan.