### PR TITLE
Add some missing override annotations to step-63.

### DIFF
--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -314,11 +314,11 @@ namespace Step63
     {}
 
     virtual double value(const Point<dim> & p,
-                         const unsigned int component = 0) const;
+                         const unsigned int component = 0) const override;
 
     virtual void value_list(const std::vector<Point<dim>> &points,
                             std::vector<double> &          values,
-                            const unsigned int             component = 0) const;
+                            const unsigned int component = 0) const override;
   };
 
   template <int dim>
@@ -357,11 +357,11 @@ namespace Step63
     {}
 
     virtual double value(const Point<dim> & p,
-                         const unsigned int component = 0) const;
+                         const unsigned int component = 0) const override;
 
     virtual void value_list(const std::vector<Point<dim>> &points,
                             std::vector<double> &          values,
-                            const unsigned int             component = 0) const;
+                            const unsigned int component = 0) const override;
   };
 
 


### PR DESCRIPTION
The CI build system currently fails when compiling this test since, AFAICT, we set `-Wsuggest-override` and `-Werror`, so we need this before we can merge more patches.