### PR TITLE
Rename Solver (base) class to SolverBase

### DIFF
--- a/include/deal.II/lac/eigen.h
+++ b/include/deal.II/lac/eigen.h
@@ -52,7 +52,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Guido Kanschat, 2000
  */
 template <typename VectorType = Vector<double>>
-class EigenPower : private Solver<VectorType>
+class EigenPower : private SolverBase<VectorType>
 {
 public:
   /**
@@ -131,7 +131,7 @@ protected:
  * @author Guido Kanschat, 2000, 2003
  */
 template <typename VectorType = Vector<double>>
-class EigenInverse : private Solver<VectorType>
+class EigenInverse : private SolverBase<VectorType>
 {
 public:
   /**
@@ -208,7 +208,7 @@ template <class VectorType>
 EigenPower<VectorType>::EigenPower(SolverControl &           cn,
                                    VectorMemory<VectorType> &mem,
                                    const AdditionalData &    data)
-  : Solver<VectorType>(cn, mem)
+  : SolverBase<VectorType>(cn, mem)
   , additional_data(data)
 {}
 
@@ -297,7 +297,7 @@ template <class VectorType>
 EigenInverse<VectorType>::EigenInverse(SolverControl &           cn,
                                        VectorMemory<VectorType> &mem,
                                        const AdditionalData &    data)
-  : Solver<VectorType>(cn, mem)
+  : SolverBase<VectorType>(cn, mem)
   , additional_data(data)
 {}
 

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -121,7 +121,7 @@ namespace internal
  *
  */
 template <typename VectorType = Vector<double>>
-class SolverBicgstab : public Solver<VectorType>,
+class SolverBicgstab : public SolverBase<VectorType>,
                        protected internal::SolverBicgstabData
 {
 public:
@@ -314,7 +314,7 @@ template <typename VectorType>
 SolverBicgstab<VectorType>::SolverBicgstab(SolverControl &           cn,
                                            VectorMemory<VectorType> &mem,
                                            const AdditionalData &    data)
-  : Solver<VectorType>(cn, mem)
+  : SolverBase<VectorType>(cn, mem)
   , Vx(nullptr)
   , Vb(nullptr)
   , additional_data(data)
@@ -325,7 +325,7 @@ SolverBicgstab<VectorType>::SolverBicgstab(SolverControl &           cn,
 template <typename VectorType>
 SolverBicgstab<VectorType>::SolverBicgstab(SolverControl &       cn,
                                            const AdditionalData &data)
-  : Solver<VectorType>(cn)
+  : SolverBase<VectorType>(cn)
   , Vx(nullptr)
   , Vb(nullptr)
   , additional_data(data)

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -93,7 +93,7 @@ class PreconditionIdentity;
  * @author W. Bangerth, G. Kanschat, R. Becker and F.-T. Suttmeier
  */
 template <typename VectorType = Vector<double>>
-class SolverCG : public Solver<VectorType>
+class SolverCG : public SolverBase<VectorType>
 {
 public:
   /**
@@ -242,7 +242,7 @@ template <typename VectorType>
 SolverCG<VectorType>::SolverCG(SolverControl &           cn,
                                VectorMemory<VectorType> &mem,
                                const AdditionalData &    data)
-  : Solver<VectorType>(cn, mem)
+  : SolverBase<VectorType>(cn, mem)
   , additional_data(data)
 {}
 
@@ -250,7 +250,7 @@ SolverCG<VectorType>::SolverCG(SolverControl &           cn,
 
 template <typename VectorType>
 SolverCG<VectorType>::SolverCG(SolverControl &cn, const AdditionalData &data)
-  : Solver<VectorType>(cn)
+  : SolverBase<VectorType>(cn)
   , additional_data(data)
 {}
 

--- a/include/deal.II/lac/solver_fire.h
+++ b/include/deal.II/lac/solver_fire.h
@@ -88,7 +88,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Vishal Boddu, Denis Davydov, 2017
  */
 template <typename VectorType = Vector<double>>
-class SolverFIRE : public Solver<VectorType>
+class SolverFIRE : public SolverBase<VectorType>
 {
 public:
   /**
@@ -214,7 +214,7 @@ template <typename VectorType>
 SolverFIRE<VectorType>::SolverFIRE(SolverControl &           solver_control,
                                    VectorMemory<VectorType> &vector_memory,
                                    const AdditionalData &    data)
-  : Solver<VectorType>(solver_control, vector_memory)
+  : SolverBase<VectorType>(solver_control, vector_memory)
   , additional_data(data)
 {}
 
@@ -223,7 +223,7 @@ SolverFIRE<VectorType>::SolverFIRE(SolverControl &           solver_control,
 template <typename VectorType>
 SolverFIRE<VectorType>::SolverFIRE(SolverControl &       solver_control,
                                    const AdditionalData &data)
-  : Solver<VectorType>(solver_control)
+  : SolverBase<VectorType>(solver_control)
   , additional_data(data)
 {}
 

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -175,7 +175,7 @@ namespace internal
  * @author Wolfgang Bangerth, Guido Kanschat, Ralf Hartmann.
  */
 template <class VectorType = Vector<double>>
-class SolverGMRES : public Solver<VectorType>
+class SolverGMRES : public SolverBase<VectorType>
 {
 public:
   /**
@@ -457,7 +457,7 @@ protected:
  * @author Guido Kanschat, 2003
  */
 template <class VectorType = Vector<double>>
-class SolverFGMRES : public Solver<VectorType>
+class SolverFGMRES : public SolverBase<VectorType>
 {
 public:
   /**
@@ -621,7 +621,7 @@ template <class VectorType>
 SolverGMRES<VectorType>::SolverGMRES(SolverControl &           cn,
                                      VectorMemory<VectorType> &mem,
                                      const AdditionalData &    data)
-  : Solver<VectorType>(cn, mem)
+  : SolverBase<VectorType>(cn, mem)
   , additional_data(data)
 {}
 
@@ -630,7 +630,7 @@ SolverGMRES<VectorType>::SolverGMRES(SolverControl &           cn,
 template <class VectorType>
 SolverGMRES<VectorType>::SolverGMRES(SolverControl &       cn,
                                      const AdditionalData &data)
-  : Solver<VectorType>(cn)
+  : SolverBase<VectorType>(cn)
   , additional_data(data)
 {}
 
@@ -1182,7 +1182,7 @@ template <class VectorType>
 SolverFGMRES<VectorType>::SolverFGMRES(SolverControl &           cn,
                                        VectorMemory<VectorType> &mem,
                                        const AdditionalData &    data)
-  : Solver<VectorType>(cn, mem)
+  : SolverBase<VectorType>(cn, mem)
   , additional_data(data)
 {}
 
@@ -1191,7 +1191,7 @@ SolverFGMRES<VectorType>::SolverFGMRES(SolverControl &           cn,
 template <class VectorType>
 SolverFGMRES<VectorType>::SolverFGMRES(SolverControl &       cn,
                                        const AdditionalData &data)
-  : Solver<VectorType>(cn)
+  : SolverBase<VectorType>(cn)
   , additional_data(data)
 {}
 

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -69,7 +69,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Thomas Richter, 2000, Luca Heltai, 2006
  */
 template <class VectorType = Vector<double>>
-class SolverMinRes : public Solver<VectorType>
+class SolverMinRes : public SolverBase<VectorType>
 {
 public:
   /**
@@ -155,7 +155,7 @@ template <class VectorType>
 SolverMinRes<VectorType>::SolverMinRes(SolverControl &           cn,
                                        VectorMemory<VectorType> &mem,
                                        const AdditionalData &)
-  : Solver<VectorType>(cn, mem)
+  : SolverBase<VectorType>(cn, mem)
   , res2(numbers::signaling_nan<double>())
 {}
 
@@ -164,7 +164,7 @@ SolverMinRes<VectorType>::SolverMinRes(SolverControl &           cn,
 template <class VectorType>
 SolverMinRes<VectorType>::SolverMinRes(SolverControl &cn,
                                        const AdditionalData &)
-  : Solver<VectorType>(cn)
+  : SolverBase<VectorType>(cn)
   , res2(numbers::signaling_nan<double>())
 {}
 

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -92,7 +92,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Guido Kanschat, 1999; Ingo Kligge 2017
  */
 template <typename VectorType = Vector<double>>
-class SolverQMRS : public Solver<VectorType>
+class SolverQMRS : public SolverBase<VectorType>
 {
 public:
   /**
@@ -255,7 +255,7 @@ template <class VectorType>
 SolverQMRS<VectorType>::SolverQMRS(SolverControl &           cn,
                                    VectorMemory<VectorType> &mem,
                                    const AdditionalData &    data)
-  : Solver<VectorType>(cn, mem)
+  : SolverBase<VectorType>(cn, mem)
   , additional_data(data)
   , step(0)
 {}
@@ -263,7 +263,7 @@ SolverQMRS<VectorType>::SolverQMRS(SolverControl &           cn,
 template <class VectorType>
 SolverQMRS<VectorType>::SolverQMRS(SolverControl &       cn,
                                    const AdditionalData &data)
-  : Solver<VectorType>(cn)
+  : SolverBase<VectorType>(cn)
   , additional_data(data)
   , step(0)
 {}

--- a/include/deal.II/lac/solver_relaxation.h
+++ b/include/deal.II/lac/solver_relaxation.h
@@ -56,7 +56,7 @@ DEAL_II_NAMESPACE_OPEN
  * @date 2010
  */
 template <typename VectorType = Vector<double>>
-class SolverRelaxation : public Solver<VectorType>
+class SolverRelaxation : public SolverBase<VectorType>
 {
 public:
   /**
@@ -95,7 +95,7 @@ public:
 template <class VectorType>
 SolverRelaxation<VectorType>::SolverRelaxation(SolverControl &cn,
                                                const AdditionalData &)
-  : Solver<VectorType>(cn)
+  : SolverBase<VectorType>(cn)
 {}
 
 

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -60,7 +60,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Ralf Hartmann
  */
 template <class VectorType = Vector<double>>
-class SolverRichardson : public Solver<VectorType>
+class SolverRichardson : public SolverBase<VectorType>
 {
 public:
   /**
@@ -175,7 +175,7 @@ template <class VectorType>
 SolverRichardson<VectorType>::SolverRichardson(SolverControl &           cn,
                                                VectorMemory<VectorType> &mem,
                                                const AdditionalData &    data)
-  : Solver<VectorType>(cn, mem)
+  : SolverBase<VectorType>(cn, mem)
   , additional_data(data)
 {}
 
@@ -184,7 +184,7 @@ SolverRichardson<VectorType>::SolverRichardson(SolverControl &           cn,
 template <class VectorType>
 SolverRichardson<VectorType>::SolverRichardson(SolverControl &       cn,
                                                const AdditionalData &data)
-  : Solver<VectorType>(cn)
+  : SolverBase<VectorType>(cn)
   , additional_data(data)
 {}
 

--- a/include/deal.II/optimization/solver_bfgs.h
+++ b/include/deal.II/optimization/solver_bfgs.h
@@ -53,7 +53,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Denis Davydov, 2018
  */
 template <typename VectorType>
-class SolverBFGS : public Solver<VectorType>
+class SolverBFGS : public SolverBase<VectorType>
 {
 public:
   /**
@@ -195,7 +195,7 @@ SolverBFGS<VectorType>::AdditionalData::AdditionalData(
 template <typename VectorType>
 SolverBFGS<VectorType>::SolverBFGS(SolverControl &       solver_control,
                                    const AdditionalData &data)
-  : Solver<VectorType>(solver_control)
+  : SolverBase<VectorType>(solver_control)
   , additional_data(data)
 {}
 

--- a/source/lac/solver.inst.in
+++ b/source/lac/solver.inst.in
@@ -17,5 +17,5 @@
 
 for (S : VECTOR_TYPES)
   {
-    template class Solver<S>;
+    template class SolverBase<S>;
   }


### PR DESCRIPTION
This aligns with the name chosen for the equivalent class in the `TrilinosWrappers` and `PetscWrappers` namespaces.

~~I also added some missing virtual destructors in solver classes that have virtual functions (which are intended to be overloaded).~~

Fixes #7642