### PR TITLE
clang-format: do not break @name lines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -147,7 +147,7 @@ PenaltyBreakBeforeFirstCallParameter: 90
 PointerAlignment: Right
 
 ReflowComments: true
-CommentPragmas: '( \| |\*--|<li>|@ref | @p | @param  |@returns |@warning |@ingroup |@author |@date |@related |@relates |@relatesalso |@deprecated |@image |@return |@brief |@attention |@copydoc |@addtogroup |@todo |@tparam |@see |@note |@skip |@skipline |@until |@line |@dontinclude |@include)'
+CommentPragmas: '( \| |\*--|<li>|@ref | @p |@param |@name |@returns |@warning |@ingroup |@author |@date |@related |@relates |@relatesalso |@deprecated |@image |@return |@brief |@attention |@copydoc |@addtogroup |@todo |@tparam |@see |@note |@skip |@skipline |@until |@line |@dontinclude |@include)'
 
 SortIncludes: true
 SortUsingDeclarations: true

--- a/include/deal.II/meshworker/scratch_data.h
+++ b/include/deal.II/meshworker/scratch_data.h
@@ -501,12 +501,10 @@ namespace MeshWorker
     GeneralDataStorage &
     get_general_data_storage();
 
-    // clang-format off
     /**
      * @name Evaluation of finite element fields and their derivatives on the current cell
      */
     /** @{ */ // CurrentCellEvaluation
-    // clang-format on
 
     /**
      * Extract the local dof values associated with the internally initialized


### PR DESCRIPTION
remove hack in scratch_data and add @name to the list of items not to
break automatically.

note: I hate having to fight clang-format.

related to #8195