### PR TITLE
Unify intrinsics headers

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -51,15 +51,9 @@
     "Mismatch in vectorization capabilities: AVX-512F was detected during configuration of deal.II and switched on, but it is apparently not available for the file you are trying to compile at the moment. Check compilation flags controlling the instruction set, such as -march=native."
 #endif
 
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && \
-  (defined(__AVX__) || defined(__AVX512F__)) // AVX, AVX-512
-#  include <immintrin.h>
-#elif DEAL_II_COMPILER_VECTORIZATION_LEVEL == 1 && defined(__SSE2__) // SSE2
-#  include <emmintrin.h>
-#endif
-
-
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__)
+#if defined(_MSC_VER)
+#  include <intrin.h>
+#elif defined(__ALTIVEC__)
 #  include <altivec.h>
 
 // altivec.h defines vector, pixel, bool, but we do not use them, so undefine
@@ -67,7 +61,8 @@
 #  undef vector
 #  undef pixel
 #  undef bool
-
+#else
+#  include <x86intrin.h>
 #endif
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
Fixes #7323. I don't think that we need to replace the headers in the `CMake` checks as well.
The ones we use there are really specific for a set of supported intrinsics and the general header is compiler-specific and requires preprocessor directives.