### PR TITLE
provide access to p4est_t

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -816,6 +816,16 @@ namespace parallel
       get_coarse_cell_to_p4est_tree_permutation() const;
 
       /**
+       * This returns a pointer to the internally stored p4est object (of type
+       * p4est_t or p8est_t depending on @p dim).
+       *
+       * @warning: If you modify the p4est object, internal data structures
+       * can become inconsistent.
+       */
+      typename dealii::internal::p4est::types<dim>::forest *
+      get_p4est() const;
+
+      /**
        * In addition to the action in the base class Triangulation, this
        * function joins faces in the p4est forest for periodic boundary
        * conditions. As a result, each pair of faces will differ by at most one

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -822,7 +822,7 @@ namespace parallel
        * @warning: If you modify the p4est object, internal data structures
        * can become inconsistent.
        */
-      typename dealii::internal::p4est::types<dim>::forest *
+      const typename dealii::internal::p4est::types<dim>::forest *
       get_p4est() const;
 
       /**

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2888,6 +2888,17 @@ namespace parallel
 
 
     template <int dim, int spacedim>
+    typename dealii::internal::p4est::types<dim>::forest *
+    Triangulation<dim, spacedim>::get_p4est() const
+    {
+      Assert(parallel_forest != nullptr,
+             ExcMessage("The forest has not been allocated yet."));
+      return parallel_forest;
+    }
+
+
+
+    template <int dim, int spacedim>
     void
     Triangulation<dim, spacedim>::update_number_cache()
     {

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2888,7 +2888,7 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    typename dealii::internal::p4est::types<dim>::forest *
+    const typename dealii::internal::p4est::types<dim>::forest *
     Triangulation<dim, spacedim>::get_p4est() const
     {
       Assert(parallel_forest != nullptr,


### PR DESCRIPTION
I need access for the p4est object inside a distributed Triangulation.
Provide an accessor function for this.