### PR TITLE
hp::DoFHandler: Moved containers with temporary content into a dedicated structure

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -2337,6 +2337,21 @@ public:
 
     /**
      * This signal is triggered at the end of execution of the
+     * parallel::distributed::Triangulation::save()
+     * function when the triangulation has reached its final state.
+     */
+    boost::signals2::signal<void()> post_distributed_save;
+
+    /**
+     * This signal is triggered at the beginning of execution of the
+     * parallel::distributed::Triangulation::load()
+     * function. At the time this signal is triggered, the triangulation
+     * is still unchanged.
+     */
+    boost::signals2::signal<void()> pre_distributed_load;
+
+    /**
+     * This signal is triggered at the end of execution of the
      * parallel::distributed::Triangulation::load()
      * function when the triangulation has reached its final state.
      */

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2753,6 +2753,9 @@ namespace parallel
         tria->cell_attached_data.pack_callbacks_fixed.clear();
         tria->cell_attached_data.pack_callbacks_variable.clear();
       }
+
+      // signal that serialization has finished
+      this->signals.post_distributed_save();
     }
 
 
@@ -2771,6 +2774,8 @@ namespace parallel
         ExcMessage(
           "Triangulation may only contain coarse cells when calling load()."));
 
+      // signal that de-serialization is going to happen
+      this->signals.pre_distributed_load();
 
       if (parallel_ghost != nullptr)
         {


### PR DESCRIPTION
Closes #7670. Part of #3511.