### PR TITLE
Use 'Tensor objects' instead of 'Tensors'.

### DIFF
--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -310,9 +310,9 @@ namespace parallel
      * // CellDataStorage::initialize()
      * data_transfer.interpolate();
      * @endcode
-     * This approach can be extended to quadrature point data with Tensors of
-     * arbitrary order, although with a little bit more work in packing and
-     * unpacking of data inside MyQData class.
+     * This approach can be extended to quadrature point data with Tensor
+     * objects of arbitrary order, although with a little bit more work in
+     * packing and unpacking of data inside MyQData class.
      *
      * @note Currently coarsening is not supported.
      *

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -827,8 +827,8 @@ public:
   norm() const;
 
   /**
-   * Tensors can be unrolled by simply pasting all elements into one long
-   * vector, but for this an order of elements has to be defined. For
+   * Tensor objects can be unrolled by simply pasting all elements into one
+   * long vector, but for this an order of elements has to be defined. For
    * symmetric tensors, this function returns which index within the range
    * <code>[0,n_independent_components)</code> the given entry in a symmetric
    * tensor has.


### PR DESCRIPTION
Motivated by a comment in #8122: this covers `Tensors` in the relevant places in the rest of the library. There were a few places where we use `Tensors` generically (it refers to DerivativeForms) so I left those alone.