### PR TITLE
SD: Better document and homogenise naming of template parameters

### DIFF
--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -741,10 +741,10 @@ namespace Differentiation
      * @ref make_substitution_map(const Expression &,const ValueType &)
      * function.
      */
-    template <typename SymbolicType, typename ValueType, typename... Args>
+    template <typename ExpressionType, typename ValueType, typename... Args>
     types::substitution_map
     make_substitution_map(
-      const std::pair<SymbolicType, ValueType> &symbol_value,
+      const std::pair<ExpressionType, ValueType> &symbol_value,
       const Args &... other_symbol_values);
 
     //@}
@@ -942,7 +942,7 @@ namespace Differentiation
      * expression, and that the paired @p symbol_value elements are compatible
      * with the other add_to_substitution_map() functions.
      *
-     * The @p SymbolicType and its associated @ValueType need not be scalar
+     * The @p ExpressionType and its associated @ValueType need not be scalar
      * types. So, for example, this function could be used to add tensor-valued
      * data to the map in the following way:
      *
@@ -965,12 +965,12 @@ namespace Differentiation
      * discussion on the role of this template argument.
      */
     template <bool ignore_invalid_symbols = false,
-              typename SymbolicType,
+              typename ExpressionType,
               typename ValueType>
     void
     add_to_substitution_map(
-      types::substitution_map &                 substitution_map,
-      const std::pair<SymbolicType, ValueType> &symbol_value);
+      types::substitution_map &                   substitution_map,
+      const std::pair<ExpressionType, ValueType> &symbol_value);
 
     /**
      * A convenience function for adding multiple entries to the
@@ -980,7 +980,7 @@ namespace Differentiation
      * symbolic expressions, and that the paired @p symbol_value elements are
      * compatible with the other add_to_substitution_map() functions.
      *
-     * The @p SymbolicType and its associated @ValueType need not be scalar
+     * The @p ExpressionType and its associated @ValueType need not be scalar
      * types. So, for example, this function could be used to add tensor-valued
      * data to the map in the following way:
      *
@@ -1007,12 +1007,12 @@ namespace Differentiation
      * discussion on the role of this template argument.
      */
     template <bool ignore_invalid_symbols = false,
-              typename SymbolicType,
+              typename ExpressionType,
               typename ValueType>
     void
     add_to_substitution_map(
-      types::substitution_map &                              substitution_map,
-      const std::vector<std::pair<SymbolicType, ValueType>> &symbol_values);
+      types::substitution_map &                                substitution_map,
+      const std::vector<std::pair<ExpressionType, ValueType>> &symbol_values);
 
     /**
      * A convenience function for adding multiple entries to the
@@ -1045,13 +1045,13 @@ namespace Differentiation
      * function.
      */
     template <bool ignore_invalid_symbols = false,
