### PR TITLE
minor fix on documentation to enum Triangulation::MeshSmoothing

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1327,7 +1327,7 @@ public:
      *
      * If the smoothing indicator given to the constructor contains the bit
      * for #limit_level_difference_at_vertices, situations as the above one
-     * are eliminated by also marking the lower left cell for refinement.
+     * are eliminated by also marking the upper right cell for refinement.
      *
      * In case of anisotropic refinement, the level of a cell is not linked to
      * the refinement of a cell as directly as in case of isotropic


### PR DESCRIPTION
Link to the documentation is here [enum Triangulation::MeshSmoothing](https://www.dealii.org/developer/doxygen/deal.II/classTriangulation.html#a0633dd17e535a59162b79f338c6ff5ae).

The documentation should be corrected if my understanding is right. 