### PR TITLE
Updating Ginkgo wrapper after Ginkgo's release 1.0.0

### DIFF
--- a/doc/external-libs/ginkgo.html
+++ b/doc/external-libs/ginkgo.html
@@ -48,17 +48,17 @@
                                       target="_top">Ginkgo</a>.
         The different flags that can be added are:
         <ul>
-           <li> <code> -DBUILD_REFERENCE={ON,OFF}</code>: Builds the reference single thread implementation
+           <li> <code> -DGINKGO_BUILD_REFERENCE={ON,OFF}</code>: Builds the reference single thread implementation
         used to check the more sophisticated implementations of the GPU/CPU.
-           <li> <code> -DBUILD_CUDA={ON,OFF}</code>: Builds the GPU implementation, specifically the NVIDIA
+           <li> <code> -DGINKGO_BUILD_CUDA={ON,OFF}</code>: Builds the GPU implementation, specifically the NVIDIA
         CUDA implementations. This needs CUDA to be installed on the machine.
-           <li> <code> -DBUILD_OMP={ON,OFF}</code>: Builds the multithreaded OpenMP implementations.
+           <li> <code> -DGINKGO_BUILD_OMP={ON,OFF}</code>: Builds the multithreaded OpenMP implementations.
         </ul>
         To install Ginkgo, you would need to:
       <pre>
 	git clone https://github.com/ginkgo-project/ginkgo.git
-  mkdir build; cd build 
-  cmake -DBUILD_REFERENCE=on/off -DBUILD_CUDA=on/off -DBUILD_OMP=on/off -DCMAKE_INSTALL_PREFIX=/path/to/install/ -DCMAKE_BUILD_TYPE=Debug
+  mkdir build; cd build
+  cmake -DGINKGO_BUILD_REFERENCE=on/off -DGINKGO_BUILD_CUDA=on/off -DGINKGO_BUILD_OMP=on/off -DCMAKE_INSTALL_PREFIX=/path/to/install/ -DCMAKE_BUILD_TYPE=Release/Debug
 	make install
       </pre>
     </p>

--- a/include/deal.II/lac/ginkgo_solver.h
+++ b/include/deal.II/lac/ginkgo_solver.h
@@ -99,8 +99,7 @@ namespace GinkgoWrappers
      * The @p solver_control object is the same as for other
      * deal.II iterative solvers.
      */
-    SolverBase(SolverControl &                solver_control,
-               std::string exec_type);
+    SolverBase(SolverControl &solver_control, std::string exec_type);
 
     /**
      * Destructor.
@@ -228,25 +227,26 @@ namespace GinkgoWrappers
      *
      * @p exec_type The execution paradigm for the CG solver.
      */
-    SolverCG(SolverControl &                solver_control,
-             std::string exec_type,
-             const AdditionalData &         data = AdditionalData());
+    SolverCG(SolverControl &       solver_control,
+             std::string           exec_type,
+             const AdditionalData &data = AdditionalData());
 
-  /**
-   * Constructor.
-   *
-   * @p solver_control The solver control object is then used to set the
-   * parameters and setup the CG solver from the CG factory which solves the
-   * linear system.
-   *
-   * @p exec_type The execution paradigm for the CG solver.
-   *
-   * @p preconditioner The preconditioner for the solver.
-   */
-  SolverCG(SolverControl &                solver_control,
-           std::string exec_type,
-           std::shared_ptr<gko::LinOpFactory> preconditioner,
-           const AdditionalData &         data = AdditionalData());
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the CG solver from the CG factory which solves the
+     * linear system.
+     *
+     * @p exec_type The execution paradigm for the CG solver.
+     *
+     * @p preconditioner The preconditioner for the solver.
+     */
+    SolverCG(SolverControl &                    solver_control,
+             std::string                        exec_type,
+             std::shared_ptr<gko::LinOpFactory> preconditioner,
+             const AdditionalData &             data = AdditionalData());
+
   protected:
     /**
      * Store a copy of the settings for this particular solver.
@@ -274,30 +274,31 @@ namespace GinkgoWrappers
      * Constructor.
      *
      * @p solver_control The solver control object is then used to set the
-     * parameters and setup the BICGSTAB solver from the BICGSTAB factory which solves the
-     * linear system.
+     * parameters and setup the BICGSTAB solver from the BICGSTAB factory which
+     * solves the linear system.
      *
      * @p exec_type The execution paradigm for the BICGSTAB solver.
      */
-    SolverBICGSTAB(SolverControl &                solver_control,
-             std::string exec_type,
-             const AdditionalData &         data = AdditionalData());
+    SolverBICGSTAB(SolverControl &       solver_control,
+                   std::string           exec_type,
+                   const AdditionalData &data = AdditionalData());
 
-  /**
-   * Constructor.
-   *
-   * @p solver_control The solver control object is then used to set the
-   * parameters and setup the BICGSTAB solver from the BICGSTAB factory which solves the
-   * linear system.
-   *
-   * @p exec_type The execution paradigm for the BICGSTAB solver.
-   *
-   * @p preconditioner The preconditioner for the solver.
-   */
-  SolverBICGSTAB(SolverControl &                solver_control,
-           std::string exec_type,
-           std::shared_ptr<gko::LinOpFactory> preconditioner,
-           const AdditionalData &         data = AdditionalData());
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the BICGSTAB solver from the BICGSTAB factory which
+     * solves the linear system.
+     *
+     * @p exec_type The execution paradigm for the BICGSTAB solver.
+     *
+     * @p preconditioner The preconditioner for the solver.
+     */
+    SolverBICGSTAB(SolverControl &                    solver_control,
+                   std::string                        exec_type,
+                   std::shared_ptr<gko::LinOpFactory> preconditioner,
+                   const AdditionalData &             data = AdditionalData());
+
   protected:
     /**
      * Store a copy of the settings for this particular solver.
@@ -311,7 +312,7 @@ namespace GinkgoWrappers
    * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
-  class SolverCGS: public SolverBase<ValueType, IndexType>
+  class SolverCGS : public SolverBase<ValueType, IndexType>
   {
   public:
     /**
@@ -329,25 +330,26 @@ namespace GinkgoWrappers
      *
      * @p exec_type The execution paradigm for the CGS solver.
      */
-    SolverCGS(SolverControl &                solver_control,
-             std::string exec_type,
-             const AdditionalData &         data = AdditionalData());
+    SolverCGS(SolverControl &       solver_control,
+              std::string           exec_type,
+              const AdditionalData &data = AdditionalData());
 
-  /**
-   * Constructor.
-   *
-   * @p solver_control The solver control object is then used to set the
-   * parameters and setup the CGS solver from the CGS factory which solves the
-   * linear system.
-   *
-   * @p exec_type The execution paradigm for the CGS solver.
-   *
-   * @p preconditioner The preconditioner for the solver.
-   */
-  SolverCGS(SolverControl &                solver_control,
-           std::string exec_type,
-           std::shared_ptr<gko::LinOpFactory> preconditioner,
-           const AdditionalData &         data = AdditionalData());
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the CGS solver from the CGS factory which solves the
+     * linear system.
+     *
+     * @p exec_type The execution paradigm for the CGS solver.
+     *
+     * @p preconditioner The preconditioner for the solver.
+     */
+    SolverCGS(SolverControl &                    solver_control,
+              std::string                        exec_type,
+              std::shared_ptr<gko::LinOpFactory> preconditioner,
+              const AdditionalData &             data = AdditionalData());
+
   protected:
     /**
      * Store a copy of the settings for this particular solver.
@@ -361,7 +363,7 @@ namespace GinkgoWrappers
    * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
-  class SolverFCG: public SolverBase<ValueType, IndexType>
+  class SolverFCG : public SolverBase<ValueType, IndexType>
   {
   public:
     /**
@@ -379,25 +381,26 @@ namespace GinkgoWrappers
      *
      * @p exec_type The execution paradigm for the FCG solver.
      */
