### PR TITLE
Deprecate nanoflann.

### DIFF
--- a/doc/news/changes/major/20190510DavidWells
+++ b/doc/news/changes/major/20190510DavidWells
@@ -1,0 +1,4 @@
+Deprecated: deal.II's nanoflann bindings (i.e., the KDTree class) have been
+deprecated in favor of using <code>boost::geometry::index::rtree</code>.
+<br>
+(2019/05/10, David Wells)

--- a/include/deal.II/numerics/kdtree.h
+++ b/include/deal.II/numerics/kdtree.h
@@ -56,10 +56,13 @@ DEAL_II_NAMESPACE_OPEN
  * > case, the hyperplane would be set by the $x$-value of the point, and its
  * > normal would be the unit $x$-axis.
  *
+ * @deprecated This class has been deprecated in favor of RTree, which is
+ * based on <code>boost::geometry::index::rtree</code>.
+ *
  * @author Luca Heltai, 2017.
  */
 template <int dim>
-class KDTree
+class DEAL_II_DEPRECATED KDTree
 {
 public:
   /**


### PR DESCRIPTION
We have reached a consensus that boost's rtree is superior.

Closes #8068.