### PR TITLE
Replace MPI_Allgather by MPI_Exscan

### DIFF
--- a/doc/news/changes/incompatibilities/20190603MartinKronbichler
+++ b/doc/news/changes/incompatibilities/20190603MartinKronbichler
@@ -1,0 +1,12 @@
+Changed: The functions DoFHandler::n_locally_owned_dofs_per_processor(),
+DoFHandler::locally_owned_dofs_per_processor() and
+DoFHandler::locally_owned_mg_dofs_per_processor() previously return a
+reference to an internally stored array of index sets on all processors. As
+this cannot scale to large processor counts, these functions have been marked
+deprecated and only populate the internal vectors on the first demand. Use the
+new functions DoFHandler::compute_n_locally_owned_dofs_per_processor(),
+DoFHandler::compute_locally_owned_dofs_per_processor() and
+DoFHandler::compute_locally_owned_mg_dofs_per_processor() instead or, even
+better for scalability, avoid them in favor of some local communication.
+<br>
+(Martin Kronbichler, 2019/06/03)

--- a/doc/news/changes/minor/20190603MartinKronbichlerPeterMunch
+++ b/doc/news/changes/minor/20190603MartinKronbichlerPeterMunch
@@ -1,0 +1,6 @@
+Improved: A number of places in deal.II previously called `MPI_Allgather`
+followed by some local sums to compute prefix sums. Now the more appropriate
+`MPI_Exscan` is used instead, which improves scalability of setup routines on
+more than 10k processors.
+<br>
+(Martin Kronbichler, Peter Munch, 2019/06/03)

--- a/examples/step-18/doc/intro.dox
+++ b/examples/step-18/doc/intro.dox
@@ -405,7 +405,7 @@ using the syntax
 This knowledge extends to the DoFHandler object built on such triangulations,
 which can then identify which degrees of freedom are locally owned
 (see @ref GlossLocallyOwnedDofs) via calls such as 
-DoFHandler::n_locally_owned_dofs_per_processor() and
+DoFHandler::compute_n_locally_owned_dofs_per_processor() and
 DoFTools::extract_locally_relevant_dofs(). Finally, the DataOut class
 also knows how to deal with such triangulations and will simply skip
 generating graphical output on cells not locally owned.

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -829,7 +829,8 @@ namespace Step18
     n_local_cells = GridTools::count_cells_with_subdomain_association(
       triangulation, triangulation.locally_owned_subdomain());
 
-    local_dofs_per_process = dof_handler.n_locally_owned_dofs_per_processor();
+    local_dofs_per_process =
+      dof_handler.compute_n_locally_owned_dofs_per_processor();
 
     // The next step is to set up constraints due to hanging nodes. This has
     // been handled many times before:

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -316,7 +316,7 @@ namespace Step40
     DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
     SparsityTools::distribute_sparsity_pattern(
       dsp,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       mpi_communicator,
       locally_relevant_dofs);
 

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -430,7 +430,7 @@ namespace Step55
 
       SparsityTools::distribute_sparsity_pattern(
         dsp,
-        dof_handler.locally_owned_dofs_per_processor(),
+        dof_handler.compute_locally_owned_dofs_per_processor(),
         mpi_communicator,
         locally_relevant_dofs);
 
@@ -457,7 +457,7 @@ namespace Step55
         dof_handler, coupling, dsp, constraints, false);
       SparsityTools::distribute_sparsity_pattern(
         dsp,
-        dof_handler.locally_owned_dofs_per_processor(),
+        dof_handler.compute_locally_owned_dofs_per_processor(),
         mpi_communicator,
         locally_relevant_dofs);
       preconditioner_matrix.reinit(owned_partitioning,

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -766,7 +766,7 @@ namespace step62
     DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
     SparsityTools::distribute_sparsity_pattern(
       dsp,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       mpi_communicator,
       locally_relevant_dofs);
 

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1046,7 +1046,7 @@ public:
    * MPI processes but the Triangulation on which this DoFHandler builds works
    * only on one MPI process.)
    */
-  const std::vector<IndexSet> &
+  std::vector<IndexSet>
   locally_owned_dofs_per_processor() const;
 
   /**
@@ -1065,7 +1065,7 @@ public:
    * or that there are multiple MPI processes but the Triangulation on which
    * this DoFHandler builds works only on one MPI process.)
    */
-  const std::vector<types::global_dof_index> &
+  std::vector<types::global_dof_index>
   n_locally_owned_dofs_per_processor() const;
 
   /**
@@ -1079,7 +1079,7 @@ public:
    * MPI processes but the Triangulation on which this DoFHandler builds works
    * only on one MPI process.)
    */
-  const std::vector<IndexSet> &
+  std::vector<IndexSet>
   locally_owned_mg_dofs_per_processor(const unsigned int level) const;
 
   /**
@@ -1461,25 +1461,39 @@ DoFHandler<dim, spacedim>::locally_owned_mg_dofs(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-const std::vector<types::global_dof_index> &
+std::vector<types::global_dof_index>
 DoFHandler<dim, spacedim>::n_locally_owned_dofs_per_processor() const
 {
-  return number_cache.n_locally_owned_dofs_per_processor;
+  const parallel::Triangulation<dim, spacedim> *tr =
+    (dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+      &this->get_triangulation()));
+  if (tr != nullptr)
+    return number_cache.get_n_locally_owned_dofs_per_processor(
+      tr->get_communicator());
+  else
+    return number_cache.get_n_locally_owned_dofs_per_processor(MPI_COMM_SELF);
 }
 
 
 
 template <int dim, int spacedim>
-const std::vector<IndexSet> &
+std::vector<IndexSet>
 DoFHandler<dim, spacedim>::locally_owned_dofs_per_processor() const
 {
-  return number_cache.locally_owned_dofs_per_processor;
+  const parallel::Triangulation<dim, spacedim> *tr =
+    (dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+      &this->get_triangulation()));
+  if (tr != nullptr)
+    return number_cache.get_locally_owned_dofs_per_processor(
+      tr->get_communicator());
+  else
+    return number_cache.get_locally_owned_dofs_per_processor(MPI_COMM_SELF);
 }
 
 
 
 template <int dim, int spacedim>
-const std::vector<IndexSet> &
+std::vector<IndexSet>
 DoFHandler<dim, spacedim>::locally_owned_mg_dofs_per_processor(
   const unsigned int level) const
 {
@@ -1489,7 +1503,15 @@ DoFHandler<dim, spacedim>::locally_owned_mg_dofs_per_processor(
     mg_number_cache.size() == this->get_triangulation().n_global_levels(),
     ExcMessage(
       "The level dofs are not set up properly! Did you call distribute_mg_dofs()?"));
-  return mg_number_cache[level].locally_owned_dofs_per_processor;
+  const parallel::Triangulation<dim, spacedim> *tr =
+    (dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+      &this->get_triangulation()));
+  if (tr != nullptr)
+    return mg_number_cache[level].get_locally_owned_dofs_per_processor(
+      tr->get_communicator());
+  else
+    return mg_number_cache[level].get_locally_owned_dofs_per_processor(
+      MPI_COMM_SELF);
 }
 
 

--- a/include/deal.II/dofs/number_cache.h
+++ b/include/deal.II/dofs/number_cache.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/index_set.h>
+#include <deal.II/base/mpi.h>
 
 #include <vector>
 
@@ -106,6 +107,28 @@ namespace internal
        */
       void
       clear();
+
+      /**
+       * Return a representation of @p n_locally_owned_dofs_per_processor both
+       * in case it was set up (directly returning the array) or in case we
+       * need to accumulate some information over all processors. The latter
+       * case involves global communication and is typically expensive to set
+       * up because it invokes MPI_Allgather.
+       */
+      std::vector<types::global_dof_index>
+      get_n_locally_owned_dofs_per_processor(
+        const MPI_Comm mpi_communicator) const;
+
+      /**
+       * Return a representation of @p locally_owned_dofs_per_processor both
+       * in case it was set up (directly returning the array of IndexSet
+       * fields) or in case we need to accumulate some information over all
+       * processors. The latter case involves global communication and is
+       * typically expensive to set up because it invokes MPI_Allgather.
+       */
+      std::vector<IndexSet>
+      get_locally_owned_dofs_per_processor(
+        const MPI_Comm mpi_communicator) const;
 
       /**
        * Total number of dofs, accumulated over all processors that may

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -826,30 +826,38 @@ namespace hp
     locally_owned_dofs() const;
 
     /**
-     * Return a vector that stores the locally owned DoFs of each processor.
-     * If you are only interested in the number of elements each processor
-     * owns then n_dofs_per_processor() is a better choice.
+     * Compute a vector with the locally owned DoFs of each processor.
+     *
+     * This function involves global communication via the @p MPI_Allgather
+     * function, so it must be called on all processors participating in the MPI
+     * communicator underlying the triangulation.
+     *
+     * If you are only interested in the number of elements each processor owns
+     * then compute_n_locally_owned_dofs_per_processor() is a better choice.
      *
      * If this is a sequential DoFHandler, then the vector has a single element
      * that equals the IndexSet representing the entire range [0,n_dofs()].
-     * (Here, "sequential" means that either
-     * the whole program does not use MPI, or that it uses MPI
-     * but only uses a single MPI process, or that there are multiple MPI
-     * processes but the Triangulation on which this DoFHandler builds
-     * works only on one MPI process.)
+     * (Here, "sequential" means that either the whole program does not use MPI,
+     * or that it uses MPI but only uses a single MPI process, or that there are
+     * multiple MPI processes but the Triangulation on which this DoFHandler
+     * builds works only on one MPI process.)
      */
     std::vector<IndexSet>
-    locally_owned_dofs_per_processor() const;
+    compute_locally_owned_dofs_per_processor() const;
 
     /**
-     * Return a vector that stores the number of degrees of freedom each
+     * Compute a vector with the number of degrees of freedom each
      * processor that participates in this triangulation owns locally. The sum
      * of all these numbers equals the number of degrees of freedom that exist
      * globally, i.e. what n_dofs() returns.
      *
-     * Each element of the vector returned by this function equals the number
-     * of elements of the corresponding sets returned by
-     * locally_owned_dofs_per_processor().
+     * This function involves global communication via the @p MPI_Allgather
+     * function, so it must be called on all processors participating in the MPI
+     * communicator underlying the triangulation.
+     *
+     * Each element of the vector returned by this function equals the number of
+     * elements of the corresponding sets returned by
+     * compute_locally_owned_dofs_per_processor().
      *
      * If this is a sequential DoFHandler, then the vector has a single element
      * equal to n_dofs(). (Here, "sequential" means that either the whole
@@ -858,7 +866,40 @@ namespace hp
      * on which this DoFHandler builds works only on one MPI process.)
      */
     std::vector<types::global_dof_index>
-    n_locally_owned_dofs_per_processor() const;
+    compute_n_locally_owned_dofs_per_processor() const;
+
+    /**
+     * Return a vector that stores the locally owned DoFs of each processor.
+     *
+     * @deprecated As of deal.II version 9.2, we do not populate a vector with
+     * the index sets of all processors by default any more due to a possibly
+     * large memory footprint on many processors. As a consequence, this
+     * function needs to call compute_locally_owned_dofs_per_processor() upon
+     * the first invocation, including global communication. Use
+     * compute_locally_owned_dofs_per_processor() instead if using up to a few
+     * thousands of MPI ranks or some variant involving local communication with
+     * more processors.
+     */
+    DEAL_II_DEPRECATED const std::vector<IndexSet> &
+                             locally_owned_dofs_per_processor() const;
+
+    /**
+     * Return a vector that stores the number of degrees of freedom each
+     * processor that participates in this triangulation owns locally. The sum
+     * of all these numbers equals the number of degrees of freedom that exist
+     * globally, i.e. what n_dofs() returns.
+     *
+     * @deprecated As of deal.II version 9.2, we do not populate a vector with
+     * the numbers of dofs of all processors by default any more due to a
+     * possibly large memory footprint on many processors. As a consequence,
+     * this function needs to call compute_n_locally_owned_dofs_per_processor()
+     * upon the first invocation, including global communication. Use
+     * compute_n_locally_owned_dofs_per_processor() instead if using up to a few
+     * thousands of MPI ranks or some variant involving local communication with
+     * more processors.
+     */
+    DEAL_II_DEPRECATED const std::vector<types::global_dof_index> &
+                             n_locally_owned_dofs_per_processor() const;
 
     /**
      * Return an IndexSet describing the set of locally owned DoFs used for
@@ -870,13 +911,38 @@ namespace hp
     locally_owned_mg_dofs(const unsigned int level) const;
 
     /**
-     * Return a vector that stores the locally owned level DoFs of each
-     * processor on the given level @p level. Since hp::DoFHandler does not
-     * support multilevel methods yet, this function throws an exception
-     * ExcNotImplemented() independent of its argument.
+     * Compute a vector with the locally owned DoFs of each processor on
+     * the given level @p level for geometric multigrid.
+     *
+     * This function involves global communication via the @p MPI_Allgather
+     * function, so it must be called on all processors participating in the MPI
+     * communicator underlying the triangulation.
+     *
+     * If this is a sequential DoFHandler, then the vector has a single element
+     * that equals the IndexSet representing the entire range [0,n_dofs()].
+     * (Here, "sequential" means that either the whole program does not use MPI,
+     * or that it uses MPI but only uses a single MPI process, or that there are
+     * multiple MPI processes but the Triangulation on which this DoFHandler
+     * builds works only on one MPI process.)
      */
     std::vector<IndexSet>
