### PR TITLE
Mark a few Subscriptor functions as inline.

### DIFF
--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -290,6 +290,37 @@ private:
 
 //---------------------------------------------------------------------------
 
+inline Subscriptor::Subscriptor()
+  : counter(0)
+  , object_info(nullptr)
+{}
+
+
+
+inline Subscriptor::Subscriptor(const Subscriptor &)
+  : counter(0)
+  , object_info(nullptr)
+{}
+
+
+
+inline Subscriptor &
+Subscriptor::operator=(const Subscriptor &s)
+{
+  object_info = s.object_info;
+  return *this;
+}
+
+
+
+inline unsigned int
+Subscriptor::n_subscriptions() const
+{
+  return counter;
+}
+
+
+
 template <class Archive>
 inline void
 Subscriptor::serialize(Archive &, const unsigned int)

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -31,23 +31,6 @@ static const char *unknown_subscriber = "unknown subscriber";
 std::mutex Subscriptor::mutex;
 
 
-Subscriptor::Subscriptor()
-  : counter(0)
-  , object_info(nullptr)
-{
-  // this has to go somewhere to avoid an extra warning.
-  (void)unknown_subscriber;
-}
-
-
-
-Subscriptor::Subscriptor(const Subscriptor &)
-  : counter(0)
-  , object_info(nullptr)
-{}
-
-
-
 Subscriptor::Subscriptor(Subscriptor &&subscriptor) noexcept
   : counter(0)
   , object_info(subscriptor.object_info)
@@ -133,15 +116,6 @@ Subscriptor::check_no_subscribers() const noexcept
 
 
 Subscriptor &
-Subscriptor::operator=(const Subscriptor &s)
-{
-  object_info = s.object_info;
-  return *this;
-}
-
-
-
-Subscriptor &
 Subscriptor::operator=(Subscriptor &&s) noexcept
 {
   for (const auto validity_ptr : s.validity_pointers)
@@ -220,14 +194,6 @@ Subscriptor::unsubscribe(std::atomic<bool> *const validity,
   validity_pointers.erase(validity_ptr_it);
   --counter;
   --it->second;
-}
-
-
-
-unsigned int
-Subscriptor::n_subscriptions() const
-{
-  return counter;
 }
 
 


### PR DESCRIPTION
These are simple enough that they should live in the header. This will allow classes inheriting from Subscriptor to potentially inline some more constructors too.