### PR TITLE
Fix some double-word typos.

### DIFF
--- a/examples/step-6/doc/intro.dox
+++ b/examples/step-6/doc/intro.dox
@@ -261,7 +261,7 @@ The steps you need to make this work are essentially like this:
 - You then solve the linear system as usual, but at the end of this
   step, you need to make sure that the degrees of "freedom" located
   on hanging nodes get their correct (constrained) value so that the
-  solution you then visualize or evaluate in other ways in in
+  solution you then visualize or evaluate in other ways is in
   fact continuous. This is done by calling
   AffineConstraints::distribute() immediately after solving.
 

--- a/examples/step-61/doc/intro.dox
+++ b/examples/step-61/doc/intro.dox
@@ -400,7 +400,7 @@ Unfortunately, $\mathbf{K} \mathbf{v}_j$ may not be in the $RT$ space
 (unless, of course, if $\mathbf K$ is constant times the identity matrix). 
 So, in order to represent it in a finite element program, we need to
 project it back into a finite dimensional space we can work with. Here,
-we we will use the $L_2$-projection to project it back to the (broken) $RT$
+we will use the $L_2$-projection to project it back to the (broken) $RT$
 space. 
 
 We define the projection as 

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -884,7 +884,7 @@ namespace Step7
     // being used, and since we would like to avoid false results due to
     // super-convergence effects at some points, we use a special quadrature
     // rule that is obtained by iterating the trapezoidal rule by the degree of
-    // of the finite element times two plus one in each space direction.
+    // the finite element times two plus one in each space direction.
     // Note that the constructor of the QIterated class
     // takes a one-dimensional quadrature rule and a number that tells it how
     // often it shall use this rule in each space direction.

--- a/include/deal.II/base/function_lib.h
+++ b/include/deal.II/base/function_lib.h
@@ -1033,7 +1033,7 @@ namespace Functions
     const double unitary_integral_value;
 
     /**
-     * Current rescaling to apply the the cut-off function.
+     * Current rescaling to apply the cut-off function.
      */
     double rescaling;
   };

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -841,7 +841,7 @@ namespace HDF5
      * The return type is `uint32_t` and corresponds to the value returned by
      * H5Pget_mpio_no_collective_cause.
      *
-     * The return value value can be
+     * The return value can be
      * Value                                      | Meaning
      * ------------------------------------------ | -------
      * H5D_MPIO_COLLECTIVE                        | Collective I/O was performed successfully.
@@ -955,7 +955,7 @@ namespace HDF5
     /**
      * This constructor creates or opens a group depending on the value of
      * @p mode. The group will be placed inside the group @p parent_group. The
-     * parameter @p mpi defines if the the I/O operations are serial or
+     * parameter @p mpi defines if the I/O operations are serial or
      * parallel. This is an internal constructor, the functions open_group() and
      * create_group() of the current class should be used to open or create a
      * group.

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -804,7 +804,7 @@ namespace Differentiation
      * @note When using the cell-level taped AD methods in 3d and/or with higher
      * order elements, it is incredibly easy to exceed the tape buffer size.
      * The reason for this is two-fold:
-     *   1. there are are many independent variables (the local
+     *   1. there are many independent variables (the local
      *      degrees-of-freedom) to take the derivatives with respect to, and
      *   2. the expressions for the dependent variables (each being a component
      *      of the residual vector) in terms of all of the independent variables

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -237,7 +237,7 @@ namespace Differentiation
      *
      * This function is guaranteed to create an ordering that is identical
      * to the typical add_to_substitution_map() call that is used when
-     * constructing a map to to perform symbol substitution.
+     * constructing a map to perform symbol substitution.
      * It exists primarily to create an initial map that can be used in the
      * optimize() call to a BatchOptimizer, specifically if the values that
      * are to be substituted into the map are not known at the time that the

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -278,7 +278,8 @@ namespace Differentiation
      * tensor @p T with respect to the rank-0 tensor @p x.
      *
      * @param[in] T A tensor of symbolic functions or (dependent) expressions.
-     * @param[in] x A rank-0 tensor symbolic symbolic (independent) variable.
+     * @param[in] x A rank-0 tensor containing a symbolic (independent)
+     *            variable.
      * @return The tensor of symbolic functions or expressions representing
      *         the result $\frac{\partial \mathbf{T}}{\partial x}$.
      */
@@ -293,7 +294,8 @@ namespace Differentiation
      *
      * @param[in] S A symmetric tensor of symbolic functions or (dependent)
      *            expressions.
-     * @param[in] x A rank-0 tensor symbolic symbolic (independent) variable.
+     * @param[in] x A rank-0 tensor containing a symbolic (independent)
+     *            variable.
      * @return The symmetric tensor of symbolic functions or expressions representing
      *         the result $\frac{\partial \mathbf{S}}{\partial x}$.
      */
