### PR TITLE
Dont install logfiles

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -52,12 +52,11 @@ INSTALL(FILES
   )
 
 #
-# Install summary.log an detailed.log
+# Install summary.log
 #
 
 INSTALL(FILES
   ${CMAKE_BINARY_DIR}/summary.log
-  ${CMAKE_BINARY_DIR}/detailed.log
   DESTINATION ${DEAL_II_DOCREADME_RELDIR}
   COMPONENT library
   )

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -52,16 +52,6 @@ INSTALL(FILES
   )
 
 #
-# Install summary.log
-#
-
-INSTALL(FILES
-  ${CMAKE_BINARY_DIR}/summary.log
-  DESTINATION ${DEAL_II_DOCREADME_RELDIR}
-  COMPONENT library
-  )
-
-#
 # Add a dummy target to make documentation files known to IDEs.
 #
 


### PR DESCRIPTION
Reverts #7201 for 9.1. Looks like, if others approve, we will need to put out 9.1.2. *we will also need to add this as a release step*.

These files should not be installed in an official release since details of the packaging environment should not be distributed with the package.