### PR TITLE
Only permit use of ld.lld linker when the Clang compiler is used.

### DIFF
--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -460,7 +460,11 @@ CHECK_CXX_SOURCE_COMPILES(
   DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
 RESET_CMAKE_REQUIRED()
 
-IF(DEAL_II_COMPILER_HAS_FUSE_LD_LLD)
+#
+# The ld.lld linker is not compatible with GCC. So we only enable it when
+# the Clang compiler is used. See https://github.com/dealii/dealii/issues/7811
+#
+IF(DEAL_II_COMPILER_HAS_FUSE_LD_LLD AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   ADD_FLAGS(DEAL_II_LINKER_FLAGS "-fuse-ld=lld")
 ELSEIF(DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
   ADD_FLAGS(DEAL_II_LINKER_FLAGS "-fuse-ld=gold")


### PR DESCRIPTION
Fixes #7811