### PR TITLE
Minor cleanup of hp::DoFHandler.

### DIFF
--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -1122,7 +1122,8 @@ namespace hp
 
     /**
      * A function that will be triggered through a triangulation
-     * signal just before the associated Triangulation is modified.
+     * signal just before the associated Triangulation or
+     * parallel::shared::Triangulation is modified.
      *
      * The function that stores the active_fe_indices of all cells that will
      * be refined or coarsened before the refinement happens, so that
@@ -1130,18 +1131,6 @@ namespace hp
      */
     void
     pre_active_fe_index_transfer();
-
-    /**
-     * A function that will be triggered through a triangulation
-     * signal just before the associated parallel::shared::Triangulation is
-     * modified.
-     *
-     * The function that stores the active_fe_indices of all cells that will
-     * be refined or coarsened before the refinement happens, so that
-     * they can be set again after refinement.
-     */
-    void
-    pre_shared_active_fe_index_transfer();
 
     /**
      * A function that will be triggered through a triangulation
@@ -1156,24 +1145,14 @@ namespace hp
 
     /**
      * A function that will be triggered through a triangulation
-     * signal just after the associated Triangulation is modified.
+     * signal just after the associated Triangulation or
+     * parallel::shared::Triangulation is modified.
      *
      * The function that restores the active_fe_indices of all cells that
      * were refined or coarsened.
      */
     void
     post_active_fe_index_transfer();
