### PR TITLE
Remove warnings generated by step-61

### DIFF
--- a/examples/step-61/step-61.cc
+++ b/examples/step-61/step-61.cc
@@ -113,6 +113,7 @@ public:
   Coefficient()
     : TensorFunction<2, dim>()
   {}
+
   virtual void value_list(const std::vector<Point<dim>> &points,
                           std::vector<Tensor<2, dim>> &  values) const override;
 };
@@ -138,6 +139,7 @@ public:
   BoundaryValues()
     : Function<dim>(2)
   {}
+
   virtual double value(const Point<dim> & p,
                        const unsigned int component = 0) const override;
 };
@@ -156,8 +158,9 @@ public:
   RightHandSide()
     : Function<dim>()
   {}
+
   virtual double value(const Point<dim> & p,
-                       const unsigned int component = 0) const;
+                       const unsigned int component = 0) const override;
 };
 
 template <int dim>
@@ -176,7 +179,8 @@ public:
   Solution()
     : Function<dim>(1)
   {}
-  virtual double value(const Point<dim> &p, const unsigned int) const;
+
+  virtual double value(const Point<dim> &p, const unsigned int) const override;
 };
 
 template <int dim>
@@ -194,6 +198,7 @@ public:
   Velocity()
     : TensorFunction<1, dim>()
   {}
+
   virtual Tensor<1, dim> value(const Point<dim> &p) const override;
 };
 


### PR DESCRIPTION
Fixes the warnings in https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=7792 and adds some blank lines for readability. Related to #7712.