### PR TITLE
Improve compress for cuda-aware mpi

### DIFF
--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -572,6 +572,13 @@ namespace Utilities
 
     private:
       /**
+       * Initialize import_indices_plain_dev from import_indices_data. This
+       * function is only used when using CUDA-aware MPI.
+       */
+      void
+      initialize_import_indices_plain_dev() const;
+
+      /**
        * The global size of the vector over all processors
        */
       types::global_dof_index global_size;

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -530,6 +530,18 @@ namespace Utilities
       const unsigned int n_import_targets = import_targets_data.size();
       const unsigned int n_ghost_targets  = ghost_targets_data.size();
 
+#    if (defined(DEAL_II_COMPILER_CUDA_AWARE) && \
+         defined(DEAL_II_WITH_CUDA_AWARE_MPI))
+      // When using CUDAs-aware MPI, the set of local indices that are ghosts
+      // indices on other processors is expanded in arrays. This is for
+      // performance reasons as this can significantly decrease the number of
+      // kernel launched. The indices are expanded the first time the function
+      // is called.
+      if ((std::is_same<MemorySpaceType, MemorySpace::CUDA>::value) &&
+          (import_indices_plain_dev.size() == 0))
+        initialize_import_indices_plain_dev();
+#    endif
+
       if (vector_operation != dealii::VectorOperation::insert)
         AssertDimension(n_ghost_targets + n_import_targets, requests.size());
       // first wait for the receive to complete
@@ -595,70 +607,82 @@ namespace Utilities
 #    else
           if (vector_operation == dealii::VectorOperation::add)
             {
-              for (const auto &import_range : import_indices_data)
+              for (auto const &import_indices_plain : import_indices_plain_dev)
                 {
-                  const auto chunk_size =
-                    import_range.second - import_range.first;
+                  const auto chunk_size = import_indices_plain.second;
                   const int n_blocks =
                     1 + (chunk_size - 1) / (::dealii::CUDAWrappers::chunk_size *
                                             ::dealii::CUDAWrappers::block_size);
-                  dealii::LinearAlgebra::CUDAWrappers::kernel::vector_bin_op<
-                    Number,
-                    dealii::LinearAlgebra::CUDAWrappers::kernel::Binop_Addition>
+                  dealii::LinearAlgebra::CUDAWrappers::kernel::
+                    masked_vector_bin_op<Number,
+                                         dealii::LinearAlgebra::CUDAWrappers::
+                                           kernel::Binop_Addition>
                     <<<n_blocks, dealii::CUDAWrappers::block_size>>>(
-                      locally_owned_array.data() + import_range.first,
+                      import_indices_plain.first.get(),
+                      locally_owned_array.data(),
                       read_position,
                       chunk_size);
                   read_position += chunk_size;
                 }
             }
           else if (vector_operation == dealii::VectorOperation::min)
-            for (const auto &import_range : import_indices_data)
-              {
-                const auto chunk_size =
-                  import_range.second - import_range.first;
-                const int n_blocks =
-                  1 + (chunk_size - 1) / (::dealii::CUDAWrappers::chunk_size *
-                                          ::dealii::CUDAWrappers::block_size);
-                dealii::LinearAlgebra::CUDAWrappers::kernel::vector_bin_op<
-                  Number,
-                  dealii::LinearAlgebra::CUDAWrappers::kernel::Binop_Min>
-                  <<<n_blocks, dealii::CUDAWrappers::block_size>>>(
-                    locally_owned_array.data() + import_range.first,
-                    read_position,
-                    chunk_size);
-                read_position += chunk_size;
-              }
+            {
+              for (auto const &import_indices_plain : import_indices_plain_dev)
+                {
+                  const auto chunk_size = import_indices_plain.second;
+                  const int n_blocks =
+                    1 + (chunk_size - 1) / (::dealii::CUDAWrappers::chunk_size *
+                                            ::dealii::CUDAWrappers::block_size);
+                  dealii::LinearAlgebra::CUDAWrappers::kernel::
+                    masked_vector_bin_op<
+                      Number,
+                      dealii::LinearAlgebra::CUDAWrappers::kernel::Binop_Min>
+                    <<<n_blocks, dealii::CUDAWrappers::block_size>>>(
+                      import_indices_plain.first.get(),
+                      locally_owned_array.data(),
+                      read_position,
+                      chunk_size);
+                  read_position += chunk_size;
+                }
+            }
           else if (vector_operation == dealii::VectorOperation::max)
