### PR TITLE
Fix renumbering of level dofs for FE_Q

### DIFF
--- a/doc/news/changes/minor/20190308MartinKronbichler
+++ b/doc/news/changes/minor/20190308MartinKronbichler
@@ -1,0 +1,5 @@
+Fixed: DoFHandler::renumber_dofs() called on levels would previously run into
+an assertion on distributed triangulation when used with continuous
+elements. This is now fixed.
+<br>
+(Martin Kronbichler, 2019/03/08)

--- a/tests/multigrid/renumbering_08.cc
+++ b/tests/multigrid/renumbering_08.cc
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// check renumbering the degrees of freedom on the multigrid levels in
+// parallel for FE_Q, otherwise similar to renumbering_05
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <algorithm>
+
+#include "../tests.h"
+
+using namespace std;
+
+
+template <int dim>
+void
+print_dof_numbers(const DoFHandler<dim> &dof)
+{
+  std::vector<types::global_dof_index> dof_indices(dof.get_fe().dofs_per_cell);
+  deallog << "DoF numbers on active cells" << std::endl;
+  for (auto cell : dof.active_cell_iterators())
+    if (!cell->is_artificial())
+      {
+        cell->get_dof_indices(dof_indices);
+        deallog << "cell " << cell->id() << ": ";
+        for (types::global_dof_index i : dof_indices)
+          deallog << i << " ";
+        deallog << std::endl;
+      }
+  for (unsigned int l = 0; l < dof.get_triangulation().n_global_levels(); ++l)
+    {
+      deallog << "DoF numbers on level " << l << std::endl;
+      for (auto cell : dof.cell_iterators_on_level(l))
+        if (cell->level_subdomain_id() != numbers::artificial_subdomain_id)
+          {
+            cell->get_mg_dof_indices(dof_indices);
+            deallog << "cell " << cell->id() << ": ";
+            for (types::global_dof_index i : dof_indices)
+              deallog << i << " ";
+            deallog << std::endl;
+          }
+    }
+}
+
+template <int dim>
+void
+check()
+{
+  FE_Q<dim> fe(2);
+
+  parallel::distributed::Triangulation<dim> tr(
+    MPI_COMM_WORLD,
+    Triangulation<dim>::limit_level_difference_at_vertices,
+    parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+  for (unsigned int cycle = 0; cycle < 5; ++cycle)
+    {
+      tr.clear();
+      const unsigned int n_refine  = cycle / 3;
+      const unsigned int remainder = cycle % 3;
+      Point<dim>         p1;
+      for (unsigned int d = 0; d < dim; ++d)
+        p1[d] = -1;
+      Point<dim> p2;
+      for (unsigned int d = 0; d < remainder; ++d)
+        p2[d] = 2.8;
+      for (unsigned int d = remainder; d < dim; ++d)
+        p2[d] = 1;
+      std::vector<unsigned int> subdivisions(dim, 1);
+      for (unsigned int d = 0; d < remainder; ++d)
+        subdivisions[d] = 2;
+      GridGenerator::subdivided_hyper_rectangle(tr, subdivisions, p1, p2);
+
+      DoFHandler<dim> mgdof(tr);
+      mgdof.distribute_dofs(fe);
+      mgdof.distribute_mg_dofs();
+
+      print_dof_numbers(mgdof);
+
+      // compute a renumbering on the level degrees of freedom by simply
+      // flipping the local numbers
+      for (unsigned int l = 0; l < tr.n_global_levels(); ++l)
+        {
+          std::vector<types::global_dof_index> new_indices;
+          if (mgdof.locally_owned_mg_dofs(l).n_elements() > 0)
+            {
+              const types::global_dof_index first =
+                mgdof.locally_owned_mg_dofs(l).nth_index_in_set(0);
+              const types::global_dof_index last =
+                first + mgdof.locally_owned_mg_dofs(l).n_elements();
+              for (unsigned int i = 0; i < last - first; ++i)
+                new_indices.push_back(last - 1 - i);
+            }
+          mgdof.renumber_dofs(l, new_indices);
+        }
+
+      print_dof_numbers(mgdof);
+    }
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  MPILogInitAll                    log;
+
+  check<2>();
+  check<3>();
+}

--- a/tests/multigrid/renumbering_08.with_p4est=true.mpirun=2.output
+++ b/tests/multigrid/renumbering_08.with_p4est=true.mpirun=2.output
@@ -1,0 +1,227 @@
+
+DEAL:0::DoF numbers on active cells
+DEAL:0::DoF numbers on level 0
+DEAL:0::DoF numbers on active cells
+DEAL:0::DoF numbers on level 0
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:0::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:0::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:0::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 8 7 6 5 4 3 2 1 0 
+DEAL:0::cell 1_0:: 7 14 5 13 3 12 11 10 9 
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:0::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:0::cell 2_0:: 2 3 15 16 17 18 7 19 20 
+DEAL:0::cell 3_0:: 3 10 16 21 18 22 13 23 24 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:0::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:0::cell 2_0:: 2 3 15 16 17 18 7 19 20 
+DEAL:0::cell 3_0:: 3 10 16 21 18 22 13 23 24 
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:0::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:0::cell 2_0:: 2 3 15 16 17 18 7 19 20 
+DEAL:0::cell 3_0:: 3 10 16 21 18 22 13 23 24 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 14 13 12 11 10 9 8 7 6 
+DEAL:0::cell 1_0:: 13 5 11 4 9 3 2 1 0 
+DEAL:0::cell 2_0:: 12 11 24 23 22 21 7 20 19 
+DEAL:0::cell 3_0:: 11 4 23 18 21 17 1 16 15 
+DEAL:0::DoF numbers on active cells
+DEAL:0::DoF numbers on level 0
+DEAL:0::DoF numbers on active cells
+DEAL:0::DoF numbers on level 0
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:0::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:0::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:0::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 8 7 6 5 4 3 2 1 0 
+DEAL:0::cell 1_0:: 7 14 5 13 3 12 11 10 9 
+DEAL:0::DoF numbers on active cells
+DEAL:0::DoF numbers on level 0
+DEAL:0::DoF numbers on active cells
+DEAL:0::DoF numbers on level 0
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:0::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:0::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:0::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0 
+DEAL:0::cell 1_0:: 25 44 23 43 21 42 19 41 17 40 39 38 13 37 36 35 9 34 7 33 5 32 31 30 29 28 27 
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:0::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:0::cell 2_0:: 2 3 45 46 6 7 47 48 49 50 11 51 52 53 15 54 18 19 55 56 57 58 23 59 60 61 62 
+DEAL:0::cell 3_0:: 3 28 46 63 7 30 48 64 50 65 33 66 53 67 36 68 19 38 56 69 58 70 41 71 72 73 74 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:0::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:0::cell 2_0:: 2 3 45 46 6 7 47 48 49 50 11 51 52 53 15 54 18 19 55 56 57 58 23 59 60 61 62 
+DEAL:0::cell 3_0:: 3 28 46 63 7 30 48 64 50 65 33 66 53 67 36 68 19 38 56 69 58 70 41 71 72 73 74 
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:0::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:0::cell 2_0:: 2 3 45 46 6 7 47 48 49 50 11 51 52 53 15 54 18 19 55 56 57 58 23 59 60 61 62 
+DEAL:0::cell 3_0:: 3 28 46 63 7 30 48 64 50 65 33 66 53 67 36 68 19 38 56 69 58 70 41 71 72 73 74 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 44 43 42 41 40 39 38 37 36 35 34 33 32 31 30 29 28 27 26 25 24 23 22 21 20 19 18 
+DEAL:0::cell 1_0:: 43 17 41 16 39 15 37 14 35 13 12 11 31 10 9 8 27 7 25 6 23 5 4 3 2 1 0 
+DEAL:0::cell 2_0:: 42 41 74 73 38 37 72 71 70 69 33 68 67 66 29 65 26 25 64 63 62 61 21 60 59 58 57 
+DEAL:0::cell 3_0:: 41 16 73 56 37 14 71 55 69 54 11 53 66 52 8 51 25 6 63 50 61 49 3 48 47 46 45 
+DEAL:0::DoF numbers on active cells
+DEAL:0::DoF numbers on level 0
+DEAL:0::DoF numbers on active cells
+DEAL:0::DoF numbers on level 0
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:0::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:0::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:0::DoF numbers on active cells
+DEAL:0::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:0::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:0::DoF numbers on level 0
+DEAL:0::cell 0_0:: 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0 
+DEAL:0::cell 1_0:: 25 44 23 43 21 42 19 41 17 40 39 38 13 37 36 35 9 34 7 33 5 32 31 30 29 28 27 
+
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 8 7 6 5 4 3 2 1 0 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 8 7 6 5 4 3 2 1 0 
+DEAL:1::cell 1_0:: 7 14 5 13 3 12 11 10 9 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:1::cell 2_0:: 2 3 15 16 17 18 7 19 20 
+DEAL:1::cell 3_0:: 3 10 16 21 18 22 13 23 24 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:1::cell 2_0:: 2 3 15 16 17 18 7 19 20 
+DEAL:1::cell 3_0:: 3 10 16 21 18 22 13 23 24 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:1::cell 2_0:: 2 3 15 16 17 18 7 19 20 
+DEAL:1::cell 3_0:: 3 10 16 21 18 22 13 23 24 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 14 13 12 11 10 9 8 7 6 
+DEAL:1::cell 1_0:: 13 5 11 4 9 3 2 1 0 
+DEAL:1::cell 2_0:: 12 11 24 23 22 21 7 20 19 
+DEAL:1::cell 3_0:: 11 4 23 18 21 17 1 16 15 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 8 7 6 5 4 3 2 1 0 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 
+DEAL:1::cell 1_0:: 1 9 3 10 5 11 12 13 14 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 8 7 6 5 4 3 2 1 0 
+DEAL:1::cell 1_0:: 7 14 5 13 3 12 11 10 9 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0 
+DEAL:1::cell 1_0:: 25 44 23 43 21 42 19 41 17 40 39 38 13 37 36 35 9 34 7 33 5 32 31 30 29 28 27 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:1::cell 2_0:: 2 3 45 46 6 7 47 48 49 50 11 51 52 53 15 54 18 19 55 56 57 58 23 59 60 61 62 
+DEAL:1::cell 3_0:: 3 28 46 63 7 30 48 64 50 65 33 66 53 67 36 68 19 38 56 69 58 70 41 71 72 73 74 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:1::cell 2_0:: 2 3 45 46 6 7 47 48 49 50 11 51 52 53 15 54 18 19 55 56 57 58 23 59 60 61 62 
+DEAL:1::cell 3_0:: 3 28 46 63 7 30 48 64 50 65 33 66 53 67 36 68 19 38 56 69 58 70 41 71 72 73 74 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:1::cell 2_0:: 2 3 45 46 6 7 47 48 49 50 11 51 52 53 15 54 18 19 55 56 57 58 23 59 60 61 62 
+DEAL:1::cell 3_0:: 3 28 46 63 7 30 48 64 50 65 33 66 53 67 36 68 19 38 56 69 58 70 41 71 72 73 74 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 44 43 42 41 40 39 38 37 36 35 34 33 32 31 30 29 28 27 26 25 24 23 22 21 20 19 18 
+DEAL:1::cell 1_0:: 43 17 41 16 39 15 37 14 35 13 12 11 31 10 9 8 27 7 25 6 23 5 4 3 2 1 0 
+DEAL:1::cell 2_0:: 42 41 74 73 38 37 72 71 70 69 33 68 67 66 29 65 26 25 64 63 62 61 21 60 59 58 57 
+DEAL:1::cell 3_0:: 41 16 73 56 37 14 71 55 69 54 11 53 66 52 8 51 25 6 63 50 61 49 3 48 47 46 45 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:1::DoF numbers on active cells
+DEAL:1::cell 0_0:: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 
+DEAL:1::cell 1_0:: 1 27 3 28 5 29 7 30 9 31 32 33 13 34 35 36 17 37 19 38 21 39 40 41 42 43 44 
+DEAL:1::DoF numbers on level 0
+DEAL:1::cell 0_0:: 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0 
+DEAL:1::cell 1_0:: 25 44 23 43 21 42 19 41 17 40 39 38 13 37 36 35 9 34 7 33 5 32 31 30 29 28 27 
+


### PR DESCRIPTION
It turned out that we run into a few assertions when trying to renumber the level dofs via `DoFHandler::renumber_dofs(level, new_numbers)` for `FE_Q`. The problem was that we forgot to skip the line and face dofs of artificial cells. Furthermore, we also went into trouble for the vertex dofs in case a processor does not own anything.