### PR TITLE
gcc9 warning: Provide copy constructor for class with operator=

### DIFF
--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -628,6 +628,7 @@ namespace Step32
       {
         StokesPreconditioner(const FiniteElement<dim> &stokes_fe);
         StokesPreconditioner(const StokesPreconditioner &data);
+        StokesPreconditioner &operator=(const StokesPreconditioner &) = default;
 
         FullMatrix<double>                   local_matrix;
         std::vector<types::global_dof_index> local_dof_indices;

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -263,6 +263,11 @@ namespace PETScWrappers
       explicit Vector(const IndexSet &local, const MPI_Comm &communicator);
 
       /**
+       * Copy constructor.
+       */
+      Vector(const Vector &v);
+
+      /**
        * Release all memory and return to a state just like after having
        * called the default constructor.
        */

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -85,6 +85,14 @@ namespace PETScWrappers
 
 
 
+    Vector::Vector(const Vector &v)
+      : VectorBase()
+    {
+      this->operator=(v);
+    }
+
+
+
     Vector::Vector(const IndexSet &local, const MPI_Comm &communicator)
       : communicator(communicator)
     {

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -87,7 +87,13 @@ namespace PETScWrappers
 
     Vector::Vector(const Vector &v)
       : VectorBase()
+      , communicator(v.communicator)
     {
+      if (v.has_ghost_elements())
+        Vector::create_vector(v.size(), v.local_size(), v.ghost_indices);
+      else
+        Vector::create_vector(v.size(), v.local_size());
+
       this->operator=(v);
     }
 


### PR DESCRIPTION
In reference to #8134.

Without this patch, gcc-9 complains:
```
/.../dealii_git/source/lac/petsc_parallel_sparse_matrix.cc: In member function ‘PetscScalar dealii::PETScWrappers::MPI::SparseMatrix::matrix_norm_square(const dealii::PETScWrappers::MPI::Vector&) const’:
/.../dealii_git/source/lac/petsc_parallel_sparse_matrix.cc:679:19: warning: implicitly-declared ‘dealii::PETScWrappers::MPI::Vector::Vector(const dealii::PETScWrappers::MPI::Vector&)’ is deprecated [-Wdeprecated-copy]
  679 |       Vector tmp(v);

/.../dealii_git/include/deal.II/lac/petsc_vector.h:277:7: note: because ‘dealii::PETScWrappers::MPI::Vector’ has user-provided ‘dealii::PETScWrappers::MPI::Vector& dealii::PETScWrappers::MPI::Vector::operator=(const dealii::PETScWrappers::MPI::Vector&)’
  277 |       operator=(const Vector &v);
      |       ^~~~~~~~
```

For your reference @drwells the place in our code. I think we should fix this.