-            for (const auto &import_range : import_indices_data)
-              {
-                const auto chunk_size =
-                  import_range.second - import_range.first;
-                const int n_blocks =
-                  1 + (chunk_size - 1) / (::dealii::CUDAWrappers::chunk_size *
-                                          ::dealii::CUDAWrappers::block_size);
-                dealii::LinearAlgebra::CUDAWrappers::kernel::vector_bin_op<
-                  Number,
-                  dealii::LinearAlgebra::CUDAWrappers::kernel::Binop_Max>
-                  <<<n_blocks, dealii::CUDAWrappers::block_size>>>(
-                    locally_owned_array.data() + import_range.first,
-                    read_position,
-                    chunk_size);
-                read_position += chunk_size;
-              }
-          else // TODO
-            for (const auto &import_range : import_indices_data)
-              {
-                const auto chunk_size =
-                  import_range.second - import_range.first;
-                const cudaError_t cuda_error_code =
-                  cudaMemcpy(locally_owned_array.data() + import_range.first,
-                             read_position,
-                             chunk_size * sizeof(Number),
-                             cudaMemcpyDeviceToDevice);
-                AssertCuda(cuda_error_code);
-                read_position += chunk_size;
-              }
+            {
+              for (auto const &import_indices_plain : import_indices_plain_dev)
+                {
+                  const auto chunk_size = import_indices_plain.second;
+                  const int n_blocks =
+                    1 + (chunk_size - 1) / (::dealii::CUDAWrappers::chunk_size *
+                                            ::dealii::CUDAWrappers::block_size);
+                  dealii::LinearAlgebra::CUDAWrappers::kernel::
+                    masked_vector_bin_op<
+                      Number,
+                      dealii::LinearAlgebra::CUDAWrappers::kernel::Binop_Max>
+                    <<<n_blocks, dealii::CUDAWrappers::block_size>>>(
+                      import_indices_plain.first.get(),
+                      locally_owned_array.data(),
+                      read_position,
+                      chunk_size);
+                  read_position += chunk_size;
+                }
+            }
+          else
+            {
+              for (auto const &import_indices_plain : import_indices_plain_dev)
+                {
+                  const auto chunk_size = import_indices_plain.second;
+                  const int n_blocks =
+                    1 + (chunk_size - 1) / (::dealii::CUDAWrappers::chunk_size *
+                                            ::dealii::CUDAWrappers::block_size);
+                  dealii::LinearAlgebra::CUDAWrappers::kernel::
+                    set_permutated<<<n_blocks,
+                                     dealii::CUDAWrappers::block_size>>>(
+                      import_indices_plain.first.get(),
+                      locally_owned_array.data(),
+                      read_position,
+                      chunk_size);
+                  read_position += chunk_size;
+                }
+            }
 #    endif
           AssertDimension(read_position - temporary_storage.data(),
                           n_import_indices());

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -161,8 +161,8 @@ namespace Utilities
               ::dealii::LinearAlgebra::CUDAWrappers::kernel::
                 gather<<<n_blocks, ::dealii::CUDAWrappers::block_size>>>(
                   temp_array_ptr,
-                  locally_owned_array.data(),
                   import_indices_plain_dev[i].first.get(),
+                  locally_owned_array.data(),
                   import_indices_plain_dev[i].second);
             }
           else

--- a/include/deal.II/lac/cuda_kernels.h
+++ b/include/deal.II/lac/cuda_kernels.h
@@ -451,12 +451,12 @@ namespace LinearAlgebra
        *
        * @ingroup CUDAWrappers
        */
-      template <typename Number>
+      template <typename Number, typename IndexType>
       __global__ void
