### PR TITLE
SD scalar and tensor operations: Substitution and evaluation

### DIFF
--- a/doc/news/changes/minor/20190507Jean-PaulPelteret
+++ b/doc/news/changes/minor/20190507Jean-PaulPelteret
@@ -1,0 +1,5 @@
+New: Some utility functions that perform symbolic substitution on, and
+evaluation of, symbolic scalar and tensor expressions have been added to the 
+Differentiation::SD namespace.
+<br>
+(Jean-Paul Pelteret, 2019/05/07)

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -1246,6 +1246,155 @@ namespace Differentiation
       const std::vector<std::pair<ExpressionType, ValueType>> &symbol_values,
       const bool force_cyclic_dependency_resolution = false);
 
+    /**
+     * Perform a single substitution sweep of a set of symbols into the given
+     * symbolic expression.
+     * The symbols in the @p expression that correspond to the entry keys
+     * of the @p substitution_map are substituted with the map entry's associated
+     * value.
+     * This substitution function may be used to give a set of symbolic
+     * variables either a numeric interpretation or some symbolic definition.
+     *
+     * @note It is not required that all symbolic expressions be fully resolved
+     * when using this function. In other words, partial substitutions are
+     * valid.
+     *
+     * @note This function call is typically expensive, as by default it performs a
+     * dictionary substitution for the symbols in the symbolic expression.
+     * Should the numerical values of some symbolic expression be derired, then
+     * this performance deficit may be mitigated through the use of the
+     * BatchOptimizer class.
+     * Situation dependent, the overhead of using a typical dictionary based
+     * substitution may be on par with that of the a substitution performed
+     * using a BatchOptimizer. This is because there is an overhead to setting
+     * up the optimizer, so this should be taken into consideration if
+     * substitution is to occur for the given symbolic
+     * expression only a few times.
+     *
+     * @note If the symbols stored in the map are explicitly dependent on one another,
+     * then the returned result depends on order in which the map is traversed.
+     * It is recommended to first resolve all inter-dependencies in the map
+     * using the resolve_explicit_dependencies() function.
+     * Examples:
+     *   1. If <tt>map["a"] == 1</tt> and <tt>map["b"] == "a"+ 2</tt> then
+     *     then the function $f(a,b(a)) = a+b$ will be evaluated and the result
+     *     $f\vert_{a=1,b=a+2} = 3+a$ is returned. This return is because the
+     *     symbol "a" is substituted throughout the function first, and only
+     * then is the symbol "b(a)" substituted, by which time its explicit
+     * dependency on "a" cannot be resolved.
+     *  2. If <tt>map["a"] == "b"+2</tt> and <tt>map["b"] == 1</tt> then
+     *     then the function $f(a(b),a) = a+b$ will be evaluated and the result
+     *     $f\vert_{a=b+2, b} = [b+2+b]_{b=1} = 4$ is returned. This is because
+     * the explicitly dependent symbol "a(b)" is substituted first followed by
+     * the symbol "b".
+     */
+    Expression
+    substitute(const Expression &             expression,
+               const types::substitution_map &substitution_map);
+
+    /**
+     * Perform a substitution of the @p symbol into the given
+     * @p expression, with the result that all matches are assigned
+     * the corresponding @p value.
+     * This substitution function may be used to give a set of symbolic
+     * variables either a numeric interpretation or some symbolic definition.
+     *
+     * For more information regarding the performance of symbolic substitution,
+     * see the other @ref substitute(const Expression &,
+     * const types::substitution_map &) function.
+     *
+     * @note It is not required that all symbolic expressions be fully resolved
+     * when using this function. In other words, partial substitutions are
+     * valid.
+     */
+    template <typename ValueType>
+    Expression
+    substitute(const Expression &expression,
+               const Expression &symbol,
+               const ValueType & value);
+
+    /**
+     * Perform a single substitution sweep of a set of symbols into the given
+     * symbolic expression.
+     * The symbols in the @p expression that correspond to a matching entry key
+     * of the @p symbol_values vector entry are substituted by the entry's associated
+     * value.
+     * This substitution function may be used to give a set of symbolic
+     * variables either a numeric interpretation or some symbolic definition.
+     *
+     * For more information regarding the performance of symbolic substitution,
+     * see the other @ref substitute(const Expression &,
+     * const types::substitution_map &) function.
+     *
+     * @note It is not required that all symbolic expressions be fully resolved
+     * when using this function. In other words, partial substitutions are
+     * valid.
+     *
+     * @tparam Args Any symbolic type and value combination that is understood
+     *         by the make_substitution_map() functions. This includes
+     *         arguments involving individual Expressions,
+     *         std::vector<Expression>, as well as Tensors and SymmetricTensors
+     *         of Expressions.
+     */
+    template <typename ExpressionType = SD::Expression, typename... Args>
+    ExpressionType
+    substitute(const ExpressionType &expression, const Args &... symbol_values);
+
+    /**
+     * Perform a single substitution sweep of a set of symbols into the given
+     * symbolic function, and immediately evaluate the result.
+     * The symbols in the @p expression that correspond to the entry keys
+     * of the @p substitution_map are substituted with the map entry's associated
+     * value.
+     * This substitution function is used to give a set of symbolic variables
+     * a numeric interpretation, with the returned result being of the type
+     * specified by the @p ValueType template argument.
+     *
+     * For more information regarding the performance of symbolic substitution,
+     * and the outcome of evaluation using a substitution map with cyclic
+     * dependencies, see the @ref substitute(const Expression &,
+     * const types::substitution_map &) function.
+     *
+     * @note It is required that all symbols in the @p expression be
+     * successfully resolved by the @p substitution_map.
+     * If only partial substitution is performed, then an error is thrown.
+     */
+    template <typename ValueType>
+    ValueType
+    substitute_and_evaluate(const Expression &             expression,
+                            const types::substitution_map &substitution_map);
+
+    /**
+     * Perform a single substitution sweep of a set of symbols into the given
+     * symbolic function, and immediately evaluate the result.
+     * The symbols in the @p expression that correspond to the entry keys
+     * of the @p substitution_map are substituted with the map entry's associated
+     * value.
+     * This substitution function is used to give a set of symbolic variables
+     * a numeric interpretation, with the returned result being of the type
+     * specified by the @p ValueType template argument.
+     *
+     * For more information regarding the performance of symbolic substitution,
+     * and the outcome of evaluation using a substitution map with cyclic
+     * dependencies, see the @ref substitute(const Expression &,
+     * const types::substitution_map &) function.
+     *
+     * @note It is required that all symbols in the @p expression be
+     * successfully resolved by the substitution map that is generated with the
+     * input collection of @p symbol_values.
+     * If only partial substitution is performed, then an error is thrown.
+     *
+     * @tparam Args Any symbolic type and value combination that is understood
+     *         by the make_substitution_map() functions. This includes
+     *         arguments involving individual Expressions,
+     *         std::vector<Expression>, as well as Tensors and SymmetricTensors
+     *         of Expressions.
+     */
+    template <typename ValueType, typename... Args>
+    ValueType
+    substitute_and_evaluate(const Expression &expression,
+                            const Args &... symbol_values);
+
     //@}
 
   } // namespace SD
