### PR TITLE
Encapsulate the calls to tbb::parallel_for

### DIFF
--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -209,7 +209,7 @@ namespace parallel
   transform(const InputIterator &begin_in,
             const InputIterator &end_in,
             OutputIterator       out,
-            Predicate &          predicate,
+            const Predicate &    predicate,
             const unsigned int   grainsize)
   {
 #ifndef DEAL_II_WITH_THREADS
@@ -265,7 +265,7 @@ namespace parallel
             const InputIterator1 &end_in1,
             InputIterator2        in2,
             OutputIterator        out,
-            Predicate &           predicate,
+            const Predicate &     predicate,
             const unsigned int    grainsize)
   {
 #ifndef DEAL_II_WITH_THREADS
@@ -324,7 +324,7 @@ namespace parallel
             InputIterator2        in2,
             InputIterator3        in3,
             OutputIterator        out,
-            Predicate &           predicate,
+            const Predicate &     predicate,
             const unsigned int    grainsize)
   {
 #ifndef DEAL_II_WITH_THREADS

--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -1154,14 +1154,13 @@ namespace WorkStream
                                                 sample_scratch_data,
                                                 sample_copy_data);
 
-              tbb::parallel_for(
-                tbb::blocked_range<RangeType>(colored_iterators[color].begin(),
-                                              colored_iterators[color].end(),
-                                              /*grain_size=*/chunk_size),
+              parallel::internal::parallel_for(
+                colored_iterators[color].begin(),
+                colored_iterators[color].end(),
                 std::bind(&WorkerAndCopier::operator(),
                           std::ref(worker_and_copier),
                           std::placeholders::_1),
-                tbb::auto_partitioner());
+                chunk_size);
             }
       }
 #  endif

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -188,10 +188,8 @@ namespace internal
             partitioner->acquire_one_partitioner();
 
           TBBForFunctor<Functor> generic_functor(functor, start, end);
-          tbb::parallel_for(
-            tbb::blocked_range<size_type>(0, generic_functor.n_chunks, 1),
-            generic_functor,
-            *tbb_partitioner);
+          parallel::internal::parallel_for(
+            0U, generic_functor.n_chunks, generic_functor, 1, tbb_partitioner);
           partitioner->release_one_partitioner(tbb_partitioner);
         }
       else if (vec_size > 0)
@@ -1389,10 +1387,8 @@ namespace internal
           TBBReduceFunctor<Operation, ResultType> generic_functor(op,
                                                                   start,
                                                                   end);
-          tbb::parallel_for(
-            tbb::blocked_range<size_type>(0, generic_functor.n_chunks, 1),
-            generic_functor,
-            *tbb_partitioner);
+          parallel::internal::parallel_for(
+            0U, generic_functor.n_chunks, generic_functor, 1, tbb_partitioner);
           partitioner->release_one_partitioner(tbb_partitioner);
           result = generic_functor.do_sum();
         }

--- a/tests/base/parallel_transform_01.cc
+++ b/tests/base/parallel_transform_01.cc
@@ -20,8 +20,6 @@
 
 #include <deal.II/lac/vector.h>
 
-#include <boost/lambda/lambda.hpp>
-
 #include "../tests.h"
 
 
@@ -39,7 +37,7 @@ main()
 
   // set y=2*x
   parallel::transform(
-    x.begin(), x.end(), y.begin(), (2 * boost::lambda::_1), 10);
+    x.begin(), x.end(), y.begin(), [](double i) { return 2. * i; }, 10);
 
   // compute y=0 from the previous result
   y -= x;

--- a/tests/base/parallel_transform_02.cc
+++ b/tests/base/parallel_transform_02.cc
@@ -20,8 +20,6 @@
 
 #include <deal.II/lac/vector.h>
 
-#include <boost/lambda/lambda.hpp>
-
 #include "../tests.h"
 
 
@@ -45,7 +43,7 @@ main()
                       x.end(),
                       y.begin(),
                       z.begin(),
-                      (boost::lambda::_1 + 2 * boost::lambda::_2),
+                      [](double i, double j) { return i + 2 * j; },
                       10);
 
   Assert(z.l2_norm() == 0, ExcInternalError());

--- a/tests/base/parallel_transform_03.cc
+++ b/tests/base/parallel_transform_03.cc
@@ -20,8 +20,6 @@
 
 #include <deal.II/lac/vector.h>
 
-#include <boost/lambda/lambda.hpp>
-
 #include "../tests.h"
 
 
@@ -48,8 +46,7 @@ main()
                       y.begin(),
                       z.begin(),
                       a.begin(),
-                      (boost::lambda::_1 + boost::lambda::_2 -
-                       boost::lambda::_3),
+                      [](double i, double j, double k) { return i + j - k; },
                       10);
 
   AssertThrow(a.l2_norm() == 0, ExcInternalError());


### PR DESCRIPTION
This PR encapsulates the calls to `tbb::parallel_for`. The reason is to simplify a future support of `OpenMP`