-              typename SymbolicType,
+              typename ExpressionType,
               typename ValueType,
               typename... Args>
     void
     add_to_substitution_map(
-      types::substitution_map &                 substitution_map,
-      const std::pair<SymbolicType, ValueType> &symbol_value,
+      types::substitution_map &                   substitution_map,
+      const std::pair<ExpressionType, ValueType> &symbol_value,
       const Args &... other_symbol_values);
 
     /**
@@ -1420,10 +1420,10 @@ namespace Differentiation
     }
 
 
-    template <typename SymbolicType, typename ValueType, typename... Args>
+    template <typename ExpressionType, typename ValueType, typename... Args>
     types::substitution_map
     make_substitution_map(
-      const std::pair<SymbolicType, ValueType> &symbol_value,
+      const std::pair<ExpressionType, ValueType> &symbol_value,
       const Args &... other_symbol_values)
     {
       types::substitution_map substitution_map;
@@ -1536,12 +1536,12 @@ namespace Differentiation
 
 
     template <bool ignore_invalid_symbols,
-              typename SymbolicType,
+              typename ExpressionType,
               typename ValueType>
     void
     add_to_substitution_map(
-      types::substitution_map &                 substitution_map,
-      const std::pair<SymbolicType, ValueType> &symbol_value)
+      types::substitution_map &                   substitution_map,
+      const std::pair<ExpressionType, ValueType> &symbol_value)
     {
       add_to_substitution_map<ignore_invalid_symbols>(substitution_map,
                                                       symbol_value.first,
@@ -1550,12 +1550,12 @@ namespace Differentiation
 
 
     template <bool ignore_invalid_symbols,
-              typename SymbolicType,
+              typename ExpressionType,
               typename ValueType>
     void
     add_to_substitution_map(
-      types::substitution_map &                              substitution_map,
-      const std::vector<std::pair<SymbolicType, ValueType>> &symbol_values)
+      types::substitution_map &                                substitution_map,
+      const std::vector<std::pair<ExpressionType, ValueType>> &symbol_values)
     {
       for (const auto &entry : symbol_values)
         {
@@ -1581,13 +1581,13 @@ namespace Differentiation
 
 
     template <bool ignore_invalid_symbols,
-              typename SymbolicType,
+              typename ExpressionType,
               typename ValueType,
               typename... Args>
     void
     add_to_substitution_map(
-      types::substitution_map &                 substitution_map,
-      const std::pair<SymbolicType, ValueType> &symbol_value,
+      types::substitution_map &                   substitution_map,
+      const std::pair<ExpressionType, ValueType> &symbol_value,
       const Args &... other_symbol_values)
     {
       add_to_substitution_map<ignore_invalid_symbols>(substitution_map,

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -1303,10 +1303,10 @@ namespace Differentiation
     }
 
 
-    template <typename ExpressionType, typename ValueType, typename>
+    template <typename SymbolicType, typename ValueType, typename>
     void
     set_value_in_symbol_map(types::substitution_map &substitution_map,
-                            const ExpressionType &   symbol,
+                            const SymbolicType &     symbol,
                             const ValueType &        value)
     {
       // Call the above function
@@ -1314,7 +1314,7 @@ namespace Differentiation
       internal::set_value_in_symbol_map(substitution_map,
                                         static_cast<SE_RCP_Basic>(symbol),
                                         static_cast<SE_RCP_Basic>(
-                                          ExpressionType(value)));
+                                          SymbolicType(value)));
     }
 
 

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -178,6 +178,10 @@ namespace Differentiation
      *         add_to_symbol_map() functions. This includes individual
      *         Expression, std::vector<Expression>, as well as
      *         Tensors and SymmetricTensors of Expressions.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. This @p ValueType is somewhat
+     *         arbitrary as it is only used to create default-constructed
+     *         values as entries in the map.
      */
     template <bool ignore_invalid_symbols = false,
               typename ValueType          = double,
@@ -211,6 +215,10 @@ namespace Differentiation
      *         add_to_symbol_map() functions. This includes individual
      *         Expression, std::vector<Expression>, as well as
      *         Tensors and SymmetricTensors of Expressions.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. This @p ValueType is somewhat
+     *         arbitrary as it is only used to create default-constructed
+     *         values as entries in the map.
      * @tparam Args A type associated with the parameter pack that contains
      *         any number of other @p SymbolicTypes. All types held by the
      *         parameter pack share the same restriction as the @p SymbolicType
@@ -324,6 +332,10 @@ namespace Differentiation
      *         add_to_symbol_map() functions. This includes an individual
      *         Expression, as well as Tensors and SymmetricTensors of
      *         Expressions.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. This @p ValueType is somewhat
+     *         arbitrary as it is only used to create default-constructed
+     *         values as entries in the map.
      */
     template <bool ignore_invalid_symbols = false,
               typename ValueType          = double,
