### PR TITLE
Run setting canonical pages as part of the doxygen generation process.

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -284,6 +284,8 @@ ADD_CUSTOM_COMMAND(
     ${CMAKE_CURRENT_BINARY_DIR}/options.dox
     > ${CMAKE_BINARY_DIR}/doxygen.log 2>&1 # *pssst*
     || ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/doxygen.log ${CMAKE_BINARY_DIR}/doxygen.err
+  COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/scripts/set_canonical_doxygen.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS
     tutorial
@@ -302,10 +304,6 @@ ADD_CUSTOM_TARGET(doxygen ALL
   DEPENDS ${CMAKE_BINARY_DIR}/doxygen.log
   )
 ADD_DEPENDENCIES(documentation doxygen)
-
-# Set the canonical link for the doxygen webpages
-ADD_CUSTOM_COMMAND(TARGET doxygen POST_BUILD
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/set_canonical_doxygen.py)
 
 INSTALL(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/deal.tag


### PR DESCRIPTION
This has the advantage that we need not worry about when that POST_BUILD
command is run. In particular, there can not be any race conditions.
This is, however, only true for the doxygen generated pages, whereas the
script also touches the other .html files for which the target I put the
script under has no in- or out-dependencies.

Follow-up to #7628.