### PR TITLE
Break long lines in step-61/doc/results.dox.

### DIFF
--- a/examples/step-61/doc/results.dox
+++ b/examples/step-61/doc/results.dox
@@ -1,9 +1,20 @@
 <h1>Results</h1>
 
-We run the test example $p = \sin(\pi x) \sin(\pi y)$ with homogenous Dirichelet boundary conditions in the domain $\Omega = (0,1)^2$. And  $\mathbf{K}$ is the identity matrix. We test it on $\mbox{WG}(Q_0,Q_0;RT_{[0]})$, $\mbox{WG}(Q_1,Q_1;RT_{[1]})$ and $\mbox{WG}(Q_2,Q_2;RT_{[2]})$. We will visualize pressure values in interiors and on faces. We want to see the pressure maximum is around 1 and the minimum is around 0. With the mesh refinement, the convergence rates of pressure, velocity and flux should be around 1 on $\mbox{WG}(Q_0,Q_0;RT_{[0]})$ , 2 on $\mbox{WG}(Q_1,Q_1;RT_{[1]})$, and 3 on $\mbox{WG}(Q_2,Q_2;RT_{[2]})$.
+We run the test example $p = \sin(\pi x) \sin(\pi y)$ with homogenous Dirichelet 
+boundary conditions in the domain $\Omega = (0,1)^2$. And  $\mathbf{K}$ is the 
+identity matrix. We test it on $\mbox{WG}(Q_0,Q_0;RT_{[0]})$, $\mbox{WG}(Q_1,Q_1;RT_{[1]})$ 
+and $\mbox{WG}(Q_2,Q_2;RT_{[2]})$. We will visualize pressure values in interiors 
+and on faces. We want to see the pressure maximum is around 1 and the minimum 
+is around 0. With the mesh refinement, the convergence rates of pressure, 
+velocity and flux should be around 1 on $\mbox{WG}(Q_0,Q_0;RT_{[0]})$ , 2 on 
+$\mbox{WG}(Q_1,Q_1;RT_{[1]})$, and 3 on $\mbox{WG}(Q_2,Q_2;RT_{[2]})$.
+
 
 <h3>Test results on <i>WG(Q<sub>0</sub>,Q<sub>0</sub>;RT<sub>[0]</sub>)</i></h3>
-The following figures are interior pressures and face pressures implemented on $\mbox{WG}(Q_0,Q_0;RT_{[0]})$. The mesh is refined 2 times and 4 times separately. 
+
+The following figures are interior pressures and face pressures implemented 
+on $\mbox{WG}(Q_0,Q_0;RT_{[0]})$. The mesh is refined 2 times and 4 times 
+separately. 
 
 <table align="center">
   <tr>
@@ -16,8 +27,11 @@ The following figures are interior pressures and face pressures implemented on $
   </tr>
 </table>
 
-From the figures, we can see that with the mesh refinement, the maximum and minimum are approaching to what we expect. 
-Since the mesh is a rectangular mesh and numbers of refinement are even, we have symmetric solutions. From the 3d figures, we can see that on $\mbox{WG}(Q_0,Q_0;RT_{[0]})$, pressure is a constant in the interior of the cell.
+From the figures, we can see that with the mesh refinement, the maximum and 
+minimum are approaching to what we expect. 
+Since the mesh is a rectangular mesh and numbers of refinement are even, we 
+have symmetric solutions. From the 3d figures, we can see that on $\mbox{WG}(Q_0,Q_0;RT_{[0]})$, 
+pressure is a constant in the interior of the cell.
 
 <h4>Convergence table</h4>
 
@@ -50,8 +64,13 @@ We can see that the convergence rates of $\mbox{WG}(Q_0,Q_0;RT_{[0]})$ are aroun
 
 <h3>Test results on <i>WG(Q<sub>1</sub>,Q<sub>1</sub>;RT<sub>[1]</sub>)</i></h3>
 
-The following figures are interior pressures and face pressures implemented on $\mbox{WG}(Q_1,Q_1;RT_{[1]})$. The mesh is refined 4 times.  Compared to the previous figures on 
-$\mbox{WG}(Q_0,Q_0;RT_{[0]})$, on each cell, the result is not a constant. Because we use higher order polynomials to do approximation. So there are 4 pressure values in one interior, 2 pressure values on each face. We use data_out_face.build_patches (fe.degree)
+The following figures are interior pressures and face pressures implemented on 
+$\mbox{WG}(Q_1,Q_1;RT_{[1]})$. The mesh is refined 4 times.  Compared to the 
+previous figures on 
+$\mbox{WG}(Q_0,Q_0;RT_{[0]})$, on each cell, the result is not a constant. 
+Because we use higher order polynomials to do approximation. So there are 4 
+pressure values in one interior, 2 pressure values on each face. We use 
+data_out_face.build_patches (fe.degree)
 to divide each cell interior into 4 subcells.
 
 <table align="center">
@@ -89,7 +108,8 @@ The convergence rates of $WG(Q_1,Q_1;RT_{[1]})$ are around 2.
 
 <h3>Test results on <i>WG(Q<sub>2</sub>,Q<sub>2</sub>;RT<sub>[2]</sub>)</i></h3>
 
-These are interior pressures and face pressures implemented on $WG(Q_2,Q_2;RT_{[2]})$, with mesh size $h = 1/32$.
+These are interior pressures and face pressures implemented on 
+$WG(Q_2,Q_2;RT_{[2]})$, with mesh size $h = 1/32$.
 
 <table align="center">
   <tr>
@@ -100,7 +120,8 @@ These are interior pressures and face pressures implemented on $WG(Q_2,Q_2;RT_{[
 
 <h4>Convergence table</h4>
 
-This is the convergence table of $L_2$ errors of pressure, velocity and flux on $\mbox{WG}(Q_2,Q_2;RT_{[2]})$
+This is the convergence table of $L_2$ errors of pressure, velocity and flux 
+on $\mbox{WG}(Q_2,Q_2;RT_{[2]})$
 
 <table align="center">
   <tr>


### PR DESCRIPTION
No content changes. I'll get to that next, but thought I'd get this
one out of the way because it would make reviewing any follow-up
patch rather awkward.