### PR TITLE
reflow comments and ensure @ref is on a newline, some doxygen bugfixs

### DIFF
--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -858,8 +858,8 @@ private:
  * }
  *
  * FunctionFromFunctionObjects<2, RangeNumberType>
- *	custom_function({&first_component, &second_component},
- *		        {&zero_gradient, &zero_gradient});
+ * custom_function({&first_component, &second_component}, {&zero_gradient,
+ * &zero_gradient});
  * @endcode
  *
  * @author Luca Heltai, 2019

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -1227,8 +1227,9 @@ namespace Differentiation
      * the returned result may still be symbolic in nature.
      *
      * For an example of what this function does, see the documentation for the
-     * other @ref resolve_explicit_dependencies(const
-     * types::substitution_map &) function.
+     * other
+     * @ref resolve_explicit_dependencies(const types::substitution_map &)
+     * function.
      *
      * @tparam ExpressionType A type that represents a symbolic expression.
      *         The Differentiation::SD::Expression class is often suitable for
@@ -1302,8 +1303,9 @@ namespace Differentiation
      * variables either a numeric interpretation or some symbolic definition.
      *
      * For more information regarding the performance of symbolic substitution,
-     * see the other @ref substitute(const Expression &,
-     * const types::substitution_map &) function.
+     * see the other
+     * @ref substitute(const Expression &, const types::substitution_map &)
+     * function.
      *
      * @note It is not required that all symbolic expressions be fully resolved
      * when using this function. In other words, partial substitutions are
@@ -1330,8 +1332,9 @@ namespace Differentiation
      * variables either a numeric interpretation or some symbolic definition.
      *
      * For more information regarding the performance of symbolic substitution,
-     * see the other @ref substitute(const Expression &,
-     * const types::substitution_map &) function.
+     * see the other
+     * @ref substitute(const Expression &, const types::substitution_map &)
+     * function.
      *
      * @note It is not required that all symbolic expressions be fully resolved
      * when using this function. In other words, partial substitutions are
@@ -1363,8 +1366,9 @@ namespace Differentiation
      *
      * For more information regarding the performance of symbolic substitution,
      * and the outcome of evaluation using a substitution map with cyclic
-     * dependencies, see the @ref substitute(const Expression &,
-     * const types::substitution_map &) function.
+     * dependencies, see the
+     * @ref substitute(const Expression &, const types::substitution_map &)
+     * function.
      *
      * @note It is required that all symbols in the @p expression be
      * successfully resolved by the @p substitution_map.
@@ -1392,8 +1396,9 @@ namespace Differentiation
      *
      * For more information regarding the performance of symbolic substitution,
      * and the outcome of evaluation using a substitution map with cyclic
-     * dependencies, see the @ref substitute(const Expression &,
-     * const types::substitution_map &) function.
+     * dependencies, see the
+     * @ref substitute(const Expression &, const types::substitution_map &)
+     * function.
      *
      * @note It is required that all symbols in the @p expression be
      * successfully resolved by the substitution map that is generated with the

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -653,8 +653,9 @@ namespace Differentiation
      *
      * For more information regarding the performance of symbolic substitution,
      * and the outcome of evaluation using a substitution map with cyclic
-     * dependencies, see the @ref substitute(const Expression &,
-     * const types::substitution_map &) function.
+     * dependencies, see the
+     * @ref substitute(const Expression &, const types::substitution_map &)
+     * function.
      *
      * @note It is not required that all symbolic expressions be fully resolved
      * when using this function. In other words, partial substitutions are
@@ -676,8 +677,9 @@ namespace Differentiation
      *
      * For more information regarding the performance of symbolic substitution,
      * and the outcome of evaluation using a substitution map with cyclic
-     * dependencies, see the @ref substitute(const Expression &,
-     * const types::substitution_map &) function.
+     * dependencies, see the
+     * @ref substitute(const Expression &, const types::substitution_map &)
+     * function.
      *
      * @note It is not required that all symbolic expressions be fully resolved
      * when using this function. In other words, partial substitutions are
@@ -701,8 +703,9 @@ namespace Differentiation
      *
      * For more information regarding the performance of symbolic substitution,
      * and the outcome of evaluation using a substitution map with cyclic
-     * dependencies, see the @ref substitute(const Expression &,
-     * const types::substitution_map &) function.
+     * dependencies, see the
+     * @ref substitute(const Expression &, const types::substitution_map &)
+     * function.
      *
      * @note It is required that all symbols in @p expression_tensor be
      * successfully resolved by the @p substitution_map.
