### PR TITLE
Adjust degree of PreconditionChebyshev to convention in literature

### DIFF
--- a/doc/news/changes/minor/20190208MartinKronbichler
+++ b/doc/news/changes/minor/20190208MartinKronbichler
@@ -1,0 +1,8 @@
+Fixed: PreconditionChebyshev would previously run one iteration more than
+requested, i.e., perform `degree+1` matrix-vector products rather than
+`degree` which is the convention in literature. This is now fixed. Note that
+the quality of PreconditionChebyshev is obviously slightly reduced by this
+change, and some solvers might need more outer iterations due to a ligher
+Chebyshev iteration.
+<br>
+(Martin Kronbichler, 2019/02/08)

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -950,7 +950,7 @@ namespace Step37
     // do not have the matrix elements available explicitly, and it is
     // difficult to make it work efficiently in %parallel.)  The smoother is
     // initialized with our level matrices and the mandatory additional data
-    // for the Chebyshev smoother. We use a relatively high degree here (4),
+    // for the Chebyshev smoother. We use a relatively high degree here (5),
     // since matrix-vector products are comparably cheap. We choose to smooth
     // out a range of $[1.2 \hat{\lambda}_{\max}/15,1.2 \hat{\lambda}_{\max}]$
     // in the smoother where $\hat{\lambda}_{\max}$ is an estimate of the
@@ -1002,7 +1002,7 @@ namespace Step37
         if (level > 0)
           {
             smoother_data[level].smoothing_range     = 15.;
-            smoother_data[level].degree              = 4;
+            smoother_data[level].degree              = 5;
             smoother_data[level].eig_cg_n_iterations = 10;
           }
         else

