### PR TITLE
Deal with empty ranges in CUDAWrappers::MatrixFree::internal_reinit

### DIFF
--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -894,7 +894,8 @@ namespace CUDAWrappers
       }
 
     // Setup row starts
-    row_start[0] = 0;
+    if (n_colors > 0)
+      row_start[0] = 0;
     for (unsigned int i = 1; i < n_colors; ++i)
       row_start[i] = row_start[i - 1] + n_cells[i - 1] * get_padding_length();
 

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -866,8 +866,9 @@ namespace CUDAWrappers
       return internal::get_conflict_indices<dim, Number>(filter, constraints);
     };
 
-    std::vector<std::vector<CellFilter>> graph =
-      GraphColoring::make_graph_coloring(begin, end, fun);
+    std::vector<std::vector<CellFilter>> graph;
+    if (begin != end)
+      graph = GraphColoring::make_graph_coloring(begin, end, fun);
     n_colors = graph.size();
 
     helper.setup_color_arrays(n_colors);
@@ -894,8 +895,8 @@ namespace CUDAWrappers
 
     // Setup row starts
     row_start[0] = 0;
-    for (unsigned int i = 0; i < n_colors - 1; ++i)
-      row_start[i + 1] = row_start[i] + n_cells[i] * get_padding_length();
+    for (unsigned int i = 1; i < n_colors; ++i)
+      row_start[i] = row_start[i - 1] + n_cells[i - 1] * get_padding_length();
 
     // Constrained indices
     n_constrained_dofs = constraints.n_constraints();

--- a/tests/cuda/matrix_free_reinit_01.cu
+++ b/tests/cuda/matrix_free_reinit_01.cu
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test that initializing with CUDAWrappers::MatrixFree with empty ranges work.
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/affine_constraints.h>
+
+#include <deal.II/matrix_free/cuda_matrix_free.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  typedef double Number;
+
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(1);
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+
+  IndexSet owned_set = dof.locally_owned_dofs();
+  IndexSet relevant_set;
+  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+
+  deallog << "locally owned dofs :" << std::endl;
+  owned_set.print(deallog.get_file_stream());
+
+  deallog << "locally relevant dofs :" << std::endl;
+  owned_set.print(deallog.get_file_stream());
+
+  AffineConstraints<double> constraints(relevant_set);
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  VectorTools::interpolate_boundary_values(dof,
+                                           0,
+                                           Functions::ZeroFunction<dim>(),
+                                           constraints);
+  constraints.close();
+
+  MappingQGeneric<dim>                  mapping(fe_degree);
+  CUDAWrappers::MatrixFree<dim, Number> mf_data;
+  const QGauss<1>                       quad(fe_degree + 1);
+  typename CUDAWrappers::MatrixFree<dim, Number>::AdditionalData
+    additional_data;
+  additional_data.mapping_update_flags = update_values | update_gradients |
+                                         update_JxW_values |
+                                         update_quadrature_points;
+  mf_data.reinit(mapping, dof, constraints, quad, additional_data);
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+
+  unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  deallog.push(Utilities::int_to_string(myid));
+
+  init_cuda(true);
+  MPILogInitAll mpi_inilog;
+
+  test<2, 1>();
+}

--- a/tests/cuda/matrix_free_reinit_01.with_mpi=on.with_p4est=on.mpirun=2.output
+++ b/tests/cuda/matrix_free_reinit_01.with_mpi=on.with_p4est=on.mpirun=2.output
@@ -1,0 +1,13 @@
+
+DEAL:0:0::locally owned dofs :
+{[0,8]}
+DEAL:0:0::locally relevant dofs :
+{[0,8]}
+DEAL:0:0::OK
+
+DEAL:1:1::locally owned dofs :
+{}
+DEAL:1:1::locally relevant dofs :
+{}
+DEAL:1:1::OK
+


### PR DESCRIPTION
`GraphColoring::make_graph_coloring` does not allow for empty ranges so we get errors in `CUDAWrappers::MatrixFree::internal_reinit` as well. This pull request just omits initializing the graph at all in this case.