### PR TITLE
Fix gcc-9 warnings

### DIFF
--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1511,16 +1511,6 @@ namespace Threads
     }
 
 
-    /**
-     * Copy constructor.
-     *
-     * @post Using this constructor automatically makes the task object
-     * joinable().
-     */
-    Task(const Task<RT> &t)
-      : task_descriptor(t.task_descriptor)
-    {}
-
 
     /**
      * Default constructor. You can't do much with a task object constructed
@@ -1532,16 +1522,6 @@ namespace Threads
      */
     Task() = default;
 
-
-    /**
-     * Copy assignment operator.
-     */
-    const Task &
-    operator=(const Task<RT> &t)
-    {
-      task_descriptor = t.task_descriptor;
-      return *this;
-    }
 
 
     /**

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1532,6 +1532,18 @@ namespace Threads
      */
     Task() = default;
 
+
+    /**
+     * Copy assignment operator.
+     */
+    const Task &
+    operator=(const Task<RT> &t)
+    {
+      task_descriptor = t.task_descriptor;
+      return *this;
+    }
+
+
     /**
      * Join the task represented by this object, i.e. wait for it to finish.
      *

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -529,13 +529,12 @@ FullMatrix<number>::mmult(FullMatrix<number2> &      dst,
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
+  const size_type max_blas_int = std::numeric_limits<types::blas_int>::max();
   if ((std::is_same<number, double>::value ||
        std::is_same<number, float>::value) &&
       std::is_same<number, number2>::value)
-    if (this->n() * this->m() * src.n() > 300 &&
-        src.n() <= std::numeric_limits<types::blas_int>::max() &&
-        this->m() <= std::numeric_limits<types::blas_int>::max() &&
-        this->n() <= std::numeric_limits<types::blas_int>::max())
+    if (this->n() * this->m() * src.n() > 300 && src.n() <= max_blas_int &&
+        this->m() <= max_blas_int && this->n() <= max_blas_int)
       {
         // In case we have the BLAS function gemm detected by CMake, we
         // use that algorithm for matrix-matrix multiplication since it
@@ -613,13 +612,12 @@ FullMatrix<number>::Tmmult(FullMatrix<number2> &      dst,
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
+  const size_type max_blas_int = std::numeric_limits<types::blas_int>::max();
   if ((std::is_same<number, double>::value ||
        std::is_same<number, float>::value) &&
       std::is_same<number, number2>::value)
-    if (this->n() * this->m() * src.n() > 300 &&
-        src.n() <= std::numeric_limits<types::blas_int>::max() &&
-        this->n() <= std::numeric_limits<types::blas_int>::max() &&
-        this->m() <= std::numeric_limits<types::blas_int>::max())
+    if (this->n() * this->m() * src.n() > 300 && src.n() <= max_blas_int &&
+        this->n() <= max_blas_int && this->m() <= max_blas_int)
       {
         // In case we have the BLAS function gemm detected by CMake, we
         // use that algorithm for matrix-matrix multiplication since it
@@ -718,13 +716,12 @@ FullMatrix<number>::mTmult(FullMatrix<number2> &      dst,
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
+  const size_type max_blas_int = std::numeric_limits<types::blas_int>::max();
   if ((std::is_same<number, double>::value ||
        std::is_same<number, float>::value) &&
       std::is_same<number, number2>::value)
-    if (this->n() * this->m() * src.m() > 300 &&
-        src.m() <= std::numeric_limits<types::blas_int>::max() &&
-        this->n() <= std::numeric_limits<types::blas_int>::max() &&
-        this->m() <= std::numeric_limits<types::blas_int>::max())
+    if (this->n() * this->m() * src.m() > 300 && src.m() <= max_blas_int &&
+        this->n() <= max_blas_int && this->m() <= max_blas_int)
       {
         // In case we have the BLAS function gemm detected by CMake, we
         // use that algorithm for matrix-matrix multiplication since it
@@ -821,13 +818,12 @@ FullMatrix<number>::TmTmult(FullMatrix<number2> &      dst,
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
+  const size_type max_blas_int = std::numeric_limits<types::blas_int>::max();
   if ((std::is_same<number, double>::value ||
        std::is_same<number, float>::value) &&
       std::is_same<number, number2>::value)
-    if (this->n() * this->m() * src.m() > 300 &&
-        src.m() <= std::numeric_limits<types::blas_int>::max() &&
-        this->n() <= std::numeric_limits<types::blas_int>::max() &&
-        this->m() <= std::numeric_limits<types::blas_int>::max())
+    if (this->n() * this->m() * src.m() > 300 && src.m() <= max_blas_int &&
+        this->n() <= max_blas_int && this->m() <= max_blas_int)
       {
         // In case we have the BLAS function gemm detected by CMake, we
         // use that algorithm for matrix-matrix multiplication since it
@@ -1829,8 +1825,8 @@ FullMatrix<number>::gauss_jordan()
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
   if (std::is_same<number, double>::value || std::is_same<number, float>::value)
-    if (this->n_cols() > 15 &&
-        this->n_cols() <= std::numeric_limits<types::blas_int>::max())
+    if (this->n_cols() > 15 && static_cast<types::blas_int>(this->n_cols()) <=
+                                 std::numeric_limits<types::blas_int>::max())
       {
         // In case we have the LAPACK functions
         // getrf and getri detected by CMake,

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -379,7 +379,7 @@ namespace SparseMatrixIterators
     Iterator(const SparseMatrixIterators::Iterator<number, false> &i);
 
     /**
-     * Copy assignment operator.
+     * Copy assignment operator from a non-const iterator to a const iterator.
      */
     const Iterator<number, Constness> &
     operator=(const SparseMatrixIterators::Iterator<number, false> &i);

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -379,6 +379,12 @@ namespace SparseMatrixIterators
     Iterator(const SparseMatrixIterators::Iterator<number, false> &i);
 
     /**
+     * Copy assignment operator.
+     */
+    const Iterator<number, Constness> &
+    operator=(const SparseMatrixIterators::Iterator<number, false> &i);
+
+    /**
      * Prefix increment.
      */
     Iterator &
