### PR TITLE
Work around nvcc_wrapper std::complex problem

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -924,6 +924,35 @@ Tensor<0, dim, Number>::operator-=(const Tensor<0, dim, OtherNumber> &p)
 }
 
 
+
+#ifdef __CUDA_ARCH__
+namespace internal
+{
+  template <typename Number, typename OtherNumber>
+  DEAL_II_CUDA_HOST_DEV void
+  multiply_assign_scalar(Number &tensor, const OtherNumber &s)
+  {
+    tensor *= s;
+  }
+
+  template <typename Number, typename OtherNumber>
+  DEAL_II_CUDA_HOST_DEV void
+  multiply_assign_scalar(std::complex<Number> &, const OtherNumber &)
+  {
+    printf("This function is not implemented for std::complex<Number>!\n");
+    assert(false);
+  }
+} // namespace internal
+
+template <int dim, typename Number>
+template <typename OtherNumber>
+inline DEAL_II_CUDA_HOST_DEV Tensor<0, dim, Number> &
+Tensor<0, dim, Number>::operator*=(const OtherNumber &s)
+{
+  internal::multiply_assign_scalar(value, s);
+  return *this;
+}
+#else
 template <int dim, typename Number>
 template <typename OtherNumber>
 inline DEAL_II_CUDA_HOST_DEV Tensor<0, dim, Number> &
@@ -932,6 +961,8 @@ Tensor<0, dim, Number>::operator*=(const OtherNumber &s)
   value *= s;
   return *this;
 }
+#endif
+
 
 
 template <int dim, typename Number>

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -925,43 +925,38 @@ Tensor<0, dim, Number>::operator-=(const Tensor<0, dim, OtherNumber> &p)
 
 
 
-#ifdef __CUDA_ARCH__
 namespace internal
 {
-  template <typename Number, typename OtherNumber>
-  DEAL_II_CUDA_HOST_DEV void
-  multiply_assign_scalar(Number &tensor, const OtherNumber &s)
+  namespace ComplexWorkaround
   {
-    tensor *= s;
-  }
+    template <typename Number, typename OtherNumber>
+    inline DEAL_II_CUDA_HOST_DEV void
+    multiply_assign_scalar(Number &val, const OtherNumber &s)
+    {
+      val *= s;
+    }
 
-  template <typename Number, typename OtherNumber>
-  DEAL_II_CUDA_HOST_DEV void
-  multiply_assign_scalar(std::complex<Number> &, const OtherNumber &)
-  {
-    printf("This function is not implemented for std::complex<Number>!\n");
-    assert(false);
-  }
+#ifdef __CUDA_ARCH__
+    template <typename Number, typename OtherNumber>
+    inline DEAL_II_CUDA_HOST_DEV void
+    multiply_assign_scalar(std::complex<Number> &, const OtherNumber &)
+    {
+      printf("This function is not implemented for std::complex<Number>!\n");
+      assert(false);
+    }
+#endif
+  } // namespace ComplexWorkaround
 } // namespace internal
 
+
 template <int dim, typename Number>
 template <typename OtherNumber>
 inline DEAL_II_CUDA_HOST_DEV Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator*=(const OtherNumber &s)
 {
-  internal::multiply_assign_scalar(value, s);
+  internal::ComplexWorkaround::multiply_assign_scalar(value, s);
   return *this;
 }
-#else
-template <int dim, typename Number>
-template <typename OtherNumber>
-inline DEAL_II_CUDA_HOST_DEV Tensor<0, dim, Number> &
-Tensor<0, dim, Number>::operator*=(const OtherNumber &s)
-{
-  value *= s;
-  return *this;
-}
-#endif
 
 
 


### PR DESCRIPTION
`CUDA` device code is not compatible with `std::complex` and compiling `deal.II` using `nvcc_wrapper` with `DEAL_II_WITH_COMPLEX_VALUES=ON` failed with error messages like
```
/export/home/darndt/dealii/include/deal.II/base/tensor.h(1261): error: a value of type "int" cannot be assigned to an entity of type "_ZNSt7complexIdE9_ComplexTE"
```
This pull request just calls `assert(false)` instead if such an operation is requested.
