### PR TITLE
Remove some unnecessary std::moves.

### DIFF
--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -357,22 +357,22 @@ protected:
       & /*output_data*/) const override
   {
     // generate a new data object and initialize some fields
-    auto data = std_cxx14::make_unique<
+    auto data_ptr = std_cxx14::make_unique<
       typename FiniteElement<1, spacedim>::InternalDataBase>();
-    data->update_each = requires_update_flags(update_flags);
+    data_ptr->update_each = requires_update_flags(update_flags);
 
     const unsigned int n_q_points = quadrature.size();
     AssertDimension(n_q_points, 1);
     (void)n_q_points;
 
     // No derivatives of this element are implemented.
-    if (data->update_each & update_gradients ||
-        data->update_each & update_hessians)
+    if (data_ptr->update_each & update_gradients ||
+        data_ptr->update_each & update_hessians)
       {
         Assert(false, ExcNotImplemented());
       }
 
-    return std::move(data);
+    return data_ptr;
   }
 
   std::unique_ptr<typename FiniteElement<1, spacedim>::InternalDataBase>

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -283,14 +283,14 @@ FE_DGPNonparametric<dim, spacedim>::get_data(
     & /*output_data*/) const
 {
   // generate a new data object
-  auto data = std_cxx14::make_unique<
+  auto data_ptr = std_cxx14::make_unique<
     typename FiniteElement<dim, spacedim>::InternalDataBase>();
-  data->update_each = requires_update_flags(update_flags);
+  data_ptr->update_each = requires_update_flags(update_flags);
 
   // other than that, there is nothing we can add here as discussed
   // in the general documentation of this class
 
-  return std::move(data);
+  return data_ptr;
 }
 
 

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -331,33 +331,35 @@ FE_Enriched<dim, spacedim>::setup_data(
   // Pass ownership of the FiniteElement::InternalDataBase object
   // that fes_data points to, to the new InternalData object.
   auto update_each_flags = fes_data->update_each;
-  auto data = std_cxx14::make_unique<InternalData>(std::move(fes_data));
+  std::unique_ptr<typename FiniteElement<dim, spacedim>::InternalDataBase>
+        data_ptr = std_cxx14::make_unique<InternalData>(std::move(fes_data));
+  auto &data     = dynamic_cast<InternalData &>(*data_ptr);
 
   // copy update_each from FESystem data:
-  data->update_each = update_each_flags;
+  data.update_each = update_each_flags;
 
   // resize cache array according to requested flags
-  data->enrichment.resize(this->n_base_elements());
+  data.enrichment.resize(this->n_base_elements());
 
   const unsigned int n_q_points = quadrature.size();
 
   for (unsigned int base = 0; base < this->n_base_elements(); ++base)
     {
-      data->enrichment[base].resize(this->element_multiplicity(base));
+      data.enrichment[base].resize(this->element_multiplicity(base));
       for (unsigned int m = 0; m < this->element_multiplicity(base); ++m)
         {
           if (flags & update_values)
-            data->enrichment[base][m].values.resize(n_q_points);
+            data.enrichment[base][m].values.resize(n_q_points);
 
           if (flags & update_gradients)
-            data->enrichment[base][m].gradients.resize(n_q_points);
+            data.enrichment[base][m].gradients.resize(n_q_points);
 
           if (flags & update_hessians)
-            data->enrichment[base][m].hessians.resize(n_q_points);
+            data.enrichment[base][m].hessians.resize(n_q_points);
         }
     }
 
-  return std::move(data);
+  return data_ptr;
 }
 
 

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -140,18 +140,19 @@ FE_P1NC::get_data(
   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2, 2>
     &output_data) const
 {
-  auto data = std_cxx14::make_unique<FiniteElement<2, 2>::InternalDataBase>();
+  auto data_ptr =
+    std_cxx14::make_unique<FiniteElement<2, 2>::InternalDataBase>();
 
-  data->update_each = requires_update_flags(update_flags);
+  data_ptr->update_each = requires_update_flags(update_flags);
 
   const unsigned int n_q_points = quadrature.size();
-  output_data.initialize(n_q_points, FE_P1NC(), data->update_each);
+  output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if (data->update_each & update_hessians)
+  if (data_ptr->update_each & update_hessians)
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
-  return data;
+  return data_ptr;
 }
 
 
