### PR TITLE
DoFHandlerPolicy::renumber_dofs: skip unnecessary index set computation

### DIFF
--- a/doc/news/changes/minor/20190510MartinKronbichler
+++ b/doc/news/changes/minor/20190510MartinKronbichler
@@ -1,0 +1,8 @@
+Improved: DoFHandler::renumber_dofs() on parallel::distributed::Triangulation
+would scale linearly with the number of MPI ranks on more than 50k ranks,
+reaching times of more than 10 seconds on 150k ranks. This is now fixed for
+the case the renumbering does not lead to a change in the underlying IndexSet
+field of locally owned unknowns, i.e., in case the numbers merely change
+within each MPI rank but not across them.
+<br>
+(Martin Kronbichler, 2019/05/10)

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -5679,6 +5679,8 @@ namespace internal
                                             *dof_handler,
                                             /*check_validity=*/false);
 
+            // Since we have not updated the number cache yet, we can use the
+            // index sets contained in the DoFHandler at this stage.
             return NumberCache(dof_handler->locally_owned_dofs_per_processor(),
                                Utilities::MPI::this_mpi_process(
                                  triangulation->get_communicator()));

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -5591,6 +5591,101 @@ namespace internal
         Assert(triangulation != nullptr, ExcInternalError());
 
 
+        // We start by checking whether only the numbering within the MPI
+        // ranks changed. In that case, we can apply the renumbering with some
+        // local renumbering only (this is similar to the renumber_mg_dofs()
+        // function below)
+        bool locally_owned_set_changes = false;
+        for (types::global_dof_index i : new_numbers)
+          if (dof_handler->locally_owned_dofs().is_element(i) == false)
+            {
+              locally_owned_set_changes = true;
+              break;
+            }
+
+        if (Utilities::MPI::sum(static_cast<unsigned int>(
+                                  locally_owned_set_changes),
+                                triangulation->get_communicator()) == 0)
+          {
+            IndexSet relevant_dofs;
+            DoFTools::extract_locally_relevant_dofs(*dof_handler,
+                                                    relevant_dofs);
+            std::vector<types::global_dof_index> ghosted_new_numbers(
+              relevant_dofs.n_elements());
+            {
+              Utilities::MPI::Partitioner partitioner(
+                dof_handler->locally_owned_dofs(),
+                relevant_dofs,
+                triangulation->get_communicator());
+
+              std::vector<types::global_dof_index> temp_array(
+                partitioner.n_import_indices());
+              const unsigned int       communication_channel = 19;
+              std::vector<MPI_Request> requests;
+              partitioner.export_to_ghosted_array_start(
+                communication_channel,
+                make_array_view(new_numbers),
+                make_array_view(temp_array),
+                ArrayView<types::global_dof_index>(
+                  ghosted_new_numbers.data() + new_numbers.size(),
+                  partitioner.n_ghost_indices()),
+                requests);
+              partitioner.export_to_ghosted_array_finish(
+                ArrayView<types::global_dof_index>(
+                  ghosted_new_numbers.data() + new_numbers.size(),
+                  partitioner.n_ghost_indices()),
+                requests);
+
+              // we need to fill the indices of the locally owned part into
+              // the new numbers array. their right position is somewhere in
+              // the middle of the array, so we first copy the ghosted part
+              // from smaller ranks to the front, then insert the data in the
+              // middle.
+              unsigned int n_ghosts_on_smaller_ranks = 0;
+              for (std::pair<unsigned int, unsigned int> t :
+                   partitioner.ghost_targets())
+                {
+                  if (t.first > partitioner.this_mpi_process())
+                    break;
+                  n_ghosts_on_smaller_ranks += t.second;
+                }
+              if (n_ghosts_on_smaller_ranks > 0)
+                {
+                  Assert(ghosted_new_numbers.data() != nullptr,
+                         ExcInternalError());
+                  std::memmove(ghosted_new_numbers.data(),
+                               ghosted_new_numbers.data() + new_numbers.size(),
+                               sizeof(types::global_dof_index) *
+                                 n_ghosts_on_smaller_ranks);
+                }
+              if (new_numbers.size() > 0)
+                {
+                  Assert(new_numbers.data() != nullptr, ExcInternalError());
+                  std::memcpy(ghosted_new_numbers.data() +
+                                n_ghosts_on_smaller_ranks,
+                              new_numbers.data(),
+                              sizeof(types::global_dof_index) *
+                                new_numbers.size());
+                }
+            }
+
+            // In case we do not carry any relevant dof (but only some remote
+            // processor), we do not need to call the renumbering. We call the
+            // version without validity check because vertex dofs will be
+            // set already in the artificial region.
+            if (relevant_dofs.n_elements() > 0)
+              Implementation::renumber_dofs(ghosted_new_numbers,
+                                            relevant_dofs,
+                                            *dof_handler,
+                                            /*check_validity=*/false);
+
+            return NumberCache(dof_handler->locally_owned_dofs_per_processor(),
+                               Utilities::MPI::this_mpi_process(
+                                 triangulation->get_communicator()));
+          }
+
+        // Now back to the more complicated case
+        //
         // First figure out the new set of locally owned DoF indices.
         // If we own no DoFs, we still need to go through this function,
         // but we can skip this calculation.
