### PR TITLE
Detect CUDA compute capability

### DIFF
--- a/cmake/configure/CUDAComputeCapability/cuda_compute_capability.cu
+++ b/cmake/configure/CUDAComputeCapability/cuda_compute_capability.cu
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <iostream>
+
+int main()
+{
+  cudaDeviceProp device_properties;
+  const cudaError_t error = cudaGetDeviceProperties(&device_properties,
+                                                    /*device*/0);
+  if( error != cudaSuccess)
+  {
+    std::cout << "CUDA error: " << cudaGetErrorString(error) << '\n';
+    return error;
+  }
+  std::cout << device_properties.major << device_properties.minor;
+  return 0;
+}

--- a/cmake/configure/configure_1_cuda.cmake
+++ b/cmake/configure/configure_1_cuda.cmake
@@ -115,7 +115,8 @@ MACRO(FEATURE_CUDA_FIND_EXTERNAL var)
           ${CUDA_ADDITIONAL_ERROR_STRING}
           "Couldn't detect CUDA Compute Capability! "
           "The error message was: ${CUDA_COMPUTE_CAPABILITY}\n"
-          "Please check the return value of ${_binary_test_dir}/cuda_compute_capability."
+          "Please check the return value of ${_binary_test_dir}/cuda_compute_capability.\n"
+          "If you want to disable the autodetection, set the compute capability to be used manually."
           )
         SET(${var} FALSE)
       ENDIF()

--- a/cmake/configure/configure_1_cuda.cmake
+++ b/cmake/configure/configure_1_cuda.cmake
@@ -85,6 +85,40 @@ MACRO(FEATURE_CUDA_FIND_EXTERNAL var)
       SET(CUDA_COMPUTE_CAPABILITY "${CMAKE_MATCH_1}")
     ELSEIF("${DEAL_II_CUDA_FLAGS_SAVED}" MATCHES "-arch=sm_([0-9]*)")
       SET(CUDA_COMPUTE_CAPABILITY "${CMAKE_MATCH_1}")
+    ELSEIF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
+      #
+      # Try to autodetect the CUDA Compute Capability by asking the device
+      #
+      SET(_binary_test_dir ${CMAKE_CURRENT_BINARY_DIR}/cmake/configure/CUDAComputeCapabilityWorkdir)
+      FILE(REMOVE_RECURSE ${_binary_test_dir})
+      FILE(MAKE_DIRECTORY ${_binary_test_dir})
+
+      EXECUTE_PROCESS(
+        COMMAND ${CUDA_NVCC_EXECUTABLE}
+          -ccbin=${CMAKE_CXX_COMPILER}
+          ${CMAKE_CURRENT_SOURCE_DIR}/cmake/configure/CUDAComputeCapability/cuda_compute_capability.cu
+          -o cuda_compute_capability
+        WORKING_DIRECTORY ${_binary_test_dir}
+        OUTPUT_QUIET
+        ERROR_QUIET
+        )
+      EXECUTE_PROCESS(COMMAND ${_binary_test_dir}/cuda_compute_capability
+                      RESULT_VARIABLE _result
+                      OUTPUT_VARIABLE CUDA_COMPUTE_CAPABILITY)
+      IF(${_result} EQUAL 0)
+        ADD_FLAGS(DEAL_II_CUDA_FLAGS "-arch=sm_${CUDA_COMPUTE_CAPABILITY}")
+        MESSAGE(STATUS "Detected CUDA Compute Capability ${CUDA_COMPUTE_CAPABILITY}")
+      ELSE()
+        MESSAGE(STATUS "Couldn't detect CUDA Compute Capability! "
+                       "The error message was: ${CUDA_COMPUTE_CAPABILITY}")
+        SET(CUDA_ADDITIONAL_ERROR_STRING
+          ${CUDA_ADDITIONAL_ERROR_STRING}
+          "Couldn't detect CUDA Compute Capability! "
+          "The error message was: ${CUDA_COMPUTE_CAPABILITY}\n"
+          "Please check the return value of ${_binary_test_dir}/cuda_compute_capability."
+          )
+        SET(${var} FALSE)
+      ENDIF()
     ELSE()
       #
       # Assume a cuda compute capability of 35

--- a/doc/external-libs/cuda.html
+++ b/doc/external-libs/cuda.html
@@ -39,8 +39,8 @@
       </pre>
       If you are using CUDA 9 or CUDA 10, you will need to turn off support for
       C++17 similarly.
-      By default, we assume that your GPU has compute capability 3.5 but you 
-      can easily set your own CUDA flags:
+      By default, we try to detect the compute capability of your device
+      but you can easily set your own CUDA flags:
       <pre>
 
         -DDEAL_II_CUDA_FLAGS="-arch=sm_60"


### PR DESCRIPTION
It's easy to forget to set the compute capability when compiling with `CUDA`. In case platform introspection is allowed, this pull request adds autodetection for the compute capability by asking device 0.