### PR TITLE
Out of date description of quadrature_point_data test fixed

### DIFF
--- a/tests/base/quadrature_point_data.cc
+++ b/tests/base/quadrature_point_data.cc
@@ -15,7 +15,7 @@
 
 
 
-// Check that QuadraturePointManager class. To that end first evaluate some
+// Check CellDataStorage class. To that end first evaluate some
 // quadratic function at quadrature points. Then refine cells and project using
 // FE_Q(2). Finally check that the values at quadrature points are still
 // consistent with the original function.

--- a/tests/base/quadrature_point_data_02.cc
+++ b/tests/base/quadrature_point_data_02.cc
@@ -15,7 +15,7 @@
 
 
 
-// Check that QuadraturePointManager class. To that end first evaluate some
+// Check CellDataStorage class. To that end first evaluate some
 // quadratic function at quadrature points. Then refine cells and project using
 // FE_Q(2). Finally check that the values at quadrature points are still
 // consistent with the original function. Same as quadrature_point_data.cc, but


### PR DESCRIPTION
I was reading the tests and the description was confusing. I noticed the name of the class within the test description must be updated.