@@ -2259,6 +2265,17 @@ namespace SparseMatrixIterators
     const SparseMatrixIterators::Iterator<number, false> &i)
     : accessor(*i)
   {}
+
+
+
+  template <typename number, bool Constness>
+  inline const Iterator<number, Constness> &
+  Iterator<number, Constness>::
+  operator=(const SparseMatrixIterators::Iterator<number, false> &i)
+  {
+    accessor = *i;
+    return *this;
+  }
 
 
 

--- a/include/deal.II/particles/particle_iterator.h
+++ b/include/deal.II/particles/particle_iterator.h
@@ -63,12 +63,6 @@ namespace Particles
     ParticleAccessor<dim, spacedim> &operator*();
 
     /**
-     * Assignment operator.
-     */
-    ParticleIterator &
-    operator=(const ParticleIterator &) = default;
-
-    /**
      * Dereferencing operator, returns a pointer of the particle pointed to.
      * Usage is thus like <tt>i->get_id ();</tt>
      *

--- a/include/deal.II/particles/particle_iterator.h
+++ b/include/deal.II/particles/particle_iterator.h
@@ -66,7 +66,7 @@ namespace Particles
      * Assignment operator.
      */
     ParticleIterator &
-    operator=(const ParticleIterator &);
+    operator=(const ParticleIterator &) = default;
 
     /**
      * Dereferencing operator, returns a pointer of the particle pointed to.

--- a/source/particles/particle_iterator.cc
+++ b/source/particles/particle_iterator.cc
@@ -62,15 +62,6 @@ namespace Particles
   }
 
 
-  template <int dim, int spacedim>
-  ParticleIterator<dim, spacedim> &
-  ParticleIterator<dim, spacedim>::operator=(const ParticleIterator &other)
-  {
-    accessor = other.accessor;
-    return *this;
-  }
-
-
 
   template <int dim, int spacedim>
   bool


### PR DESCRIPTION
This pull request fixes the `gcc-9` warnings for a minimal configuration (no bundled `boost`, `muparser` or `TBB`).
In particular, `gcc-9` is complaining if there is an explicitly defined copy constructor but no copy assignment operator (or the other way around). In most of the cases, we can just avoid declaring them at all since they are implicitly generated. As a side-effect also move assignment and move constructor are implicitly generated.
I also included a commit that just removes `std::move` at all the places #8034 addresses to see the CI response (addressing https://github.com/dealii/dealii/pull/8034#issuecomment-490709483).
Apart from that, there also some signed-unsigned comparisons `gcc-9` doesn't like.