### PR TITLE
SD scalar operations: Symbol and symbolic function creation

### DIFF
--- a/include/deal.II/differentiation/sd.h
+++ b/include/deal.II/differentiation/sd.h
@@ -24,6 +24,7 @@
 #  include <deal.II/differentiation/sd/symengine_number_traits.h>
 #  include <deal.II/differentiation/sd/symengine_number_types.h>
 #  include <deal.II/differentiation/sd/symengine_types.h>
+#  include <deal.II/differentiation/sd/symengine_utilities.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -109,6 +109,27 @@ namespace Differentiation
 
     //@}
 
+    /**
+     * @name Symbolic differentiation
+     */
+    //@{
+
+    /**
+     * Return the symbolic result of computing the partial derivative of the
+     * scalar @p f with respect to the scalar @p x.
+     * In most use cases the function or variable @f would be called the
+     * dependent variable, and @p x the independent variable.
+     *
+     * @param[in] f A scalar symbolic function or (dependent) variable.
+     * @param[in] x A scalar symbolic (independent) variable.
+     * @return The symbolic function or variable representing the result
+     *         $\frac{\partial f}{\partial x}$.
+     */
+    Expression
+    differentiate(const Expression &f, const Expression &x);
+
+    //@}
+
   } // namespace SD
 } // namespace Differentiation
 

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -1,0 +1,119 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_differentiation_sd_symengine_scalar_operations_h
+#define dealii_differentiation_sd_symengine_scalar_operations_h
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_SYMENGINE
+
+#  include <deal.II/base/numbers.h>
+
+#  include <deal.II/differentiation/sd/symengine_number_types.h>
+#  include <deal.II/differentiation/sd/symengine_types.h>
+
+#  include <algorithm>
+#  include <type_traits>
+#  include <utility>
+#  include <vector>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace Differentiation
+{
+  namespace SD
+  {
+    /**
+     * @name Symbolic variable creation
+     */
+    //@{
+
+    /**
+     * Return an Expression representing a scalar symbolic variable
+     * with the identifier specified by @p symbol.
+     *
+     * For example, if the @p symbol is the string `"x"` then the scalar
+     * symbolic variable that is returned represents the scalar $x$.
+     *
+     * @param[in] symbol An indentifier (or name) for the returned symbolic
+     *            variable.
+     * @return A scalar symbolic variable with the name @p symbol.
+     *
+     * @warning It is up to the user to ensure that there is no ambiguity in the
+     * symbols used within a section of code.
+     */
+    Expression
+    make_symbol(const std::string &symbol);
+
+    /**
+     * Return an Expression representing a scalar symbolic function
+     * with the identifier specified by @p symbol. The function's symbolic
+     * dependencies are specified by the input @p arguments.
+     *
+     * For example, if the @p symbol is the string `"f"`, and the
+     * arguments to the function that is generated  are the
+     * symbolic variable `x` and the symbolic expression `y+z`, then the
+     * generic symbolic function that is returned represents $f(x, y+z)$.
+     *
+     * @param[in] symbol An indentifier (or name) for the returned symbolic
+     *            function.
+     * @param[in] arguments A vector of input arguments to the returned
+     *            symbolic function.
+     * @return A generic symbolic function with the identifier @p symbolic and
+     *         the number of input arguments equal to the length of @p arguments.
+     *
+     * @warning It is up to the user to ensure that there is no ambiguity in the
+     * symbols used within a section of code.
+     */
+    Expression
+    make_symbolic_function(const std::string &         symbol,
+                           const types::symbol_vector &arguments);
+
+    /**
+     * Return an Expression representing a scalar symbolic function
+     * with the identifier specified by @p symbol. The function's symbolic
+     * dependencies are specified by the keys to the input @p arguments map;
+     * the values stored in the map are ignored.
+     *
+     * For example, if the @p symbol is the string `"f"`, and the
+     * arguments to the function that is generated are the
+     * symbolic variable `x` and the symbolic expression `y+z`, then the
+     * generic symbolic function that is returned represents $f(x, y+z)$.
+     *
+     * @param[in] symbol An indentifier (or name) for the returned symbolic
+     *            function.
+     * @param[in] arguments A map of input arguments to the returned
+     *            symbolic function.
+     * @return A generic symbolic function with the identifier @p symbolic and
+     *         the number of input arguments equal to the length of @p arguments.
+     *
+     * @warning It is up to the user to ensure that there is no ambiguity in the
+     * symbols used within a section of code.
+     */
+    Expression
+    make_symbolic_function(const std::string &            symbol,
+                           const types::substitution_map &arguments);
+
+    //@}
+
+  } // namespace SD
+} // namespace Differentiation
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_WITH_SYMENGINE
+
+#endif