-    SolverFCG(SolverControl &                solver_control,
-             std::string exec_type,
-             const AdditionalData &         data = AdditionalData());
+    SolverFCG(SolverControl &       solver_control,
+              std::string           exec_type,
+              const AdditionalData &data = AdditionalData());
 
-  /**
-   * Constructor.
-   *
-   * @p solver_control The solver control object is then used to set the
-   * parameters and setup the FCG solver from the FCG factory which solves the
-   * linear system.
-   *
-   * @p exec_type The execution paradigm for the FCG solver.
-   *
-   * @p preconditioner The preconditioner for the solver.
-   */
-  SolverFCG(SolverControl &                solver_control,
-           std::string exec_type,
-           std::shared_ptr<gko::LinOpFactory> preconditioner,
-           const AdditionalData &         data = AdditionalData());
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the FCG solver from the FCG factory which solves the
+     * linear system.
+     *
+     * @p exec_type The execution paradigm for the FCG solver.
+     *
+     * @p preconditioner The preconditioner for the solver.
+     */
+    SolverFCG(SolverControl &                    solver_control,
+              std::string                        exec_type,
+              std::shared_ptr<gko::LinOpFactory> preconditioner,
+              const AdditionalData &             data = AdditionalData());
+
   protected:
     /**
      * Store a copy of the settings for this particular solver.
@@ -411,55 +414,55 @@ namespace GinkgoWrappers
    * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
-  class SolverGMRES: public SolverBase<ValueType, IndexType>
+  class SolverGMRES : public SolverBase<ValueType, IndexType>
   {
   public:
     /**
      * A standardized data struct to pipe additional data to the solver.
      */
     struct AdditionalData
-  {
-    /**
-     * Constructor. By default, set the number of temporary vectors to 30,
-     * i.e. do a restart every 30 iterations.
-     */
-    AdditionalData(const unsigned int restart_parameter     = 30);
+    {
+      /**
+       * Constructor. By default, set the number of temporary vectors to 30,
+       * i.e. do a restart every 30 iterations.
+       */
+      AdditionalData(const unsigned int restart_parameter = 30);
 
-    /**
-     * Maximum number of tmp vectors.
-     */
-    unsigned int restart_parameter;
-
+      /**
+       * Maximum number of tmp vectors.
+       */
+      unsigned int restart_parameter;
     };
 
     /**
      * Constructor.
      *
      * @p solver_control The solver control object is then used to set the
-     * parameters and setup the GMRES solver from the GMRES factory which solves the
-     * linear system.
+     * parameters and setup the GMRES solver from the GMRES factory which solves
+     * the linear system.
      *
      * @p exec_type The execution paradigm for the GMRES solver.
      */
-    SolverGMRES(SolverControl &                solver_control,
-             std::string exec_type,
-             const AdditionalData &         data = AdditionalData());
+    SolverGMRES(SolverControl &       solver_control,
+                std::string           exec_type,
+                const AdditionalData &data = AdditionalData());
 
-  /**
-   * Constructor.
-   *
-   * @p solver_control The solver control object is then used to set the
-   * parameters and setup the GMRES solver from the GMRES factory which solves the
-   * linear system.
-   *
-   * @p exec_type The execution paradigm for the GMRES solver.
-   *
-   * @p preconditioner The preconditioner for the solver.
-   */
-  SolverGMRES(SolverControl &                solver_control,
-           std::string exec_type,
-           std::shared_ptr<gko::LinOpFactory> preconditioner,
-           const AdditionalData &         data = AdditionalData());
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the GMRES solver from the GMRES factory which solves
+     * the linear system.
+     *
+     * @p exec_type The execution paradigm for the GMRES solver.
+     *
+     * @p preconditioner The preconditioner for the solver.
+     */
+    SolverGMRES(SolverControl &                    solver_control,
+                std::string                        exec_type,
+                std::shared_ptr<gko::LinOpFactory> preconditioner,
+                const AdditionalData &             data = AdditionalData());
+
   protected:
     /**
      * Store a copy of the settings for this particular solver.
@@ -473,7 +476,7 @@ namespace GinkgoWrappers
    * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
-  class SolverIR: public SolverBase<ValueType, IndexType>
+  class SolverIR : public SolverBase<ValueType, IndexType>
   {
   public:
     /**
@@ -491,25 +494,25 @@ namespace GinkgoWrappers
      *
      * @p exec_type The execution paradigm for the IR solver.
      */
-    SolverIR(SolverControl &                solver_control,
-             std::string exec_type,
-             const AdditionalData &         data = AdditionalData());
+    SolverIR(SolverControl &       solver_control,
+             std::string           exec_type,
+             const AdditionalData &data = AdditionalData());
 
-  /**
-   * Constructor.
-   *
-   * @p solver_control The solver control object is then used to set the
-   * parameters and setup the IR solver from the IR factory which solves the
-   * linear system.
-   *
-   * @p exec_type The execution paradigm for the IR solver.
-   *
-   * @p inner_solver The Inner solver for the IR solver.
-   */
-  SolverIR(SolverControl &                solver_control,
-           std::string exec_type,
-           std::shared_ptr<gko::LinOpFactory> inner_solver,
-           const AdditionalData &         data = AdditionalData());
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the IR solver from the IR factory which solves the
+     * linear system.
+     *
+     * @p exec_type The execution paradigm for the IR solver.
+     *
+     * @p inner_solver The Inner solver for the IR solver.
+     */
+    SolverIR(SolverControl &                    solver_control,
+             std::string                        exec_type,
+             std::shared_ptr<gko::LinOpFactory> inner_solver,
+             const AdditionalData &             data = AdditionalData());
 
   protected:
     /**

--- a/include/deal.II/lac/ginkgo_solver.h
+++ b/include/deal.II/lac/ginkgo_solver.h
@@ -54,6 +54,9 @@ namespace GinkgoWrappers
      * Constructor.
      *
      * The @p exec_type defines the paradigm where the solution is computed.
+     * It is a string and the choices are "omp" , "reference" or "cuda".
+     * The respective strings create the respective executors as given below.
+     *
      * Ginkgo currently supports three different executor types:
      *
      * +    OmpExecutor specifies that the data should be stored and the
@@ -99,7 +102,7 @@ namespace GinkgoWrappers
      * The @p solver_control object is the same as for other
      * deal.II iterative solvers.
      */
-    SolverBase(SolverControl &solver_control, std::string exec_type);
+    SolverBase(SolverControl &solver_control, const std::string &exec_type);
 
     /**
      * Destructor.
@@ -195,11 +198,11 @@ namespace GinkgoWrappers
     std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>> system_matrix;
 
     /**
-     * The execution paradigm to be set by the user. The choices are between
-     * `omp`, `cuda` and `reference`
-     * and more details can be found in Ginkgo's documentation.
+     * The execution paradigm as a string to be set by the user . The choices
+     * are between `omp`, `cuda` and `reference` and more details can be found
+     * in Ginkgo's documentation.
      */
-    std::string exec_type;
+    const std::string exec_type;
   };
 
 
@@ -228,7 +231,7 @@ namespace GinkgoWrappers
      * @p exec_type The execution paradigm for the CG solver.
      */
     SolverCG(SolverControl &       solver_control,
-             std::string           exec_type,
+             const std::string &   exec_type,
              const AdditionalData &data = AdditionalData());
 
     /**
@@ -242,10 +245,10 @@ namespace GinkgoWrappers
      *
      * @p preconditioner The preconditioner for the solver.
      */
