### PR TITLE
Disable intrinsics includes if DEAL_II_VECTORIZATION_LEVEL=0

### DIFF
--- a/cmake/checks/check_01_cpu_features.cmake
+++ b/cmake/checks/check_01_cpu_features.cmake
@@ -78,7 +78,7 @@ IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
 
   CHECK_CXX_SOURCE_RUNS(
     "
-    #include <emmintrin.h>
+    #include <x86intrin.h>
     int main()
     {
     __m128d a, b;
@@ -116,7 +116,7 @@ IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
     #ifndef __AVX__
     #error \"__AVX__ flag not set, no support for AVX\"
     #endif
-    #include <immintrin.h>
+    #include <x86intrin.h>
     class VectorizedArray
     {
     public:
@@ -175,7 +175,7 @@ IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
     #ifndef __AVX512F__
     #error \"__AVX512F__ flag not set, no support for AVX512\"
     #endif
-    #include <immintrin.h>
+    #include <x86intrin.h>
     int main()
     {
       __m512d a, b;

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -118,7 +118,7 @@
 // We need to disable SIMD vectorization for CUDA device code.
 // Otherwise, nvcc compilers from version 9 on will emit an error message like:
 // "[...] contains a vector, which is not supported in device code"
-#ifdef __CUDA_ARCH__
+#ifdef DEAL_II_WITH_CUDA
 #  define DEAL_II_COMPILER_VECTORIZATION_LEVEL 0
 #else
 #  define DEAL_II_COMPILER_VECTORIZATION_LEVEL @DEAL_II_COMPILER_VECTORIZATION_LEVEL@

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -26,7 +26,7 @@
 
 // Note:
 // The flag DEAL_II_COMPILER_VECTORIZATION_LEVEL is essentially constructed
-// according to the following scheme
+// according to the following scheme (on x86-based architectures)
 // #ifdef __AVX512F__
 // #define DEAL_II_COMPILER_VECTORIZATION_LEVEL 3
 // #elif defined (__AVX__)
@@ -40,30 +40,35 @@
 // 'check_01_cpu_features.cmake', ensures that these feature are not only
 // present in the compilation unit but also working properly.
 
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__SSE2__) && \
-  !defined(__AVX__)
-#  error \
-    "Mismatch in vectorization capabilities: AVX was detected during configuration of deal.II and switched on, but it is apparently not available for the file you are trying to compile at the moment. Check compilation flags controlling the instruction set, such as -march=native."
-#endif
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__SSE2__) && \
-  !defined(__AVX512F__)
-#  error \
-    "Mismatch in vectorization capabilities: AVX-512F was detected during configuration of deal.II and switched on, but it is apparently not available for the file you are trying to compile at the moment. Check compilation flags controlling the instruction set, such as -march=native."
-#endif
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL > 0
 
-#if defined(_MSC_VER)
-#  include <intrin.h>
-#elif defined(__ALTIVEC__)
-#  include <altivec.h>
+#  if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__SSE2__) && \
+    !defined(__AVX__)
+#    error \
+      "Mismatch in vectorization capabilities: AVX was detected during configuration of deal.II and switched on, but it is apparently not available for the file you are trying to compile at the moment. Check compilation flags controlling the instruction set, such as -march=native."
+#  endif
+#  if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__SSE2__) && \
+    !defined(__AVX512F__)
+#    error \
+      "Mismatch in vectorization capabilities: AVX-512F was detected during configuration of deal.II and switched on, but it is apparently not available for the file you are trying to compile at the moment. Check compilation flags controlling the instruction set, such as -march=native."
+#  endif
+
+#  if defined(_MSC_VER)
+#    include <intrin.h>
+#  elif defined(__ALTIVEC__)
+#    include <altivec.h>
 
 // altivec.h defines vector, pixel, bool, but we do not use them, so undefine
 // them before they make trouble
-#  undef vector
-#  undef pixel
-#  undef bool
-#else
-#  include <x86intrin.h>
+#    undef vector
+#    undef pixel
+#    undef bool
+#  else
+#    include <x86intrin.h>
+#  endif
+
 #endif
+
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
This disables all includes to intrinsics headers in case `DEAL_II_VECTORIZATION_LEVEL=0` as suggested by https://github.com/dealii/dealii/pull/8125#issuecomment-491659211

This supersedes #8125 
This fixes #8075.