### PR TITLE
Rewrite parts of step-61.

### DIFF
--- a/examples/step-61/doc/intro.dox
+++ b/examples/step-61/doc/intro.dox
@@ -390,7 +390,7 @@ On cell $K$,
 the numerical velocity $ \mathbf{u}_h = -\mathbf{K} \nabla_{w,d}p_h$ can be written as
 @f{align*}{
   \mathbf{u}_h 
-  &= -\mathbf{K} \nabla_{w,d} p 
+  &= -\mathbf{K} \nabla_{w,d} p_h 
    = -\mathbf{K}\sum_{i} \sum_{j} P_i C^K_{ij}\mathbf{v}_j,
 @f}
 where $C^K$ is the expansion matrix from above, and
@@ -440,7 +440,7 @@ Then the elementwise velocity is
 \sum_{k}- \left(\sum_{j} \sum_{i} P_ic_{ij}d_{jk} \right)\mathbf{v}_k,
 @f}
 where $-\sum_{j} \sum_{i} P_ic_{ij}d_{jk}$ is called 
-<code>beta</code> in the code.
+`cell_velocity` in the code.
 
 Using this velocity obtained by "postprocessing" the solution, we can
 define the $L_2$-errors of pressure, velocity, and flux 


### PR DESCRIPTION
This PR adjusts some of the variable names so that they match what is used in
the introduction of the tutorial program. It also generally adjusts the style
of the program to what is used in other tutorials.

The only functional change is to use 2 refinement levels instead of 1 since
the results section starts with output for 2 refinement levels. The
remainder is functionally equivalent, and I've made sure the results are
unaffected. The patch may be hard to read, though :-(

Continuation of @sophy1029's #6455. The only part that's still missing
is to look at the compute_pressure_error() function, which I suspect
could be simplified. I'll get to that tomorrow.