@@ -1703,6 +1852,45 @@ namespace Differentiation
     {
       return resolve_explicit_dependencies(make_substitution_map(symbol_values),
                                            force_cyclic_dependency_resolution);
+    }
+
+
+    template <typename ValueType>
+    Expression
+    substitute(const Expression &expression,
+               const Expression &symbol,
+               const ValueType & value)
+    {
+      return expression.substitute(symbol, value);
+    }
+
+
+    template <typename ExpressionType, typename... Args>
+    ExpressionType
+    substitute(const ExpressionType &expression, const Args &... symbol_values)
+    {
+      // Call other function
+      return substitute(expression, make_substitution_map(symbol_values...));
+    }
+
+
+    template <typename ValueType>
+    ValueType
+    substitute_and_evaluate(const Expression &             expression,
+                            const types::substitution_map &substitution_map)
+    {
+      return expression.substitute_and_evaluate<ValueType>(substitution_map);
+    }
+
+
+    template <typename ValueType, typename... Args>
+    ValueType
+    substitute_and_evaluate(const Expression &expression,
+                            const Args &... symbol_values)
+    {
+      // Call other function
+      return substitute_and_evaluate<ValueType>(
+        expression, make_substitution_map(symbol_values...));
     }
 
   } // namespace SD

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -1196,7 +1196,8 @@ namespace Differentiation
      * rendered by a single substitition of the returned dependency-resolved
      * map.
      *
-     * Example: If <tt>map["a"] -> 1</tt> and
+     * Example:
+     * If <tt>map["a"] -> 1</tt> and
      * <tt>map["b"] -> "a"+ 2</tt>, then then the function $f(a,b(a)) = a+b$
      * will be evaluated and the result $f\vert_{a=1,b=a+2} = 3+a$ is determined
      * upon the completion of the first sweep. A second sweep is therefore
@@ -1261,32 +1262,33 @@ namespace Differentiation
      *
      * @note This function call is typically expensive, as by default it performs a
      * dictionary substitution for the symbols in the symbolic expression.
-     * Should the numerical values of some symbolic expression be derired, then
+     * Should the numerical value of some symbolic expression be desired, then
      * this performance deficit may be mitigated through the use of the
      * BatchOptimizer class.
      * Situation dependent, the overhead of using a typical dictionary based
-     * substitution may be on par with that of the a substitution performed
+     * substitution may be on par with that of a substitution performed
      * using a BatchOptimizer. This is because there is an overhead to setting
      * up the optimizer, so this should be taken into consideration if
      * substitution is to occur for the given symbolic
      * expression only a few times.
      *
      * @note If the symbols stored in the map are explicitly dependent on one another,
-     * then the returned result depends on order in which the map is traversed.
-     * It is recommended to first resolve all inter-dependencies in the map
-     * using the resolve_explicit_dependencies() function.
+     * then the returned result depends on the order in which the map is
+     * traversed. It is recommended to first resolve all interdependencies in
+     * the map using the resolve_explicit_dependencies() function.
+     *
      * Examples:
