### PR TITLE
Fix 'test' target for MSVC

### DIFF
--- a/tests/quick_tests/CMakeLists.txt
+++ b/tests/quick_tests/CMakeLists.txt
@@ -44,9 +44,9 @@ MACRO(make_quicktest test_basename build_name mpi_run)
   DEAL_II_INSOURCE_SETUP_TARGET(${_target} ${build_name})
 
   IF("${mpi_run}" STREQUAL "")
-    SET(_command ./${_target})
+    SET(_command ${_target})
   ELSE()
-    SET(_command ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${mpi_run} ${MPIEXEC_PREFLAGS} ./${_target})
+    SET(_command ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${mpi_run} ${MPIEXEC_PREFLAGS} ${_target})
   ENDIF()
   ADD_CUSTOM_TARGET(${_target}.run
     DEPENDS ${_target}
@@ -195,7 +195,7 @@ ENDIF()
 
 # A custom test target:
 ADD_CUSTOM_TARGET(test
-  COMMAND ${CMAKE_COMMAND} -D ALL_TESTS="${ALL_TESTS}" -P ${CMAKE_CURRENT_SOURCE_DIR}/run.cmake
+  COMMAND ${CMAKE_COMMAND} -D ALL_TESTS="${ALL_TESTS}" -DCMAKE_BUILD_TYPE=${_mybuild} -P ${CMAKE_CURRENT_SOURCE_DIR}/run.cmake
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Running quicktests..."
   )

--- a/tests/quick_tests/run.cmake
+++ b/tests/quick_tests/run.cmake
@@ -25,6 +25,7 @@ ENDIF()
 SEPARATE_ARGUMENTS(ALL_TESTS)
 
 EXECUTE_PROCESS(COMMAND ${CMAKE_CTEST_COMMAND} -j${_n_processors}
+  -C ${CMAKE_BUILD_TYPE}
   --force-new-ctest-process
   --output-on-failure
   -O quicktests.log


### PR DESCRIPTION
The `Visual Studio` generator is a multi-configuration generator and thus we need to specify a configuration when running the tests. Also, `Windows` doesn't recognize the `./executable`-syntax for executing files.