### PR TITLE
Fix some doxygen errors

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -185,7 +185,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -210,7 +210,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -246,7 +246,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -283,7 +283,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -322,7 +322,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -363,7 +363,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -409,7 +409,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -461,7 +461,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -485,7 +485,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -507,7 +507,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -530,7 +530,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -553,7 +553,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -576,7 +576,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -602,7 +602,7 @@ private:
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1393,7 +1393,7 @@ namespace deal_II_exceptions
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1456,7 +1456,7 @@ namespace deal_II_exceptions
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1505,7 +1505,7 @@ namespace deal_II_exceptions
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1555,7 +1555,7 @@ namespace deal_II_exceptions
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1583,7 +1583,7 @@ namespace deal_II_exceptions
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1625,7 +1625,7 @@ namespace internal
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1657,7 +1657,7 @@ namespace internal
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1682,7 +1682,7 @@ namespace internal
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1709,7 +1709,7 @@ namespace internal
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1737,7 +1737,7 @@ namespace internal
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1766,7 +1766,7 @@ namespace internal
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1797,7 +1797,7 @@ namespace internal
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other
@@ -1829,7 +1829,7 @@ namespace internal
  * them unique to deal.II. As a consequence, it is possible that other
  * libraries your code interfaces with define the same name, and the result
  * will be name collisions (see
- * https://en.wikipedia.org/wiki/Name_collision). One can <code>#undef</code>
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
  * this macro, as well as all other macros defined by deal.II that are not
  * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
  * the header <code>deal.II/base/undefine_macros.h</code> after all other

--- a/include/deal.II/lac/qr.h
+++ b/include/deal.II/lac/qr.h
@@ -127,8 +127,8 @@ public:
    * Connect a slot to retrieve a notification when the Givens rotations
    * are performed.
    *
-   * The function takes @p i'th and @p j'th indices of the plane of rotation
-   * and a triplet of numbers @p csr (cosine, sine and radius, see
+   * The function takes two indices, @p i and @p j, describing the plane of
+   * rotation, and a triplet of numbers @p csr (cosine, sine and radius, see
    * Utilities::LinearAlgebra::givens_rotation()) which represents the rotation
    * matrix.
    */
@@ -169,7 +169,7 @@ protected:
 
   /**
    * Signal used to retrieve a notification
-   * when Givens rotations are performed in plane @p i and @p j.
+   * when Givens rotations are performed in the `(i,j)`-plane.
    */
   boost::signals2::signal<void(const unsigned int i,
                                const unsigned int j,
@@ -254,7 +254,7 @@ public:
   virtual ~QR() = default;
 
   /**
-   * @copyfrom BaseQR::append_column
+   * @copydoc BaseQR::append_column
    *
    * @note Currently this function always returns <code>true</code>.
    */
@@ -310,7 +310,7 @@ public:
 
 private:
   /**
-   * Apply givens rotation in plane @p i @p k to @p Q and @p R so that
+   * Apply givens rotation in the `(i,j)`-plane to @p Q and @p R so that
    * <code>R(k,k)</code> is zeroed.
    *
    * See Chapter 5.1.9 of Golub 2013, Matrix computations.
@@ -396,7 +396,7 @@ public:
    * Connect a slot to implement a custom check of linear dependency
    * during addition of a column.
    *
-   * Here, @p u is the last column of the to-be R matrix , @p rho
+   * Here, @p u is the last column of the to-be R matrix, @p rho
    * is its diagonal and @p col_norm_sqr is the square of the $l2$ norm of the column.
    * The function should return <code>true</code> if the new column is
    * linearly independent.
@@ -409,7 +409,7 @@ public:
 
 private:
   /**
-   * Apply givens rotation in plane @i @p k to zero out $R(k,k)$.
+   * Apply givens rotation in the `(i,k)`-plane to zero out $R(k,k)$.
    */
   void
   apply_givens_rotation(const unsigned int i, const unsigned int k);
@@ -417,7 +417,7 @@ private:
   /**
    * Signal used to decide if the new column is linear dependent.
    *
-   * Here, @p u is the last column of the to-be R matrix , @p rho
+   * Here, @p u is the last column of the to-be R matrix, @p rho
    * is its diagonal and @p col_norm_sqr is the square of the $l2$ norm of the column.
    * The function should return <code>true</code> if the new column is
    * linearly independent.

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -2184,7 +2184,7 @@ namespace VectorTools
    *   function for the problem you are solving. This is because the
    *   Green's function $G(x,p)$ is defined by
    *   @f{align*}{
-   *     L G(x,p) &= \delta(x-p)$
+   *     L G(x,p) &= \delta(x-p)
    *   @f}
    *   where $L$ is the differential operator of your problem. The discrete
    *   version then requires computing the right hand side vector


### PR DESCRIPTION
- the `#` in `#undef` needs to be escaped when used in `doxygen` comments
- there was a stray `$` in the documentation for `VectorTools::create_point_source_vector`
- there was a  `@i` command in the `QR` documentation and I tried to improve some of the formulations there as well.