### PR TITLE
Avoid calling a deprecated MPI function.

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -448,7 +448,7 @@ namespace Utilities
       MPI_Aint     displacements[] = {0, offsetof(MinMaxAvg, min_index)};
       MPI_Datatype types[]         = {MPI_DOUBLE, MPI_INT};
 
-      ierr = MPI_Type_struct(2, lengths, displacements, types, &type);
+      ierr = MPI_Type_create_struct(2, lengths, displacements, types, &type);
       AssertThrowMPI(ierr);
 
       ierr = MPI_Type_commit(&type);


### PR DESCRIPTION
Fixes #7676 (this one is easy).

This was deprecated a long time ago (1996) and is not present in the latest version of openMPI (4.0): see

https://www.open-mpi.org/faq/?category=mpi-removed

Credit goes to Pratik Nayak for finding this issue; thanks a lot @pratikvn!