### PR TITLE
Remove make slice

### DIFF
--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -25,7 +25,6 @@
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/symmetric_tensor.h>
-#include <deal.II/base/vector_slice.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -21,7 +21,6 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/subscriptor.h>
-#include <deal.II/base/vector_slice.h>
 
 #include <deal.II/lac/sparsity_pattern.h>
 

--- a/include/deal.II/meshworker/vector_selector.templates.h
+++ b/include/deal.II/meshworker/vector_selector.templates.h
@@ -132,21 +132,21 @@ namespace MeshWorker
     for (unsigned int i = 0; i < this->n_values(); ++i)
       {
         const VectorType *src = data.read_ptr<VectorType>(this->value_index(i));
-        VectorSlice<std::vector<std::vector<typename VectorType::value_type>>>
-          dst(values[i], component, n_comp);
-        fe.get_function_values(*src, make_slice(index, start, size), dst, true);
+        fe.get_function_values(*src,
+                               make_array_view(index, start, size),
+                               make_array_view(values[i], component, n_comp),
+                               true);
       }
 
     for (unsigned int i = 0; i < this->n_gradients(); ++i)
       {
         const VectorType *src =
           data.read_ptr<VectorType>(this->gradient_index(i));
-        VectorSlice<std::vector<
-          std::vector<Tensor<1, spacedim, typename VectorType::value_type>>>>
-          dst(gradients[i], component, n_comp);
         fe.get_function_gradients(*src,
-                                  make_slice(index, start, size),
-                                  dst,
+                                  make_array_view(index, start, size),
+                                  make_array_view(gradients[i],
+                                                  component,
+                                                  n_comp),
                                   true);
       }
 
@@ -154,12 +154,11 @@ namespace MeshWorker
       {
         const VectorType *src =
           data.read_ptr<VectorType>(this->hessian_index(i));
-        VectorSlice<std::vector<
-          std::vector<Tensor<2, spacedim, typename VectorType::value_type>>>>
-          dst(hessians[i], component, n_comp);
         fe.get_function_hessians(*src,
-                                 make_slice(index, start, size),
-                                 dst,
+                                 make_array_view(index, start, size),
+                                 make_array_view(hessians[i],
+                                                 component,
+                                                 n_comp),
                                  true);
       }
   }
@@ -233,11 +232,9 @@ namespace MeshWorker
       {
         const MGLevelObject<VectorType> *src =
           data.read_ptr<MGLevelObject<VectorType>>(this->value_index(i));
-        VectorSlice<std::vector<std::vector<typename VectorType::value_type>>>
-          dst(values[i], component, n_comp);
         fe.get_function_values((*src)[level],
-                               make_slice(index, start, size),
-                               dst,
+                               make_array_view(index, start, size),
+                               make_array_view(values[i], component, n_comp),
                                true);
       }
 
@@ -245,12 +242,11 @@ namespace MeshWorker
       {
         const MGLevelObject<VectorType> *src =
           data.read_ptr<MGLevelObject<VectorType>>(this->value_index(i));
-        VectorSlice<std::vector<
-          std::vector<Tensor<1, spacedim, typename VectorType::value_type>>>>
-          dst(gradients[i], component, n_comp);
         fe.get_function_gradients((*src)[level],
-                                  make_slice(index, start, size),
-                                  dst,
+                                  make_array_view(index, start, size),
+                                  make_array_view(gradients[i],
+                                                  component,
+                                                  n_comp),
                                   true);
       }
 
@@ -258,12 +254,11 @@ namespace MeshWorker
       {
         const MGLevelObject<VectorType> *src =
           data.read_ptr<MGLevelObject<VectorType>>(this->value_index(i));
-        VectorSlice<std::vector<
-          std::vector<Tensor<2, spacedim, typename VectorType::value_type>>>>
-          dst(hessians[i], component, n_comp);
         fe.get_function_hessians((*src)[level],
-                                 make_slice(index, start, size),
-                                 dst,
+                                 make_array_view(index, start, size),
+                                 make_array_view(hessians[i],
+                                                 component,
+                                                 n_comp),
                                  true);
       }
   }

