### PR TITLE
Do not use I in header files due to conflict with <complex.h>

### DIFF
--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -2296,15 +2296,15 @@ namespace Patterns
       }
 
     private:
-      template <std::size_t... I>
+      template <std::size_t... U>
       static std::array<std::string, std::tuple_size<T>::value>
       to_string_internal_1(const T &              t,
                            const Patterns::Tuple &pattern,
-                           std_cxx14::index_sequence<I...>)
+                           std_cxx14::index_sequence<U...>)
       {
         std::array<std::string, std::tuple_size<T>::value> a = {
-          {Convert<typename std::tuple_element<I, T>::type>::to_string(
-            std::get<I>(t), pattern.get_pattern(I).clone())...}};
+          {Convert<typename std::tuple_element<U, T>::type>::to_string(
+            std::get<U>(t), pattern.get_pattern(U).clone())...}};
         return a;
       }
 
@@ -2317,15 +2317,15 @@ namespace Patterns
           std_cxx14::make_index_sequence<std::tuple_size<T>::value>{});
       }
 
-      template <std::size_t... I>
+      template <std::size_t... U>
       static T
       to_value_internal_1(const std::vector<std::string> &s,
                           const Patterns::Tuple &         pattern,
-                          std_cxx14::index_sequence<I...>)
+                          std_cxx14::index_sequence<U...>)
       {
         return std::make_tuple(
-          Convert<typename std::tuple_element<I, T>::type>::to_value(
-            s[I], pattern.get_pattern(I).clone())...);
+          Convert<typename std::tuple_element<U, T>::type>::to_value(
+            s[U], pattern.get_pattern(U).clone())...);
       }
 
       static T

--- a/include/deal.II/physics/transformations.h
+++ b/include/deal.II/physics/transformations.h
@@ -852,8 +852,9 @@ namespace internal
       Tensor<2, dim, Number> tmp_1;
       for (unsigned int i = 0; i < dim; ++i)
         for (unsigned int J = 0; J < dim; ++J)
-          for (unsigned int I = 0; I < dim; ++I)
-            tmp_1[i][J] += F[i][I] * T[I][J];
+          // Loop over I but complex.h defines a macro I, so use I_ instead
+          for (unsigned int I_ = 0; I_ < dim; ++I_)
+            tmp_1[i][J] += F[i][I_] * T[I_][J];
 
       dealii::SymmetricTensor<2, dim, Number> out;
       for (unsigned int i = 0; i < dim; ++i)
@@ -918,12 +919,13 @@ namespace internal
 
       // Push forward (inner) index 1
       Tensor<4, dim, Number> tmp;
-      for (unsigned int I = 0; I < dim; ++I)
+      // Loop over I but complex.h defines a macro I, so use I_ instead
+      for (unsigned int I_ = 0; I_ < dim; ++I_)
         for (unsigned int j = 0; j < dim; ++j)
           for (unsigned int K = 0; K < dim; ++K)
             for (unsigned int L = 0; L < dim; ++L)
               for (unsigned int J = 0; J < dim; ++J)
-                tmp[I][j][K][L] += F[j][J] * H[I][J][K][L];
+                tmp[I_][j][K][L] += F[j][J] * H[I_][J][K][L];
 
       // Push forward (outer) indices 0 and 3
       tmp = contract<1, 0>(F, contract<3, 1>(tmp, F));


### PR DESCRIPTION
In one of our code, we use `lapacke` which includes the C version of `<complex.h>`. `<complex.h>` defines a macro `I` (see [here](https://en.cppreference.com/w/c/numeric/complex/I)). This is problematic in the header files where we are using `I`. I only removed `I` in the header files that are not controversial, I did keep it in [/physics/elasticity/standard_tensors.h](https://github.com/dealii/dealii/blob/master/include/deal.II/physics/elasticity/standard_tensors.h#L70) for example.
