### PR TITLE
tutorials: add keywords

### DIFF
--- a/doc/doxygen/tutorial/tutorial.h.in
+++ b/doc/doxygen/tutorial/tutorial.h.in
@@ -86,6 +86,7 @@
  *   <tr valign="top">
  *       <td width="100px">step-1</td>
  *       <td> Creating a grid. A simple way to write it to a file.
+ *       <br/> keywords: Triangulation, GridGenerator::hyper_cube, GridGenerator::hyper_shell, GridOut, Triangulation::execute_coarsening_and_refinement
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -95,6 +96,7 @@
  *       matrices. Show that renumbering reduces the bandwidth of
  *       matrices significantly, i.e. clusters nonzero entries around the
  *       diagonal.
+ *       <br/> keywords: FE_Q, DynamicSparsityPattern, DoFTools::make_sparsity_pattern, DoFHandler::distribute_dofs, DoFRenumbering, SparsityPattern
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -102,6 +104,7 @@
  *       <td> Actually solve Laplace's
  *       problem. Object-orientation. Assembling matrices and
  *       vectors. Boundary values.
+ *       <br/> keywords: FEValues, VectorTools::interpolate_boundary_values, MatrixTools::apply_boundary_values, SolverCG, Vector<double>, SparseMatrix<double>, DataOut
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -111,6 +114,7 @@
  *       solve Laplace's equation; we will solve the equation in 2D and
  *       3D, although the program is exactly the same. Non-constant right
  *       hand side function. Non-homogeneous boundary values.
+ *       <br/> keywords: VectorTools::point_value, VectorTools::compute_mean_value
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -121,6 +125,7 @@
  *       the elliptic operator (yielding the extended Poisson
  *       equation). Preconditioning the CG solver for the
  *       linear system of equations.
+ *       <br/> keywords: PreconditionSSOR, GridIn, SphericalManifold
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -128,6 +133,7 @@
  *       <td> Adaptive local
  *       refinement. Handling of hanging nodes. Higher order elements.
  *       Catching exceptions in the <code>main</code>; function.
+ *       <br/> keywords: DoFTools::make_hanging_node_constraints, AffineConstraints::distribute_local_to_global,  KellyErrorEstimator, GridRefinement::refine_and_coarsen_fixed_number
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -137,6 +143,7 @@
  *       boundary integrals. Verification of correctness of computed
  *       solutions. Computing the error between exact and numerical
  *       solution and output of the data in tables. Using counted pointers.
+ *       <br/> keywords: FEFaceValues, VectorTools::integrate_difference,  VectorTools::compute_global_error, TableHandler
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -145,6 +152,7 @@
  *       solved instead of Laplace's equation. The solution is
  *       vector-valued and the equations form a system with as many
  *       equations as the dimension of the space in which it is posed.
+ *       <br/> keywords: FESystem
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -153,6 +161,8 @@
  *       the system of equations in parallel using multi-threading,
  *       implementing a refinement criterion based on a finite difference
  *       approximation of the gradient.
+ *       <br/> keywords: TensorFunction, WorkStream::run, SolverGMRES
+ *       </td></tr>
  *
  *   <tr valign="top">
  *       <td>step-10</td>
@@ -270,12 +280,14 @@
  *
  *   <tr valign="top">
  *       <td>step-27</td>
- *       <td> hp finite element methods  </td></tr>
+ *       <td> The hp finite element method.
+ *       </td></tr>
  *
  *   <tr valign="top">
  *       <td>step-28</td>
  *       <td> Multiple grids for solving a multigroup diffusion equation
- *       in nuclear physics simulating a nuclear reactor core  </td></tr>
+ *       in nuclear physics simulating a nuclear reactor core.
+ *       </td></tr>
  *
  *   <tr valign="top">
  *       <td>step-29</td>
@@ -437,6 +449,7 @@
  *       <td> Solving a Poisson problem discretized with an interior penalty DG
  *       method and a multilevel preconditioner in a matrix-free fashion using
  *       a massively parallel implementation.
+ *       </td></tr>
  *
  *   <tr valign="top">
  *       <td>step-60</td>

--- a/doc/doxygen/tutorial/tutorial.h.in
+++ b/doc/doxygen/tutorial/tutorial.h.in
@@ -86,7 +86,9 @@
  *   <tr valign="top">
  *       <td width="100px">step-1</td>
  *       <td> Creating a grid. A simple way to write it to a file.