-     *   1. If <tt>map["a"] == 1</tt> and <tt>map["b"] == "a"+ 2</tt> then
-     *     then the function $f(a,b(a)) = a+b$ will be evaluated and the result
+     *   1. If <tt>map["a"] == 1</tt> and <tt>map["b"] == "a" + 2</tt>,
+     *     then the function $f(a,b(a)) := a+b$ will be evaluated and the result
      *     $f\vert_{a=1,b=a+2} = 3+a$ is returned. This return is because the
      *     symbol "a" is substituted throughout the function first, and only
-     * then is the symbol "b(a)" substituted, by which time its explicit
-     * dependency on "a" cannot be resolved.
-     *  2. If <tt>map["a"] == "b"+2</tt> and <tt>map["b"] == 1</tt> then
-     *     then the function $f(a(b),a) = a+b$ will be evaluated and the result
+     *     then is the symbol "b(a)" substituted, by which time its explicit
+     *     dependency on "a" cannot be resolved.
+     *  2. If <tt>map["a"] == "b"+2</tt> and <tt>map["b"] == 1</tt>,
+     *     then the function $f(a(b),b): = a+b$ will be evaluated and the result
      *     $f\vert_{a=b+2, b} = [b+2+b]_{b=1} = 4$ is returned. This is because
-     * the explicitly dependent symbol "a(b)" is substituted first followed by
-     * the symbol "b".
+     *     the explicitly dependent symbol "a(b)" is substituted first followed
+     *     by the symbol "b".
      */
     Expression
     substitute(const Expression &             expression,
@@ -1294,7 +1296,7 @@ namespace Differentiation
 
     /**
      * Perform a substitution of the @p symbol into the given
-     * @p expression, with the result that all matches are assigned
+     * @p expression. All matches are assigned
      * the corresponding @p value.
      * This substitution function may be used to give a set of symbolic
      * variables either a numeric interpretation or some symbolic definition.
@@ -1385,7 +1387,7 @@ namespace Differentiation
      * of the @p substitution_map are substituted with the map entry's associated
      * value.
      * This substitution function is used to give a set of symbolic variables
-     * a numeric interpretation, with the returned result being of the type
+     * a numeric interpretation with the returned result being of the type
      * specified by the @p ValueType template argument.
      *
      * For more information regarding the performance of symbolic substitution,

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -1306,6 +1306,11 @@ namespace Differentiation
      * @note It is not required that all symbolic expressions be fully resolved
      * when using this function. In other words, partial substitutions are
      * valid.
+     *
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. Although it is typically
+     *         arithmetic in nature, it may also represent another symbolic
+     *         expression type.
      */
     template <typename ValueType>
     Expression
@@ -1330,13 +1335,17 @@ namespace Differentiation
      * when using this function. In other words, partial substitutions are
      * valid.
      *
+     * @tparam ExpressionType A type that represents a symbolic expression.
+     *         The Differentiation::SD::Expression class is often suitable for
+     *         this purpose, but this may also represent Tensors and
+     *         SymmetricTensors of Expressions.
      * @tparam Args Any symbolic type and value combination that is understood
      *         by the make_substitution_map() functions. This includes
      *         arguments involving individual Expressions,
      *         std::vector<Expression>, as well as Tensors and SymmetricTensors
      *         of Expressions.
      */
-    template <typename ExpressionType = SD::Expression, typename... Args>
+    template <typename ExpressionType, typename... Args>
     ExpressionType
     substitute(const ExpressionType &expression, const Args &... symbol_values);
 
@@ -1358,6 +1367,11 @@ namespace Differentiation
      * @note It is required that all symbols in the @p expression be
      * successfully resolved by the @p substitution_map.
      * If only partial substitution is performed, then an error is thrown.
+     *
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. In the context of this particular
+     *         function, this template parameter is typically arithmetic in
+     *         nature.
      */
     template <typename ValueType>
     ValueType
@@ -1384,6 +1398,10 @@ namespace Differentiation
      * input collection of @p symbol_values.
      * If only partial substitution is performed, then an error is thrown.
      *
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. In the context of this particular
+     *         function, this template parameter is typically arithmetic in
+     *         nature.
      * @tparam Args Any symbolic type and value combination that is understood
      *         by the make_substitution_map() functions. This includes
      *         arguments involving individual Expressions,

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -1308,6 +1308,18 @@ namespace Differentiation
       template <int dim, typename ExpressionType, typename ValueType>
       std::vector<std::pair<ExpressionType, ValueType>>
       tensor_substitution_map(
+        const Tensor<0, dim, ExpressionType> &symbol_tensor,
+        const Tensor<0, dim, ValueType> &     value_tensor)
+      {
+        const ExpressionType &expression = symbol_tensor;
+        const ValueType &     value      = value_tensor;
+        return {std::make_pair(expression, value)};
+      }
+
+
+      template <int dim, typename ExpressionType, typename ValueType>
+      std::vector<std::pair<ExpressionType, ValueType>>
+      tensor_substitution_map(
         const SymmetricTensor<4, dim, ExpressionType> &symbol_tensor,
         const SymmetricTensor<4, dim, ValueType> &     value_tensor)
       {
@@ -1389,6 +1401,16 @@ namespace Differentiation
 
 
       template <int dim>
+      Tensor<0, dim, Expression>
+      tensor_substitute(const Tensor<0, dim, Expression> &expression_tensor,
+                        const types::substitution_map &   substitution_map)
+      {
+        const Expression &expression = expression_tensor;
+        return substitute(expression, substitution_map);
+      }
+
+
+      template <int dim>
       SymmetricTensor<4, dim, Expression>
       tensor_substitute(
         const SymmetricTensor<4, dim, Expression> &expression_tensor,
@@ -1430,6 +1452,17 @@ namespace Differentiation
                                                  substitution_map);
           }
         return out;
+      }
+
+
+      template <typename ValueType, int dim>
+      Tensor<0, dim, ValueType>
+      tensor_substitute_evaluate(
+        const Tensor<0, dim, Expression> &expression_tensor,
+        const types::substitution_map &   substitution_map)
+      {
+        const Expression &expression = expression_tensor;
+        return substitute_and_evaluate<ValueType>(expression, substitution_map);
       }
 
 

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -1298,7 +1298,7 @@ namespace Differentiation
                 typename ValueType,
                 template <int, int, typename> class TensorType>
       std::vector<std::pair<ExpressionType, ValueType>>
