### PR TITLE
Documentation fix Physics::Transformations::Rotations::rotation_matrix_2d

### DIFF
--- a/include/deal.II/physics/transformations.h
+++ b/include/deal.II/physics/transformations.h
@@ -44,8 +44,8 @@ namespace Physics
        * Return the rotation matrix for 2-d Euclidean space, namely
        * @f[
        *  \mathbf{R} \dealcoloneq \left[ \begin{array}{cc}
-       *  cos(\theta) & sin(\theta) \\
-       *  -sin(\theta) & cos(\theta)
+       *  cos(\theta) & -sin(\theta) \\
+       *  sin(\theta) & cos(\theta)
        * \end{array}\right]
        * @f]
        * where $\theta$ is the rotation angle given in radians. In particular,


### PR DESCRIPTION
The documentation apparently has a sign error, as observed by my student Daniel Appel. The implementation here https://github.com/dealii/dealii/blob/master/include/deal.II/physics/transformations.h#L953-L954 indeed implies the `-` sign in the top row.