### PR TITLE
Fix an array initialization.

### DIFF
--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1801,7 +1801,8 @@ namespace
         // identify the weights for the lines to be accumulated (vertex
         // weights are set outside and coincide with the flat manifold case)
 
-        std::array<double, GeometryInfo<3>::lines_per_cell> weights_lines{};
+        std::array<double, GeometryInfo<3>::lines_per_cell> weights_lines;
+        std::fill(weights_lines.begin(), weights_lines.end(), 0.0);
 
         // start with the contributions of the faces
         std::array<double, GeometryInfo<2>::vertices_per_cell>          weights;


### PR DESCRIPTION
GCC 4.8 complains about the brace initialization:
```
./source/grid/manifold_lib.cc:1804:75:
warning: missing initializer for member 'std::array<double, 12ul>::_M_elems'
[-Wmissing-field-initializers]
         std::array<double, GeometryInfo<3>::lines_per_cell> weights_lines{};
                                                                           ^
```
so be safe and initialize explicitly with `fill`.