### PR TITLE
[CI]: add Jenkins marking

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,9 @@ pipeline
         {
           steps
           {
+            // we are finally running, so we can mark the 'ready' context from Jenkinsfile.mark as success:
+            githubNotify context: 'ready', description: ':-)',  status: 'SUCCESS'
+
             // We can not use 'indent' because we are missing the master branch:
             // "fatal: ambiguous argument 'master': unknown revision or path"
             sh '''

--- a/contrib/ci/Jenkinsfile.mark
+++ b/contrib/ci/Jenkinsfile.mark
@@ -1,0 +1,51 @@
+#!groovy
+
+// This Jenkinsfile is used to mark jobs as "pending" as quickly as
+// possible. The other longer running jobs only set the status to pending once
+// they start running.
+//
+// See https://jenkins.tjhei.info/job/dealii-mark/ for details.
+
+/*
+Settings to apply inside Jenkins:
+  - discover pull requests (remove branches/master)
+  - Strategy: merged PR
+  - enable "Disable GitHub Multibranch Status Plugin"
+  - trigger build on pull request comment: .* /rebuild.* (without space)
+  - Jenkinsfile: choose contrib/ci/Jenkinsfile.mark
+  - scan: every 4 hours
+  - discard: 5+ items
+  - docker label: small
+*/
+
+pipeline
+{
+  agent none
+
+  stages
+  {
+    stage("check")
+    {
+      steps
+      {
+        githubNotify context: 'ready', description: 'please be patient, testers are spinning up...',  status: 'PENDING'
+        sh '''
+               wget -q -O - https://api.github.com/repos/dealii/dealii/issues/${CHANGE_ID}/labels | grep 'ready to test' || \
+               { echo "This commit will only be tested when it has the label 'ready to test'. Trigger a rebuild by adding a comment that contains '/rebuild'..."; exit 1; }
+            '''
+      }
+      post
+      {
+        failure
+        {
+          githubNotify context: 'ready', description: 'need ready to test label and /rebuild',  status: 'PENDING'
+          script
+          {
+            currentBuild.result='NOT_BUILT'
+          }
+        }
+      }
+    }
+
+  }
+}

--- a/contrib/ci/Jenkinsfile.mark
+++ b/contrib/ci/Jenkinsfile.mark
@@ -20,7 +20,13 @@ Settings to apply inside Jenkins:
 
 pipeline
 {
-  agent none
+  agent
+  {
+    docker
+    {
+      image 'dealii/indent'
+    }
+  }
 
   stages
   {


### PR DESCRIPTION
Add a separate Jenkins pipeline that runs in a few seconds to set the
commit status to pending. This is needed as Jenkins only starts setting
a commit status when the normal jobs start running and not when they are
in the queue. This can lead to a) accidental merges before we test
things and b) repeated /rebuild triggers.