### PR TITLE
Disable floating point exceptions in some scalapack tests.

### DIFF
--- a/tests/scalapack/scalapack_10.cc
+++ b/tests/scalapack/scalapack_10.cc
@@ -81,6 +81,16 @@ test(const unsigned int size, const unsigned int block_size)
 int
 main(int argc, char **argv)
 {
+  // tests.h enables floating point exceptions in debug mode, but this test
+  // generates an (irrelevant) exception when run with more than one MPI
+  // process so disable them again:
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  {
+    const int current_fe_except = fegetexcept();
+    fedisableexcept(current_fe_except);
+  }
+#endif
+
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, numbers::invalid_unsigned_int);
 

--- a/tests/scalapack/scalapack_10_a.cc
+++ b/tests/scalapack/scalapack_10_a.cc
@@ -103,6 +103,16 @@ test(const unsigned int size, const unsigned int block_size)
 int
 main(int argc, char **argv)
 {
+  // tests.h enables floating point exceptions in debug mode, but this test
+  // generates an (irrelevant) exception when run with more than one MPI
+  // process so disable them again:
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  {
+    const int current_fe_except = fegetexcept();
+    fedisableexcept(current_fe_except);
+  }
+#endif
+
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, numbers::invalid_unsigned_int);
 

--- a/tests/scalapack/scalapack_10_b.cc
+++ b/tests/scalapack/scalapack_10_b.cc
@@ -79,6 +79,16 @@ test(const std::pair<unsigned int, unsigned int> &size,
 int
 main(int argc, char **argv)
 {
+  // tests.h enables floating point exceptions in debug mode, but this test
+  // generates an (irrelevant) exception when run with more than one MPI
+  // process so disable them again:
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  {
+    const int current_fe_except = fegetexcept();
+    fedisableexcept(current_fe_except);
+  }
+#endif
+
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, numbers::invalid_unsigned_int);
 

--- a/tests/scalapack/scalapack_10_c.cc
+++ b/tests/scalapack/scalapack_10_c.cc
@@ -140,6 +140,16 @@ test()
 int
 main(int argc, char **argv)
 {
+  // tests.h enables floating point exceptions in debug mode, but this test
+  // generates an (irrelevant) exception when run with more than one MPI
+  // process so disable them again:
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  {
+    const int current_fe_except = fegetexcept();
+    fedisableexcept(current_fe_except);
+  }
+#endif
+
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, numbers::invalid_unsigned_int);
 

--- a/tests/scalapack/scalapack_10_d.cc
+++ b/tests/scalapack/scalapack_10_d.cc
@@ -87,6 +87,16 @@ test(const unsigned int size, const unsigned int block_size)
 int
 main(int argc, char **argv)
 {
+  // tests.h enables floating point exceptions in debug mode, but this test
+  // generates an (irrelevant) exception when run with more than one MPI
+  // process so disable them again:
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  {
+    const int current_fe_except = fegetexcept();
+    fedisableexcept(current_fe_except);
+  }
+#endif
+
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, numbers::invalid_unsigned_int);
 


### PR DESCRIPTION
I ran the full test suite on my desktop and got a few interesting failures: this is the first of a few patches.

This PR fixes a bunch of scalapack tests that would otherwise fail due to a floating point exception. Since these tests only verify that we can save and load scalapack matrices correctly the floating point exceptions are not relevant.