### PR TITLE
add explicit instantiations for shared::Triangulation

### DIFF
--- a/source/grid/grid_tools_dof_handlers.inst.in
+++ b/source/grid/grid_tools_dof_handlers.inst.in
@@ -337,3 +337,51 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 #  endif
 #endif
   }
+
+// TODO the text above the last instantiation block implies that this should not
+// be necessary... is it?
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+#  if deal_II_dimension >= 2
+
+    namespace GridTools
+    \{
+      template void
+      collect_periodic_faces<
+        parallel::shared::Triangulation<deal_II_dimension,
+                                        deal_II_space_dimension>>(
+        const parallel::shared::Triangulation<deal_II_dimension,
+                                              deal_II_space_dimension> &,
+        const types::boundary_id,
+        const types::boundary_id,
+        const int,
+        std::vector<PeriodicFacePair<parallel::shared::Triangulation<
+          deal_II_dimension,
+          deal_II_space_dimension>::cell_iterator>> &,
+        const Tensor<1,
+                     parallel::shared::Triangulation<
+                       deal_II_dimension,
+                       deal_II_space_dimension>::space_dimension> &,
+        const FullMatrix<double> &);
+
+      template void
+      collect_periodic_faces<
+        parallel::shared::Triangulation<deal_II_dimension,
+                                        deal_II_space_dimension>>(
+        const parallel::shared::Triangulation<deal_II_dimension,
+                                              deal_II_space_dimension> &,
+        const types::boundary_id,
+        const int,
+        std::vector<PeriodicFacePair<parallel::shared::Triangulation<
+          deal_II_dimension,
+          deal_II_space_dimension>::cell_iterator>> &,
+        const Tensor<1,
+                     parallel::shared::Triangulation<
+                       deal_II_dimension,
+                       deal_II_space_dimension>::space_dimension> &,
+        const FullMatrix<double> &);
+    \}
+#  endif
+#endif
+  }


### PR DESCRIPTION
just adding explicit instantiations of `collect_periodic_faces` for `shared::Triangulation`
If necessary, I could add some test, which should be the same as for the other triangulation classes. 