### PR TITLE
Avoid ICC-19 warning

### DIFF
--- a/examples/step-61/step-61.cc
+++ b/examples/step-61/step-61.cc
@@ -119,6 +119,10 @@ namespace Step61
   class Coefficient : public TensorFunction<2, dim>
   {
   public:
+    Coefficient()
+      : TensorFunction<2, dim>()
+    {}
+
     virtual void value_list(const std::vector<Point<dim>> &points,
                             std::vector<Tensor<2, dim>> &values) const override;
   };
@@ -164,6 +168,10 @@ namespace Step61
   class RightHandSide : public Function<dim>
   {
   public:
+    RightHandSide()
+      : Function<dim>()
+    {}
+
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
   };
@@ -218,6 +226,10 @@ namespace Step61
   class ExactVelocity : public TensorFunction<1, dim>
   {
   public:
+    ExactVelocity()
+      : TensorFunction<1, dim>()
+    {}
+
     virtual Tensor<1, dim> value(const Point<dim> &p) const override;
   };
 


### PR DESCRIPTION
Intel C++ Compiler 2019 complained:
```
 ../examples/step-61/step-61.cc(399): warning #854: const variable "right_hand_side" requires an initializer -- class "Step61::RightHandSide<2>" has no user-provided default constructor
       const RightHandSide<dim> right_hand_side;
                                ^
           detected during:
             instantiation of "void Step61::WGDarcyEquation<dim>::assemble_system() [with dim=2]" at line 957
             instantiation of "void Step61::WGDarcyEquation<dim>::run() [with dim=2]" at line 976
 
 ../examples/step-61/step-61.cc(402): warning #854: const variable "coefficient" requires an initializer -- class "Step61::Coefficient<2>" has no user-provided default constructor
       const Coefficient<dim>      coefficient;
                                   ^
           detected during:
             instantiation of "void Step61::WGDarcyEquation<dim>::assemble_system() [with dim=2]" at line 957
             instantiation of "void Step61::WGDarcyEquation<dim>::run() [with dim=2]" at line 976
 
 ../examples/step-61/step-61.cc(705): warning #854: const variable "coefficient" requires an initializer -- class "Step61::Coefficient<2>" has no user-provided default constructor
       const Coefficient<dim>      coefficient;
                                   ^
           detected during:
             instantiation of "void Step61::WGDarcyEquation<dim>::compute_velocity_errors() [with dim=2]" at line 960
             instantiation of "void Step61::WGDarcyEquation<dim>::run() [with dim=2]" at line 976
 
 ../examples/step-61/step-61.cc(713): warning #854: const variable "exact_velocity" requires an initializer -- class "Step61::ExactVelocity<2>" has no user-provided default constructor
       const ExactVelocity<dim> exact_velocity;
                                ^
           detected during:
             instantiation of "void Step61::WGDarcyEquation<dim>::compute_velocity_errors() [with dim=2]" at line 960
             instantiation of "void Step61::WGDarcyEquation<dim>::run() [with dim=2]" at line 976
```