### PR TITLE
Use integers in cudaMemset

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -349,7 +349,7 @@ namespace LinearAlgebra
           Number *    result_device;
           cudaError_t error_code = cudaMalloc(&result_device, sizeof(Number));
           AssertCuda(error_code);
-          error_code = cudaMemset(result_device, Number(), sizeof(Number));
+          error_code = cudaMemset(result_device, 0, sizeof(Number));
 
           const int n_blocks =
             1 + (size - 1) / (::dealii::CUDAWrappers::chunk_size *

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -2363,7 +2363,7 @@ namespace internal
         cudaError_t error_code =
           cudaMalloc(&result_device, size * sizeof(Number));
         AssertCuda(error_code);
-        error_code = cudaMemset(result_device, Number(), sizeof(Number));
+        error_code = cudaMemset(result_device, 0, sizeof(Number));
 
         const int n_blocks = 1 + (size - 1) / (chunk_size * block_size);
         ::dealii::LinearAlgebra::CUDAWrappers::kernel::double_vector_reduction<
@@ -2414,7 +2414,7 @@ namespace internal
         Number *    result_device;
         cudaError_t error_code = cudaMalloc(&result_device, sizeof(Number));
         AssertCuda(error_code);
-        error_code = cudaMemset(result_device, Number(), sizeof(Number));
+        error_code = cudaMemset(result_device, 0, sizeof(Number));
 
         const int n_blocks = 1 + (size - 1) / (chunk_size * block_size);
         ::dealii::LinearAlgebra::CUDAWrappers::kernel::reduction<
@@ -2451,7 +2451,7 @@ namespace internal
         Number *    result_device;
         cudaError_t error_code = cudaMalloc(&result_device, sizeof(Number));
         AssertCuda(error_code);
-        error_code = cudaMemset(result_device, Number(), sizeof(Number));
+        error_code = cudaMemset(result_device, 0, sizeof(Number));
 
         const int n_blocks = 1 + (size - 1) / (chunk_size * block_size);
         ::dealii::LinearAlgebra::CUDAWrappers::kernel::reduction<
@@ -2501,7 +2501,7 @@ namespace internal
         Number *    res_d;
         cudaError_t error_code = cudaMalloc(&res_d, sizeof(Number));
         AssertCuda(error_code);
-        error_code = cudaMemset(res_d, 0., sizeof(Number));
+        error_code = cudaMemset(res_d, 0, sizeof(Number));
         AssertCuda(error_code);
 
         const int n_blocks = 1 + (size - 1) / (chunk_size * block_size);

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -313,7 +313,7 @@ namespace LinearAlgebra
       cudaError_t error_code =
         cudaMalloc(&result_device, n_elements * sizeof(Number));
       AssertCuda(error_code);
-      error_code = cudaMemset(result_device, Number(), sizeof(Number));
+      error_code = cudaMemset(result_device, 0, sizeof(Number));
 
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::double_vector_reduction<Number, kernel::DotProduct<Number>>
@@ -540,7 +540,7 @@ namespace LinearAlgebra
       Number *    result_device;
       cudaError_t error_code = cudaMalloc(&result_device, sizeof(Number));
       AssertCuda(error_code);
-      error_code = cudaMemset(result_device, Number(), sizeof(Number));
+      error_code = cudaMemset(result_device, 0, sizeof(Number));
 
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::reduction<Number, kernel::ElemSum<Number>>
@@ -571,7 +571,7 @@ namespace LinearAlgebra
       Number *    result_device;
       cudaError_t error_code = cudaMalloc(&result_device, sizeof(Number));
       AssertCuda(error_code);
-      error_code = cudaMemset(result_device, Number(), sizeof(Number));
+      error_code = cudaMemset(result_device, 0, sizeof(Number));
 
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::reduction<Number, kernel::L1Norm<Number>>
@@ -619,7 +619,7 @@ namespace LinearAlgebra
       Number *    result_device;
       cudaError_t error_code = cudaMalloc(&result_device, sizeof(Number));
       AssertCuda(error_code);
-      error_code = cudaMemset(result_device, Number(), sizeof(Number));
+      error_code = cudaMemset(result_device, 0, sizeof(Number));
 
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::reduction<Number, kernel::LInfty<Number>>
@@ -667,7 +667,7 @@ namespace LinearAlgebra
       Number *    result_device;
       cudaError_t error_code = cudaMalloc(&result_device, sizeof(Number));
       AssertCuda(error_code);
-      error_code = cudaMemset(result_device, 0., sizeof(Number));
+      error_code = cudaMemset(result_device, 0, sizeof(Number));
       AssertCuda(error_code);
 
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);


### PR DESCRIPTION
The interface for `cudaMemset` is
```
cudaError_t cudaMemset ( void * devPtr, int value, size_t count)
```
and the value to be set should be an integer.
