### PR TITLE
Fix MatrixFree::loop() for the case where VectorType is not a vector

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1436,7 +1436,6 @@ public:
    * Queries whether or not the geometry-related information for the cells has
    * been set.
    */
-
   bool
   mapping_initialized() const;
 
@@ -3321,13 +3320,15 @@ namespace internal
 
 
     /**
-     * Zero out vector region for vector that do _not_ support
-     * exchange on a subset of DoFs <==> begin() + ind == local_element(ind)
+     * Zero out vector region for vector that do _not_ support exchange on a
+     * subset of DoFs <==> begin() + ind == local_element(ind) but are still a
+     * vector type
      */
     template <
       typename VectorType,
       typename std::enable_if<!has_exchange_on_subset<VectorType>::value,
-                              VectorType>::type * = nullptr>
+                              VectorType>::type * = nullptr,
+      typename VectorType::value_type *           = nullptr>
     void
     zero_vector_region(const unsigned int range_index, VectorType &vec) const
     {
@@ -3337,6 +3338,20 @@ namespace internal
         {
           Assert(false, ExcNotImplemented());
         }
+    }
+
+
+
+    /**
+     * Zero out vector region for non-vector types, i.e., classes that do not
+     * have VectorType::value_type
+     */
+    void
+    zero_vector_region(const unsigned int, ...) const
+    {
+      Assert(false,
+             ExcNotImplemented("Zeroing is only implemented for vector types "
+                               "which provide VectorType::value_type"));
     }
 
 

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -631,6 +631,7 @@ namespace internal
       n_blocks             = 0;
       scheme               = none;
       partition_row_index.clear();
+      partition_row_index.resize(2);
       cell_partition_data.clear();
       face_partition_data.clear();
       boundary_partition_data.clear();

--- a/tests/matrix_free/matrix_free_type_traits.cc
+++ b/tests/matrix_free/matrix_free_type_traits.cc
@@ -90,5 +90,16 @@ main()
           << "unsigned int = "
           << internal::is_serial_or_dummy<unsigned int>::value << std::endl;
 
+  // check that MatrixFree::cell_loop can run for non-vector types
+  MatrixFree<2> matrix_free;
+  int           dummy = 0;
+  matrix_free.cell_loop(
+    std::function<void(const MatrixFree<2> &,
+                       int &,
+                       const int &,
+                       const std::pair<unsigned int, unsigned int> &)>(),
+    dummy,
+    dummy);
+
   deallog << "OK" << std::endl;
 }


### PR DESCRIPTION
The matrix-free loops previously also supported the case where the `VectorType` that is passed in as a second/third argument to `cell_loop()` and `loop()` is not actually a vector but say a dummy. Of course, in that case we would get an error with the old code:
```
6527: /home/kronbichler/deal/deal.II/include/deal.II/matrix_free/matrix_free.h:3335:36: error: ‘int’ is not a class, struct, or union type
6527:          vec = typename VectorType::value_type();
6527:                                     ^~~~~~~~~~~~
```
To fix this, we need to add `VectorType::value_type` to the SFINAE argument and further introduce a default `zero_vector_region` function.

I added a basic version of this scenario to the `type_traits` test (see #7787) to make sure we have this use case in mind.

(The matrix-free object is not initialized there, so it does not run anything. Note that I changed the default initialization of `MF::TaskInfo` to make sure it does not segfault for an empty object.)