@@ -732,8 +735,9 @@ namespace Differentiation
      *
      * For more information regarding the performance of symbolic substitution,
      * and the outcome of evaluation using a substitution map with cyclic
-     * dependencies, see the @ref substitute(const Expression &,
-     * const types::substitution_map &) function.
+     * dependencies, see the
+     * @ref substitute(const Expression &, const types::substitution_map &)
+     * function.
      *
      * @note It is required that all symbols in @p expression_tensor be
      * successfully resolved by the @p substitution_map.

--- a/include/deal.II/dofs/deprecated_function_map.h
+++ b/include/deal.II/dofs/deprecated_function_map.h
@@ -29,7 +29,8 @@ class Function;
 
 /**
  * This class declares a local alias that denotes a mapping between a boundary
- * indicator (see @ref GlossBoundaryIndicator) that is used to describe what
+ * indicator (see
+ * @ref GlossBoundaryIndicator) that is used to describe what
  * kind of boundary condition holds on a particular piece of the boundary, and
  * the function describing the actual function that provides the boundary values
  * on this part of the boundary. This type is required in many functions in the

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -478,8 +478,9 @@ class FESystem;
  * The matrix <i>M</i> may be computed with FETools::compute_node_matrix().
  * This function relies on the existence of #generalized_support_points and
  * FiniteElement::convert_generalized_support_point_values_to_dof_values()
- * (see the @ref GlossGeneralizedSupport "glossary entry on generalized
- * support points" for more information). With this, one can then use the
+ * (see the
+ * @ref GlossGeneralizedSupport "glossary entry on generalized support points"
+ * for more information). With this, one can then use the
  * following piece of code in the constructor of a class derived from
  * FiniteElement to compute the $M$ matrix:
  * @code

--- a/include/deal.II/fe/fe_rannacher_turek.h
+++ b/include/deal.II/fe/fe_rannacher_turek.h
@@ -61,7 +61,8 @@ DEAL_II_NAMESPACE_OPEN
  *
  * <h4>Node values</h4>
  *
- * The @ref GlossNodes "node values" are moments on faces.
+ * The
+ * @ref GlossNodes "node values" are moments on faces.
  *
  * <h4>Generalized support points</h4>
  *

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -153,10 +153,11 @@ namespace GridGenerator
    * corresponds to the numbers of faces of the unit square of cube as laid
    * out in the documentation of the GeometryInfo class; see also
    * @ref GlossColorization "the glossary entry on colorization". Importantly,
-   * however, in 3d @ref GlossColorization "colorization" does not set @p
-   * boundary_ids of <i>edges</i>, but only of <i>faces</i>, because each
-   * boundary edge is shared between two faces and it is not clear how the
-   * boundary id of an edge should be set in that case.
+   * however, in 3d
+   * @ref GlossColorization "colorization" does not set @p boundary_ids of
+   * <i>edges</i>, but only of <i>faces</i>, because each boundary edge is
+   * shared between two faces and it is not clear how the boundary id of an
+   * edge should be set in that case.
    *
    * Additionally, if @p colorize is @p true, material ids are assigned to the
    * cells according to the octant their center is in: being in the right half
@@ -394,17 +395,17 @@ namespace GridGenerator
    * The resulting Triangulation uses three manifolds: a PolarManifold (in 2D)
    * or CylindricalManifold (in 3D) with manifold id $0$, a
    * TransfiniteInterpolationManifold with manifold id $1$, and a FlatManifold
-   * everywhere else. For more information on this topic see @ref
-   * GlossManifoldIndicator "the glossary entry on manifold indicators".  The
-   * cell faces on the cylinder and surrounding shells have manifold ids of
-   * $0$, while the cell volumes adjacent to the shells (or, if they do not
-   * exist, the cylinder) have a manifold id of $1$. Put another way: this
-   * grid uses TransfiniteInterpolationManifold to smoothly transition from
-   * the shells (generated with GridGenerator::concentric_hyper_shells) to the
-   * bulk region. All other cell volumes and faces have manifold id
-   * numbers::flat_manifold_id and use FlatManifold. All cells with id
-   * numbers::flat_manifold_id are rectangular prisms aligned with the
-   * coordinate axes.
+   * everywhere else. For more information on this topic see
+   * @ref GlossManifoldIndicator "the glossary entry on manifold indicators".
+   * The cell faces on the cylinder and surrounding shells have manifold
+   * ids of $0$, while the cell volumes adjacent to the shells (or, if they
+   * do not exist, the cylinder) have a manifold id of $1$. Put another
+   * way: this grid uses TransfiniteInterpolationManifold to smoothly
+   * transition from the shells (generated with
+   * GridGenerator::concentric_hyper_shells) to the bulk region. All other
+   * cell volumes and faces have manifold id numbers::flat_manifold_id and
+   * use FlatManifold. All cells with id numbers::flat_manifold_id are
+   * rectangular prisms aligned with the coordinate axes.
    *
    * The picture below shows part of the 2D grid (using all default arguments
    * to this function) after two global refinements. The cells with manifold
@@ -597,8 +598,8 @@ namespace GridGenerator
    * If the flag @p colorize is set, the outer cells get material ids
    * according to the following scheme: extending over the inner cube in (+/-)
    * x-direction: 1/2. In y-direction 4/8, in z-direction 16/32. The cells at
-   * corners and edges (3d) get these values bitwise or'd (see also @ref
-   * GlossColorization "the glossary entry on colorization").
+   * corners and edges (3d) get these values bitwise or'd (see also
+   * @ref GlossColorization "the glossary entry on colorization").
    *
    * Presently only available in 2d and 3d.
    *
@@ -1083,7 +1084,8 @@ namespace GridGenerator
    * @param repetitions Number of subdivisions along the @p z-direction.
    * @param colorize Whether to assign different boundary indicators to
    * different faces
-   * (see @ref GlossColorization "the glossary entry on colorization").
+   * (see
+   * @ref GlossColorization "the glossary entry on colorization").
    * The colors are given in lexicographic ordering for the
    * flat faces (0 to 3 in 2d, 0 to 5 in 3d) plus the curved hole (4 in 2d,
    * and 6 in 3d). If @p colorize is set to false, then flat faces get the

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2849,7 +2849,8 @@ namespace GridTools
    * individually, which could also be of use to other processes. An
    * example would be if the input vector of bounding boxes
    * corresponded to a covering of the locally owned partition of a
-   * mesh (see @ref GlossLocallyOwnedCell) of a
+   * mesh (see
+   * @ref GlossLocallyOwnedCell) of a
    * parallel::distributed::Triangulation object. While these may
    * overlap the bounding boxes of other processes, finding which
    * process owns the cell that encloses a given point is vastly

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1378,7 +1378,8 @@ public:
      */
     patch_level_1 = 0x4,
     /**
-     * Each @ref GlossCoarseMesh "coarse grid" cell is refined at least once,
+     * Each
+     * @ref GlossCoarseMesh "coarse grid" cell is refined at least once,
      * i.e., the triangulation
      * might have active cells on level 1 but not on level 0. This flag
      * ensures that a mesh which has coarsest_level_1 has still
@@ -1954,7 +1955,8 @@ public:
    * of the latter being a list of <tt>1<<dim</tt> vertex indices. The
    * triangulation must be empty upon calling this function and the cell list
    * should be useful (connected domain, etc.). The result of calling this
-   * function is a @ref GlossCoarseMesh "coarse mesh".
+   * function is a
+   * @ref GlossCoarseMesh "coarse mesh".
    *
    * Material data for the cells is given within the @p cells array, while
    * boundary information is given in the @p subcelldata field.

--- a/include/deal.II/lac/cuda_kernels.h
+++ b/include/deal.II/lac/cuda_kernels.h
@@ -171,7 +171,8 @@ namespace LinearAlgebra
 
 
       /**
-       * Apply the functor @tparam Binop to each element of @p v1 and @p v2.
+       * Apply the functor
+       * @tparam Binop to each element of @p v1 and @p v2.
        *
        * @ingroup CUDAWrappers
        */