-      tensor_substitution_map(
+      make_tensor_entries_for_substitution_map(
         const TensorType<rank, dim, ExpressionType> &symbol_tensor,
         const TensorType<rank, dim, ValueType> &     value_tensor)
       {
@@ -1317,7 +1317,7 @@ namespace Differentiation
 
       template <int dim, typename ExpressionType, typename ValueType>
       std::vector<std::pair<ExpressionType, ValueType>>
-      tensor_substitution_map(
+      make_tensor_entries_for_substitution_map(
         const Tensor<0, dim, ExpressionType> &symbol_tensor,
         const Tensor<0, dim, ValueType> &     value_tensor)
       {
@@ -1329,7 +1329,7 @@ namespace Differentiation
 
       template <int dim, typename ExpressionType, typename ValueType>
       std::vector<std::pair<ExpressionType, ValueType>>
-      tensor_substitution_map(
+      make_tensor_entries_for_substitution_map(
         const SymmetricTensor<4, dim, ExpressionType> &symbol_tensor,
         const SymmetricTensor<4, dim, ValueType> &     value_tensor)
       {
@@ -1364,7 +1364,8 @@ namespace Differentiation
     {
       add_to_substitution_map<ignore_invalid_symbols>(
         substitution_map,
-        internal::tensor_substitution_map(symbol_tensor, value_tensor));
+        internal::make_tensor_entries_for_substitution_map(symbol_tensor,
+                                                           value_tensor));
     }
 
 
@@ -1381,7 +1382,8 @@ namespace Differentiation
     {
       add_to_substitution_map<ignore_invalid_symbols>(
         substitution_map,
-        internal::tensor_substitution_map(symbol_tensor, value_tensor));
+        internal::make_tensor_entries_for_substitution_map(symbol_tensor,
+                                                           value_tensor));
     }
 
 
@@ -1394,7 +1396,7 @@ namespace Differentiation
                 int dim,
                 template <int, int, typename> class TensorType>
       TensorType<rank, dim, Expression>
-      tensor_substitute(
+      substitute_tensor(
         const TensorType<rank, dim, Expression> &expression_tensor,
         const types::substitution_map &          substitution_map)
       {
@@ -1412,7 +1414,7 @@ namespace Differentiation
 
       template <int dim>
       Tensor<0, dim, Expression>
-      tensor_substitute(const Tensor<0, dim, Expression> &expression_tensor,
+      substitute_tensor(const Tensor<0, dim, Expression> &expression_tensor,
                         const types::substitution_map &   substitution_map)
       {
         const Expression &expression = expression_tensor;
@@ -1422,7 +1424,7 @@ namespace Differentiation
 
       template <int dim>
       SymmetricTensor<4, dim, Expression>
-      tensor_substitute(
+      substitute_tensor(
         const SymmetricTensor<4, dim, Expression> &expression_tensor,
         const types::substitution_map &            substitution_map)
       {
@@ -1448,7 +1450,7 @@ namespace Differentiation
                 int dim,
                 template <int, int, typename> class TensorType>
       TensorType<rank, dim, ValueType>
-      tensor_substitute_evaluate(
+      substitute_and_evaluate_tensor(
         const TensorType<rank, dim, Expression> &expression_tensor,
         const types::substitution_map &          substitution_map)
       {
@@ -1467,7 +1469,7 @@ namespace Differentiation
 
       template <typename ValueType, int dim>
       Tensor<0, dim, ValueType>
-      tensor_substitute_evaluate(
+      substitute_and_evaluate_tensor(
         const Tensor<0, dim, Expression> &expression_tensor,
         const types::substitution_map &   substitution_map)
       {
@@ -1478,7 +1480,7 @@ namespace Differentiation
 
       template <typename ValueType, int dim>
       SymmetricTensor<4, dim, ValueType>
-      tensor_substitute_evaluate(
+      substitute_and_evaluate_tensor(
         const SymmetricTensor<4, dim, Expression> &expression_tensor,
         const types::substitution_map &            substitution_map)
       {
@@ -1506,7 +1508,7 @@ namespace Differentiation
     substitute(const Tensor<rank, dim, Expression> &expression_tensor,
                const types::substitution_map &      substitution_map)
     {
-      return internal::tensor_substitute(expression_tensor, substitution_map);
+      return internal::substitute_tensor(expression_tensor, substitution_map);
     }
 
 
@@ -1515,7 +1517,7 @@ namespace Differentiation
     substitute(const SymmetricTensor<rank, dim, Expression> &expression_tensor,
                const types::substitution_map &               substitution_map)
     {
-      return internal::tensor_substitute(expression_tensor, substitution_map);
+      return internal::substitute_tensor(expression_tensor, substitution_map);
     }
 
 
@@ -1525,8 +1527,8 @@ namespace Differentiation
       const Tensor<rank, dim, Expression> &expression_tensor,
       const types::substitution_map &      substitution_map)
     {
-      return internal::tensor_substitute_evaluate<ValueType>(expression_tensor,
-                                                             substitution_map);
+      return internal::substitute_and_evaluate_tensor<ValueType>(
+        expression_tensor, substitution_map);
     }
 
 
@@ -1536,8 +1538,8 @@ namespace Differentiation
       const SymmetricTensor<rank, dim, Expression> &expression_tensor,
       const types::substitution_map &               substitution_map)
     {
-      return internal::tensor_substitute_evaluate<ValueType>(expression_tensor,
-                                                             substitution_map);
+      return internal::substitute_and_evaluate_tensor<ValueType>(
+        expression_tensor, substitution_map);
     }
 
 

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -761,7 +761,17 @@ namespace Differentiation
       template <int dim>
       TableIndices<4>
       make_rank_4_tensor_indices(const unsigned int &idx_i,
-                                 const unsigned int &idx_j);
+                                 const unsigned int &idx_j)
+      {
+        const TableIndices<2> indices_i(
+          SymmetricTensor<2, dim>::unrolled_to_component_indices(idx_i));
+        const TableIndices<2> indices_j(
+          SymmetricTensor<2, dim>::unrolled_to_component_indices(idx_j));
+        return TableIndices<4>(indices_i[0],
+                               indices_i[1],
+                               indices_j[0],
+                               indices_j[1]);
+      }
 
 
       template <int rank_1, int rank_2>

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -694,7 +694,7 @@ namespace Differentiation
      * of the @p substitution_map are substituted with the map entry's associated
      * value.
      * This substitution function is used to give a set of symbolic variables
-     * a numeric interpretation, with the returned result being of the type
+     * a numeric interpretation with the returned result being of the type
      * specified by the @p ValueType template argument.
      *
      * For more information regarding the performance of symbolic substitution,

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -705,6 +705,11 @@ namespace Differentiation
      * @note It is required that all symbols in @p expression_tensor be
      * successfully resolved by the @p substitution_map.
      * If only partial substitution is performed, then an error is thrown.
+     *
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. In the context of this particular
+     *         function, this template parameter is typically arithmetic in
+     *         nature.
      */
     template <typename ValueType, int rank, int dim>
     Tensor<rank, dim, ValueType>
@@ -731,6 +736,11 @@ namespace Differentiation
      * @note It is required that all symbols in @p expression_tensor be
      * successfully resolved by the @p substitution_map.
      * If only partial substitution is performed, then an error is thrown.
+     *
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. In the context of this particular
+     *         function, this template parameter is typically arithmetic in
+     *         nature.
      */
     template <typename ValueType, int rank, int dim>
     SymmetricTensor<rank, dim, ValueType>

--- a/source/differentiation/sd/symengine_scalar_operations.cc
+++ b/source/differentiation/sd/symengine_scalar_operations.cc
@@ -253,6 +253,14 @@ namespace Differentiation
       return symbol_values_resolved;
     }
 
+
+    Expression
+    substitute(const Expression &             expression,
+               const types::substitution_map &substitution_map)
+    {
+      return expression.substitute(substitution_map);
+    }
+
   } // namespace SD
 } // namespace Differentiation
 

--- a/source/differentiation/sd/symengine_tensor_operations.cc
+++ b/source/differentiation/sd/symengine_tensor_operations.cc
@@ -38,21 +38,6 @@ namespace Differentiation
 
     namespace internal
     {
-      template <int dim>
-      TableIndices<4>
-      make_rank_4_tensor_indices(const unsigned int &idx_i,
-                                 const unsigned int &idx_j)
-      {
-        const TableIndices<2> indices_i(
-          SymmetricTensor<2, dim>::unrolled_to_component_indices(idx_i));
-        const TableIndices<2> indices_j(
-          SymmetricTensor<2, dim>::unrolled_to_component_indices(idx_j));
-        return TableIndices<4>(indices_i[0],
-                               indices_i[1],
-                               indices_j[0],
-                               indices_j[1]);
-      }
-
       namespace
       {
         template <int rank>

--- a/tests/symengine/symengine_scalar_operations_03.cc
+++ b/tests/symengine/symengine_scalar_operations_03.cc
@@ -1,0 +1,97 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that symbol substitution works for scalars
+
+#include <deal.II/differentiation/sd.h>
+
+#include "../tests.h"
+
+using namespace dealii;
+namespace SD = Differentiation::SD;
+
+
+int
+main()
+{
+  initlog();
+
+  using SD_number_t = SD::Expression;
+
+  const double a = 1.0;
+  const double b = 2.0;
+
+  const SD_number_t symb_a = SD::make_symbol("a");
+  const SD_number_t symb_b = SD::make_symbol("b");
+
+  deallog.push("Substitution: Individual");
+  {
+    const SD_number_t symb_a_plus_b = symb_a + symb_b;
+    deallog << "Symbolic a+b: " << symb_a_plus_b << std::endl;
+
+    const SD_number_t symb_a_plus_b_1 =
+      SD::substitute(symb_a_plus_b, symb_a, a);
+    deallog << "Symbolic a+b (a=1): " << symb_a_plus_b_1 << std::endl;
+
+    const SD_number_t symb_a_plus_b_subs =
+      SD::substitute(symb_a_plus_b_1, symb_b, b);
+    deallog << "Symbolic a+b (a=1, b=2): " << symb_a_plus_b_subs << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Substitution: Vector");
+  {
+    const SD_number_t symb_a_plus_b = symb_a + symb_b;
+
+    const std::vector<std::pair<SD_number_t, double>> symbol_values{
+      std::make_pair(symb_a, a), std::make_pair(symb_b, b)};
+
+    const SD_number_t symb_a_plus_b_subs =
+      SD::substitute(symb_a_plus_b, symbol_values);
+    deallog << "Symbolic a+b (a=1, b=2): " << symb_a_plus_b_subs << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Substitution: Map");
+  {
+    const SD_number_t symb_a_plus_b = symb_a + symb_b;
+
+    const SD::types::substitution_map substitution_map =
+      SD::make_substitution_map(std::make_pair(symb_a, a),
+                                std::make_pair(symb_b, b));
+
+    const SD_number_t symb_a_plus_b_subs =
+      SD::substitute(symb_a_plus_b, substitution_map);
+    deallog << "Symbolic a+b (a=1, b=2): " << symb_a_plus_b_subs << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Substitution with evaluation");
+  {
+    const SD_number_t symb_a_plus_b = symb_a + symb_b;
+
+    const SD::types::substitution_map substitution_map =
+      SD::make_substitution_map(std::make_pair(symb_a, a),
+                                std::make_pair(symb_b, b));
+
+    const double symb_a_plus_b_subs =
+      SD::substitute_and_evaluate<double>(symb_a_plus_b, substitution_map);
+    Assert(symb_a_plus_b_subs == (a + b), ExcInternalError());
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/symengine/symengine_scalar_operations_03.output
+++ b/tests/symengine/symengine_scalar_operations_03.output
@@ -1,0 +1,7 @@
+
+DEAL:Substitution: Individual::Symbolic a+b: a + b
+DEAL:Substitution: Individual::Symbolic a+b (a=1): 1.0 + b
+DEAL:Substitution: Individual::Symbolic a+b (a=1, b=2): 3.0
+DEAL:Substitution: Vector::Symbolic a+b (a=1, b=2): 3.0
+DEAL:Substitution: Map::Symbolic a+b (a=1, b=2): 3.0
+DEAL::OK

--- a/tests/symengine/symengine_tensor_operations_04.cc
+++ b/tests/symengine/symengine_tensor_operations_04.cc
@@ -1,0 +1,163 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that symbol substitution works for tensors
+
+#include <deal.II/differentiation/sd.h>
+
+#include "../tests.h"
+
+using namespace dealii;
+namespace SD = Differentiation::SD;
+
+using SD_number_t = SD::Expression;
+
+template <int rank, int dim, template <int, int, typename> class TensorType>
+void
+test(const TensorType<rank, dim, double>      a,
+     const TensorType<rank, dim, double>      b,
+     const TensorType<rank, dim, SD_number_t> symb_a,
+     const TensorType<rank, dim, SD_number_t> symb_b)
+{
+  using Tensor_SD_number_t = TensorType<rank, dim, SD_number_t>;
+  using Tensor_t           = TensorType<rank, dim, double>;
+
+  deallog.push("Substitution: Individual");
+  {
+    const Tensor_SD_number_t symb_a_plus_b = symb_a + symb_b;
+    deallog << "Symbolic a+b: " << symb_a_plus_b << std::endl;
+
+    const Tensor_SD_number_t symb_a_plus_b_1 =
+      SD::substitute(symb_a_plus_b, symb_a, a);
+    deallog << "Symbolic a+b (a=1): " << symb_a_plus_b_1 << std::endl;
+
+    const Tensor_SD_number_t symb_a_plus_b_subs =
+      SD::substitute(symb_a_plus_b_1, symb_b, b);
+    deallog << "Symbolic a+b (a=1, b=2): " << symb_a_plus_b_subs << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Substitution: Vector");
+  {
+    const Tensor_SD_number_t symb_a_plus_b = symb_a + symb_b;
+
+    const std::vector<std::pair<Tensor_SD_number_t, Tensor_t>> symbol_values{
+      std::make_pair(symb_a, a), std::make_pair(symb_b, b)};
+
+    const Tensor_SD_number_t symb_a_plus_b_subs =
+      SD::substitute(symb_a_plus_b, symbol_values);
+    deallog << "Symbolic a+b (a=1, b=2): " << symb_a_plus_b_subs << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Substitution: Map");
+  {
+    const Tensor_SD_number_t symb_a_plus_b = symb_a + symb_b;
+
+    const SD::types::substitution_map substitution_map =
+      SD::make_substitution_map(std::make_pair(symb_a, a),
+                                std::make_pair(symb_b, b));
+
+    const Tensor_SD_number_t symb_a_plus_b_subs =
+      SD::substitute(symb_a_plus_b, substitution_map);
+    deallog << "Symbolic a+b (a=1, b=2): " << symb_a_plus_b_subs << std::endl;
+  }
+  deallog.pop();
+
+  deallog.push("Substitution with evaluation");
+  {
+    const Tensor_SD_number_t symb_a_plus_b = symb_a + symb_b;
+
+    const SD::types::substitution_map substitution_map =
+      SD::make_substitution_map(std::make_pair(symb_a, a),
+                                std::make_pair(symb_b, b));
+
+    const Tensor_t symb_a_plus_b_subs =
+      SD::substitute_and_evaluate<double>(symb_a_plus_b, substitution_map);
+    Assert(symb_a_plus_b_subs == (a + b), ExcInternalError());
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl << std::endl;
+}
+
+
+template <int rank, int dim>
+void
+test_tensor()
+{
+  deallog << "Tensor: Rank " << rank << ", dim " << dim << std::endl;
+
+  using Tensor_SD_number_t = Tensor<rank, dim, SD_number_t>;
+  using Tensor_t           = Tensor<rank, dim, double>;
+
+  Tensor_t t_a, t_b;
+  for (auto it = t_a.begin_raw(); it != t_a.end_raw(); ++it)
+    *it = 1.0;
+  for (auto it = t_b.begin_raw(); it != t_b.end_raw(); ++it)
+    *it = 2.0;
+
+  const Tensor_SD_number_t symb_t_a =
+    SD::make_tensor_of_symbols<rank, dim>("a");
+  const Tensor_SD_number_t symb_t_b =
+    SD::make_tensor_of_symbols<rank, dim>("b");
+
+  test(t_a, t_b, symb_t_a, symb_t_b);
+}
+
+
+template <int rank, int dim>
+void
+test_symmetric_tensor()
+{
+  deallog << "SymmetricTensor: Rank " << rank << ", dim " << dim << std::endl;
+
+  using Tensor_SD_number_t = SymmetricTensor<rank, dim, SD_number_t>;
+  using Tensor_t           = SymmetricTensor<rank, dim, double>;
+
+  Tensor_t t_a, t_b;
+  for (auto it = t_a.begin_raw(); it != t_a.end_raw(); ++it)
+    *it = 1.0;
+  for (auto it = t_b.begin_raw(); it != t_b.end_raw(); ++it)
+    *it = 2.0;
+
+  const Tensor_SD_number_t symb_t_a =
+    SD::make_symmetric_tensor_of_symbols<rank, dim>("a");
+  const Tensor_SD_number_t symb_t_b =
+    SD::make_symmetric_tensor_of_symbols<rank, dim>("b");
+
+  test(t_a, t_b, symb_t_a, symb_t_b);
+}
+
+
+int
+main()
+{
+  initlog();
+
+  const int dim = 2;
+
+  test_tensor<0, dim>();
+  test_tensor<1, dim>();
+  test_tensor<2, dim>();
+  test_tensor<3, dim>();
+  test_tensor<4, dim>();
+
+  test_symmetric_tensor<2, dim>();
+  test_symmetric_tensor<4, dim>();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/symengine/symengine_tensor_operations_04.output
+++ b/tests/symengine/symengine_tensor_operations_04.output
@@ -1,0 +1,58 @@
+
+DEAL::Tensor: Rank 0, dim 2
+DEAL:Substitution: Individual::Symbolic a+b: a + b
+DEAL:Substitution: Individual::Symbolic a+b (a=1): 1.0 + b
+DEAL:Substitution: Individual::Symbolic a+b (a=1, b=2): 3.0
+DEAL:Substitution: Vector::Symbolic a+b (a=1, b=2): 3.0
+DEAL:Substitution: Map::Symbolic a+b (a=1, b=2): 3.0
+DEAL::OK
+DEAL::
+DEAL::Tensor: Rank 1, dim 2
+DEAL:Substitution: Individual::Symbolic a+b: a_0 + b_0 a_1 + b_1
+DEAL:Substitution: Individual::Symbolic a+b (a=1): 1.0 + b_0 1.0 + b_1
+DEAL:Substitution: Individual::Symbolic a+b (a=1, b=2): 3.0 3.0
+DEAL:Substitution: Vector::Symbolic a+b (a=1, b=2): 3.0 3.0
+DEAL:Substitution: Map::Symbolic a+b (a=1, b=2): 3.0 3.0
+DEAL::OK
+DEAL::
+DEAL::Tensor: Rank 2, dim 2
+DEAL:Substitution: Individual::Symbolic a+b: a_00 + b_00 a_01 + b_01 a_10 + b_10 a_11 + b_11
+DEAL:Substitution: Individual::Symbolic a+b (a=1): 1.0 + b_00 1.0 + b_01 1.0 + b_10 1.0 + b_11
+DEAL:Substitution: Individual::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0
+DEAL:Substitution: Vector::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0
+DEAL:Substitution: Map::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0
+DEAL::OK
+DEAL::
+DEAL::Tensor: Rank 3, dim 2
+DEAL:Substitution: Individual::Symbolic a+b: a_000 + b_000 a_001 + b_001 a_010 + b_010 a_011 + b_011 a_100 + b_100 a_101 + b_101 a_110 + b_110 a_111 + b_111
+DEAL:Substitution: Individual::Symbolic a+b (a=1): 1.0 + b_000 1.0 + b_001 1.0 + b_010 1.0 + b_011 1.0 + b_100 1.0 + b_101 1.0 + b_110 1.0 + b_111
+DEAL:Substitution: Individual::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0
+DEAL:Substitution: Vector::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0
+DEAL:Substitution: Map::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0
+DEAL::OK
+DEAL::
+DEAL::Tensor: Rank 4, dim 2
+DEAL:Substitution: Individual::Symbolic a+b: a_0000 + b_0000 a_0001 + b_0001 a_0010 + b_0010 a_0011 + b_0011 a_0100 + b_0100 a_0101 + b_0101 a_0110 + b_0110 a_0111 + b_0111 a_1000 + b_1000 a_1001 + b_1001 a_1010 + b_1010 a_1011 + b_1011 a_1100 + b_1100 a_1101 + b_1101 a_1110 + b_1110 a_1111 + b_1111
+DEAL:Substitution: Individual::Symbolic a+b (a=1): 1.0 + b_0000 1.0 + b_0001 1.0 + b_0010 1.0 + b_0011 1.0 + b_0100 1.0 + b_0101 1.0 + b_0110 1.0 + b_0111 1.0 + b_1000 1.0 + b_1001 1.0 + b_1010 1.0 + b_1011 1.0 + b_1100 1.0 + b_1101 1.0 + b_1110 1.0 + b_1111
+DEAL:Substitution: Individual::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0
+DEAL:Substitution: Vector::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0
+DEAL:Substitution: Map::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0
+DEAL::OK
+DEAL::
+DEAL::SymmetricTensor: Rank 2, dim 2
+DEAL:Substitution: Individual::Symbolic a+b: a_00 + b_00 a_01 + b_01 a_01 + b_01 a_11 + b_11
+DEAL:Substitution: Individual::Symbolic a+b (a=1): 1.0 + b_00 1.0 + b_01 1.0 + b_01 1.0 + b_11
+DEAL:Substitution: Individual::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0
+DEAL:Substitution: Vector::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0
+DEAL:Substitution: Map::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0
+DEAL::OK
+DEAL::
+DEAL::SymmetricTensor: Rank 4, dim 2
+DEAL:Substitution: Individual::Symbolic a+b: a_0000 + b_0000 a_0001 + b_0001 a_0001 + b_0001 a_0011 + b_0011 a_0100 + b_0100 a_0101 + b_0101 a_0101 + b_0101 a_0111 + b_0111 a_0100 + b_0100 a_0101 + b_0101 a_0101 + b_0101 a_0111 + b_0111 a_1100 + b_1100 a_1101 + b_1101 a_1101 + b_1101 a_1111 + b_1111
+DEAL:Substitution: Individual::Symbolic a+b (a=1): 1.0 + b_0000 1.0 + b_0001 1.0 + b_0001 1.0 + b_0011 1.0 + b_0100 1.0 + b_0101 1.0 + b_0101 1.0 + b_0111 1.0 + b_0100 1.0 + b_0101 1.0 + b_0101 1.0 + b_0111 1.0 + b_1100 1.0 + b_1101 1.0 + b_1101 1.0 + b_1111
+DEAL:Substitution: Individual::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0
+DEAL:Substitution: Vector::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0
+DEAL:Substitution: Map::Symbolic a+b (a=1, b=2): 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0
+DEAL::OK
+DEAL::
+DEAL::OK


### PR DESCRIPTION
This is the last set of patches required to make it possible to do something useful with scalar and tensor symbolic expressions. This will not be useful for terribly much other than debugging because dictionary-based substitution is not particularly performant when the expressions are long, there are many symbols to be substituted, or one performs the substitution many times. It will, however, not be feasible to get the tools to increase the performance of the substitution/evaluation step before the next release since the implementation is a bit more intricate. 

So, after this and until the next release is done, I will focus on adding more tests and cleaning up the documentation.