### PR TITLE
Add missing #ifdef DEAL_II_WITH_THREADS around tbb calls

### DIFF
--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -147,6 +147,7 @@ namespace parallel
 
 
 
+#ifdef DEAL_II_WITH_THREADS
     /**
      * Encapsulate tbb::parallel_for.
      */
@@ -179,6 +180,7 @@ namespace parallel
                         functor,
                         *partitioner);
     }
+#endif
   } // namespace internal
 
   /**


### PR DESCRIPTION
Fix #7824

@dangars with this I can compile with `DEAL_II_WITH_THREADS=OFF`