@@ -182,7 +183,8 @@ namespace LinearAlgebra
 
 
       /**
-       * Apply the functor @tparam Binop to the elements of @p v1 that have
+       * Apply the functor
+       * @tparam Binop to the elements of @p v1 that have
        * indices in @p mask and @p v2. The size of @p mask should be greater
        * than the size of @p v1. @p mask and @p v2 should have the same size @p
        * N.
@@ -271,7 +273,8 @@ namespace LinearAlgebra
 
 
       /**
-       * Perform a reduction on @p v using @tparam Operation.
+       * Perform a reduction on @p v using
+       * @tparam Operation.
        *
        * @ingroup CUDAWrappers
        */

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -183,7 +183,8 @@ namespace LinearAlgebra
      * CPU. When the memory space is CUDA, all the data is allocated on the GPU.
      * The operations on the vector are performed on the chosen memory space. *
      * From the host, there are two methods to access the elements of the Vector
-     * when using the CUDA memory space: <ul>
+     * when using the CUDA memory space:
+     * <ul>
      * <li> use get_values()
      * <code>
      * Vector<double, MemorySpace::CUDA> vector(local_range, comm);

--- a/include/deal.II/lac/scalapack.templates.h
+++ b/include/deal.II/lac/scalapack.templates.h
@@ -449,15 +449,15 @@ extern "C"
 
   /**
    * Perform one of the matrix-matrix operations:
-   * @f{align*}
+   * @f{align*}{
    * \mathrm{sub}(C) &\dealcoloneq \alpha op(\mathrm{sub}(A))op(\mathrm{sub}(B))
-   *                            + \beta \mathrm{sub}(C), \\
+   * + \beta \mathrm{sub}(C),
+   * \\
    * \mathrm{sub}(C) &\dealcoloneq \alpha op(\mathrm{sub}(A))op(\mathrm{sub}(B))
-   *                            + beta sub(C),
-   * @f
-   * where
-   * $\mathrm{sub}(C)$ denotes C(IC:IC+M-1,JC:JC+N-1),  and, $op(X)$ is one of
-   * $op(X) = X$ or $op(X) = X^T$.
+   * + beta sub(C),
+   * @f}
+   * where $\mathrm{sub}(C)$ denotes C(IC:IC+M-1,JC:JC+N-1),
+   * and $op(X)$ is one of $op(X) = X$ or $op(X) = X^T$.
    */
   void
   pdgemm_(const char *  transa,

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -80,7 +80,8 @@ namespace parallel
 
 /**
  * A class that represents a vector of numerical elements. As for the
- * other classes, in the @ref Vectors group, this class has a substantial
+ * other classes, in the
+ * @ref Vectors group, this class has a substantial
  * number of member functions. These include:
  * - functions that initialize the vector or change its size;
  * - functions that compute properties of the vector, such as a variety of

--- a/include/deal.II/meshworker/scratch_data.h
+++ b/include/deal.II/meshworker/scratch_data.h
@@ -69,12 +69,14 @@ namespace MeshWorker
    *   construction of these temporaries *on demand*, and easy access to
    *   values, gradients, etc., of already computed solution vectors.
    *
-   * The methods in @ref CurrentCellMethods initialize on demand internal FEValues,
+   * The methods in
+   * @ref CurrentCellMethods initialize on demand internal FEValues,
    * FEFaceValues, and FESubfaceValues objects on the current cell, allowing the
    * use of this class as a single substitute for three different objects used
    * to integrate and query finite element values on cells, faces, and subfaces.
    *
-   * Similarly, the methods in @ref NeighborCellMethods initialize on demand
+   * Similarly, the methods in
+   * @ref NeighborCellMethods initialize on demand
    * (different) internal FEValues, FEFaceValues, and FESubfaceValues, on
    * neighbor cells, allowing the use of this class also as a single substitute
    * for the additional three objects you would typically need to integrate on
@@ -83,8 +85,10 @@ namespace MeshWorker
    *
    * If you need to retrieve values or gradients of finite element solution
    * vectors, on the cell, face, or subface that has just beeing initialized
-   * with one of the functions in @ref CurrentCellMethods, you can use the
-   * methods in @ref CurrentCellEvaluation.
+   * with one of the functions in
+   * @ref CurrentCellMethods, you can use the
+   * methods in
+   * @ref CurrentCellEvaluation.
    *
    * An example usage for this class is given by the following snippet of code:
    *

--- a/include/deal.II/optimization/rol/vector_adaptor.h
+++ b/include/deal.II/optimization/rol/vector_adaptor.h
@@ -102,8 +102,8 @@ namespace Rol
    * @endcode
    *
    * @note The current implementation in ROL doesn't support vector sizes above
-   * the largest value of int type. Some of the vectors in deal.II (@ref Vector)
-   * may not satisfy the above requirements.
+   * the largest value of int type. Some of the vectors in deal.II (
+   * @ref Vector) may not satisfy the above requirements.
    *
    * @author Vishal Boddu, 2017
    */


### PR DESCRIPTION
This is in preparation of running wrapcomments.py

Part of release step 0c/ (#8080)