@@ -307,7 +309,7 @@ namespace Differentiation
      * tensor @p T1 with respect to the tensor @p T2.
      *
      * @param[in] T1 A tensor of symbolic functions or (dependent) expressions.
-     * @param[in] T2 A tensor symbolic symbolic (independent) variables.
+     * @param[in] T2 A tensor of symbolic (independent) variables.
      * @return The tensor of symbolic functions or variables representing
      *         the result $\frac{\partial \mathbf{T}_{1}}{\partial
      * \mathbf{T}_{2}}$.
@@ -323,7 +325,7 @@ namespace Differentiation
      *
      * @param[in] S1 A symmetric tensor of symbolic functions or (dependent)
      *            expressions.
-     * @param[in] S2 A symmetric tensor symbolic symbolic (independent)
+     * @param[in] S2 A symmetric tensor of symbolic (independent)
      *            variables.
      * @return The symmetric tensor of symbolic functions or variables representing
      *         the result $\frac{\partial \mathbf{S}_{1}}{\partial
@@ -339,7 +341,7 @@ namespace Differentiation
      * tensor @p T with respect to the symmetric tensor @p S.
      *
      * @param[in] T A tensor of symbolic functions or (dependent) expressions.
-     * @param[in] S A symmetric tensor symbolic symbolic (independent)
+     * @param[in] S A symmetric tensor of symbolic (independent)
      *            variables.
      * @return The tensor of symbolic functions or variables representing
      *         the result $\frac{\partial \mathbf{T}}{\partial \mathbf{S}}$.
@@ -355,7 +357,7 @@ namespace Differentiation
      *
      * @param[in] S A symmetric tensor of symbolic functions or (dependent)
      *            expressions.
-     * @param[in] T A tensor symbolic symbolic (independent) variables.
+     * @param[in] T A tensor of symbolic (independent) variables.
      * @return The tensor of symbolic functions or variables representing
      *         the result $\frac{\partial \mathbf{S}}{\partial \mathbf{T}}$.
      */

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -169,7 +169,7 @@ namespace FETools
    * returned.
    *
    * The vector <tt>renumbering</tt> will be indexed by the standard numbering
-   * of local degrees of freedom, namely first first vertex, then second
+   * of local degrees of freedom, namely the first vertex, then the second
    * vertex, after vertices lines, quads, and hexes. For each index, the entry
    * indicates the index which this degree of freedom receives in a numbering
    * scheme, where the first block is numbered completely before the second.

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -450,7 +450,7 @@ public:
 
     /**
      * In case the quadrature rule given represents a tensor product
-     * we need to store the evaluations of the 1d polynomials at the
+     * we need to store the evaluations of the 1d polynomials at
      * the 1d quadrature points. That is what this variable is for.
      */
     internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<double>>

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -631,7 +631,7 @@ namespace GridGenerator
    * dimensions, but throws an error if called in 1d.
    *
    * By default, the manifold_id is set to 0 on the boundary faces, 1 on the
-   * the boundary cells, and types::flat_manifold_id on the central cell and on
+   * boundary cells, and types::flat_manifold_id on the central cell and on
    * internal faces.
    *
    * A SphericalManifold is attached by default to the boundary faces for

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -768,8 +768,8 @@ namespace GridTools
    * @return A tuple containing four elements; the first three
    * are documented in GridTools::compute_point_locations().
    * The last element of the @p return_type contains the
-   * indices of points which are not not found inside the mesh
-   * or lie on artificial cells. The @p return_type equals the
+   * indices of points which are neither found inside the mesh
+   * nor lie in artificial cells. The @p return_type equals the
    * following tuple type:
    * @code
    *   std::tuple<
@@ -2262,7 +2262,7 @@ namespace GridTools
    * build a Triangulation from those, and then adaptively refine it so that
    * the input cells all also exist in the output Triangulation.
    *
-   * A consequence of this procedure is that that output Triangulation may
+   * A consequence of this procedure is that the output Triangulation may
    * contain more active cells than the ones that exist in the input vector.
    * On the other hand, one typically wants to solve the local problem not on
    * the entire output Triangulation, but only on those cells of it that

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -388,7 +388,7 @@ namespace hp
      * and therefore this function will return their indices in the
      * FECollection, namely `{2,3}`.
      *
-     * The @p codim parameter describes the codimension of of the investigated
+     * The @p codim parameter describes the codimension of the investigated
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */
@@ -424,7 +424,7 @@ namespace hp
      * then one could return zero or one.  In that case, the function returns
      * either `0` or `1` since there is no tie-breaker between the two.
      *
-     * The @p codim parameter describes the codimension of of the investigated
+     * The @p codim parameter describes the codimension of the investigated
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */
@@ -460,7 +460,7 @@ namespace hp
      * indices, then one could return two or three.  In that case, the function
      * returns either `2` or `3` since there is no tie-breaker between the two.
      *
-     * The @p codim parameter describes the codimension of of the investigated
+     * The @p codim parameter describes the codimension of the investigated
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */
@@ -487,7 +487,7 @@ namespace hp
      * function is not able to find a finite element at all, it returns
      * numbers::invalid_unsigned_int.
      *
-     * The @p codim parameter describes the codimension of of the investigated
+     * The @p codim parameter describes the codimension of the investigated
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */
@@ -513,7 +513,7 @@ namespace hp
      * function is not able to find a finite element at all, it returns
      * numbers::invalid_unsigned_int.
      *
-     * The @p codim parameter describes the codimension of of the investigated
+     * The @p codim parameter describes the codimension of the investigated
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */

--- a/include/deal.II/integrators/l2.h
+++ b/include/deal.II/integrators/l2.h
@@ -50,7 +50,7 @@ namespace LocalIntegrators
      * integrals \f[ \int_F uv\,ds \quad \text{or} \quad \int_F \mathbf u\cdot
      * \mathbf v\,ds \f]
      *
-     * @param M The mass matrix matrix obtained as result.
+     * @param M The mass matrix obtained as result.
      * @param fe The FEValues object describing the local trial function
      * space. #update_values and #update_JxW_values must be set.
      * @param factor A constant that multiplies the mass matrix.
@@ -102,7 +102,7 @@ namespace LocalIntegrators
      * integrals \f[ \int_F \omega(x) uv\,ds \quad \text{or} \quad \int_F
      * \omega(x) \mathbf u\cdot \mathbf v\,ds \f]
      *
-     * @param M The weighted mass matrix matrix obtained as result.
+     * @param M The weighted mass matrix obtained as result.
      * @param fe The FEValues object describing the local trial function
      * space. #update_values and #update_JxW_values must be set.
      * @param weights The weights, $\omega(x)$, evaluated at the quadrature

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -705,7 +705,7 @@ public:
    * condensed and compressed.  This function is the appropriate choice for
    * applying inhomogeneous constraints.
    *
-   * The current object object must be closed to call this function.
+   * The current object must be closed to call this function.
    *
    * See the general documentation of this class for more detailed
    * information.

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -516,8 +516,8 @@ AffineConstraints<number>::close()
             new_entries = line.entries;
           else
             {
-              // otherwise, we need to go through the list by and and
-              // resolve the duplicates
+              // otherwise, we need to go through the list and resolve the
+              // duplicates
               new_entries.reserve(line.entries.size() - duplicates);
               new_entries.push_back(line.entries[0]);
               for (size_type j = 1; j < line.entries.size(); ++j)

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -921,7 +921,7 @@ namespace LinearAlgebra
 #  if defined DEAL_II_COMPILER_CUDA_AWARE && \
     !defined(DEAL_II_MPI_WITH_CUDA_SUPPORT)
       // Move the data to the host and then move it back to the
-      // the device. We use values to store the elements because the function
+      // device. We use values to store the elements because the function
       // uses a view of the array and thus we need the data on the host to
       // outlive the scope of the function.
       Number *new_val;
@@ -1081,7 +1081,7 @@ namespace LinearAlgebra
 #  if defined DEAL_II_COMPILER_CUDA_AWARE && \
     !defined(DEAL_II_MPI_WITH_CUDA_SUPPORT)
       // Move the data to the host and then move it back to the
-      // the device. We use values to store the elements because the function
+      // device. We use values to store the elements because the function
       // uses a view of the array and thus we need the data on the host to
       // outlive the scope of the function.
       Number *new_val;

--- a/include/deal.II/meshworker/scratch_data.h
+++ b/include/deal.II/meshworker/scratch_data.h
@@ -495,9 +495,9 @@ namespace MeshWorker
     /** @} */ // NeighborCellMethods
 
     /**
-     * Return a GeneralDataStorage object that can be used to store store any
-     * amount of data, of any type, which is then made accessible by an
-     * identifier string.
+     * Return a GeneralDataStorage object that can be used to store any amount
+     * of data, of any type, which is then made accessible by an identifier
+     * string.
      */
     GeneralDataStorage &
     get_general_data_storage();

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -999,7 +999,7 @@ namespace MeshWorker
             // degree of freedom on the refinement edge, k does
             // not, and both are not on the boundary. This is part
             // the difference between the complete matrix with no
-            // boundary condition at the refinement edge and and
+            // boundary condition at the refinement edge and
             // the matrix assembled above by assemble().
 
             // Thus the logic is: enter the row if it is


### PR DESCRIPTION
e.g., "the the".

@jppelteret I am pretty sure that `symbolic symbolic` is not a technical term. Is it? If so I will revert the changes I made.