### PR TITLE
Fix link targets in frames.

### DIFF
--- a/doc/documentation.html
+++ b/doc/documentation.html
@@ -36,7 +36,7 @@
           <li><a href="http://www.dealii.org/code-gallery.html" target="_top">Code gallery</a></li>
           <li><a href="doxygen/deal.II/index.html" target="_top">Manual</a></li>
           <li><a href="http://www.math.colostate.edu/~bangerth/videos.html" target="_top">Wolfgang's lectures</a></li>
-          <li><a href="http://www.dealii.org/reports.html" target="body">Technical reports</a></li>
+          <li><a href="http://www.dealii.org/reports.html" target="_top">Technical reports</a></li>
           <li><a href="http://www.dealii.org/publications.html" target="_top">Publications</a></li>
         </ol>
       </div>
@@ -52,7 +52,7 @@
           <li><a href="developers/cmake-internals.html" target="body">CMake internals</a></li>
           <li><a href="developers/writing-documentation.html" target="body">Writing documentation</a></li>
           <li><a href="developers/porting.html" target="body">Porting</a></li>
-          <li><a href="doxygen/deal.II/CodingConventions.html" target="body">Coding conventions</a></li>
+          <li><a href="doxygen/deal.II/CodingConventions.html" target="_top">Coding conventions</a></li>
           <li><a href="developers/testsuite.html" target="body">Testsuite</a></li>
         </ol>
       </div>


### PR DESCRIPTION
The first link is currently unclickable and it should have `target="body"` anyway since it should not be framed.

The second link works but it should not be framed.

This should fix #7040. I am not certain that it will since the current link set up works with my local copy of the documentation but does not on the server.