### PR TITLE
fix tables in tutorials

### DIFF
--- a/examples/step-20/doc/results.dox
+++ b/examples/step-20/doc/results.dox
@@ -80,42 +80,33 @@ in the pressure variable:
     <td></td>
     <td colspan="3" align="center">Finite element order</td>
   </tr>
-
   <tr>
     <td>Refinement level</td>
     <td>0</td>
     <td>1</td>
     <td>2</td>
   </tr>
-
   <tr>
     <td>0</td>  <td>1.45344</td>  <td>0.0831743</td>  <td>0.0235186</td>
   </tr>
-
   <tr>
     <td>1</td>  <td>0.715099</td>  <td>0.0245341</td>  <td>0.00293983</td>
   </tr>
-
   <tr>
     <td>2</td>  <td>0.356383</td>  <td>0.0063458</td>  <td>0.000367478</td>
   </tr>
-
   <tr>
     <td>3</td>  <td>0.178055</td>  <td>0.00159944</td>  <td>4.59349e-05</td>
   </tr>
-
   <tr>
     <td>4</td>  <td>0.0890105</td>  <td>0.000400669</td>  <td>5.74184e-06</td>
   </tr>
-
   <tr>
     <td>5</td>  <td>0.0445032</td>  <td>0.000100218</td>  <td>7.17799e-07</td>
   </tr>
-
   <tr>
     <td>6</td>  <td>0.0222513</td>  <td>2.50576e-05</td>  <td>9.0164e-08</td>
   </tr>
-
   <tr>
     <td></td>  <td>$O(h)$</td>  <td>$O(h^2)$</td>  <td>$O(h^3)$</td>
   </tr>
@@ -133,42 +124,33 @@ in the velocity variables:
     <td></td>
     <td colspan="3" align="center">Finite element order</td>
   </tr>
-
   <tr>
     <td>Refinement level</td>
     <td>0</td>
     <td>1</td>
     <td>2</td>
   </tr>
-
   <tr>
     <td>0</td> <td>0.367423</td> <td>0.127657</td> <td>5.10388e-14</td>
   </tr>
-
   <tr>
     <td>1</td> <td>0.175891</td> <td>0.0319142</td> <td>9.04414e-15</td>
   </tr>
-
   <tr>
     <td>2</td> <td>0.0869402</td> <td>0.00797856</td> <td>1.23723e-14</td>
   </tr>
-
   <tr>
     <td>3</td> <td>0.0433435</td> <td>0.00199464</td> <td>1.86345e-07</td>
   </tr>
-
   <tr>
     <td>4</td> <td>0.0216559</td> <td>0.00049866</td> <td>2.72566e-07</td>
   </tr>
-
   <tr>
     <td>5</td> <td>0.010826</td> <td>0.000124664</td> <td>3.57141e-07</td>
   </tr>
-
   <tr>
     <td>6</td> <td>0.00541274</td> <td>3.1166e-05</td> <td>4.46124e-07</td>
   </tr>
-
   <tr>
     <td></td>  <td>$O(h)$</td>  <td>$O(h^2)$</td>  <td>$O(h^3)$</td>
   </tr>

--- a/examples/step-56/doc/results.dox
+++ b/examples/step-56/doc/results.dox
@@ -74,7 +74,6 @@ memory (VM) peak usage:
   <th colspan="6">ILU</th>
   <th colspan="3">UMFPACK</th>
 </tr>
-
 <tr>
   <th></th>
   <th></th>
@@ -88,7 +87,6 @@ memory (VM) peak usage:
   <th colspan="2">Timings</th>
   <th></th>
 </tr>
-
 <tr>
   <th>Cycle</th>
   <th>DoFs</th>
@@ -110,7 +108,6 @@ memory (VM) peak usage:
   <th>Solve</th>
   <th>VM Peak</th>
 </tr>
-
 <tr>
   <td>0</td>
   <td>15468</td>
@@ -132,7 +129,6 @@ memory (VM) peak usage:
   <td>2.8s</td>
   <td>5054</td>
 </tr>
-
 <tr>
   <td>1</td>
   <td>112724</td>
@@ -154,7 +150,6 @@ memory (VM) peak usage:
   <td>237s</td>
   <td>11288</td>
 </tr>
-
 <tr>
   <td>2</td>
   <td>859812</td>
@@ -176,7 +171,6 @@ memory (VM) peak usage:
   <td>-</td>
   <td>-</td>
 </tr>
-
 </table>
 
 As can be seen from the table,


### PR DESCRIPTION
it turns out doxygen breaks the formatting if you have empty lines
within a table (check
https://www.dealii.org/developer/doxygen/deal.II/step_56.html#TimingResults
for an example)