### PR TITLE
Fix compiling with MSVC

### DIFF
--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -340,6 +340,11 @@ Subscriptor::list_subscribers(StreamType &stream) const
            << it.first << '\"' << std::endl;
 }
 
+// forward declare template specialization
+template <>
+void
+Subscriptor::subscribe<const char *>(std::atomic<bool> *const validity,
+                                     const char *             id) const;
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -178,7 +178,7 @@ public:
    * case, there is only one element. Specializations use SIMD intrinsics and
    * can work on multiple elements at the same time.
    */
-  static const unsigned int n_array_elements;
+  static const unsigned int n_array_elements = 1;
 
   // POD means that there should be no user-defined constructors, destructors
   // and copy functions (the standard is somewhat relaxed in C++2011, though).
@@ -453,7 +453,7 @@ private:
 
 // We need to have a separate declaration for static const members
 template <typename Number>
-const unsigned int VectorizedArray<Number>::n_array_elements = 1;
+const unsigned int VectorizedArray<Number>::n_array_elements;
 
 
 

--- a/source/base/vectorization.cc
+++ b/source/base/vectorization.cc
@@ -17,7 +17,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && !defined(DEAL_II_MSVC)
 const unsigned int VectorizedArray<double>::n_array_elements;
 const unsigned int VectorizedArray<float>::n_array_elements;
 #endif


### PR DESCRIPTION
These are the fixes I need to compile with MSVC again.
- MSVC doesn't find the specialization for `Subscriptor::subscribe` if we don't forward declare it in the header file.
- MSVC complains saying
```
'dealii::VectorizedArray<double>::n_array_elements': 'const' object must be initialized if not 'extern'
```
in `include/deal.II/base/vectorization.h` and 
```
error C2131: expression did not evaluate to a constant
```
at various places where `VectorizedArray::n_array_elements` is used.
- MSVC complains saying
```
error C2908: explicit specialization 'const unsigned int dealii::VectorizedArray<double>::n_array_elements' has already been instantiated`
```
in ` source/base/vectorization.cc`.


With these changes I can compile the library and build `step-1` at least.