### PR TITLE
[9.1] Cleanup documentation: find_common_subspace()

### DIFF
--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -127,11 +127,12 @@ namespace hp
    *   the parent.
    * - When coarsening cells, the (now active) parent cell will be assigned
    *   an active FE index that is determined from its (no longer active)
-   *   children, following the FiniteElementDomination logic: We choose the
-   *   least dominant element of their common subspace. See
-   *   hp::FECollection::find_common_subspace() and
-   *   hp::FECollection::find_dominted_fe() for further information on this
-   *   topic.
+   *   children, following the FiniteElementDomination logic: Out of the set of
+   *   elements previously assigned to the former children, we choose the
+   *   dominating one for the parent cell. If none was found, we pick the least
+   *   dominant element in the whole collection that dominates all former
+   *   children. See hp::FECollection::find_dominating_fe_extended() for further
+   *   information on this topic.
    *
    * @note Finite elements need to be assigned to each cell by calling
    * distribute_dofs() first to make this functionality available.

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -1266,14 +1266,13 @@ namespace ColorEnriched
        * until #1496 (https://github.com/dealii/dealii/issues/1496) is resolved.
        * Each time we build constraints at the interface between two different
        * FE_Enriched, we look for the least dominating FE of their common
-       * subspace via hp::FECollection::find_common_subspace() and
-       * hp::FECollection::find_dominated_fe(). If we don't take further
-       * actions, we may find a dominating FE that is too restrictive, i.e.
-       * enriched FE consisting of only FE_Nothing. New elements needs to be
-       * added to FECollection object to help find the correct enriched FE
-       * underlying the spaces in the adjacent cells. This is done by creating
-       * an appropriate set in fe_sets and a call to the function
-       * make_fe_collection_from_colored_enrichments at a later stage.
+       * subspace via hp::FECollection::find_dominating_fe_extended().
+       * If we don't take further actions, we may find a dominating FE that is
+       * too restrictive, i.e. enriched FE consisting of only FE_Nothing. New
+       * elements needs to be added to FECollection object to help find the
+       * correct enriched FE underlying the spaces in the adjacent cells. This
+       * is done by creating an appropriate set in fe_sets and a call to the
+       * function make_fe_collection_from_colored_enrichments at a later stage.
        *
        * Consider a domain with three predicates and hence with three different
        * enrichment functions. Let the enriched finite element of a cell with

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -1080,14 +1080,14 @@ namespace internal
          * be distributed on on the updated triangulation later.
          *
          * On cells to be refined, the active_fe_index will be inherited to
-         * their childrean and thus will be stored as such.
+         * their children and thus will be stored as such.
          *
-         * On cells to be coarsened, the active_fe_index on parent cells will be
-         * determined by the least dominating finite element of its children's
-         * common subspace. We  will thus assign the corresponding fe_index to
-         * the parent cell. See documentation of
-         * hp::FECollection::find_common_subspace() and
-         * hp::FECollection::find_dominated_fe() for further information.
+         * On cells to be coarsened, we choose the finite element on the parent
+         * cell from those assigned to their children to be the one dominating
+         * all children. If none was found, we pick the least dominant element
+         * in the whole collection that dominates all children. See
+         * documentation of hp::FECollection::find_dominating_fe_extended() for
+         * further information.
          *
          * On cells intended for p-refinement or p-coarsening, those
          * active_fe_indices will be determined by the corresponding flags that


### PR DESCRIPTION
Minor changes on documentation.

Closes #8255.