-    SolverCG(SolverControl &                    solver_control,
-             std::string                        exec_type,
-             std::shared_ptr<gko::LinOpFactory> preconditioner,
-             const AdditionalData &             data = AdditionalData());
+    SolverCG(SolverControl &                           solver_control,
+             const std::string &                       exec_type,
+             const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+             const AdditionalData &                    data = AdditionalData());
 
   protected:
     /**
@@ -256,12 +259,12 @@ namespace GinkgoWrappers
 
 
   /**
-   * An implementation of the solver interface using the Ginkgo BICGSTAB solver.
+   * An implementation of the solver interface using the Ginkgo Bicgstab solver.
    *
    * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
-  class SolverBICGSTAB : public SolverBase<ValueType, IndexType>
+  class SolverBicgstab : public SolverBase<ValueType, IndexType>
   {
   public:
     /**
@@ -274,30 +277,30 @@ namespace GinkgoWrappers
      * Constructor.
      *
      * @p solver_control The solver control object is then used to set the
-     * parameters and setup the BICGSTAB solver from the BICGSTAB factory which
+     * parameters and setup the Bicgstab solver from the Bicgstab factory which
      * solves the linear system.
      *
-     * @p exec_type The execution paradigm for the BICGSTAB solver.
+     * @p exec_type The execution paradigm for the Bicgstab solver.
      */