-      set_permutated(Number *         val,
+      set_permutated(const IndexType *indices,
+                     Number *         val,
                      const Number *   v,
-                     const size_type *indices,
-                     const size_type  N);
+                     const IndexType  N);
 
 
 
@@ -469,8 +469,8 @@ namespace LinearAlgebra
       template <typename Number, typename IndexType>
       __global__ void
       gather(Number *         val,
-             const Number *   v,
              const IndexType *indices,
+             const Number *   v,
              const IndexType  N);
 
 
@@ -483,9 +483,9 @@ namespace LinearAlgebra
        */
       template <typename Number>
       __global__ void
-      add_permutated(Number *         val,
+      add_permutated(const size_type *indices,
+                     Number *         val,
                      const Number *   v,
-                     const size_type *indices,
                      const size_type  N);
     } // namespace kernel
   }   // namespace CUDAWrappers

--- a/include/deal.II/lac/cuda_kernels.h
+++ b/include/deal.II/lac/cuda_kernels.h
@@ -182,6 +182,23 @@ namespace LinearAlgebra
 
 
       /**
+       * Apply the functor @tparam Binop to the elements of @p v1 that have
+       * indices in @p mask and @p v2. The size of @p mask should be greater
+       * than the size of @p v1. @p mask and @p v2 should have the same size @p
+       * N.
+       *
+       * @ingroup CUDAWrappers
+       */
+      template <typename Number, template <typename> class Binop>
+      __global__ void
+      masked_vector_bin_op(const unsigned int *mask,
+                           Number *            v1,
+                           const Number *      v2,
+                           const size_type     N);
+
+
+
+      /**
        * Structure implementing the functions used to add elements when
        * using a reduction.
        *

--- a/include/deal.II/lac/cuda_kernels.templates.h
+++ b/include/deal.II/lac/cuda_kernels.templates.h
@@ -533,12 +533,12 @@ namespace LinearAlgebra
 
 
 
-      template <typename Number>
+      template <typename Number, typename IndexType>
       __global__ void
-      set_permutated(Number *         val,
+      set_permutated(const IndexType *indices,
+                     Number *         val,
                      const Number *   v,
-                     const size_type *indices,
-                     const size_type  N)
+                     const IndexType  N)
       {
         const size_type idx_base =
           threadIdx.x + blockIdx.x * (blockDim.x * chunk_size);
@@ -555,8 +555,8 @@ namespace LinearAlgebra
       template <typename Number, typename IndexType>
       __global__ void
       gather(Number *         val,
-             const Number *   v,
              const IndexType *indices,
+             const Number *   v,
              const IndexType  N)
       {
         const IndexType idx_base =
@@ -573,9 +573,9 @@ namespace LinearAlgebra
 
       template <typename Number>
       __global__ void
-      add_permutated(Number *         val,
+      add_permutated(const size_type *indices,
+                     Number *         val,
                      const Number *   v,
-                     const size_type *indices,
                      const size_type  N)
       {
         const size_type idx_base =

--- a/include/deal.II/lac/cuda_kernels.templates.h
+++ b/include/deal.II/lac/cuda_kernels.templates.h
@@ -60,6 +60,24 @@ namespace LinearAlgebra
 
 
 
+      template <typename Number, template <typename> class Binop>
+      __global__ void
+      masked_vector_bin_op(const unsigned int *mask,
+                           Number *            v1,
+                           const Number *      v2,
+                           const size_type     N)
+      {
+        const size_type idx_base =
+          threadIdx.x + blockIdx.x * (blockDim.x * chunk_size);
+        for (unsigned int i = 0; i < chunk_size; ++i)
+          {
+            const size_type idx = idx_base + i * block_size;
+            if (idx < N)
+              v1[mask[idx]] = Binop<Number>::operation(v1[mask[idx]], v2[idx]);
+          }
+      }
+
+
       template <typename Number>
       __device__ Number
                  ElemSum<Number>::reduction_op(const Number a, const Number b)

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -301,7 +301,7 @@ namespace LinearAlgebra
                                     ::dealii::CUDAWrappers::block_size);
           ::dealii::LinearAlgebra::CUDAWrappers::kernel::set_permutated<Number>
             <<<n_blocks, ::dealii::CUDAWrappers::block_size>>>(
-              tmp_vector.begin(), V_dev, indices_dev, n_elements);
+              indices_dev, tmp_vector.begin(), V_dev, n_elements);
 
           tmp_vector.compress(operation);
 
@@ -319,16 +319,16 @@ namespace LinearAlgebra
           if (operation == VectorOperation::add)
             ::dealii::LinearAlgebra::CUDAWrappers::kernel::add_permutated<
               Number><<<n_blocks, ::dealii::CUDAWrappers::block_size>>>(
+              indices_dev,
               data.values_dev.get(),
               tmp_vector.begin(),
-              indices_dev,
               tmp_n_elements);
           else
             ::dealii::LinearAlgebra::CUDAWrappers::kernel::set_permutated<
               Number><<<n_blocks, ::dealii::CUDAWrappers::block_size>>>(
+              indices_dev,
               data.values_dev.get(),
               tmp_vector.begin(),
-              indices_dev,
               tmp_n_elements);
 
           ::dealii::Utilities::CUDA::free(indices_dev);

--- a/source/base/partitioner.cu
+++ b/source/base/partitioner.cu
@@ -18,6 +18,50 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+
+
+namespace Utilities
+{
+  namespace MPI
+  {
+    void
+    Partitioner::initialize_import_indices_plain_dev() const
+    {
+      const unsigned int n_import_targets = import_targets_data.size();
+      import_indices_plain_dev.reserve(n_import_targets);
+      for (unsigned int i = 0; i < n_import_targets; i++)
+        {
+          // Expand the indices on the host
+          std::vector<std::pair<unsigned int, unsigned int>>::const_iterator
+            my_imports = import_indices_data.begin() +
+                         import_indices_chunks_by_rank_data[i],
+            end_my_imports = import_indices_data.begin() +
+                             import_indices_chunks_by_rank_data[i + 1];
+          std::vector<unsigned int> import_indices_plain_host;
+          for (; my_imports != end_my_imports; ++my_imports)
+            {
+              const unsigned int chunk_size =
+                my_imports->second - my_imports->first;
+              for (unsigned int j = 0; j < chunk_size; ++j)
+                import_indices_plain_host.push_back(my_imports->first + j);
+            }
+
+          // Move the indices to the device
+          import_indices_plain_dev.emplace_back(std::make_pair(
+            std::unique_ptr<unsigned int[], void (*)(unsigned int *)>(
+              nullptr, Utilities::CUDA::delete_device_data<unsigned int>),
+            import_indices_plain_host.size()));
+
+          import_indices_plain_dev[i].first.reset(
+            Utilities::CUDA::allocate_device_data<unsigned int>(
+              import_indices_plain_dev[i].second));
+          Utilities::CUDA::copy_to_dev(import_indices_plain_host,
+                                       import_indices_plain_dev[i].first.get());
+        }
+    }
+  } // namespace MPI
+} // namespace Utilities
+
 // explicit instantiations from .templates.h file
 #include "partitioner.cuda.inst"
 

--- a/source/lac/cuda_kernels.cu
+++ b/source/lac/cuda_kernels.cu
@@ -37,6 +37,16 @@ namespace LinearAlgebra
       vector_bin_op<float, Binop_Subtraction>(float *         v1,
                                               const float *   v2,
                                               const size_type N);
+      template __global__ void
+      masked_vector_bin_op<float, Binop_Addition>(const unsigned int *mask,
+                                                  float *             v1,
+                                                  const float *       v2,
+                                                  const size_type     N);
+      template __global__ void
+      masked_vector_bin_op<float, Binop_Subtraction>(const unsigned int *mask,
+                                                     float *             v1,
+                                                     const float *       v2,
+                                                     const size_type     N);
       template struct ElemSum<float>;
       template struct L1Norm<float>;
       template struct LInfty<float>;
@@ -137,6 +147,16 @@ namespace LinearAlgebra
       vector_bin_op<double, Binop_Subtraction>(double *        v1,
                                                const double *  v2,
                                                const size_type N);
+      template __global__ void
+      masked_vector_bin_op<double, Binop_Addition>(const unsigned int *mask,
+                                                   double *            v1,
+                                                   const double *      v2,
+                                                   const size_type     N);
+      template __global__ void
+      masked_vector_bin_op<double, Binop_Subtraction>(const unsigned int *mask,
+                                                      double *            v1,
+                                                      const double *      v2,
+                                                      const size_type     N);
       template struct ElemSum<double>;
       template struct L1Norm<double>;
       template struct LInfty<double>;

--- a/source/lac/cuda_kernels.cu
+++ b/source/lac/cuda_kernels.cu
@@ -94,12 +94,12 @@ namespace LinearAlgebra
                  const float *   V_val,
                  const size_type N);
       template __global__ void
-      equ(float *         val,
-          const float     a,
-          const float *   V_val,
-          const float     b,
-          const float *   W_val,
-          const size_type N);
+      equ<float>(float *         val,
+                 const float     a,
+                 const float *   V_val,
+                 const float     b,
+                 const float *   W_val,
+                 const size_type N);
       template __global__ void
       add_and_dot<float>(float *         res,
                          float *         v1,
@@ -110,19 +110,19 @@ namespace LinearAlgebra
       template __global__ void
       set<float>(float *val, const float s, const size_type N);
       template __global__ void
-      set_permutated<float>(float *          val,
-                            const float *    v,
-                            const size_type *indices,
-                            const size_type  N);
+      set_permutated<float, size_type>(const size_type *indices,
+                                       float *          val,
+                                       const float *    v,
+                                       const size_type  N);
       template __global__ void
-      gather(float *          val,
-             const float *    v,
-             const size_type *indices,
-             const size_type  N);
+      gather<float, size_type>(float *          val,
+                               const size_type *indices,
+                               const float *    v,
+                               const size_type  N);
       template __global__ void
-      add_permutated<float>(float *          val,
+      add_permutated<float>(const size_type *indices,
+                            float *          val,
                             const float *    v,
-                            const size_type *indices,
                             const size_type  N);
 
 
@@ -194,12 +194,12 @@ namespace LinearAlgebra
                   const double *  V_val,
                   const size_type N);
       template __global__ void
-      equ(double *        val,
-          const double    a,
-          const double *  V_val,
-          const double    b,
-          const double *  W_val,
-          const size_type N);
+      equ<double>(double *        val,
+                  const double    a,
+                  const double *  V_val,
+                  const double    b,
+                  const double *  W_val,
+                  const size_type N);
       template __global__ void
       add_and_dot<double>(double *        res,
                           double *        v1,
@@ -210,19 +210,19 @@ namespace LinearAlgebra
       template __global__ void
       set<double>(double *val, const double s, const size_type N);
       template __global__ void
-      set_permutated<double>(double *         val,
-                             const double *   v,
-                             const size_type *indices,
-                             const size_type  N);
+      set_permutated<double, size_type>(const size_type *indices,
+                                        double *         val,
+                                        const double *   v,
+                                        const size_type  N);
       template __global__ void
-      gather(double *         val,
-             const double *   v,
-             const size_type *indices,
-             const size_type  N);
+      gather<double, size_type>(double *         val,
+                                const size_type *indices,
+                                const double *   v,
+                                const size_type  N);
       template __global__ void
-      add_permutated<double>(double *         val,
+      add_permutated<double>(const size_type *indices,
+                             double *         val,
                              const double *   v,
-                             const size_type *indices,
                              const size_type  N);
     } // namespace kernel
   }   // namespace CUDAWrappers


### PR DESCRIPTION
This PR does two things:
 - update the api of a few functions in `cuda_kernel` for consistency (these functions are a couple of months old so we are free to change the API)
 - use the same logic found in #7303 (where it was used to speed up `update_ghost`) to speed up `compress`

cc: @dsambit 