### PR TITLE
Fix a mistaken assertion that only succeeds by accident.

### DIFF
--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -1742,7 +1742,7 @@ namespace Step18
           Assert(local_quadrature_points_history >=
                    &quadrature_point_history.front(),
                  ExcInternalError());
-          Assert(local_quadrature_points_history <
+          Assert(local_quadrature_points_history <=
                    &quadrature_point_history.back(),
                  ExcInternalError());
 


### PR DESCRIPTION
Specifically, it succeeds because we get a pointer to the first of a block of
elements where the size of the block is greater than one. If one had a 1-point
quadrature formula, the assertion would fail.

See also the discussion in https://github.com/dealii/dealii/pull/6747/files#r277197764
as part of #6747.