### PR TITLE
Add make_const_array_view

### DIFF
--- a/doc/news/changes/minor/20190209Arndt
+++ b/doc/news/changes/minor/20190209Arndt
@@ -1,0 +1,3 @@
+New: make_const_array_view creates a constant view from a non-const object.
+<br>
+(Daniel Arndt, 2019/02/09)

--- a/doc/news/changes/minor/20190209Arndt
+++ b/doc/news/changes/minor/20190209Arndt
@@ -1,3 +1,3 @@
-New: make_const_array_view creates a constant view from a non-const object.
+New: make_const_array_view() creates a constant view from a non-const object.
 <br>
 (Daniel Arndt, 2019/02/09)

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -1134,6 +1134,25 @@ make_array_view(const Table<2, ElementType> &                   table,
 
 
 
+/*
+ * Create a view that doesn't allow the container it points to to be modified.
+ * This is useful if the object passed in is not `const` already and a function
+ * requires a view to constant memory in its signature.
+ *
+ * This function returns an object of type `ArrayView<const T>` where `T` is the
+ * element type of the container.
+ *
+ * @relatesalso ArrayView
+ */
+template <typename Container>
+inline auto
+make_const_array_view(const Container &container)
+  -> decltype(make_array_view(container))
+{
+  return make_array_view(container);
+}
+
+
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/tests/base/array_view_07.cc
+++ b/tests/base/array_view_07.cc
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// test make_const_array_view
+
+#include <deal.II/base/array_view.h>
+
+#include "../tests.h"
+
+template <typename ElementType>
+void
+const_foo(const ArrayView<const std::vector<ElementType>> &view)
+{
+  AssertThrow(view[0][0] == 1, ExcInternalError());
+  deallog << "OK" << std::endl;
+}
+
+template <typename ElementType>
+void
+foo(const ArrayView<std::vector<ElementType>> &view)
+{
+  AssertThrow(view[0][0] == 1, ExcInternalError());
+  deallog << "OK" << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+  std::vector<std::vector<int>> v(1, std::vector<int>(1, 1));
+  // this doesn't work
+  // const_foo(make_array_view(v));
+  const_foo(make_const_array_view(v));
+  foo(make_array_view(v));
+  // this doesn't work
+  // foo(make_const_array_view(v));
+}

--- a/tests/base/array_view_07.output
+++ b/tests/base/array_view_07.output
@@ -1,0 +1,3 @@
+
+DEAL::OK
+DEAL::OK


### PR DESCRIPTION
In the test below, I get the error message
```
 562: /mnt/data/darndt/Sources/dealii-clang-6.0.0/tests/base/array_view_07.cc:45:3: error: no matching function for call to 'const_foo'
 562:   const_foo(make_array_view(v));
 562:   ^~~~~~~~~
 562: /mnt/data/darndt/Sources/dealii-clang-6.0.0/tests/base/array_view_07.cc:25:1: note: candidate template ignored: could not match 'const vector<type-parameter-0-0, allocator<type-parameter-0-0>>' against 'vector<int,       allocator<int>>'
 562: const_foo(const ArrayView<const std::vector<ElementType>> &view)
```
from
```
const_foo(make_array_view(v));
```
and I need to pass a `const` somewhere in between to make this work. This is exactly what `make_const_array_view` does. Of course, I am open to better solutions.

If `const_foo` is not templated, the issue disappears.