### PR TITLE
Unrestrict ScaLAPACKMatrix::copy_to/from

### DIFF
--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -203,8 +203,6 @@ public:
    * The user has to ensure that all processes call this with identical @p rank.
    * The @p rank refers to a process of the MPI communicator used to create the process grid
    * of the distributed matrix.
-   *
-   * @note This function requires MPI-3.0 support
    */
   void
   copy_from(const LAPACKFullMatrix<NumberType> &matrix,
@@ -215,7 +213,6 @@ public:
    *
    * @note This function should only be used for relatively small matrix
    * dimensions. It is primarily intended for debugging purposes.
-   * This function requires MPI-3.0 support
    */
   void
   copy_to(FullMatrix<NumberType> &matrix) const;

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -361,19 +361,18 @@ void
 ScaLAPACKMatrix<NumberType>::copy_from(const LAPACKFullMatrix<NumberType> &B,
                                        const unsigned int                  rank)
 {
-#  if DEAL_II_MPI_VERSION_GTE(3, 0)
   if (n_rows * n_columns == 0)
     return;
 
   const unsigned int this_mpi_process(
     Utilities::MPI::this_mpi_process(this->grid->mpi_communicator));
 
-#    ifdef DEBUG
+#  ifdef DEBUG
   Assert(Utilities::MPI::max(rank, this->grid->mpi_communicator) == rank,
          ExcMessage("All processes have to call routine with identical rank"));
   Assert(Utilities::MPI::min(rank, this->grid->mpi_communicator) == rank,
          ExcMessage("All processes have to call routine with identical rank"));
-#    endif
+#  endif
 
   // root process has to be active in the grid of A
   if (this_mpi_process == rank)
@@ -391,12 +390,12 @@ ScaLAPACKMatrix<NumberType>::copy_from(const LAPACKFullMatrix<NumberType> &B,
   const int              n = 1;
   const std::vector<int> ranks(n, rank);
   MPI_Group              group_B;
-  MPI_Group_incl(group_A, n, ranks.data(), &group_B);
+  MPI_Group_incl(group_A, n, DEAL_II_MPI_CONST_CAST(ranks.data()), &group_B);
   MPI_Comm communicator_B;
-  MPI_Comm_create_group(this->grid->mpi_communicator,
-                        group_B,
-                        0,
-                        &communicator_B);
+  Utilities::MPI::create_group(this->grid->mpi_communicator,
+                               group_B,
+                               0,
+                               &communicator_B);
   int n_proc_rows_B = 1, n_proc_cols_B = 1;
   int this_process_row_B = -1, this_process_column_B = -1;
   int blacs_context_B = -1;
@@ -485,11 +484,6 @@ ScaLAPACKMatrix<NumberType>::copy_from(const LAPACKFullMatrix<NumberType> &B,
     MPI_Comm_free(&communicator_B);
 
   state = LAPACKSupport::matrix;
-#  else
-  (void)B;
-  (void)rank;
-  AssertThrow(false, ExcNotImplemented());
-#  endif
 }
 
 
@@ -534,19 +528,18 @@ void
 ScaLAPACKMatrix<NumberType>::copy_to(LAPACKFullMatrix<NumberType> &B,
                                      const unsigned int            rank) const
 {
-#  if DEAL_II_MPI_VERSION_GTE(3, 0)
   if (n_rows * n_columns == 0)
     return;
 
   const unsigned int this_mpi_process(
     Utilities::MPI::this_mpi_process(this->grid->mpi_communicator));
 
-#    ifdef DEBUG
+#  ifdef DEBUG
   Assert(Utilities::MPI::max(rank, this->grid->mpi_communicator) == rank,
          ExcMessage("All processes have to call routine with identical rank"));
   Assert(Utilities::MPI::min(rank, this->grid->mpi_communicator) == rank,
          ExcMessage("All processes have to call routine with identical rank"));
-#    endif
+#  endif
 
   if (this_mpi_process == rank)
     {
@@ -565,12 +558,12 @@ ScaLAPACKMatrix<NumberType>::copy_to(LAPACKFullMatrix<NumberType> &B,
   const int              n = 1;
   const std::vector<int> ranks(n, rank);
   MPI_Group              group_B;
-  MPI_Group_incl(group_A, n, ranks.data(), &group_B);
+  MPI_Group_incl(group_A, n, DEAL_II_MPI_CONST_CAST(ranks.data()), &group_B);
   MPI_Comm communicator_B;
-  MPI_Comm_create_group(this->grid->mpi_communicator,
-                        group_B,
-                        0,
-                        &communicator_B);
+  Utilities::MPI::create_group(this->grid->mpi_communicator,
+                               group_B,
+                               0,
+                               &communicator_B);
   int n_proc_rows_B = 1, n_proc_cols_B = 1;
   int this_process_row_B = -1, this_process_column_B = -1;
   int blacs_context_B = -1;
@@ -657,11 +650,6 @@ ScaLAPACKMatrix<NumberType>::copy_to(LAPACKFullMatrix<NumberType> &B,
   MPI_Group_free(&group_B);
   if (MPI_COMM_NULL != communicator_B)
     MPI_Comm_free(&communicator_B);
-#  else
-  (void)B;
-  (void)rank;
-  AssertThrow(false, ExcNotImplemented());
-#  endif
 }
 
 


### PR DESCRIPTION
In #7680, I restricted `ScaLAPACKMatrix::copy_to/from` to `MPI-3.0` support. However, it turned out that a lot of the implementations that are used on the tester have an incompatible version but still support `MPI_Comm_create_group`.
Hence, I looked for a simple workaround and found one. We already had our own (`MPI-2.0`-conforming) helper for `MPI_Comm_create_group` and we just need to use some more `const_casts` for older `MPI` versions to make these function compile.