### PR TITLE
MappingQGeneric: use of MatrixFree only for higher order elements

### DIFF
--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -730,6 +730,10 @@ MappingQGeneric<dim, spacedim>::InternalData::initialize(
 
   tensor_product_quadrature = q.is_tensor_product();
 
+  // use of MatrixFree only for higher order elements
+  if (polynomial_degree < 2)
+    tensor_product_quadrature = false;
+
   if (dim > 1)
     {
       // find out if the one-dimensional formula is the same


### PR DESCRIPTION
In my work I need to use quadrature formulas with very high orders (around 500 quadrature points and more) and a linear mapping to catch very small oscillations of coefficient functions.
Unfortunately, `MappingQGeneric::InternalData::initialize` crashes with
```
An error occurred in line <88> of file </mnt/data/smeggend/dealii/source/source/base/polynomial.cc> in function
    dealii::Polynomials::Polynomial<number>::Polynomial(const std::vector<dealii::Point<1> >&, unsigned int) [with number = double]
The violated condition was: 
    std::fabs(tmp_lagrange_weight) > std::numeric_limits<number>::min()
Additional information: 
    Underflow in computation of Lagrange denominator.

Stacktrace:
-----------
#0  /mnt/data/smeggend/dealii/build_gcc-7.3.0_nothreads/lib/libdeal_II.g.so.9.1.0-pre: dealii::Polynomials::Polynomial<double>::Polynomial(std::vector<dealii::Point<1, double>, std::allocator<dealii::Point<1, double> > > const&, unsigned int)
#1  /mnt/data/smeggend/dealii/build_gcc-7.3.0_nothreads/lib/libdeal_II.g.so.9.1.0-pre: void __gnu_cxx::new_allocator<dealii::Polynomials::Polynomial<double> >::construct<dealii::Polynomials::Polynomial<double>, std::vector<dealii::Point<1, double>, std::allocator<dealii::Point<1, double> > > const&, unsigned int&>(dealii::Polynomials::Polynomial<double>*, std::vector<dealii::Point<1, double>, std::allocator<dealii::Point<1, double> > > const&, unsigned int&)
#2  /mnt/data/smeggend/dealii/build_gcc-7.3.0_nothreads/lib/libdeal_II.g.so.9.1.0-pre: void std::allocator_traits<std::allocator<dealii::Polynomials::Polynomial<double> > >::construct<dealii::Polynomials::Polynomial<double>, std::vector<dealii::Point<1, double>, std::allocator<dealii::Point<1, double> > > const&, unsigned int&>(std::allocator<dealii::Polynomials::Polynomial<double> >&, dealii::Polynomials::Polynomial<double>*, std::vector<dealii::Point<1, double>, std::allocator<dealii::Point<1, double> > > const&, unsigned int&)
#3  /mnt/data/smeggend/dealii/build_gcc-7.3.0_nothreads/lib/libdeal_II.g.so.9.1.0-pre: dealii::Polynomials::Polynomial<double>& std::vector<dealii::Polynomials::Polynomial<double>, std::allocator<dealii::Polynomials::Polynomial<double> > >::emplace_back<std::vector<dealii::Point<1, double>, std::allocator<dealii::Point<1, double> > > const&, unsigned int&>(std::vector<dealii::Point<1, double>, std::allocator<dealii::Point<1, double> > > const&, unsigned int&)
#4  /mnt/data/smeggend/dealii/build_gcc-7.3.0_nothreads/lib/libdeal_II.g.so.9.1.0-pre: dealii::Polynomials::generate_complete_Lagrange_basis(std::vector<dealii::Point<1, double>, std::allocator<dealii::Point<1, double> > > const&)
#5  /mnt/data/smeggend/dealii/build_gcc-7.3.0_nothreads/lib/libdeal_II.g.so.9.1.0-pre: dealii::FE_DGQArbitraryNodes<1, 1>::FE_DGQArbitraryNodes(dealii::Quadrature<1> const&)
#6  /mnt/data/smeggend/dealii/build_gcc-7.3.0_nothreads/lib/libdeal_II.g.so.9.1.0-pre: void dealii::internal::MatrixFreeFunctions::ShapeInfo<dealii::VectorizedArray<double> >::reinit<2>(dealii::Quadrature<1> const&, dealii::FiniteElement<2, 2> const&, unsigned int)
#7  /mnt/data/smeggend/dealii/build_gcc-7.3.0_nothreads/lib/libdeal_II.g.so.9.1.0-pre: dealii::MappingQGeneric<2, 2>::InternalData::initialize(dealii::UpdateFlags, dealii::Quadrature<2> const&, unsigned int)
#8  /mnt/data/smeggend/dealii/build_gcc-7.3.0_nothreads/lib/libdeal_II.g.so.9.1.0-pre: dealii::MappingQGeneric<2, 2>::get_data(dealii::UpdateFlags, dealii::Quadrature<2> const&) const
--------------------------------------------------------

Aborted
```
It seems that `MappingQGeneric` always uses `MatrixFree` and constructs an `FE_DGQArbitraryNodes` object with `polynomial_degree = number_of_quadrature_points`, which leads to an underflow, because of the use of collocation methods.

@kronbichler: It is not quite clear to me why `ShapeInfo::reinit` always tries to initialize `shape_gradients_collocation_eo` for all combinations of degree and quadrature points.

In general we don't profit from using `MatrixFree` for polynomial degree less or equal 1 and in my special case, avoiding `MatrixFree` fixes the issue.
Thus, the workaround just skips the calculation here.