### PR TITLE
Disable floating point exceptions in two HDF5 tests.

### DIFF
--- a/tests/base/hdf5_03.cc
+++ b/tests/base/hdf5_03.cc
@@ -754,6 +754,16 @@ read_test(HDF5::Group        root_group,
 int
 main(int argc, char **argv)
 {
+  // tests.h enables floating point exceptions in debug mode, but this test
+  // generates an (irrelevant) exception when run with more than one MPI
+  // process so disable them again:
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  {
+    const int current_fe_except = fegetexcept();
+    fedisableexcept(current_fe_except);
+  }
+#endif
+
   initlog();
 
   try

--- a/tests/base/hdf5_05.cc
+++ b/tests/base/hdf5_05.cc
@@ -1394,6 +1394,16 @@ read_test(HDF5::Group        root_group,
 int
 main(int argc, char **argv)
 {
+  // tests.h enables floating point exceptions in debug mode, but this test
+  // generates an (irrelevant) exception when run with more than one MPI
+  // process so disable them again:
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  {
+    const int current_fe_except = fegetexcept();
+    fedisableexcept(current_fe_except);
+  }
+#endif
+
   initlog();
 
   try


### PR DESCRIPTION
Fixes #7869 on my machine. I am not sure what is going on with the release builds: I cannot reproduce the problem with the optimized build.