### PR TITLE
Use std::string in SmartPointer and Subscriptor interface

### DIFF
--- a/doc/news/changes/minor/20190408Arndt
+++ b/doc/news/changes/minor/20190408Arndt
@@ -1,0 +1,4 @@
+Changed: SmartPointer and Subscriptor use a std::string
+instead of a const char * as identifier.
+<br>
+(Daniel Arndt, 2019/04/08)

--- a/include/deal.II/base/smartpointer.h
+++ b/include/deal.II/base/smartpointer.h
@@ -95,7 +95,7 @@ public:
    * The <tt>id</tt> is used in the call to Subscriptor::subscribe(id) and by
    * ~SmartPointer() in the call to Subscriptor::unsubscribe().
    */
-  SmartPointer(T *t, const char *id);
+  SmartPointer(T *t, const std::string &id);
 
   /**
    * Constructor taking a normal pointer. If possible, i.e. if the pointer is
@@ -200,7 +200,7 @@ private:
   /**
    * The identification for the subscriptor.
    */
-  const char *const id;
+  const std::string id;
 
   /**
    * The Smartpointer is invalidated when the object pointed to is destroyed
@@ -235,7 +235,7 @@ inline SmartPointer<T, P>::SmartPointer(T *t)
 
 
 template <typename T, typename P>
-inline SmartPointer<T, P>::SmartPointer(T *t, const char *id)
+inline SmartPointer<T, P>::SmartPointer(T *t, const std::string &id)
   : t(t)
   , id(id)
   , pointed_to_object_is_alive(false)

--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -105,23 +105,11 @@ public:
 
   /**
    * Subscribes a user of the object by storing the pointer @p validity. The
-   * subscriber may be identified by text supplied as @p identifier. The latter
-   * variable must not be a temporary and its type must decay to
-   * const char *. In particular, calling this function with a rvalue reference
-   * is not allowed.
-   */
-  template <typename ConstCharStar = const char *>
-  typename std::enable_if<
-    std::is_same<ConstCharStar, const char *>::value>::type
-  subscribe(std::atomic<bool> *const validity,
-            ConstCharStar            identifier = nullptr) const;
-
-  /**
-   * Calling subscribe() with a rvalue reference as identifier is not allowed.
+   * subscriber may be identified by text supplied as @p identifier.
    */
   void
   subscribe(std::atomic<bool> *const validity,
-            const char *&&           identifier) const = delete;
+            const std::string &      identifier = "") const;
 
   /**
    * Unsubscribes a user from the object.
@@ -131,7 +119,7 @@ public:
    */
   void
   unsubscribe(std::atomic<bool> *const validity,
-              const char *             identifier = nullptr) const;
+              const std::string &      identifier = "") const;
 
   /**
    * Return the present number of subscriptions to this object. This allows to
@@ -222,24 +210,11 @@ private:
    */
   mutable std::atomic<unsigned int> counter;
 
-  /*
-   * Functor struct used for key comparison in #counter_map.
-   * Not the memory location but the actual C-string content is compared.
-   */
-  struct MapCompare
-  {
-    bool
-    operator()(const char *lhs, const char *rhs) const
-    {
-      return std::strcmp(lhs, rhs) > 0;
-    }
-  };
-
   /**
    * In this map, we count subscriptions for each different identification
    * string supplied to subscribe().
    */