@@ -345,6 +357,11 @@ namespace Differentiation
      * @ref add_to_symbol_map(types::substitution_map &,const
      * Expression &) function for a detailed discussion on the role of this
      * template argument.
+     *
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. This @p ValueType is somewhat
+     *         arbitrary as it is only used to create default-constructed
+     *         values as entries in the map.
      */
     template <bool ignore_invalid_symbols = false, typename ValueType = double>
     void
@@ -384,6 +401,10 @@ namespace Differentiation
      *         add_to_symbol_map() functions. This includes individual
      *         Expression, std::vector<Expression>, as well as
      *         Tensors and SymmetricTensors of Expressions.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. This @p ValueType is somewhat
+     *         arbitrary as it is only used to create default-constructed
+     *         values as entries in the map.
      * @tparam Args A type associated with the parameter pack that contains
      *         any number of other @p SymbolicTypes. All types held by the
      *         parameter pack share the same restriction as the @p SymbolicType
@@ -740,6 +761,20 @@ namespace Differentiation
      * using this function. For more details on this, see the other
      * @ref make_substitution_map(const Expression &,const ValueType &)
      * function.
+     *
+     * @tparam ExpressionType Any symbolic expression type that is understood
+     *         by the make_substitution_map() functions. This includes
+     *         individual Expression, as well as Tensors and SymmetricTensors
+     *         of Expressions.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. Although it is typically
+     *         arithmetic in nature, it may also represent another symbolic
+     *         expression type or be a special type that a user-defined
+     *         @p ExpressionType can be constructed from.
+     * @tparam Args A type associated with the parameter pack that contains
+     *         any number of other @p ExpressionTypes. All types held by the
+     *         parameter pack share the same restriction as the
+     *         @p ExpressionType documented above.
      */
     template <typename ExpressionType, typename ValueType, typename... Args>
     types::substitution_map
@@ -963,6 +998,16 @@ namespace Differentiation
      * @ref add_to_substitution_map(types::substitution_map &,const
      * Expression &,const Expression &) function for a detailed
      * discussion on the role of this template argument.
+     *
+     * @tparam ExpressionType Any symbolic expression type that is understood
+     *         by the add_to_substitution_map() functions. This includes
+     *         individual Expression, as well as Tensors and SymmetricTensors
+     *         of Expressions.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. Although it is typically
+     *         arithmetic in nature, it may also represent another symbolic
+     *         expression type or be a special type that a user-defined
+     *         @p ExpressionType can be constructed from.
      */
     template <bool ignore_invalid_symbols = false,
               typename ExpressionType,
@@ -1005,6 +1050,16 @@ namespace Differentiation
      * @ref add_to_substitution_map(types::substitution_map &,const
      * Expression &,const Expression &) function for a detailed
      * discussion on the role of this template argument.
+     *
+     * @tparam ExpressionType Any symbolic expression type that is understood
+     *         by the add_to_substitution_map() functions. This includes
+     *         individual Expression, as well as Tensors and SymmetricTensors
+     *         of Expressions.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. Although it is typically
+     *         arithmetic in nature, it may also represent another symbolic
+     *         expression type or be a special type that a user-defined
+     *         @p ExpressionType can be constructed from.
      */
     template <bool ignore_invalid_symbols = false,
               typename ExpressionType,
@@ -1043,6 +1098,20 @@ namespace Differentiation
      * using this function. For more details on this, see the other
      * @ref make_substitution_map(const Expression &,const ValueType &)
      * function.
+     *
+     * @tparam ExpressionType Any symbolic expression type that is understood
+     *         by the add_to_substitution_map() functions. This includes
+     *         individual Expression, as well as Tensors and SymmetricTensors
+     *         of Expressions.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. Although it is typically
+     *         arithmetic in nature, it may also represent another symbolic
+     *         expression type or be a special type that a user-defined
+     *         @p ExpressionType can be constructed from.
+     * @tparam Args A type associated with the parameter pack that contains
+     *         any number of other @p ExpressionTypes. All types held by the
+     *         parameter pack share the same restriction as the
+     *         @p ExpressionType documented above.
      */
     template <bool ignore_invalid_symbols = false,
               typename ExpressionType,

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -553,7 +553,7 @@ namespace Differentiation
      *         expression type or be a special type that a user-defined
      *         @p SymbolicType can be constructed from.
      */