-    SolverBICGSTAB(SolverControl &       solver_control,
-                   std::string           exec_type,
+    SolverBicgstab(SolverControl &       solver_control,
+                   const std::string &   exec_type,
                    const AdditionalData &data = AdditionalData());
 
     /**
      * Constructor.
      *
      * @p solver_control The solver control object is then used to set the
-     * parameters and setup the BICGSTAB solver from the BICGSTAB factory which
+     * parameters and setup the Bicgstab solver from the Bicgstab factory which
      * solves the linear system.
      *
-     * @p exec_type The execution paradigm for the BICGSTAB solver.
+     * @p exec_type The execution paradigm for the Bicgstab solver.
      *
      * @p preconditioner The preconditioner for the solver.
      */
-    SolverBICGSTAB(SolverControl &                    solver_control,
-                   std::string                        exec_type,
-                   std::shared_ptr<gko::LinOpFactory> preconditioner,
-                   const AdditionalData &             data = AdditionalData());
+    SolverBicgstab(SolverControl &                           solver_control,
+                   const std::string &                       exec_type,
+                   const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+                   const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -331,7 +334,7 @@ namespace GinkgoWrappers
      * @p exec_type The execution paradigm for the CGS solver.
      */
     SolverCGS(SolverControl &       solver_control,
-              std::string           exec_type,
+              const std::string &   exec_type,
               const AdditionalData &data = AdditionalData());
 
     /**
@@ -345,10 +348,10 @@ namespace GinkgoWrappers
      *
      * @p preconditioner The preconditioner for the solver.
      */
-    SolverCGS(SolverControl &                    solver_control,
-              std::string                        exec_type,
-              std::shared_ptr<gko::LinOpFactory> preconditioner,
-              const AdditionalData &             data = AdditionalData());
+    SolverCGS(SolverControl &                           solver_control,
+              const std::string &                       exec_type,
+              const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+              const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -382,7 +385,7 @@ namespace GinkgoWrappers
      * @p exec_type The execution paradigm for the FCG solver.
      */
     SolverFCG(SolverControl &       solver_control,
-              std::string           exec_type,
+              const std::string &   exec_type,
               const AdditionalData &data = AdditionalData());
 
     /**
@@ -396,10 +399,10 @@ namespace GinkgoWrappers
      *
      * @p preconditioner The preconditioner for the solver.
      */
-    SolverFCG(SolverControl &                    solver_control,
-              std::string                        exec_type,
-              std::shared_ptr<gko::LinOpFactory> preconditioner,
-              const AdditionalData &             data = AdditionalData());
+    SolverFCG(SolverControl &                           solver_control,
+              const std::string &                       exec_type,
+              const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+              const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -444,7 +447,7 @@ namespace GinkgoWrappers
      * @p exec_type The execution paradigm for the GMRES solver.
      */
     SolverGMRES(SolverControl &       solver_control,
-                std::string           exec_type,
+                const std::string &   exec_type,
                 const AdditionalData &data = AdditionalData());
 
     /**
@@ -458,10 +461,10 @@ namespace GinkgoWrappers
      *
      * @p preconditioner The preconditioner for the solver.
      */
-    SolverGMRES(SolverControl &                    solver_control,
-                std::string                        exec_type,
-                std::shared_ptr<gko::LinOpFactory> preconditioner,
-                const AdditionalData &             data = AdditionalData());
+    SolverGMRES(SolverControl &                           solver_control,
+                const std::string &                       exec_type,
+                const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+                const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -495,7 +498,7 @@ namespace GinkgoWrappers
      * @p exec_type The execution paradigm for the IR solver.
      */
     SolverIR(SolverControl &       solver_control,
-             std::string           exec_type,
+             const std::string &   exec_type,
              const AdditionalData &data = AdditionalData());
 
     /**
@@ -509,10 +512,10 @@ namespace GinkgoWrappers
      *
      * @p inner_solver The Inner solver for the IR solver.
      */
-    SolverIR(SolverControl &                    solver_control,
-             std::string                        exec_type,
-             std::shared_ptr<gko::LinOpFactory> inner_solver,
-             const AdditionalData &             data = AdditionalData());
+    SolverIR(SolverControl &                           solver_control,
+             const std::string &                       exec_type,
+             const std::shared_ptr<gko::LinOpFactory> &inner_solver,
+             const AdditionalData &                    data = AdditionalData());
 
   protected:
     /**

--- a/include/deal.II/lac/ginkgo_solver.h
+++ b/include/deal.II/lac/ginkgo_solver.h
@@ -100,7 +100,7 @@ namespace GinkgoWrappers
      * deal.II iterative solvers.
      */
     SolverBase(SolverControl &                solver_control,
-               std::shared_ptr<gko::Executor> executor);
+               std::string exec_type);
 
     /**
      * Destructor.
@@ -194,6 +194,13 @@ namespace GinkgoWrappers
      * @todo Templatize based on Matrix type.
      */
     std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>> system_matrix;
+
+    /**
+     * The execution paradigm to be set by the user. The choices are between
+     * `omp`, `cuda` and `reference`
+     * and more details can be found in Ginkgo's documentation.
+     */
+    std::string exec_type;
   };
 
 
@@ -222,7 +229,7 @@ namespace GinkgoWrappers
      * @p executor The execution paradigm for the CG solver.
      */
     SolverCG(SolverControl &                solver_control,
-             std::shared_ptr<gko::Executor> executor,
+             std::string exec_type,
              const AdditionalData &         data = AdditionalData());
 
   /**
@@ -235,7 +242,7 @@ namespace GinkgoWrappers
    * @p executor The execution paradigm for the CG solver.
    */
   SolverCG(SolverControl &                solver_control,
-           std::shared_ptr<gko::Executor> executor,
+           std::string exec_type,
            std::shared_ptr<gko::LinOpFactory> preconditioner,
            const AdditionalData &         data = AdditionalData());
   protected:

--- a/include/deal.II/lac/ginkgo_solver.h
+++ b/include/deal.II/lac/ginkgo_solver.h
@@ -225,6 +225,19 @@ namespace GinkgoWrappers
              std::shared_ptr<gko::Executor> executor,
              const AdditionalData &         data = AdditionalData());
 
+  /**
+   * Constructor.
+   *
+   * @p solver_control The solver control object is then used to set the
+   * parameters and setup the CG solver from the CG factory which solves the
+   * linear system.
+   *
+   * @p executor The execution paradigm for the CG solver.
+   */
+  SolverCG(SolverControl &                solver_control,
+           std::shared_ptr<gko::Executor> executor,
+           std::shared_ptr<gko::LinOpFactory> preconditioner,
+           const AdditionalData &         data = AdditionalData());
   protected:
     /**
      * Store a copy of the settings for this particular solver.

--- a/include/deal.II/lac/ginkgo_solver.h
+++ b/include/deal.II/lac/ginkgo_solver.h
@@ -53,7 +53,7 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * The @p executor defines the paradigm where the solution is computed.
+     * The @p exec_type defines the paradigm where the solution is computed.
      * Ginkgo currently supports three different executor types:
      *
      * +    OmpExecutor specifies that the data should be stored and the
@@ -226,7 +226,7 @@ namespace GinkgoWrappers
      * parameters and setup the CG solver from the CG factory which solves the
      * linear system.
      *
-     * @p executor The execution paradigm for the CG solver.
+     * @p exec_type The execution paradigm for the CG solver.
      */
     SolverCG(SolverControl &                solver_control,
              std::string exec_type,
@@ -239,12 +239,278 @@ namespace GinkgoWrappers
    * parameters and setup the CG solver from the CG factory which solves the
    * linear system.
    *
-   * @p executor The execution paradigm for the CG solver.
+   * @p exec_type The execution paradigm for the CG solver.
+   *
+   * @p preconditioner The preconditioner for the solver.
    */
   SolverCG(SolverControl &                solver_control,
            std::string exec_type,
            std::shared_ptr<gko::LinOpFactory> preconditioner,
            const AdditionalData &         data = AdditionalData());
+  protected:
+    /**
+     * Store a copy of the settings for this particular solver.
+     */
+    const AdditionalData additional_data;
+  };
+
+
+  /**
+   * An implementation of the solver interface using the Ginkgo BICGSTAB solver.
+   *
+   * @ingroup GinkgoWrappers
+   */
+  template <typename ValueType = double, typename IndexType = int32_t>
+  class SolverBICGSTAB : public SolverBase<ValueType, IndexType>
+  {
+  public:
+    /**
+     * A standardized data struct to pipe additional data to the solver.
+     */
+    struct AdditionalData
+    {};
+
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the BICGSTAB solver from the BICGSTAB factory which solves the
+     * linear system.
+     *
+     * @p exec_type The execution paradigm for the BICGSTAB solver.
+     */
+    SolverBICGSTAB(SolverControl &                solver_control,
+             std::string exec_type,
+             const AdditionalData &         data = AdditionalData());
+
+  /**
+   * Constructor.
+   *
+   * @p solver_control The solver control object is then used to set the
+   * parameters and setup the BICGSTAB solver from the BICGSTAB factory which solves the
+   * linear system.
+   *
+   * @p exec_type The execution paradigm for the BICGSTAB solver.
+   *
+   * @p preconditioner The preconditioner for the solver.
+   */
+  SolverBICGSTAB(SolverControl &                solver_control,
+           std::string exec_type,
+           std::shared_ptr<gko::LinOpFactory> preconditioner,
+           const AdditionalData &         data = AdditionalData());
+  protected:
+    /**
+     * Store a copy of the settings for this particular solver.
+     */
+    const AdditionalData additional_data;
+  };
+
+  /**
+   * An implementation of the solver interface using the Ginkgo CGS solver.
+   *
+   * @ingroup GinkgoWrappers
+   */
+  template <typename ValueType = double, typename IndexType = int32_t>
+  class SolverCGS: public SolverBase<ValueType, IndexType>
+  {
+  public:
+    /**
+     * A standardized data struct to pipe additional data to the solver.
+     */
+    struct AdditionalData
+    {};
+
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the CGS solver from the CGS factory which solves the
+     * linear system.
+     *
+     * @p exec_type The execution paradigm for the CGS solver.
+     */
+    SolverCGS(SolverControl &                solver_control,
+             std::string exec_type,
+             const AdditionalData &         data = AdditionalData());
+
+  /**
+   * Constructor.
+   *
+   * @p solver_control The solver control object is then used to set the
+   * parameters and setup the CGS solver from the CGS factory which solves the
+   * linear system.
+   *
+   * @p exec_type The execution paradigm for the CGS solver.
+   *
+   * @p preconditioner The preconditioner for the solver.
+   */
+  SolverCGS(SolverControl &                solver_control,
+           std::string exec_type,
+           std::shared_ptr<gko::LinOpFactory> preconditioner,
+           const AdditionalData &         data = AdditionalData());
+  protected:
+    /**
+     * Store a copy of the settings for this particular solver.
+     */
+    const AdditionalData additional_data;
+  };
+
+  /**
+   * An implementation of the solver interface using the Ginkgo FCG solver.
+   *
+   * @ingroup GinkgoWrappers
+   */
+  template <typename ValueType = double, typename IndexType = int32_t>
+  class SolverFCG: public SolverBase<ValueType, IndexType>
+  {
+  public:
+    /**
+     * A standardized data struct to pipe additional data to the solver.
+     */
+    struct AdditionalData
+    {};
+
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the FCG solver from the FCG factory which solves the
+     * linear system.
+     *
+     * @p exec_type The execution paradigm for the FCG solver.
+     */
+    SolverFCG(SolverControl &                solver_control,
+             std::string exec_type,
+             const AdditionalData &         data = AdditionalData());
+
+  /**
+   * Constructor.
+   *
+   * @p solver_control The solver control object is then used to set the
+   * parameters and setup the FCG solver from the FCG factory which solves the
+   * linear system.
+   *
+   * @p exec_type The execution paradigm for the FCG solver.
+   *
+   * @p preconditioner The preconditioner for the solver.
+   */
+  SolverFCG(SolverControl &                solver_control,
+           std::string exec_type,
+           std::shared_ptr<gko::LinOpFactory> preconditioner,
+           const AdditionalData &         data = AdditionalData());
+  protected:
+    /**
+     * Store a copy of the settings for this particular solver.
+     */
+    const AdditionalData additional_data;
+  };
+
+  /**
+   * An implementation of the solver interface using the Ginkgo GMRES solver.
+   *
+   * @ingroup GinkgoWrappers
+   */
+  template <typename ValueType = double, typename IndexType = int32_t>
+  class SolverGMRES: public SolverBase<ValueType, IndexType>
+  {
+  public:
+    /**
+     * A standardized data struct to pipe additional data to the solver.
+     */
+    struct AdditionalData
+  {
+    /**
+     * Constructor. By default, set the number of temporary vectors to 30,
+     * i.e. do a restart every 30 iterations.
+     */
+    AdditionalData(const unsigned int restart_parameter     = 30);
+
+    /**
+     * Maximum number of tmp vectors.
+     */
+    unsigned int restart_parameter;
+
+    };
+
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the GMRES solver from the GMRES factory which solves the
+     * linear system.
+     *
+     * @p exec_type The execution paradigm for the GMRES solver.
+     */
+    SolverGMRES(SolverControl &                solver_control,
+             std::string exec_type,
+             const AdditionalData &         data = AdditionalData());
+
+  /**
+   * Constructor.
+   *
+   * @p solver_control The solver control object is then used to set the
+   * parameters and setup the GMRES solver from the GMRES factory which solves the
+   * linear system.
+   *
+   * @p exec_type The execution paradigm for the GMRES solver.
+   *
+   * @p preconditioner The preconditioner for the solver.
+   */
+  SolverGMRES(SolverControl &                solver_control,
+           std::string exec_type,
+           std::shared_ptr<gko::LinOpFactory> preconditioner,
+           const AdditionalData &         data = AdditionalData());
+  protected:
+    /**
+     * Store a copy of the settings for this particular solver.
+     */
+    const AdditionalData additional_data;
+  };
+
+  /**
+   * An implementation of the solver interface using the Ginkgo IR solver.
+   *
+   * @ingroup GinkgoWrappers
+   */
+  template <typename ValueType = double, typename IndexType = int32_t>
+  class SolverIR: public SolverBase<ValueType, IndexType>
+  {
+  public:
+    /**
+     * A standardized data struct to pipe additional data to the solver.
+     */
+    struct AdditionalData
+    {};
+
+    /**
+     * Constructor.
+     *
+     * @p solver_control The solver control object is then used to set the
+     * parameters and setup the IR solver from the IR factory which solves the
+     * linear system.
+     *
+     * @p exec_type The execution paradigm for the IR solver.
+     */
+    SolverIR(SolverControl &                solver_control,
+             std::string exec_type,
+             const AdditionalData &         data = AdditionalData());
+
+  /**
+   * Constructor.
+   *
+   * @p solver_control The solver control object is then used to set the
+   * parameters and setup the IR solver from the IR factory which solves the
+   * linear system.
+   *
+   * @p exec_type The execution paradigm for the IR solver.
+   *
+   * @p inner_solver The Inner solver for the IR solver.
+   */
+  SolverIR(SolverControl &                solver_control,
+           std::string exec_type,
+           std::shared_ptr<gko::LinOpFactory> inner_solver,
+           const AdditionalData &         data = AdditionalData());
+
   protected:
     /**
      * Store a copy of the settings for this particular solver.

--- a/include/deal.II/lac/ginkgo_solver.h
+++ b/include/deal.II/lac/ginkgo_solver.h
@@ -198,7 +198,7 @@ namespace GinkgoWrappers
     std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>> system_matrix;
 
     /**
-     * The execution paradigm as a string to be set by the user . The choices
+     * The execution paradigm as a string to be set by the user. The choices
      * are between `omp`, `cuda` and `reference` and more details can be found
      * in Ginkgo's documentation.
      */
@@ -224,11 +224,13 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the CG solver from the CG factory which solves the
-     * linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the CG solver from the CG factory which
+     * solves the linear system.
      *
-     * @p exec_type The execution paradigm for the CG solver.
+     * @param[in] exec_type The execution paradigm for the CG solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverCG(SolverControl &       solver_control,
              const std::string &   exec_type,
@@ -237,13 +239,15 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the CG solver from the CG factory which solves the
-     * linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the CG solver from the CG factory which
+     * solves the linear system.
      *
-     * @p exec_type The execution paradigm for the CG solver.
+     * @param[in] exec_type The execution paradigm for the CG solver.
      *
-     * @p preconditioner The preconditioner for the solver.
+     * @param[in] preconditioner The preconditioner for the solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverCG(SolverControl &                           solver_control,
              const std::string &                       exec_type,
@@ -276,11 +280,13 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the Bicgstab solver from the Bicgstab factory which
-     * solves the linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the Bicgstab solver from the Bicgstab
+     * factory which solves the linear system.
      *
-     * @p exec_type The execution paradigm for the Bicgstab solver.
+     * @param[in] exec_type The execution paradigm for the Bicgstab solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverBicgstab(SolverControl &       solver_control,
                    const std::string &   exec_type,
@@ -289,13 +295,15 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the Bicgstab solver from the Bicgstab factory which
-     * solves the linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the Bicgstab solver from the Bicgstab
+     * factory which solves the linear system.
      *
-     * @p exec_type The execution paradigm for the Bicgstab solver.
+     * @param[in] exec_type The execution paradigm for the Bicgstab solver.
      *
-     * @p preconditioner The preconditioner for the solver.
+     * @param[in] preconditioner The preconditioner for the solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverBicgstab(SolverControl &                           solver_control,
                    const std::string &                       exec_type,
@@ -312,6 +320,9 @@ namespace GinkgoWrappers
   /**
    * An implementation of the solver interface using the Ginkgo CGS solver.
    *
+   * CGS or the conjugate gradient square method is an iterative type Krylov
+   * subspace method which is suitable for general systems.
+   *
    * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
@@ -327,11 +338,13 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the CGS solver from the CGS factory which solves the
-     * linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the CGS solver from the CGS factory which
+     * solves the linear system.
      *
-     * @p exec_type The execution paradigm for the CGS solver.
+     * @param[in] exec_type The execution paradigm for the CGS solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverCGS(SolverControl &       solver_control,
               const std::string &   exec_type,
@@ -340,13 +353,15 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the CGS solver from the CGS factory which solves the
-     * linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the CGS solver from the CGS factory which
+     * solves the linear system.
      *
-     * @p exec_type The execution paradigm for the CGS solver.
+     * @param[in] exec_type The execution paradigm for the CGS solver.
      *
-     * @p preconditioner The preconditioner for the solver.
+     * @param[in] preconditioner The preconditioner for the solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverCGS(SolverControl &                           solver_control,
               const std::string &                       exec_type,
@@ -363,6 +378,18 @@ namespace GinkgoWrappers
   /**
    * An implementation of the solver interface using the Ginkgo FCG solver.
    *
+   * FCG or the flexible conjugate gradient method is an iterative type Krylov
+   * subspace method which is suitable for symmetric positive definite methods.
+   *
+   * Though this method performs very well for symmetric positive definite
+   * matrices, it is in general not suitable for general matrices.
+   *
+   * In contrast to the standard CG based on the Polack-Ribiere formula, the
+   * flexible CG uses the Fletcher-Reeves formula for creating the orthonormal
+   * vectors spanning the Krylov subspace. This increases the computational cost
+   * of every Krylov solver iteration but allows for non-constant
+   * preconditioners.
+   *
    * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
@@ -378,11 +405,13 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the FCG solver from the FCG factory which solves the
-     * linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the FCG solver from the FCG factory which
+     * solves the linear system.
      *
-     * @p exec_type The execution paradigm for the FCG solver.
+     * @param[in] exec_type The execution paradigm for the FCG solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverFCG(SolverControl &       solver_control,
               const std::string &   exec_type,
@@ -391,13 +420,15 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the FCG solver from the FCG factory which solves the
-     * linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the FCG solver from the FCG factory which
+     * solves the linear system.
      *
-     * @p exec_type The execution paradigm for the FCG solver.
+     * @param[in] exec_type The execution paradigm for the FCG solver.
      *
-     * @p preconditioner The preconditioner for the solver.
+     * @param[in] preconditioner The preconditioner for the solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverFCG(SolverControl &                           solver_control,
               const std::string &                       exec_type,
@@ -440,11 +471,13 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the GMRES solver from the GMRES factory which solves
-     * the linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the GMRES solver from the GMRES factory
+     * which solves the linear system.
      *
-     * @p exec_type The execution paradigm for the GMRES solver.
+     * @param[in] exec_type The execution paradigm for the GMRES solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverGMRES(SolverControl &       solver_control,
                 const std::string &   exec_type,
@@ -453,13 +486,15 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the GMRES solver from the GMRES factory which solves
-     * the linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the GMRES solver from the GMRES factory
+     * which solves the linear system.
      *
-     * @p exec_type The execution paradigm for the GMRES solver.
+     * @param[in] exec_type The execution paradigm for the GMRES solver.
      *
-     * @p preconditioner The preconditioner for the solver.
+     * @param[in] preconditioner The preconditioner for the solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverGMRES(SolverControl &                           solver_control,
                 const std::string &                       exec_type,
@@ -476,6 +511,10 @@ namespace GinkgoWrappers
   /**
    * An implementation of the solver interface using the Ginkgo IR solver.
    *
+   * Iterative refinement (IR) is an iterative method that uses another coarse
+   * method to approximate the error of the current solution via the current
+   * residual.
+   *
    * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
@@ -491,11 +530,13 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the IR solver from the IR factory which solves the
-     * linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the IR solver from the IR factory which
+     * solves the linear system.
      *
-     * @p exec_type The execution paradigm for the IR solver.
+     * @param[in] exec_type The execution paradigm for the IR solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverIR(SolverControl &       solver_control,
              const std::string &   exec_type,
@@ -504,13 +545,15 @@ namespace GinkgoWrappers
     /**
      * Constructor.
      *
-     * @p solver_control The solver control object is then used to set the
-     * parameters and setup the IR solver from the IR factory which solves the
-     * linear system.
+     * @param[in,out] solver_control The solver control object is then used to
+     * set the parameters and setup the IR solver from the IR factory which
+     * solves the linear system.
      *
-     * @p exec_type The execution paradigm for the IR solver.
+     * @param[in] exec_type The execution paradigm for the IR solver.
      *
-     * @p inner_solver The Inner solver for the IR solver.
+     * @param[in] inner_solver The Inner solver for the IR solver.
+     *
+     * @param[in] data The additional data required by the solver.
      */
     SolverIR(SolverControl &                           solver_control,
              const std::string &                       exec_type,

--- a/source/lac/ginkgo_solver.cc
+++ b/source/lac/ginkgo_solver.cc
@@ -50,10 +50,10 @@ namespace GinkgoWrappers
       }
     else
       {
-        std::cerr
-          << "exec_type needs to be one of the three strings: \"reference\", \"cuda\" or \"omp\", but provided with"
-          << exec_type << std::endl;
-        std::exit(-1);
+        Assert(
+          false,
+          ExcMessage(
+            " exec_type needs to be one of the three strings: \"reference\", \"cuda\" or \"omp\" "));
       }
     using ResidualCriterionFactory = gko::stop::ResidualNormReduction<>;
     residual_criterion             = ResidualCriterionFactory::build()
@@ -69,6 +69,8 @@ namespace GinkgoWrappers
         .on(executor);
   }
 
+
+
   template <typename ValueType, typename IndexType>
   void
   SolverBase<ValueType, IndexType>::initialize_ginkgo_log()
@@ -78,6 +80,8 @@ namespace GinkgoWrappers
     convergence_logger = gko::log::Convergence<>::create(
       executor, gko::log::Logger::criterion_check_completed_mask);
   }
+
+
 
   template <typename ValueType, typename IndexType>
   void
@@ -199,12 +203,14 @@ namespace GinkgoWrappers
   }
 
 
+
   template <typename ValueType, typename IndexType>
   SolverControl &
   SolverBase<ValueType, IndexType>::control() const
   {
     return solver_control;
   }
+
 
 
   template <typename ValueType, typename IndexType>
@@ -280,6 +286,7 @@ namespace GinkgoWrappers
   }
 
 
+
   template <typename ValueType, typename IndexType>
   void
   SolverBase<ValueType, IndexType>::solve(const SparseMatrix<ValueType> &matrix,
@@ -291,8 +298,8 @@ namespace GinkgoWrappers
   }
 
 
-  /* ---------------------- SolverCG ------------------------ */
 
+  /* ---------------------- SolverCG ------------------------ */
   template <typename ValueType, typename IndexType>
   SolverCG<ValueType, IndexType>::SolverCG(SolverControl &       solver_control,
                                            const std::string &   exec_type,
@@ -304,6 +311,8 @@ namespace GinkgoWrappers
     this->solver_gen =
       cg::build().with_criteria(this->combined_factory).on(this->executor);
   }
+
+
 
   template <typename ValueType, typename IndexType>
   SolverCG<ValueType, IndexType>::SolverCG(
@@ -322,8 +331,8 @@ namespace GinkgoWrappers
   }
 
 
-  /* ---------------------- SolverBicgstab ------------------------ */
 
+  /* ---------------------- SolverBicgstab ------------------------ */
   template <typename ValueType, typename IndexType>
   SolverBicgstab<ValueType, IndexType>::SolverBicgstab(
     SolverControl &       solver_control,
@@ -337,6 +346,8 @@ namespace GinkgoWrappers
                          .with_criteria(this->combined_factory)
                          .on(this->executor);
   }
+
+
 
   template <typename ValueType, typename IndexType>
   SolverBicgstab<ValueType, IndexType>::SolverBicgstab(
@@ -354,8 +365,9 @@ namespace GinkgoWrappers
                          .on(this->executor);
   }
 
-  /* ---------------------- SolverCGS ------------------------ */
 
+
+  /* ---------------------- SolverCGS ------------------------ */
   template <typename ValueType, typename IndexType>
   SolverCGS<ValueType, IndexType>::SolverCGS(SolverControl &    solver_control,
                                              const std::string &exec_type,
@@ -367,6 +379,8 @@ namespace GinkgoWrappers
     this->solver_gen =
       cgs::build().with_criteria(this->combined_factory).on(this->executor);
   }
+
+
 
   template <typename ValueType, typename IndexType>
   SolverCGS<ValueType, IndexType>::SolverCGS(
@@ -384,8 +398,9 @@ namespace GinkgoWrappers
                          .on(this->executor);
   }
 
-  /* ---------------------- SolverFCG ------------------------ */
 
+
+  /* ---------------------- SolverFCG ------------------------ */
   template <typename ValueType, typename IndexType>
   SolverFCG<ValueType, IndexType>::SolverFCG(SolverControl &    solver_control,
                                              const std::string &exec_type,
@@ -397,6 +412,8 @@ namespace GinkgoWrappers
     this->solver_gen =
       fcg::build().with_criteria(this->combined_factory).on(this->executor);
   }
+
+
 
   template <typename ValueType, typename IndexType>
   SolverFCG<ValueType, IndexType>::SolverFCG(
@@ -414,13 +431,16 @@ namespace GinkgoWrappers
                          .on(this->executor);
   }
 
-  /* ---------------------- SolverGMRES ------------------------ */
 
+
+  /* ---------------------- SolverGMRES ------------------------ */
   template <typename ValueType, typename IndexType>
   SolverGMRES<ValueType, IndexType>::AdditionalData::AdditionalData(
     const unsigned int restart_parameter)
     : restart_parameter(restart_parameter)
   {}
+
+
 
   template <typename ValueType, typename IndexType>
   SolverGMRES<ValueType, IndexType>::SolverGMRES(SolverControl &solver_control,
@@ -435,6 +455,8 @@ namespace GinkgoWrappers
                          .with_criteria(this->combined_factory)
                          .on(this->executor);
   }
+
+
 
   template <typename ValueType, typename IndexType>
   SolverGMRES<ValueType, IndexType>::SolverGMRES(
@@ -453,8 +475,9 @@ namespace GinkgoWrappers
                          .on(this->executor);
   }
 
-  /* ---------------------- SolverIR ------------------------ */
 
+
+  /* ---------------------- SolverIR ------------------------ */
   template <typename ValueType, typename IndexType>
   SolverIR<ValueType, IndexType>::SolverIR(SolverControl &       solver_control,
                                            const std::string &   exec_type,
@@ -466,6 +489,8 @@ namespace GinkgoWrappers
     this->solver_gen =
       ir::build().with_criteria(this->combined_factory).on(this->executor);
   }
+
+
 
   template <typename ValueType, typename IndexType>
   SolverIR<ValueType, IndexType>::SolverIR(
@@ -482,6 +507,8 @@ namespace GinkgoWrappers
                          .with_solver(inner_solver)
                          .on(this->executor);
   }
+
+
 
   // Explicit instantiations in GinkgoWrappers
 #  define DEALII_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro) \

--- a/source/lac/ginkgo_solver.cc
+++ b/source/lac/ginkgo_solver.cc
@@ -288,6 +288,19 @@ namespace GinkgoWrappers
       cg::build().with_criteria(this->combined_factory).on(executor);
   }
 
+  template <typename ValueType, typename IndexType>
+  SolverCG<ValueType, IndexType>::SolverCG(
+                                           SolverControl &                solver_control,
+                                           std::shared_ptr<gko::Executor> executor,
+                                           std::shared_ptr<gko::LinOpFactory> preconditioner,
+                                           const AdditionalData &         data)
+    : SolverBase<ValueType, IndexType>(solver_control, executor)
+    , additional_data(data)
+  {
+    using cg = gko::solver::Cg<ValueType>;
+    this->solver_gen =
+      cg::build().with_criteria(this->combined_factory).with_preconditioner(preconditioner).on(executor);
+  }
   // Explicit instantiations in GinkgoWrappers
 #  define DEALII_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro) \
     template _macro(float, int32_t);                               \

--- a/source/lac/ginkgo_solver.cc
+++ b/source/lac/ginkgo_solver.cc
@@ -32,7 +32,7 @@ namespace GinkgoWrappers
 {
   template <typename ValueType, typename IndexType>
   SolverBase<ValueType, IndexType>::SolverBase(SolverControl &solver_control,
-                                               std::string    exec_type)
+                                               const std::string &exec_type)
     : solver_control(solver_control)
     , exec_type(exec_type)
   {
@@ -51,7 +51,7 @@ namespace GinkgoWrappers
     else
       {
         std::cerr
-          << "exec_type needs to be one of the three strings: reference, cuda or omp, but provided with"
+          << "exec_type needs to be one of the three strings: \"reference\", \"cuda\" or \"omp\", but provided with"
           << exec_type << std::endl;
         std::exit(-1);
       }
@@ -295,7 +295,7 @@ namespace GinkgoWrappers
 
   template <typename ValueType, typename IndexType>
   SolverCG<ValueType, IndexType>::SolverCG(SolverControl &       solver_control,
-                                           std::string           exec_type,
+                                           const std::string &   exec_type,
                                            const AdditionalData &data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
@@ -307,10 +307,10 @@ namespace GinkgoWrappers
 
   template <typename ValueType, typename IndexType>
   SolverCG<ValueType, IndexType>::SolverCG(
-    SolverControl &                    solver_control,
-    std::string                        exec_type,
-    std::shared_ptr<gko::LinOpFactory> preconditioner,
-    const AdditionalData &             data)
+    SolverControl &                           solver_control,
+    const std::string &                       exec_type,
+    const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+    const AdditionalData &                    data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
   {
@@ -322,12 +322,12 @@ namespace GinkgoWrappers
   }
 
 
-  /* ---------------------- SolverBICGSTAB ------------------------ */
+  /* ---------------------- SolverBicgstab ------------------------ */
 
   template <typename ValueType, typename IndexType>
-  SolverBICGSTAB<ValueType, IndexType>::SolverBICGSTAB(
+  SolverBicgstab<ValueType, IndexType>::SolverBicgstab(
     SolverControl &       solver_control,
-    std::string           exec_type,
+    const std::string &   exec_type,
     const AdditionalData &data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
@@ -339,11 +339,11 @@ namespace GinkgoWrappers
   }
 
   template <typename ValueType, typename IndexType>
-  SolverBICGSTAB<ValueType, IndexType>::SolverBICGSTAB(
-    SolverControl &                    solver_control,
-    std::string                        exec_type,
-    std::shared_ptr<gko::LinOpFactory> preconditioner,
-    const AdditionalData &             data)
+  SolverBicgstab<ValueType, IndexType>::SolverBicgstab(
+    SolverControl &                           solver_control,
+    const std::string &                       exec_type,
+    const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+    const AdditionalData &                    data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
   {
@@ -357,8 +357,8 @@ namespace GinkgoWrappers
   /* ---------------------- SolverCGS ------------------------ */
 
   template <typename ValueType, typename IndexType>
-  SolverCGS<ValueType, IndexType>::SolverCGS(SolverControl &solver_control,
-                                             std::string    exec_type,
+  SolverCGS<ValueType, IndexType>::SolverCGS(SolverControl &    solver_control,
+                                             const std::string &exec_type,
                                              const AdditionalData &data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
@@ -370,10 +370,10 @@ namespace GinkgoWrappers
 
   template <typename ValueType, typename IndexType>
   SolverCGS<ValueType, IndexType>::SolverCGS(
-    SolverControl &                    solver_control,
-    std::string                        exec_type,
-    std::shared_ptr<gko::LinOpFactory> preconditioner,
-    const AdditionalData &             data)
+    SolverControl &                           solver_control,
+    const std::string &                       exec_type,
+    const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+    const AdditionalData &                    data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
   {
@@ -387,8 +387,8 @@ namespace GinkgoWrappers
   /* ---------------------- SolverFCG ------------------------ */
 
   template <typename ValueType, typename IndexType>
-  SolverFCG<ValueType, IndexType>::SolverFCG(SolverControl &solver_control,
-                                             std::string    exec_type,
+  SolverFCG<ValueType, IndexType>::SolverFCG(SolverControl &    solver_control,
+                                             const std::string &exec_type,
                                              const AdditionalData &data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
@@ -400,10 +400,10 @@ namespace GinkgoWrappers
 
   template <typename ValueType, typename IndexType>
   SolverFCG<ValueType, IndexType>::SolverFCG(
-    SolverControl &                    solver_control,
-    std::string                        exec_type,
-    std::shared_ptr<gko::LinOpFactory> preconditioner,
-    const AdditionalData &             data)
+    SolverControl &                           solver_control,
+    const std::string &                       exec_type,
+    const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+    const AdditionalData &                    data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
   {
@@ -424,7 +424,7 @@ namespace GinkgoWrappers
 
   template <typename ValueType, typename IndexType>
   SolverGMRES<ValueType, IndexType>::SolverGMRES(SolverControl &solver_control,
-                                                 std::string    exec_type,
+                                                 const std::string &exec_type,
                                                  const AdditionalData &data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
@@ -438,10 +438,10 @@ namespace GinkgoWrappers
 
   template <typename ValueType, typename IndexType>
   SolverGMRES<ValueType, IndexType>::SolverGMRES(
-    SolverControl &                    solver_control,
-    std::string                        exec_type,
-    std::shared_ptr<gko::LinOpFactory> preconditioner,
-    const AdditionalData &             data)
+    SolverControl &                           solver_control,
+    const std::string &                       exec_type,
+    const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+    const AdditionalData &                    data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
   {
@@ -457,7 +457,7 @@ namespace GinkgoWrappers
 
   template <typename ValueType, typename IndexType>
   SolverIR<ValueType, IndexType>::SolverIR(SolverControl &       solver_control,
-                                           std::string           exec_type,
+                                           const std::string &   exec_type,
                                            const AdditionalData &data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
@@ -469,10 +469,10 @@ namespace GinkgoWrappers
 
   template <typename ValueType, typename IndexType>
   SolverIR<ValueType, IndexType>::SolverIR(
-    SolverControl &                    solver_control,
-    std::string                        exec_type,
-    std::shared_ptr<gko::LinOpFactory> inner_solver,
-    const AdditionalData &             data)
+    SolverControl &                           solver_control,
+    const std::string &                       exec_type,
+    const std::shared_ptr<gko::LinOpFactory> &inner_solver,
+    const AdditionalData &                    data)
     : SolverBase<ValueType, IndexType>(solver_control, exec_type)
     , additional_data(data)
   {
@@ -500,10 +500,10 @@ namespace GinkgoWrappers
   DEALII_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(DECLARE_SOLVER_CG)
 #  undef DECLARE_SOLVER_CG
 
-#  define DECLARE_SOLVER_BICGSTAB(ValueType, IndexType) \
-    class SolverBICGSTAB<ValueType, IndexType>
-  DEALII_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(DECLARE_SOLVER_BICGSTAB)
-#  undef DECLARE_SOLVER_BICGSTAB
+#  define DECLARE_SOLVER_Bicgstab(ValueType, IndexType) \
+    class SolverBicgstab<ValueType, IndexType>
+  DEALII_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(DECLARE_SOLVER_Bicgstab)
+#  undef DECLARE_SOLVER_Bicgstab
 
 #  define DECLARE_SOLVER_CGS(ValueType, IndexType) \
     class SolverCGS<ValueType, IndexType>

--- a/tests/ginkgo/solver.cc
+++ b/tests/ginkgo/solver.cc
@@ -69,7 +69,7 @@ main(int argc, char **argv)
                          .on(exec))
         .on(exec);
     GinkgoWrappers::SolverCG<>       cg_solver(control, executor);
-    GinkgoWrappers::SolverBICGSTAB<> bicgstab_solver(control, executor);
+    GinkgoWrappers::SolverBicgstab<> bicgstab_solver(control, executor);
     GinkgoWrappers::SolverCGS<>      cgs_solver(control, executor);
     GinkgoWrappers::SolverFCG<>      fcg_solver(control, executor);
     GinkgoWrappers::SolverGMRES<>    gmres_solver(control, executor);

--- a/tests/ginkgo/solver.cc
+++ b/tests/ginkgo/solver.cc
@@ -56,10 +56,11 @@ main(int argc, char **argv)
     // std::shared_ptr<gko::Executor> exec = gko::CudaExecutor::create(0,
     //                                                               gko::OmpExecutor::create());
     // std::shared_ptr<gko::Executor> exec = gko::OmpExecutor::create();
+    auto executor = "reference";
     std::shared_ptr<gko::Executor> exec = gko::ReferenceExecutor::create();
     std::shared_ptr<gko::LinOpFactory> jacobi = gko::preconditioner::Jacobi<>::build().on(exec);
-    GinkgoWrappers::SolverCG<>     solver(control, exec);
-    GinkgoWrappers::SolverCG<>     solver_with_jacobi_precond(control, exec, jacobi);
+    GinkgoWrappers::SolverCG<>     solver(control, executor);
+    GinkgoWrappers::SolverCG<>     solver_with_jacobi_precond(control, executor, jacobi);
 
     check_solver_within_range(solver.solve(A, u, f),
                               control.last_step(),

--- a/tests/ginkgo/solver.cc
+++ b/tests/ginkgo/solver.cc
@@ -57,11 +57,18 @@ main(int argc, char **argv)
     //                                                               gko::OmpExecutor::create());
     // std::shared_ptr<gko::Executor> exec = gko::OmpExecutor::create();
     std::shared_ptr<gko::Executor> exec = gko::ReferenceExecutor::create();
+    std::shared_ptr<gko::LinOpFactory> jacobi = gko::preconditioner::Jacobi<>::build().on(exec);
     GinkgoWrappers::SolverCG<>     solver(control, exec);
+    GinkgoWrappers::SolverCG<>     solver_with_jacobi_precond(control, exec, jacobi);
 
     check_solver_within_range(solver.solve(A, u, f),
                               control.last_step(),
                               35,
                               39);
+    u = 0.;
+    check_solver_within_range(solver_with_jacobi_precond.solve(A, u, f),
+                              control.last_step(),
+                              29,
+                              33);
   }
 }

--- a/tests/ginkgo/solver.cc
+++ b/tests/ginkgo/solver.cc
@@ -56,23 +56,27 @@ main(int argc, char **argv)
     // std::shared_ptr<gko::Executor> exec = gko::CudaExecutor::create(0,
     //                                                               gko::OmpExecutor::create());
     // std::shared_ptr<gko::Executor> exec = gko::OmpExecutor::create();
-    auto executor = "reference";
-    std::shared_ptr<gko::Executor> exec = gko::ReferenceExecutor::create();
-    std::shared_ptr<gko::LinOpFactory> jacobi = gko::preconditioner::Jacobi<>::build().on(exec);
-    std::shared_ptr<gko::LinOpFactory> inner_cg = gko::solver::Cg<>::build()
-      .with_criteria(
-                     gko::stop::Iteration::build().with_max_iters(45u).on(exec),
-                     gko::stop::ResidualNormReduction<>::build()
-                     .with_reduction_factor(1e-5)
-                     .on(exec))
-      .on(exec);
-    GinkgoWrappers::SolverCG<>     cg_solver(control, executor);
-    GinkgoWrappers::SolverBICGSTAB<>     bicgstab_solver(control, executor);
-    GinkgoWrappers::SolverCGS<>     cgs_solver(control, executor);
-    GinkgoWrappers::SolverFCG<>     fcg_solver(control, executor);
-    GinkgoWrappers::SolverGMRES<>     gmres_solver(control, executor);
-    GinkgoWrappers::SolverIR<>     ir_solver_cg(control, executor, inner_cg);
-    GinkgoWrappers::SolverCG<>     cg_solver_with_jacobi_precond(control, executor, jacobi);
+    auto                               executor = "reference";
+    std::shared_ptr<gko::Executor>     exec = gko::ReferenceExecutor::create();
+    std::shared_ptr<gko::LinOpFactory> jacobi =
+      gko::preconditioner::Jacobi<>::build().on(exec);
+    std::shared_ptr<gko::LinOpFactory> inner_cg =
+      gko::solver::Cg<>::build()
+        .with_criteria(gko::stop::Iteration::build().with_max_iters(45u).on(
+                         exec),
+                       gko::stop::ResidualNormReduction<>::build()
+                         .with_reduction_factor(1e-5)
+                         .on(exec))
+        .on(exec);
+    GinkgoWrappers::SolverCG<>       cg_solver(control, executor);
+    GinkgoWrappers::SolverBICGSTAB<> bicgstab_solver(control, executor);
+    GinkgoWrappers::SolverCGS<>      cgs_solver(control, executor);
+    GinkgoWrappers::SolverFCG<>      fcg_solver(control, executor);
+    GinkgoWrappers::SolverGMRES<>    gmres_solver(control, executor);
+    GinkgoWrappers::SolverIR<>       ir_solver_cg(control, executor, inner_cg);
+    GinkgoWrappers::SolverCG<>       cg_solver_with_jacobi_precond(control,
+                                                             executor,
+                                                             jacobi);
 
     check_solver_within_range(cg_solver.solve(A, u, f),
                               control.last_step(),

--- a/tests/ginkgo/solver.output
+++ b/tests/ginkgo/solver.output
@@ -1,4 +1,9 @@
 
 DEAL::Size 32 Unknowns 961
 DEAL::Solver stopped within 35 - 39 iterations
+DEAL::Solver stopped within 59 - 65 iterations
+DEAL::Solver stopped within 72 - 79 iterations
+DEAL::Solver stopped within 33 - 39 iterations
+DEAL::Solver stopped within 23 - 29 iterations
+DEAL::Solver stopped within 0 - 2 iterations
 DEAL::Solver stopped within 29 - 33 iterations

--- a/tests/ginkgo/solver.output
+++ b/tests/ginkgo/solver.output
@@ -1,3 +1,4 @@
 
 DEAL::Size 32 Unknowns 961
 DEAL::Solver stopped within 35 - 39 iterations
+DEAL::Solver stopped within 29 - 33 iterations


### PR DESCRIPTION
Since we have released Ginkgo version 1.0.0, here is an update for the wrapper. 

This pull request adds:

1. Some updated documentation
2. Hiding the executor creation from the user for the plain solver. The user can just use a string now.
3. Adds support for the other solvers (bicgstab, cgs, fcg, gmres and ir).
4. Adds support for using Ginkgo's preconditioners.

  