### PR TITLE
cppcheck: Fix include/deal.II/algorithms/general_data_storage.h

### DIFF
--- a/include/deal.II/algorithms/general_data_storage.h
+++ b/include/deal.II/algorithms/general_data_storage.h
@@ -414,10 +414,10 @@ GeneralDataStorage::get_object_with_name(const std::string &name)
     }
   else
     {
-      Assert(false,
-             ExcTypeMismatch(name,
-                             any_data[name].type().name(),
-                             typeid(Type).name()));
+      AssertThrow(false,
+                  ExcTypeMismatch(name,
+                                  any_data[name].type().name(),
+                                  typeid(Type).name()));
     }
 
   return *p;
@@ -444,10 +444,10 @@ GeneralDataStorage::get_object_with_name(const std::string &name) const
     }
   else
     {
-      Assert(false,
-             ExcTypeMismatch(name,
-                             it->second.type().name(),
-                             typeid(Type).name()));
+      AssertThrow(false,
+                  ExcTypeMismatch(name,
+                                  it->second.type().name(),
+                                  typeid(Type).name()));
       const Type *p = nullptr;
       return *p;
     }


### PR DESCRIPTION
- Avoid nullpointer dereference by using AssertThrow (to abort the
   program). Idiomatic this actually makes more sense: The string might
   be user supplied and the error should thus be handled at runtime

 - Minor code refactoring to make the code in both functions more
   similar.

In reference to #8080