### PR TITLE
Update PETSc version compatibility

### DIFF
--- a/doc/external-libs/petsc.html
+++ b/doc/external-libs/petsc.html
@@ -37,7 +37,7 @@
 
     <p style="color: red"><b>Note:</b> The most recent version of PETSc
       that has been reported to be compatible with
-      <acronym>deal.II</acronym> is version 3.9.0. If you use a later
+      <acronym>deal.II</acronym> is version 3.11.0. If you use a later
       version than this and encounter problems, let us
       know. <acronym>deal.II</acronym> does not support versions of PETSc prior
       to 3.3.0.


### PR DESCRIPTION
I just checked that I can compile with `PETSc 3.11.0` and all the tests pass.