### PR TITLE
add and use more type traits in FEEvaluation

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1192,6 +1192,13 @@ namespace LinearAlgebra
       bool
       partitioners_are_globally_compatible(
         const Utilities::MPI::Partitioner &part) const;
+
+      /**
+       * Change the ghost state of this vector to @p ghosted.
+       */
+      void
+      set_ghost_state(const bool ghosted) const;
+
       //@}
 
       /**
@@ -1810,6 +1817,15 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::get_partitioner() const
     {
       return partitioner;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    inline void
+    Vector<Number, MemorySpace>::set_ghost_state(const bool ghosted) const
+    {
+      vector_is_ghosted = ghosted;
     }
 
 #endif

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3431,6 +3431,58 @@ namespace internal
   template <typename T>
   const bool has_local_element<T>::value;
 
+
+
+  // a helper type-trait that leverage SFINAE to figure out if type T has
+  // void T::add_local_element(const uint, const typename T::value_type)
+  template <typename T>
+  struct has_add_local_element
+  {
+  private:
+    static int
+    detect(...);
+
+    template <typename U>
+    static decltype(
+      std::declval<U>().add_local_element(0, typename T::value_type()))
+    detect(const U &);
+
+  public:
+    static const bool value =
+      !std::is_same<int, decltype(detect(std::declval<T>()))>::value;
+  };
+
+  // We need to have a separate declaration for static const members
+  template <typename T>
+  const bool has_add_local_element<T>::value;
+
+
+
+  // a helper type-trait that leverage SFINAE to figure out if type T has
+  // void T::set_local_element(const uint, const typename T::value_type)
+  template <typename T>
+  struct has_set_local_element
+  {
+  private:
+    static int
+    detect(...);
+
+    template <typename U>
+    static decltype(
+      std::declval<U>().set_local_element(0, typename T::value_type()))
+    detect(const U &);
+
+  public:
+    static const bool value =
+      !std::is_same<int, decltype(detect(std::declval<T>()))>::value;
+  };
+
+  // We need to have a separate declaration for static const members
+  template <typename T>
+  const bool has_set_local_element<T>::value;
+
+
+
   // same as above to check
   // bool T::partitioners_are_compatible(const Utilities::MPI::Partitioner &)
   // const

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -2805,6 +2805,10 @@ namespace internal
           matrix_free.release_scratch_data_non_threadsafe(
             tmp_data[component_in_block_vector]);
           tmp_data[component_in_block_vector] = nullptr;
+
+          // let vector know that ghosts are being updated and we can read from
+          // them
+          vec.set_ghost_state(true);
 #  endif
         }
     }
@@ -2938,6 +2942,9 @@ namespace internal
                       .local_element(j + part.local_size()) = 0.;
                   }
             }
+
+          // let vector know that it's not ghosted anymore
+          vec.set_ghost_state(false);
 #  endif
         }
     }

--- a/tests/matrix_free/fe_evaluation_type_traits_02.cc
+++ b/tests/matrix_free/fe_evaluation_type_traits_02.cc
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test internal typetraits used in FEEvaluation
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+
+#include "../tests.h"
+
+// dummy class we use to check typetraits and internal function.
+// this one mimics LA::d::Vec
+template <typename Number>
+class Dummy
+{
+public:
+  using value_type = Number;
+
+  Number
+  local_element(const unsigned int) const
+  {
+    deallog << "Dummy::local_element() const" << std::endl;
+    return Number();
+  }
+
+  void
+  set_local_element(const unsigned int, const Number)
+  {
+    deallog << "Dummy::set_local_element()" << std::endl;
+  }
+
+  void
+  add_local_element(const unsigned int, const Number)
+  {
+    deallog << "Dummy::add_local_element()" << std::endl;
+  }
+
+  Number
+  operator()(const unsigned int) const
+  {
+    deallog << "Dummy::operator() const" << std::endl;
+    return Number();
+  }
+};
+
+
+template <typename Number>
+class Dummy2
+{
+public:
+  using value_type = Number;
+
+  Number
+  local_element(const unsigned int) const
+  {
+    deallog << "Dummy2::local_element() const" << std::endl;
+    return Number();
+  }
+
+  Number &
+  local_element(const unsigned int)
+  {
+    deallog << "Dummy2::local_element()" << std::endl;
+    return dummy;
+  }
+
+  Number
+  operator()(const unsigned int) const
+  {
+    deallog << "Dummy2::operator() const" << std::endl;
+    return Number();
+  }
+
+  Number &
+  operator()(const unsigned int)
+  {
+    deallog << "Dummy2::operator()" << std::endl;
+    return dummy;
+  }
+
+private:
+  Number dummy;
+};
+
+
+int
+main()
+{
+  initlog();
+
+  Dummy<double>  dummy;
+  Dummy2<double> dummy2;
+
+  deallog << "has_add_local_element:" << std::endl
+          << "Dummy = " << internal::has_add_local_element<Dummy<double>>::value
+          << std::endl
+          << "Dummy2 = "
+          << internal::has_add_local_element<Dummy2<double>>::value << std::endl
+          << "has_set_local_element:" << std::endl
+          << "Dummy = " << internal::has_set_local_element<Dummy<double>>::value
+          << std::endl
+          << "Dummy2 = "
+          << internal::has_set_local_element<Dummy2<double>>::value
+          << std::endl;
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/matrix_free/fe_evaluation_type_traits_02.cc
+++ b/tests/matrix_free/fe_evaluation_type_traits_02.cc
@@ -116,5 +116,14 @@ main()
           << internal::has_set_local_element<Dummy2<double>>::value
           << std::endl;
 
+  // now check internal::vector_access_[set|add] wrappers
+  deallog << "internal::vector_access_set:" << std::endl;
+  internal::vector_access_set(dummy, 0, 0);
+  internal::vector_access_set(dummy2, 0, 0);
+
+  deallog << "internal::vector_access_add:" << std::endl;
+  internal::vector_access_add(dummy, 0, 0);
+  internal::vector_access_add(dummy2, 0, 0);
+
   deallog << "OK" << std::endl;
 }

--- a/tests/matrix_free/fe_evaluation_type_traits_02.output
+++ b/tests/matrix_free/fe_evaluation_type_traits_02.output
@@ -5,4 +5,10 @@ DEAL::Dummy2 = 0
 DEAL::has_set_local_element:
 DEAL::Dummy = 1
 DEAL::Dummy2 = 0
+DEAL::internal::vector_access_set:
+DEAL::Dummy::set_local_element()
+DEAL::Dummy2::local_element()
+DEAL::internal::vector_access_add:
+DEAL::Dummy::add_local_element()
+DEAL::Dummy2::local_element()
 DEAL::OK

--- a/tests/matrix_free/fe_evaluation_type_traits_02.output
+++ b/tests/matrix_free/fe_evaluation_type_traits_02.output
@@ -1,0 +1,8 @@
+
+DEAL::has_add_local_element:
+DEAL::Dummy = 1
+DEAL::Dummy2 = 0
+DEAL::has_set_local_element:
+DEAL::Dummy = 1
+DEAL::Dummy2 = 0
+DEAL::OK


### PR DESCRIPTION
these extension are need for vectors which are like sparse matrices. There should be no performance degradation for standard vectors, we just add a redirection mechanism in vector accessors.