### PR TITLE
Disable SIMD vectorization in CUDA device code

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -114,7 +114,14 @@
  */
 
 #cmakedefine DEAL_II_WORDS_BIGENDIAN
-#define DEAL_II_COMPILER_VECTORIZATION_LEVEL @DEAL_II_COMPILER_VECTORIZATION_LEVEL@
+// We need to disable SIMD vectorization for CUDA device code.
+// Otherwise, nvcc compilers from version 9 on will emit an error message like:
+// "[...] contains a vector, which is not supported in device code"
+#ifdef __CUDA_ARCH__
+#  define DEAL_II_COMPILER_VECTORIZATION_LEVEL 0
+#else
+#  define DEAL_II_COMPILER_VECTORIZATION_LEVEL @DEAL_II_COMPILER_VECTORIZATION_LEVEL@
+#endif
 #define DEAL_II_OPENMP_SIMD_PRAGMA @DEAL_II_OPENMP_SIMD_PRAGMA@
 
 


### PR DESCRIPTION
Fixes #7542. As discussed there, we need to disable `SIMD` vectorization for `CUDA` device code with recent `nvcc` compilers. Otherwise, they fail with an error message like
```
"const dealii::VectorizedArray<double> &(const dealii::VectorizedArray<double> &)" contains a vector, which is not supported in device code".
```

In the end, I have no idea what `nvcc-8` did with these instructions...

@dsambit Can you try if this patch works for you as well?