-
-    /**
-     * A function that will be triggered through a triangulation
-     * signal just after the associated parallel::shared::Triangulation is
-     * modified.
-     *
-     * The function that restores the active_fe_indices of all cells that
-     * were refined or coarsened.
-     */
-    void
-    post_shared_active_fe_index_transfer();
 
     /**
      * A function that will be triggered through a triangulation

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3705,16 +3705,12 @@ namespace internal
           {
             saved_subdomain_ids.resize(tr->n_active_cells());
 
-            typename parallel::shared::Triangulation<dim, spacedim>::
-              active_cell_iterator
-                cell = this->dof_handler->get_triangulation().begin_active(),
-                endc = this->dof_handler->get_triangulation().end();
-
             const std::vector<types::subdomain_id> &true_subdomain_ids =
               tr->get_true_subdomain_ids_of_cells();
 
-            for (unsigned int index = 0; cell != endc; ++cell, ++index)
+            for (const auto &cell : tr->active_cell_iterators())
               {
+                const unsigned int index   = cell->active_cell_index();
                 saved_subdomain_ids[index] = cell->subdomain_id();
                 cell->set_subdomain_id(true_subdomain_ids[index]);
               }
@@ -3834,15 +3830,9 @@ namespace internal
 
         // finally, restore current subdomain ids
         if (tr->with_artificial_cells())
-          {
-            typename parallel::shared::Triangulation<dim, spacedim>::
-              active_cell_iterator
-                cell = this->dof_handler->get_triangulation().begin_active(),
-                endc = this->dof_handler->get_triangulation().end();
-
-            for (unsigned int index = 0; cell != endc; ++cell, ++index)
-              cell->set_subdomain_id(saved_subdomain_ids[index]);
-          }
+          for (const auto &cell : tr->active_cell_iterators())
+            cell->set_subdomain_id(
+              saved_subdomain_ids[cell->active_cell_index()]);
 
         // return a NumberCache object made up from the sets of locally
         // owned DoFs

--- a/tests/mpi/hp_cell_weights_04.cc
+++ b/tests/mpi/hp_cell_weights_04.cc
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Cell Weights Test
+// -----------------
+// Create a 4x4(x4) grid, on which all cells are associated with a Q1
+// element besides the very first one, which has a Q5 element.
+// We choose a cell weighting algorithm based on the number of degrees
+// of freedom and check if load is balanced as expected after
+// repartitioning the triangulation. The expected accumulated weight on
+// each processor should correlate to the sum of all degrees of
+// freedom on all cells of the corresponding subdomain.
+// We employ a large proportionality factor on our weighting function
+// to neglect the standard weight of '1000' per cell.
+//
+// This test works on a parallel::shared::Triangulation with METIS
+// as a partitioner. Cell weighting with ZOLTAN was not available
+// during the time this test was written.
+//
+// We consider aritifical cells in this case.
+
+
+#include <deal.II/distributed/cell_weights.h>
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/hp/dof_handler.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  parallel::shared::Triangulation<dim> tria(
+    MPI_COMM_WORLD,
+    ::Triangulation<dim>::none,
+    true,
+    parallel::shared::Triangulation<dim>::Settings::partition_metis);
+
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  // Apply ndof cell weights.
+  hp::FECollection<dim> fe_collection;
+  fe_collection.push_back(FE_Q<dim>(1));
+  fe_collection.push_back(FE_Q<dim>(5));
+
+  hp::DoFHandler<dim> dh(tria);
+  dh.set_fe(fe_collection);
+  // default: active_fe_index = 0
+  for (auto &cell : dh.active_cell_iterators())
+    if (cell->is_locally_owned())
+      if (cell->id().to_string() == "0_2:00")
+        cell->set_active_fe_index(1);
+
+  deallog << "Number of cells before repartitioning: "
+          << tria.n_locally_owned_active_cells() << std::endl;
+  {
+    unsigned int dof_counter = 0;
+    for (auto &cell : dh.active_cell_iterators())
+      if (cell->is_locally_owned())
+        dof_counter += cell->get_fe().dofs_per_cell;
+    deallog << "  Cumulative dofs per cell: " << dof_counter << std::endl;
+  }
+
+
+  parallel::CellWeights<dim> cell_weights(dh);
+  cell_weights.register_ndofs_weighting(100000);
+
+  // we didn't mark any cells, but we want to repartition our domain
+  tria.execute_coarsening_and_refinement();
+
+
+  deallog << "Number of cells after repartitioning: "
+          << tria.n_locally_owned_active_cells() << std::endl;
+  {
+    unsigned int dof_counter = 0;
+    for (auto &cell : dh.active_cell_iterators())
+      if (cell->is_locally_owned())
+        dof_counter += cell->get_fe().dofs_per_cell;
+    deallog << "  Cumulative dofs per cell: " << dof_counter << std::endl;
+  }
+
+  // make sure no processor is hanging
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/mpi/hp_cell_weights_04.with_mpi=true.with_metis=true.mpirun=2.output
+++ b/tests/mpi/hp_cell_weights_04.with_mpi=true.with_metis=true.mpirun=2.output
@@ -1,0 +1,23 @@
+
+DEAL:0:2d::Number of cells before repartitioning: 8
+DEAL:0:2d::  Cumulative dofs per cell: 32
+DEAL:0:2d::Number of cells after repartitioning: 13
+DEAL:0:2d::  Cumulative dofs per cell: 52
+DEAL:0:2d::OK
+DEAL:0:3d::Number of cells before repartitioning: 33
+DEAL:0:3d::  Cumulative dofs per cell: 264
+DEAL:0:3d::Number of cells after repartitioning: 47
+DEAL:0:3d::  Cumulative dofs per cell: 376
+DEAL:0:3d::OK
+
+DEAL:1:2d::Number of cells before repartitioning: 8
+DEAL:1:2d::  Cumulative dofs per cell: 64
+DEAL:1:2d::Number of cells after repartitioning: 3
+DEAL:1:2d::  Cumulative dofs per cell: 44
+DEAL:1:2d::OK
+DEAL:1:3d::Number of cells before repartitioning: 31
+DEAL:1:3d::  Cumulative dofs per cell: 456
+DEAL:1:3d::Number of cells after repartitioning: 17
+DEAL:1:3d::  Cumulative dofs per cell: 344
+DEAL:1:3d::OK
+

--- a/tests/mpi/hp_cell_weights_04.with_mpi=true.with_metis=true.mpirun=2.output.1
+++ b/tests/mpi/hp_cell_weights_04.with_mpi=true.with_metis=true.mpirun=2.output.1
@@ -1,0 +1,23 @@
+
+DEAL:0:2d::Number of cells before repartitioning: 8
+DEAL:0:2d::  Cumulative dofs per cell: 64
+DEAL:0:2d::Number of cells after repartitioning: 13
+DEAL:0:2d::  Cumulative dofs per cell: 52
+DEAL:0:2d::OK
+DEAL:0:3d::Number of cells before repartitioning: 32
+DEAL:0:3d::  Cumulative dofs per cell: 256
+DEAL:0:3d::Number of cells after repartitioning: 47
+DEAL:0:3d::  Cumulative dofs per cell: 376
+DEAL:0:3d::OK
+
+DEAL:1:2d::Number of cells before repartitioning: 8
+DEAL:1:2d::  Cumulative dofs per cell: 32
+DEAL:1:2d::Number of cells after repartitioning: 3
+DEAL:1:2d::  Cumulative dofs per cell: 44
+DEAL:1:2d::OK
+DEAL:1:3d::Number of cells before repartitioning: 32
+DEAL:1:3d::  Cumulative dofs per cell: 464
+DEAL:1:3d::Number of cells after repartitioning: 17
+DEAL:1:3d::  Cumulative dofs per cell: 344
+DEAL:1:3d::OK
+

--- a/tests/mpi/hp_refinement_01.cc
+++ b/tests/mpi/hp_refinement_01.cc
@@ -88,7 +88,7 @@ test()
         }
     }
 
-  dh.distribute_dofs(fe_collection);
+  dh.set_fe(fe_collection);
 
   // ----- refine -----
   tria.execute_coarsening_and_refinement();

--- a/tests/mpi/hp_refinement_02.cc
+++ b/tests/mpi/hp_refinement_02.cc
@@ -88,7 +88,7 @@ test()
         }
     }
 
-  dh.distribute_dofs(fe_collection);
+  dh.set_fe(fe_collection);
 
   // ----- refine -----
   tria.execute_coarsening_and_refinement();


### PR DESCRIPTION
Woops: For tests in #7305, I did only consider `p::s::Triangulation` objects without artificial cells. These tests fail when taking into account artificial ones: For partitioning with individual cell weights, we have to make the `active_fe_index` information available on all cells. This is achieved by temporarily modifying the subdomains to become the 'true' ones.

Further, while transferring `active_fe_indices` during refinement and/or coarsening, we need to communicate all indices not before, but after the triangulation was changed. This will make sure that all `active_fe_indices` are available for partitioning during the `p::s::Triangulation::execute_coarsening_and_refinement()` call.

However, if someone would like to directly partition the mesh via `GridTools::partition_triangulation()` we cannot make sure that all `active_fe_indices` have been broadcasted before. And I don't know how to check this via an assertion. Do you have an idea how to cope with that? Or shall we provide a note in the documentation instead?

EDIT: Further, I enhanced the `hp::DoFHandler::set_fe()` function with assertions and the communiction of all `active_fe_indices`. `hp::DoFHandler::distribute_dofs()` now calls this function right in the beginning. Part of #3511.