### PR TITLE
Fix building TBB with nvcc_wrapper

### DIFF
--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -379,16 +379,8 @@ private:
    * storing a unique_ptr so that we don't need to include the definition of
    * mu::Parser in this header.
    */
-#  if TBB_VERSION_MAJOR >= 4
   mutable Threads::ThreadLocalStorage<std::vector<std::unique_ptr<mu::Parser>>>
     fp;
-#  else
-  // older TBBs have a bug in which they want to return thread-local
-  // objects by value. this doesn't work for std::unique_ptr, so use a
-  // std::shared_ptr
-  mutable Threads::ThreadLocalStorage<std::vector<std::shared_ptr<mu::Parser>>>
-    fp;
-#  endif
 
   /**
    * An array to keep track of all the constants, required to initialize fp in

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1353,16 +1353,7 @@ namespace Threads
       tbb::task *worker =
         new (task->allocate_child()) TaskEntryPoint<RT>(*this);
 
-      // in earlier versions of the TBB, task::spawn was a regular
-      // member function; however, in later versions, it was converted
-      // into a static function. we could always call it as a regular member
-      // function of *task, but that appears to confuse the NVidia nvcc
-      // compiler. consequently, the following work-around:
-#    if TBB_VERSION_MAJOR >= 4
       tbb::task::spawn(*worker);
-#    else
-      task->spawn(*worker);
-#    endif
     }
 
 

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -118,7 +118,7 @@ namespace internal
           work();
 
           if (is_blocked == true)
-            dummy->spawn(*dummy);
+            tbb::empty_task::spawn(*dummy);
           return nullptr;
         }
 
@@ -172,7 +172,7 @@ namespace internal
                   worker[j]->set_ref_count(2);
                   blocked_worker[j - 1]->dummy =
                     new (worker[j]->allocate_child()) tbb::empty_task;
-                  worker[j - 1]->spawn(*blocked_worker[j - 1]);
+                  tbb::task::spawn(*blocked_worker[j - 1]);
                 }
               else
                 worker[j]->set_ref_count(1);
@@ -195,13 +195,13 @@ namespace internal
                                    2 * j + 1,
                                  task_info,
                                  false);
-                      worker[j]->spawn(*worker[evens]);
+                      tbb::task::spawn(*worker[evens]);
                     }
                   else
                     {
                       tbb::empty_task *child =
                         new (worker[j]->allocate_child()) tbb::empty_task();
-                      worker[j]->spawn(*child);
+                      tbb::task::spawn(*child);
                     }
                 }
             }
@@ -209,7 +209,7 @@ namespace internal
           root->wait_for_all();
           root->destroy(*root);
           if (is_blocked == true)
-            dummy->spawn(*dummy);
+            tbb::empty_task::spawn(*dummy);
           return nullptr;
         }
 
@@ -289,7 +289,7 @@ namespace internal
           parallel_for(tbb::blocked_range<unsigned int>(0, n_chunks, 1),
                        CellWork(worker, task_info, partition));
           if (is_blocked == true)
-            dummy->spawn(*dummy);
+            tbb::empty_task::spawn(*dummy);
           return nullptr;
         }
 
@@ -364,9 +364,9 @@ namespace internal
                       blocked_worker[j - 1]->dummy =
                         new (worker[j]->allocate_child()) tbb::empty_task;
                       if (j > 1)
-                        worker[j - 1]->spawn(*blocked_worker[j - 1]);
+                        tbb::task::spawn(*blocked_worker[j - 1]);
                       else
-                        worker_compr->spawn(*blocked_worker[j - 1]);
+                        tbb::task::spawn(*blocked_worker[j - 1]);
                     }
                   else
                     {
@@ -376,7 +376,7 @@ namespace internal
                       MPICommunication *worker_dist =
                         new (worker[j]->allocate_child())
                           MPICommunication(funct, false);
-                      worker_dist->spawn(*worker_dist);
+                      tbb::task::spawn(*worker_dist);
                     }
                   if (j < evens - 1)
                     {
@@ -392,13 +392,13 @@ namespace internal
                                                      2 * j + 1,
                                                      *this,
                                                      false);
-                          worker[j]->spawn(*worker[evens]);
+                          tbb::task::spawn(*worker[evens]);
                         }
                       else
                         {
                           tbb::empty_task *child =
                             new (worker[j]->allocate_child()) tbb::empty_task();
-                          worker[j]->spawn(*child);
+                          tbb::task::spawn(*child);
                         }
                     }
                 }
@@ -467,14 +467,12 @@ namespace internal
                               tbb::empty_task;
                           worker_index++;
                           if (spawn_index_child == -1)
-                            worker[spawn_index]->spawn(
-                              *blocked_worker[(part - 1) / 2]);
+                            tbb::task::spawn(*blocked_worker[(part - 1) / 2]);
                           else
                             {
                               Assert(spawn_index_child >= 0,
                                      ExcInternalError());
-                              worker[spawn_index]->spawn(
-                                *worker[spawn_index_child]);
+                              tbb::task::spawn(*worker[spawn_index_child]);
                             }
                           spawn_index       = spawn_index_new;
                           spawn_index_child = -2;
@@ -484,7 +482,7 @@ namespace internal
                           MPICommunication *worker_dist =
                             new (worker[worker_index]->allocate_child())
                               MPICommunication(funct, false);
-                          worker_dist->spawn(*worker_dist);
+                          tbb::task::spawn(*worker_dist);
                           worker_index++;
                         }
                       part += 1;
@@ -539,14 +537,14 @@ namespace internal
                           tbb::empty_task *final =
                             new (worker[worker_index - 1]->allocate_child())
                               tbb::empty_task;
-                          worker[spawn_index]->spawn(*final);
+                          tbb::task::spawn(*final);
                           spawn_index_child = worker_index - 1;
                         }
                     }
                   if (evens == odds)
                     {
                       Assert(spawn_index_child >= 0, ExcInternalError());
-                      worker[spawn_index]->spawn(*worker[spawn_index_child]);
+                      tbb::task::spawn(*worker[spawn_index_child]);
                     }
                   root->wait_for_all();
                   root->destroy(*root);
@@ -568,7 +566,7 @@ namespace internal
                       color::PartitionWork *worker =
                         new (root->allocate_child())
                           color::PartitionWork(funct, color, *this, false);
-                      root->spawn(*worker);
+                      tbb::empty_task::spawn(*worker);
                       root->wait_for_all();
                       root->destroy(*root);
                     }

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -423,7 +423,6 @@ namespace internal
                   std::vector<color::PartitionWork *> blocked_worker(
                     n_blocked_workers);
                   unsigned int      worker_index = 0, slice_index = 0;
-                  unsigned int      spawn_index       = 0;
                   int               spawn_index_child = -2;
                   MPICommunication *worker_compr =
                     new (root->allocate_child()) MPICommunication(funct, true);
@@ -432,7 +431,6 @@ namespace internal
                        part < partition_row_index.size() - 1;
                        part++)
                     {
-                      const unsigned int spawn_index_new = worker_index;
                       if (part == 0)
                         worker[worker_index] =
                           new (worker_compr->allocate_child())
@@ -474,7 +472,6 @@ namespace internal
                                      ExcInternalError());
                               tbb::task::spawn(*worker[spawn_index_child]);
                             }
-                          spawn_index       = spawn_index_new;
                           spawn_index_child = -2;
                         }
                       else


### PR DESCRIPTION
Without this, we get errors like
```
/export/home/darndt/dealii/source/matrix_free/task_info.cc:121:49: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘tbb::empty_task’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:175:57: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::partition::CellWork’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:198:51: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::partition::CellWork’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:204:51: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::partition::CellWork’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:212:49: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘tbb::empty_task’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:292:49: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘tbb::empty_task’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:367:57: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::partition::PartitionWork’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:369:54: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::MPICommunication’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:379:53: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::MPICommunication’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:395:51: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::partition::PartitionWork’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:401:51: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::partition::PartitionWork’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:470:61: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::color::PartitionWork’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:476:61: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::color::PartitionWork’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:487:53: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::MPICommunication’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:542:61: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::color::PartitionWork’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:549:61: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘dealii::internal::MatrixFreeFunctions::color::PartitionWork’
/export/home/darndt/dealii/source/matrix_free/task_info.cc:571:46: error: ‘tbb::interface5::internal::task_base’ is an inaccessible base of ‘tbb::empty_task’
```
when building with `nvcc_wrapper`. ~~Probably, this will never get into the upstream repository but we can improve the situation at least for users using `nvcc_wrapper`.~~