### PR TITLE
Use the usual grammar for make targets.

### DIFF
--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -148,7 +148,7 @@ MACRO(DEAL_II_INVOKE_AUTOPILOT)
       COMMAND ${CMAKE_COMMAND} -E echo "***"
       COMMAND ${CMAKE_COMMAND} -E echo "*** Switched to Debug mode. Now recompile with: ${_make_command}"
       COMMAND ${CMAKE_COMMAND} -E echo "***"
-      COMMENT "Switch CMAKE_BUILD_TYPE to Debug"
+      COMMENT "Switching CMAKE_BUILD_TYPE to Debug"
       VERBATIM
       )
   ENDIF()
@@ -159,7 +159,7 @@ MACRO(DEAL_II_INVOKE_AUTOPILOT)
       COMMAND ${CMAKE_COMMAND} -E echo "***"
       COMMAND ${CMAKE_COMMAND} -E echo "*** Switched to Release mode. Now recompile with: ${_make_command}"
       COMMAND ${CMAKE_COMMAND} -E echo "***"
-      COMMENT "Switch CMAKE_BUILD_TYPE to Release"
+      COMMENT "Switching CMAKE_BUILD_TYPE to Release"
       VERBATIM
       )
   ENDIF()


### PR DESCRIPTION
This is a follow-up to #7694. We usually use the present progressive form
for makefile targets. For example, the last command executed when
compiling a program is shown as
  Linking CXX executable aspect
so use the same form here as well.