--- a/include/deal.II/differentiation/sd/symengine_utilities.h
+++ b/include/deal.II/differentiation/sd/symengine_utilities.h
@@ -49,10 +49,95 @@ namespace Differentiation
       convert_expression_vector_to_basic_vector(
         const SD::types::symbol_vector &symbol_vector);
 
+      /**
+       * Extract the symbols (key entries) from a substitution map.
+       *
+       * @note It is guarenteed that the order of extraction of data into the
+       * output vector is the same as that for extract_values().
+       * That is to say that the unzipped key and value pairs as given by
+       * extract_symbols() and extract_values() always have a 1:1
+       * correspondence.
+       */
+      SD::types::symbol_vector
+      extract_symbols(const SD::types::substitution_map &substitution_values);
+
+      /**
+       * Extract the values from a substitution map.
+       * The value entries will be converted into the @p NumberType given
+       * as a template parameter to this function via the @p ExpressionType.
+       *
+       * @note It is guarenteed that the order of extraction of data into the
+       * output vector is the same as that for extract_symbols().
+       * That is to say that the unzipped key and value pairs as given by
+       * extract_symbols() and extract_values() always have a 1:1
+       * correspondence.
+       */
+      template <typename NumberType, typename ExpressionType = SD::Expression>
+      std::vector<NumberType>
+      extract_values(const SD::types::substitution_map &substitution_values);
+
+      /**
+       * Print the key and value pairs stored in a substitution map.
+       */
+      template <typename StreamType>
+      StreamType &
+      print_substitution_map(
+        StreamType &                       stream,
+        const SD::types::substitution_map &symbol_value_map);
+
     } // namespace Utilities
 
   } // namespace SD
 } // namespace Differentiation
+
+
+/* -------------------- inline and template functions ------------------ */
+
+
+#  ifndef DOXYGEN
+
+
+namespace Differentiation
+{
+  namespace SD
+  {
+    namespace Utilities
+    {
+      template <typename NumberType, typename ExpressionType>
+      std::vector<NumberType>
+      extract_values(const SD::types::substitution_map &substitution_values)
+      {
+        std::vector<NumberType> values;
+        values.reserve(substitution_values.size());
+
+        for (const auto &entry : substitution_values)
+          values.push_back(
+            static_cast<NumberType>(ExpressionType(entry.second)));
+
+        return values;
+      }
+
+
+      template <typename StreamType>
+      StreamType &
+      print_substitution_map(
+        StreamType &                       stream,
+        const SD::types::substitution_map &symbol_value_map)
+      {
+        for (const auto &entry : symbol_value_map)
+          stream << entry.first << " = " << entry.second << "\n";
+
+        stream << std::flush;
+        return stream;
+      }
+
+    } // namespace Utilities
+
+  } // namespace SD
+} // namespace Differentiation
+
+
+#  endif // DOXYGEN
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/sd/CMakeLists.txt
+++ b/source/differentiation/sd/CMakeLists.txt
@@ -18,6 +18,7 @@ INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 SET(_src
   symengine_math.cc
   symengine_number_types.cc
+  symengine_scalar_operations.cc
   symengine_types.cc
   symengine_utilities.cc
   )

--- a/source/differentiation/sd/symengine_scalar_operations.cc
+++ b/source/differentiation/sd/symengine_scalar_operations.cc
@@ -13,15 +13,11 @@
 //
 // ---------------------------------------------------------------------
 