-  mutable std::map<const char *, unsigned int, MapCompare> counter_map;
+  mutable std::map<std::string, unsigned int> counter_map;
 
   /**
    * The data type used in #counter_map.
@@ -340,11 +315,6 @@ Subscriptor::list_subscribers(StreamType &stream) const
            << it.first << '\"' << std::endl;
 }
 
-// forward declare template specialization
-template <>
-void
-Subscriptor::subscribe<const char *>(std::atomic<bool> *const validity,
-                                     const char *             id) const;
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/block_matrix_array.h
+++ b/include/deal.II/lac/block_matrix_array.h
@@ -609,7 +609,7 @@ BlockMatrixArray<number, BlockVectorType>::print_latex(StreamType &out) const
 
       std::ostringstream stream;
 
-      if (array(m->row, m->col) != "" && m->prefix >= 0)
+      if (!array(m->row, m->col).empty() && m->prefix >= 0)
         stream << "+";
       if (m->prefix != 1.)
         stream << m->prefix << 'x';

--- a/include/deal.II/lac/swappable_vector.templates.h
+++ b/include/deal.II/lac/swappable_vector.templates.h
@@ -39,7 +39,7 @@ SwappableVector<number>::SwappableVector(const SwappableVector<number> &v)
   , filename()
   , data_is_preloaded(false)
 {
-  Assert(v.filename == "", ExcInvalidCopyOperation());
+  Assert(v.filename.empty(), ExcInvalidCopyOperation());
 }
 
 
@@ -54,7 +54,7 @@ SwappableVector<number>::~SwappableVector()
   // first, before killing the vector
   // itself
 
-  if (filename != "")
+  if (!filename.empty())
     {
       try
         {
@@ -72,7 +72,7 @@ SwappableVector<number> &
 SwappableVector<number>::operator=(const SwappableVector<number> &v)
 {
   // if necessary, first delete data
-  if (filename != "")
+  if (!filename.empty())
     kill_file();
 
   // if in MT mode, block all other
@@ -97,7 +97,7 @@ SwappableVector<number>::swap_out(const std::string &name)
   // that has not been deleted in the
   // meantime, then we kill that file
   // first
-  if (filename != "")
+  if (!filename.empty())
     kill_file();
 
   filename = name;
@@ -197,7 +197,7 @@ SwappableVector<number>::reload_vector(const bool set_flag)
 {
   (void)set_flag;
 
-  Assert(filename != "", ExcInvalidFilename(filename));
+  Assert(!filename.empty(), ExcInvalidFilename(filename));
   Assert(this->size() == 0, ExcSizeNonzero());
 
   std::ifstream tmp_in(filename.c_str());
@@ -233,7 +233,7 @@ SwappableVector<number>::kill_file()
   // is most probably an error, not?
   Assert(data_is_preloaded == false, ExcInternalError());
 
-  if (filename != "")
+  if (!filename.empty())
     {
       int status = std::remove(filename.c_str());
       (void)status;

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -5345,7 +5345,7 @@ namespace DataOutBase
         // underscores unless a vector name has been specified
         out << "VECTORS ";
 
-        if (std::get<2>(nonscalar_data_range) != "")
+        if (!std::get<2>(nonscalar_data_range).empty())
           out << std::get<2>(nonscalar_data_range);
         else
           {
@@ -5580,7 +5580,7 @@ namespace DataOutBase
             // underscores unless a vector name has been specified
             out << "    <DataArray type=\"Float32\" Name=\"";
 
-            if (std::get<2>(nonscalar_data_range) != "")
+            if (!std::get<2>(nonscalar_data_range).empty())
               out << std::get<2>(nonscalar_data_range);
             else
               {
@@ -5811,7 +5811,7 @@ namespace DataOutBase
         // underscores unless a vector name has been specified
         out << "    <DataArray type=\"Float32\" Name=\"";
 
-        if (name != "")
+        if (!name.empty())
           out << name;
         else
           {
@@ -6025,7 +6025,7 @@ namespace DataOutBase
         // underscores unless a vector name has been specified
         out << "    <PDataArray type=\"Float32\" Name=\"";
 
-        if (std::get<2>(nonscalar_data_range) != "")
+        if (!std::get<2>(nonscalar_data_range).empty())
           out << std::get<2>(nonscalar_data_range);
         else
           {
@@ -7820,7 +7820,7 @@ DataOutBase::write_filtered_data(
 
           // Determine the vector name. Concatenate all the component names with
           // double underscores unless a vector name has been specified
-          if (std::get<2>(nonscalar_data_ranges[n_th_vector]) != "")
+          if (!std::get<2>(nonscalar_data_ranges[n_th_vector]).empty())
             {
               vector_name = std::get<2>(nonscalar_data_ranges[n_th_vector]);
             }
@@ -8565,7 +8565,7 @@ DataOutInterface<dim, spacedim>::validate_dataset_names() const
     for (const auto &range : ranges)
       {
         const std::string &name = std::get<2>(range);
-        if (name != "")
+        if (!name.empty())
           {
             Assert(all_names.find(name) == all_names.end(),
                    ExcMessage(
@@ -9013,7 +9013,7 @@ namespace DataOutBase
           while ((header.size() != 0) && (header[header.size() - 1] == ' '))
             header.erase(header.size() - 1);
         }
-      while ((header == "") && in);
+      while ((header.empty()) && in);
 
       std::ostringstream s;
       s << "[deal.II intermediate Patch<" << dim << ',' << spacedim << ">]";

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -147,7 +147,7 @@ const char *
 ExceptionBase::what() const noexcept
 {
   // If no error c_string was generated so far, do it now:
-  if (what_str == "")
+  if (what_str.empty())
     {
 #ifdef DEAL_II_HAVE_GLIBC_STACKTRACE
       // We have deferred the symbol lookup to this point to avoid costly

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -47,8 +47,8 @@ ParameterAcceptor::~ParameterAcceptor()
 std::string
 ParameterAcceptor::get_section_name() const
 {
-  return (section_name != "" ? section_name :
-                               boost::core::demangle(typeid(*this).name()));
+  return (!section_name.empty() ? section_name :
+                                  boost::core::demangle(typeid(*this).name()));
 }
 
 
@@ -60,7 +60,7 @@ ParameterAcceptor::initialize(
   ParameterHandler &                  prm)
 {
   declare_all_parameters(prm);
-  if (filename != "")
+  if (!filename.empty())
     {
       // check the extension of input file
       if (filename.substr(filename.find_last_of('.') + 1) == "prm")
@@ -106,7 +106,7 @@ ParameterAcceptor::initialize(
             "Invalid extension of parameter file. Please use .prm or .xml"));
     }
 
-  if (output_filename != "")
+  if (!output_filename.empty())
     {
       std::ofstream outfile(output_filename.c_str());
       Assert(outfile, ExcIO());

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -494,8 +494,8 @@ namespace
             // make sure we have a corresponding entry in the destination
             // object as well
             const std::string full_path =
-              (current_path == "" ? p->first :
-                                    current_path + path_separator + p->first);
+              (current_path.empty() ? p->first :
+                                      current_path + path_separator + p->first);
 
             const std::string new_value = p->second.get<std::string>("value");
             AssertThrow(destination.get_optional<std::string>(full_path) &&
@@ -533,7 +533,7 @@ namespace
           {
             // it must be a subsection
             read_xml_recursively(p->second,
-                                 (current_path == "" ?
+                                 (current_path.empty() ?
                                     p->first :
                                     current_path + path_separator + p->first),
                                  path_separator,

--- a/source/base/path_search.cc
+++ b/source/base/path_search.cc
@@ -146,7 +146,7 @@ PathSearch::find(const std::string &filename,
 
       // try again with the suffix appended, unless there is
       // no suffix
-      if (suffix != "")
+      if (!suffix.empty())
         {
           real_name = *path + filename + suffix;
           if (debug > 1)

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -84,7 +84,7 @@ Subscriptor::check_no_subscribers() const noexcept
                               std::string(map_entry.first);
             }
 
-          if (infostring == "")
+          if (infostring.empty())
             infostring = "<none>";
 
           AssertNothrow(counter == 0,
@@ -136,7 +136,7 @@ Subscriptor::subscribe(std::atomic<bool> *const validity,
     object_info = &typeid(*this);
   ++counter;
 
-  const std::string name = (id != "") ? id : unknown_subscriber;
+  const std::string name = (!id.empty()) ? id : unknown_subscriber;
 
   map_iterator it = counter_map.find(name);
   if (it == counter_map.end())
@@ -154,7 +154,7 @@ void
 Subscriptor::unsubscribe(std::atomic<bool> *const validity,
                          const std::string &      id) const
 {
-  const std::string name = (id != "") ? id : unknown_subscriber;
+  const std::string name = (!id.empty()) ? id : unknown_subscriber;
   if (counter == 0)
     {
       AssertNothrow(counter > 0, ExcNoSubscriber(object_info->name(), name));

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -136,13 +136,9 @@ Subscriptor::subscribe(std::atomic<bool> *const validity,
     object_info = &typeid(*this);
   ++counter;
 
-  const std::string name = (!id.empty()) ? id : unknown_subscriber;
+  const std::string &name = id.empty() ? unknown_subscriber : id;
 
-  map_iterator it = counter_map.find(name);
-  if (it == counter_map.end())
-    counter_map.insert(map_value_type(name, 1U));
-  else
-    it->second++;
+  ++counter_map[name];
 
   *validity = true;
   validity_pointers.push_back(validity);
@@ -154,7 +150,8 @@ void
 Subscriptor::unsubscribe(std::atomic<bool> *const validity,
                          const std::string &      id) const
 {
-  const std::string name = (!id.empty()) ? id : unknown_subscriber;
+  const std::string &name = id.empty() ? unknown_subscriber : id;
+
   if (counter == 0)
     {
       AssertNothrow(counter > 0, ExcNoSubscriber(object_info->name(), name));

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -126,10 +126,9 @@ Subscriptor::operator=(Subscriptor &&s) noexcept
 
 
 
-template <>
 void
-Subscriptor::subscribe<const char *>(std::atomic<bool> *const validity,
-                                     const char *             id) const
+Subscriptor::subscribe(std::atomic<bool> *const validity,
+                       const std::string &      id) const
 {
   std::lock_guard<std::mutex> lock(mutex);
 
@@ -137,7 +136,7 @@ Subscriptor::subscribe<const char *>(std::atomic<bool> *const validity,
     object_info = &typeid(*this);
   ++counter;
 
-  const char *const name = (id != nullptr) ? id : unknown_subscriber;
+  const std::string name = (id != "") ? id : unknown_subscriber;
 
   map_iterator it = counter_map.find(name);
   if (it == counter_map.end())
@@ -153,9 +152,9 @@ Subscriptor::subscribe<const char *>(std::atomic<bool> *const validity,
 
 void
 Subscriptor::unsubscribe(std::atomic<bool> *const validity,
-                         const char *             id) const
+                         const std::string &      id) const
 {
-  const char *name = (id != nullptr) ? id : unknown_subscriber;
+  const std::string name = (id != "") ? id : unknown_subscriber;
   if (counter == 0)
     {
       AssertNothrow(counter > 0, ExcNoSubscriber(object_info->name(), name));

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -722,9 +722,9 @@ TableHandler::write_tex(std::ostream &out, const bool with_header) const
     }
 
   out << "\\end{tabular}" << std::endl << "\\end{center}" << std::endl;
-  if (tex_table_caption != "")
+  if (!tex_table_caption.empty())
     out << "\\caption{" << tex_table_caption << "}" << std::endl;
-  if (tex_table_label != "")
+  if (!tex_table_label.empty())
     out << "\\label{" << tex_table_label << "}" << std::endl;
   out << "\\end{table}" << std::endl;
   if (with_header)

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -459,7 +459,7 @@ TimerOutput::leave_subsection(const std::string &section_name)
 
   std::lock_guard<std::mutex> lock(mutex);
 
-  if (section_name != "")
+  if (!section_name.empty())
     {
       Assert(sections.find(section_name) != sections.end(),
              ExcMessage("Cannot delete a section that was never created."));
@@ -472,7 +472,7 @@ TimerOutput::leave_subsection(const std::string &section_name)
   // if no string is given, exit the last
   // active section.
   const std::string actual_section_name =
-    (section_name == "" ? active_sections.back() : section_name);
+    (section_name.empty() ? active_sections.back() : section_name);
 
   sections[actual_section_name].timer.stop();
   sections[actual_section_name].total_wall_time +=

--- a/source/gmsh/utilities.cc
+++ b/source/gmsh/utilities.cc
@@ -59,7 +59,7 @@ namespace Gmsh
   {
     std::string base_name      = prm.output_base_name;
     char        dir_template[] = "ctfbc-XXXXXX";
-    if (base_name == "")
+    if (base_name.empty())
       {
         const char *temp = mkdtemp(dir_template);
         AssertThrow(temp != nullptr,

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -382,7 +382,7 @@ GridIn<dim, spacedim>::read_vtk(std::istream &in)
                             set = keyword;
                             break;
                           }
-                      if (set == "")
+                      if (set.empty())
                         // keep ignoring everything until the next SCALARS
                         // keyword
                         continue;

--- a/tests/base/unsubscribe_subscriptor.debug.output
+++ b/tests/base/unsubscribe_subscriptor.debug.output
@@ -3,7 +3,7 @@ DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
 DEAL::
 --------------------------------------------------------
 An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::unsubscribe(std::atomic<bool>*, const char*) const
+    void dealii::Subscriptor::unsubscribe(std::atomic<bool>*, const string&) const
 The violated condition was: 
     it != counter_map.end()
 Additional information: 
@@ -14,7 +14,7 @@ DEAL::Exception: ExcMessage( "This Subscriptor object does not know anything abo
 DEAL::
 --------------------------------------------------------
 An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::unsubscribe(std::atomic<bool>*, const char*) const
+    void dealii::Subscriptor::unsubscribe(std::atomic<bool>*, const string&) const
 The violated condition was: 
     validity_ptr_it != validity_pointers.end()
 Additional information: 

--- a/tests/base/unsubscribe_subscriptor.debug.output.clang-6
+++ b/tests/base/unsubscribe_subscriptor.debug.output.clang-6
@@ -3,7 +3,7 @@ DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
 DEAL::
 --------------------------------------------------------
 An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::unsubscribe(std::atomic<bool> *const, const char *) const
+    void dealii::Subscriptor::unsubscribe(std::atomic<bool> *const, const std::string &) const
 The violated condition was: 
     it != counter_map.end()
 Additional information: 
@@ -14,7 +14,7 @@ DEAL::Exception: ExcMessage( "This Subscriptor object does not know anything abo
 DEAL::
 --------------------------------------------------------
 An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::unsubscribe(std::atomic<bool> *const, const char *) const
+    void dealii::Subscriptor::unsubscribe(std::atomic<bool> *const, const std::string &) const
 The violated condition was: 
     validity_ptr_it != validity_pointers.end()
 Additional information: 

--- a/tests/base/unsubscribe_subscriptor.debug.output.intel
+++ b/tests/base/unsubscribe_subscriptor.debug.output.intel
@@ -3,7 +3,7 @@ DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
 DEAL::
 --------------------------------------------------------
 An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::unsubscribe(std::atomic<bool> *, const char *) const
+    void dealii::Subscriptor::unsubscribe(std::atomic<bool> *, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &) const
 The violated condition was: 
     it != counter_map.end()
 Additional information: 
@@ -14,7 +14,7 @@ DEAL::Exception: ExcMessage( "This Subscriptor object does not know anything abo
 DEAL::
 --------------------------------------------------------
 An error occurred in file <subscriptor.cc> in function
-    void dealii::Subscriptor::unsubscribe(std::atomic<bool> *, const char *) const
+    void dealii::Subscriptor::unsubscribe(std::atomic<bool> *, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &) const
 The violated condition was: 
     validity_ptr_it != validity_pointers.end()
 Additional information: 


### PR DESCRIPTION
Fixes #7892. Using `std::string` instead of `const char *` in `SmartPointer` and `Subscriptor` is just easier.