### PR TITLE
Correct MeshWorker::DoFInfo indices docstring

### DIFF
--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -96,7 +96,7 @@ namespace MeshWorker
      */
     unsigned int sub_number;
 
-    /*
+    /**
      * The DoF indices of the
      * current cell
      */


### PR DESCRIPTION
`indices` doesn't show up in Doxygen otherwise.