### PR TITLE
Adding inline in header file

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -930,7 +930,7 @@ namespace internal
   namespace ComplexWorkaround
   {
     template <typename Number, typename OtherNumber>
-    DEAL_II_CUDA_HOST_DEV void
+    inline DEAL_II_CUDA_HOST_DEV void
     multiply_assign_scalar(Number &val, const OtherNumber &s)
     {
       val *= s;
@@ -938,7 +938,7 @@ namespace internal
 
 #ifdef __CUDA_ARCH__
     template <typename Number, typename OtherNumber>
-    DEAL_II_CUDA_HOST_DEV void
+    inline DEAL_II_CUDA_HOST_DEV void
     multiply_assign_scalar(std::complex<Number> &, const OtherNumber &)
     {
       printf("This function is not implemented for std::complex<Number>!\n");


### PR DESCRIPTION
Following #8037 , the `inline` keyword should be added.