### PR TITLE
Reduce chunk_size used in CUDA kernels from 8 to 1

### DIFF
--- a/doc/news/changes/minor/20190423BrunoTurcksin
+++ b/doc/news/changes/minor/20190423BrunoTurcksin
@@ -1,0 +1,4 @@
+Changed: The chunk_size used in CUDA kernels has been reduced from 8 to 1 to
+improve performance on newer architectures.
+<br>
+(Bruno Turcksin, 2019/04/23)

--- a/include/deal.II/base/cuda_size.h
+++ b/include/deal.II/base/cuda_size.h
@@ -23,14 +23,16 @@ DEAL_II_NAMESPACE_OPEN
 namespace CUDAWrappers
 {
   /**
-   * Define the size of a block when launching a CUDA kernel.
+   * Define the size of a block when launching a CUDA kernel. This number can be
+   * changed depending on the architecture the code is running on.
    */
   constexpr int block_size = 512;
 
   /**
-   * Define the size of chunk of data worked on by a thread.
+   * Define the size of chunk of data worked on by a thread. This number can be
+   * changed depending on the architecture the code is running on.
    */
-  constexpr int chunk_size = 8;
+  constexpr int chunk_size = 1;
 } // namespace CUDAWrappers
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
I'd like to change the default size of the chunk size in the kernels. The previous was 8 because that's what Karl was using but I have no idea how he picked it. However, I have been told that we get better result choosing 1 on Volta architecture. So I would like something that works better out-of-the-box for the majority of users. I have also added a comment that this is a parameter that should probably be tweaked for you architecture.