### PR TITLE
Add missing headers in CUDA header file

### DIFF
--- a/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
@@ -19,6 +19,10 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/matrix_free/cuda_matrix_free.templates.h>
+
 #ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
Using `nvcc_wrapper`, `DEAL_II_COMPILER_CUDA_AWARE` is always true and all the header files are also tested properly in the `all-headers` tests. It turned out that `include/deal.II/matrix_free/cuda_tensor_product_kernels.h` missed two include files to be able to stand for its own.