### PR TITLE
Document the minimal supported MPI version

### DIFF
--- a/doc/news/changes/minor/20190202Arndt
+++ b/doc/news/changes/minor/20190202Arndt
@@ -1,0 +1,3 @@
+Documented: The minimal supported MPI version is MPI-2.0.
+<br>
+(Daniel Arndt, 2019/02/02)

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -312,6 +312,7 @@
                 <i>MPI</i>: To enable parallel computations beyond a single node using the <a href="http://mpi-forum.org/" target="_top">Message
 	  Passing Interface (MPI)</a>, pass the
                 <code>-DDEAL_II_WITH_MPI=ON</code> argument to <code>cmake</code>. If <code>cmake</code> found MPI but you specifically do not want to use it, then pass <code>-DDEAL_II_WITH_MPI=OFF</code>.
+                The minimal supported version is MPI-2.0.
             </p>
         </li>
 

--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -203,6 +203,8 @@ public:
    * The user has to ensure that all processes call this with identical @p rank.
    * The @p rank refers to a process of the MPI communicator used to create the process grid
    * of the distributed matrix.
+   *
+   * @note This function requires MPI-3.0 support
    */
   void
   copy_from(const LAPACKFullMatrix<NumberType> &matrix,
@@ -213,6 +215,7 @@ public:
    *
    * @note This function should only be used for relatively small matrix
    * dimensions. It is primarily intended for debugging purposes.
+   * This function requires MPI-3.0 support
    */
   void
   copy_to(FullMatrix<NumberType> &matrix) const;

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -361,18 +361,19 @@ void
 ScaLAPACKMatrix<NumberType>::copy_from(const LAPACKFullMatrix<NumberType> &B,
                                        const unsigned int                  rank)
 {
+#  if DEAL_II_MPI_VERSION_GTE(3, 0)
   if (n_rows * n_columns == 0)
     return;
 
   const unsigned int this_mpi_process(
     Utilities::MPI::this_mpi_process(this->grid->mpi_communicator));
 
-#  ifdef DEBUG
+#    ifdef DEBUG
   Assert(Utilities::MPI::max(rank, this->grid->mpi_communicator) == rank,
          ExcMessage("All processes have to call routine with identical rank"));
   Assert(Utilities::MPI::min(rank, this->grid->mpi_communicator) == rank,
          ExcMessage("All processes have to call routine with identical rank"));
-#  endif
+#    endif
 
   // root process has to be active in the grid of A
   if (this_mpi_process == rank)
@@ -484,6 +485,11 @@ ScaLAPACKMatrix<NumberType>::copy_from(const LAPACKFullMatrix<NumberType> &B,
     MPI_Comm_free(&communicator_B);
 
   state = LAPACKSupport::matrix;
+#  else
+  (void)B;
+  (void)rank;
+  AssertThrow(false, ExcNotImplemented());
+#  endif
 }
 
 
@@ -528,18 +534,19 @@ void
 ScaLAPACKMatrix<NumberType>::copy_to(LAPACKFullMatrix<NumberType> &B,
                                      const unsigned int            rank) const
 {
+#  if DEAL_II_MPI_VERSION_GTE(3, 0)
   if (n_rows * n_columns == 0)
     return;
 
   const unsigned int this_mpi_process(
     Utilities::MPI::this_mpi_process(this->grid->mpi_communicator));
 
-#  ifdef DEBUG
+#    ifdef DEBUG
   Assert(Utilities::MPI::max(rank, this->grid->mpi_communicator) == rank,
          ExcMessage("All processes have to call routine with identical rank"));
   Assert(Utilities::MPI::min(rank, this->grid->mpi_communicator) == rank,
          ExcMessage("All processes have to call routine with identical rank"));
-#  endif
+#    endif
 
   if (this_mpi_process == rank)
     {
@@ -650,6 +657,11 @@ ScaLAPACKMatrix<NumberType>::copy_to(LAPACKFullMatrix<NumberType> &B,
   MPI_Group_free(&group_B);
   if (MPI_COMM_NULL != communicator_B)
     MPI_Comm_free(&communicator_B);
+#  else
+  (void)B;
+  (void)rank;
+  AssertThrow(false, ExcNotImplemented());
+#  endif
 }
 
 

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -994,13 +994,14 @@ namespace SparsityTools
       unsigned int idx = 0;
       for (const auto &sparsity_line : send_data)
         {
-          const int ierr = MPI_Isend(sparsity_line.second.data(),
-                                     sparsity_line.second.size(),
-                                     DEAL_II_DOF_INDEX_MPI_TYPE,
-                                     sparsity_line.first,
-                                     124,
-                                     mpi_comm,
-                                     &requests[idx++]);
+          const int ierr =
+            MPI_Isend(DEAL_II_MPI_CONST_CAST(sparsity_line.second.data()),
+                      sparsity_line.second.size(),
+                      DEAL_II_DOF_INDEX_MPI_TYPE,
+                      sparsity_line.first,
+                      124,
+                      mpi_comm,
+                      &requests[idx++]);
           AssertThrowMPI(ierr);
         }
     }
@@ -1138,13 +1139,14 @@ namespace SparsityTools
       unsigned int idx = 0;
       for (const auto &sparsity_line : send_data)
         {
-          const int ierr = MPI_Isend(sparsity_line.second.data(),
-                                     sparsity_line.second.size(),
-                                     DEAL_II_DOF_INDEX_MPI_TYPE,
-                                     sparsity_line.first,
-                                     124,
-                                     mpi_comm,
-                                     &requests[idx++]);
+          const int ierr =
+            MPI_Isend(DEAL_II_MPI_CONST_CAST(sparsity_line.second.data()),
+                      sparsity_line.second.size(),
+                      DEAL_II_DOF_INDEX_MPI_TYPE,
+                      sparsity_line.first,
+                      124,
+                      mpi_comm,
+                      &requests[idx++]);
           AssertThrowMPI(ierr);
         }
     }


### PR DESCRIPTION
Related to #7677. Looking at `FindMPI.cmake` it doesn't seem feasible to check for the `MPI` version being at least 2.0 since there seem to be cases where we fail to detect the correct version.