### PR TITLE
Remove namespace aliases in SymEngine headers

### DIFF
--- a/include/deal.II/differentiation/sd/symengine_math.h
+++ b/include/deal.II/differentiation/sd/symengine_math.h
@@ -30,15 +30,13 @@ namespace Differentiation
 {
   namespace SD
   {
-    namespace SE = ::SymEngine;
-
     /**
      * @name Mathematical functions
      *
      * It is necessary that all computed inputs to SymEngine functions are
-     * of type SE::RCP<SE::Basic>. So we instead simply offer a unified
-     * interface to Expression types and with other permutations of numbers
-     * we convert between them.
+     * of type SymEngine::RCP<SymEngine::Basic>. So we instead simply offer a
+     * unified interface to Expression types and with other permutations of
+     * numbers we convert between them.
      *
      * For a full list of functions that we (ultimately) expect to support, see
      * http://www.cplusplus.com/reference/cmath/. Those that are currently

--- a/include/deal.II/differentiation/sd/symengine_number_types.h
+++ b/include/deal.II/differentiation/sd/symengine_number_types.h
@@ -66,8 +66,6 @@ namespace Differentiation
 {
   namespace SD
   {
-    namespace SE = ::SymEngine;
-
     /**
      * @addtogroup Exceptions
      * @{
@@ -225,7 +223,7 @@ namespace Differentiation
       /**
        * Constructor for integer types.
        */
-      Expression(const SE::integer_class &value);
+      Expression(const SymEngine::integer_class &value);
 
       /**
        * Constructor for rational types.
@@ -241,7 +239,7 @@ namespace Differentiation
       /**
        * Constructor for rational types.
        */
-      Expression(const SE::rational_class &value);
+      Expression(const SymEngine::rational_class &value);
 
       /**
        * Constructor for a piecewise defined function.
@@ -375,7 +373,7 @@ namespace Differentiation
        * from implicit conversion when both the deal.II and SymEngine namespaces
        * are imported.
        */
-      explicit Expression(const SE::Expression &rhs);
+      explicit Expression(const SymEngine::Expression &rhs);
 
       /**
        * Copy constructor.
@@ -385,7 +383,7 @@ namespace Differentiation
        * "diff", because the returned result is not primitive, but rather a set
        * of compound operations.
        */
-      Expression(const SE::RCP<const SE::Basic> &rhs);
+      Expression(const SymEngine::RCP<const SymEngine::Basic> &rhs);
 
       /**
        * Move constructor.
@@ -400,7 +398,7 @@ namespace Differentiation
        * "diff", because the returned result is not primitive, but rather a set
        * of compound operations.
        */
-      Expression(SE::RCP<const SE::Basic> &&rhs);
+      Expression(SymEngine::RCP<const SymEngine::Basic> &&rhs);
 
       /**
        * Destructor.
@@ -479,21 +477,21 @@ namespace Differentiation
       /**
        * Return the value or expression that this class instance represents.
        */
-      const SE::Expression &
+      const SymEngine::Expression &
       get_expression() const;
 
       /**
        * Return the primitive SymEngine data type that stores the value or
        * expression represented by this object.
        */
-      const SE::Basic &
+      const SymEngine::Basic &
       get_value() const;
 
       /**
        * Return the pointer to the primitive SymEngine data type that stores
        * the value or expression represented by this object.
        */
-      const SE::RCP<const SE::Basic> &
+      const SymEngine::RCP<const SymEngine::Basic> &
       get_RCP() const;
 
       //@}
@@ -644,14 +642,15 @@ namespace Differentiation
        * with respect to the given @p symbol.
        */
       Expression
-      differentiate(const SE::RCP<const SE::Symbol> &symbol) const;
+      differentiate(
+        const SymEngine::RCP<const SymEngine::Symbol> &symbol) const;
 
       /**
        * Return the derivative of this object's @p expression
        * with respect to the potential @p symbol.
        */
       Expression
-      differentiate(const SE::RCP<const SE::Basic> &symbol) const;
+      differentiate(const SymEngine::RCP<const SymEngine::Basic> &symbol) const;
 
       //@}
 
@@ -755,7 +754,8 @@ namespace Differentiation
        *     template <typename ResultType>
        *     explicit operator ResultType() const
        *     {
-       *       if (this->get_value()->get_type_code() == SE::NUMBER_WRAPPER)
+       *       if (this->get_value()->get_type_code() ==
+       * SymEngine::NUMBER_WRAPPER)
        *       {
        *         // Implement custom evaluation function
        *         const ResultType result = ...;
@@ -775,13 +775,13 @@ namespace Differentiation
        * Conversion operator that returns the value or expression that this
        * class instance represents.
        */
-      explicit operator const SE::Expression &() const;
+      explicit operator const SymEngine::Expression &() const;
 
       /**
        * Conversion operator that returns a SymEngine reference counted pointer
        * to the fundamental type.
        */
-      operator const SE::RCP<const SE::Basic> &() const;
+      operator const SymEngine::RCP<const SymEngine::Basic> &() const;
 
       //@}
 
@@ -789,7 +789,7 @@ namespace Differentiation
       /**
        * Return the value or expression that this class instance represents.
        */
-      SE::Expression &
+      SymEngine::Expression &
       get_expression();
 
     private:
@@ -797,7 +797,7 @@ namespace Differentiation
        * The value or expression that this instance of this class is to
        * represent.
        */
-      SE::Expression expression;
+      SymEngine::Expression expression;
     };
 
     /**
@@ -1170,8 +1170,9 @@ namespace Differentiation
     template <typename NumberType, typename>
     Expression::Expression(const NumberType &numerator,
                            const NumberType &denominator)
-      : expression(SE::Rational::from_two_ints(*SE::integer(numerator),
-                                               *SE::integer(denominator)))
+      : expression(
+          SymEngine::Rational::from_two_ints(*SymEngine::integer(numerator),
+                                             *SymEngine::integer(denominator)))
     {}
 
 
@@ -1220,7 +1221,7 @@ namespace Differentiation
     Expression::substitute(const Expression &symbol,
                            const NumberType &value) const
     {
-      Assert(SE::is_a<SE::Symbol>(symbol.get_value()),
+      Assert(SymEngine::is_a<SymEngine::Symbol>(symbol.get_value()),
              ExcMessage(
                "Substitution with a number that does not represent a symbol."));
 
@@ -1252,7 +1253,7 @@ namespace Differentiation
     Expression &
     Expression::operator+=(const NumberType &rhs)
     {
-      *this = Expression(SE::add(get_RCP(), Expression(rhs).get_RCP()));
+      *this = Expression(SymEngine::add(get_RCP(), Expression(rhs).get_RCP()));
       return *this;
     }
 
@@ -1261,7 +1262,7 @@ namespace Differentiation
     Expression &
     Expression::operator-=(const NumberType &rhs)
     {
-      *this = Expression(SE::sub(get_RCP(), Expression(rhs).get_RCP()));
+      *this = Expression(SymEngine::sub(get_RCP(), Expression(rhs).get_RCP()));
       return *this;
     }
 
@@ -1270,7 +1271,7 @@ namespace Differentiation
     Expression &
     Expression::operator*=(const NumberType &rhs)
     {
-      *this = Expression(SE::mul(get_RCP(), Expression(rhs).get_RCP()));
+      *this = Expression(SymEngine::mul(get_RCP(), Expression(rhs).get_RCP()));
       return *this;
     }
 
@@ -1279,7 +1280,7 @@ namespace Differentiation
     Expression &
     Expression::operator/=(const NumberType &rhs)
     {
-      *this = Expression(SE::div(get_RCP(), Expression(rhs).get_RCP()));
+      *this = Expression(SymEngine::div(get_RCP(), Expression(rhs).get_RCP()));
       return *this;
     }
 

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -270,7 +270,7 @@ namespace Differentiation
     //@}
 
     /**
-     * @name Symbolic substitution map enlargement
+     * @name Symbol substitution map enlargement
      */
     //@{
 

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -39,8 +39,6 @@ namespace Differentiation
 {
   namespace SD
   {
-    namespace SE = ::SymEngine;
-
     /**
      * @name Symbolic variable creation
      */
@@ -147,7 +145,7 @@ namespace Differentiation
        * we can expect to perform substitution on.
        */
       bool
-      is_valid_substitution_symbol(const SE::Basic &entry);
+      is_valid_substitution_symbol(const SymEngine::Basic &entry);
     } // namespace internal
 
     //@}
@@ -300,9 +298,10 @@ namespace Differentiation
        */
       template <bool ignore_invalid_symbols = false>
       void
-      add_to_substitution_map(types::substitution_map &       substitution_map,
-                              const SE::RCP<const SE::Basic> &symbol,
-                              const SE::RCP<const SE::Basic> &value);
+      add_to_substitution_map(
+        types::substitution_map &                     substitution_map,
+        const SymEngine::RCP<const SymEngine::Basic> &symbol,
+        const SymEngine::RCP<const SymEngine::Basic> &value);
     } // namespace internal
 
     /**
@@ -350,7 +349,8 @@ namespace Differentiation
      * compatible SymEngine number type.
      * It is therefore required that the @p ExpressionType
      * 1. can be constructed from a @p ValueType, and that
-     * 2. it is convertible to a `const SE::RCP<const SE::Basic> &`.
+     * 2. it is convertible to a `const SymEngine::RCP<const SymEngine::Basic>
+     * &`.
      *
      * For more context which this function is used, see the other
      * \ref add_to_substitution_map(types::substitution_map &,const
@@ -367,7 +367,7 @@ namespace Differentiation
               typename = typename std::enable_if<
                 dealii::internal::is_explicitly_convertible<
                   ExpressionType,
-                  const SE::RCP<const SE::Basic> &>::value &&
+                  const SymEngine::RCP<const SymEngine::Basic> &>::value &&
                 std::is_constructible<ExpressionType, ValueType>::value>::type>
     void
     add_to_substitution_map(types::substitution_map &substitution_map,
@@ -384,7 +384,8 @@ namespace Differentiation
      * be used to convert the p value to a compatible SymEngine number type.
      * It is therefore required that the @p ExpressionType
      * 1. can be constructed from a @p ValueType, and that
-     * 2. it is convertible to a `const SE::RCP<const SE::Basic> &`.
+     * 2. it is convertible to a `const SymEngine::RCP<const SymEngine::Basic>
+     * &`.
      *
      * For more context which this function is used, see the other
      * \ref add_to_substitution_map(types::substitution_map &,const
@@ -401,7 +402,7 @@ namespace Differentiation
               typename = typename std::enable_if<
                 dealii::internal::is_explicitly_convertible<
                   ExpressionType,
-                  const SE::RCP<const SE::Basic> &>::value &&
+                  const SymEngine::RCP<const SymEngine::Basic> &>::value &&
                 std::is_constructible<ExpressionType, ValueType>::value>::type>
     void
     add_to_substitution_map(types::substitution_map &          substitution_map,
@@ -681,9 +682,10 @@ namespace Differentiation
        */
       template <bool ignore_invalid_symbols>
       void
-      add_to_substitution_map(types::substitution_map &       substitution_map,
-                              const SE::RCP<const SE::Basic> &symbol,
-                              const SE::RCP<const SE::Basic> &value)
+      add_to_substitution_map(
+        types::substitution_map &                     substitution_map,
+        const SymEngine::RCP<const SymEngine::Basic> &symbol,
+        const SymEngine::RCP<const SymEngine::Basic> &value)
       {
         if (ignore_invalid_symbols == false)
           {
@@ -729,7 +731,7 @@ namespace Differentiation
                             const ExpressionType &   symbol,
                             const ValueType &        value)
     {
-      using SE_RCP_Basic = const SE::RCP<const SE::Basic> &;
+      using SE_RCP_Basic = const SymEngine::RCP<const SymEngine::Basic> &;
       internal::add_to_substitution_map<ignore_invalid_symbols>(
         substitution_map,
         static_cast<SE_RCP_Basic>(symbol),
@@ -752,7 +754,7 @@ namespace Differentiation
 
       typename types::symbol_vector::const_iterator   it_s = symbols.begin();
       typename std::vector<ValueType>::const_iterator it_v = values.begin();
-      using SE_RCP_Basic = const SE::RCP<const SE::Basic> &;
+      using SE_RCP_Basic = const SymEngine::RCP<const SymEngine::Basic> &;
       for (; it_s != symbols.end(); ++it_s, ++it_v)
         {
           Assert(it_v != values.end(), ExcInternalError());
@@ -801,8 +803,8 @@ namespace Differentiation
     {
       for (const auto &entry : symbol_values)
         {
-          const SE::RCP<const SE::Basic> &symbol = entry.first;
-          const SE::RCP<const SE::Basic> &value  = entry.second;
+          const SymEngine::RCP<const SymEngine::Basic> &symbol = entry.first;
+          const SymEngine::RCP<const SymEngine::Basic> &value  = entry.second;
           internal::add_to_substitution_map<ignore_invalid_symbols>(
             substitution_map, symbol, value);
         }

--- a/include/deal.II/differentiation/sd/symengine_types.h
+++ b/include/deal.II/differentiation/sd/symengine_types.h
@@ -53,8 +53,8 @@ namespace Differentiation
        *
        * This serves the same purpose as a
        * <code>SymEngine::map_basic_basic</code>, which is equivalent to a
-       * <code>std::map<SE::RCP<const SE::Basic>,  SE::RCP<const
-       * SE::Basic>></code>.
+       * <code>std::map<SymEngine::RCP<const SymEngine::Basic>,
+       * SymEngine::RCP<const SymEngine::Basic>></code>.
        */
       using substitution_map =
         std::map<SD::Expression, SD::Expression, internal::ExpressionKeyLess>;
@@ -63,8 +63,8 @@ namespace Differentiation
        * Type definition for a vector of symbols.
        *
        * This serves the same purpose as a <code>SymEngine::vec_basic</code>,
-       * which is equivalent to a <code>std::vector<SE::RCP<const
-       * SE::Basic>></code>
+       * which is equivalent to a <code>std::vector<SymEngine::RCP<const
+       * SymEngine::Basic>></code>
        */
       using symbol_vector = std::vector<SD::Expression>;
 

--- a/include/deal.II/differentiation/sd/symengine_utilities.h
+++ b/include/deal.II/differentiation/sd/symengine_utilities.h
@@ -32,21 +32,19 @@ namespace Differentiation
 {
   namespace SD
   {
-    namespace SE = ::SymEngine;
-
     namespace Utilities
     {
       /**
        * Convert a map of Expressions to its SymEngine counterpart.
        */
-      SE::map_basic_basic
+      SymEngine::map_basic_basic
       convert_expression_map_to_basic_map(
         const SD::types::substitution_map &substitution_map);
 
       /**
        * Convert a vector of Expressions to its SymEngine counterpart.
        */
-      SE::vec_basic
+      SymEngine::vec_basic
       convert_expression_vector_to_basic_vector(
         const SD::types::symbol_vector &symbol_vector);
 

--- a/source/differentiation/sd/symengine_scalar_operations.cc
+++ b/source/differentiation/sd/symengine_scalar_operations.cc
@@ -31,6 +31,9 @@ namespace Differentiation
 {
   namespace SD
   {
+    namespace SE = ::SymEngine;
+
+
     /* ------------------------- Symbol creation -----------------------*/
 
 


### PR DESCRIPTION
Also, the first commit makes a section header consistent. See https://dealii.org/developer/doxygen/deal.II/namespaceDifferentiation_1_1SD.html

@bangerth ping

This passes all test on my machine.