-    template <typename SymbolicType = SD::Expression, typename ValueType>
+    template <typename SymbolicType, typename ValueType>
     void
     set_value_in_symbol_map(
       types::substitution_map &                              substitution_map,

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -555,11 +555,13 @@ namespace Differentiation
     template <bool ignore_invalid_symbols = false,
               int  rank,
               int  dim,
+              typename ExpressionType,
               typename ValueType>
     void
-    add_to_substitution_map(types::substitution_map &substitution_map,
-                            const Tensor<rank, dim, Expression> &symbol_tensor,
-                            const Tensor<rank, dim, ValueType> & value_tensor);
+    add_to_substitution_map(
+      types::substitution_map &                substitution_map,
+      const Tensor<rank, dim, ExpressionType> &symbol_tensor,
+      const Tensor<rank, dim, ValueType> &     value_tensor);
 
     /**
      * A convenience function for adding an entry to the @p substitution_map.
@@ -578,12 +580,13 @@ namespace Differentiation
     template <bool ignore_invalid_symbols = false,
               int  rank,
               int  dim,
+              typename ExpressionType,
               typename ValueType>
     void
     add_to_substitution_map(
-      types::substitution_map &                     substitution_map,
-      const SymmetricTensor<rank, dim, Expression> &symbol_tensor,
-      const SymmetricTensor<rank, dim, ValueType> & value_tensor);
+      types::substitution_map &                         substitution_map,
+      const SymmetricTensor<rank, dim, ExpressionType> &symbol_tensor,
+      const SymmetricTensor<rank, dim, ValueType> &     value_tensor);
 
     //@}
 
@@ -1122,12 +1125,12 @@ namespace Differentiation
                 int dim,
                 typename ValueType,
                 template <int, int, typename> class TensorType>
-      std::vector<std::pair<Expression, ValueType>>
+      std::vector<std::pair<ExpressionType, ValueType>>
       tensor_substitution_map(
-        const TensorType<rank, dim, Expression> &symbol_tensor,
-        const TensorType<rank, dim, ValueType> & value_tensor)
+        const TensorType<rank, dim, ExpressionType> &symbol_tensor,
+        const TensorType<rank, dim, ValueType> &     value_tensor)
       {
-        std::vector<std::pair<Expression, ValueType>> symbol_values;
+        std::vector<std::pair<ExpressionType, ValueType>> symbol_values;
         for (unsigned int i = 0; i < symbol_tensor.n_independent_components;
              ++i)
           {
@@ -1140,13 +1143,13 @@ namespace Differentiation
       }
 
 
-      template <int dim, typename ValueType>
-      std::vector<std::pair<Expression, ValueType>>
+      template <int dim, typename ExpressionType, typename ValueType>
+      std::vector<std::pair<ExpressionType, ValueType>>
       tensor_substitution_map(
-        const SymmetricTensor<4, dim, Expression> &symbol_tensor,
-        const SymmetricTensor<4, dim, ValueType> & value_tensor)
+        const SymmetricTensor<4, dim, ExpressionType> &symbol_tensor,
+        const SymmetricTensor<4, dim, ValueType> &     value_tensor)
       {
-        std::vector<std::pair<Expression, ValueType>> symbol_values;
+        std::vector<std::pair<ExpressionType, ValueType>> symbol_values;
         for (unsigned int i = 0;
              i < SymmetricTensor<2, dim>::n_independent_components;
              ++i)
@@ -1167,11 +1170,13 @@ namespace Differentiation
     template <bool ignore_invalid_symbols,
               int  rank,
               int  dim,
+              typename ExpressionType,
               typename ValueType>
     void
-    add_to_substitution_map(types::substitution_map &substitution_map,
-                            const Tensor<rank, dim, Expression> &symbol_tensor,
-                            const Tensor<rank, dim, ValueType> & value_tensor)
+    add_to_substitution_map(
+      types::substitution_map &                substitution_map,
+      const Tensor<rank, dim, ExpressionType> &symbol_tensor,
+      const Tensor<rank, dim, ValueType> &     value_tensor)
     {
       add_to_substitution_map<ignore_invalid_symbols>(
         substitution_map,
@@ -1182,12 +1187,13 @@ namespace Differentiation
     template <bool ignore_invalid_symbols,
               int  rank,
               int  dim,
+              typename ExpressionType,
               typename ValueType>
     void
     add_to_substitution_map(
-      types::substitution_map &                     substitution_map,
-      const SymmetricTensor<rank, dim, Expression> &symbol_tensor,
-      const SymmetricTensor<rank, dim, ValueType> & value_tensor)
+      types::substitution_map &                         substitution_map,
+      const SymmetricTensor<rank, dim, ExpressionType> &symbol_tensor,
+      const SymmetricTensor<rank, dim, ValueType> &     value_tensor)
     {
       add_to_substitution_map<ignore_invalid_symbols>(
         substitution_map,

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -509,10 +509,11 @@ namespace Differentiation
      * @ref make_substitution_map(const Expression &,const ValueType &)
      * function.
      */
-    template <int rank, int dim, typename ValueType>
+    template <int rank, int dim, typename ExpressionType, typename ValueType>
     types::substitution_map
-    make_substitution_map(const Tensor<rank, dim, Expression> &symbol_tensor,
-                          const Tensor<rank, dim, ValueType> & value_tensor);
+    make_substitution_map(
+      const Tensor<rank, dim, ExpressionType> &symbol_tensor,
+      const Tensor<rank, dim, ValueType> &     value_tensor);
 
     /**
      * Return a substitution map that has the entry keys given by the
@@ -524,11 +525,11 @@ namespace Differentiation
      * @ref make_substitution_map(const Expression &,const ValueType &)
      * function.
      */
-    template <int rank, int dim, typename ValueType>
+    template <int rank, int dim, typename ExpressionType, typename ValueType>
     types::substitution_map
     make_substitution_map(
-      const SymmetricTensor<rank, dim, Expression> &symbol_tensor,
-      const SymmetricTensor<rank, dim, ValueType> & value_tensor);
+      const SymmetricTensor<rank, dim, ExpressionType> &symbol_tensor,
+      const SymmetricTensor<rank, dim, ValueType> &     value_tensor);
 
     //@}
 
