### PR TITLE
Fix compatibility with nanoflann 1.3.

### DIFF
--- a/tests/numerics/kdtree_01.cc
+++ b/tests/numerics/kdtree_01.cc
@@ -50,6 +50,8 @@ main()
       auto res = kdtree.get_closest_points(p, 1)[0];
       deallog << "P: " << p << ", distance: " << res.second
               << ", index: " << res.first << std::endl;
+      AssertThrow(std::abs(points[res.first].distance(p) - res.second) < 1e-10,
+                  ExcInternalError());
     }
 
   deallog


### PR DESCRIPTION
It looks like nanoflann switched to doing all computations with squared distances so all of our tests currently fail with the latest release. This PR fixes the problem by adding nanoflann version checks (so our interface is the same).

This is an extraordinary incompatibility in one of our dependencies. @luca-heltai have you tried running anything with this version of nanoflann?