### PR TITLE
Fix some gcc9 warnings in bundled boost and muparser

### DIFF
--- a/bundled/boost-1.62.0/include/boost/iostreams/detail/adapter/concept_adapter.hpp
+++ b/bundled/boost-1.62.0/include/boost/iostreams/detail/adapter/concept_adapter.hpp
@@ -118,6 +118,7 @@ public:
     std::streamsize optimal_buffer_size() const
     { return iostreams::optimal_buffer_size(t_); }
 public:
+    concept_adapter(const concept_adapter&) = default;
     concept_adapter& operator=(const concept_adapter&);
     value_type t_;
 };

--- a/bundled/boost-1.62.0/include/boost/iostreams/detail/functional.hpp
+++ b/bundled/boost-1.62.0/include/boost/iostreams/detail/functional.hpp
@@ -114,6 +114,7 @@ public:
         : t_(t), which_(which) 
         { }
     void operator()() const { t_.close(which_); }
+    member_close_operation(const member_close_operation&) = default;
 private:
     member_close_operation& operator=(const member_close_operation&);
     T&                   t_;
@@ -132,6 +133,7 @@ class reset_operation {
 public:
     reset_operation(T& t) : t_(t) { }
     void operator()() const { t_.reset(); }
+    reset_operation(const reset_operation&) = default;
 private:
     reset_operation& operator=(const reset_operation&);
     T& t_;
@@ -148,6 +150,7 @@ public:
     typedef void result_type;
     clear_flags_operation(T& t) : t_(t) { }
     void operator()() const { t_ = 0; }
+    clear_flags_operation(const clear_flags_operation&) = default;
 private:
     clear_flags_operation& operator=(const clear_flags_operation&);
     T& t_;
@@ -172,6 +175,7 @@ public:
         if (flush_) 
             buf_.flush(dev_);
     }
+    flush_buffer_operation(const flush_buffer_operation&) = default;
 private:
     flush_buffer_operation& operator=(const flush_buffer_operation&);
     Buffer&  buf_;

--- a/bundled/boost-1.62.0/include/boost/iostreams/device/mapped_file.hpp
+++ b/bundled/boost-1.62.0/include/boost/iostreams/device/mapped_file.hpp
@@ -142,6 +142,9 @@ struct basic_mapped_file_params
         : base_type(other), path(other.path)
         { }
 
+    basic_mapped_file_params &
+    operator= (const basic_mapped_file_params& other) { path = other.path; return *this; }
+
     typedef Path  path_type;
     Path          path;
 };

--- a/bundled/boost-1.62.0/include/boost/multi_index/detail/ord_index_node.hpp
+++ b/bundled/boost-1.62.0/include/boost/multi_index/detail/ord_index_node.hpp
@@ -152,6 +152,8 @@ struct ordered_index_node_compressed_base
   
   struct parent_ref
   {
+    parent_ref(const parent_ref& x) = default;
+
     parent_ref(uintptr_type* r_):r(r_){}
     
     operator pointer()const

--- a/bundled/boost-1.62.0/include/boost/tuple/detail/tuple_basic.hpp
+++ b/bundled/boost-1.62.0/include/boost/tuple/detail/tuple_basic.hpp
@@ -313,6 +313,8 @@ struct cons {
   template <class HT2, class TT2>
   cons( const cons<HT2, TT2>& u ) : head(u.head), tail(u.tail) {}
 
+  cons( const cons &u ) : head(u.head), tail(u.tail) {}
+
   template <class HT2, class TT2>
   cons& operator=( const cons<HT2, TT2>& u ) {
     head=u.head; tail=u.tail; return *this;
@@ -371,6 +373,8 @@ struct cons<HT, null_type> {
 
   //  cons() : head(detail::default_arg<HT>::f()) {}
   cons() : head() {}
+
+  cons( const cons & u ) : head(u.head) {}
 
   cons(typename access_traits<stored_head_type>::parameter_type h,
        const null_type& = null_type())

--- a/bundled/boost-1.62.0/libs/serialization/src/basic_xml_grammar.ipp
+++ b/bundled/boost-1.62.0/libs/serialization/src/basic_xml_grammar.ipp
@@ -80,6 +80,7 @@ struct assign_impl<std::string> {
             ++b;
         }
     }
+    assign_impl(const assign_impl & rhs) = default;
     assign_impl<std::string> & operator=(
         assign_impl<std::string> & rhs
     );

--- a/bundled/muparser_v2_2_4/include/muParserCallback.h
+++ b/bundled/muparser_v2_2_4/include/muParserCallback.h
@@ -81,7 +81,8 @@ public:
     ParserCallback(strfun_type3 a_pFun, bool a_bAllowOpti);
     ParserCallback();
     ParserCallback(const ParserCallback &a_Fun);
-    
+    ParserCallback & operator=(const ParserCallback &a_Fun) = default;   
+ 
     ParserCallback* Clone() const;
 
     bool  IsOptimizable() const;


### PR DESCRIPTION
Not sure if we trust these changes in the bundled libraries - I posted them here so we can have a look. The description of the changes is given in #8134. There are a few more in bundled tbb as well (I think I saw at least 2).