@@ -5713,115 +5808,97 @@ namespace internal
         //
         // this step is substantially more complicated than it is in
         // distribute_dofs() in case the IndexSets of locally owned DoFs after
-        // renumbering are not contiguous any more (we first check whether
-        // there is any change in the index sets at all). for
-        // distribute_dofs() it was enough to exchange the starting indices
-        // for each processor and the global number of DoFs, but here we
-        // actually have to serialize the IndexSet objects and shop them
-        // across the network.
-        bool locally_owned_set_changes = false;
-        for (types::global_dof_index i : new_numbers)
-          if (dof_handler->locally_owned_dofs().is_element(i) == false)
-            {
-              locally_owned_set_changes = true;
-              break;
-            }
-
-        if (Utilities::MPI::sum(static_cast<unsigned int>(
-                                  locally_owned_set_changes),
-                                triangulation->get_communicator()) > 0)
-          {
-            const unsigned int n_cpus = Utilities::MPI::n_mpi_processes(
-              triangulation->get_communicator());
-            std::vector<IndexSet> locally_owned_dofs_per_processor(
-              n_cpus, IndexSet(dof_handler->n_dofs()));
-            // serialize our own IndexSet
-            std::vector<char> my_data;
-            {
+        // renumbering are not contiguous any more (which we have done at the
+        // top of this function). for distribute_dofs() it was enough to
+        // exchange the starting indices for each processor and the global
+        // number of DoFs, but here we actually have to serialize the IndexSet
+        // objects and shop them across the network.
+        const unsigned int n_cpus =
+          Utilities::MPI::n_mpi_processes(triangulation->get_communicator());
+        std::vector<IndexSet> locally_owned_dofs_per_processor(
+          n_cpus, IndexSet(dof_handler->n_dofs()));
+        // serialize our own IndexSet
+        std::vector<char> my_data;
+        {
 #  ifdef DEAL_II_WITH_ZLIB
 
-              boost::iostreams::filtering_ostream out;
-              out.push(
-                boost::iostreams::gzip_compressor(boost::iostreams::gzip_params(
-                  boost::iostreams::gzip::best_compression)));
-              out.push(boost::iostreams::back_inserter(my_data));
+          boost::iostreams::filtering_ostream out;
+          out.push(
+            boost::iostreams::gzip_compressor(boost::iostreams::gzip_params(
+              boost::iostreams::gzip::best_compression)));
+          out.push(boost::iostreams::back_inserter(my_data));
 
-              boost::archive::binary_oarchive archive(out);
+          boost::archive::binary_oarchive archive(out);
 
-              archive << my_locally_owned_new_dof_indices;
-              out.flush();
+          archive << my_locally_owned_new_dof_indices;
+          out.flush();
 #  else
-              std::ostringstream              out;
-              boost::archive::binary_oarchive archive(out);
-              archive << my_locally_owned_new_dof_indices;
-              const std::string &s = out.str();
-              my_data.reserve(s.size());
-              my_data.assign(s.begin(), s.end());
+          std::ostringstream              out;
+          boost::archive::binary_oarchive archive(out);
+          archive << my_locally_owned_new_dof_indices;
+          const std::string &s = out.str();
+          my_data.reserve(s.size());
+          my_data.assign(s.begin(), s.end());
 #  endif
-            }
+        }
 
-            // determine maximum size of IndexSet
-            const unsigned int max_size =
-              Utilities::MPI::max(my_data.size(),
-                                  triangulation->get_communicator());
+        // determine maximum size of IndexSet
+        const unsigned int max_size =
+          Utilities::MPI::max(my_data.size(),
+                              triangulation->get_communicator());
 
-            // as the MPI_Allgather call will be reading max_size elements, and
-            // as this may be past the end of my_data, we need to increase the
-            // size of the local buffer. This is filled with zeros.
-            my_data.resize(max_size);
+        // as the MPI_Allgather call will be reading max_size elements, and
+        // as this may be past the end of my_data, we need to increase the
+        // size of the local buffer. This is filled with zeros.
+        my_data.resize(max_size);
 
-            std::vector<char> buffer(max_size * n_cpus);
-            const int         ierr = MPI_Allgather(my_data.data(),
-                                           max_size,
-                                           MPI_BYTE,
-                                           buffer.data(),
-                                           max_size,
-                                           MPI_BYTE,
-                                           triangulation->get_communicator());
-            AssertThrowMPI(ierr);
+        std::vector<char> buffer(max_size * n_cpus);
+        const int         ierr = MPI_Allgather(my_data.data(),
+                                       max_size,
+                                       MPI_BYTE,
+                                       buffer.data(),
+                                       max_size,
+                                       MPI_BYTE,
+                                       triangulation->get_communicator());
+        AssertThrowMPI(ierr);
 
-            for (unsigned int i = 0; i < n_cpus; ++i)
-              if (i == Utilities::MPI::this_mpi_process(
-                         triangulation->get_communicator()))
-                locally_owned_dofs_per_processor[i] =
-                  my_locally_owned_new_dof_indices;
-              else
-                {
-                  // copy the data previously received into a stringstream
-                  // object and then read the IndexSet from it
-                  std::string decompressed_buffer;
+        for (unsigned int i = 0; i < n_cpus; ++i)
+          if (i == Utilities::MPI::this_mpi_process(
+                     triangulation->get_communicator()))
+            locally_owned_dofs_per_processor[i] =
+              my_locally_owned_new_dof_indices;
+          else
+            {
+              // copy the data previously received into a stringstream
+              // object and then read the IndexSet from it
+              std::string decompressed_buffer;
 
-                  // first decompress the buffer
-                  {
+              // first decompress the buffer
+              {
 #  ifdef DEAL_II_WITH_ZLIB
 
-                    boost::iostreams::filtering_ostream decompressing_stream;
-                    decompressing_stream.push(
-                      boost::iostreams::gzip_decompressor());
-                    decompressing_stream.push(
-                      boost::iostreams::back_inserter(decompressed_buffer));
+                boost::iostreams::filtering_ostream decompressing_stream;
+                decompressing_stream.push(
+                  boost::iostreams::gzip_decompressor());
+                decompressing_stream.push(
+                  boost::iostreams::back_inserter(decompressed_buffer));
 
-                    decompressing_stream.write(&buffer[i * max_size], max_size);
+                decompressing_stream.write(&buffer[i * max_size], max_size);
 #  else
-                    decompressed_buffer.assign(&buffer[i * max_size], max_size);
+                decompressed_buffer.assign(&buffer[i * max_size], max_size);
 #  endif
-                  }
+              }
 
-                  // then restore the object from the buffer
-                  std::istringstream              in(decompressed_buffer);
-                  boost::archive::binary_iarchive archive(in);
+              // then restore the object from the buffer
+              std::istringstream              in(decompressed_buffer);
+              boost::archive::binary_iarchive archive(in);
 
-                  archive >> locally_owned_dofs_per_processor[i];
-                }
+              archive >> locally_owned_dofs_per_processor[i];
+            }
 
-            return NumberCache(locally_owned_dofs_per_processor,
-                               Utilities::MPI::this_mpi_process(
-                                 triangulation->get_communicator()));
-          }
-        else
-          return NumberCache(dof_handler->locally_owned_dofs_per_processor(),
-                             Utilities::MPI::this_mpi_process(
-                               triangulation->get_communicator()));
+        return NumberCache(locally_owned_dofs_per_processor,
+                           Utilities::MPI::this_mpi_process(
+                             triangulation->get_communicator()));
 #endif
       }
 


