### PR TITLE
Update allowed MSVC version in bundled boost

### DIFF
--- a/bundled/boost-1.62.0/include/boost/config/compiler/visualc.hpp
+++ b/bundled/boost-1.62.0/include/boost/config/compiler/visualc.hpp
@@ -294,10 +294,10 @@
 #endif
 
 //
-// masterleinad: upgrade supported MSVC version to 19.16 (last checked 19.16.27024.1)
+// masterleinad: upgrade supported MSVC version to 19.20 (last checked 19.20.27404)
 // Boost repo has only 19.10:
 // last known and checked version is 19.10.24629 (VC++ 2017 RC):
-#if (_MSC_VER > 1916)
+#if (_MSC_VER > 1920)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"
 #  else


### PR DESCRIPTION
This avoids a ton of warnings when compiling with `Visual Studio 2019`'s compiler.