### PR TITLE
Revise iteration in PreconditionChebyshev

### DIFF
--- a/doc/news/changes/minor/20190207MartinKronbichler
+++ b/doc/news/changes/minor/20190207MartinKronbichler
@@ -1,0 +1,5 @@
+Improved: The iteration of PreconditionChebyshev has been overhauled to reduce
+the number of vectors written per iteration to one, leading to slightly faster
+execution of the vector updates.
+<br>
+(Martin Kronbichler, 2019/02/07)

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -1950,12 +1950,17 @@ namespace internal
       VectorUpdatesRange<Number>(upd, rhs.size());
 
       // swap vectors x^{n+1}->x^{n}, given the updates in the function above
-      if (iteration_index == 1)
+      if (iteration_index == 0)
+        {
+          // nothing to do here because we can immediately write into the
+          // solution vector without remembering any of the other vectors
+        }
+      else if (iteration_index == 1)
         {
           solution.swap(temp_vector1);
           solution_old.swap(temp_vector1);
         }
-      else if (iteration_index > 1)
+      else
         solution.swap(solution_old);
     }
 
@@ -1985,12 +1990,17 @@ namespace internal
       VectorUpdatesRange<Number>(upd, rhs.local_size());
 
       // swap vectors x^{n+1}->x^{n}, given the updates in the function above
-      if (iteration_index == 1)
+      if (iteration_index == 0)
+        {
+          // nothing to do here because we can immediately write into the
+          // solution vector without remembering any of the other vectors
+        }
+      else if (iteration_index == 1)
         {
           solution.swap(temp_vector1);
           solution_old.swap(temp_vector1);
         }
-      else if (iteration_index > 1)
+      else
         solution.swap(solution_old);
     }
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_08.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_08.cc
@@ -342,7 +342,7 @@ do_test(const DoFHandler<dim> &dof)
        ++level)
     {
       smoother_data[level].smoothing_range     = 15.;
-      smoother_data[level].degree              = 5;
+      smoother_data[level].degree              = 6;
       smoother_data[level].eig_cg_n_iterations = 15;
       smoother_data[level].preconditioner =
         mg_matrices[level].get_matrix_diagonal_inverse();


### PR DESCRIPTION
The old implementation of `PreconditionChebyshev` used an iteration that was more complicated than necessary due to a temporary vector representing `x^{n-1}-x^{n}`. I have rewritten the algorithm directly in terms of the underlying three-term recurrence `x^{n+1} = x^{n} + f1 (x^{n}-x^{n-1}) + f2 P^{-1} (b-A x^{n})` where `f1` and `f2` are some factors. This has the advantage of being slightly faster because we do not need to update the temporary vector and only load from `x^{n-1}` instead, i.e., we save one vector write, reducing the access in the vector updates from five reads and two writes to five reads (`x^n, x^{n-1}, P^{-1}, t=Ax^n, b`) and one write to `x`. Overall, it depends on the cost of the matrix-vector product how much this reduction by around 15% helps in final cost. I measured up to 5% of the solution with a multigrid algorithm, which is not bad.

Furthermore, the new implementation should be more comprehensible to someone familiar with Chebyshev polynomials. I adapted the variable names for the temporary vectors to make things clearer and have also stated the recurrence relation in the class description.

Since the algorithm should be mathematically equivalent to the one we had before, we should not need any test changes (checked on my machine).