- *       <br/> keywords: Triangulation, GridGenerator::hyper_cube, GridGenerator::hyper_shell, GridOut, Triangulation::execute_coarsening_and_refinement
+ *       <br/> Keywords: Triangulation, GridGenerator::hyper_cube,
+ *       GridGenerator::hyper_shell, GridOut,
+ *       Triangulation::execute_coarsening_and_refinement
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -96,7 +98,9 @@
  *       matrices. Show that renumbering reduces the bandwidth of
  *       matrices significantly, i.e. clusters nonzero entries around the
  *       diagonal.
- *       <br/> keywords: FE_Q, DynamicSparsityPattern, DoFTools::make_sparsity_pattern, DoFHandler::distribute_dofs, DoFRenumbering, SparsityPattern
+ *       <br/> Keywords: FE_Q, DynamicSparsityPattern,
+ *       DoFTools::make_sparsity_pattern, DoFHandler::distribute_dofs,
+ *       DoFRenumbering, SparsityPattern
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -104,7 +108,9 @@
  *       <td> Actually solve Laplace's
  *       problem. Object-orientation. Assembling matrices and
  *       vectors. Boundary values.
- *       <br/> keywords: FEValues, VectorTools::interpolate_boundary_values, MatrixTools::apply_boundary_values, SolverCG, Vector<double>, SparseMatrix<double>, DataOut
+ *       <br/> Keywords: FEValues, VectorTools::interpolate_boundary_values,
+ *       MatrixTools::apply_boundary_values, SolverCG, Vector<double>,
+ *       SparseMatrix<double>, DataOut
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -114,7 +120,8 @@
  *       solve Laplace's equation; we will solve the equation in 2D and
  *       3D, although the program is exactly the same. Non-constant right
  *       hand side function. Non-homogeneous boundary values.
- *       <br/> keywords: VectorTools::point_value, VectorTools::compute_mean_value
+ *       <br/> Keywords: VectorTools::point_value,
+ *       VectorTools::compute_mean_value
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -125,7 +132,7 @@
  *       the elliptic operator (yielding the extended Poisson
  *       equation). Preconditioning the CG solver for the
  *       linear system of equations.
- *       <br/> keywords: PreconditionSSOR, GridIn, SphericalManifold
+ *       <br/> Keywords: PreconditionSSOR, GridIn, SphericalManifold
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -133,7 +140,9 @@
  *       <td> Adaptive local
  *       refinement. Handling of hanging nodes. Higher order elements.
  *       Catching exceptions in the <code>main</code>; function.
- *       <br/> keywords: DoFTools::make_hanging_node_constraints, AffineConstraints::distribute_local_to_global,  KellyErrorEstimator, GridRefinement::refine_and_coarsen_fixed_number
+ *       <br/> Keywords: DoFTools::make_hanging_node_constraints,
+ *       AffineConstraints::distribute_local_to_global, KellyErrorEstimator,
+ *       GridRefinement::refine_and_coarsen_fixed_number
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -143,7 +152,8 @@
  *       boundary integrals. Verification of correctness of computed
  *       solutions. Computing the error between exact and numerical
  *       solution and output of the data in tables. Using counted pointers.
- *       <br/> keywords: FEFaceValues, VectorTools::integrate_difference,  VectorTools::compute_global_error, TableHandler
+ *       <br/> Keywords: FEFaceValues, VectorTools::integrate_difference,
+ *       VectorTools::compute_global_error, TableHandler
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -152,7 +162,7 @@
  *       solved instead of Laplace's equation. The solution is
  *       vector-valued and the equations form a system with as many
  *       equations as the dimension of the space in which it is posed.
- *       <br/> keywords: FESystem
+ *       <br/> Keywords: FESystem
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -161,7 +171,7 @@
  *       the system of equations in parallel using multi-threading,
  *       implementing a refinement criterion based on a finite difference
  *       approximation of the gradient.
- *       <br/> keywords: TensorFunction, WorkStream::run, SolverGMRES
+ *       <br/> Keywords: TensorFunction, WorkStream::run, SolverGMRES
  *       </td></tr>
  *
  *   <tr valign="top">


### PR DESCRIPTION
I am often searching on the tutorial overview page in the browser. It is
helpful to have additional keywords available to know where a feature is
used/introduced. Right now I am only adding this for the first few steps
(and only class/function names).

I can follow up on this later for the other tutorials if we agree this
makes sense.