### PR TITLE
Define GridTools::Cache::get_covering_rtree also without nanoflann support

### DIFF
--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -140,6 +140,8 @@ namespace GridTools
     return cell_bounding_boxes_rtree;
   }
 
+
+
 #ifdef DEAL_II_WITH_NANOFLANN
   template <int dim, int spacedim>
   const KDTree<spacedim> &
@@ -152,6 +154,7 @@ namespace GridTools
       }
     return vertex_kdtree;
   }
+#endif
 
 
 
@@ -187,7 +190,6 @@ namespace GridTools
 
     return covering_rtree;
   }
-#endif
 
 #include "grid_tools_cache.inst"
 


### PR DESCRIPTION
~~This tests requires `dealii::GridTools::Cache::get_covering_rtree` that is only defined if `deal.II` is built with `nanoflann` support.
We might also just declare `dealii::GridTools::Cache::get_covering_rtree` if there is `nanoflann` support.~~

`GridTools::Cache::get_covering_rtree` also works without `nanoflann`. Hence, remove the preprocessor switch.