### PR TITLE
remove unneeded assert in internal::update_ghost_values_finish()

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -2897,12 +2897,6 @@ namespace internal
                                const VectorType & vec)
     {
       (void)component_in_block_vector;
-      Assert(
-        (vector_face_access ==
-           dealii::MatrixFree<dim, Number>::DataAccessOnFaces::unspecified ||
-         vec.size() == 0),
-        ExcNotImplemented());
-
       vec.update_ghost_values_finish();
     }
 


### PR DESCRIPTION
minor follow up to https://github.com/dealii/dealii/pull/7787

AFICT assert is not needed here, also some types may not have `vec.size()`.