### PR TITLE
step-40 disable logic with complex PETSc

### DIFF
--- a/examples/step-40/CMakeLists.txt
+++ b/examples/step-40/CMakeLists.txt
@@ -37,7 +37,7 @@ ENDIF()
 #
 # Are all dependencies fulfilled?
 #
-IF(NOT (DEAL_II_WITH_PETSC OR DEAL_II_WITH_TRILINOS) OR NOT DEAL_II_WITH_P4EST OR DEAL_II_PETSC_WITH_COMPLEX) # keep in one line
+IF(NOT ((DEAL_II_WITH_PETSC AND NOT DEAL_II_PETSC_WITH_COMPLEX) OR DEAL_II_WITH_TRILINOS) OR NOT DEAL_II_WITH_P4EST) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_PETSC = ON

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -39,7 +39,7 @@
 // if we are using PETSc (see solve() for an example where this is necessary)
 namespace LA
 {
-#if defined(DEAL_II_WITH_PETSC) && \
+#if defined(DEAL_II_WITH_PETSC) && !defined(DEAL_II_PETSC_WITH_COMPLEX) && \
   !(defined(DEAL_II_WITH_TRILINOS) && defined(FORCE_USE_OF_TRILINOS))
   using namespace dealii::LinearAlgebraPETSc;
 #  define USE_PETSC_LA


### PR DESCRIPTION
Having PETSC_WITH_COMPLEX would stop step-40 from being able to
configure/build. Now we fall back to Trilinos as described in the error
message.

part of #7946