### PR TITLE
Improve FEEvaluation for large number of quadrature points

### DIFF
--- a/doc/news/changes/minor/20190206MartinKronbichler
+++ b/doc/news/changes/minor/20190206MartinKronbichler
@@ -1,0 +1,9 @@
+Improved: The FEEvaluation::evaluate() and FEEvaluation::integrate() routines
+would previously unconditionally use an evaluation routine with a
+transformation to a collocation basis and subsequent collocation derivative
+for `n_q_points_1d > fe_degree` because it is faster for the usual case of
+`n_q_points_1d` close to the polynomial degree. Now, we switch back to the
+standard evaluation if `n_q_points_1d > 3 * (fe_degree+1) / 2` where that
+variant is faster.
+<br>
+(Martin Kronbichler, 2019/02/06)

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -1337,6 +1337,16 @@ namespace internal
             typename Number>
   struct FEFaceEvaluationImpl
   {
+    // We enable a transformation to collocation for derivatives if it gives
+    // correct results (first two conditions), if it is the most efficient
+    // choice in terms of operation counts (third condition) and if we were
+    // able to initialize the fields in shape_info.templates.h from the
+    // polynomials (fourth condition).
+    static constexpr bool use_collocation =
+      symmetric_evaluate &&
+      n_q_points_1d > fe_degree &&n_q_points_1d <= 3 * fe_degree / 2 + 1 &&
+      n_q_points_1d < 200;
+
     static void
     evaluate_in_face(const MatrixFreeFunctions::ShapeInfo<Number> &data,
                      Number *                                      values_dofs,
@@ -1431,7 +1441,7 @@ namespace internal
             switch (dim)
               {
                 case 3:
-                  if (symmetric_evaluate && n_q_points_1d > fe_degree)
+                  if (use_collocation)
                     {
                       eval1.template values<0, true, false>(values_dofs,
                                                             values_quad);
@@ -1590,7 +1600,7 @@ namespace internal
                                                            2 * n_q_points);
                   eval1.template values<0, false, false>(
                     gradients_quad + 2 * n_q_points, values_dofs + size_deg);
-                  if (symmetric_evaluate && n_q_points_1d > fe_degree)
+                  if (use_collocation)
                     {
                       internal::EvaluatorTensorProduct<
                         internal::evaluate_evenodd,

--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -36,6 +36,15 @@ namespace internal
      * initialization. FEEvaluation will select the most efficient algorithm
      * based on the given element type.
      *
+     * There is an implied ordering in the type ElementType::tensor_symmetric
+     * in the sense that both ElementType::tensor_symmetric_collocation and
+     * ElementType::tensor_symmetric_hermite are also of type
+     * ElementType::tensor_symmetric. Likewise, a configuration of type
+     * ElementType::tensor_symmetric is also of type
+     * ElementType::tensor_general. As a consequence, we support `<=`
+     * operations between the types with this sorting, but not against the
+     * even higher indexed types such as ElementType::truncated_tensor.
+     *
      * @ingroup matrixfree
      */
     enum ElementType

--- a/tests/matrix_free/matrix_vector_large_degree_03.cc
+++ b/tests/matrix_free/matrix_vector_large_degree_03.cc
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test that FEEvaluation can correctly handle large polynomial degrees of 20
+// with 100, 200, 500 and 1000 quadrature points per direction in 2D. Since we
+// have a constant-coefficient Laplacian, we can verify the implementation by
+// comparing to the result with 21 quadrature points.
+
+#include "../tests.h"
+
+std::ofstream logfile("output");
+
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/vector.h>
+
+#include "matrix_vector_mf.h"
+
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(1);
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+
+  Vector<double> in(dof.n_dofs()), out(dof.n_dofs()), ref(dof.n_dofs());
+
+  for (unsigned int i = 0; i < dof.n_dofs(); ++i)
+    {
+      if (constraints.is_constrained(i))
+        continue;
+      in(i) = static_cast<double>(i % 13) / 11.;
+    }
+
+  {
+    MatrixFree<dim, double> mf_data;
+    {
+      const QGauss<1>                                  quad(fe_degree + 1);
+      typename MatrixFree<dim, double>::AdditionalData data;
+      data.tasks_parallel_scheme =
+        MatrixFree<dim, double>::AdditionalData::none;
+      mf_data.reinit(dof, constraints, quad, data);
+    }
+
+    MatrixFreeTest<dim, fe_degree, double, Vector<double>, fe_degree + 1> mf(
+      mf_data);
+    mf.vmult(ref, in);
+  }
+
+  typename MatrixFree<dim, double>::AdditionalData data;
+  data.tasks_parallel_scheme = MatrixFree<dim, double>::AdditionalData::none;
+  MatrixFree<dim, double> mf_data;
+
+  {
+    mf_data.reinit(dof, constraints, QGauss<1>(fe_degree + 2), data);
+    MatrixFreeTest<dim, fe_degree, double, Vector<double>, fe_degree + 2> mf(
+      mf_data);
+    mf.vmult(out, in);
+    out -= ref;
+    deallog << "Error with " << fe_degree + 2 << "^" << dim
+            << " quadrature points: " << out.l2_norm() << std::endl;
+  }
+
+  // unfortunately we cannot use for loops due to the template, so duplicate
+  // some code here
+  {
+    mf_data.reinit(dof, constraints, QGauss<1>(100), data);
+    MatrixFreeTest<dim, fe_degree, double, Vector<double>, 100> mf(mf_data);
+    mf.vmult(out, in);
+    out -= ref;
+    deallog << "Error with " << 100 << "^" << dim
+            << " quadrature points: " << out.l2_norm() << std::endl;
+  }
+  {
+    mf_data.reinit(dof, constraints, QGauss<1>(200), data);
+    MatrixFreeTest<dim, fe_degree, double, Vector<double>, 200> mf(mf_data);
+    mf.vmult(out, in);
+    out -= ref;
+    deallog << "Error with " << 200 << "^" << dim
+            << " quadrature points: " << out.l2_norm() << std::endl;
+  }
+  {
+    mf_data.reinit(dof, constraints, QGauss<1>(500), data);
+    MatrixFreeTest<dim, fe_degree, double, Vector<double>, 500> mf(mf_data);
+    mf.vmult(out, in);
+    out -= ref;
+    deallog << "Error with " << 500 << "^" << dim
+            << " quadrature points: " << out.l2_norm() << std::endl;
+  }
+  {
+    mf_data.reinit(dof, constraints, QGauss<1>(1000), data);
+    MatrixFreeTest<dim, fe_degree, double, Vector<double>, 1000> mf(mf_data);
+    mf.vmult(out, in);
+    out -= ref;
+    deallog << "Error with " << 1000 << "^" << dim
+            << " quadrature points: " << out.l2_norm() << std::endl;
+  }
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  test<2, 20>();
+}

--- a/tests/matrix_free/matrix_vector_large_degree_03.output
+++ b/tests/matrix_free/matrix_vector_large_degree_03.output
@@ -1,0 +1,7 @@
+
+DEAL::Testing FE_Q<2>(20)
+DEAL::Error with 22^2 quadrature points: 7.12679e-13
+DEAL::Error with 100^2 quadrature points: 3.09514e-13
+DEAL::Error with 200^2 quadrature points: 3.05924e-13
+DEAL::Error with 500^2 quadrature points: 3.28960e-13
+DEAL::Error with 1000^2 quadrature points: 3.39364e-13


### PR DESCRIPTION
- Avoid underflow in construction of `MF::ShapeInfo` for large number of quadrature points
- Disable collocation code path of `n_q_points_1d > (3*fe_degree+3)/2` because it is less efficient than the alternative in that case
- Add a test case with very large number of quadrature points

Closes #7690.