### PR TITLE
Fix symengine_number_type_01 in Release mode

### DIFF
--- a/tests/symengine/symengine_number_type_01.cc
+++ b/tests/symengine/symengine_number_type_01.cc
@@ -1125,7 +1125,7 @@ main()
 
       // No condition is met
       {
-#if defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
         fedisableexcept(FE_INVALID);
 #endif
 


### PR DESCRIPTION
In #7917 I missed that we only include the necessary headers in `Debug` mode. That should fix http://cdash.kyomu.43-1.org/testSummary.php?project=1&name=symengine%2Fsymengine_number_type_01.release&date=2019-04-14.