### PR TITLE
Fix Tpetra test for std::fabs without std::complex overload

### DIFF
--- a/tests/trilinos/tpetra_vector_02.cc
+++ b/tests/trilinos/tpetra_vector_02.cc
@@ -196,7 +196,7 @@ test()
   AssertThrow(b.l1_norm() == 95., ExcMessage("Problem in l1_norm."));
 
   const double eps = 1e-6;
-  AssertThrow(std::fabs(b.l2_norm() - Number(31.3847096)) < eps,
+  AssertThrow(std::fabs(b.l2_norm() - 31.3847096) < eps,
               ExcMessage("Problem in l2_norm"));
 
   AssertThrow(b.linfty_norm() == 14., ExcMessage("Problem in linfty_norm."));


### PR DESCRIPTION
Ought to fix the failing test in https://cdash.kyomu.43-1.org/testDetails.php?test=57178128&build=8491.
Converting the desired value to an `std::complex<>` type is not necessary here and leads to problems in case `std::fabs` does not have an `std::complex<>` overload.