### PR TITLE
CMake: Do not automatically rebuild a project when switching build type

### DIFF
--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -141,13 +141,11 @@ MACRO(DEAL_II_INVOKE_AUTOPILOT)
   # Define custom targets to easily switch the build type:
   ADD_CUSTOM_TARGET(debug
     COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Debug ${CMAKE_SOURCE_DIR}
-    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target all
     COMMENT "Switch CMAKE_BUILD_TYPE to Debug"
     )
 
   ADD_CUSTOM_TARGET(release
     COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Release ${CMAKE_SOURCE_DIR}
-    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target all
     COMMENT "Switch CMAKE_BUILD_TYPE to Release"
     )
 

--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -138,19 +138,37 @@ MACRO(DEAL_II_INVOKE_AUTOPILOT)
       )
   ENDIF()
 
+  #
   # Define custom targets to easily switch the build type:
-  ADD_CUSTOM_TARGET(debug
-    COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Debug ${CMAKE_SOURCE_DIR}
-    COMMENT "Switch CMAKE_BUILD_TYPE to Debug"
-    )
+  #
 
-  ADD_CUSTOM_TARGET(release
-    COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Release ${CMAKE_SOURCE_DIR}
-    COMMENT "Switch CMAKE_BUILD_TYPE to Release"
-    )
+  IF(${DEAL_II_BUILD_TYPE} MATCHES "Debug")
+    ADD_CUSTOM_TARGET(debug
+      COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Debug ${CMAKE_SOURCE_DIR}
+      COMMAND ${CMAKE_COMMAND} -E echo "***"
+      COMMAND ${CMAKE_COMMAND} -E echo "*** Switched to Debug mode. Now recompile with: ${_make_command}"
+      COMMAND ${CMAKE_COMMAND} -E echo "***"
+      COMMENT "Switch CMAKE_BUILD_TYPE to Debug"
+      VERBATIM
+      )
+  ENDIF()
 
+  IF(${DEAL_II_BUILD_TYPE} MATCHES "Release")
+    ADD_CUSTOM_TARGET(release
+      COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Release ${CMAKE_SOURCE_DIR}
+      COMMAND ${CMAKE_COMMAND} -E echo "***"
+      COMMAND ${CMAKE_COMMAND} -E echo "*** Switched to Release mode. Now recompile with: ${_make_command}"
+      COMMAND ${CMAKE_COMMAND} -E echo "***"
+      COMMENT "Switch CMAKE_BUILD_TYPE to Release"
+      VERBATIM
+      )
+  ENDIF()
+
+  #
   # Only mention release and debug targets if it is actually possible to
   # switch between them:
+  #
+
   IF(${DEAL_II_BUILD_TYPE} MATCHES "DebugRelease")
     SET(_switch_targets
 "#      ${_make_command} debug          - to switch the build type to 'Debug'

--- a/doc/news/changes/incompatibilities/20190205Maier
+++ b/doc/news/changes/incompatibilities/20190205Maier
@@ -1,0 +1,5 @@
+Changed: The "debug" and "release" targets that are created by the
+DEAL_II_INVOKE_AUTOPILOT() macro no longer automatically rebuild the
+project.
+<br>
+(Matthias Maier, 2019/02/05)


### PR DESCRIPTION
For a long time the "debug" and "release" targets of our convenience macro
DEAL_II_INVOKE_AUTOPILOT automatically rebuild the project when switching
to the debug or release flavor.

Closes #7693