### PR TITLE
Band-aid for a failing AD test

### DIFF
--- a/tests/ad_common_tests/helper_scalar_coupled_4_components_01.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_4_components_01.h
@@ -417,7 +417,7 @@ test_symmetric_tensor_tensor_vector_scalar_coupled()
   SymmetricTensor<2, dim, ScalarNumberType> st =
     unit_symmetric_tensor<dim, ScalarNumberType>();
   for (unsigned int i = 0; i < st.n_independent_components; ++i)
-    st[st.unrolled_to_component_indices(i)] += 0.72 * (1.5 * i + 0.12);
+    st[st.unrolled_to_component_indices(i)] += 0.1 * i;
   Tensor<2, dim, ScalarNumberType> t =
     unit_symmetric_tensor<dim, ScalarNumberType>();
   for (unsigned int i = 0; i < t.n_independent_components; ++i)


### PR DESCRIPTION
https://github.com/dealii/dealii/issues/8080#issuecomment-492182558 refers

Sacado::Rad::Advar<Sacado::Fad::Dfad<double>> fails for the second derivatives (nan) with the current evaluation point. This fixes the test, but one still wonders what the underlying issue is :-/

Before this patch:
```
$ ctest -R sacado/helper_scalar_coupled_4_components_01 -j4
Test project <path>/dealii/build
    Start 1579: sacado/helper_scalar_coupled_4_components_01_4.debug
    Start 1576: sacado/helper_scalar_coupled_4_components_01_2.release
    Start 1580: sacado/helper_scalar_coupled_4_components_01_4.release
    Start 1573: sacado/helper_scalar_coupled_4_components_01_1.debug
1/8 Test #1580: sacado/helper_scalar_coupled_4_components_01_4.release ...   Passed   13.72 sec
    Start 1574: sacado/helper_scalar_coupled_4_components_01_1.release
2/8 Test #1579: sacado/helper_scalar_coupled_4_components_01_4.debug .....***Failed   13.93 sec
3/8 Test #1573: sacado/helper_scalar_coupled_4_components_01_1.debug .....   Passed   14.03 sec
    Start 1577: sacado/helper_scalar_coupled_4_components_01_3.debug
    Start 1578: sacado/helper_scalar_coupled_4_components_01_3.release
4/8 Test #1576: sacado/helper_scalar_coupled_4_components_01_2.release ...   Passed   14.95 sec
    Start 1575: sacado/helper_scalar_coupled_4_components_01_2.debug
5/8 Test #1577: sacado/helper_scalar_coupled_4_components_01_3.debug .....   Passed   16.29 sec
6/8 Test #1578: sacado/helper_scalar_coupled_4_components_01_3.release ...   Passed   16.59 sec
7/8 Test #1574: sacado/helper_scalar_coupled_4_components_01_1.release ...   Passed   16.98 sec
8/8 Test #1575: sacado/helper_scalar_coupled_4_components_01_2.debug .....   Passed   17.12 sec

88% tests passed, 1 tests failed out of 8

Total Test time (real) =  32.66 sec

The following tests FAILED:
	1579 - sacado/helper_scalar_coupled_4_components_01_4.debug (Failed)
Errors while running CTest
```

Afterwards:
```
$ ctest -R sacado/helper_scalar_coupled_4_components_01 -j4
Test project <path>/deal.II/dealii/build
    Start 1579: sacado/helper_scalar_coupled_4_components_01_4.debug
    Start 1576: sacado/helper_scalar_coupled_4_components_01_2.release
    Start 1580: sacado/helper_scalar_coupled_4_components_01_4.release
    Start 1574: sacado/helper_scalar_coupled_4_components_01_1.release
1/8 Test #1574: sacado/helper_scalar_coupled_4_components_01_1.release ...   Passed   13.52 sec
2/8 Test #1579: sacado/helper_scalar_coupled_4_components_01_4.debug .....   Passed   13.53 sec
3/8 Test #1580: sacado/helper_scalar_coupled_4_components_01_4.release ...   Passed   13.63 sec
    Start 1577: sacado/helper_scalar_coupled_4_components_01_3.debug
    Start 1573: sacado/helper_scalar_coupled_4_components_01_1.debug
    Start 1578: sacado/helper_scalar_coupled_4_components_01_3.release
4/8 Test #1576: sacado/helper_scalar_coupled_4_components_01_2.release ...   Passed   15.07 sec
    Start 1575: sacado/helper_scalar_coupled_4_components_01_2.debug
5/8 Test #1577: sacado/helper_scalar_coupled_4_components_01_3.debug .....   Passed   13.32 sec
6/8 Test #1573: sacado/helper_scalar_coupled_4_components_01_1.debug .....   Passed   13.34 sec
7/8 Test #1578: sacado/helper_scalar_coupled_4_components_01_3.release ...   Passed   13.34 sec
8/8 Test #1575: sacado/helper_scalar_coupled_4_components_01_2.debug .....   Passed   14.26 sec

100% tests passed, 0 tests failed out of 8
```