-    locally_owned_mg_dofs_per_processor(const unsigned int level) const;
+    compute_locally_owned_mg_dofs_per_processor(const unsigned int level) const;
+
+    /**
+     * Return a vector that stores the locally owned DoFs of each processor on
+     * the given level @p level.
+     *
+     * @deprecated As of deal.II version 9.2, we do not populate a vector with
+     * the index sets of all processors by default any more due to a possibly
+     * large memory footprint on many processors. As a consequence, this
+     * function needs to call compute_locally_owned_dofs_mg_per_processor() upon
+     * the first invocation, including global communication. Use
+     * compute_locally_owned_mg_dofs_per_processor() instead if using up to a
+     * few thousands of MPI ranks or some variant involving local communication
+     * with more processors.
+     */
+    DEAL_II_DEPRECATED const std::vector<IndexSet> &
+                             locally_owned_mg_dofs_per_processor(const unsigned int level) const;
 
     /**
      * Return a constant reference to the set of finite element objects that
@@ -1487,8 +1553,42 @@ namespace hp
 
 
   template <int dim, int spacedim>
-  std::vector<types::global_dof_index>
+  const std::vector<types::global_dof_index> &
   DoFHandler<dim, spacedim>::n_locally_owned_dofs_per_processor() const
+  {
+    if (number_cache.n_locally_owned_dofs_per_processor.empty() &&
+        number_cache.n_global_dofs > 0)
+      {
+        const_cast<dealii::internal::DoFHandlerImplementation::NumberCache &>(
+          number_cache)
+          .n_locally_owned_dofs_per_processor =
+          compute_n_locally_owned_dofs_per_processor();
+      }
+    return number_cache.n_locally_owned_dofs_per_processor;
+  }
+
+
+
+  template <int dim, int spacedim>
+  const std::vector<IndexSet> &
+  DoFHandler<dim, spacedim>::locally_owned_dofs_per_processor() const
+  {
+    if (number_cache.locally_owned_dofs_per_processor.empty() &&
+        number_cache.n_global_dofs > 0)
+      {
+        const_cast<dealii::internal::DoFHandlerImplementation::NumberCache &>(
+          number_cache)
+          .locally_owned_dofs_per_processor =
+          compute_locally_owned_dofs_per_processor();
+      }
+    return number_cache.locally_owned_dofs_per_processor;
+  }
+
+
+
+  template <int dim, int spacedim>
+  std::vector<types::global_dof_index>
+  DoFHandler<dim, spacedim>::compute_n_locally_owned_dofs_per_processor() const
   {
     const parallel::Triangulation<dim, spacedim> *tr =
       (dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
@@ -1504,7 +1604,7 @@ namespace hp
 
   template <int dim, int spacedim>
   std::vector<IndexSet>
-  DoFHandler<dim, spacedim>::locally_owned_dofs_per_processor() const
+  DoFHandler<dim, spacedim>::compute_locally_owned_dofs_per_processor() const
   {
     const parallel::Triangulation<dim, spacedim> *tr =
       (dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
@@ -1526,20 +1626,48 @@ namespace hp
     Assert(false, ExcNotImplemented());
     (void)level;
     Assert(level < this->get_triangulation().n_global_levels(),
-           ExcMessage("invalid level in locally_owned_mg_dofs"));
+           ExcMessage("The given level index exceeds the number of levels "
+                      "present in the triangulation"));
     return mg_number_cache[0].locally_owned_dofs;
   }
 
 
+
+  template <int dim, int spacedim>
+  const std::vector<IndexSet> &
+  DoFHandler<dim, spacedim>::locally_owned_mg_dofs_per_processor(
+    const unsigned int level) const
+  {
+    Assert(level < this->get_triangulation().n_global_levels(),
+           ExcMessage("The given level index exceeds the number of levels "
+                      "present in the triangulation"));
+    Assert(
+      mg_number_cache.size() == this->get_triangulation().n_global_levels(),
+      ExcMessage(
+        "The level dofs are not set up properly! Did you call distribute_mg_dofs()?"));
+    if (mg_number_cache[level].locally_owned_dofs_per_processor.empty() &&
+        mg_number_cache[level].n_global_dofs > 0)
+      {
+        const_cast<dealii::internal::DoFHandlerImplementation::NumberCache &>(
+          mg_number_cache[level])
+          .locally_owned_dofs_per_processor =
+          compute_locally_owned_mg_dofs_per_processor(level);
+      }
+    return mg_number_cache[level].locally_owned_dofs_per_processor;
+  }
+
+
+
   template <int dim, int spacedim>
   std::vector<IndexSet>
-  DoFHandler<dim, spacedim>::locally_owned_mg_dofs_per_processor(
+  DoFHandler<dim, spacedim>::compute_locally_owned_mg_dofs_per_processor(
     const unsigned int level) const
   {
     Assert(false, ExcNotImplemented());
     (void)level;
     Assert(level < this->get_triangulation().n_global_levels(),
-           ExcMessage("invalid level in locally_owned_mg_dofs_per_processor"));
+           ExcMessage("The given level index exceeds the number of levels "
+                      "present in the triangulation"));
     const parallel::Triangulation<dim, spacedim> *tr =
       (dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
         &this->get_triangulation()));

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -877,39 +877,26 @@ namespace DoFRenumbering
         for (unsigned int c = 0; c < n_buckets; ++c)
           local_dof_count[c] = component_to_dof_map[c].size();
 
-
-        // gather information from all CPUs
-        std::vector<types::global_dof_index> all_dof_counts(
-          fe_collection.n_components() *
-          Utilities::MPI::n_mpi_processes(tria->get_communicator()));
-
-        const int ierr = MPI_Allgather(local_dof_count.data(),
-                                       n_buckets,
-                                       DEAL_II_DOF_INDEX_MPI_TYPE,
-                                       all_dof_counts.data(),
-                                       n_buckets,
-                                       DEAL_II_DOF_INDEX_MPI_TYPE,
-                                       tria->get_communicator());
+        std::vector<types::global_dof_index> prefix_dof_count(n_buckets);
+        const int ierr = MPI_Exscan(local_dof_count.data(),
+                                    prefix_dof_count.data(),
+                                    n_buckets,
+                                    DEAL_II_DOF_INDEX_MPI_TYPE,
+                                    MPI_SUM,
+                                    tria->get_communicator());
         AssertThrowMPI(ierr);
 
-        for (unsigned int i = 0; i < n_buckets; ++i)
-          Assert(
-            all_dof_counts[n_buckets * tria->locally_owned_subdomain() + i] ==
-              local_dof_count[i],
-            ExcInternalError());
+        std::vector<types::global_dof_index> global_dof_count(n_buckets);
+        Utilities::MPI::sum(local_dof_count,
+                            tria->get_communicator(),
+                            global_dof_count);
 
         // calculate shifts
-        unsigned int cumulated = 0;
+        types::global_dof_index cumulated = 0;
         for (unsigned int c = 0; c < n_buckets; ++c)
           {
-            shifts[c] = cumulated;
-            for (types::subdomain_id i = 0; i < tria->locally_owned_subdomain();
-                 ++i)
-              shifts[c] += all_dof_counts[c + n_buckets * i];
-            for (unsigned int i = 0;
-                 i < Utilities::MPI::n_mpi_processes(tria->get_communicator());
-                 ++i)
-              cumulated += all_dof_counts[c + n_buckets * i];
+            shifts[c] = prefix_dof_count[c] + cumulated;
+            cumulated += global_dof_count[c];
           }
 #else
         (void)tria;
@@ -1193,39 +1180,26 @@ namespace DoFRenumbering
         for (unsigned int c = 0; c < n_buckets; ++c)
           local_dof_count[c] = block_to_dof_map[c].size();
 
-
-        // gather information from all CPUs
-        std::vector<types::global_dof_index> all_dof_counts(
-          fe_collection.n_components() *
-          Utilities::MPI::n_mpi_processes(tria->get_communicator()));
-
-        const int ierr = MPI_Allgather(local_dof_count.data(),
-                                       n_buckets,
-                                       DEAL_II_DOF_INDEX_MPI_TYPE,
-                                       all_dof_counts.data(),
-                                       n_buckets,
-                                       DEAL_II_DOF_INDEX_MPI_TYPE,
-                                       tria->get_communicator());
+        std::vector<types::global_dof_index> prefix_dof_count(n_buckets);
+        const int ierr = MPI_Exscan(local_dof_count.data(),
+                                    prefix_dof_count.data(),
+                                    n_buckets,
+                                    DEAL_II_DOF_INDEX_MPI_TYPE,
+                                    MPI_SUM,
+                                    tria->get_communicator());
         AssertThrowMPI(ierr);
 
-        for (unsigned int i = 0; i < n_buckets; ++i)
-          Assert(
-            all_dof_counts[n_buckets * tria->locally_owned_subdomain() + i] ==
-              local_dof_count[i],
-            ExcInternalError());
+        std::vector<types::global_dof_index> global_dof_count(n_buckets);
+        Utilities::MPI::sum(local_dof_count,
+                            tria->get_communicator(),
+                            global_dof_count);
 
         // calculate shifts
         types::global_dof_index cumulated = 0;
         for (unsigned int c = 0; c < n_buckets; ++c)
           {
-            shifts[c] = cumulated;
-            for (types::subdomain_id i = 0; i < tria->locally_owned_subdomain();
-                 ++i)
-              shifts[c] += all_dof_counts[c + n_buckets * i];
-            for (unsigned int i = 0;
-                 i < Utilities::MPI::n_mpi_processes(tria->get_communicator());
-                 ++i)
-              cumulated += all_dof_counts[c + n_buckets * i];
+            shifts[c] = prefix_dof_count[c] + cumulated;
+            cumulated += global_dof_count[c];
           }
 #else
         (void)tria;

--- a/source/dofs/number_cache.cc
+++ b/source/dofs/number_cache.cc
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/mpi.h>
 
 #include <deal.II/dofs/number_cache.h>
 
@@ -79,6 +80,154 @@ namespace internal
       n_locally_owned_dofs_per_processor.clear();
       locally_owned_dofs_per_processor.clear();
     }
+
+
+
+    std::vector<types::global_dof_index>
+    NumberCache::get_n_locally_owned_dofs_per_processor(
+      const MPI_Comm mpi_communicator) const
+    {
+      const unsigned int n_procs =
+        Utilities::MPI::job_supports_mpi() ?
+          Utilities::MPI::n_mpi_processes(mpi_communicator) :
+          1;
+      if (n_global_dofs == 0)
+        return std::vector<types::global_dof_index>();
+      else if (n_locally_owned_dofs_per_processor.empty() == false)
+        {
+          AssertDimension(n_locally_owned_dofs_per_processor.size(), n_procs);
+          return n_locally_owned_dofs_per_processor;
+        }
+      else
+        {
+          std::vector<types::global_dof_index> result(n_procs,
+                                                      n_locally_owned_dofs);
+#ifdef DEAL_II_WITH_MPI
+          if (n_procs > 1)
+            MPI_Allgather(DEAL_II_MPI_CONST_CAST(&n_locally_owned_dofs),
+                          1,
+                          DEAL_II_DOF_INDEX_MPI_TYPE,
+                          result.data(),
+                          1,
+                          DEAL_II_DOF_INDEX_MPI_TYPE,
+                          mpi_communicator);
+#endif
+          return result;
+        }
+    }
+
+
+
+    std::vector<IndexSet>
+    NumberCache::get_locally_owned_dofs_per_processor(
+      const MPI_Comm mpi_communicator) const
+    {
+      AssertDimension(locally_owned_dofs.size(), n_global_dofs);
+      const unsigned int n_procs =
+        Utilities::MPI::job_supports_mpi() ?
+          Utilities::MPI::n_mpi_processes(mpi_communicator) :
+          1;
+      if (n_global_dofs == 0)
+        return std::vector<IndexSet>();
+      else if (locally_owned_dofs_per_processor.empty() == false)
+        {
+          AssertDimension(locally_owned_dofs_per_processor.size(), n_procs);
+          return locally_owned_dofs_per_processor;
+        }
+      else
+        {
+          std::vector<IndexSet> locally_owned_dofs_per_processor(
+            n_procs, locally_owned_dofs);
+
+#ifdef DEAL_II_WITH_MPI
+          if (n_procs > 1)
+            {
+              // this step is substantially more complicated because indices
+              // might be distributed arbitrarily among the processors. Here we
+              // have to serialize the IndexSet objects and shop them across the
+              // network.
+              std::vector<char> my_data;
+              {
+#  ifdef DEAL_II_WITH_ZLIB
+
+                boost::iostreams::filtering_ostream out;
+                out.push(boost::iostreams::gzip_compressor(
+                  boost::iostreams::gzip_params(
+                    boost::iostreams::gzip::best_compression)));
+                out.push(boost::iostreams::back_inserter(my_data));
+
+                boost::archive::binary_oarchive archive(out);
+
+                archive << locally_owned_dofs;
+                out.flush();
+#  else
+                std::ostringstream              out;
+                boost::archive::binary_oarchive archive(out);
+                archive << locally_owned_dofs;
+                const std::string &s = out.str();
+                my_data.reserve(s.size());
+                my_data.assign(s.begin(), s.end());
+#  endif
+              }
+
+              // determine maximum size of IndexSet
+              const unsigned int max_size =
+                Utilities::MPI::max(my_data.size(), mpi_communicator);
+
+              // as the MPI_Allgather call will be reading max_size elements,
+              // and as this may be past the end of my_data, we need to increase
+              // the size of the local buffer. This is filled with zeros.
+              my_data.resize(max_size);
+
+              std::vector<char> buffer(max_size * n_procs);
+              const int         ierr = MPI_Allgather(my_data.data(),
+                                             max_size,
+                                             MPI_BYTE,
+                                             buffer.data(),
+                                             max_size,
+                                             MPI_BYTE,
+                                             mpi_communicator);
+              AssertThrowMPI(ierr);
+
+              for (unsigned int i = 0; i < n_procs; ++i)
+                if (i == Utilities::MPI::this_mpi_process(mpi_communicator))
+                  locally_owned_dofs_per_processor[i] = locally_owned_dofs;
+                else
+                  {
+                    // copy the data previously received into a stringstream
+                    // object and then read the IndexSet from it
+                    std::string decompressed_buffer;
+
+                    // first decompress the buffer
+                    {
+#  ifdef DEAL_II_WITH_ZLIB
+
+                      boost::iostreams::filtering_ostream decompressing_stream;
+                      decompressing_stream.push(
+                        boost::iostreams::gzip_decompressor());
+                      decompressing_stream.push(
+                        boost::iostreams::back_inserter(decompressed_buffer));
+
+                      decompressing_stream.write(&buffer[i * max_size],
+                                                 max_size);
+#  else
+                      decompressed_buffer.assign(&buffer[i * max_size],
+                                                 max_size);
+#  endif
+                    }
+
+                    // then restore the object from the buffer
+                    std::istringstream              in(decompressed_buffer);
+                    boost::archive::binary_iarchive archive(in);
+
+                    archive >> locally_owned_dofs_per_processor[i];
+                  }
+            }
+#endif
+          return locally_owned_dofs_per_processor;
+        }
+    }
+
 
     std::size_t
     NumberCache::memory_consumption() const

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2347,24 +2347,14 @@ namespace GridTools
 
     // Make indices global by getting the number of vertices owned by each
     // processors and shifting the indices accordingly
-    const unsigned int n_cpu =
-      Utilities::MPI::n_mpi_processes(triangulation.get_communicator());
-    std::vector<types::global_vertex_index> indices(n_cpu);
-    int ierr = MPI_Allgather(&next_index,
-                             1,
-                             DEAL_II_VERTEX_INDEX_MPI_TYPE,
-                             indices.data(),
-                             1,
-                             DEAL_II_VERTEX_INDEX_MPI_TYPE,
-                             triangulation.get_communicator());
+    types::global_dof_index shift = 0;
+    int ierr = MPI_Exscan(&next_index,
+                          &shift,
+                          1,
+                          DEAL_II_VERTEX_INDEX_MPI_TYPE,
+                          MPI_SUM,
+                          triangulation.get_communicator());
     AssertThrowMPI(ierr);
-    Assert(indices.begin() + triangulation.locally_owned_subdomain() <
-             indices.end(),
-           ExcInternalError());
-    const types::global_vertex_index shift =
-      std::accumulate(indices.begin(),
-                      indices.begin() + triangulation.locally_owned_subdomain(),
-                      types::global_vertex_index(0));
 
     std::map<unsigned int, types::global_vertex_index>::iterator
       global_index_it = local_to_global_vertex_index.begin(),

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -191,7 +191,7 @@ namespace internal
             locally_owned_mg_dofs_per_processor;
           for (unsigned int l = 0; l < tria->n_global_levels(); ++l)
             locally_owned_mg_dofs_per_processor.push_back(
-              mg_dof.locally_owned_mg_dofs_per_processor(l));
+              mg_dof.compute_locally_owned_mg_dofs_per_processor(l));
 
           const std::set<types::subdomain_id> &neighbors =
             tria->level_ghost_owners();

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -187,6 +187,12 @@ namespace internal
           // The list of neighbors is symmetric (our neighbors have us as a
           // neighbor), so we can use it to send and to know how many messages
           // we will get.
+          std::vector<std::vector<IndexSet>>
+            locally_owned_mg_dofs_per_processor;
+          for (unsigned int l = 0; l < tria->n_global_levels(); ++l)
+            locally_owned_mg_dofs_per_processor.push_back(
+              mg_dof.locally_owned_mg_dofs_per_processor(l));
+
           const std::set<types::subdomain_id> &neighbors =
             tria->level_ghost_owners();
           std::map<int, std::vector<DoFPair>> send_data;
@@ -198,8 +204,7 @@ namespace internal
               std::set<types::subdomain_id>::iterator it;
               for (it = neighbors.begin(); it != neighbors.end(); ++it)
                 {
-                  if (mg_dof
-                        .locally_owned_mg_dofs_per_processor(dofpair.level)[*it]
+                  if (locally_owned_mg_dofs_per_processor[dofpair.level][*it]
                         .is_element(dofpair.level_dof_index))
                     {
                       send_data[*it].push_back(dofpair);

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -284,7 +284,7 @@ MGTransferPrebuilt<VectorType>::build_matrices(
           // Compute # of locally owned MG dofs / processor for distribution
           const std::vector<::dealii::IndexSet>
             locally_owned_mg_dofs_per_processor =
-              mg_dof.locally_owned_mg_dofs_per_processor(level + 1);
+              mg_dof.compute_locally_owned_mg_dofs_per_processor(level + 1);
           std::vector<::dealii::types::global_dof_index>
             n_locally_owned_mg_dofs_per_processor(
               locally_owned_mg_dofs_per_processor.size(), 0);

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -283,7 +283,7 @@ MGTransferPrebuilt<VectorType>::build_matrices(
 
           // Compute # of locally owned MG dofs / processor for distribution
           const std::vector<::dealii::IndexSet>
-            &locally_owned_mg_dofs_per_processor =
+            locally_owned_mg_dofs_per_processor =
               mg_dof.locally_owned_mg_dofs_per_processor(level + 1);
           std::vector<::dealii::types::global_dof_index>
             n_locally_owned_mg_dofs_per_processor(

--- a/tests/distributed_grids/dof_handler_number_cache.cc
+++ b/tests/distributed_grids/dof_handler_number_cache.cc
@@ -99,10 +99,10 @@ test()
 
       AssertThrow(dof_handler.n_locally_owned_dofs() == N, ExcInternalError());
       AssertThrow(dof_handler.locally_owned_dofs() == all, ExcInternalError());
-      AssertThrow(dof_handler.n_locally_owned_dofs_per_processor() ==
+      AssertThrow(dof_handler.compute_n_locally_owned_dofs_per_processor() ==
                     std::vector<types::global_dof_index>(1, N),
                   ExcInternalError());
-      AssertThrow(dof_handler.locally_owned_dofs_per_processor() ==
+      AssertThrow(dof_handler.compute_locally_owned_dofs_per_processor() ==
                     std::vector<IndexSet>(1, all),
                   ExcInternalError());
     }

--- a/tests/distributed_grids/hp_dof_handler_number_cache.cc
+++ b/tests/distributed_grids/hp_dof_handler_number_cache.cc
@@ -106,10 +106,10 @@ test()
 
       AssertThrow(dof_handler.n_locally_owned_dofs() == N, ExcInternalError());
       AssertThrow(dof_handler.locally_owned_dofs() == all, ExcInternalError());
-      AssertThrow(dof_handler.n_locally_owned_dofs_per_processor() ==
+      AssertThrow(dof_handler.compute_n_locally_owned_dofs_per_processor() ==
                     std::vector<types::global_dof_index>(1, N),
                   ExcInternalError());
-      AssertThrow(dof_handler.locally_owned_dofs_per_processor() ==
+      AssertThrow(dof_handler.compute_locally_owned_dofs_per_processor() ==
                     std::vector<IndexSet>(1, all),
                   ExcInternalError());
     }

--- a/tests/dofs/dof_handler_number_cache.cc
+++ b/tests/dofs/dof_handler_number_cache.cc
@@ -96,10 +96,10 @@ test()
 
       AssertThrow(dof_handler.n_locally_owned_dofs() == N, ExcInternalError());
       AssertThrow(dof_handler.locally_owned_dofs() == all, ExcInternalError());
-      AssertThrow(dof_handler.n_locally_owned_dofs_per_processor() ==
+      AssertThrow(dof_handler.compute_n_locally_owned_dofs_per_processor() ==
                     std::vector<types::global_dof_index>(1, N),
                   ExcInternalError());
-      AssertThrow(dof_handler.locally_owned_dofs_per_processor() ==
+      AssertThrow(dof_handler.compute_locally_owned_dofs_per_processor() ==
                     std::vector<IndexSet>(1, all),
                   ExcInternalError());
     }

--- a/tests/dofs/dof_handler_number_cache_02.cc
+++ b/tests/dofs/dof_handler_number_cache_02.cc
@@ -95,16 +95,17 @@ test()
 
       Assert(dof_handler.n_locally_owned_dofs() == N, ExcInternalError());
       Assert(dof_handler.locally_owned_dofs() == all, ExcInternalError());
-      Assert(dof_handler.n_locally_owned_dofs_per_processor() ==
+      Assert(dof_handler.compute_n_locally_owned_dofs_per_processor() ==
                std::vector<types::global_dof_index>(1, N),
              ExcInternalError());
-      Assert(dof_handler.locally_owned_dofs_per_processor() ==
+      Assert(dof_handler.compute_locally_owned_dofs_per_processor() ==
                std::vector<IndexSet>(1, all),
              ExcInternalError());
 
       dof_handler.clear();
       deallog << "those should be zero: " << dof_handler.n_locally_owned_dofs()
-              << " " << dof_handler.n_locally_owned_dofs_per_processor().size()
+              << " "
+              << dof_handler.compute_n_locally_owned_dofs_per_processor().size()
               << " " << dof_handler.n_dofs() << std::endl;
     }
 }

--- a/tests/dofs/dof_tools_22a.cc
+++ b/tests/dofs/dof_tools_22a.cc
@@ -114,7 +114,7 @@ test()
                                          MPI_COMM_WORLD));
   SparsityTools::distribute_sparsity_pattern(
     sp,
-    dh.n_locally_owned_dofs_per_processor(),
+    dh.compute_n_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     relevant_partitioning);
 

--- a/tests/dofs/sparsity_pattern_06.cc
+++ b/tests/dofs/sparsity_pattern_06.cc
@@ -138,7 +138,7 @@ main(int argc, char **argv)
   dynamic_sparsity_pattern.print(deallog.get_file_stream());
   SparsityTools::distribute_sparsity_pattern(
     dynamic_sparsity_pattern,
-    dof_handler_0.n_locally_owned_dofs_per_processor(),
+    dof_handler_0.compute_n_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     dof_handler_0.locally_owned_dofs());
   dynamic_sparsity_pattern.print(deallog.get_file_stream());

--- a/tests/dofs/sparsity_pattern_07.cc
+++ b/tests/dofs/sparsity_pattern_07.cc
@@ -155,7 +155,7 @@ main(int argc, char **argv)
   dynamic_sparsity_pattern.print(deallog.get_file_stream());
   SparsityTools::distribute_sparsity_pattern(
     dynamic_sparsity_pattern,
-    dof_handler_0.n_locally_owned_dofs_per_processor(),
+    dof_handler_0.compute_n_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     dof_handler_0.locally_owned_dofs());
   dynamic_sparsity_pattern.print(deallog.get_file_stream());

--- a/tests/gla/block_mat_02.cc
+++ b/tests/gla/block_mat_02.cc
@@ -125,7 +125,7 @@ test()
 
   SparsityTools::distribute_sparsity_pattern(
     sp,
-    stokes_dof_handler.locally_owned_dofs_per_processor(),
+    stokes_dof_handler.compute_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     stokes_relevant_set);
 

--- a/tests/gla/block_mat_03.cc
+++ b/tests/gla/block_mat_03.cc
@@ -110,7 +110,7 @@ test()
   DoFTools::make_sparsity_pattern(dof_handler, bcsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(
     bcsp,
-    dof_handler.locally_owned_dofs_per_processor(),
+    dof_handler.compute_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     locally_relevant_dofs);
 

--- a/tests/gla/mat_03.cc
+++ b/tests/gla/mat_03.cc
@@ -85,7 +85,7 @@ test()
                                     MPI_COMM_WORLD));
   SparsityTools::distribute_sparsity_pattern(
     sp,
-    dof_handler.n_locally_owned_dofs_per_processor(),
+    dof_handler.compute_n_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     relevant);
   sp.compress();

--- a/tests/gla/mat_04.cc
+++ b/tests/gla/mat_04.cc
@@ -84,7 +84,7 @@ test()
                                     MPI_COMM_WORLD));
   SparsityTools::distribute_sparsity_pattern(
     sp,
-    dof_handler.n_locally_owned_dofs_per_processor(),
+    dof_handler.compute_n_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     relevant);
   sp.compress();

--- a/tests/hp/dof_handler_number_cache.cc
+++ b/tests/hp/dof_handler_number_cache.cc
@@ -107,10 +107,10 @@ test()
 
       AssertThrow(dof_handler.n_locally_owned_dofs() == N, ExcInternalError());
       AssertThrow(dof_handler.locally_owned_dofs() == all, ExcInternalError());
-      AssertThrow(dof_handler.n_locally_owned_dofs_per_processor() ==
+      AssertThrow(dof_handler.compute_n_locally_owned_dofs_per_processor() ==
                     std::vector<types::global_dof_index>(1, N),
                   ExcInternalError());
-      AssertThrow(dof_handler.locally_owned_dofs_per_processor() ==
+      AssertThrow(dof_handler.compute_locally_owned_dofs_per_processor() ==
                     std::vector<IndexSet>(1, all),
                   ExcInternalError());
     }

--- a/tests/lac/linear_operator_12.cc
+++ b/tests/lac/linear_operator_12.cc
@@ -204,7 +204,7 @@ Step4<dim>::setup_system()
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(
     dsp,
-    dof_handler.n_locally_owned_dofs_per_processor(),
+    dof_handler.compute_n_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     locally_relevant_dofs);
 

--- a/tests/lac/linear_operator_12a.cc
+++ b/tests/lac/linear_operator_12a.cc
@@ -205,7 +205,7 @@ Step4<dim>::setup_system()
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(
     dsp,
-    dof_handler.n_locally_owned_dofs_per_processor(),
+    dof_handler.compute_n_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     locally_relevant_dofs);
 

--- a/tests/matrix_free/dg_pbc_01.cc
+++ b/tests/matrix_free/dg_pbc_01.cc
@@ -95,6 +95,9 @@ test()
   SolverControl control(1000, 1e-12 * std::sqrt(rhs.size()));
   SolverCG<LinearAlgebra::distributed::Vector<double>> solver(control);
   solver.solve(mf, sol, rhs, PreconditionIdentity());
+
+  const std::vector<IndexSet> locally_owned_dofs_per_processor =
+    dof.locally_owned_dofs_per_processor();
   // gather all data at root
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {
@@ -107,14 +110,13 @@ test()
            ++i)
         {
           MPI_Recv(sol_gather_ptr,
-                   dof.locally_owned_dofs_per_processor()[i].n_elements(),
+                   locally_owned_dofs_per_processor[i].n_elements(),
                    MPI_DOUBLE,
                    i,
                    i,
                    MPI_COMM_WORLD,
                    MPI_STATUS_IGNORE);
-          sol_gather_ptr +=
-            dof.locally_owned_dofs_per_processor()[i].n_elements();
+          sol_gather_ptr += locally_owned_dofs_per_processor[i].n_elements();
         }
       solution_gather0.print(deallog.get_file_stream());
     }

--- a/tests/matrix_free/dg_pbc_01.cc
+++ b/tests/matrix_free/dg_pbc_01.cc
@@ -97,7 +97,7 @@ test()
   solver.solve(mf, sol, rhs, PreconditionIdentity());
 
   const std::vector<IndexSet> locally_owned_dofs_per_processor =
-    dof.locally_owned_dofs_per_processor();
+    dof.compute_locally_owned_dofs_per_processor();
   // gather all data at root
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {

--- a/tests/mpi/constraints_consistent_01.cc
+++ b/tests/mpi/constraints_consistent_01.cc
@@ -84,7 +84,7 @@ check(parallel::distributed::Triangulation<dim> &tria)
   constraints.print(deallog.get_file_stream());
   deallog << "consistent? "
           << constraints.is_consistent_in_parallel(
-               dof_handler.locally_owned_dofs_per_processor(),
+               dof_handler.compute_locally_owned_dofs_per_processor(),
                locally_active_dofs,
                MPI_COMM_WORLD,
                true)

--- a/tests/mpi/distribute_flux_sparsity_pattern.cc
+++ b/tests/mpi/distribute_flux_sparsity_pattern.cc
@@ -134,7 +134,7 @@ namespace LinearAdvectionTest
                                          flux_integral_mask);
     SparsityTools::distribute_sparsity_pattern(
       dynamic_sparsity_pattern,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       MPI_COMM_WORLD,
       locally_relevant_dofs);
 

--- a/tests/mpi/dof_handler_number_cache.cc
+++ b/tests/mpi/dof_handler_number_cache.cc
@@ -107,20 +107,21 @@ test()
 
       Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
       for (unsigned int i = 0;
-           i < dof_handler.n_locally_owned_dofs_per_processor().size();
+           i < dof_handler.compute_n_locally_owned_dofs_per_processor().size();
            ++i)
-        AssertThrow(dof_handler.n_locally_owned_dofs_per_processor()[i] <= N,
-                    ExcInternalError());
+        AssertThrow(
+          dof_handler.compute_n_locally_owned_dofs_per_processor()[i] <= N,
+          ExcInternalError());
       const std::vector<types::global_dof_index>
         n_locally_owned_dofs_per_processor =
-          dof_handler.n_locally_owned_dofs_per_processor();
+          dof_handler.compute_n_locally_owned_dofs_per_processor();
       AssertThrow(std::accumulate(n_locally_owned_dofs_per_processor.begin(),
                                   n_locally_owned_dofs_per_processor.end(),
                                   0U) == N,
                   ExcInternalError());
 
       const std::vector<IndexSet> locally_owned_dofs_per_processor =
-        dof_handler.locally_owned_dofs_per_processor();
+        dof_handler.compute_locally_owned_dofs_per_processor();
       IndexSet all(N), really_all(N);
       // poor man's union operation
       for (unsigned int i = 0; i < n_locally_owned_dofs_per_processor.size();

--- a/tests/mpi/dof_handler_number_cache.cc
+++ b/tests/mpi/dof_handler_number_cache.cc
@@ -111,19 +111,22 @@ test()
            ++i)
         AssertThrow(dof_handler.n_locally_owned_dofs_per_processor()[i] <= N,
                     ExcInternalError());
-      AssertThrow(std::accumulate(
-                    dof_handler.n_locally_owned_dofs_per_processor().begin(),
-                    dof_handler.n_locally_owned_dofs_per_processor().end(),
-                    0U) == N,
+      const std::vector<types::global_dof_index>
+        n_locally_owned_dofs_per_processor =
+          dof_handler.n_locally_owned_dofs_per_processor();
+      AssertThrow(std::accumulate(n_locally_owned_dofs_per_processor.begin(),
+                                  n_locally_owned_dofs_per_processor.end(),
+                                  0U) == N,
                   ExcInternalError());
 
+      const std::vector<IndexSet> locally_owned_dofs_per_processor =
+        dof_handler.locally_owned_dofs_per_processor();
       IndexSet all(N), really_all(N);
       // poor man's union operation
-      for (unsigned int i = 0;
-           i < dof_handler.n_locally_owned_dofs_per_processor().size();
+      for (unsigned int i = 0; i < n_locally_owned_dofs_per_processor.size();
            ++i)
         for (unsigned int j = 0; j < N; ++j)
-          if (dof_handler.locally_owned_dofs_per_processor()[i].is_element(j))
+          if (locally_owned_dofs_per_processor[i].is_element(j))
             {
               AssertThrow(all.is_element(j) == false, ExcInternalError());
               all.add_index(j);

--- a/tests/mpi/hp_step-40.cc
+++ b/tests/mpi/hp_step-40.cc
@@ -163,14 +163,15 @@ namespace Step40
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
     SparsityTools::distribute_sparsity_pattern(
       csp,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       mpi_communicator,
       locally_relevant_dofs);
-    system_matrix.reinit(mpi_communicator,
-                         csp,
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         Utilities::MPI::this_mpi_process(mpi_communicator));
+    system_matrix.reinit(
+      mpi_communicator,
+      csp,
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      Utilities::MPI::this_mpi_process(mpi_communicator));
   }
 
 
@@ -341,7 +342,8 @@ namespace Step40
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << dof_handler.n_locally_owned_dofs_per_processor()[i] << '+';
+          pcout << dof_handler.compute_n_locally_owned_dofs_per_processor()[i]
+                << '+';
         pcout << std::endl;
 
         assemble_system();

--- a/tests/mpi/hp_step-40_variable_01.cc
+++ b/tests/mpi/hp_step-40_variable_01.cc
@@ -169,14 +169,15 @@ namespace Step40
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
     SparsityTools::distribute_sparsity_pattern(
       csp,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       mpi_communicator,
       locally_relevant_dofs);
-    system_matrix.reinit(mpi_communicator,
-                         csp,
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         Utilities::MPI::this_mpi_process(mpi_communicator));
+    system_matrix.reinit(
+      mpi_communicator,
+      csp,
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      Utilities::MPI::this_mpi_process(mpi_communicator));
   }
 
 
@@ -344,7 +345,8 @@ namespace Step40
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << dof_handler.n_locally_owned_dofs_per_processor()[i] << '+';
+          pcout << dof_handler.compute_n_locally_owned_dofs_per_processor()[i]
+                << '+';
         pcout << std::endl;
 
         assemble_system();

--- a/tests/mpi/interpolate_to_different_mesh_02.cc
+++ b/tests/mpi/interpolate_to_different_mesh_02.cc
@@ -153,7 +153,7 @@ SeventhProblem<dim>::setup_system()
   DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(
     csp,
-    dof_handler.n_locally_owned_dofs_per_processor(),
+    dof_handler.compute_n_locally_owned_dofs_per_processor(),
     mpi_communicator,
     locally_relevant_dofs);
   system_matrix.reinit(locally_owned_dofs,

--- a/tests/mpi/mg_02.cc
+++ b/tests/mpi/mg_02.cc
@@ -96,7 +96,7 @@ test()
 
     const std::vector<types::global_dof_index>
       n_locally_owned_dofs_per_processor =
-        dofh.n_locally_owned_dofs_per_processor();
+        dofh.compute_n_locally_owned_dofs_per_processor();
     deallog << "n_locally_owned_dofs_per_processor:" << std::endl;
     for (unsigned int i = 0; i < n_locally_owned_dofs_per_processor.size(); ++i)
       deallog << n_locally_owned_dofs_per_processor[i] << std::endl;
@@ -107,7 +107,7 @@ test()
         deallog << "level " << lvl << ":" << std::endl;
 
         const std::vector<IndexSet> vec =
-          dofh.locally_owned_mg_dofs_per_processor(lvl);
+          dofh.compute_locally_owned_mg_dofs_per_processor(lvl);
 
         for (unsigned int i = 0; i < vec.size(); ++i)
           deallog << vec[i].n_elements() << std::endl;

--- a/tests/mpi/mg_02.cc
+++ b/tests/mpi/mg_02.cc
@@ -94,18 +94,19 @@ test()
     deallog << "Levels: " << tr.n_global_levels() << std::endl;
     std::cout << "Levels: " << tr.n_global_levels() << std::endl;
 
+    const std::vector<types::global_dof_index>
+      n_locally_owned_dofs_per_processor =
+        dofh.n_locally_owned_dofs_per_processor();
     deallog << "n_locally_owned_dofs_per_processor:" << std::endl;
-    for (unsigned int i = 0;
-         i < dofh.n_locally_owned_dofs_per_processor().size();
-         ++i)
-      deallog << dofh.n_locally_owned_dofs_per_processor()[i] << std::endl;
+    for (unsigned int i = 0; i < n_locally_owned_dofs_per_processor.size(); ++i)
+      deallog << n_locally_owned_dofs_per_processor[i] << std::endl;
 
     deallog << "locally_owned_mg_dofs_per_processor:" << std::endl;
     for (unsigned int lvl = 0; lvl < tr.n_global_levels(); ++lvl)
       {
         deallog << "level " << lvl << ":" << std::endl;
 
-        const std::vector<IndexSet> &vec =
+        const std::vector<IndexSet> vec =
           dofh.locally_owned_mg_dofs_per_processor(lvl);
 
         for (unsigned int i = 0; i < vec.size(); ++i)

--- a/tests/mpi/p4est_2d_dofhandler_01.cc
+++ b/tests/mpi/p4est_2d_dofhandler_01.cc
@@ -55,9 +55,12 @@ test()
   static const FE_Q<dim> fe(2);
   dofh.distribute_dofs(fe);
 
+  const std::vector<types::global_dof_index>
+    n_locally_owned_dofs_per_processor =
+      dofh.n_locally_owned_dofs_per_processor();
   if (myid == 0)
     {
-      deallog << "dofh.n_dofs() " << dofh.n_locally_owned_dofs_per_processor()
+      deallog << "dofh.n_dofs() " << n_locally_owned_dofs_per_processor
               << std::endl;
       deallog << "dofh.n_locally_owned_dofs() " << dofh.n_locally_owned_dofs()
               << std::endl;

--- a/tests/mpi/p4est_2d_dofhandler_01.cc
+++ b/tests/mpi/p4est_2d_dofhandler_01.cc
@@ -57,7 +57,7 @@ test()
 
   const std::vector<types::global_dof_index>
     n_locally_owned_dofs_per_processor =
-      dofh.n_locally_owned_dofs_per_processor();
+      dofh.compute_n_locally_owned_dofs_per_processor();
   if (myid == 0)
     {
       deallog << "dofh.n_dofs() " << n_locally_owned_dofs_per_processor

--- a/tests/mpi/p4est_2d_dofhandler_02.cc
+++ b/tests/mpi/p4est_2d_dofhandler_02.cc
@@ -89,10 +89,12 @@ test()
       static const FE_Q<dim> fe(2);
       dofh.distribute_dofs(fe);
 
+      std::vector<types::global_dof_index> n_locally_owned_dofs_per_processor =
+        dofh.n_locally_owned_dofs_per_processor();
       if (myid == 0)
         {
-          deallog << "dofh.n_dofs() "
-                  << dofh.n_locally_owned_dofs_per_processor() << std::endl;
+          deallog << "dofh.n_dofs() " << n_locally_owned_dofs_per_processor
+                  << std::endl;
           deallog << "dofh.n_locally_owned_dofs() "
                   << dofh.n_locally_owned_dofs() << std::endl;
         }

--- a/tests/mpi/p4est_2d_dofhandler_02.cc
+++ b/tests/mpi/p4est_2d_dofhandler_02.cc
@@ -90,7 +90,7 @@ test()
       dofh.distribute_dofs(fe);
 
       std::vector<types::global_dof_index> n_locally_owned_dofs_per_processor =
-        dofh.n_locally_owned_dofs_per_processor();
+        dofh.compute_n_locally_owned_dofs_per_processor();
       if (myid == 0)
         {
           deallog << "dofh.n_dofs() " << n_locally_owned_dofs_per_processor

--- a/tests/mpi/p4est_2d_dofhandler_03.cc
+++ b/tests/mpi/p4est_2d_dofhandler_03.cc
@@ -90,10 +90,12 @@ test()
       static const FE_Q<dim> fe(2);
       dofh.distribute_dofs(fe);
 
+      std::vector<types::global_dof_index> n_locally_owned_dofs_per_processor =
+        dofh.n_locally_owned_dofs_per_processor();
       if (myid == 0)
         {
-          deallog << "dofh.n_dofs() "
-                  << dofh.n_locally_owned_dofs_per_processor() << std::endl;
+          deallog << "dofh.n_dofs() " << n_locally_owned_dofs_per_processor
+                  << std::endl;
           deallog << "dofh.n_locally_owned_dofs() "
                   << dofh.n_locally_owned_dofs() << std::endl;
         }

--- a/tests/mpi/p4est_2d_dofhandler_03.cc
+++ b/tests/mpi/p4est_2d_dofhandler_03.cc
@@ -91,7 +91,7 @@ test()
       dofh.distribute_dofs(fe);
 
       std::vector<types::global_dof_index> n_locally_owned_dofs_per_processor =
-        dofh.n_locally_owned_dofs_per_processor();
+        dofh.compute_n_locally_owned_dofs_per_processor();
       if (myid == 0)
         {
           deallog << "dofh.n_dofs() " << n_locally_owned_dofs_per_processor

--- a/tests/mpi/p4est_2d_dofhandler_04.cc
+++ b/tests/mpi/p4est_2d_dofhandler_04.cc
@@ -90,10 +90,12 @@ test()
       static const FE_Q<dim> fe(2);
       dofh.distribute_dofs(fe);
 
+      std::vector<types::global_dof_index> n_locally_owned_dofs_per_processor =
+        dofh.n_locally_owned_dofs_per_processor();
       if (myid == 0)
         {
-          deallog << "dofh.n_dofs() "
-                  << dofh.n_locally_owned_dofs_per_processor() << std::endl;
+          deallog << "dofh.n_dofs() " << n_locally_owned_dofs_per_processor
+                  << std::endl;
           deallog << "dofh.n_locally_owned_dofs() "
                   << dofh.n_locally_owned_dofs() << std::endl;
         }

--- a/tests/mpi/p4est_2d_dofhandler_04.cc
+++ b/tests/mpi/p4est_2d_dofhandler_04.cc
@@ -91,7 +91,7 @@ test()
       dofh.distribute_dofs(fe);
 
       std::vector<types::global_dof_index> n_locally_owned_dofs_per_processor =
-        dofh.n_locally_owned_dofs_per_processor();
+        dofh.compute_n_locally_owned_dofs_per_processor();
       if (myid == 0)
         {
           deallog << "dofh.n_dofs() " << n_locally_owned_dofs_per_processor

--- a/tests/mpi/p4est_2d_renumber_02.cc
+++ b/tests/mpi/p4est_2d_renumber_02.cc
@@ -80,6 +80,8 @@ test()
     IndexSet dof_set;
     DoFTools::extract_locally_active_dofs(dofh, dof_set);
 
+    const std::vector<IndexSet> owned_dofs =
+      dofh.locally_owned_dofs_per_processor();
     if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
       {
         dof_set.print(deallog);
@@ -88,7 +90,7 @@ test()
              ++i)
           {
             deallog << "Dofs owned by processor " << i << ": ";
-            dofh.locally_owned_dofs_per_processor()[i].print(deallog);
+            owned_dofs[i].print(deallog);
             deallog << std::endl;
           }
       }

--- a/tests/mpi/p4est_2d_renumber_02.cc
+++ b/tests/mpi/p4est_2d_renumber_02.cc
@@ -81,7 +81,7 @@ test()
     DoFTools::extract_locally_active_dofs(dofh, dof_set);
 
     const std::vector<IndexSet> owned_dofs =
-      dofh.locally_owned_dofs_per_processor();
+      dofh.compute_locally_owned_dofs_per_processor();
     if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
       {
         dof_set.print(deallog);

--- a/tests/mpi/p4est_data_out_01.cc
+++ b/tests/mpi/p4est_data_out_01.cc
@@ -75,7 +75,7 @@ test()
   data_out.build_patches();
 
   std::vector<types::global_dof_index> n_locally_owned_dofs_per_processor =
-    dofh.n_locally_owned_dofs_per_processor();
+    dofh.compute_n_locally_owned_dofs_per_processor();
   if (myid == 0)
     {
       for (unsigned int i = 0; i < n_locally_owned_dofs_per_processor.size();

--- a/tests/mpi/p4est_data_out_01.cc
+++ b/tests/mpi/p4est_data_out_01.cc
@@ -74,12 +74,13 @@ test()
   data_out.add_data_vector(x, "x");
   data_out.build_patches();
 
+  std::vector<types::global_dof_index> n_locally_owned_dofs_per_processor =
+    dofh.n_locally_owned_dofs_per_processor();
   if (myid == 0)
     {
-      for (unsigned int i = 0;
-           i < dofh.n_locally_owned_dofs_per_processor().size();
+      for (unsigned int i = 0; i < n_locally_owned_dofs_per_processor.size();
            ++i)
-        deallog << dofh.n_locally_owned_dofs_per_processor()[i] << std::endl;
+        deallog << n_locally_owned_dofs_per_processor[i] << std::endl;
       data_out.write_vtu(deallog.get_file_stream());
     }
 }

--- a/tests/mpi/p4est_get_subdomain_association.cc
+++ b/tests/mpi/p4est_get_subdomain_association.cc
@@ -59,9 +59,12 @@ test()
   static const FE_Q<dim> fe(2);
   dofh.distribute_dofs(fe);
 
+  const std::vector<types::global_dof_index>
+    n_locally_owned_dofs_per_processor =
+      dofh.n_locally_owned_dofs_per_processor();
   if (myid == 1)
     {
-      deallog << "dofh.n_dofs() " << dofh.n_locally_owned_dofs_per_processor()
+      deallog << "dofh.n_dofs() " << n_locally_owned_dofs_per_processor
               << std::endl;
       deallog << "dofh.n_locally_owned_dofs() " << dofh.n_locally_owned_dofs()
               << std::endl;

--- a/tests/mpi/p4est_get_subdomain_association.cc
+++ b/tests/mpi/p4est_get_subdomain_association.cc
@@ -61,7 +61,7 @@ test()
 
   const std::vector<types::global_dof_index>
     n_locally_owned_dofs_per_processor =
-      dofh.n_locally_owned_dofs_per_processor();
+      dofh.compute_n_locally_owned_dofs_per_processor();
   if (myid == 1)
     {
       deallog << "dofh.n_dofs() " << n_locally_owned_dofs_per_processor

--- a/tests/mpi/periodicity_01.cc
+++ b/tests/mpi/periodicity_01.cc
@@ -168,7 +168,7 @@ namespace Step40
     constraints.close();
 
     const std::vector<IndexSet> &locally_owned_dofs =
-      dof_handler.locally_owned_dofs_per_processor();
+      dof_handler.compute_locally_owned_dofs_per_processor();
     IndexSet locally_active_dofs;
     DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
     AssertThrow(constraints.is_consistent_in_parallel(locally_owned_dofs,
@@ -183,14 +183,15 @@ namespace Step40
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
     SparsityTools::distribute_sparsity_pattern(
       csp,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       mpi_communicator,
       locally_relevant_dofs);
-    system_matrix.reinit(mpi_communicator,
-                         csp,
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         Utilities::MPI::this_mpi_process(mpi_communicator));
+    system_matrix.reinit(
+      mpi_communicator,
+      csp,
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      Utilities::MPI::this_mpi_process(mpi_communicator));
   }
 
   template <int dim>

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -398,7 +398,7 @@ namespace Step22
     constraints.close();
 
     const std::vector<IndexSet> &locally_owned_dofs =
-      dof_handler.locally_owned_dofs_per_processor();
+      dof_handler.compute_locally_owned_dofs_per_processor();
     IndexSet locally_active_dofs;
     DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
     AssertThrow(constraints.is_consistent_in_parallel(locally_owned_dofs,

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -328,7 +328,7 @@ namespace Step22
     constraints.close();
 
     const std::vector<IndexSet> &locally_owned_dofs =
-      dof_handler.locally_owned_dofs_per_processor();
+      dof_handler.compute_locally_owned_dofs_per_processor();
     IndexSet locally_active_dofs;
     DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
     AssertThrow(constraints.is_consistent_in_parallel(locally_owned_dofs,

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -205,7 +205,7 @@ check(const unsigned int orientation, bool reverse)
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   constraints.print(deallog.get_file_stream());
 
-  const std::vector<IndexSet> &locally_owned_dofs_vector =
+  const std::vector<IndexSet> locally_owned_dofs_vector =
     dof_handler.locally_owned_dofs_per_processor();
   IndexSet locally_active_dofs;
   DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -206,7 +206,7 @@ check(const unsigned int orientation, bool reverse)
   constraints.print(deallog.get_file_stream());
 
   const std::vector<IndexSet> locally_owned_dofs_vector =
-    dof_handler.locally_owned_dofs_per_processor();
+    dof_handler.compute_locally_owned_dofs_per_processor();
   IndexSet locally_active_dofs;
   DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
   AssertThrow(constraints.is_consistent_in_parallel(locally_owned_dofs_vector,

--- a/tests/mpi/periodicity_06.cc
+++ b/tests/mpi/periodicity_06.cc
@@ -188,7 +188,7 @@ test(const unsigned numRefinementLevels = 2)
   constraints.close();
 
   const std::vector<IndexSet> &locally_owned_dofs =
-    dof_handler.locally_owned_dofs_per_processor();
+    dof_handler.compute_locally_owned_dofs_per_processor();
   IndexSet locally_active_dofs;
   DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
   AssertThrow(constraints.is_consistent_in_parallel(locally_owned_dofs,

--- a/tests/mpi/periodicity_07.cc
+++ b/tests/mpi/periodicity_07.cc
@@ -138,7 +138,7 @@ test(const unsigned numRefinementLevels = 2)
   IndexSet locally_active_dofs;
   DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
 
-  const std::vector<IndexSet> &locally_owned_dofs =
+  const std::vector<IndexSet> locally_owned_dofs =
     dof_handler.locally_owned_dofs_per_processor();
 
   std::map<types::global_dof_index, Point<dim>> supportPoints;

--- a/tests/mpi/periodicity_07.cc
+++ b/tests/mpi/periodicity_07.cc
@@ -139,7 +139,7 @@ test(const unsigned numRefinementLevels = 2)
   DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
 
   const std::vector<IndexSet> locally_owned_dofs =
-    dof_handler.locally_owned_dofs_per_processor();
+    dof_handler.compute_locally_owned_dofs_per_processor();
 
   std::map<types::global_dof_index, Point<dim>> supportPoints;
   DoFTools::map_dofs_to_support_points(MappingQ1<dim>(),

--- a/tests/mpi/renumber_cuthill_mckee.cc
+++ b/tests/mpi/renumber_cuthill_mckee.cc
@@ -74,7 +74,9 @@ test()
   std::copy(renumbering.begin(),
             renumbering.end(),
             complete_renumbering.begin());
-  unsigned int offset = renumbering.size();
+  unsigned int                offset = renumbering.size();
+  const std::vector<IndexSet> dofs_per_proc =
+    dofh.locally_owned_dofs_per_processor();
   for (unsigned int i = 1; i < nprocs; ++i)
     {
       if (myid == i)
@@ -87,14 +89,14 @@ test()
                  MPI_COMM_WORLD);
       else if (myid == 0)
         MPI_Recv(&complete_renumbering[offset],
-                 dofh.locally_owned_dofs_per_processor()[i].n_elements(),
+                 dofs_per_proc[i].n_elements(),
                  Utilities::MPI::internal::mpi_type_id(
                    &complete_renumbering[0]),
                  i,
                  i,
                  MPI_COMM_WORLD,
                  MPI_STATUSES_IGNORE);
-      offset += dofh.locally_owned_dofs_per_processor()[i].n_elements();
+      offset += dofs_per_proc[i].n_elements();
     }
 
   if (myid == 0)

--- a/tests/mpi/renumber_cuthill_mckee.cc
+++ b/tests/mpi/renumber_cuthill_mckee.cc
@@ -76,7 +76,7 @@ test()
             complete_renumbering.begin());
   unsigned int                offset = renumbering.size();
   const std::vector<IndexSet> dofs_per_proc =
-    dofh.locally_owned_dofs_per_processor();
+    dofh.compute_locally_owned_dofs_per_processor();
   for (unsigned int i = 1; i < nprocs; ++i)
     {
       if (myid == i)

--- a/tests/mpi/renumber_cuthill_mckee_02.cc
+++ b/tests/mpi/renumber_cuthill_mckee_02.cc
@@ -77,7 +77,9 @@ test()
   std::copy(renumbering.begin(),
             renumbering.end(),
             complete_renumbering.begin());
-  unsigned int offset = renumbering.size();
+  unsigned int                offset = renumbering.size();
+  const std::vector<IndexSet> locally_owned_dofs_per_processor =
+    dofh.locally_owned_dofs_per_processor();
   for (unsigned int i = 1; i < nprocs; ++i)
     {
       if (myid == i)
@@ -90,14 +92,14 @@ test()
                  MPI_COMM_WORLD);
       else if (myid == 0)
         MPI_Recv(&complete_renumbering[offset],
-                 dofh.locally_owned_dofs_per_processor()[i].n_elements(),
+                 locally_owned_dofs_per_processor[i].n_elements(),
                  Utilities::MPI::internal::mpi_type_id(
                    &complete_renumbering[0]),
                  i,
                  i,
                  MPI_COMM_WORLD,
                  MPI_STATUSES_IGNORE);
-      offset += dofh.locally_owned_dofs_per_processor()[i].n_elements();
+      offset += locally_owned_dofs_per_processor[i].n_elements();
     }
 
   if (myid == 0)

--- a/tests/mpi/renumber_cuthill_mckee_02.cc
+++ b/tests/mpi/renumber_cuthill_mckee_02.cc
@@ -79,7 +79,7 @@ test()
             complete_renumbering.begin());
   unsigned int                offset = renumbering.size();
   const std::vector<IndexSet> locally_owned_dofs_per_processor =
-    dofh.locally_owned_dofs_per_processor();
+    dofh.compute_locally_owned_dofs_per_processor();
   for (unsigned int i = 1; i < nprocs; ++i)
     {
       if (myid == i)

--- a/tests/mpi/step-40.cc
+++ b/tests/mpi/step-40.cc
@@ -157,14 +157,15 @@ namespace Step40
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
     SparsityTools::distribute_sparsity_pattern(
       csp,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       mpi_communicator,
       locally_relevant_dofs);
-    system_matrix.reinit(mpi_communicator,
-                         csp,
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         Utilities::MPI::this_mpi_process(mpi_communicator));
+    system_matrix.reinit(
+      mpi_communicator,
+      csp,
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      Utilities::MPI::this_mpi_process(mpi_communicator));
   }
 
 
@@ -326,7 +327,8 @@ namespace Step40
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << dof_handler.n_locally_owned_dofs_per_processor()[i] << '+';
+          pcout << dof_handler.compute_n_locally_owned_dofs_per_processor()[i]
+                << '+';
         pcout << std::endl;
 
         assemble_system();

--- a/tests/mpi/step-40_cuthill_mckee.cc
+++ b/tests/mpi/step-40_cuthill_mckee.cc
@@ -221,14 +221,15 @@ namespace Step40
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
     SparsityTools::distribute_sparsity_pattern(
       csp,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       mpi_communicator,
       locally_relevant_dofs);
-    system_matrix.reinit(mpi_communicator,
-                         csp,
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         Utilities::MPI::this_mpi_process(mpi_communicator));
+    system_matrix.reinit(
+      mpi_communicator,
+      csp,
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      Utilities::MPI::this_mpi_process(mpi_communicator));
   }
 
 
@@ -390,7 +391,8 @@ namespace Step40
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << dof_handler.n_locally_owned_dofs_per_processor()[i] << '+';
+          pcout << dof_handler.compute_n_locally_owned_dofs_per_processor()[i]
+                << '+';
         pcout << std::endl;
 
         assemble_system();

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
@@ -222,14 +222,15 @@ namespace Step40
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
     SparsityTools::distribute_sparsity_pattern(
       csp,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       mpi_communicator,
       locally_relevant_dofs);
-    system_matrix.reinit(mpi_communicator,
-                         csp,
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         Utilities::MPI::this_mpi_process(mpi_communicator));
+    system_matrix.reinit(
+      mpi_communicator,
+      csp,
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      Utilities::MPI::this_mpi_process(mpi_communicator));
   }
 
 
@@ -390,7 +391,7 @@ namespace Step40
               << "      ";
         const std::vector<types::global_dof_index>
           n_locally_owned_dofs_per_processor =
-            dof_handler.n_locally_owned_dofs_per_processor();
+            dof_handler.compute_n_locally_owned_dofs_per_processor();
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
@@ -388,10 +388,13 @@ namespace Step40
         pcout << "   Number of degrees of freedom: " << dof_handler.n_dofs()
               << std::endl
               << "      ";
+        const std::vector<types::global_dof_index>
+          n_locally_owned_dofs_per_processor =
+            dof_handler.n_locally_owned_dofs_per_processor();
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << dof_handler.n_locally_owned_dofs_per_processor()[i] << '+';
+          pcout << n_locally_owned_dofs_per_processor[i] << '+';
         pcout << std::endl;
 
         assemble_system();

--- a/tests/mpi/step-40_direct_solver.cc
+++ b/tests/mpi/step-40_direct_solver.cc
@@ -157,14 +157,15 @@ namespace Step40
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
     SparsityTools::distribute_sparsity_pattern(
       csp,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       mpi_communicator,
       locally_relevant_dofs);
-    system_matrix.reinit(mpi_communicator,
-                         csp,
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         dof_handler.n_locally_owned_dofs_per_processor(),
-                         Utilities::MPI::this_mpi_process(mpi_communicator));
+    system_matrix.reinit(
+      mpi_communicator,
+      csp,
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
+      Utilities::MPI::this_mpi_process(mpi_communicator));
   }
 
 
@@ -304,7 +305,8 @@ namespace Step40
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << dof_handler.n_locally_owned_dofs_per_processor()[i] << '+';
+          pcout << dof_handler.compute_n_locally_owned_dofs_per_processor()[i]
+                << '+';
         pcout << std::endl;
 
         assemble_system();

--- a/tests/petsc_complex/parallel_sparse_matrix_01.cc
+++ b/tests/petsc_complex/parallel_sparse_matrix_01.cc
@@ -94,7 +94,7 @@ test(const unsigned int poly_degree = 1)
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(
     dsp,
-    dof_handler.n_locally_owned_dofs_per_processor(),
+    dof_handler.compute_n_locally_owned_dofs_per_processor(),
     mpi_communicator,
     locally_relevant_dofs);
 

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -358,7 +358,8 @@ namespace Step18
     DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
     n_local_cells = GridTools::count_cells_with_subdomain_association(
       triangulation, triangulation.locally_owned_subdomain());
-    local_dofs_per_process = dof_handler.n_locally_owned_dofs_per_processor();
+    local_dofs_per_process =
+      dof_handler.compute_n_locally_owned_dofs_per_processor();
     hanging_node_constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler,
                                             hanging_node_constraints);

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -374,7 +374,8 @@ namespace Step18
     DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
     n_local_cells = GridTools::count_cells_with_subdomain_association(
       triangulation, triangulation.locally_owned_subdomain());
-    local_dofs_per_process = dof_handler.n_locally_owned_dofs_per_processor();
+    local_dofs_per_process =
+      dof_handler.compute_n_locally_owned_dofs_per_processor();
     hanging_node_constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler,
                                             hanging_node_constraints);

--- a/tests/sharedtria/dof_01.cc
+++ b/tests/sharedtria/dof_01.cc
@@ -114,9 +114,12 @@ test()
       //        }
       //      deallog << " sum: " << sum << std::endl;
 
+      const std::vector<types::global_dof_index>
+        n_locally_owned_dofs_per_processor =
+          dof_handler.n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
-               dof_handler.n_locally_owned_dofs_per_processor()
-                 [triangulation.locally_owned_subdomain()],
+               n_locally_owned_dofs_per_processor[triangulation
+                                                    .locally_owned_subdomain()],
              ExcInternalError());
       Assert(dof_handler.n_locally_owned_dofs() ==
                dof_handler.locally_owned_dofs().n_elements(),
@@ -125,21 +128,19 @@ test()
       const unsigned int N = dof_handler.n_dofs();
 
       Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
-      Assert(std::accumulate(
-               dof_handler.n_locally_owned_dofs_per_processor().begin(),
-               dof_handler.n_locally_owned_dofs_per_processor().end(),
-               0U) == N,
+      Assert(std::accumulate(n_locally_owned_dofs_per_processor.begin(),
+                             n_locally_owned_dofs_per_processor.end(),
+                             0U) == N,
              ExcInternalError());
 
+      const std::vector<IndexSet> locally_owned_dofs_per_processor =
+        dof_handler.locally_owned_dofs_per_processor();
       IndexSet all(N);
-      for (unsigned int i = 0;
-           i < dof_handler.locally_owned_dofs_per_processor().size();
-           ++i)
+      for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {
-          IndexSet intersect =
-            all & dof_handler.locally_owned_dofs_per_processor()[i];
+          IndexSet intersect = all & locally_owned_dofs_per_processor[i];
           Assert(intersect.n_elements() == 0, ExcInternalError());
-          all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+          all.add_indices(locally_owned_dofs_per_processor[i]);
         }
 
       Assert(all == complete_index_set(N), ExcInternalError());

--- a/tests/sharedtria/dof_01.cc
+++ b/tests/sharedtria/dof_01.cc
@@ -106,8 +106,9 @@ test()
 
       //      deallog << "n_locally_owned_dofs_per_processor: ";
       //      std::vector<types::global_dof_index> v =
-      //      dof_handler.n_locally_owned_dofs_per_processor(); unsigned int sum
-      //      = 0; for (unsigned int i=0; i<v.size(); ++i)
+      //        dof_handler.compute_n_locally_owned_dofs_per_processor();
+      //      unsigned int sum = 0;
+      //      for (unsigned int i=0; i<v.size(); ++i)
       //        {
       //          deallog << v[i] << " ";
       //          sum += v[i];
@@ -116,7 +117,7 @@ test()
 
       const std::vector<types::global_dof_index>
         n_locally_owned_dofs_per_processor =
-          dof_handler.n_locally_owned_dofs_per_processor();
+          dof_handler.compute_n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
                n_locally_owned_dofs_per_processor[triangulation
                                                     .locally_owned_subdomain()],
@@ -134,7 +135,7 @@ test()
              ExcInternalError());
 
       const std::vector<IndexSet> locally_owned_dofs_per_processor =
-        dof_handler.locally_owned_dofs_per_processor();
+        dof_handler.compute_locally_owned_dofs_per_processor();
       IndexSet all(N);
       for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {

--- a/tests/sharedtria/dof_02.cc
+++ b/tests/sharedtria/dof_02.cc
@@ -106,8 +106,9 @@ test()
       //
       //      deallog << "n_locally_owned_dofs_per_processor: ";
       //      std::vector<types::global_dof_index> v =
-      //      dof_handler.n_locally_owned_dofs_per_processor(); unsigned int sum
-      //      = 0; for (unsigned int i=0; i<v.size(); ++i)
+      //        dof_handler.compute_n_locally_owned_dofs_per_processor();
+      //      unsigned int sum = 0;
+      //      for (unsigned int i=0; i<v.size(); ++i)
       //        {
       //          deallog << v[i] << " ";
       //          sum += v[i];
@@ -116,7 +117,7 @@ test()
 
       const std::vector<types::global_dof_index>
         n_locally_owned_dofs_per_processor =
-          dof_handler.n_locally_owned_dofs_per_processor();
+          dof_handler.compute_n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
                n_locally_owned_dofs_per_processor[triangulation
                                                     .locally_owned_subdomain()],
@@ -134,7 +135,7 @@ test()
              ExcInternalError());
 
       const std::vector<IndexSet> locally_owned_dofs_per_processor =
-        dof_handler.locally_owned_dofs_per_processor();
+        dof_handler.compute_locally_owned_dofs_per_processor();
       IndexSet all(N);
       for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {

--- a/tests/sharedtria/dof_02.cc
+++ b/tests/sharedtria/dof_02.cc
@@ -114,9 +114,12 @@ test()
       //        }
       //      deallog << " sum: " << sum << std::endl;
 
+      const std::vector<types::global_dof_index>
+        n_locally_owned_dofs_per_processor =
+          dof_handler.n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
-               dof_handler.n_locally_owned_dofs_per_processor()
-                 [triangulation.locally_owned_subdomain()],
+               n_locally_owned_dofs_per_processor[triangulation
+                                                    .locally_owned_subdomain()],
              ExcInternalError());
       Assert(dof_handler.n_locally_owned_dofs() ==
                dof_handler.locally_owned_dofs().n_elements(),
@@ -125,21 +128,19 @@ test()
       const unsigned int N = dof_handler.n_dofs();
 
       Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
-      Assert(std::accumulate(
-               dof_handler.n_locally_owned_dofs_per_processor().begin(),
-               dof_handler.n_locally_owned_dofs_per_processor().end(),
-               0U) == N,
+      Assert(std::accumulate(n_locally_owned_dofs_per_processor.begin(),
+                             n_locally_owned_dofs_per_processor.end(),
+                             0U) == N,
              ExcInternalError());
 
+      const std::vector<IndexSet> locally_owned_dofs_per_processor =
+        dof_handler.locally_owned_dofs_per_processor();
       IndexSet all(N);
-      for (unsigned int i = 0;
-           i < dof_handler.locally_owned_dofs_per_processor().size();
-           ++i)
+      for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {
-          IndexSet intersect =
-            all & dof_handler.locally_owned_dofs_per_processor()[i];
+          IndexSet intersect = all & locally_owned_dofs_per_processor[i];
           Assert(intersect.n_elements() == 0, ExcInternalError());
-          all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+          all.add_indices(locally_owned_dofs_per_processor[i]);
         }
       Assert(all == complete_index_set(N), ExcInternalError());
     }

--- a/tests/sharedtria/dof_03.cc
+++ b/tests/sharedtria/dof_03.cc
@@ -104,8 +104,9 @@ test()
       //
       //      deallog << "n_locally_owned_dofs_per_processor: ";
       //      std::vector<types::global_dof_index> v =
-      //      dof_handler.n_locally_owned_dofs_per_processor(); unsigned int sum
-      //      = 0; for (unsigned int i=0; i<v.size(); ++i)
+      //        dof_handler.compute_n_locally_owned_dofs_per_processor();
+      //      unsigned int sum = 0;
+      //      for (unsigned int i=0; i<v.size(); ++i)
       //        {
       //          deallog << v[i] << " ";
       //          sum += v[i];
@@ -114,7 +115,7 @@ test()
 
       const std::vector<types::global_dof_index>
         n_locally_owned_dofs_per_processor =
-          dof_handler.n_locally_owned_dofs_per_processor();
+          dof_handler.compute_n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
                n_locally_owned_dofs_per_processor[triangulation
                                                     .locally_owned_subdomain()],
@@ -132,7 +133,7 @@ test()
              ExcInternalError());
 
       const std::vector<IndexSet> locally_owned_dofs_per_processor =
-        dof_handler.locally_owned_dofs_per_processor();
+        dof_handler.compute_locally_owned_dofs_per_processor();
       IndexSet all(N);
       for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {

--- a/tests/sharedtria/dof_03.cc
+++ b/tests/sharedtria/dof_03.cc
@@ -112,9 +112,12 @@ test()
       //        }
       //      deallog << " sum: " << sum << std::endl;
 
+      const std::vector<types::global_dof_index>
+        n_locally_owned_dofs_per_processor =
+          dof_handler.n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
-               dof_handler.n_locally_owned_dofs_per_processor()
-                 [triangulation.locally_owned_subdomain()],
+               n_locally_owned_dofs_per_processor[triangulation
+                                                    .locally_owned_subdomain()],
              ExcInternalError());
       Assert(dof_handler.n_locally_owned_dofs() ==
                dof_handler.locally_owned_dofs().n_elements(),
@@ -123,21 +126,19 @@ test()
       const unsigned int N = dof_handler.n_dofs();
 
       Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
-      Assert(std::accumulate(
-               dof_handler.n_locally_owned_dofs_per_processor().begin(),
-               dof_handler.n_locally_owned_dofs_per_processor().end(),
-               0U) == N,
+      Assert(std::accumulate(n_locally_owned_dofs_per_processor.begin(),
+                             n_locally_owned_dofs_per_processor.end(),
+                             0U) == N,
              ExcInternalError());
 
+      const std::vector<IndexSet> locally_owned_dofs_per_processor =
+        dof_handler.locally_owned_dofs_per_processor();
       IndexSet all(N);
-      for (unsigned int i = 0;
-           i < dof_handler.locally_owned_dofs_per_processor().size();
-           ++i)
+      for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {
-          IndexSet intersect =
-            all & dof_handler.locally_owned_dofs_per_processor()[i];
+          IndexSet intersect = all & locally_owned_dofs_per_processor[i];
           Assert(intersect.n_elements() == 0, ExcInternalError());
-          all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+          all.add_indices(locally_owned_dofs_per_processor[i]);
         }
 
       Assert(all == complete_index_set(N), ExcInternalError());

--- a/tests/sharedtria/dof_04.cc
+++ b/tests/sharedtria/dof_04.cc
@@ -114,9 +114,12 @@ test()
       //        }
       //      deallog << " sum: " << sum << std::endl;
 
+      const std::vector<types::global_dof_index>
+        n_locally_owned_dofs_per_processor =
+          dof_handler.n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
-               dof_handler.n_locally_owned_dofs_per_processor()
-                 [triangulation.locally_owned_subdomain()],
+               n_locally_owned_dofs_per_processor[triangulation
+                                                    .locally_owned_subdomain()],
              ExcInternalError());
       Assert(dof_handler.n_locally_owned_dofs() ==
                dof_handler.locally_owned_dofs().n_elements(),
@@ -125,21 +128,19 @@ test()
       const unsigned int N = dof_handler.n_dofs();
 
       Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
-      Assert(std::accumulate(
-               dof_handler.n_locally_owned_dofs_per_processor().begin(),
-               dof_handler.n_locally_owned_dofs_per_processor().end(),
-               0U) == N,
+      Assert(std::accumulate(n_locally_owned_dofs_per_processor.begin(),
+                             n_locally_owned_dofs_per_processor.end(),
+                             0U) == N,
              ExcInternalError());
 
+      const std::vector<IndexSet> locally_owned_dofs_per_processor =
+        dof_handler.locally_owned_dofs_per_processor();
       IndexSet all(N);
-      for (unsigned int i = 0;
-           i < dof_handler.locally_owned_dofs_per_processor().size();
-           ++i)
+      for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {
-          IndexSet intersect =
-            all & dof_handler.locally_owned_dofs_per_processor()[i];
+          IndexSet intersect = all & locally_owned_dofs_per_processor[i];
           Assert(intersect.n_elements() == 0, ExcInternalError());
-          all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+          all.add_indices(locally_owned_dofs_per_processor[i]);
         }
 
       Assert(all == complete_index_set(N), ExcInternalError());

--- a/tests/sharedtria/dof_04.cc
+++ b/tests/sharedtria/dof_04.cc
@@ -106,8 +106,9 @@ test()
       //
       //      deallog << "n_locally_owned_dofs_per_processor: ";
       //      std::vector<types::global_dof_index> v =
-      //      dof_handler.n_locally_owned_dofs_per_processor(); unsigned int sum
-      //      = 0; for (unsigned int i=0; i<v.size(); ++i)
+      //        dof_handler.compute_n_locally_owned_dofs_per_processor();
+      //      unsigned int sum = 0;
+      //      for (unsigned int i=0; i<v.size(); ++i)
       //        {
       //          deallog << v[i] << " ";
       //          sum += v[i];
@@ -116,7 +117,7 @@ test()
 
       const std::vector<types::global_dof_index>
         n_locally_owned_dofs_per_processor =
-          dof_handler.n_locally_owned_dofs_per_processor();
+          dof_handler.compute_n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
                n_locally_owned_dofs_per_processor[triangulation
                                                     .locally_owned_subdomain()],
@@ -134,7 +135,7 @@ test()
              ExcInternalError());
 
       const std::vector<IndexSet> locally_owned_dofs_per_processor =
-        dof_handler.locally_owned_dofs_per_processor();
+        dof_handler.compute_locally_owned_dofs_per_processor();
       IndexSet all(N);
       for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {

--- a/tests/sharedtria/dof_05.cc
+++ b/tests/sharedtria/dof_05.cc
@@ -57,9 +57,9 @@ compare_meshes(DoFHandler<dim> &shared_dof_handler,
   shared_dofs.print(deallog.get_file_stream());
 
   std::vector<IndexSet> shared_dofs_per_proc =
-    shared_dof_handler.locally_owned_dofs_per_processor();
+    shared_dof_handler.compute_locally_owned_dofs_per_processor();
   std::vector<IndexSet> distributed_dofs_per_proc =
-    distributed_dof_handler.locally_owned_dofs_per_processor();
+    distributed_dof_handler.compute_locally_owned_dofs_per_processor();
   for (unsigned int i = 0; i < Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
        ++i)
     Assert(shared_dofs_per_proc[i] == distributed_dofs_per_proc[i],

--- a/tests/sharedtria/dof_06.cc
+++ b/tests/sharedtria/dof_06.cc
@@ -73,7 +73,7 @@ test()
           << dof_handler.n_locally_owned_dofs() << std::endl;
 
   std::vector<IndexSet> shared_dofs_per_proc =
-    dof_handler.locally_owned_dofs_per_processor();
+    dof_handler.compute_locally_owned_dofs_per_processor();
   for (unsigned int i = 0; i < Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
        ++i)
     shared_dofs_per_proc[i].print(deallog.get_file_stream());

--- a/tests/sharedtria/hp_dof_01.cc
+++ b/tests/sharedtria/hp_dof_01.cc
@@ -119,9 +119,12 @@ test()
       //        }
       //      deallog << " sum: " << sum << std::endl;
 
+      const std::vector<types::global_dof_index>
+        n_locally_owned_dofs_per_processor =
+          dof_handler.n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
-               dof_handler.n_locally_owned_dofs_per_processor()
-                 [triangulation.locally_owned_subdomain()],
+               n_locally_owned_dofs_per_processor[triangulation
+                                                    .locally_owned_subdomain()],
              ExcInternalError());
       Assert(dof_handler.n_locally_owned_dofs() ==
                dof_handler.locally_owned_dofs().n_elements(),
@@ -130,21 +133,19 @@ test()
       const unsigned int N = dof_handler.n_dofs();
 
       Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
-      Assert(std::accumulate(
-               dof_handler.n_locally_owned_dofs_per_processor().begin(),
-               dof_handler.n_locally_owned_dofs_per_processor().end(),
-               0U) == N,
+      Assert(std::accumulate(n_locally_owned_dofs_per_processor.begin(),
+                             n_locally_owned_dofs_per_processor.end(),
+                             0U) == N,
              ExcInternalError());
 
+      const std::vector<IndexSet> locally_owned_dofs_per_processor =
+        dof_handler.locally_owned_dofs_per_processor();
       IndexSet all(N);
-      for (unsigned int i = 0;
-           i < dof_handler.locally_owned_dofs_per_processor().size();
-           ++i)
+      for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {
-          IndexSet intersect =
-            all & dof_handler.locally_owned_dofs_per_processor()[i];
+          IndexSet intersect = all & locally_owned_dofs_per_processor[i];
           Assert(intersect.n_elements() == 0, ExcInternalError());
-          all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+          all.add_indices(locally_owned_dofs_per_processor[i]);
         }
 
       Assert(all == complete_index_set(N), ExcInternalError());

--- a/tests/sharedtria/hp_dof_01.cc
+++ b/tests/sharedtria/hp_dof_01.cc
@@ -111,8 +111,9 @@ test()
 
       //      deallog << "n_locally_owned_dofs_per_processor: ";
       //      std::vector<types::global_dof_index> v =
-      //      dof_handler.n_locally_owned_dofs_per_processor(); unsigned int sum
-      //      = 0; for (unsigned int i=0; i<v.size(); ++i)
+      //        dof_handler.compute_n_locally_owned_dofs_per_processor();
+      //      unsigned int sum = 0;
+      //      for (unsigned int i=0; i<v.size(); ++i)
       //        {
       //          deallog << v[i] << " ";
       //          sum += v[i];
@@ -121,7 +122,7 @@ test()
 
       const std::vector<types::global_dof_index>
         n_locally_owned_dofs_per_processor =
-          dof_handler.n_locally_owned_dofs_per_processor();
+          dof_handler.compute_n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
                n_locally_owned_dofs_per_processor[triangulation
                                                     .locally_owned_subdomain()],
@@ -139,7 +140,7 @@ test()
              ExcInternalError());
 
       const std::vector<IndexSet> locally_owned_dofs_per_processor =
-        dof_handler.locally_owned_dofs_per_processor();
+        dof_handler.compute_locally_owned_dofs_per_processor();
       IndexSet all(N);
       for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {

--- a/tests/sharedtria/hp_dof_02.cc
+++ b/tests/sharedtria/hp_dof_02.cc
@@ -120,9 +120,12 @@ test()
       //        }
       //      deallog << " sum: " << sum << std::endl;
 
+      const std::vector<types::global_dof_index>
+        n_locally_owned_dofs_per_processor =
+          dof_handler.n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
-               dof_handler.n_locally_owned_dofs_per_processor()
-                 [triangulation.locally_owned_subdomain()],
+               n_locally_owned_dofs_per_processor[triangulation
+                                                    .locally_owned_subdomain()],
              ExcInternalError());
       Assert(dof_handler.n_locally_owned_dofs() ==
                dof_handler.locally_owned_dofs().n_elements(),
@@ -131,21 +134,19 @@ test()
       const unsigned int N = dof_handler.n_dofs();
 
       Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
-      Assert(std::accumulate(
-               dof_handler.n_locally_owned_dofs_per_processor().begin(),
-               dof_handler.n_locally_owned_dofs_per_processor().end(),
-               0U) == N,
+      Assert(std::accumulate(n_locally_owned_dofs_per_processor.begin(),
+                             n_locally_owned_dofs_per_processor.end(),
+                             0U) == N,
              ExcInternalError());
 
+      const std::vector<IndexSet> locally_owned_dofs_per_processor =
+        dof_handler.locally_owned_dofs_per_processor();
       IndexSet all(N);
-      for (unsigned int i = 0;
-           i < dof_handler.locally_owned_dofs_per_processor().size();
-           ++i)
+      for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {
-          IndexSet intersect =
-            all & dof_handler.locally_owned_dofs_per_processor()[i];
+          IndexSet intersect = all & locally_owned_dofs_per_processor[i];
           Assert(intersect.n_elements() == 0, ExcInternalError());
-          all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+          all.add_indices(locally_owned_dofs_per_processor[i]);
         }
       Assert(all == complete_index_set(N), ExcInternalError());
     }

--- a/tests/sharedtria/hp_dof_02.cc
+++ b/tests/sharedtria/hp_dof_02.cc
@@ -112,8 +112,9 @@ test()
       //
       //      deallog << "n_locally_owned_dofs_per_processor: ";
       //      std::vector<types::global_dof_index> v =
-      //      dof_handler.n_locally_owned_dofs_per_processor(); unsigned int sum
-      //      = 0; for (unsigned int i=0; i<v.size(); ++i)
+      //        dof_handler.compute_n_locally_owned_dofs_per_processor();
+      //      unsigned int sum = 0;
+      //      for (unsigned int i=0; i<v.size(); ++i)
       //        {
       //          deallog << v[i] << " ";
       //          sum += v[i];
@@ -122,7 +123,7 @@ test()
 
       const std::vector<types::global_dof_index>
         n_locally_owned_dofs_per_processor =
-          dof_handler.n_locally_owned_dofs_per_processor();
+          dof_handler.compute_n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
                n_locally_owned_dofs_per_processor[triangulation
                                                     .locally_owned_subdomain()],
@@ -140,7 +141,7 @@ test()
              ExcInternalError());
 
       const std::vector<IndexSet> locally_owned_dofs_per_processor =
-        dof_handler.locally_owned_dofs_per_processor();
+        dof_handler.compute_locally_owned_dofs_per_processor();
       IndexSet all(N);
       for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {

--- a/tests/sharedtria/hp_dof_03.cc
+++ b/tests/sharedtria/hp_dof_03.cc
@@ -109,8 +109,9 @@ test()
       //
       //      deallog << "n_locally_owned_dofs_per_processor: ";
       //      std::vector<types::global_dof_index> v =
-      //      dof_handler.n_locally_owned_dofs_per_processor(); unsigned int sum
-      //      = 0; for (unsigned int i=0; i<v.size(); ++i)
+      //        dof_handler.compute_n_locally_owned_dofs_per_processor();
+      //      unsigned int sum = 0;
+      //      for (unsigned int i=0; i<v.size(); ++i)
       //        {
       //          deallog << v[i] << " ";
       //          sum += v[i];
@@ -119,7 +120,7 @@ test()
 
       const std::vector<types::global_dof_index>
         n_locally_owned_dofs_per_processor =
-          dof_handler.n_locally_owned_dofs_per_processor();
+          dof_handler.compute_n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
                n_locally_owned_dofs_per_processor[triangulation
                                                     .locally_owned_subdomain()],
@@ -137,7 +138,7 @@ test()
              ExcInternalError());
 
       const std::vector<IndexSet> locally_owned_dofs_per_processor =
-        dof_handler.locally_owned_dofs_per_processor();
+        dof_handler.compute_locally_owned_dofs_per_processor();
       IndexSet all(N);
       for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {

--- a/tests/sharedtria/hp_dof_03.cc
+++ b/tests/sharedtria/hp_dof_03.cc
@@ -117,9 +117,12 @@ test()
       //        }
       //      deallog << " sum: " << sum << std::endl;
 
+      const std::vector<types::global_dof_index>
+        n_locally_owned_dofs_per_processor =
+          dof_handler.n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
-               dof_handler.n_locally_owned_dofs_per_processor()
-                 [triangulation.locally_owned_subdomain()],
+               n_locally_owned_dofs_per_processor[triangulation
+                                                    .locally_owned_subdomain()],
              ExcInternalError());
       Assert(dof_handler.n_locally_owned_dofs() ==
                dof_handler.locally_owned_dofs().n_elements(),
@@ -128,21 +131,19 @@ test()
       const unsigned int N = dof_handler.n_dofs();
 
       Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
-      Assert(std::accumulate(
-               dof_handler.n_locally_owned_dofs_per_processor().begin(),
-               dof_handler.n_locally_owned_dofs_per_processor().end(),
-               0U) == N,
+      Assert(std::accumulate(n_locally_owned_dofs_per_processor.begin(),
+                             n_locally_owned_dofs_per_processor.end(),
+                             0U) == N,
              ExcInternalError());
 
+      const std::vector<IndexSet> locally_owned_dofs_per_processor =
+        dof_handler.locally_owned_dofs_per_processor();
       IndexSet all(N);
-      for (unsigned int i = 0;
-           i < dof_handler.locally_owned_dofs_per_processor().size();
-           ++i)
+      for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {
-          IndexSet intersect =
-            all & dof_handler.locally_owned_dofs_per_processor()[i];
+          IndexSet intersect = all & locally_owned_dofs_per_processor[i];
           Assert(intersect.n_elements() == 0, ExcInternalError());
-          all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+          all.add_indices(locally_owned_dofs_per_processor[i]);
         }
 
       Assert(all == complete_index_set(N), ExcInternalError());

--- a/tests/sharedtria/hp_dof_04.cc
+++ b/tests/sharedtria/hp_dof_04.cc
@@ -120,9 +120,12 @@ test()
       //        }
       //      deallog << " sum: " << sum << std::endl;
 
+      const std::vector<types::global_dof_index>
+        n_locally_owned_dofs_per_processor =
+          dof_handler.n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
-               dof_handler.n_locally_owned_dofs_per_processor()
-                 [triangulation.locally_owned_subdomain()],
+               n_locally_owned_dofs_per_processor[triangulation
+                                                    .locally_owned_subdomain()],
              ExcInternalError());
       Assert(dof_handler.n_locally_owned_dofs() ==
                dof_handler.locally_owned_dofs().n_elements(),
@@ -131,21 +134,19 @@ test()
       const unsigned int N = dof_handler.n_dofs();
 
       Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
-      Assert(std::accumulate(
-               dof_handler.n_locally_owned_dofs_per_processor().begin(),
-               dof_handler.n_locally_owned_dofs_per_processor().end(),
-               0U) == N,
+      Assert(std::accumulate(n_locally_owned_dofs_per_processor.begin(),
+                             n_locally_owned_dofs_per_processor.end(),
+                             0U) == N,
              ExcInternalError());
 
+      const std::vector<IndexSet> locally_owned_dofs_per_processor =
+        dof_handler.locally_owned_dofs_per_processor();
       IndexSet all(N);
-      for (unsigned int i = 0;
-           i < dof_handler.locally_owned_dofs_per_processor().size();
-           ++i)
+      for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {
-          IndexSet intersect =
-            all & dof_handler.locally_owned_dofs_per_processor()[i];
+          IndexSet intersect = all & locally_owned_dofs_per_processor[i];
           Assert(intersect.n_elements() == 0, ExcInternalError());
-          all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+          all.add_indices(locally_owned_dofs_per_processor[i]);
         }
 
       Assert(all == complete_index_set(N), ExcInternalError());

--- a/tests/sharedtria/hp_dof_04.cc
+++ b/tests/sharedtria/hp_dof_04.cc
@@ -112,8 +112,9 @@ test()
       //
       //      deallog << "n_locally_owned_dofs_per_processor: ";
       //      std::vector<types::global_dof_index> v =
-      //      dof_handler.n_locally_owned_dofs_per_processor(); unsigned int sum
-      //      = 0; for (unsigned int i=0; i<v.size(); ++i)
+      //        dof_handler.compute_n_locally_owned_dofs_per_processor();
+      //      unsigned int sum = 0;
+      //      for (unsigned int i=0; i<v.size(); ++i)
       //        {
       //          deallog << v[i] << " ";
       //          sum += v[i];
@@ -122,7 +123,7 @@ test()
 
       const std::vector<types::global_dof_index>
         n_locally_owned_dofs_per_processor =
-          dof_handler.n_locally_owned_dofs_per_processor();
+          dof_handler.compute_n_locally_owned_dofs_per_processor();
       Assert(dof_handler.n_locally_owned_dofs() ==
                n_locally_owned_dofs_per_processor[triangulation
                                                     .locally_owned_subdomain()],
@@ -140,7 +141,7 @@ test()
              ExcInternalError());
 
       const std::vector<IndexSet> locally_owned_dofs_per_processor =
-        dof_handler.locally_owned_dofs_per_processor();
+        dof_handler.compute_locally_owned_dofs_per_processor();
       IndexSet all(N);
       for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
         {

--- a/tests/sharedtria/hp_no_cells_01.cc
+++ b/tests/sharedtria/hp_no_cells_01.cc
@@ -93,8 +93,7 @@ test()
   deallog << std::endl;
 
   Assert(dof_handler.n_locally_owned_dofs() ==
-           dof_handler.n_locally_owned_dofs_per_processor()
-             [triangulation.locally_owned_subdomain()],
+           v[triangulation.locally_owned_subdomain()],
          ExcInternalError());
   Assert(dof_handler.n_locally_owned_dofs() ==
            dof_handler.locally_owned_dofs().n_elements(),
@@ -103,21 +102,16 @@ test()
   const unsigned int N = dof_handler.n_dofs();
 
   Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
-  Assert(
-    std::accumulate(dof_handler.n_locally_owned_dofs_per_processor().begin(),
-                    dof_handler.n_locally_owned_dofs_per_processor().end(),
-                    0U) == N,
-    ExcInternalError());
+  Assert(std::accumulate(v.begin(), v.end(), 0U) == N, ExcInternalError());
 
+  std::vector<IndexSet> locally_owned_dofs_per_processor =
+    dof_handler.locally_owned_dofs_per_processor();
   IndexSet all(N);
-  for (unsigned int i = 0;
-       i < dof_handler.locally_owned_dofs_per_processor().size();
-       ++i)
+  for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
     {
-      IndexSet intersect =
-        all & dof_handler.locally_owned_dofs_per_processor()[i];
+      IndexSet intersect = all & locally_owned_dofs_per_processor[i];
       Assert(intersect.n_elements() == 0, ExcInternalError());
-      all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+      all.add_indices(locally_owned_dofs_per_processor[i]);
     }
 
   Assert(all == complete_index_set(N), ExcInternalError());

--- a/tests/sharedtria/hp_no_cells_01.cc
+++ b/tests/sharedtria/hp_no_cells_01.cc
@@ -80,7 +80,7 @@ test()
 
   deallog << "n_locally_owned_dofs_per_processor: ";
   std::vector<types::global_dof_index> v =
-    dof_handler.n_locally_owned_dofs_per_processor();
+    dof_handler.compute_n_locally_owned_dofs_per_processor();
   unsigned int sum = 0;
   for (unsigned int i = 0; i < v.size(); ++i)
     {
@@ -105,7 +105,7 @@ test()
   Assert(std::accumulate(v.begin(), v.end(), 0U) == N, ExcInternalError());
 
   std::vector<IndexSet> locally_owned_dofs_per_processor =
-    dof_handler.locally_owned_dofs_per_processor();
+    dof_handler.compute_locally_owned_dofs_per_processor();
   IndexSet all(N);
   for (unsigned int i = 0; i < locally_owned_dofs_per_processor.size(); ++i)
     {

--- a/tests/sharedtria/mg_dof_02.cc
+++ b/tests/sharedtria/mg_dof_02.cc
@@ -52,7 +52,7 @@ write_dof_data(DoFHandler<dim> &dof_handler)
   for (unsigned int lvl = 0; lvl < n_levels; ++lvl)
     {
       std::vector<IndexSet> dof_index_per_proc =
-        dof_handler.locally_owned_mg_dofs_per_processor(lvl);
+        dof_handler.compute_locally_owned_mg_dofs_per_processor(lvl);
       for (unsigned int i = 0; i < dof_index_per_proc.size(); ++i)
         dof_index_per_proc[i].print(deallog);
 

--- a/tests/sharedtria/no_cells_01.cc
+++ b/tests/sharedtria/no_cells_01.cc
@@ -74,7 +74,7 @@ test()
 
   deallog << "n_locally_owned_dofs_per_processor: ";
   const std::vector<types::global_dof_index> v =
-    dof_handler.n_locally_owned_dofs_per_processor();
+    dof_handler.compute_n_locally_owned_dofs_per_processor();
   unsigned int sum = 0;
   for (unsigned int i = 0; i < v.size(); ++i)
     {
@@ -87,7 +87,7 @@ test()
   deallog << std::endl;
 
   Assert(dof_handler.n_locally_owned_dofs() ==
-           dof_handler.n_locally_owned_dofs_per_processor()
+           dof_handler.compute_n_locally_owned_dofs_per_processor()
              [triangulation.locally_owned_subdomain()],
          ExcInternalError());
   Assert(dof_handler.n_locally_owned_dofs() ==
@@ -98,12 +98,12 @@ test()
 
   Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
   const std::vector<types::global_dof_index> n_owned_dofs =
-    dof_handler.n_locally_owned_dofs_per_processor();
+    dof_handler.compute_n_locally_owned_dofs_per_processor();
   Assert(std::accumulate(n_owned_dofs.begin(), n_owned_dofs.end(), 0U) == N,
          ExcInternalError());
 
   const std::vector<IndexSet> owned_dofs =
-    dof_handler.locally_owned_dofs_per_processor();
+    dof_handler.compute_locally_owned_dofs_per_processor();
   IndexSet all(N);
   for (unsigned int i = 0; i < owned_dofs.size(); ++i)
     {

--- a/tests/sharedtria/no_cells_01.cc
+++ b/tests/sharedtria/no_cells_01.cc
@@ -73,7 +73,7 @@ test()
           << std::endl;
 
   deallog << "n_locally_owned_dofs_per_processor: ";
-  std::vector<types::global_dof_index> v =
+  const std::vector<types::global_dof_index> v =
     dof_handler.n_locally_owned_dofs_per_processor();
   unsigned int sum = 0;
   for (unsigned int i = 0; i < v.size(); ++i)
@@ -97,21 +97,19 @@ test()
   const unsigned int N = dof_handler.n_dofs();
 
   Assert(dof_handler.n_locally_owned_dofs() <= N, ExcInternalError());
-  Assert(
-    std::accumulate(dof_handler.n_locally_owned_dofs_per_processor().begin(),
-                    dof_handler.n_locally_owned_dofs_per_processor().end(),
-                    0U) == N,
-    ExcInternalError());
+  const std::vector<types::global_dof_index> n_owned_dofs =
+    dof_handler.n_locally_owned_dofs_per_processor();
+  Assert(std::accumulate(n_owned_dofs.begin(), n_owned_dofs.end(), 0U) == N,
+         ExcInternalError());
 
+  const std::vector<IndexSet> owned_dofs =
+    dof_handler.locally_owned_dofs_per_processor();
   IndexSet all(N);
-  for (unsigned int i = 0;
-       i < dof_handler.locally_owned_dofs_per_processor().size();
-       ++i)
+  for (unsigned int i = 0; i < owned_dofs.size(); ++i)
     {
-      IndexSet intersect =
-        all & dof_handler.locally_owned_dofs_per_processor()[i];
+      IndexSet intersect = all & owned_dofs[i];
       Assert(intersect.n_elements() == 0, ExcInternalError());
-      all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+      all.add_indices(owned_dofs[i]);
     }
 
   Assert(all == complete_index_set(N), ExcInternalError());

--- a/tests/trilinos/direct_solver_2.cc
+++ b/tests/trilinos/direct_solver_2.cc
@@ -203,7 +203,7 @@ Step4<dim>::setup_system()
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(
     dsp,
-    dof_handler.n_locally_owned_dofs_per_processor(),
+    dof_handler.compute_n_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     locally_relevant_dofs);
 

--- a/tests/trilinos/direct_solver_3.cc
+++ b/tests/trilinos/direct_solver_3.cc
@@ -165,7 +165,7 @@ Step4<dim>::setup_system()
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(
     dsp,
-    dof_handler.n_locally_owned_dofs_per_processor(),
+    dof_handler.compute_n_locally_owned_dofs_per_processor(),
     MPI_COMM_WORLD,
     locally_relevant_dofs);
 

--- a/tests/trilinos/elide_zeros.cc
+++ b/tests/trilinos/elide_zeros.cc
@@ -173,7 +173,7 @@ namespace LinearAdvectionTest
 
     SparsityTools::distribute_sparsity_pattern(
       dynamic_sparsity_pattern,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       MPI_COMM_WORLD,
       locally_relevant_dofs);
 

--- a/tests/trilinos/renumbering_01.cc
+++ b/tests/trilinos/renumbering_01.cc
@@ -127,7 +127,7 @@ private:
                                     /*keep constrained dofs*/ false);
     SparsityTools::distribute_sparsity_pattern(
       sparsity_pattern,
-      dof_handler.n_locally_owned_dofs_per_processor(),
+      dof_handler.compute_n_locally_owned_dofs_per_processor(),
       MPI_COMM_WORLD,
       locally_relevant_dofs);
 

