### PR TITLE
CI: kill older running builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,25 @@
 #!groovy
 
+// load library https://github.com/tjhei/jenkins-stuff to provide
+// killold.killOldBuilds() function:
+@Library('tjhei') _
+
 pipeline
 {
   agent none
 
   stages
   {
+    stage("abort old")
+    {
+      agent none
+      steps
+      {
+        // kill older builds in this PR:
+        script { killold.killOldBuilds() }
+      }
+    }
+
     stage("check")
     {
       agent

--- a/contrib/ci/Jenkinsfile.osx
+++ b/contrib/ci/Jenkinsfile.osx
@@ -41,80 +41,80 @@ pipeline
 
     stage("main")
     {
-  agent {
-    node {
-        label 'osx'
-    }
-  }
-
-  post { cleanup { cleanWs() } }
-
-  stages
-  {
-    stage("check")
-    {
-      when {
-        allOf {
-          not {branch 'master'}
+      agent {
+        node {
+          label 'osx'
         }
       }
 
-      steps
+      post { cleanup { cleanWs() } }
+
+      stages
       {
-        githubNotify context: 'OSX', description: 'pending...',  status: 'PENDING'
-        sh '''
+        stage("check")
+        {
+          when {
+            allOf {
+              not {branch 'master'}
+            }
+          }
+
+          steps
+          {
+            githubNotify context: 'OSX', description: 'pending...',  status: 'PENDING'
+            sh '''
                wget -q -O - https://api.github.com/repos/dealii/dealii/issues/${CHANGE_ID}/labels | grep 'ready to test' || \
                { echo "This commit will only be tested when it has the label 'ready to test'. Trigger a rebuild by adding a comment that contains '/rebuild'..."; exit 1; }
-            '''
-      }
-      post
-      {
-        failure
-        {
-          githubNotify context: 'OSX', description: 'need ready to test label and /rebuild',  status: 'PENDING'
-          script
+               '''
+          }
+          post
           {
-            currentBuild.result='NOT_BUILT'
+            failure
+            {
+              githubNotify context: 'OSX', description: 'need ready to test label and /rebuild',  status: 'PENDING'
+              script
+              {
+                currentBuild.result='NOT_BUILT'
+              }
+            }
+          }
+        }
+
+        stage('build')
+        {
+          steps
+          {
+            timeout(time: 1, unit: 'HOURS')
+            {
+              sh "echo \"building on node ${env.NODE_NAME}\""
+              sh '''#!/bin/bash
+                    mkdir build && cd build
+                    cmake \
+                      -D DEAL_II_WITH_MPI=OFF \
+                      -D DEAL_II_CXX_FLAGS='-Werror' \
+                      -D CMAKE_BUILD_TYPE=Debug \
+                      $WORKSPACE/ && make -j 4
+                 '''
+            }
+          }
+
+          post
+          {
+            failure
+            {
+              githubNotify context: 'OSX', description: 'build failed',  status: 'FAILURE'
+            }
+          }
+        }
+
+        stage("finalize")
+        {
+          steps
+          {
+            githubNotify context: 'OSX', description: 'OK',  status: 'SUCCESS'
           }
         }
       }
     }
-
-    stage('build')
-    {
-      steps
-      {
-        timeout(time: 1, unit: 'HOURS')
-        {
-           sh "echo \"building on node ${env.NODE_NAME}\""
-           sh '''#!/bin/bash
-              mkdir build && cd build
-              cmake \
-                -D DEAL_II_WITH_MPI=OFF \
-                -D DEAL_II_CXX_FLAGS='-Werror' \
-                -D CMAKE_BUILD_TYPE=Debug \
-                $WORKSPACE/ && make -j 4
-            '''
-        }
-      }
-
-      post
-      {
-        failure
-        {
-          githubNotify context: 'OSX', description: 'build failed',  status: 'FAILURE'
-        }
-      }
-    }
-
-    stage("finalize")
-    {
-      steps
-      {
-        githubNotify context: 'OSX', description: 'OK',  status: 'SUCCESS'
-      }
-    }
-  }
-  }
   }
 }

--- a/contrib/ci/Jenkinsfile.osx
+++ b/contrib/ci/Jenkinsfile.osx
@@ -19,8 +19,28 @@ Settings to apply inside Jenkins:
   - discard: 5+ items
 */
 
+// load library https://github.com/tjhei/jenkins-stuff to provide
+// killold.killOldBuilds() function:
+@Library('tjhei') _
+
 pipeline
 {
+  agent none
+
+  stages
+  {
+    stage("abort old")
+    {
+      agent none
+      steps
+      {
+        // kill older builds in this PR:
+        script { killold.killOldBuilds() }
+      }
+    }
+
+    stage("main")
+    {
   agent {
     node {
         label 'osx'
@@ -94,5 +114,7 @@ pipeline
         githubNotify context: 'OSX', description: 'OK',  status: 'SUCCESS'
       }
     }
+  }
+  }
   }
 }

