### PR TITLE
Use python, not python3.

### DIFF
--- a/contrib/utilities/check_encoding.py
+++ b/contrib/utilities/check_encoding.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 ## ---------------------------------------------------------------------
 ##
 ## Copyright (C) 2019 by the deal.II authors

--- a/contrib/utilities/double_word_typos.py
+++ b/contrib/utilities/double_word_typos.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+
 # ---------------------------------------------------------------------
 #
 # Copyright (C) 2018 by the deal.II authors

--- a/doc/doxygen/scripts/set_canonical_doxygen.py
+++ b/doc/doxygen/scripts/set_canonical_doxygen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 ## ---------------------------------------------------------------------
 ##
 ## Copyright (C) 2019 by the deal.II authors


### PR DESCRIPTION
I don't have python3 on my system, so I can't build the documentation any more.
This is a follow-up to #7628.

The big question of course is whether these scripts actually use an python3 features.