--- a/tests/trilinos/solver_control_06.cc
+++ b/tests/trilinos/solver_control_06.cc
@@ -220,7 +220,7 @@ Test_Solver_Output::setup_system()
 
   SparsityTools::distribute_sparsity_pattern(
     dsp,
-    dof_handler.n_locally_owned_dofs_per_processor(),
+    dof_handler.compute_n_locally_owned_dofs_per_processor(),
     mpi_comm,
     locally_relevant_dofs);
 


### PR DESCRIPTION
This PR, prepared together with @peterrum, replaces the use of `MPI_Allgather` by the much more efficient `MPI_Exscan` in those cases where we wanted to get a parallel prefix sum (MPI calls the version of the prefix sum where the local element is excluded `MPI_Exscan`).

The second component of this PR is to not store `locally_owned_dofs_per_processor` and `n_locally_dofs_per_processor` in the `NumberCache` of `DoFHandler` according to the discussion in #8067. A clean solution to this change necessitates an incompatible change, namely that we have to make the return type of those vectors by value rather than const reference. I think the use cases are limited. We use those vectors in a few dozens of tests - on the one hand, we utilize them for `distribute_sparsity_pattern` that we should replace by a better implementation in a subsequent pull request, and then for some sanity checks. One thing that does not work any more is that we cannot call `dof_handler.locally_owned_dofs_per_processor()` inside loops whose number of execution is different on different ranks because each call now implies global communication. The alternative would had been to populate the variable on the first call to those functions and then return it. It would have required a lock instead to make only one thread fill it. It would have avoided touching all those tests, but I really think we should discourage those functions because they intrinsically do not scale.

Closes #8067.