@@ -1093,10 +1094,11 @@ namespace Differentiation
     /* ------------------ Symbol substitution map creation ----------------*/
 
 
-    template <int rank, int dim, typename ValueType>
+    template <int rank, int dim, typename ExpressionType, typename ValueType>
     types::substitution_map
-    make_substitution_map(const Tensor<rank, dim, Expression> &symbol_tensor,
-                          const Tensor<rank, dim, ValueType> & value_tensor)
+    make_substitution_map(
+      const Tensor<rank, dim, ExpressionType> &symbol_tensor,
+      const Tensor<rank, dim, ValueType> &     value_tensor)
     {
       types::substitution_map substitution_map;
       add_to_substitution_map(substitution_map, symbol_tensor, value_tensor);
@@ -1104,11 +1106,11 @@ namespace Differentiation
     }
 
 
-    template <int rank, int dim, typename ValueType>
+    template <int rank, int dim, typename ExpressionType, typename ValueType>
     types::substitution_map
     make_substitution_map(
-      const SymmetricTensor<rank, dim, Expression> &symbol_tensor,
-      const SymmetricTensor<rank, dim, ValueType> & value_tensor)
+      const SymmetricTensor<rank, dim, ExpressionType> &symbol_tensor,
+      const SymmetricTensor<rank, dim, ValueType> &     value_tensor)
     {
       types::substitution_map substitution_map;
       add_to_substitution_map(substitution_map, symbol_tensor, value_tensor);
@@ -1123,6 +1125,7 @@ namespace Differentiation
     {
       template <int rank,
                 int dim,
+                typename ExpressionType,
                 typename ValueType,
                 template <int, int, typename> class TensorType>
       std::vector<std::pair<ExpressionType, ValueType>>

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -508,6 +508,17 @@ namespace Differentiation
      * using this function. For more details on this, see the other
      * @ref make_substitution_map(const Expression &,const ValueType &)
      * function.
+     *
+     * @tparam ExpressionType A type that represents a symbolic expression.
+     *         The Differentiation::SD::Expression class is often suitable for
+     *         this purpose, although if the @p ValueType is not supported
+     *         by this class then a user-defined @p ExpressionType should be
+     *         used.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. Although it is typically
+     *         arithmetic in nature, it may also represent another symbolic
+     *         expression type or be a special type that a user-defined
+     *         @p ExpressionType can be constructed from.
      */
     template <int rank, int dim, typename ExpressionType, typename ValueType>
     types::substitution_map
@@ -524,6 +535,17 @@ namespace Differentiation
      * using this function. For more details on this, see the other
      * @ref make_substitution_map(const Expression &,const ValueType &)
      * function.
+     *
+     * @tparam ExpressionType A type that represents a symbolic expression.
+     *         The Differentiation::SD::Expression class is often suitable for
+     *         this purpose, although if the @p ValueType is not supported
+     *         by this class then a user-defined @p ExpressionType should be
+     *         used.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. Although it is typically
+     *         arithmetic in nature, it may also represent another symbolic
+     *         expression type or be a special type that a user-defined
+     *         @p ExpressionType can be constructed from.
      */
     template <int rank, int dim, typename ExpressionType, typename ValueType>
     types::substitution_map
@@ -552,6 +574,17 @@ namespace Differentiation
      * @ref add_to_substitution_map(types::substitution_map &,const
      * Expression &,const Expression &) function for a detailed
      * discussion on the role of this template argument.
+     *
+     * @tparam ExpressionType A type that represents a symbolic expression.
+     *         The Differentiation::SD::Expression class is often suitable for
+     *         this purpose, although if the @p ValueType is not supported
+     *         by this class then a user-defined @p ExpressionType should be
+     *         used.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. Although it is typically
+     *         arithmetic in nature, it may also represent another symbolic
+     *         expression type or be a special type that a user-defined
+     *         @p ExpressionType can be constructed from.
      */
     template <bool ignore_invalid_symbols = false,
               int  rank,
@@ -577,6 +610,17 @@ namespace Differentiation
      * @ref add_to_substitution_map(types::substitution_map &,const
      * Expression &,const Expression &) function for a detailed
      * discussion on the role of this template argument.
+     *
+     * @tparam ExpressionType A type that represents a symbolic expression.
+     *         The Differentiation::SD::Expression class is often suitable for
+     *         this purpose, although if the @p ValueType is not supported
+     *         by this class then a user-defined @p ExpressionType should be
+     *         used.
+     * @tparam ValueType A type that corresponds to the @p value that the
+     *         @p symbol is to represent. Although it is typically
+     *         arithmetic in nature, it may also represent another symbolic
+     *         expression type or be a special type that a user-defined
+     *         @p ExpressionType can be constructed from.
      */
     template <bool ignore_invalid_symbols = false,
               int  rank,


### PR DESCRIPTION
Also add the `ExpressionType` template parameter where applicable. This aligns with the other implemented functions of the same name.

Passes tests locally.