### PR TITLE
 Be explicit about initialization of static const Tensor variables

### DIFF
--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1521,7 +1521,7 @@ namespace Patterns
             std::is_same<T, signed char>::value || std::is_same<T, char>::value)
           str << static_cast<int>(value);
         else if (std::is_same<T, bool>::value)
-          str << (value ? "true" : "false");
+          str << (static_cast<bool>(value) ? "true" : "false");
         else
           str << value;
         AssertThrow(p->match(str.str()), ExcNoMatch(str.str(), p.get()));

--- a/include/deal.II/base/tensor_function.templates.h
+++ b/include/deal.II/base/tensor_function.templates.h
@@ -123,7 +123,7 @@ template <int rank, int dim, typename Number>
 typename TensorFunction<rank, dim, Number>::gradient_type
 ConstantTensorFunction<rank, dim, Number>::gradient(const Point<dim> &) const
 {
-  static const Tensor<rank + 1, dim, Number> zero;
+  static const Tensor<rank + 1, dim, Number> zero{};
 
   return zero;
 }
@@ -140,7 +140,7 @@ ConstantTensorFunction<rank, dim, Number>::gradient_list(
   Assert(gradients.size() == points.size(),
          ExcDimensionMismatch(gradients.size(), points.size()));
 
-  static const Tensor<rank + 1, dim, Number> zero;
+  static const Tensor<rank + 1, dim, Number> zero{};
 
   for (unsigned int i = 0; i < gradients.size(); ++i)
     gradients[i] = zero;


### PR DESCRIPTION
Supersedes #7668. This is needed for older `clang` compilers.