### PR TITLE
Fix compressing TrilinosWrappers::SparsityPattern with empty column map

### DIFF
--- a/doc/news/changes/minor/20190522ArndtAnselmann
+++ b/doc/news/changes/minor/20190522ArndtAnselmann
@@ -1,0 +1,3 @@
+Fixed: TrilinosWrappers::SparsityPattern can deal with empty column maps.
+<br>
+(Daniel Arndt, Mathias Anselmann, 2019/05/22)

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -792,7 +792,7 @@ namespace TrilinosWrappers
       {
         if (nonlocal_graph->IndicesAreGlobal() == false &&
             nonlocal_graph->RowMap().NumMyElements() > 0 &&
-            column_space_map->NumMyElements() > 0)
+            column_space_map->NumGlobalElements() > 0)
           {
             // Insert dummy element at (row, column) that corresponds to row 0
             // in local index counting.
@@ -814,7 +814,7 @@ namespace TrilinosWrappers
             AssertThrow(ierr == 0, ExcTrilinosError(ierr));
           }
         Assert(nonlocal_graph->RowMap().NumMyElements() == 0 ||
-                 column_space_map->NumMyElements() == 0 ||
+                 column_space_map->NumGlobalElements() == 0 ||
                  nonlocal_graph->IndicesAreGlobal() == true,
                ExcInternalError());
 

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -791,7 +791,8 @@ namespace TrilinosWrappers
     if (nonlocal_graph.get() != nullptr)
       {
         if (nonlocal_graph->IndicesAreGlobal() == false &&
-            nonlocal_graph->RowMap().NumMyElements() > 0)
+            nonlocal_graph->RowMap().NumMyElements() > 0 &&
+            column_space_map->NumMyElements() > 0)
           {
             // Insert dummy element at (row, column) that corresponds to row 0
             // in local index counting.
@@ -813,6 +814,7 @@ namespace TrilinosWrappers
             AssertThrow(ierr == 0, ExcTrilinosError(ierr));
           }
         Assert(nonlocal_graph->RowMap().NumMyElements() == 0 ||
+                 column_space_map->NumMyElements() == 0 ||
                  nonlocal_graph->IndicesAreGlobal() == true,
                ExcInternalError());
 

--- a/tests/trilinos/sparsity_pattern_07.cc
+++ b/tests/trilinos/sparsity_pattern_07.cc
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check TrilinosWrappers::SparsityPattern::row_length
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/lac/block_sparsity_pattern.h>
+
+#include "../tests.h"
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll mpi_log;
+
+  const unsigned int n = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  IndexSet           owned_set(n);
+  owned_set.add_index(Utilities::MPI::this_mpi_process(MPI_COMM_WORLD));
+  IndexSet relevant_set(n);
+  relevant_set.add_range(0, n);
+  IndexSet                          empty_set;
+  TrilinosWrappers::SparsityPattern sparsity(owned_set,
+                                             empty_set,
+                                             relevant_set,
+                                             MPI_COMM_WORLD);
+
+  deallog << "\nBefore compressing sparsity pattern..." << std::endl;
+  sparsity.compress();
+  deallog << "Compressing sparsity pattern worked!\n\n" << std::endl;
+
+  return 0;
+}

--- a/tests/trilinos/sparsity_pattern_07.mpirun=1.output
+++ b/tests/trilinos/sparsity_pattern_07.mpirun=1.output
@@ -1,0 +1,6 @@
+
+DEAL:0::
+Before compressing sparsity pattern...
+DEAL:0::Compressing sparsity pattern worked!
+
+

--- a/tests/trilinos/sparsity_pattern_07.mpirun=2.output
+++ b/tests/trilinos/sparsity_pattern_07.mpirun=2.output
@@ -1,0 +1,13 @@
+
+DEAL:0::
+Before compressing sparsity pattern...
+DEAL:0::Compressing sparsity pattern worked!
+
+
+
+DEAL:1::
+Before compressing sparsity pattern...
+DEAL:1::Compressing sparsity pattern worked!
+
+
+


### PR DESCRIPTION
Fixes the problem in https://groups.google.com/forum/#!topic/dealii/Pb4xy7qcNW0

```
nonlocal_graph->FillComplete(*column_space_map, graph->RangeMap());
```
causes problems if we try to insert an entry that it is not contained in the row and column maps.
If the column map is empty, we consequently can't insert any dummy element at all.