### PR TITLE
Fix codespell findings

### DIFF
--- a/doc/news/8.4.2-vs-8.5.0.h
+++ b/doc/news/8.4.2-vs-8.5.0.h
@@ -1656,7 +1656,7 @@ inconvenience this causes.
   New: Added TrilinosWrappers::SolveDirect::initialize and
   TrilinosWrappers::SolverDirect::solve to solve distributed linear systems
   with multiple right hand sides without needing to refactorize the matrix
-  everytime.
+  every time.
   <br>
   (Michael Harmon, 2016/06/30)
  </li>

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -1013,7 +1013,7 @@ namespace step62
          position_idx < parameters.nb_probe_points;
          ++position_idx)
       {
-        // Because of the way the operator + and - are overloaded. To substract
+        // Because of the way the operator + and - are overloaded to subtract
         // two points, the following has to be done:
         // `Point_b<dim> + (-Point_a<dim>)`
         const Point<dim> p =

--- a/include/deal.II/differentiation/sd/symengine_math.h
+++ b/include/deal.II/differentiation/sd/symengine_math.h
@@ -194,7 +194,7 @@ namespace Differentiation
     //@}
 
     /**
-     * @name Trignometric functions
+     * @name Trigonometric functions
      */
     //@{
 
@@ -378,7 +378,7 @@ namespace Differentiation
     //@}
 
     /**
-     * @name Hyperbolic trignometric functions
+     * @name Hyperbolic trigonometric functions
      */
     //@{
 

--- a/include/deal.II/meshworker/scratch_data.h
+++ b/include/deal.II/meshworker/scratch_data.h
@@ -82,7 +82,7 @@ namespace MeshWorker
    * discontinuous Galerkin methods).
    *
    * If you need to retrieve values or gradients of finite element solution
-   * vectors, on the cell, face, or subface that has just beeing initialized
+   * vectors, on the cell, face, or subface that has just been initialized
    * with one of the functions in @ref CurrentCellMethods, you can use the
    * methods in @ref CurrentCellEvaluation.
    *

--- a/include/deal.II/opencascade/manifold_lib.h
+++ b/include/deal.II/opencascade/manifold_lib.h
@@ -361,7 +361,7 @@ namespace OpenCASCADE
     /**
      * The constructor takes an OpenCASCADE TopoDS_Face @p face and an optional
      * @p tolerance. This class uses the interval OpenCASCADE variables @var u,
-     * @var v to descrive the manifold.
+     * @var v to describe the manifold.
      */
     NURBSPatchManifold(const TopoDS_Face &face, const double tolerance = 1e-7);
 

--- a/source/algorithms/timestep_control.cc
+++ b/source/algorithms/timestep_control.cc
@@ -73,11 +73,11 @@ TimestepControl::parse_parameters(ParameterHandler &param)
   max_step(param.get_double("Max step"));
   final(param.get_double("Final"));
   tolerance(param.get_double("Tolerance"));
-  print_step              = param.get_double("Print step");
-  const std::string strat = param.get("Strategy");
-  if (strat == std::string("uniform"))
+  print_step                 = param.get_double("Print step");
+  const std::string strategy = param.get("Strategy");
+  if (strategy == std::string("uniform"))
     strategy_val = uniform;
-  else if (strat == std::string("doubling"))
+  else if (strategy == std::string("doubling"))
     strategy_val = doubling;
 }
 

--- a/source/differentiation/sd/symengine_scalar_operations.cc
+++ b/source/differentiation/sd/symengine_scalar_operations.cc
@@ -229,7 +229,7 @@ namespace Differentiation
                   // Here we substitute in symbol_values_resolved instead of
                   // symbol_values, in order to break any cyclic dependencies.
                   // The earlier entries in the dictionary are in this way
-                  // guarenteed to be resolved before any subsequent entries,
+                  // guaranteed to be resolved before any subsequent entries,
                   // thereby breaking the dependency loop.
                   out = out.substitute(symbol_values_resolved);
                 }

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1351,7 +1351,7 @@ namespace parallel
       //
       // To deal with the case that at least one of the processors does not own
       // any cell at all, we will exchange the information about the data sizes
-      // among them later. The code inbetween is still well-defined, since the
+      // among them later. The code in between is still well-defined, since the
       // following loops will be skipped.
       std::vector<unsigned int> local_sizes_fixed(
         1 + n_callbacks_fixed + (variable_size_data_stored ? 1 : 0));

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -69,12 +69,13 @@ namespace Particles
   template <int dim, int spacedim>
   void
   ParticleHandler<dim, spacedim>::initialize(
-    const parallel::distributed::Triangulation<dim, spacedim> &tria,
-    const Mapping<dim, spacedim> &                             mapp,
-    const unsigned int                                         n_properties)
+    const parallel::distributed::Triangulation<dim, spacedim>
+      &                           new_triangulation,
+    const Mapping<dim, spacedim> &new_mapping,
+    const unsigned int            n_properties)
   {
-    triangulation = &tria;
-    mapping       = &mapp;
+    triangulation = &new_triangulation;
+    mapping       = &new_mapping;
 
     // Create the memory pool that will store all particle properties
     property_pool = std_cxx14::make_unique<PropertyPool>(n_properties);

--- a/tests/fe/fe_enriched_color_07.cc
+++ b/tests/fe/fe_enriched_color_07.cc
@@ -1247,12 +1247,12 @@ LaplaceProblem<dim>::make_enrichment_functions()
        * function for which the enrichment function is to be estimated.
        *
        * The center is 0 since the function is evaluated with respect to
-       * relative position from focal point anyway.
+       * the relative position from the focal point anyway.
        *
-       * For hexahedral cells, dimension can extend upto sqrt(3) < 2 times!
-       * So take a factor of 4 as size of the problem. This ensures that
+       * For hexahedral cells, the dimension can extend up to sqrt(3) < 2 times!
+       * So take a factor of 4 as size of the problem. This ensures that the
        * enrichment function can be evaluated at all points in the enrichment
-       * domain
+       * domain.
        */
       double center = 0;
       double sigma  = prm.sigmas[i];

--- a/tests/hp/crash_21.cc
+++ b/tests/hp/crash_21.cc
@@ -18,7 +18,7 @@
 // a problem uncovered by Baerbel Janssen in that
 // DoFTools::make_flux_sparsity_pattern aborted in 1d with adaptively refined
 // meshes and hp DoFHandlers. this actually uncovered all sorts of other
-// problems that led to a long sequence of assertions triggered everytime one
+// problems that led to a long sequence of assertions triggered every time one
 // of them was fixed. this test cumulatively makes sure everything is ok
 
 // while there, also test the same code in 2d (3d appears to take too long)


### PR DESCRIPTION
Step 0g in #8080. Since the last time `codespell` was run (#7979) is not so long ago, there is not much to do here. I included some more naming improvements as well.