### PR TITLE
Fix compiling with Sacado and CUDA

### DIFF
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -175,6 +175,13 @@ namespace numbers
   {};
 
   /**
+   * std::complex cannot be used in CUDA device code.
+   */
+  template <typename Number>
+  struct is_cuda_compatible<std::complex<Number>, void> : std::false_type
+  {};
+
+  /**
    * Check whether a value is not a number.
    *
    * This function uses either <code>std::isnan</code>, <code>isnan</code>, or
@@ -442,12 +449,6 @@ namespace numbers
   };
 
   // --------------- inline and template functions ---------------- //
-
-  template <typename Number>
-  struct is_cuda_compatible<std::complex<Number>, void> : std::false_type
-  {};
-
-
 
   inline bool
   is_nan(const double x)

--- a/include/deal.II/differentiation/ad/sacado_number_types.h
+++ b/include/deal.II/differentiation/ad/sacado_number_types.h
@@ -926,6 +926,17 @@ namespace Differentiation
   } // namespace AD
 } // namespace Differentiation
 
+
+namespace numbers
+{
+  template <typename NumberType>
+  struct is_cuda_compatible<
+    NumberType,
+    typename std::enable_if<dealii::Differentiation::AD::is_sacado_rad_number<
+      NumberType>::value>::type> : std::false_type
+  {};
+} // namespace numbers
+
 #  endif // DOXYGEN
 
 

--- a/source/base/tensor.cc
+++ b/source/base/tensor.cc
@@ -19,6 +19,7 @@
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/differentiation/ad/adolc_product_types.h>
+#include <deal.II/differentiation/ad/sacado_number_types.h>
 #include <deal.II/differentiation/ad/sacado_product_types.h>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
Fixes #6856. This is the minimal change I could find to allow compiling in case `Trilinos` has `Sacado` and `CUDA` support.
`Trilinos`' `Sacado::Rad::Adcontext` `struct` is inherently incompatible with `CUDA`, e.g. due to having `non-const` `static` member variables. 
Since we can't instantiate only the `__host__` half of a `__host__ __device__` function, we run into problems as soon as `nvcc` is invoked for a class that is based on a `Sacado::Rad` number.
Removing the `__device__` part of certain functions helps to prevent this problem. 

I am not yet sure why the code compiles with all the other `__host__ __device__` functions still in place, though. With this pull request, all the `Sacado` tests still work when compiling with `nvcc_wrapper`.