--- a/contrib/ci/Jenkinsfile.tidy
+++ b/contrib/ci/Jenkinsfile.tidy
@@ -19,8 +19,30 @@ Settings to apply inside Jenkins:
   - discard: 5+ items
 */
 
+// load library https://github.com/tjhei/jenkins-stuff to provide
+// killold.killOldBuilds() function:
+@Library('tjhei') _
+
 pipeline
 {
+  agent none
+
+  stages
+  {
+    stage("abort old")
+    {
+      agent none
+      steps
+      {
+        githubNotify context: 'tidy', description: 'initializing...',  status: 'PENDING'
+        // kill older builds in this PR:
+        script { killold.killOldBuilds() }
+      }
+    }
+
+    stage("main")
+    {
+
   agent
   {
     docker
@@ -87,5 +109,7 @@ pipeline
       }
     }
 
+  }
+  }
   }
 }

--- a/contrib/ci/Jenkinsfile.tidy
+++ b/contrib/ci/Jenkinsfile.tidy
@@ -42,74 +42,72 @@ pipeline
 
     stage("main")
     {
-
-  agent
-  {
-    docker
-    {
-      image 'tjhei/candi-base-clang'
-    }
-  }
-
-  post { cleanup { cleanWs() } }
-
-  stages
-  {
-    stage("check")
-    {
-      when {
-        allOf {
-          not {branch 'master'}
+      agent
+      {
+        docker
+        {
+          image 'tjhei/candi-base-clang'
         }
       }
 
-      steps
+      post { cleanup { cleanWs() } }
+
+      stages
       {
-        githubNotify context: 'tidy', description: 'pending...',  status: 'PENDING'
-        sh '''
+        stage("check")
+        {
+          when {
+            allOf {
+              not {branch 'master'}
+            }
+          }
+
+          steps
+          {
+            githubNotify context: 'tidy', description: 'pending...',  status: 'PENDING'
+            sh '''
                wget -q -O - https://api.github.com/repos/dealii/dealii/issues/${CHANGE_ID}/labels | grep 'ready to test' || \
                { echo "This commit will only be tested when it has the label 'ready to test'. Trigger a rebuild by adding a comment that contains '/rebuild'..."; exit 1; }
-            '''
-      }
-      post
-      {
-        failure
-        {
-          githubNotify context: 'tidy', description: 'need ready to test label and /rebuild',  status: 'PENDING'
-          script
+               '''
+          }
+          post
           {
-            currentBuild.result='NOT_BUILT'
+            failure
+            {
+              githubNotify context: 'tidy', description: 'need ready to test label and /rebuild',  status: 'PENDING'
+              script
+              {
+                currentBuild.result='NOT_BUILT'
+              }
+            }
           }
         }
+
+        stage('build')
+        {
+          steps
+          {
+            timeout(time: 2, unit: 'HOURS')
+            {
+              sh "echo \"building on node ${env.NODE_NAME}\""
+              sh '''#!/bin/bash
+                    mkdir build && cd build
+                    $WORKSPACE/contrib/utilities/run_clang_tidy.sh $WORKSPACE
+                 '''
+              githubNotify context: 'tidy', description: 'OK',  status: 'SUCCESS'
+            }
+          }
+
+          post
+          {
+            failure
+            {
+              githubNotify context: 'tidy', description: 'build failed',  status: 'FAILURE'
+            }
+          }
+        }
+
       }
     }
-
-    stage('build')
-    {
-      steps
-      {
-        timeout(time: 2, unit: 'HOURS')
-        {
-           sh "echo \"building on node ${env.NODE_NAME}\""
-	   
-           sh '''#!/bin/bash
-              mkdir build && cd build
-	      $WORKSPACE/contrib/utilities/run_clang_tidy.sh $WORKSPACE
-            '''
-           githubNotify context: 'tidy', description: 'OK',  status: 'SUCCESS'
-        }
-      }
-
-      post
-      {
-        failure
-        {
-          githubNotify context: 'tidy', description: 'build failed',  status: 'FAILURE'
-        }
-      }
-    }
-
-  }
-  }
   }
 }


### PR DESCRIPTION
Currently, every push queues another build, but older builds and now irrelevant builds still occupy the tester. This commit tries to fix this.

Please ignore for a while until I figure out how make this work...