### PR TITLE
Update dead LICENSE link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ on how to set this up.
 License:
 --------
 
-Please see the file [./LICENSE](LICENSE) for details
+Please see the file [./LICENSE.md](LICENSE.md) for details
 
 Further information:
 --------------------


### PR DESCRIPTION
Hi, I noticed the LICENSE link in the README was dead.