--- a/include/deal.II/meshworker/vector_selector.templates.h
+++ b/include/deal.II/meshworker/vector_selector.templates.h
@@ -17,8 +17,6 @@
 #define dealii_vector_selector_templates_h
 
 
-#include <deal.II/base/vector_slice.h>
-
 #include <deal.II/fe/fe_values.h>
 
 #include <deal.II/meshworker/vector_selector.h>

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -15,7 +15,6 @@
 
 
 #include <deal.II/base/memory_consumption.h>
-#include <deal.II/base/vector_slice.h>
 
 #include <deal.II/lac/block_sparsity_pattern.h>
 

--- a/source/lac/chunk_sparsity_pattern.cc
+++ b/source/lac/chunk_sparsity_pattern.cc
@@ -264,7 +264,7 @@ ChunkSparsityPattern::reinit(const size_type               m,
 {
   Assert(chunk_size > 0, ExcInvalidNumber(chunk_size));
 
-  reinit(m, n, make_slice(row_lengths), chunk_size);
+  reinit(m, n, make_array_view(row_lengths), chunk_size);
 }
 
 

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -16,7 +16,6 @@
 
 #include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/utilities.h>
-#include <deal.II/base/vector_slice.h>
 
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/full_matrix.h>

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -605,7 +605,7 @@ SparsityPattern::reinit(const size_type                  m,
                         const size_type                  n,
                         const std::vector<unsigned int> &row_lengths)
 {
-  reinit(m, n, make_slice(row_lengths));
+  reinit(m, n, make_array_view(row_lengths));
 }
 
 

--- a/tests/integrators/advection_01.cc
+++ b/tests/integrators/advection_01.cc
@@ -16,6 +16,7 @@
 
 // Test the functions in integrators/laplace.h
 // Output matrices and assert consistency of residuals
+#include <deal.II/base/vector_slice.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nedelec.h>

--- a/tests/integrators/divergence_01.cc
+++ b/tests/integrators/divergence_01.cc
@@ -16,6 +16,7 @@
 
 // Test the functions in integrators/divergence.h
 // Output matrices and assert consistency of residuals
+#include <deal.II/base/vector_slice.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nedelec.h>

--- a/tests/integrators/elasticity_01.cc
+++ b/tests/integrators/elasticity_01.cc
@@ -16,6 +16,7 @@
 
 // Test the functions in integrators/elasticity.h
 // Output matrices and assert consistency of residuals
+#include <deal.II/base/vector_slice.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nedelec.h>

--- a/tests/integrators/elasticity_02.cc
+++ b/tests/integrators/elasticity_02.cc
@@ -16,6 +16,7 @@
 
 // Test nitsche_tangential in Elasticity
 // Output matrices and assert consistency of residuals
+#include <deal.II/base/vector_slice.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nedelec.h>

--- a/tests/integrators/grad_div_01.cc
+++ b/tests/integrators/grad_div_01.cc
@@ -16,6 +16,7 @@
 
 // Test the functions in integrators/grad_div.h
 // Output matrices and assert consistency of residuals
+#include <deal.II/base/vector_slice.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nedelec.h>

--- a/tests/integrators/laplacian_01.cc
+++ b/tests/integrators/laplacian_01.cc
@@ -16,6 +16,7 @@
 
 // Test the functions in integrators/laplace.h
 // Output matrices and assert consistency of residuals
+#include <deal.II/base/vector_slice.h>
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nedelec.h>


### PR DESCRIPTION
Possibly fixes #7794: MSVC apparently encounters an error when converting a `VectorSlice` temporary into an `ArrayView` temporary. I suspect, though I do not have a Windows machine handy, that we can fix this by completely removing all intermediate `VectorSlice` constructors.