### PR TITLE
Add missing header in symengine_tensor_operations.h

### DIFF
--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -24,6 +24,7 @@
 #  include <deal.II/base/tensor.h>
 
 #  include <deal.II/differentiation/sd/symengine_number_types.h>
+#  include <deal.II/differentiation/sd/symengine_scalar_operations.h>
 #  include <deal.II/differentiation/sd/symengine_types.h>
 
 #  include <utility>


### PR DESCRIPTION
Fixes https://cdash.kyomu.43-1.org/testDetails.php?test=64939384&build=9774.