### PR TITLE
fix internal::has_begin type trait used in FEEvaluation

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3423,10 +3423,13 @@ namespace internal
     // finally here we check if our detector has non-void return type
     // T::value_type. This will happen if compiler can use second detector,
     // otherwise SFINAE let it work with the more general first one that is void
-    static constexpr bool value =
+    static const bool value =
       !std::is_same<void, decltype(detect(std::declval<T>()))>::value;
   };
 
+  // We need to have a separate declaration for static const members
+  template <typename T>
+  const bool has_local_element<T>::value;
 
   // same as above to check
   // bool T::partitioners_are_compatible(const Utilities::MPI::Partitioner &)
@@ -3444,10 +3447,13 @@ namespace internal
     detect(const U &);
 
   public:
-    static constexpr bool value =
+    static const bool value =
       std::is_same<bool, decltype(detect(std::declval<T>()))>::value;
   };
 
+  // We need to have a separate declaration for static const members
+  template <typename T>
+  const bool has_partitioners_are_compatible<T>::value;
 
 
   // same as above to check
@@ -3464,10 +3470,13 @@ namespace internal
     detect(const U &);
 
   public:
-    static constexpr bool value =
+    static const bool value =
       !std::is_same<void, decltype(detect(std::declval<T>()))>::value;
   };
 
+  // We need to have a separate declaration for static const members
+  template <typename T>
+  const bool has_begin<T>::value;
 
 
   // type trait for vector T and Number to see if
@@ -3478,12 +3487,15 @@ namespace internal
   template <typename T, typename Number>
   struct is_vectorizable
   {
-    static constexpr bool value =
+    static const bool value =
       has_begin<T>::value &&
       (has_local_element<T>::value || is_serial_vector<T>::value) &&
       std::is_same<typename T::value_type, Number>::value;
   };
 
+  // We need to have a separate declaration for static const members
+  template <typename T, typename Number>
+  const bool is_vectorizable<T, Number>::value;
 
 
   // access to generic const vectors that have operator ().

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3420,12 +3420,11 @@ namespace internal
     detect(const U &);
 
   public:
-    // finally here we check if our detector has return type same as
+    // finally here we check if our detector has non-void return type
     // T::value_type. This will happen if compiler can use second detector,
     // otherwise SFINAE let it work with the more general first one that is void
     static constexpr bool value =
-      std::is_same<typename T::value_type,
-                   decltype(detect(std::declval<T>()))>::value;
+      !std::is_same<void, decltype(detect(std::declval<T>()))>::value;
   };
 
 
@@ -3452,7 +3451,7 @@ namespace internal
 
 
   // same as above to check
-  // T::const_iterator T::begin() const
+  // ... T::begin() const
   template <typename T>
   struct has_begin
   {

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3466,8 +3466,7 @@ namespace internal
 
   public:
     static constexpr bool value =
-      std::is_same<typename T::const_iterator,
-                   decltype(detect(std::declval<T>()))>::value;
+      !std::is_same<void, decltype(detect(std::declval<T>()))>::value;
   };
 
 

--- a/tests/matrix_free/fe_evaluation_type_traits.cc
+++ b/tests/matrix_free/fe_evaluation_type_traits.cc
@@ -142,7 +142,8 @@ main()
     << std::endl
     << "TrilinosWrappers::MPI::Vector = "
     << internal::has_begin<TrilinosWrappers::MPI::Vector>::value << std::endl
-    << "Vector = " << internal::has_begin<Vector<double>>::value << std::endl;
+    << "Vector = " << internal::has_begin<Vector<double>>::value << std::endl
+    << "Dummy = " << internal::has_begin<Dummy<double>>::value << std::endl;
   // check is_vectorizable:
   deallog
     << "is_vectorizable:" << std::endl

--- a/tests/matrix_free/fe_evaluation_type_traits.with_trilinos=true.output
+++ b/tests/matrix_free/fe_evaluation_type_traits.with_trilinos=true.output
@@ -16,6 +16,7 @@ DEAL::has_begin:
 DEAL::LinearAlgebra::distributed::Vector = 1
 DEAL::TrilinosWrappers::MPI::Vector = 1
 DEAL::Vector = 1
+DEAL::Dummy = 0
 DEAL::is_vectorizable:
 DEAL::LinearAlgebra::distributed::Vector<double> && double = 1
 DEAL::LinearAlgebra::distributed::Vector<double> && float = 0


### PR DESCRIPTION
minor fix and follow up to https://github.com/dealii/dealii/pull/7744 . The original implementation would only work if `T::const_iterator` exist, which defeats the point of the type trait.