### PR TITLE
Clean up CUDAWrappers::MatrixFree::reinit interface

### DIFF
--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -156,35 +156,7 @@ namespace CUDAWrappers
      * degrees of freedom, the DoFHandler and the mapping describe the
      * transformation from unit to real cell, and the finite element
      * underlying the DoFHandler together with the quadrature formula
-     * describe the local operations. This function supports distributed
-     * computation (MPI).
-     */
-    void
-    reinit(const Mapping<dim> &             mapping,
-           const DoFHandler<dim> &          dof_handler,
-           const AffineConstraints<Number> &constraints,
-           const Quadrature<1> &            quad,
-           const MPI_Comm &                 comm,
-           const AdditionalData             additional_data = AdditionalData());
-
-    /**
-     * Initializes the data structures. Same as above but using a Q1 mapping.
-     */
-    void
-    reinit(const DoFHandler<dim> &          dof_handler,
-           const AffineConstraints<Number> &constraints,
-           const Quadrature<1> &            quad,
-           const MPI_Comm &                 comm,
-           const AdditionalData             AdditionalData = AdditionalData());
-
-    /**
-     * Extracts the information needed to perform loops over cells. The
-     * DoFHandler and AffineConstraints objects describe the layout of
-     * degrees of freedom, the DoFHandler and the mapping describe the
-     * transformation from unit to real cell, and the finite element
-     * underlying the DoFHandler together with the quadrature formula
-     * describe the local operations. This function does not support distributed
-     * computation.
+     * describe the local operations.
      */
     void
     reinit(const Mapping<dim> &             mapping,

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -539,47 +539,21 @@ namespace CUDAWrappers
                                   const DoFHandler<dim> &          dof_handler,
                                   const AffineConstraints<Number> &constraints,
                                   const Quadrature<1> &            quad,
-                                  const MPI_Comm &                 comm,
                                   const AdditionalData additional_data)
   {
-    internal_reinit(mapping,
-                    dof_handler,
-                    constraints,
-                    quad,
-                    std::make_shared<const MPI_Comm>(comm),
-                    additional_data);
-  }
-
-
-
-  template <int dim, typename Number>
-  void
-  MatrixFree<dim, Number>::reinit(const DoFHandler<dim> &          dof_handler,
-                                  const AffineConstraints<Number> &constraints,
-                                  const Quadrature<1> &            quad,
-                                  const MPI_Comm &                 comm,
-                                  const AdditionalData additional_data)
-  {
-    internal_reinit(StaticMappingQ1<dim>::mapping,
-                    dof_handler,
-                    constraints,
-                    quad,
-                    std::make_shared<const MPI_Comm>(comm),
-                    additional_data);
-  }
-
-
-
-  template <int dim, typename Number>
-  void
-  MatrixFree<dim, Number>::reinit(const Mapping<dim> &             mapping,
-                                  const DoFHandler<dim> &          dof_handler,
-                                  const AffineConstraints<Number> &constraints,
-                                  const Quadrature<1> &            quad,
-                                  const AdditionalData additional_data)
-  {
-    internal_reinit(
-      mapping, dof_handler, constraints, quad, nullptr, additional_data);
+    const auto &triangulation = dof_handler.get_triangulation();
+    if (const auto parallel_triangulation =
+          dynamic_cast<const parallel::Triangulation<dim> *>(&triangulation))
+      internal_reinit(mapping,
+                      dof_handler,
+                      constraints,
+                      quad,
+                      std::make_shared<const MPI_Comm>(
+                        parallel_triangulation->get_communicator()),
+                      additional_data);
+    else
+      internal_reinit(
+        mapping, dof_handler, constraints, quad, nullptr, additional_data);
   }
 
 
@@ -591,12 +565,11 @@ namespace CUDAWrappers
                                   const Quadrature<1> &            quad,
                                   const AdditionalData additional_data)
   {
-    internal_reinit(StaticMappingQ1<dim>::mapping,
-                    dof_handler,
-                    constraints,
-                    quad,
-                    nullptr,
-                    additional_data);
+    reinit(StaticMappingQ1<dim>::mapping,
+           dof_handler,
+           constraints,
+           quad,
+           additional_data);
   }
 
 

--- a/tests/cuda/matrix_free_matrix_vector_10.cu
+++ b/tests/cuda/matrix_free_matrix_vector_10.cu
@@ -112,8 +112,7 @@ test()
   additional_data.mapping_update_flags = update_values | update_gradients |
                                          update_JxW_values |
                                          update_quadrature_points;
-  mf_data.reinit(
-    mapping, dof, constraints, quad, MPI_COMM_WORLD, additional_data);
+  mf_data.reinit(mapping, dof, constraints, quad, additional_data);
 
   const unsigned int coef_size =
     tria.n_locally_owned_active_cells() * std::pow(fe_degree + 1, dim);

--- a/tests/cuda/matrix_free_matrix_vector_10a.cu
+++ b/tests/cuda/matrix_free_matrix_vector_10a.cu
@@ -114,8 +114,7 @@ test()
   additional_data.mapping_update_flags = update_values | update_gradients |
                                          update_JxW_values |
                                          update_quadrature_points;
-  mf_data.reinit(
-    mapping, dof, constraints, quad, MPI_COMM_WORLD, additional_data);
+  mf_data.reinit(mapping, dof, constraints, quad, additional_data);
 
   const unsigned int coef_size =
     tria.n_locally_owned_active_cells() * std::pow(fe_degree + 1, dim);

--- a/tests/cuda/matrix_free_matrix_vector_19.cu
+++ b/tests/cuda/matrix_free_matrix_vector_19.cu
@@ -108,8 +108,7 @@ test()
   additional_data.mapping_update_flags = update_values | update_gradients |
                                          update_JxW_values |
                                          update_quadrature_points;
-  mf_data.reinit(
-    mapping, dof, constraints, quad, MPI_COMM_WORLD, additional_data);
+  mf_data.reinit(mapping, dof, constraints, quad, additional_data);
 
   const unsigned int coef_size =
     tria.n_locally_owned_active_cells() * std::pow(fe_degree + 1, dim);


### PR DESCRIPTION
There is no need to force the user to explicitly provide a `MPI_Communicator`. It is available through the `DoFHandler` argument.