### PR TITLE
Modernize step-46

### DIFF
--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -150,7 +150,7 @@ namespace Step46
 
   // @sect3{Boundary values and right hand side}
 
-  // The following class does as its names suggest. The boundary values for
+  // The following class does as its name suggests. The boundary values for
   // the velocity are $\mathbf u=(0, \sin(\pi x))^T$ in 2d and $\mathbf u=(0,
   // 0, \sin(\pi x)\sin(\pi y))^T$ in 3d, respectively. The remaining boundary
   // conditions for this problem are all homogeneous and have been discussed in

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -280,20 +280,14 @@ namespace Step46
   {
     GridGenerator::subdivided_hyper_cube(triangulation, 8, -1, 1);
 
-    for (typename Triangulation<dim>::active_cell_iterator cell =
-           triangulation.begin_active();
-         cell != triangulation.end();
-         ++cell)
+    for (const auto &cell : triangulation.active_cell_iterators())
       for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->face(f)->at_boundary() &&
             (cell->face(f)->center()[dim - 1] == 1))
           cell->face(f)->set_all_boundary_ids(1);
 
 
-    for (typename Triangulation<dim>::active_cell_iterator cell =
-           dof_handler.begin_active();
-         cell != dof_handler.end();
-         ++cell)
+    for (const auto &cell : dof_handler.active_cell_iterators())
       if (((std::fabs(cell->center()[0]) < 0.25) &&
            (cell->center()[dim - 1] > 0.5)) ||
           ((std::fabs(cell->center()[0]) >= 0.25) &&
@@ -317,10 +311,7 @@ namespace Step46
   template <int dim>
   void FluidStructureProblem<dim>::set_active_fe_indices()
   {
-    for (typename hp::DoFHandler<dim>::active_cell_iterator cell =
-           dof_handler.begin_active();
-         cell != dof_handler.end();
-         ++cell)
+    for (const auto &cell : dof_handler.active_cell_iterators())
       {
         if (cell_is_in_fluid_domain(cell))
           cell->set_active_fe_index(0);
@@ -375,10 +366,7 @@ namespace Step46
     {
       std::vector<types::global_dof_index> local_face_dof_indices(
         stokes_fe.dofs_per_face);
-      for (typename hp::DoFHandler<dim>::active_cell_iterator cell =
-             dof_handler.begin_active();
-           cell != dof_handler.end();
-           ++cell)
+      for (const auto &cell : dof_handler.active_cell_iterators())
         if (cell_is_in_fluid_domain(cell))
           for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
             if (!cell->at_boundary(f))
@@ -544,10 +532,7 @@ namespace Step46
     // initialization of the hp::FEValues object for the current cell and the
     // extraction of a FEValues object that is appropriate for the current
     // cell:
-    typename hp::DoFHandler<dim>::active_cell_iterator cell = dof_handler
-                                                                .begin_active(),
-                                                       endc = dof_handler.end();
-    for (; cell != endc; ++cell)
+    for (const auto &cell : dof_handler.active_cell_iterators())
       {
         hp_fe_values.reinit(cell);
 
@@ -963,10 +948,7 @@ namespace Step46
     // more. The structure of these nested conditions is much the same as we
     // encountered when assembling interface terms in
     // <code>assemble_system</code>.
-    for (typename hp::DoFHandler<dim>::active_cell_iterator cell =
-           dof_handler.begin_active();
-         cell != dof_handler.end();
-         ++cell)
+    for (const auto &cell : dof_handler.active_cell_iterators())
       for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell_is_in_solid_domain(cell))
           {

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -150,12 +150,12 @@ namespace Step46
 
   // @sect3{Boundary values and right hand side}
 
-  // The following classes do as their names suggest. The boundary values for
+  // The following class does as its names suggest. The boundary values for
   // the velocity are $\mathbf u=(0, \sin(\pi x))^T$ in 2d and $\mathbf u=(0,
   // 0, \sin(\pi x)\sin(\pi y))^T$ in 3d, respectively. The remaining boundary
   // conditions for this problem are all homogeneous and have been discussed in
   // the introduction. The right hand side forcing term is zero for both the
-  // fluid and the solid.
+  // fluid and the solid so we don't need an extra class for it.
   template <int dim>
   class StokesBoundaryValues : public Function<dim>
   {
@@ -200,40 +200,6 @@ namespace Step46
   {
     for (unsigned int c = 0; c < this->n_components; ++c)
       values(c) = StokesBoundaryValues<dim>::value(p, c);
-  }
-
-
-
-  template <int dim>
-  class RightHandSide : public Function<dim>
-  {
-  public:
-    RightHandSide()
-      : Function<dim>(dim + 1)
-    {}
-
-    virtual double value(const Point<dim> & p,
-                         const unsigned int component = 0) const override;
-
-    virtual void vector_value(const Point<dim> &p,
-                              Vector<double> &  value) const override;
-  };
-
-
-  template <int dim>
-  double RightHandSide<dim>::value(const Point<dim> & /*p*/,
-                                   const unsigned int /*component*/) const
-  {
-    return 0;
-  }
-
-
-  template <int dim>
-  void RightHandSide<dim>::vector_value(const Point<dim> &p,
-                                        Vector<double> &  values) const
-  {
-    for (unsigned int c = 0; c < this->n_components; ++c)
-      values(c) = RightHandSide<dim>::value(p, c);
   }
 
 
@@ -556,7 +522,7 @@ namespace Step46
     std::vector<types::global_dof_index> neighbor_dof_indices(
       stokes_dofs_per_cell);
 
-    const RightHandSide<dim> right_hand_side;
+    const Functions::ZeroFunction<dim> right_hand_side(dim + 1);
 
     // ...to variables that allow us to extract certain components of the
     // shape functions and cache their values rather than having to recompute


### PR DESCRIPTION
Part of #6774.
- The `RightHandSide` class is just a `ZeroFunction`. No need to duplicate it.
- use range-based for loops