--- a/examples/step-59/step-59.cc
+++ b/examples/step-59/step-59.cc
@@ -1235,7 +1235,7 @@ namespace Step59
         if (level > 0)
           {
             smoother_data[level].smoothing_range     = 15.;
-            smoother_data[level].degree              = 2;
+            smoother_data[level].degree              = 3;
             smoother_data[level].eig_cg_n_iterations = 10;
           }
         else

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -2250,13 +2250,16 @@ inline void
 PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
   do_chebyshev_loop(VectorType &dst, const VectorType &src) const
 {
+  if (data.degree < 2)
+    return;
+
   // if delta is zero, we do not need to iterate because the updates will be
   // zero
   if (std::abs(delta) < 1e-40)
     return;
 
   double rhok = delta / theta, sigma = theta / delta;
-  for (unsigned int k = 0; k < data.degree; ++k)
+  for (unsigned int k = 0; k < data.degree - 1; ++k)
     {
       matrix_ptr->vmult(update2, dst);
       const double rhokp   = 1. / (2. * sigma - rhok);
@@ -2282,8 +2285,11 @@ inline void
 PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
   do_transpose_chebyshev_loop(VectorType &dst, const VectorType &src) const
 {
+  if (data.degree < 2)
+    return;
+
   double rhok = delta / theta, sigma = theta / delta;
-  for (unsigned int k = 0; k < data.degree; ++k)
+  for (unsigned int k = 0; k < data.degree - 1; ++k)
     {
       matrix_ptr->Tvmult(update2, dst);
       const double rhokp   = 1. / (2. * sigma - rhok);

--- a/tests/lac/precondition_chebyshev_01.cc
+++ b/tests/lac/precondition_chebyshev_01.cc
@@ -56,7 +56,7 @@ check()
   PreconditionChebyshev<FullMatrixModified, Vector<double>>::AdditionalData
     data;
   data.smoothing_range = 2 * size;
-  data.degree          = 3;
+  data.degree          = 4;
   prec.initialize(m, data);
 
   deallog << "Exact inverse:     ";

--- a/tests/lac/precondition_chebyshev_02.cc
+++ b/tests/lac/precondition_chebyshev_02.cc
@@ -87,7 +87,7 @@ check()
                         Vector<double>,
                         DiagonalMatrixManual>::AdditionalData data;
   data.smoothing_range = 2 * size;
-  data.degree          = 3;
+  data.degree          = 4;
   data.preconditioner.reset(new DiagonalMatrixManual());
   data.preconditioner->set_vector_one(size);
   prec.initialize(m, data);

--- a/tests/lac/precondition_chebyshev_03.cc
+++ b/tests/lac/precondition_chebyshev_03.cc
@@ -59,7 +59,7 @@ main()
                             SparseILU<double>>::AdditionalData cheby_data;
       cheby_data.preconditioner.reset(new SparseILU<double>());
       cheby_data.preconditioner->initialize(A);
-      cheby_data.degree          = 10;
+      cheby_data.degree          = 11;
       cheby_data.smoothing_range = 40;
       cheby.initialize(A, cheby_data);
 

--- a/tests/lac/precondition_chebyshev_04.cc
+++ b/tests/lac/precondition_chebyshev_04.cc
@@ -87,7 +87,7 @@ check()
                         Vector<double>,
                         DiagonalMatrixManual>::AdditionalData data;
   data.smoothing_range = 2 * size;
-  data.degree          = 3;
+  data.degree          = 4;
   data.preconditioner.reset(new DiagonalMatrixManual());
   data.preconditioner->set_vector_one(size);
   prec.initialize(m, data);

--- a/tests/lac/precondition_chebyshev_05.cc
+++ b/tests/lac/precondition_chebyshev_05.cc
@@ -67,7 +67,7 @@ main(int argc, char **argv)
       cheby_data.preconditioner.reset(
         new TrilinosWrappers::PreconditionJacobi());
       cheby_data.preconditioner->initialize(AA);
-      cheby_data.degree          = 10;
+      cheby_data.degree          = 11;
       cheby_data.smoothing_range = 40;
       cheby.initialize(AA, cheby_data);
 

--- a/tests/matrix_free/multigrid_dg_periodic.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/matrix_free/multigrid_dg_periodic.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -2,40 +2,40 @@
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 256
 DEAL:2d:cg::Starting value 16.0000
-DEAL:2d:cg::Convergence step 6 value 3.31973e-12
+DEAL:2d:cg::Convergence step 7 value 1.80729e-11
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 1024
 DEAL:2d:cg::Starting value 32.0000
-DEAL:2d:cg::Convergence step 6 value 1.50088e-09
+DEAL:2d:cg::Convergence step 8 value 8.73511e-11
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 4096
 DEAL:2d:cg::Starting value 64.0000
-DEAL:2d:cg::Convergence step 7 value 7.89595e-10
+DEAL:2d:cg::Convergence step 8 value 4.57619e-10
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 576
 DEAL:2d:cg::Starting value 24.0000
-DEAL:2d:cg::Convergence step 6 value 2.18769e-10
+DEAL:2d:cg::Convergence step 7 value 1.07430e-09
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 2304
 DEAL:2d:cg::Starting value 48.0000
-DEAL:2d:cg::Convergence step 6 value 1.04858e-09
+DEAL:2d:cg::Convergence step 8 value 1.87005e-10
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 512
 DEAL:3d:cg::Starting value 22.6274
-DEAL:3d:cg::Convergence step 4 value 1.39603e-17
+DEAL:3d:cg::Convergence step 4 value 7.99677e-17
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 4096
 DEAL:3d:cg::Starting value 64.0000
-DEAL:3d:cg::Convergence step 6 value 2.68072e-11
+DEAL:3d:cg::Convergence step 6 value 2.27740e-11
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 32768
 DEAL:3d:cg::Starting value 181.019
-DEAL:3d:cg::Convergence step 7 value 8.70647e-10
+DEAL:3d:cg::Convergence step 7 value 2.41331e-09
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 1728
 DEAL:3d:cg::Starting value 41.5692
-DEAL:3d:cg::Convergence step 7 value 1.39310e-09
+DEAL:3d:cg::Convergence step 8 value 1.14978e-09
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 13824
 DEAL:3d:cg::Starting value 117.576
-DEAL:3d:cg::Convergence step 8 value 1.40299e-09
+DEAL:3d:cg::Convergence step 9 value 1.16347e-09

--- a/tests/matrix_free/multigrid_dg_periodic.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/matrix_free/multigrid_dg_periodic.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -2,40 +2,40 @@
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 256
 DEAL:2d:cg::Starting value 16.0000
-DEAL:2d:cg::Convergence step 6 value 3.31973e-12
+DEAL:2d:cg::Convergence step 7 value 1.80729e-11
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 1024
 DEAL:2d:cg::Starting value 32.0000
-DEAL:2d:cg::Convergence step 6 value 1.50088e-09
+DEAL:2d:cg::Convergence step 8 value 8.73511e-11
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 4096
 DEAL:2d:cg::Starting value 64.0000
-DEAL:2d:cg::Convergence step 7 value 7.89595e-10
+DEAL:2d:cg::Convergence step 8 value 4.57619e-10
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 576
 DEAL:2d:cg::Starting value 24.0000
-DEAL:2d:cg::Convergence step 6 value 2.18769e-10
+DEAL:2d:cg::Convergence step 7 value 1.07430e-09
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 2304
 DEAL:2d:cg::Starting value 48.0000
-DEAL:2d:cg::Convergence step 6 value 1.04858e-09
+DEAL:2d:cg::Convergence step 8 value 1.87005e-10
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 512
 DEAL:3d:cg::Starting value 22.6274
-DEAL:3d:cg::Convergence step 4 value 1.45014e-17
+DEAL:3d:cg::Convergence step 4 value 9.91449e-17
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 4096
 DEAL:3d:cg::Starting value 64.0000
-DEAL:3d:cg::Convergence step 6 value 2.68072e-11
+DEAL:3d:cg::Convergence step 6 value 2.27740e-11
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 32768
 DEAL:3d:cg::Starting value 181.019
-DEAL:3d:cg::Convergence step 7 value 8.70647e-10
+DEAL:3d:cg::Convergence step 7 value 2.41331e-09
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 1728
 DEAL:3d:cg::Starting value 41.5692
-DEAL:3d:cg::Convergence step 7 value 1.39310e-09
+DEAL:3d:cg::Convergence step 8 value 1.14978e-09
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 13824
 DEAL:3d:cg::Starting value 117.576
-DEAL:3d:cg::Convergence step 8 value 1.40299e-09
+DEAL:3d:cg::Convergence step 9 value 1.16347e-09

--- a/tests/matrix_free/multigrid_dg_periodic.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=5.output
+++ b/tests/matrix_free/multigrid_dg_periodic.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=5.output
@@ -2,40 +2,40 @@
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 256
 DEAL:2d:cg::Starting value 16.0000
-DEAL:2d:cg::Convergence step 6 value 3.31973e-12
+DEAL:2d:cg::Convergence step 7 value 1.80729e-11
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 1024
 DEAL:2d:cg::Starting value 32.0000
-DEAL:2d:cg::Convergence step 6 value 1.50088e-09
+DEAL:2d:cg::Convergence step 8 value 8.73511e-11
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 4096
 DEAL:2d:cg::Starting value 64.0000
-DEAL:2d:cg::Convergence step 7 value 7.89595e-10
+DEAL:2d:cg::Convergence step 8 value 4.57619e-10
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 576
 DEAL:2d:cg::Starting value 24.0000
-DEAL:2d:cg::Convergence step 6 value 2.18769e-10
+DEAL:2d:cg::Convergence step 7 value 1.07430e-09
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 2304
 DEAL:2d:cg::Starting value 48.0000
-DEAL:2d:cg::Convergence step 6 value 1.04858e-09
+DEAL:2d:cg::Convergence step 8 value 1.87005e-10
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 512
 DEAL:3d:cg::Starting value 22.6274
-DEAL:3d:cg::Convergence step 4 value 1.18679e-17
+DEAL:3d:cg::Convergence step 4 value 7.23452e-17
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 4096
 DEAL:3d:cg::Starting value 64.0000
-DEAL:3d:cg::Convergence step 6 value 2.68072e-11
+DEAL:3d:cg::Convergence step 6 value 2.27740e-11
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 32768
 DEAL:3d:cg::Starting value 181.019
-DEAL:3d:cg::Convergence step 7 value 8.70647e-10
+DEAL:3d:cg::Convergence step 7 value 2.41331e-09
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 1728
 DEAL:3d:cg::Starting value 41.5692
-DEAL:3d:cg::Convergence step 7 value 1.39310e-09
+DEAL:3d:cg::Convergence step 8 value 1.14978e-09
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 13824
 DEAL:3d:cg::Starting value 117.576
-DEAL:3d:cg::Convergence step 8 value 1.40299e-09
+DEAL:3d:cg::Convergence step 9 value 1.16347e-09

--- a/tests/matrix_free/multigrid_dg_sip_01.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/matrix_free/multigrid_dg_sip_01.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -2,40 +2,40 @@
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 256
 DEAL:2d:cg::Starting value 16.0000
-DEAL:2d:cg::Convergence step 4 value 1.45213e-06
+DEAL:2d:cg::Convergence step 5 value 3.60502e-07
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 1024
 DEAL:2d:cg::Starting value 32.0000
-DEAL:2d:cg::Convergence step 5 value 8.09074e-08
+DEAL:2d:cg::Convergence step 5 value 2.14074e-06
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 4096
 DEAL:2d:cg::Starting value 64.0000
-DEAL:2d:cg::Convergence step 5 value 9.08540e-07
+DEAL:2d:cg::Convergence step 5 value 5.99637e-06
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 576
 DEAL:2d:cg::Starting value 24.0000
-DEAL:2d:cg::Convergence step 5 value 4.02774e-08
+DEAL:2d:cg::Convergence step 5 value 1.81901e-06
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 2304
 DEAL:2d:cg::Starting value 48.0000
-DEAL:2d:cg::Convergence step 5 value 7.58404e-08
+DEAL:2d:cg::Convergence step 6 value 1.94976e-07
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 512
 DEAL:3d:cg::Starting value 22.6274
-DEAL:3d:cg::Convergence step 5 value 2.70681e-07
+DEAL:3d:cg::Convergence step 6 value 7.43327e-08
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 4096
 DEAL:3d:cg::Starting value 64.0000
-DEAL:3d:cg::Convergence step 5 value 3.69638e-06
+DEAL:3d:cg::Convergence step 6 value 2.28298e-06
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 32768
 DEAL:3d:cg::Starting value 181.019
-DEAL:3d:cg::Convergence step 5 value 5.56024e-06
+DEAL:3d:cg::Convergence step 6 value 5.09300e-06
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 1728
 DEAL:3d:cg::Starting value 41.5692
-DEAL:3d:cg::Convergence step 5 value 5.30416e-07
+DEAL:3d:cg::Convergence step 6 value 1.73456e-07
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 13824
 DEAL:3d:cg::Starting value 117.576
-DEAL:3d:cg::Convergence step 6 value 8.58800e-07
+DEAL:3d:cg::Convergence step 7 value 5.35539e-07

--- a/tests/matrix_free/multigrid_dg_sip_01.with_mpi=true.with_p4est=true.mpirun=5.output
+++ b/tests/matrix_free/multigrid_dg_sip_01.with_mpi=true.with_p4est=true.mpirun=5.output
@@ -2,40 +2,40 @@
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 256
 DEAL:2d:cg::Starting value 16.0000
-DEAL:2d:cg::Convergence step 4 value 1.45213e-06
+DEAL:2d:cg::Convergence step 5 value 3.60502e-07
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 1024
 DEAL:2d:cg::Starting value 32.0000
-DEAL:2d:cg::Convergence step 5 value 8.09074e-08
+DEAL:2d:cg::Convergence step 5 value 2.14074e-06
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 4096
 DEAL:2d:cg::Starting value 64.0000
-DEAL:2d:cg::Convergence step 5 value 9.08540e-07
+DEAL:2d:cg::Convergence step 5 value 5.99637e-06
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 576
 DEAL:2d:cg::Starting value 24.0000
-DEAL:2d:cg::Convergence step 5 value 4.02774e-08
+DEAL:2d:cg::Convergence step 5 value 1.81901e-06
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 2304
 DEAL:2d:cg::Starting value 48.0000
-DEAL:2d:cg::Convergence step 5 value 7.58404e-08
+DEAL:2d:cg::Convergence step 6 value 1.94976e-07
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 512
 DEAL:3d:cg::Starting value 22.6274
-DEAL:3d:cg::Convergence step 5 value 2.70681e-07
+DEAL:3d:cg::Convergence step 6 value 7.43327e-08
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 4096
 DEAL:3d:cg::Starting value 64.0000
-DEAL:3d:cg::Convergence step 5 value 3.69638e-06
+DEAL:3d:cg::Convergence step 6 value 2.28298e-06
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 32768
 DEAL:3d:cg::Starting value 181.019
-DEAL:3d:cg::Convergence step 5 value 5.56024e-06
+DEAL:3d:cg::Convergence step 6 value 5.09300e-06
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 1728
 DEAL:3d:cg::Starting value 41.5692
-DEAL:3d:cg::Convergence step 5 value 5.30416e-07
+DEAL:3d:cg::Convergence step 6 value 1.73456e-07
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 13824
 DEAL:3d:cg::Starting value 117.576
-DEAL:3d:cg::Convergence step 6 value 8.58800e-07
+DEAL:3d:cg::Convergence step 7 value 5.35539e-07

--- a/tests/matrix_free/multigrid_dg_sip_02.with_mpi=true.with_p4est=true.mpirun=5.output
+++ b/tests/matrix_free/multigrid_dg_sip_02.with_mpi=true.with_p4est=true.mpirun=5.output
@@ -2,40 +2,40 @@
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 256
 DEAL:2d:cg::Starting value 16.0000
-DEAL:2d:cg::Convergence step 4 value 1.45213e-06
+DEAL:2d:cg::Convergence step 5 value 3.60502e-07
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 1024
 DEAL:2d:cg::Starting value 32.0000
-DEAL:2d:cg::Convergence step 5 value 8.09074e-08
+DEAL:2d:cg::Convergence step 5 value 2.14074e-06
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Number of degrees of freedom: 4096
 DEAL:2d:cg::Starting value 64.0000
-DEAL:2d:cg::Convergence step 5 value 9.08540e-07
+DEAL:2d:cg::Convergence step 5 value 5.99637e-06
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 576
 DEAL:2d:cg::Starting value 24.0000
-DEAL:2d:cg::Convergence step 5 value 4.02774e-08
+DEAL:2d:cg::Convergence step 5 value 1.81901e-06
 DEAL:2d::Testing FE_DGQ<2>(2)
 DEAL:2d::Number of degrees of freedom: 2304
 DEAL:2d:cg::Starting value 48.0000
-DEAL:2d:cg::Convergence step 5 value 7.58404e-08
+DEAL:2d:cg::Convergence step 6 value 1.94976e-07
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 512
 DEAL:3d:cg::Starting value 22.6274
-DEAL:3d:cg::Convergence step 5 value 2.70681e-07
+DEAL:3d:cg::Convergence step 6 value 7.43327e-08
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 4096
 DEAL:3d:cg::Starting value 64.0000
-DEAL:3d:cg::Convergence step 5 value 3.69638e-06
+DEAL:3d:cg::Convergence step 6 value 2.28298e-06
 DEAL:3d::Testing FE_DGQ<3>(1)
 DEAL:3d::Number of degrees of freedom: 32768
 DEAL:3d:cg::Starting value 181.019
-DEAL:3d:cg::Convergence step 5 value 5.56024e-06
+DEAL:3d:cg::Convergence step 6 value 5.09300e-06
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 1728
 DEAL:3d:cg::Starting value 41.5692
-DEAL:3d:cg::Convergence step 5 value 5.30416e-07
+DEAL:3d:cg::Convergence step 6 value 1.73456e-07
 DEAL:3d::Testing FE_DGQ<3>(2)
 DEAL:3d::Number of degrees of freedom: 13824
 DEAL:3d:cg::Starting value 117.576
-DEAL:3d:cg::Convergence step 6 value 8.58800e-07
+DEAL:3d:cg::Convergence step 7 value 5.35539e-07

--- a/tests/matrix_free/parallel_multigrid.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=3.output
@@ -2,130 +2,144 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 81
 DEAL:2d:cg::Starting value 9.000
-DEAL:2d:cg:cg::Starting value 0.008804
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.035e-05
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 9.380e-08
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 4.632e-07
+DEAL:2d:cg:cg::Starting value 0.02203
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 0.0001585
+DEAL:2d:cg:cg::Convergence step 1 value 2.711e-20
+DEAL:2d:cg:cg::Starting value 8.884e-07
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 3.123e-09
+DEAL:2d:cg:cg::Convergence step 1 value 8.272e-25
+DEAL:2d:cg::Convergence step 4 value 2.071e-08
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.02904
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 5.542e-06
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.318e-09
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 4.000e-07
+DEAL:2d:cg:cg::Starting value 0.005310
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 5.163e-06
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 2.182e-08
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 9.610e-10
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg::Convergence step 4 value 2.778e-08
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 0.1041
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.041e-06
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.133e-07
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.824e-10
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 4 value 1.222e-08
+DEAL:2d:cg:cg::Starting value 0.008242
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 2.754e-06
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 9.820e-09
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 8.188e-12
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg::Convergence step 4 value 8.029e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.4928
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 7.433e-05
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 4.269e-07
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 1.107e-09
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 1.339e-08
+DEAL:2d:cg:cg::Starting value 3.849
+DEAL:2d:cg:cg::Convergence step 2 value 4.030e-15
+DEAL:2d:cg:cg::Starting value 0.0007035
+DEAL:2d:cg:cg::Convergence step 2 value 5.474e-20
+DEAL:2d:cg:cg::Starting value 4.286e-06
+DEAL:2d:cg:cg::Convergence step 2 value 4.924e-21
+DEAL:2d:cg:cg::Starting value 2.909e-08
+DEAL:2d:cg:cg::Convergence step 2 value 6.440e-24
+DEAL:2d:cg::Convergence step 4 value 3.931e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 1.857
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 6.915e-05
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 9.008e-07
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 2.272e-09
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 1.555e-08
+DEAL:2d:cg:cg::Starting value 14.69
+DEAL:2d:cg:cg::Convergence step 2 value 1.477e-14
+DEAL:2d:cg:cg::Starting value 0.002915
+DEAL:2d:cg:cg::Convergence step 2 value 8.995e-19
+DEAL:2d:cg:cg::Starting value 3.439e-06
+DEAL:2d:cg:cg::Convergence step 2 value 3.178e-21
+DEAL:2d:cg:cg::Starting value 1.212e-08
+DEAL:2d:cg:cg::Convergence step 2 value 1.500e-23
+DEAL:2d:cg::Convergence step 4 value 8.121e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 4225
 DEAL:2d:cg::Starting value 65.00
-DEAL:2d:cg:cg::Starting value 7.324
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 0.0003835
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 5.631e-07
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 8.812e-09
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 3.108e-08
+DEAL:2d:cg:cg::Starting value 58.09
+DEAL:2d:cg:cg::Convergence step 2 value 5.909e-15
+DEAL:2d:cg:cg::Starting value 0.01056
+DEAL:2d:cg:cg::Convergence step 2 value 5.646e-18
+DEAL:2d:cg:cg::Starting value 2.588e-05
+DEAL:2d:cg:cg::Convergence step 2 value 8.081e-21
+DEAL:2d:cg:cg::Starting value 6.672e-08
+DEAL:2d:cg:cg::Convergence step 2 value 4.727e-23
+DEAL:2d:cg::Convergence step 4 value 1.695e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
-DEAL:3d:cg:cg::Starting value 0.1411
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 7.053e-05
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 4.822e-09
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 9.057e-09
+DEAL:3d:cg:cg::Starting value 0.5164
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 0.02357
+DEAL:3d:cg:cg::Convergence step 1 value 4.907e-18
+DEAL:3d:cg:cg::Starting value 5.322e-05
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 1.537e-07
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg::Convergence step 4 value 3.460e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 0.03502
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 0.0002864
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.471e-07
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 1.321e-06
+DEAL:3d:cg:cg::Starting value 0.1824
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 0.004902
+DEAL:3d:cg:cg::Convergence step 1 value 6.133e-19
+DEAL:3d:cg:cg::Starting value 5.629e-06
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 3.386e-10
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg::Convergence step 4 value 1.074e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 0.06187
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 7.069e-05
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 8.132e-07
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.153e-09
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 4 value 6.546e-08
+DEAL:3d:cg:cg::Starting value 0.1633
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 0.0001064
+DEAL:3d:cg:cg::Convergence step 1 value 1.917e-20
+DEAL:3d:cg:cg::Starting value 1.367e-06
+DEAL:3d:cg:cg::Convergence step 1 value 2.995e-22
+DEAL:3d:cg:cg::Starting value 1.607e-08
+DEAL:3d:cg:cg::Convergence step 1 value 4.679e-24
+DEAL:3d:cg::Convergence step 4 value 5.067e-08
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 1.198
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.0001874
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 8.519e-08
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 4.352e-08
+DEAL:3d:cg:cg::Starting value 1.696
+DEAL:3d:cg:cg::Convergence step 2 value 3.019e-16
+DEAL:3d:cg:cg::Starting value 0.1038
+DEAL:3d:cg:cg::Convergence step 2 value 1.281e-17
+DEAL:3d:cg:cg::Starting value 0.0001778
+DEAL:3d:cg:cg::Convergence step 2 value 2.774e-20
+DEAL:3d:cg:cg::Starting value 5.289e-06
+DEAL:3d:cg:cg::Convergence step 2 value 5.235e-22
+DEAL:3d:cg::Convergence step 4 value 2.355e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 6.688
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.0005904
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 2.187e-06
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 2.196e-06
+DEAL:3d:cg:cg::Starting value 2.313
+DEAL:3d:cg:cg::Convergence step 2 value 3.056e-16
+DEAL:3d:cg:cg::Starting value 0.04486
+DEAL:3d:cg:cg::Convergence step 2 value 9.479e-18
+DEAL:3d:cg:cg::Starting value 0.0007197
+DEAL:3d:cg:cg::Convergence step 2 value 1.099e-19
+DEAL:3d:cg:cg::Starting value 2.909e-06
+DEAL:3d:cg:cg::Convergence step 2 value 1.507e-22
+DEAL:3d:cg::Convergence step 4 value 4.578e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 35937
 DEAL:3d:cg::Starting value 189.6
-DEAL:3d:cg:cg::Starting value 49.17
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.006462
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 8.640e-06
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 9.302e-06
+DEAL:3d:cg:cg::Starting value 17.40
+DEAL:3d:cg:cg::Convergence step 2 value 1.067e-14
+DEAL:3d:cg:cg::Starting value 0.01679
+DEAL:3d:cg:cg::Convergence step 2 value 2.474e-18
+DEAL:3d:cg:cg::Starting value 0.001098
+DEAL:3d:cg:cg::Convergence step 2 value 8.085e-20
+DEAL:3d:cg:cg::Starting value 1.006e-06
+DEAL:3d:cg:cg::Convergence step 2 value 9.940e-23
+DEAL:3d:cg::Convergence step 4 value 1.784e-05

--- a/tests/matrix_free/parallel_multigrid.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=7.output
@@ -2,130 +2,144 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 81
 DEAL:2d:cg::Starting value 9.000
-DEAL:2d:cg:cg::Starting value 0.008804
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.035e-05
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 9.380e-08
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 4.632e-07
+DEAL:2d:cg:cg::Starting value 0.02203
+DEAL:2d:cg:cg::Convergence step 1 value 3.469e-18
+DEAL:2d:cg:cg::Starting value 0.0001585
+DEAL:2d:cg:cg::Convergence step 1 value 2.711e-20
+DEAL:2d:cg:cg::Starting value 8.884e-07
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 3.123e-09
+DEAL:2d:cg:cg::Convergence step 1 value 4.136e-25
+DEAL:2d:cg::Convergence step 4 value 2.071e-08
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.02904
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 5.542e-06
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.318e-09
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 4.000e-07
+DEAL:2d:cg:cg::Starting value 0.005310
+DEAL:2d:cg:cg::Convergence step 1 value 8.674e-19
+DEAL:2d:cg:cg::Starting value 5.163e-06
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 2.182e-08
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 9.610e-10
+DEAL:2d:cg:cg::Convergence step 1 value 2.068e-25
+DEAL:2d:cg::Convergence step 4 value 2.778e-08
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 0.1041
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.041e-06
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.133e-07
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.824e-10
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 4 value 1.222e-08
+DEAL:2d:cg:cg::Starting value 0.008242
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 2.754e-06
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 9.820e-09
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 8.188e-12
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg::Convergence step 4 value 8.029e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.4928
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 7.433e-05
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 4.269e-07
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 1.107e-09
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 1.339e-08
+DEAL:2d:cg:cg::Starting value 3.849
+DEAL:2d:cg:cg::Convergence step 2 value 2.944e-15
+DEAL:2d:cg:cg::Starting value 0.0007035
+DEAL:2d:cg:cg::Convergence step 2 value 9.681e-20
+DEAL:2d:cg:cg::Starting value 4.286e-06
+DEAL:2d:cg:cg::Convergence step 2 value 3.549e-21
+DEAL:2d:cg:cg::Starting value 2.909e-08
+DEAL:2d:cg:cg::Convergence step 2 value 1.182e-23
+DEAL:2d:cg::Convergence step 4 value 3.931e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 1.857
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 6.915e-05
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 9.008e-07
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 2.272e-09
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 1.555e-08
+DEAL:2d:cg:cg::Starting value 14.69
+DEAL:2d:cg:cg::Convergence step 2 value 4.231e-15
+DEAL:2d:cg:cg::Starting value 0.002915
+DEAL:2d:cg:cg::Convergence step 2 value 5.424e-18
+DEAL:2d:cg:cg::Starting value 3.439e-06
+DEAL:2d:cg:cg::Convergence step 2 value 1.113e-21
+DEAL:2d:cg:cg::Starting value 1.212e-08
+DEAL:2d:cg:cg::Convergence step 2 value 7.249e-24
+DEAL:2d:cg::Convergence step 4 value 8.121e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 4225
 DEAL:2d:cg::Starting value 65.00
-DEAL:2d:cg:cg::Starting value 7.324
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 0.0003835
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 5.631e-07
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 8.812e-09
-DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 3.108e-08
+DEAL:2d:cg:cg::Starting value 58.09
+DEAL:2d:cg:cg::Convergence step 2 value 5.109e-14
+DEAL:2d:cg:cg::Starting value 0.01056
+DEAL:2d:cg:cg::Convergence step 2 value 7.258e-19
+DEAL:2d:cg:cg::Starting value 2.588e-05
+DEAL:2d:cg:cg::Convergence step 2 value 8.491e-21
+DEAL:2d:cg:cg::Starting value 6.672e-08
+DEAL:2d:cg:cg::Convergence step 2 value 1.252e-23
+DEAL:2d:cg::Convergence step 4 value 1.695e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
-DEAL:3d:cg:cg::Starting value 0.1411
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 7.053e-05
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 4.822e-09
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 9.057e-09
+DEAL:3d:cg:cg::Starting value 0.5164
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 0.02357
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 5.322e-05
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 1.537e-07
+DEAL:3d:cg:cg::Convergence step 1 value 3.743e-23
+DEAL:3d:cg::Convergence step 4 value 3.460e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 0.03502
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 0.0002864
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.471e-07
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 1.321e-06
+DEAL:3d:cg:cg::Starting value 0.1824
+DEAL:3d:cg:cg::Convergence step 1 value 3.925e-17
+DEAL:3d:cg:cg::Starting value 0.004902
+DEAL:3d:cg:cg::Convergence step 1 value 6.133e-19
+DEAL:3d:cg:cg::Starting value 5.629e-06
+DEAL:3d:cg:cg::Convergence step 1 value 1.198e-21
+DEAL:3d:cg:cg::Starting value 3.386e-10
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg::Convergence step 4 value 1.074e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 0.06187
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 7.069e-05
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 8.132e-07
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.153e-09
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 4 value 6.546e-08
+DEAL:3d:cg:cg::Starting value 0.1633
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 0.0001064
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 1.367e-06
+DEAL:3d:cg:cg::Convergence step 1 value 2.995e-22
+DEAL:3d:cg:cg::Starting value 1.607e-08
+DEAL:3d:cg:cg::Convergence step 1 value 4.679e-24
+DEAL:3d:cg::Convergence step 4 value 5.067e-08
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 1.198
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.0001874
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 8.519e-08
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 4.352e-08
+DEAL:3d:cg:cg::Starting value 1.696
+DEAL:3d:cg:cg::Convergence step 2 value 2.866e-16
+DEAL:3d:cg:cg::Starting value 0.1038
+DEAL:3d:cg:cg::Convergence step 2 value 2.373e-17
+DEAL:3d:cg:cg::Starting value 0.0001778
+DEAL:3d:cg:cg::Convergence step 2 value 2.322e-20
+DEAL:3d:cg:cg::Starting value 5.289e-06
+DEAL:3d:cg:cg::Convergence step 2 value 3.474e-22
+DEAL:3d:cg::Convergence step 4 value 2.355e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 6.688
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.0005904
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 2.187e-06
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 2.196e-06
+DEAL:3d:cg:cg::Starting value 2.313
+DEAL:3d:cg:cg::Convergence step 2 value 2.276e-15
+DEAL:3d:cg:cg::Starting value 0.04486
+DEAL:3d:cg:cg::Convergence step 2 value 8.352e-19
+DEAL:3d:cg:cg::Starting value 0.0007197
+DEAL:3d:cg:cg::Convergence step 2 value 7.308e-20
+DEAL:3d:cg:cg::Starting value 2.909e-06
+DEAL:3d:cg:cg::Convergence step 2 value 1.373e-22
+DEAL:3d:cg::Convergence step 4 value 4.578e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 35937
 DEAL:3d:cg::Starting value 189.6
-DEAL:3d:cg:cg::Starting value 49.17
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.006462
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 8.640e-06
-DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 9.302e-06
+DEAL:3d:cg:cg::Starting value 17.40
+DEAL:3d:cg:cg::Convergence step 2 value 1.045e-14
+DEAL:3d:cg:cg::Starting value 0.01679
+DEAL:3d:cg:cg::Convergence step 2 value 2.190e-18
+DEAL:3d:cg:cg::Starting value 0.001098
+DEAL:3d:cg:cg::Convergence step 2 value 1.752e-19
+DEAL:3d:cg:cg::Starting value 1.006e-06
+DEAL:3d:cg:cg::Convergence step 2 value 7.732e-22
+DEAL:3d:cg::Convergence step 4 value 1.784e-05

--- a/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=3.output
@@ -2,68 +2,77 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 81
 DEAL:2d:cg::Starting value 9.000
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg::Convergence step 3 value 3.515e-08
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg::Convergence step 3 value 6.753e-07
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg::Convergence step 3 value 2.831e-08
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg::Convergence step 4 value 2.625e-09
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.4815
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 9.432e-05
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 2.174e-07
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 3.366e-07
+DEAL:2d:cg:cg::Starting value 3.765
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 0.0005314
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 3.806e-06
+DEAL:2d:cg:cg::Convergence step 1 value 4.235e-22
+DEAL:2d:cg:cg::Starting value 1.628e-08
+DEAL:2d:cg:cg::Convergence step 1 value 3.309e-24
+DEAL:2d:cg::Convergence step 4 value 1.712e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 1.818
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 0.0001408
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.548e-08
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 8.040e-07
+DEAL:2d:cg:cg::Starting value 14.37
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 0.002280
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 6.550e-06
+DEAL:2d:cg:cg::Convergence step 1 value 8.470e-22
+DEAL:2d:cg:cg::Starting value 5.084e-08
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg::Convergence step 4 value 4.315e-08
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg::Convergence step 3 value 9.624e-10
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg::Convergence step 3 value 4.383e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg::Convergence step 3 value 1.308e-07
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg::Convergence step 3 value 1.025e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 1.147
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 4.360e-05
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.203e-07
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 2.611e-08
+DEAL:3d:cg:cg::Starting value 0.3913
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 0.0006066
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 3.469e-07
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 5.798e-10
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg::Convergence step 4 value 5.998e-09
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 6.424
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 0.0006099
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.980e-06
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 1.197e-06
+DEAL:3d:cg:cg::Starting value 2.274
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 0.0007566
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 3.302e-06
+DEAL:3d:cg:cg::Convergence step 1 value 4.235e-22
+DEAL:3d:cg:cg::Starting value 1.183e-08
+DEAL:3d:cg:cg::Convergence step 1 value 1.654e-24
+DEAL:3d:cg::Convergence step 4 value 5.811e-08

--- a/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=7.output
@@ -2,68 +2,77 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 81
 DEAL:2d:cg::Starting value 9.000
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg::Convergence step 3 value 3.515e-08
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg::Convergence step 3 value 6.753e-07
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg::Convergence step 3 value 2.831e-08
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg:cg::Convergence step 0 value 0.000
+DEAL:2d:cg::Convergence step 4 value 2.625e-09
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.4815
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 9.432e-05
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 2.174e-07
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 3.366e-07
+DEAL:2d:cg:cg::Starting value 3.765
+DEAL:2d:cg:cg::Convergence step 1 value 4.441e-16
+DEAL:2d:cg:cg::Starting value 0.0005314
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 3.806e-06
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 1.628e-08
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg::Convergence step 4 value 1.712e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 1.818
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 0.0001408
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.548e-08
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 8.040e-07
+DEAL:2d:cg:cg::Starting value 14.37
+DEAL:2d:cg:cg::Convergence step 1 value 1.776e-15
+DEAL:2d:cg:cg::Starting value 0.002280
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 6.550e-06
+DEAL:2d:cg:cg::Convergence step 1 value 8.470e-22
+DEAL:2d:cg:cg::Starting value 5.084e-08
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg::Convergence step 4 value 4.315e-08
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg::Convergence step 3 value 9.624e-10
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg::Convergence step 3 value 4.383e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg::Convergence step 3 value 1.308e-07
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg:cg::Convergence step 0 value 0.000
+DEAL:3d:cg::Convergence step 3 value 1.025e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 1.147
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 4.360e-05
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.203e-07
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 2.611e-08
+DEAL:3d:cg:cg::Starting value 0.3913
+DEAL:3d:cg:cg::Convergence step 1 value 5.551e-17
+DEAL:3d:cg:cg::Starting value 0.0006066
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 3.469e-07
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 5.798e-10
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg::Convergence step 4 value 5.998e-09
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 6.424
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 0.0006099
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.980e-06
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 1.197e-06
+DEAL:3d:cg:cg::Starting value 2.274
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 0.0007566
+DEAL:3d:cg:cg::Convergence step 1 value 1.084e-19
+DEAL:3d:cg:cg::Starting value 3.302e-06
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 1.183e-08
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg::Convergence step 4 value 5.811e-08

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=3.output
@@ -2,28 +2,28 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 507
 DEAL:2d:cg::Starting value 21.93
-DEAL:2d:cg::Convergence step 5 value 7.800e-07
+DEAL:2d:cg::Convergence step 5 value 1.167e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 881
 DEAL:2d:cg::Starting value 27.77
-DEAL:2d:cg::Convergence step 6 value 9.250e-07
+DEAL:2d:cg::Convergence step 6 value 1.190e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 2147
 DEAL:2d:cg::Starting value 43.26
-DEAL:2d:cg::Convergence step 6 value 1.135e-06
+DEAL:2d:cg::Convergence step 6 value 1.886e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 6517
 DEAL:2d:cg::Starting value 76.92
-DEAL:2d:cg::Convergence step 6 value 1.557e-06
+DEAL:2d:cg::Convergence step 6 value 3.143e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 1103
 DEAL:3d:cg::Starting value 31.21
-DEAL:3d:cg::Convergence step 6 value 3.602e-08
+DEAL:3d:cg::Convergence step 6 value 2.139e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 3694
 DEAL:3d:cg::Starting value 55.00
-DEAL:3d:cg::Convergence step 7 value 3.930e-06
+DEAL:3d:cg::Convergence step 7 value 4.724e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 9566
 DEAL:3d:cg::Starting value 76.18
-DEAL:3d:cg::Convergence step 8 value 5.370e-06
+DEAL:3d:cg::Convergence step 8 value 6.234e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.with_mpi=true.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=7.output
@@ -2,28 +2,28 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 507
 DEAL:2d:cg::Starting value 21.93
-DEAL:2d:cg::Convergence step 5 value 7.800e-07
+DEAL:2d:cg::Convergence step 5 value 1.145e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 881
 DEAL:2d:cg::Starting value 27.77
-DEAL:2d:cg::Convergence step 6 value 9.250e-07
+DEAL:2d:cg::Convergence step 6 value 1.176e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 2147
 DEAL:2d:cg::Starting value 43.26
-DEAL:2d:cg::Convergence step 6 value 1.135e-06
+DEAL:2d:cg::Convergence step 6 value 1.884e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 6517
 DEAL:2d:cg::Starting value 76.92
-DEAL:2d:cg::Convergence step 6 value 1.557e-06
+DEAL:2d:cg::Convergence step 6 value 3.090e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 1103
 DEAL:3d:cg::Starting value 31.21
-DEAL:3d:cg::Convergence step 6 value 3.602e-08
+DEAL:3d:cg::Convergence step 6 value 2.139e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 3694
 DEAL:3d:cg::Starting value 55.00
-DEAL:3d:cg::Convergence step 7 value 3.930e-06
+DEAL:3d:cg::Convergence step 7 value 4.739e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 9566
 DEAL:3d:cg::Starting value 76.18
-DEAL:3d:cg::Convergence step 8 value 5.370e-06
+DEAL:3d:cg::Convergence step 8 value 6.236e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=3.output
@@ -2,48 +2,48 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 507
 DEAL:2d:cg::Starting value 21.93
-DEAL:2d:cg::Convergence step 5 value 7.781e-07
+DEAL:2d:cg::Convergence step 5 value 1.167e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 881
 DEAL:2d:cg::Starting value 27.77
-DEAL:2d:cg::Convergence step 6 value 9.215e-07
+DEAL:2d:cg::Convergence step 6 value 1.190e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 2147
 DEAL:2d:cg::Starting value 43.26
-DEAL:2d:cg::Convergence step 6 value 1.142e-06
+DEAL:2d:cg::Convergence step 6 value 1.886e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 6517
 DEAL:2d:cg::Starting value 76.92
-DEAL:2d:cg::Convergence step 6 value 1.563e-06
+DEAL:2d:cg::Convergence step 6 value 3.143e-06
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Number of degrees of freedom: 4259
 DEAL:2d:cg::Starting value 64.26
-DEAL:2d:cg::Convergence step 5 value 1.632e-06
+DEAL:2d:cg::Convergence step 5 value 2.131e-06
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Number of degrees of freedom: 7457
 DEAL:2d:cg::Starting value 83.11
-DEAL:2d:cg::Convergence step 5 value 7.695e-06
+DEAL:2d:cg::Convergence step 6 value 5.783e-07
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Number of degrees of freedom: 18535
 DEAL:2d:cg::Starting value 131.0
-DEAL:2d:cg::Convergence step 5 value 6.059e-06
+DEAL:2d:cg::Convergence step 6 value 6.147e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 1103
 DEAL:3d:cg::Starting value 31.21
-DEAL:3d:cg::Convergence step 6 value 3.615e-08
+DEAL:3d:cg::Convergence step 6 value 2.139e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 3694
 DEAL:3d:cg::Starting value 55.00
-DEAL:3d:cg::Convergence step 7 value 3.941e-06
+DEAL:3d:cg::Convergence step 7 value 4.724e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 9566
 DEAL:3d:cg::Starting value 76.18
-DEAL:3d:cg::Convergence step 8 value 5.362e-06
+DEAL:3d:cg::Convergence step 8 value 6.234e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 7494
 DEAL:3d:cg::Starting value 82.90
-DEAL:3d:cg::Convergence step 7 value 8.682e-07
+DEAL:3d:cg::Convergence step 7 value 1.038e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 26548
 DEAL:3d:cg::Starting value 152.6
-DEAL:3d:cg::Convergence step 7 value 3.969e-06
+DEAL:3d:cg::Convergence step 7 value 4.360e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=7.output
@@ -2,48 +2,48 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 507
 DEAL:2d:cg::Starting value 21.93
-DEAL:2d:cg::Convergence step 5 value 7.781e-07
+DEAL:2d:cg::Convergence step 5 value 1.145e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 881
 DEAL:2d:cg::Starting value 27.77
-DEAL:2d:cg::Convergence step 6 value 9.215e-07
+DEAL:2d:cg::Convergence step 6 value 1.176e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 2147
 DEAL:2d:cg::Starting value 43.26
-DEAL:2d:cg::Convergence step 6 value 1.142e-06
+DEAL:2d:cg::Convergence step 6 value 1.884e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 6517
 DEAL:2d:cg::Starting value 76.92
-DEAL:2d:cg::Convergence step 6 value 1.563e-06
+DEAL:2d:cg::Convergence step 6 value 3.090e-06
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Number of degrees of freedom: 4259
 DEAL:2d:cg::Starting value 64.26
-DEAL:2d:cg::Convergence step 5 value 1.632e-06
+DEAL:2d:cg::Convergence step 5 value 2.131e-06
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Number of degrees of freedom: 7457
 DEAL:2d:cg::Starting value 83.11
-DEAL:2d:cg::Convergence step 5 value 7.695e-06
+DEAL:2d:cg::Convergence step 6 value 5.788e-07
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Number of degrees of freedom: 18535
 DEAL:2d:cg::Starting value 131.0
-DEAL:2d:cg::Convergence step 5 value 6.059e-06
+DEAL:2d:cg::Convergence step 6 value 6.134e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 1103
 DEAL:3d:cg::Starting value 31.21
-DEAL:3d:cg::Convergence step 6 value 3.615e-08
+DEAL:3d:cg::Convergence step 6 value 2.139e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 3694
 DEAL:3d:cg::Starting value 55.00
-DEAL:3d:cg::Convergence step 7 value 3.941e-06
+DEAL:3d:cg::Convergence step 7 value 4.739e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 9566
 DEAL:3d:cg::Starting value 76.18
-DEAL:3d:cg::Convergence step 8 value 5.362e-06
+DEAL:3d:cg::Convergence step 8 value 6.236e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 7494
 DEAL:3d:cg::Starting value 82.90
-DEAL:3d:cg::Convergence step 7 value 8.682e-07
+DEAL:3d:cg::Convergence step 7 value 1.039e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 26548
 DEAL:3d:cg::Starting value 152.6
-DEAL:3d:cg::Convergence step 7 value 3.969e-06
+DEAL:3d:cg::Convergence step 7 value 4.352e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=4.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=4.output
@@ -2,104 +2,104 @@
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 507
 DEAL:nothread:cg::Starting value 21.9317
-DEAL:nothread:cg::Convergence step 5 value 7.78558e-07
+DEAL:nothread:cg::Convergence step 5 value 1.14537e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 507
 DEAL:threaded:cg::Starting value 21.9317
-DEAL:threaded:cg::Convergence step 5 value 7.78558e-07
+DEAL:threaded:cg::Convergence step 5 value 1.14537e-06
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 881
 DEAL:nothread:cg::Starting value 27.7669
-DEAL:nothread:cg::Convergence step 6 value 9.22164e-07
+DEAL:nothread:cg::Convergence step 6 value 1.18996e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 881
 DEAL:threaded:cg::Starting value 27.7669
-DEAL:threaded:cg::Convergence step 6 value 9.22164e-07
+DEAL:threaded:cg::Convergence step 6 value 1.18996e-06
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 2147
 DEAL:nothread:cg::Starting value 43.2551
-DEAL:nothread:cg::Convergence step 6 value 1.15108e-06
+DEAL:nothread:cg::Convergence step 6 value 1.86235e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 2147
 DEAL:threaded:cg::Starting value 43.2551
-DEAL:threaded:cg::Convergence step 6 value 1.15108e-06
+DEAL:threaded:cg::Convergence step 6 value 1.86235e-06
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 6517
 DEAL:nothread:cg::Starting value 76.9220
-DEAL:nothread:cg::Convergence step 6 value 1.56831e-06
+DEAL:nothread:cg::Convergence step 6 value 3.14118e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 6517
 DEAL:threaded:cg::Starting value 76.9220
-DEAL:threaded:cg::Convergence step 6 value 1.56831e-06
+DEAL:threaded:cg::Convergence step 6 value 3.14118e-06
 DEAL:nothread::Testing FE_Q<2>(2)
 DEAL:nothread::Number of degrees of freedom: 1935
 DEAL:nothread:cg::Starting value 43.0929
-DEAL:nothread:cg::Convergence step 5 value 2.13384e-06
+DEAL:nothread:cg::Convergence step 5 value 3.22495e-06
 DEAL:threaded::Testing FE_Q<2>(2)
 DEAL:threaded::Number of degrees of freedom: 1935
 DEAL:threaded:cg::Starting value 43.0929
-DEAL:threaded:cg::Convergence step 5 value 2.13388e-06
+DEAL:threaded:cg::Convergence step 5 value 3.22504e-06
 DEAL:nothread::Testing FE_Q<2>(2)
 DEAL:nothread::Number of degrees of freedom: 3403
 DEAL:nothread:cg::Starting value 55.4346
-DEAL:nothread:cg::Convergence step 6 value 4.27828e-07
+DEAL:nothread:cg::Convergence step 6 value 8.67853e-07
 DEAL:threaded::Testing FE_Q<2>(2)
 DEAL:threaded::Number of degrees of freedom: 3403
 DEAL:threaded:cg::Starting value 55.4346
-DEAL:threaded:cg::Convergence step 6 value 4.27798e-07
+DEAL:threaded:cg::Convergence step 6 value 8.67861e-07
 DEAL:nothread::Testing FE_Q<2>(2)
 DEAL:nothread::Number of degrees of freedom: 8417
 DEAL:nothread:cg::Starting value 87.1149
-DEAL:nothread:cg::Convergence step 6 value 2.55138e-07
+DEAL:nothread:cg::Convergence step 6 value 5.47715e-07
 DEAL:threaded::Testing FE_Q<2>(2)
 DEAL:threaded::Number of degrees of freedom: 8417
 DEAL:threaded:cg::Starting value 87.1149
-DEAL:threaded:cg::Convergence step 6 value 2.55129e-07
+DEAL:threaded:cg::Convergence step 6 value 5.47726e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 186
 DEAL:nothread:cg::Starting value 12.3693
-DEAL:nothread:cg::Convergence step 3 value 2.26211e-07
+DEAL:nothread:cg::Convergence step 4 value 2.87808e-08
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 186
 DEAL:threaded:cg::Starting value 12.3693
-DEAL:threaded:cg::Convergence step 3 value 2.26211e-07
+DEAL:threaded:cg::Convergence step 4 value 2.87808e-08
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 648
 DEAL:nothread:cg::Starting value 21.1424
-DEAL:nothread:cg::Convergence step 6 value 1.11426e-07
+DEAL:nothread:cg::Convergence step 6 value 6.44935e-07
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 648
 DEAL:threaded:cg::Starting value 21.1424
-DEAL:threaded:cg::Convergence step 6 value 1.11426e-07
+DEAL:threaded:cg::Convergence step 6 value 6.44935e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 2930
 DEAL:nothread:cg::Starting value 47.1699
-DEAL:nothread:cg::Convergence step 7 value 1.63079e-06
+DEAL:nothread:cg::Convergence step 7 value 2.56010e-06
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 2930
 DEAL:threaded:cg::Starting value 47.1699
-DEAL:threaded:cg::Convergence step 7 value 1.63079e-06
+DEAL:threaded:cg::Convergence step 7 value 2.56010e-06
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 186
 DEAL:nothread:cg::Starting value 12.3693
-DEAL:nothread:cg::Convergence step 3 value 2.24462e-07
+DEAL:nothread:cg::Convergence step 4 value 2.88983e-08
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 186
 DEAL:threaded:cg::Starting value 12.3693
-DEAL:threaded:cg::Convergence step 3 value 2.24473e-07
+DEAL:threaded:cg::Convergence step 4 value 2.88980e-08
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 648
 DEAL:nothread:cg::Starting value 21.1424
-DEAL:nothread:cg::Convergence step 6 value 1.06988e-07
+DEAL:nothread:cg::Convergence step 6 value 6.40524e-07
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 648
 DEAL:threaded:cg::Starting value 21.1424
-DEAL:threaded:cg::Convergence step 6 value 1.06988e-07
+DEAL:threaded:cg::Convergence step 6 value 6.40523e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 2930
 DEAL:nothread:cg::Starting value 47.1699
-DEAL:nothread:cg::Convergence step 7 value 1.63550e-06
+DEAL:nothread:cg::Convergence step 7 value 2.56010e-06
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 2930
 DEAL:threaded:cg::Starting value 47.1699
-DEAL:threaded:cg::Convergence step 7 value 1.63550e-06
+DEAL:threaded:cg::Convergence step 7 value 2.56010e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=7.output
@@ -2,104 +2,104 @@
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 507
 DEAL:nothread:cg::Starting value 21.9317
-DEAL:nothread:cg::Convergence step 5 value 7.76680e-07
+DEAL:nothread:cg::Convergence step 5 value 1.14539e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 507
 DEAL:threaded:cg::Starting value 21.9317
-DEAL:threaded:cg::Convergence step 5 value 7.76680e-07
+DEAL:threaded:cg::Convergence step 5 value 1.14539e-06
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 881
 DEAL:nothread:cg::Starting value 27.7669
-DEAL:nothread:cg::Convergence step 6 value 9.25965e-07
+DEAL:nothread:cg::Convergence step 6 value 1.17649e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 881
 DEAL:threaded:cg::Starting value 27.7669
-DEAL:threaded:cg::Convergence step 6 value 9.25965e-07
+DEAL:threaded:cg::Convergence step 6 value 1.17649e-06
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 2147
 DEAL:nothread:cg::Starting value 43.2551
-DEAL:nothread:cg::Convergence step 6 value 1.14972e-06
+DEAL:nothread:cg::Convergence step 6 value 1.88354e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 2147
 DEAL:threaded:cg::Starting value 43.2551
-DEAL:threaded:cg::Convergence step 6 value 1.14972e-06
+DEAL:threaded:cg::Convergence step 6 value 1.88354e-06
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 6517
 DEAL:nothread:cg::Starting value 76.9220
-DEAL:nothread:cg::Convergence step 6 value 1.56712e-06
+DEAL:nothread:cg::Convergence step 6 value 3.08982e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 6517
 DEAL:threaded:cg::Starting value 76.9220
-DEAL:threaded:cg::Convergence step 6 value 1.56712e-06
+DEAL:threaded:cg::Convergence step 6 value 3.08982e-06
 DEAL:nothread::Testing FE_Q<2>(2)
 DEAL:nothread::Number of degrees of freedom: 1935
 DEAL:nothread:cg::Starting value 43.0929
-DEAL:nothread:cg::Convergence step 5 value 2.13377e-06
+DEAL:nothread:cg::Convergence step 5 value 3.19333e-06
 DEAL:threaded::Testing FE_Q<2>(2)
 DEAL:threaded::Number of degrees of freedom: 1935
 DEAL:threaded:cg::Starting value 43.0929
-DEAL:threaded:cg::Convergence step 5 value 2.13371e-06
+DEAL:threaded:cg::Convergence step 5 value 3.19334e-06
 DEAL:nothread::Testing FE_Q<2>(2)
 DEAL:nothread::Number of degrees of freedom: 3403
 DEAL:nothread:cg::Starting value 55.4346
-DEAL:nothread:cg::Convergence step 6 value 4.27767e-07
+DEAL:nothread:cg::Convergence step 6 value 8.71780e-07
 DEAL:threaded::Testing FE_Q<2>(2)
 DEAL:threaded::Number of degrees of freedom: 3403
 DEAL:threaded:cg::Starting value 55.4346
-DEAL:threaded:cg::Convergence step 6 value 4.27807e-07
+DEAL:threaded:cg::Convergence step 6 value 8.71685e-07
 DEAL:nothread::Testing FE_Q<2>(2)
 DEAL:nothread::Number of degrees of freedom: 8417
 DEAL:nothread:cg::Starting value 87.1149
-DEAL:nothread:cg::Convergence step 6 value 2.55168e-07
+DEAL:nothread:cg::Convergence step 6 value 5.47238e-07
 DEAL:threaded::Testing FE_Q<2>(2)
 DEAL:threaded::Number of degrees of freedom: 8417
 DEAL:threaded:cg::Starting value 87.1149
-DEAL:threaded:cg::Convergence step 6 value 2.55163e-07
+DEAL:threaded:cg::Convergence step 6 value 5.47227e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 186
 DEAL:nothread:cg::Starting value 12.3693
-DEAL:nothread:cg::Convergence step 3 value 2.28324e-07
+DEAL:nothread:cg::Convergence step 4 value 2.87808e-08
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 186
 DEAL:threaded:cg::Starting value 12.3693
-DEAL:threaded:cg::Convergence step 3 value 2.28324e-07
+DEAL:threaded:cg::Convergence step 4 value 2.87808e-08
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 648
 DEAL:nothread:cg::Starting value 21.1424
-DEAL:nothread:cg::Convergence step 6 value 1.11195e-07
+DEAL:nothread:cg::Convergence step 6 value 6.44905e-07
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 648
 DEAL:threaded:cg::Starting value 21.1424
-DEAL:threaded:cg::Convergence step 6 value 1.11195e-07
+DEAL:threaded:cg::Convergence step 6 value 6.44905e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 2930
 DEAL:nothread:cg::Starting value 47.1699
-DEAL:nothread:cg::Convergence step 7 value 1.63163e-06
+DEAL:nothread:cg::Convergence step 7 value 2.56063e-06
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 2930
 DEAL:threaded:cg::Starting value 47.1699
-DEAL:threaded:cg::Convergence step 7 value 1.63163e-06
+DEAL:threaded:cg::Convergence step 7 value 2.56063e-06
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 186
 DEAL:nothread:cg::Starting value 12.3693
-DEAL:nothread:cg::Convergence step 3 value 1.58643e-07
+DEAL:nothread:cg::Convergence step 4 value 2.88986e-08
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 186
 DEAL:threaded:cg::Starting value 12.3693
-DEAL:threaded:cg::Convergence step 3 value 1.58660e-07
+DEAL:threaded:cg::Convergence step 4 value 2.88984e-08
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 648
 DEAL:nothread:cg::Starting value 21.1424
-DEAL:nothread:cg::Convergence step 6 value 1.06758e-07
+DEAL:nothread:cg::Convergence step 6 value 6.39127e-07
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 648
 DEAL:threaded:cg::Starting value 21.1424
-DEAL:threaded:cg::Convergence step 6 value 1.06760e-07
+DEAL:threaded:cg::Convergence step 6 value 6.39130e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 2930
 DEAL:nothread:cg::Starting value 47.1699
-DEAL:nothread:cg::Convergence step 7 value 1.63203e-06
+DEAL:nothread:cg::Convergence step 7 value 2.55900e-06
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 2930
 DEAL:threaded:cg::Starting value 47.1699
-DEAL:threaded:cg::Convergence step 7 value 1.63203e-06
+DEAL:threaded:cg::Convergence step 7 value 2.55899e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_05.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=4.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_05.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=4.output
@@ -2,16 +2,16 @@
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 507
 DEAL:threaded:cg::Starting value 21.9317
-DEAL:threaded:cg::Convergence step 5 value 7.81205e-07
+DEAL:threaded:cg::Convergence step 5 value 1.14537e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 881
 DEAL:threaded:cg::Starting value 27.7669
-DEAL:threaded:cg::Convergence step 6 value 9.24482e-07
+DEAL:threaded:cg::Convergence step 6 value 1.18996e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 2147
 DEAL:threaded:cg::Starting value 43.2551
-DEAL:threaded:cg::Convergence step 6 value 1.14520e-06
+DEAL:threaded:cg::Convergence step 6 value 1.86235e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 6517
 DEAL:threaded:cg::Starting value 76.9220
-DEAL:threaded:cg::Convergence step 6 value 1.55925e-06
+DEAL:threaded:cg::Convergence step 6 value 3.14118e-06

--- a/tests/matrix_free/parallel_multigrid_mf.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_mf.with_mpi=true.with_p4est=true.with_lapack=true.mpirun=7.output
@@ -2,32 +2,32 @@
 DEAL::Testing FE_Q<2>(1)
 DEAL::Number of degrees of freedom: 81
 DEAL:cg::Starting value 9.00000
-DEAL:cg::Convergence step 3 value 3.51890e-08
+DEAL:cg::Convergence step 3 value 6.75256e-07
 DEAL::Testing FE_Q<2>(1)
 DEAL::Number of degrees of freedom: 289
 DEAL:cg::Starting value 17.0000
-DEAL:cg::Convergence step 3 value 2.90115e-08
+DEAL:cg::Convergence step 4 value 2.62465e-09
 DEAL::Testing FE_Q<2>(2)
 DEAL::Number of degrees of freedom: 289
 DEAL:cg::Starting value 17.0000
-DEAL:cg::Convergence step 3 value 2.86879e-07
+DEAL:cg::Convergence step 4 value 1.71224e-08
 DEAL::Testing FE_Q<2>(2)
 DEAL::Number of degrees of freedom: 1089
 DEAL:cg::Starting value 33.0000
-DEAL:cg::Convergence step 3 value 7.11331e-07
+DEAL:cg::Convergence step 4 value 4.31534e-08
 DEAL::Testing FE_Q<3>(1)
 DEAL::Number of degrees of freedom: 125
 DEAL:cg::Starting value 11.1803
-DEAL:cg::Convergence step 3 value 0
+DEAL:cg::Convergence step 3 value 4.38307e-07
 DEAL::Testing FE_Q<3>(1)
 DEAL::Number of degrees of freedom: 729
 DEAL:cg::Starting value 27.0000
-DEAL:cg::Convergence step 3 value 1.30374e-07
+DEAL:cg::Convergence step 3 value 1.02520e-06
 DEAL::Testing FE_Q<3>(2)
 DEAL::Number of degrees of freedom: 729
 DEAL:cg::Starting value 27.0000
-DEAL:cg::Convergence step 3 value 2.75558e-08
+DEAL:cg::Convergence step 4 value 5.99244e-09
 DEAL::Testing FE_Q<3>(2)
 DEAL::Number of degrees of freedom: 4913
 DEAL:cg::Starting value 70.0928
-DEAL:cg::Convergence step 3 value 1.14078e-06
+DEAL:cg::Convergence step 4 value 5.81100e-08

--- a/tests/matrix_free/step-37-inhomogeneous-1.mpirun=4.with_p4est=true.output
+++ b/tests/matrix_free/step-37-inhomogeneous-1.mpirun=4.with_p4est=true.output
@@ -2,149 +2,149 @@
 Cycle 0
 Number of degrees of freedom: 81
 DEAL:0:cg::Starting value 45.0807
-DEAL:0:cg::Convergence step 6 value 2.23481e-13
+DEAL:0:cg::Convergence step 7 value 2.65304e-12
 max error: 0.00772526
 error ratio: 1.00000
 
 Cycle 1
 Number of degrees of freedom: 289
 DEAL:0:cg::Starting value 68.5863
-DEAL:0:cg::Convergence step 6 value 4.06929e-13
+DEAL:0:cg::Convergence step 7 value 3.81082e-12
 max error: 0.000971239
 error ratio: 7.95402
 
 Cycle 2
 Number of degrees of freedom: 1089
 DEAL:0:cg::Starting value 95.4381
-DEAL:0:cg::Convergence step 6 value 5.78305e-13
+DEAL:0:cg::Convergence step 7 value 7.14371e-12
 max error: 0.000120278
 error ratio: 8.07497
 
 Cycle 3
 Number of degrees of freedom: 4225
 DEAL:0:cg::Starting value 131.732
-DEAL:0:cg::Convergence step 6 value 1.31602e-12
+DEAL:0:cg::Convergence step 7 value 1.44204e-11
 max error: 1.49228e-05
 error ratio: 8.05998
 
 Cycle 4
 Number of degrees of freedom: 16641
 DEAL:0:cg::Starting value 183.473
-DEAL:0:cg::Convergence step 6 value 2.60867e-12
+DEAL:0:cg::Convergence step 7 value 2.54095e-11
 max error: 1.85713e-06
 error ratio: 8.03544
 
 Cycle 5
 Number of degrees of freedom: 66049
 DEAL:0:cg::Starting value 257.379
-DEAL:0:cg::Convergence step 6 value 4.17156e-12
+DEAL:0:cg::Convergence step 7 value 3.94318e-11
 max error: 2.31590e-07
 error ratio: 8.01904
 
 Cycle 0
 Number of degrees of freedom: 125
 DEAL:0:cg::Starting value 6.44073
-DEAL:0:cg::Convergence step 6 value 2.97002e-14
+DEAL:0:cg::Convergence step 7 value 4.64523e-13
 max error: 0.0499110
 error ratio: 1.00000
 
 Cycle 1
 Number of degrees of freedom: 729
 DEAL:0:cg::Starting value 8.68642
-DEAL:0:cg::Convergence step 6 value 6.80139e-14
+DEAL:0:cg::Convergence step 7 value 5.79753e-13
 max error: 0.00756448
 error ratio: 6.59807
 
 Cycle 2
 Number of degrees of freedom: 4913
 DEAL:0:cg::Starting value 9.47362
-DEAL:0:cg::Convergence step 6 value 6.56927e-14
+DEAL:0:cg::Convergence step 7 value 6.67651e-13
 max error: 0.000965192
 error ratio: 7.83728
 
 Cycle 3
 Number of degrees of freedom: 35937
 DEAL:0:cg::Starting value 9.30402
-DEAL:0:cg::Convergence step 6 value 7.06917e-14
+DEAL:0:cg::Convergence step 7 value 9.36336e-13
 max error: 0.000120048
 error ratio: 8.04008
 
 Cycle 4
 Number of degrees of freedom: 274625
 DEAL:0:cg::Starting value 8.99023
-DEAL:0:cg::Convergence step 6 value 8.15983e-14
+DEAL:0:cg::Convergence step 7 value 1.22268e-12
 max error: 1.49140e-05
 error ratio: 8.04933
 
 
 DEAL:1:cg::Starting value 45.0807
-DEAL:1:cg::Convergence step 6 value 2.23481e-13
+DEAL:1:cg::Convergence step 7 value 2.65304e-12
 DEAL:1:cg::Starting value 68.5863
-DEAL:1:cg::Convergence step 6 value 4.06929e-13
+DEAL:1:cg::Convergence step 7 value 3.81082e-12
 DEAL:1:cg::Starting value 95.4381
-DEAL:1:cg::Convergence step 6 value 5.78305e-13
+DEAL:1:cg::Convergence step 7 value 7.14371e-12
 DEAL:1:cg::Starting value 131.732
-DEAL:1:cg::Convergence step 6 value 1.31602e-12
+DEAL:1:cg::Convergence step 7 value 1.44204e-11
 DEAL:1:cg::Starting value 183.473
-DEAL:1:cg::Convergence step 6 value 2.60867e-12
+DEAL:1:cg::Convergence step 7 value 2.54095e-11
 DEAL:1:cg::Starting value 257.379
-DEAL:1:cg::Convergence step 6 value 4.17156e-12
+DEAL:1:cg::Convergence step 7 value 3.94318e-11
 DEAL:1:cg::Starting value 6.44073
-DEAL:1:cg::Convergence step 6 value 2.97002e-14
+DEAL:1:cg::Convergence step 7 value 4.64523e-13
 DEAL:1:cg::Starting value 8.68642
-DEAL:1:cg::Convergence step 6 value 6.80139e-14
+DEAL:1:cg::Convergence step 7 value 5.79753e-13
 DEAL:1:cg::Starting value 9.47362
-DEAL:1:cg::Convergence step 6 value 6.56927e-14
+DEAL:1:cg::Convergence step 7 value 6.67651e-13
 DEAL:1:cg::Starting value 9.30402
-DEAL:1:cg::Convergence step 6 value 7.06917e-14
+DEAL:1:cg::Convergence step 7 value 9.36336e-13
 DEAL:1:cg::Starting value 8.99023
-DEAL:1:cg::Convergence step 6 value 8.15983e-14
+DEAL:1:cg::Convergence step 7 value 1.22268e-12
 
 
 DEAL:2:cg::Starting value 45.0807
-DEAL:2:cg::Convergence step 6 value 2.23481e-13
+DEAL:2:cg::Convergence step 7 value 2.65304e-12
 DEAL:2:cg::Starting value 68.5863
-DEAL:2:cg::Convergence step 6 value 4.06929e-13
+DEAL:2:cg::Convergence step 7 value 3.81082e-12
 DEAL:2:cg::Starting value 95.4381
-DEAL:2:cg::Convergence step 6 value 5.78305e-13
+DEAL:2:cg::Convergence step 7 value 7.14371e-12
 DEAL:2:cg::Starting value 131.732
-DEAL:2:cg::Convergence step 6 value 1.31602e-12
+DEAL:2:cg::Convergence step 7 value 1.44204e-11
 DEAL:2:cg::Starting value 183.473
-DEAL:2:cg::Convergence step 6 value 2.60867e-12
+DEAL:2:cg::Convergence step 7 value 2.54095e-11
 DEAL:2:cg::Starting value 257.379
-DEAL:2:cg::Convergence step 6 value 4.17156e-12
+DEAL:2:cg::Convergence step 7 value 3.94318e-11
 DEAL:2:cg::Starting value 6.44073
-DEAL:2:cg::Convergence step 6 value 2.97002e-14
+DEAL:2:cg::Convergence step 7 value 4.64523e-13
 DEAL:2:cg::Starting value 8.68642
-DEAL:2:cg::Convergence step 6 value 6.80139e-14
+DEAL:2:cg::Convergence step 7 value 5.79753e-13
 DEAL:2:cg::Starting value 9.47362
-DEAL:2:cg::Convergence step 6 value 6.56927e-14
+DEAL:2:cg::Convergence step 7 value 6.67651e-13
 DEAL:2:cg::Starting value 9.30402
-DEAL:2:cg::Convergence step 6 value 7.06917e-14
+DEAL:2:cg::Convergence step 7 value 9.36336e-13
 DEAL:2:cg::Starting value 8.99023
-DEAL:2:cg::Convergence step 6 value 8.15983e-14
+DEAL:2:cg::Convergence step 7 value 1.22268e-12
 
 
 DEAL:3:cg::Starting value 45.0807
-DEAL:3:cg::Convergence step 6 value 2.23481e-13
+DEAL:3:cg::Convergence step 7 value 2.65304e-12
 DEAL:3:cg::Starting value 68.5863
-DEAL:3:cg::Convergence step 6 value 4.06929e-13
+DEAL:3:cg::Convergence step 7 value 3.81082e-12
 DEAL:3:cg::Starting value 95.4381
-DEAL:3:cg::Convergence step 6 value 5.78305e-13
+DEAL:3:cg::Convergence step 7 value 7.14371e-12
 DEAL:3:cg::Starting value 131.732
-DEAL:3:cg::Convergence step 6 value 1.31602e-12
+DEAL:3:cg::Convergence step 7 value 1.44204e-11
 DEAL:3:cg::Starting value 183.473
-DEAL:3:cg::Convergence step 6 value 2.60867e-12
+DEAL:3:cg::Convergence step 7 value 2.54095e-11
 DEAL:3:cg::Starting value 257.379
-DEAL:3:cg::Convergence step 6 value 4.17156e-12
+DEAL:3:cg::Convergence step 7 value 3.94318e-11
 DEAL:3:cg::Starting value 6.44073
-DEAL:3:cg::Convergence step 6 value 2.97002e-14
+DEAL:3:cg::Convergence step 7 value 4.64523e-13
 DEAL:3:cg::Starting value 8.68642
-DEAL:3:cg::Convergence step 6 value 6.80139e-14
+DEAL:3:cg::Convergence step 7 value 5.79753e-13
 DEAL:3:cg::Starting value 9.47362
-DEAL:3:cg::Convergence step 6 value 6.56927e-14
+DEAL:3:cg::Convergence step 7 value 6.67651e-13
 DEAL:3:cg::Starting value 9.30402
-DEAL:3:cg::Convergence step 6 value 7.06917e-14
+DEAL:3:cg::Convergence step 7 value 9.36336e-13
 DEAL:3:cg::Starting value 8.99023
-DEAL:3:cg::Convergence step 6 value 8.15983e-14
+DEAL:3:cg::Convergence step 7 value 1.22268e-12
 

--- a/tests/matrix_free/step-37.with_lapack=true.output
+++ b/tests/matrix_free/step-37.with_lapack=true.output
@@ -2,30 +2,30 @@
 DEAL:2d::Cycle 0
 DEAL:2d::Number of degrees of freedom: 81
 DEAL:2d:cg::Starting value 0.132
-DEAL:2d:cg::Convergence step 4 value 0
+DEAL:2d:cg::Convergence step 5 value 4.87e-15
 DEAL:2d::
 DEAL:2d::Cycle 1
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 0.0677
-DEAL:2d:cg::Convergence step 5 value 0
+DEAL:2d:cg::Convergence step 5 value 6.38e-14
 DEAL:2d::
 DEAL:2d::Cycle 2
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 0.0343
-DEAL:2d:cg::Convergence step 5 value 0
+DEAL:2d:cg::Convergence step 6 value 8.43e-16
 DEAL:2d::
 DEAL:3d::Cycle 0
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 0.125
-DEAL:3d:cg::Convergence step 5 value 0
+DEAL:3d:cg::Convergence step 4 value 2.35e-14
 DEAL:3d::
 DEAL:3d::Cycle 1
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 0.0479
-DEAL:3d:cg::Convergence step 4 value 0
+DEAL:3d:cg::Convergence step 5 value 1.75e-17
 DEAL:3d::
 DEAL:3d::Cycle 2
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 0.0176
-DEAL:3d:cg::Convergence step 4 value 0
+DEAL:3d:cg::Convergence step 5 value 1.68e-16
 DEAL:3d::

--- a/tests/matrix_free/stokes_computation.with_mpi=true.with_p4est=true.mpirun=4.output
+++ b/tests/matrix_free/stokes_computation.with_mpi=true.with_p4est=true.mpirun=4.output
@@ -4,16 +4,16 @@ DEAL:2d::n_sinker: 4       max/min viscosity ratio: 1000.00
 DEAL:2d::
 DEAL:2d::Number of active cells: 1024 (on 6 levels)
 DEAL:2d::Number of degrees of freedom: 9539 (8450+1089)
-DEAL:2d::Solved-in 62 iterations, final residual: 5.37736e-08
+DEAL:2d::Solved-in 69 iterations, final residual: 5.58979e-08
 DEAL:2d::
 DEAL:2d::Number of active cells: 4096 (on 7 levels)
 DEAL:2d::Number of degrees of freedom: 37507 (33282+4225)
-DEAL:2d::Solved-in 61 iterations, final residual: 2.94930e-08
+DEAL:2d::Solved-in 69 iterations, final residual: 2.58019e-08
 DEAL:2d::
 DEAL:3d::Sinker problem in 3D.
 DEAL:3d::n_sinker: 4       max/min viscosity ratio: 1000.00
 DEAL:3d::
 DEAL:3d::Number of active cells: 512 (on 4 levels)
 DEAL:3d::Number of degrees of freedom: 15468 (14739+729)
-DEAL:3d::Solved-in 54 iterations, final residual: 2.12652e-08
+DEAL:3d::Solved-in 62 iterations, final residual: 1.99453e-08
 DEAL:3d::

--- a/tests/multigrid/step-16-04.cc
+++ b/tests/multigrid/step-16-04.cc
@@ -397,7 +397,7 @@ LaplaceProblem<dim>::solve()
                                     mg_smoother;
   typename Smoother::AdditionalData smoother_data;
   smoother_data.smoothing_range     = 20.;
-  smoother_data.degree              = 2;
+  smoother_data.degree              = 3;
   smoother_data.eig_cg_n_iterations = 20;
   mg_smoother.initialize(mg_matrices, smoother_data);
 

--- a/tests/multigrid/step-16-05.cc
+++ b/tests/multigrid/step-16-05.cc
@@ -398,7 +398,7 @@ LaplaceProblem<dim>::solve()
                                     mg_smoother;
   typename Smoother::AdditionalData smoother_data;
   smoother_data.smoothing_range     = 20.;
-  smoother_data.degree              = 2;
+  smoother_data.degree              = 3;
   smoother_data.eig_cg_n_iterations = 20;
   mg_smoother.initialize(mg_matrices, smoother_data);
 

--- a/tests/multigrid/step-16-06.cc
+++ b/tests/multigrid/step-16-06.cc
@@ -398,7 +398,7 @@ LaplaceProblem<dim>::solve()
                                     mg_smoother;
   typename Smoother::AdditionalData smoother_data;
   smoother_data.smoothing_range     = 20.;
-  smoother_data.degree              = 2;
+  smoother_data.degree              = 3;
   smoother_data.eig_cg_n_iterations = 20;
   mg_smoother.initialize(mg_matrices, smoother_data);
 

--- a/tests/multigrid/step-16-50-serial.cc
+++ b/tests/multigrid/step-16-50-serial.cc
@@ -470,6 +470,7 @@ int
 main()
 {
   initlog();
+  deallog << std::setprecision(10);
 
   try
     {

--- a/tests/multigrid/step-16-50-serial.output
+++ b/tests/multigrid/step-16-50-serial.output
@@ -2,25 +2,25 @@
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       256
 DEAL::   Number of degrees of freedom: 289 (by level: 4, 9, 25, 81, 289)
-DEAL:cg::Starting value 0.585938
-DEAL:cg::Convergence step 7 value 4.58200e-09
+DEAL:cg::Starting value 0.5859375000
+DEAL:cg::Convergence step 7 value 4.581996212e-09
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       418
 DEAL::   Number of degrees of freedom: 495 (by level: 4, 9, 25, 81, 289, 305)
-DEAL:cg::Starting value 0.533937
-DEAL:cg::Convergence step 10 value 7.40543e-10
+DEAL:cg::Starting value 0.5339372772
+DEAL:cg::Convergence step 10 value 7.405430549e-10
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       865
 DEAL::   Number of degrees of freedom: 952 (by level: 4, 9, 25, 81, 289, 769, 153)
-DEAL:cg::Starting value 0.378780
-DEAL:cg::Convergence step 11 value 1.39894e-09
+DEAL:cg::Starting value 0.3787800687
+DEAL:cg::Convergence step 11 value 1.398936158e-09
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       1219
 DEAL::   Number of degrees of freedom: 1354 (by level: 4, 9, 25, 81, 289, 953, 277, 261)
-DEAL:cg::Starting value 0.343729
-DEAL:cg::Convergence step 13 value 6.16552e-10
+DEAL:cg::Starting value 0.3437292109
+DEAL:cg::Convergence step 13 value 6.165515097e-10
 DEAL::Cycle 4:
 DEAL::   Number of active cells:       1297
 DEAL::   Number of degrees of freedom: 1446 (by level: 4, 9, 25, 81, 289, 961, 313, 349)
-DEAL:cg::Starting value 0.339440
-DEAL:cg::Convergence step 13 value 7.00850e-10
+DEAL:cg::Starting value 0.3394403283
+DEAL:cg::Convergence step 13 value 7.008502779e-10


### PR DESCRIPTION
Our implementation of `PreconditionChebyshev` did not follow the usual convention of literature in terms of the number of matrix-vector products. The `degree` of the Chebyshev polynomial involves just as many matrix-vector products, not one more as we did previously. This means that the variable `PreconditionChebyshev::AdditionalData::degree` must now be raised by one to produce the same behavior is before.

There is a number of tests affected by this change of course. I opted to change the number for the Chebyshev degree in about half of them, and change the output in the other half. From comparison to literature it seems we use a rather high degree overall, so some more tests with a lower degree seem appropriate.

This change will conflict with #7703, but I wanted to post it already to have the bulk of the work done, and I wanted to keep it separate from #7703 because that PR changes mathematics. Whichever PR of this and #7703 is merged later must be adjusted to fix the merge conflict, but it is only 2 lines (or 4 lines after #7703).