### PR TITLE
Avoid floating point exception in symengine_number_type_01

### DIFF
--- a/tests/symengine/symengine_number_type_01.cc
+++ b/tests/symengine/symengine_number_type_01.cc
@@ -1125,6 +1125,10 @@ main()
 
       // No condition is met
       {
+#if defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+        fedisableexcept(FE_INVALID);
+#endif
+
         const double                x_val = -1.0;
         SD::types::substitution_map sub_map;
         sub_map[x]               = SD_number_t(x_val);


### PR DESCRIPTION
We expect `nan` here and we should not abort the program if we encounter it. Fixes https://cdash.kyomu.43-1.org/testSummary.php?project=1&name=symengine%2Fsymengine_number_type_01.debug&date=2019-04-12.