-#ifndef dealii_differentiation_sd_h
-#define dealii_differentiation_sd_h
 
 #include <deal.II/base/config.h>
 
 #ifdef DEAL_II_WITH_SYMENGINE
 
-#  include <deal.II/differentiation/sd/symengine_math.h>
-#  include <deal.II/differentiation/sd/symengine_number_traits.h>
 #  include <deal.II/differentiation/sd/symengine_number_types.h>
 #  include <deal.II/differentiation/sd/symengine_scalar_operations.h>
 #  include <deal.II/differentiation/sd/symengine_types.h>
@@ -31,19 +27,38 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace Differentiation
 {
-  /**
-   * Wrappers for symbolic differentiation libraries. Currently there is support
-   * for the following libraries:
-   *   - SymEngine
-   *
-   * @ingroup auto_symb_diff
-   */
   namespace SD
-  {}
+  {
+    /* ------------------------- Symbol creation -----------------------*/
+
+
+    Expression
+    make_symbol(const std::string &symbol)
+    {
+      return Expression(symbol);
+    }
+
+
+    Expression
+    make_symbolic_function(const std::string &             symbol,
+                           const SD::types::symbol_vector &arguments)
+    {
+      return Expression(symbol, arguments);
+    }
+
+
+    Expression
+    make_symbolic_function(const std::string &                symbol,
+                           const SD::types::substitution_map &arguments)
+    {
+      return make_symbolic_function(symbol,
+                                    SD::Utilities::extract_symbols(arguments));
+    }
+
+
+  } // namespace SD
 } // namespace Differentiation
 
 DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_SYMENGINE
-
-#endif // dealii_differentiation_sd_h

--- a/source/differentiation/sd/symengine_scalar_operations.cc
+++ b/source/differentiation/sd/symengine_scalar_operations.cc
@@ -56,6 +56,15 @@ namespace Differentiation
     }
 
 
+    /* --------------------------- Differentiation ------------------------- */
+
+
+    Expression
+    differentiate(const Expression &func, const Expression &op)
+    {
+      return func.differentiate(op);
+    }
+
   } // namespace SD
 } // namespace Differentiation
 

--- a/source/differentiation/sd/symengine_utilities.cc
+++ b/source/differentiation/sd/symengine_utilities.cc
@@ -52,6 +52,22 @@ namespace Differentiation
         return symb_vec;
       }
 
+
+      SD::types::symbol_vector
+      extract_symbols(const SD::types::substitution_map &substitution_values)
+      {
+        SD::types::symbol_vector symbols;
+        symbols.reserve(substitution_values.size());
+
+        for (typename SD::types::substitution_map::const_iterator it =
+               substitution_values.begin();
+             it != substitution_values.end();
+             ++it)
+          symbols.push_back(it->first);
+
+        return symbols;
+      }
+
     } // namespace Utilities
 
   } // namespace SD