@@ -164,18 +165,19 @@ FE_P1NC::get_face_data(
   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2, 2>
     &output_data) const
 {
-  auto data = std_cxx14::make_unique<FiniteElement<2, 2>::InternalDataBase>();
+  auto data_ptr =
+    std_cxx14::make_unique<FiniteElement<2, 2>::InternalDataBase>();
 
-  data->update_each = requires_update_flags(update_flags);
+  data_ptr->update_each = requires_update_flags(update_flags);
 
   const unsigned int n_q_points = quadrature.size();
-  output_data.initialize(n_q_points, FE_P1NC(), data->update_each);
+  output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if (data->update_each & update_hessians)
+  if (data_ptr->update_each & update_hessians)
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
-  return data;
+  return data_ptr;
 }
 
 
@@ -188,18 +190,19 @@ FE_P1NC::get_subface_data(
   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<2, 2>
     &output_data) const
 {
-  auto data = std_cxx14::make_unique<FiniteElement<2, 2>::InternalDataBase>();
+  auto data_ptr =
+    std_cxx14::make_unique<FiniteElement<2, 2>::InternalDataBase>();
 
-  data->update_each = requires_update_flags(update_flags);
+  data_ptr->update_each = requires_update_flags(update_flags);
 
   const unsigned int n_q_points = quadrature.size();
-  output_data.initialize(n_q_points, FE_P1NC(), data->update_each);
+  output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if (data->update_each & update_hessians)
+  if (data_ptr->update_each & update_hessians)
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
-  return data;
+  return data_ptr;
 }
 
 

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -940,8 +940,10 @@ FESystem<dim, spacedim>::get_data(
   // and so the current object's update_each flag needs to be
   // correct in case the current FESystem is a base element for another,
   // higher-level FESystem itself.
-  auto data = std_cxx14::make_unique<InternalData>(this->n_base_elements());
-  data->update_each = requires_update_flags(flags);
+  std::unique_ptr<typename FiniteElement<dim, spacedim>::InternalDataBase>
+        data_ptr = std_cxx14::make_unique<InternalData>(this->n_base_elements());
+  auto &data     = dynamic_cast<InternalData &>(*data_ptr);
+  data.update_each = requires_update_flags(flags);
 
   // get data objects from each of the base elements and store
   // them. one might think that doing this in parallel (over the
@@ -958,7 +960,7 @@ FESystem<dim, spacedim>::get_data(
   for (unsigned int base_no = 0; base_no < this->n_base_elements(); ++base_no)
     {
       internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim>
-        &base_fe_output_object = data->get_fe_output_object(base_no);
+        &base_fe_output_object = data.get_fe_output_object(base_no);
       base_fe_output_object.initialize(
         quadrature.size(),
         base_element(base_no),
@@ -975,10 +977,10 @@ FESystem<dim, spacedim>::get_data(
                                                          quadrature,
                                                          base_fe_output_object);
 
-      data->set_fe_data(base_no, std::move(base_fe_data));
+      data.set_fe_data(base_no, std::move(base_fe_data));
     }
 
-  return std::move(data);
+  return data_ptr;
 }
 
 // The following function is a clone of get_data, with the exception
@@ -1001,8 +1003,10 @@ FESystem<dim, spacedim>::get_face_data(
   // and so the current object's update_each flag needs to be
   // correct in case the current FESystem is a base element for another,
   // higher-level FESystem itself.
-  auto data = std_cxx14::make_unique<InternalData>(this->n_base_elements());
-  data->update_each = requires_update_flags(flags);
+  std::unique_ptr<typename FiniteElement<dim, spacedim>::InternalDataBase>
+        data_ptr = std_cxx14::make_unique<InternalData>(this->n_base_elements());
+  auto &data     = dynamic_cast<InternalData &>(*data_ptr);
+  data.update_each = requires_update_flags(flags);
 
   // get data objects from each of the base elements and store
   // them. one might think that doing this in parallel (over the
@@ -1019,7 +1023,7 @@ FESystem<dim, spacedim>::get_face_data(
   for (unsigned int base_no = 0; base_no < this->n_base_elements(); ++base_no)
     {
       internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim>
-        &base_fe_output_object = data->get_fe_output_object(base_no);
+        &base_fe_output_object = data.get_fe_output_object(base_no);
       base_fe_output_object.initialize(
         quadrature.size(),
         base_element(base_no),
@@ -1034,10 +1038,10 @@ FESystem<dim, spacedim>::get_face_data(
       auto base_fe_data = base_element(base_no).get_face_data(
         flags, mapping, quadrature, base_fe_output_object);
 
-      data->set_fe_data(base_no, std::move(base_fe_data));
+      data.set_fe_data(base_no, std::move(base_fe_data));
     }
 
-  return std::move(data);
+  return data_ptr;
 }
 
 
@@ -1062,8 +1066,11 @@ FESystem<dim, spacedim>::get_subface_data(
   // and so the current object's update_each flag needs to be
   // correct in case the current FESystem is a base element for another,
   // higher-level FESystem itself.
-  auto data = std_cxx14::make_unique<InternalData>(this->n_base_elements());
-  data->update_each = requires_update_flags(flags);
+  std::unique_ptr<typename FiniteElement<dim, spacedim>::InternalDataBase>
+        data_ptr = std_cxx14::make_unique<InternalData>(this->n_base_elements());
+  auto &data     = dynamic_cast<InternalData &>(*data_ptr);
+
+  data.update_each = requires_update_flags(flags);
 
   // get data objects from each of the base elements and store
   // them. one might think that doing this in parallel (over the
@@ -1080,7 +1087,7 @@ FESystem<dim, spacedim>::get_subface_data(
   for (unsigned int base_no = 0; base_no < this->n_base_elements(); ++base_no)
     {
       internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim>
-        &base_fe_output_object = data->get_fe_output_object(base_no);
+        &base_fe_output_object = data.get_fe_output_object(base_no);
       base_fe_output_object.initialize(
         quadrature.size(),
         base_element(base_no),
@@ -1095,10 +1102,10 @@ FESystem<dim, spacedim>::get_subface_data(
       auto base_fe_data = base_element(base_no).get_subface_data(
         flags, mapping, quadrature, base_fe_output_object);
 
-      data->set_fe_data(base_no, std::move(base_fe_data));
+      data.set_fe_data(base_no, std::move(base_fe_data));
     }
 
-  return std::move(data);
+  return data_ptr;
 }
 
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -98,14 +98,16 @@ std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
 MappingCartesian<dim, spacedim>::get_data(const UpdateFlags      update_flags,
                                           const Quadrature<dim> &q) const
 {
-  auto data = std_cxx14::make_unique<InternalData>(q);
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>(q);
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // store the flags in the internal data object so we can access them
   // in fill_fe_*_values(). use the transitive hull of the required
   // flags
-  data->update_each = requires_update_flags(update_flags);
+  data.update_each = requires_update_flags(update_flags);
 
-  return std::move(data);
+  return data_ptr;
 }
 
 
@@ -116,8 +118,10 @@ MappingCartesian<dim, spacedim>::get_face_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  auto data = std_cxx14::make_unique<InternalData>(
-    QProjector<dim>::project_to_all_faces(quadrature));
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>(
+      QProjector<dim>::project_to_all_faces(quadrature));
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // verify that we have computed the transitive hull of the required
   // flags and that FEValues has faithfully passed them on to us
@@ -126,9 +130,9 @@ MappingCartesian<dim, spacedim>::get_face_data(
 
   // store the flags in the internal data object so we can access them
   // in fill_fe_*_values()
-  data->update_each = update_flags;
+  data.update_each = update_flags;
 
-  return std::move(data);
+  return data_ptr;
 }
 
 
@@ -139,8 +143,10 @@ MappingCartesian<dim, spacedim>::get_subface_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  auto data = std_cxx14::make_unique<InternalData>(
-    QProjector<dim>::project_to_all_subfaces(quadrature));
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>(
+      QProjector<dim>::project_to_all_subfaces(quadrature));
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // verify that we have computed the transitive hull of the required
   // flags and that FEValues has faithfully passed them on to us
@@ -149,9 +155,9 @@ MappingCartesian<dim, spacedim>::get_subface_data(
 
   // store the flags in the internal data object so we can access them
   // in fill_fe_*_values()
-  data->update_each = update_flags;
+  data.update_each = update_flags;
 
-  return std::move(data);
+  return data_ptr;
 }
 
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -566,10 +566,12 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::get_data(
   const UpdateFlags      update_flags,
   const Quadrature<dim> &quadrature) const
 {
-  auto data =
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std_cxx14::make_unique<InternalData>(euler_dof_handler->get_fe(), fe_mask);
-  this->compute_data(update_flags, quadrature, quadrature.size(), *data);
-  return std::move(data);
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
+  this->compute_data(update_flags, quadrature, quadrature.size(), data);
+
+  return data_ptr;
 }
 
 
@@ -580,12 +582,13 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::get_face_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  auto data =
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std_cxx14::make_unique<InternalData>(euler_dof_handler->get_fe(), fe_mask);
+  auto &                data = dynamic_cast<InternalData &>(*data_ptr);
   const Quadrature<dim> q(QProjector<dim>::project_to_all_faces(quadrature));
-  this->compute_face_data(update_flags, q, quadrature.size(), *data);
+  this->compute_face_data(update_flags, q, quadrature.size(), data);
 
-  return std::move(data);
+  return data_ptr;
 }
 
 
@@ -595,12 +598,13 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::get_subface_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  auto data =
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std_cxx14::make_unique<InternalData>(euler_dof_handler->get_fe(), fe_mask);
+  auto &                data = dynamic_cast<InternalData &>(*data_ptr);
   const Quadrature<dim> q(QProjector<dim>::project_to_all_subfaces(quadrature));
-  this->compute_face_data(update_flags, q, quadrature.size(), *data);
+  this->compute_face_data(update_flags, q, quadrature.size(), data);
 
-  return std::move(data);
+  return data_ptr;
 }
 
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -314,10 +314,12 @@ std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
 MappingManifold<dim, spacedim>::get_data(const UpdateFlags      update_flags,
                                          const Quadrature<dim> &q) const
 {
-  auto data = std_cxx14::make_unique<InternalData>();
-  data->initialize(this->requires_update_flags(update_flags), q, q.size());
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>();
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
+  data.initialize(this->requires_update_flags(update_flags), q, q.size());
 
-  return std::move(data);
+  return data_ptr;
 }
 
 
@@ -328,12 +330,14 @@ MappingManifold<dim, spacedim>::get_face_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  auto data = std_cxx14::make_unique<InternalData>();
-  data->initialize_face(this->requires_update_flags(update_flags),
-                        QProjector<dim>::project_to_all_faces(quadrature),
-                        quadrature.size());
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>();
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
+  data.initialize_face(this->requires_update_flags(update_flags),
+                       QProjector<dim>::project_to_all_faces(quadrature),
+                       quadrature.size());
 
-  return std::move(data);
+  return data_ptr;
 }
 
 
@@ -344,12 +348,14 @@ MappingManifold<dim, spacedim>::get_subface_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  auto data = std_cxx14::make_unique<InternalData>();
-  data->initialize_face(this->requires_update_flags(update_flags),
-                        QProjector<dim>::project_to_all_subfaces(quadrature),
-                        quadrature.size());
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>();
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
+  data.initialize_face(this->requires_update_flags(update_flags),
+                       QProjector<dim>::project_to_all_subfaces(quadrature),
+                       quadrature.size());
 
-  return std::move(data);
+  return data_ptr;
 }
 
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -151,7 +151,9 @@ std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
 MappingQ<dim, spacedim>::get_data(const UpdateFlags      update_flags,
                                   const Quadrature<dim> &quadrature) const
 {
-  auto data = std_cxx14::make_unique<InternalData>();
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>();
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // build the Q1 and Qp internal data objects in parallel
   Threads::Task<
@@ -162,15 +164,15 @@ MappingQ<dim, spacedim>::get_data(const UpdateFlags      update_flags,
                                     quadrature);
 
   if (!use_mapping_q_on_all_cells)
-    data->mapping_q1_data = Utilities::dynamic_unique_cast<
+    data.mapping_q1_data = Utilities::dynamic_unique_cast<
       typename MappingQGeneric<dim, spacedim>::InternalData>(
       std::move(q1_mapping->get_data(update_flags, quadrature)));
 
   // wait for the task above to finish and use returned value
-  data->mapping_qp_data = Utilities::dynamic_unique_cast<
+  data.mapping_qp_data = Utilities::dynamic_unique_cast<
     typename MappingQGeneric<dim, spacedim>::InternalData>(
     std::move(do_get_data.return_value()));
-  return std::move(data);
+  return data_ptr;
 }
 
 
@@ -181,7 +183,9 @@ MappingQ<dim, spacedim>::get_face_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  auto data = std_cxx14::make_unique<InternalData>();
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>();
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // build the Q1 and Qp internal data objects in parallel
   Threads::Task<
@@ -193,15 +197,15 @@ MappingQ<dim, spacedim>::get_face_data(
                         quadrature);
 
   if (!use_mapping_q_on_all_cells)
-    data->mapping_q1_data = Utilities::dynamic_unique_cast<
+    data.mapping_q1_data = Utilities::dynamic_unique_cast<
       typename MappingQGeneric<dim, spacedim>::InternalData>(
       std::move(q1_mapping->get_face_data(update_flags, quadrature)));
 
   // wait for the task above to finish and use returned value
-  data->mapping_qp_data = Utilities::dynamic_unique_cast<
+  data.mapping_qp_data = Utilities::dynamic_unique_cast<
     typename MappingQGeneric<dim, spacedim>::InternalData>(
     std::move(do_get_data.return_value()));
-  return std::move(data);
+  return data_ptr;
 }
 
 
@@ -212,7 +216,9 @@ MappingQ<dim, spacedim>::get_subface_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  auto data = std_cxx14::make_unique<InternalData>();
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>();
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // build the Q1 and Qp internal data objects in parallel
   Threads::Task<
@@ -224,15 +230,15 @@ MappingQ<dim, spacedim>::get_subface_data(
                         quadrature);
 
   if (!use_mapping_q_on_all_cells)
-    data->mapping_q1_data = Utilities::dynamic_unique_cast<
+    data.mapping_q1_data = Utilities::dynamic_unique_cast<
       typename MappingQGeneric<dim, spacedim>::InternalData>(
       std::move(q1_mapping->get_subface_data(update_flags, quadrature)));
 
   // wait for the task above to finish and use returned value
-  data->mapping_qp_data = Utilities::dynamic_unique_cast<
+  data.mapping_qp_data = Utilities::dynamic_unique_cast<
     typename MappingQGeneric<dim, spacedim>::InternalData>(
     std::move(do_get_data.return_value()));
-  return std::move(data);
+  return data_ptr;
 }
 
 

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -2724,10 +2724,12 @@ std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
 MappingQGeneric<dim, spacedim>::get_data(const UpdateFlags      update_flags,
                                          const Quadrature<dim> &q) const
 {
-  auto data = std_cxx14::make_unique<InternalData>(polynomial_degree);
-  data->initialize(this->requires_update_flags(update_flags), q, q.size());
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>(polynomial_degree);
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
+  data.initialize(this->requires_update_flags(update_flags), q, q.size());
 
-  return std::move(data);
+  return data_ptr;
 }
 
 
@@ -2738,12 +2740,14 @@ MappingQGeneric<dim, spacedim>::get_face_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  auto data = std_cxx14::make_unique<InternalData>(polynomial_degree);
-  data->initialize_face(this->requires_update_flags(update_flags),
-                        QProjector<dim>::project_to_all_faces(quadrature),
-                        quadrature.size());
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>(polynomial_degree);
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
+  data.initialize_face(this->requires_update_flags(update_flags),
+                       QProjector<dim>::project_to_all_faces(quadrature),
+                       quadrature.size());
 
-  return std::move(data);
+  return data_ptr;
 }
 
 
@@ -2754,12 +2758,14 @@ MappingQGeneric<dim, spacedim>::get_subface_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  auto data = std_cxx14::make_unique<InternalData>(polynomial_degree);
-  data->initialize_face(this->requires_update_flags(update_flags),
-                        QProjector<dim>::project_to_all_subfaces(quadrature),
-                        quadrature.size());
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std_cxx14::make_unique<InternalData>(polynomial_degree);
+  auto &data = dynamic_cast<InternalData &>(*data_ptr);
+  data.initialize_face(this->requires_update_flags(update_flags),
+                       QProjector<dim>::project_to_all_subfaces(quadrature),
+                       quadrature.size());
 
-  return std::move(data);
+  return data_ptr;
 }
 
 


### PR DESCRIPTION
GCC 9 and newer complain about this. Fix it by making the original pointer type correct.

This gets rid of the warnings with the current version of GCC 10, so I assume it will fix the same warning with GCC 9. Fixes #8015.