### PR TITLE
Avoid ambiguous function declaration/variable initialization

### DIFF
--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -623,8 +623,8 @@ block_operator(const BlockMatrixType &block_matrix)
   using BlockType =
     typename BlockLinearOperator<Range, Domain, BlockPayload>::BlockType;
 
-  BlockLinearOperator<Range, Domain, BlockPayload> return_op(
-    BlockPayload(block_matrix, block_matrix));
+  BlockLinearOperator<Range, Domain, BlockPayload> return_op{
+    BlockPayload(block_matrix, block_matrix)};
 
   return_op.n_block_rows = [&block_matrix]() -> unsigned int {
     return block_matrix.n_block_rows();
@@ -698,9 +698,8 @@ block_operator(
   using BlockType =
     typename BlockLinearOperator<Range, Domain, BlockPayload>::BlockType;
 
-  BlockLinearOperator<Range, Domain, BlockPayload> return_op(
-    (BlockPayload())); // TODO: Create block payload so that this can be
-                       // initialized correctly
+  // TODO: Create block payload so that this can be initialized correctly
+  BlockLinearOperator<Range, Domain, BlockPayload> return_op{BlockPayload()};
 
   return_op.n_block_rows = []() -> unsigned int { return m; };
 
@@ -744,8 +743,8 @@ block_diagonal_operator(const BlockMatrixType &block_matrix)
   using BlockType =
     typename BlockLinearOperator<Range, Domain, BlockPayload>::BlockType;
 
-  BlockLinearOperator<Range, Domain, BlockPayload> return_op(
-    BlockPayload(block_matrix, block_matrix));
+  BlockLinearOperator<Range, Domain, BlockPayload> return_op{
+    BlockPayload(block_matrix, block_matrix)};
 
   return_op.n_block_rows = [&block_matrix]() -> unsigned int {
     return block_matrix.n_block_rows();
@@ -910,8 +909,8 @@ block_forward_substitution(
   const BlockLinearOperator<Range, Domain, BlockPayload> &block_operator,
   const BlockLinearOperator<Domain, Range, BlockPayload> &diagonal_inverse)
 {
-  LinearOperator<Range, Range, typename BlockPayload::BlockType> return_op(
-    (typename BlockPayload::BlockType(diagonal_inverse)));
+  LinearOperator<Range, Range, typename BlockPayload::BlockType> return_op{
+    typename BlockPayload::BlockType(diagonal_inverse)};
 
   return_op.reinit_range_vector  = diagonal_inverse.reinit_range_vector;
   return_op.reinit_domain_vector = diagonal_inverse.reinit_domain_vector;
@@ -1025,8 +1024,8 @@ block_back_substitution(
   const BlockLinearOperator<Range, Domain, BlockPayload> &block_operator,
   const BlockLinearOperator<Domain, Range, BlockPayload> &diagonal_inverse)
 {
-  LinearOperator<Range, Range, typename BlockPayload::BlockType> return_op(
-    (typename BlockPayload::BlockType(diagonal_inverse)));
+  LinearOperator<Range, Range, typename BlockPayload::BlockType> return_op{
+    typename BlockPayload::BlockType(diagonal_inverse)};
 
   return_op.reinit_range_vector  = diagonal_inverse.reinit_range_vector;
   return_op.reinit_domain_vector = diagonal_inverse.reinit_domain_vector;

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -389,9 +389,9 @@ operator+(const LinearOperator<Range, Domain, Payload> &first_op,
     }
   else
     {
-      LinearOperator<Range, Domain, Payload> return_op(
+      LinearOperator<Range, Domain, Payload> return_op{
         static_cast<const Payload &>(first_op) +
-        static_cast<const Payload &>(second_op));
+        static_cast<const Payload &>(second_op)};
 
       return_op.reinit_range_vector  = first_op.reinit_range_vector;
       return_op.reinit_domain_vector = first_op.reinit_domain_vector;
@@ -585,9 +585,9 @@ operator*(const LinearOperator<Range, Intermediate, Payload> & first_op,
     }
   else
     {
-      LinearOperator<Range, Domain, Payload> return_op(
+      LinearOperator<Range, Domain, Payload> return_op{
         static_cast<const Payload &>(first_op) *
-        static_cast<const Payload &>(second_op));
+        static_cast<const Payload &>(second_op)};
 
       return_op.reinit_domain_vector = second_op.reinit_domain_vector;
       return_op.reinit_range_vector  = first_op.reinit_range_vector;
@@ -649,7 +649,7 @@ template <typename Range, typename Domain, typename Payload>
 LinearOperator<Domain, Range, Payload>
 transpose_operator(const LinearOperator<Range, Domain, Payload> &op)
 {
-  LinearOperator<Domain, Range, Payload> return_op(op.transpose_payload());
+  LinearOperator<Domain, Range, Payload> return_op{op.transpose_payload()};
 
   return_op.reinit_range_vector  = op.reinit_domain_vector;
   return_op.reinit_domain_vector = op.reinit_range_vector;
@@ -693,8 +693,8 @@ inverse_operator(const LinearOperator<Range, Domain, Payload> &op,
                  Solver &                                      solver,
                  const Preconditioner &                        preconditioner)
 {
-  LinearOperator<Domain, Range, Payload> return_op(
-    op.inverse_payload(solver, preconditioner));
+  LinearOperator<Domain, Range, Payload> return_op{
+    op.inverse_payload(solver, preconditioner)};
 
   return_op.reinit_range_vector  = op.reinit_domain_vector;
   return_op.reinit_domain_vector = op.reinit_range_vector;
@@ -750,8 +750,8 @@ inverse_operator(const LinearOperator<Range, Domain, Payload> &op,
                  Solver &                                      solver,
                  const LinearOperator<Range, Domain, Payload> &preconditioner)
 {
-  LinearOperator<Domain, Range, Payload> return_op(
-    op.inverse_payload(solver, preconditioner));
+  LinearOperator<Domain, Range, Payload> return_op{
+    op.inverse_payload(solver, preconditioner)};
 
   return_op.reinit_range_vector  = op.reinit_domain_vector;
   return_op.reinit_domain_vector = op.reinit_range_vector;
@@ -856,7 +856,7 @@ template <
 LinearOperator<Range, Range, Payload>
 identity_operator(const std::function<void(Range &, bool)> &reinit_vector)
 {
-  LinearOperator<Range, Range, Payload> return_op((Payload()));
+  LinearOperator<Range, Range, Payload> return_op{Payload()};
 
   return_op.reinit_range_vector  = reinit_vector;
   return_op.reinit_domain_vector = reinit_vector;
@@ -909,7 +909,7 @@ template <typename Range, typename Domain, typename Payload>
 LinearOperator<Range, Domain, Payload>
 null_operator(const LinearOperator<Range, Domain, Payload> &op)
 {
-  LinearOperator<Range, Domain, Payload> return_op(op.null_payload());
+  LinearOperator<Range, Domain, Payload> return_op{op.null_payload()};
 
   return_op.is_null_operator = true;
 
@@ -946,7 +946,7 @@ template <
 LinearOperator<Range, Range, Payload>
 mean_value_filter(const std::function<void(Range &, bool)> &reinit_vector)
 {
-  LinearOperator<Range, Range, Payload> return_op((Payload()));
+  LinearOperator<Range, Range, Payload> return_op{Payload()};
 
   return_op.reinit_range_vector  = reinit_vector;
   return_op.reinit_domain_vector = reinit_vector;
@@ -1402,8 +1402,8 @@ linear_operator(const OperatorExemplar &operator_exemplar, const Matrix &matrix)
 {
   using namespace internal::LinearOperatorImplementation;
   // Initialize the payload based on the input exemplar matrix
-  LinearOperator<Range, Domain, Payload> return_op(
-    Payload(operator_exemplar, matrix));
+  LinearOperator<Range, Domain, Payload> return_op{
+    Payload(operator_exemplar, matrix)};
 
   // Always store a reference to matrix and operator_exemplar in the lambda
   // functions. This ensures that a modification of the matrix after the


### PR DESCRIPTION
When compiling `step-20` `gcc-5.5` (called via `nvcc_wrapper`) decided to interpret
```
LinearOperator<Range, Range, Payload> return_op((Payload()));
```
as a function declaration instead of a definition of a variable for an empty payload.
Let's just use brace-initialization in all these places to be on the safe side.