--- a/tests/symengine/symengine_scalar_operations_01.cc
+++ b/tests/symengine/symengine_scalar_operations_01.cc
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that symbols and symbolic functions can be created using the
+// utility functions
+
+#include <deal.II/differentiation/sd.h>
+
+#include "../tests.h"
+
+using namespace dealii;
+namespace SD = Differentiation::SD;
+
+
+int
+main()
+{
+  initlog();
+
+  using SD_number_t = SD::Expression;
+
+  const SD::types::substitution_map sub_map{
+    {SD_number_t("c"), SD_number_t(1.0)},
+    {SD_number_t("b"), SD_number_t(2)},
+    {SD_number_t("a"), SD_number_t(3.0f)}};
+
+  const SD::types::symbol_vector symbols{SD_number_t("c"),
+                                         SD_number_t("b"),
+                                         SD_number_t("a")};
+
+  const SD_number_t symb        = SD::make_symbol("d");
+  const SD_number_t symb_func_1 = SD::make_symbolic_function("f", symbols);
+  const SD_number_t symb_func_2 = SD::make_symbolic_function("g", sub_map);
+
+  deallog << "Symbol: " << symb << std::endl;
+  deallog << "Symbolic function (vector of arguments): " << symb_func_1
+          << std::endl;
+  deallog << "Symbolic function (map of arguments): " << symb_func_2
+          << std::endl;
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/symengine/symengine_scalar_operations_01.output
+++ b/tests/symengine/symengine_scalar_operations_01.output
@@ -1,0 +1,5 @@
+
+DEAL::Symbol: d
+DEAL::Symbolic function (vector of arguments): f(c, b, a)
+DEAL::Symbolic function (map of arguments): g(a, b, c)
+DEAL::OK

--- a/tests/symengine/symengine_scalar_operations_02.cc
+++ b/tests/symengine/symengine_scalar_operations_02.cc
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that scalar differentiation can be performed using the utility
+// functions
+
+#include <deal.II/differentiation/sd.h>
+
+#include "../tests.h"
+
+using namespace dealii;
+namespace SD = Differentiation::SD;
+
+
+int
+main()
+{
+  initlog();
+
+  using SD_number_t = SD::Expression;
+
+  const SD_number_t x     = SD::make_symbol("x");
+  const SD_number_t f     = 2 * x * x;
+  const SD_number_t df_dx = SD::differentiate(f, x);
+
+  deallog << "x: " << x << std::endl;
+  deallog << "f: " << f << std::endl;
+  deallog << "df_dx: " << df_dx << std::endl;
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/symengine/symengine_scalar_operations_02.output
+++ b/tests/symengine/symengine_scalar_operations_02.output
@@ -1,0 +1,5 @@
+
+DEAL::x: x
+DEAL::f: 2*x**2
+DEAL::df_dx: 4*x
+DEAL::OK

--- a/tests/symengine/symengine_utilities_01.cc
+++ b/tests/symengine/symengine_utilities_01.cc
@@ -1,0 +1,57 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that substitution map decomposition and printing work as expected
+
+#include <deal.II/differentiation/sd.h>
+
+#include "../tests.h"
+
+using namespace dealii;
+namespace SD = Differentiation::SD;
+
+
+int
+main()
+{
+  initlog();
+
+  using SD_number_t = SD::Expression;
+
+  const SD::types::substitution_map sub_map{
+    {SD_number_t("c"), SD_number_t(1.0)},
+    {SD_number_t("b"), SD_number_t(2)},
+    {SD_number_t("a"), SD_number_t(3.0f)}};
+
+  const SD::types::symbol_vector symbols =
+    SD::Utilities::extract_symbols(sub_map);
+  const std::vector<double> values =
+    SD::Utilities::extract_values<double>(sub_map);
+  Assert(values.size() == symbols.size(),
+         ExcDimensionMismatch(values.size(), symbols.size()));
+
+  // Print the map itself (this should be dictionary ordered)
+  deallog << "Print substitution map" << std::endl;
+  SD::Utilities::print_substitution_map(deallog, sub_map);
+
+  // Print the extracted symbol-value pairs (the ordering should match that of
+  // the map)
+  deallog << "Print extracted symbol-value pairs" << std::endl;
+  for (unsigned int i = 0; i < symbols.size(); ++i)
+    deallog << symbols[i] << " = " << values[i] << std::endl;
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/symengine/symengine_utilities_01.output
+++ b/tests/symengine/symengine_utilities_01.output
@@ -1,0 +1,10 @@
+
+DEAL::Print substitution map
+DEAL::a = 3.0
+b = 2
+c = 1.0
+Print extracted symbol-value pairs
+DEAL::a = 3.00000
+DEAL::b = 2.00000
+DEAL::c = 1.00000
+DEAL::OK


### PR DESCRIPTION
 Add some SD-related convenience functions for scalar operations. Specifically, these can be used to create a scalar symbol and symbolic function. At the same time, I've added some required utility functions.

Although these seem a bit trivial (as might other functions being added to `sd/scalar_operations.h`), they will later be paired with functions that perform similar operations for tensors of symbolic expressions.