### PR TITLE
Fix serialization of XDMFEntry class

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -26,6 +26,9 @@
 
 #include <deal.II/numerics/data_component_interpretation.h>
 
+// To be able to serialize XDMFEntry
+#include <boost/serialization/map.hpp>
+
 #include <limits>
 #include <string>
 #include <tuple>
@@ -3599,7 +3602,7 @@ public:
   serialize(Archive &ar, const unsigned int /*version*/)
   {
     ar &valid &h5_sol_filename &h5_mesh_filename &entry_time &num_nodes
-      &num_cells &dimension &attribute_dims;
+      &num_cells &dimension &space_dimension &attribute_dims;
   }
 
   /**

--- a/tests/serialization/xdmf_entry.cc
+++ b/tests/serialization/xdmf_entry.cc
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// check serialization for XDMFEntry
+
+#include <deal.II/base/data_out_base.h>
+
+#include "serialization.h"
+
+void
+test()
+{
+  const std::string mesh_filename     = "mesh.h5";
+  const std::string solution_filename = "solution.h5";
+
+  const double       time     = 0.5;
+  const unsigned int nodes    = 128;
+  const unsigned int cells    = 16;
+  const unsigned int dim      = 2;
+  const unsigned int spacedim = 3;
+
+  XDMFEntry entry1(
+    mesh_filename, solution_filename, time, nodes, cells, dim, spacedim);
+  XDMFEntry entry2;
+
+  // save data to archive
+  std::ostringstream oss;
+  {
+    boost::archive::text_oarchive oa(oss, boost::archive::no_header);
+    oa << entry1;
+    // archive and stream closed when destructors are called
+  }
+  deallog << oss.str() << std::endl;
+
+  // verify correctness of the serialization
+  {
+    std::istringstream            iss(oss.str());
+    boost::archive::text_iarchive ia(iss, boost::archive::no_header);
+    ia >> entry2;
+  }
+
+  deallog << "XDMFEntry before serialization: " << std::endl
+          << std::endl
+          << entry1.get_xdmf_content(0) << std::endl;
+
+  deallog << "XDMFEntry after de-serialization: " << std::endl
+          << std::endl
+          << entry2.get_xdmf_content(0) << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+  deallog << std::setprecision(3);
+
+  test();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/serialization/xdmf_entry.output
+++ b/tests/serialization/xdmf_entry.output
@@ -1,0 +1,36 @@
+
+DEAL::0 0 1 11 solution.h5 7 mesh.h5 5.00000000000000000e-01 128 16 2 3 0 0 0 0
+
+DEAL::XDMFEntry before serialization: 
+DEAL::
+DEAL::<Grid Name="mesh" GridType="Uniform">
+  <Time Value="0.5"/>
+  <Geometry GeometryType="XYZ">
+    <DataItem Dimensions="128 3" NumberType="Float" Precision="8" Format="HDF">
+      mesh.h5:/nodes
+    </DataItem>
+  </Geometry>
+  <Topology TopologyType="Quadrilateral" NumberOfElements="16">
+    <DataItem Dimensions="16 4" NumberType="UInt" Format="HDF">
+      mesh.h5:/cells
+    </DataItem>
+  </Topology>
+</Grid>
+
+DEAL::XDMFEntry after de-serialization: 
+DEAL::
+DEAL::<Grid Name="mesh" GridType="Uniform">
+  <Time Value="0.5"/>
+  <Geometry GeometryType="XYZ">
+    <DataItem Dimensions="128 3" NumberType="Float" Precision="8" Format="HDF">
+      mesh.h5:/nodes
+    </DataItem>
+  </Geometry>
+  <Topology TopologyType="Quadrilateral" NumberOfElements="16">
+    <DataItem Dimensions="16 4" NumberType="UInt" Format="HDF">
+      mesh.h5:/cells
+    </DataItem>
+  </Topology>
+</Grid>
+
+DEAL::OK


### PR DESCRIPTION
This fixes two issues with the serialization of the XDMFEntry class. First the space dimension was not properly stored, leading to broken xdmf files after a restart, as reported in geodynamics/aspect#2797. Second, data_out_base did not include a necessary header to serialize this class. I am unsure why this worked so far, I suppose the function is nowhere instantiated in deal.II, and in ASPECT we had the necessary header included by chance anyway. I noticed the missing header while creating the test.