### PR DESCRIPTION
In big computations with more than a few tens of thousands of MPI ranks, we run into a bottleneck in the parallel distributed DoFHandler policy: We need to communicate the `locally_owned_dofs_per_processor` indices of all MPI ranks to each MPI rank via `MPI_Allgather`. Even though we do compress the data, this is an extraordinary bottleneck. Here are some numbers on 152k cores, using a uniform mesh and some polynomials of degree 6 (the numbers are min, avg, max measured over all ranks, and square brackets indicate the MPI rank recording the min/max value):
```
Number of MPI ranks:            152064
Number of degrees of freedom  216 = (1 x 1 x 1) x 6^3
Compute numbering L4294967295 0.201704    [p80622 ] 0.218089    0.236915    [p50712 ]
Apply new numbers active      8.49583     [p35779 ] 8.66721     9.87496     [p48829 ]
Apply new numbers L0          0.252382    [p42669 ] 0.275474    0.28986     [p110928]
...
Number of degrees of freedom  3,538,944 = (32 x 32 x 16) x 6^3
Compute numbering L4294967295 0.28779     [p75992 ] 0.30067     0.323       [p19894 ]
Apply new numbers active      8.6115      [p134858] 8.8409      13.736      [p29856 ]
Apply new numbers L4          0.3022      [p78760 ] 0.31913     0.34386     [p39958 ]
...
Number of degrees of freedom  1,811,939,328 = (256 x 256 x 128) x 6^3
Compute numbering L4294967295 0.20529     [p100023] 0.21996     0.23896     [p12012 ]
Apply new numbers active      8.9139      [p66215 ] 9.0564      10.075      [p73339 ]
Apply new numbers L7          0.22079     [p114292] 0.22863     0.23356     [p103642]
...
Number of degrees of freedom  115,964,116,992 = (1,024 x 1,024 x 512) x 6^3
Compute numbering L4294967295 0.37199     [p146539] 0.39865     0.46468     [p49392 ]
Apply new numbers active      12.803      [p66215 ] 12.932      16.182      [p80663 ]
Apply new numbers L9          0.46495     [p297   ] 0.48376     0.52693     [p84744 ]
...
Number of degrees of freedom  231,928,233,984 = (1,024 x 1,024 x 1,024) x 6^3
Compute numbering L4294967295 0.48401     [p62903 ] 0.5403      0.64773     [p145108]
Apply new numbers active      13.934      [p95571 ] 14.074      15.201      [p109733]
Apply new numbers L10         0.39767     [p147311] 0.41914     0.49085     [p118765]
...
Number of degrees of freedom  927,712,935,936 = (2,048 x 2,048 x 1,024) x 6^3
Compute numbering L4294967295 1.2914      [p39381 ] 1.4717      1.5792      [p42462 ]
Apply new numbers active      21.882      [p84107 ] 22.001      22.807      [p97853 ]
Apply new numbers L10         0.70318     [p10713 ] 0.74297     0.84018     [p90262 ]
```

All the way up to 115b DoFs, the time "Apply new numbers active", which is essentially `ParallelDistributed<DoFHandlerType>::renumber_dofs` in `dof_handler_policy.cc:5573`, is constant and disturbingly high. What is worse, these times scale linearly with the number of MPI ranks. On 50k ranks, the times are around 2.8 seconds, for example.

The problematic part is that we exchange the `locally_owned_dofs_per_processor` to all ranks with an `MPI_Allgather` command, compressing an IndexSet and then sending it around. This PR implements a simple solution: In case the renumbering does not change the index sets, i.e., numbers merely change the order within each MPI rank, we do not need to do this expensive step. I am currently running the test suite locally and have submitted a job on 150k ranks to see if things get better.