### PR TITLE
examples: ignore temporary cc files in cmake

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -53,8 +53,8 @@ IF(DEAL_II_COMPONENT_EXAMPLES)
     # Set up all executables:
     #
     FILE(GLOB _steps 
-      ${CMAKE_CURRENT_SOURCE_DIR}/step-*/*.cc
-      ${CMAKE_CURRENT_SOURCE_DIR}/step-*/*.cu)
+      ${CMAKE_CURRENT_SOURCE_DIR}/step-*/step-*.cc
+      ${CMAKE_CURRENT_SOURCE_DIR}/step-*/step-*.cu)
     FOREACH(_step ${_steps})
       GET_FILENAME_COMPONENT(_name ${_step} NAME_WE)
       GET_FILENAME_COMPONENT(_directory ${_step} DIRECTORY)


### PR DESCRIPTION
I had an editor leave a temporary cc file in the example directory. This
caused cmake/make to fail in hilarious ways. To try it yourself:
``touch examples/step-63/a#.cc``

By reducing the glob to files that are of the form "step-*.cc", we
should be able to avoid this problem. In my case the file was
".#step-63.cc".