### PR TITLE
Mpi compute index owner

### DIFF
--- a/doc/news/changes/minor/20190603PeterMunch
+++ b/doc/news/changes/minor/20190603PeterMunch
@@ -1,0 +1,4 @@
+New: The function Utilities::MPI::compute_index_owner() provides the owner of
+the ghost degrees of freedom relative to a set of locally owned ones. 
+<br>
+(Peter Munch, 2019/06/03)

--- a/doc/news/changes/minor/20190603PeterMunch-1
+++ b/doc/news/changes/minor/20190603PeterMunch-1
@@ -1,0 +1,5 @@
+Improved: The function Utilities::MPI::compute_index_owner() is used in 
+Utilities::MPI::Partitioner to avoid global all-to-all communication, 
+speeding up computations on many MPI ranks.
+<br>
+(Peter Munch, 2019/06/03)

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <numeric>
+#include <set>
 #include <vector>
 
 #if !defined(DEAL_II_WITH_MPI) && !defined(DEAL_II_WITH_PETSC)
@@ -707,6 +708,495 @@ namespace Utilities
     gather(const MPI_Comm &   comm,
            const T &          object_to_send,
            const unsigned int root_process = 0);
+
+    /**
+     * An interface to be able to use the ConsensusAlgorithm classes. The main
+     * functionality of the implementations is to return a list of process ranks
+     * this process wants data from and to deal with the optional payload of the
+     * messages sent/received by the ConsensusAlgorithm classes.
+     *
+     * There are two kinds of messages:
+     * - send/request message: A message consisting of a data request
+     *   which should be answered by another process. This message is
+     *   considered as a request message by the receiving rank.
+     * - recv message: The answer to a send/request message.
+     *
+     * @tparam T1 the type of the elements of the vector to sent
+     * @tparam T2 the type of the elements of the vector to received
+     *
+     * @note Since the payloads of the messages are optional, users have
+     *       to deal with buffers themselves. The ConsensusAlgorithm classes 1)
+     *       deliver only references to empty vectors (of size 0)
+     *       the data to be sent can be inserted to or read from, and
+     *       2) communicate these vectors blindly.
+     *
+     * @author Peter Munch, 2019
+     */
+    template <typename T1, typename T2>
+    class ConsensusAlgorithmProcess
+    {
+    public:
+      /**
+       * @return A vector of ranks this process wants to send a request to.
+       *
+       * @note This is the only method which has to be implemented since the
+       *       payloads of the messages are optional.
+       */
+      virtual std::vector<unsigned int>
+      compute_targets() = 0;
+
+      /**
+       * Add to the request to the process with the specified rank a payload.
+       *
+       * @param[in]  other_rank rank of the process
+       * @param[out] send_buffer data to be sent part of the request (optional)
+       *
+       * @note The buffer is empty. Before using it, you have to set its size.
+       */
+      virtual void
+      pack_recv_buffer(const int other_rank, std::vector<T1> &send_buffer);
+
+      /**
+       * Prepare the buffer where the payload of the answer of the request to
+       * the process with the specified rank is saved in. The most obvious task
+       * is to resize the buffer, since it is empty when the function is called.
+       *
+       * @param[in]  other_rank rank of the process
+       * @param[out] recv_buffer data to be sent part of the request (optional)
+       */
+      virtual void
+      prepare_recv_buffer(const int other_rank, std::vector<T2> &recv_buffer);
+
+      /**
+       * Prepare the buffer where the payload of the answer of the request to
+       * the process with the specified rank is saved in.
+       *
+       * @param[in]  other_rank rank of the process
+       * @param[in]  buffer_recv received payload (optional)
+       * @param[out] request_buffer payload to be sent as part of the request
+       *             (optional)
+       *
+       * @note The request_buffer is empty. Before using it, you have to set
+       *       its size.
+       */
+      virtual void
+      process_request(const unsigned int     other_rank,
+                      const std::vector<T1> &buffer_recv,
+                      std::vector<T2> &      request_buffer);
+
+      /**
+       * Process the payload of the answer of the request to the process with
+       * the specified rank.
+       *
+       * @param[in] other_rank rank of the process
+       * @param[in] recv_buffer data to be sent part of the request (optional)
+       */
+      virtual void
+      unpack_recv_buffer(const int              other_rank,
+                         const std::vector<T2> &recv_buffer);
+    };
+
+    /**
+     * The task of the implementations of this class is to provide the
+     * communication patterns to retrieve data from other processes in a
+     * dynamic-sparse way.
+     *
+     * Dynamic-sparse means in this context:
+     * - by the time this function is called, the other processes do
+     *   not know yet that they have to answer requests
+     * - each process only has to communicate with a small subset of
+     *   processes of the MPI communicator
+     *
+     * Naturally, the user has to provide:
+     * - a communicator
+     * - for each rank a list of ranks of processes this process should
+     *   communicate to
+     * - a functionality to pack/unpack data to be sent/received
+     *
+     * The latter two features should be implemented in a class derived from
+     * ConsensusAlgorithmProcess.
+     *
+     * @tparam T1 the type of the elements of the vector to sent
+     * @tparam T2 the type of the elements of the vector to received
+     *
+     * @author Peter Munch, 2019
+     */
+    template <typename T1, typename T2>
+    class ConsensusAlgorithm
+    {
+    public:
+      ConsensusAlgorithm(ConsensusAlgorithmProcess<T1, T2> &process,
+                         const MPI_Comm &                   comm);
+
+      /**
+       * Destructor.
+       */
+      virtual ~ConsensusAlgorithm() = default;
+
+      virtual void
+      run() = 0;
+
+    protected:
+      /**
+       * Reference to the process provided by the user.
+       */
+      ConsensusAlgorithmProcess<T1, T2> &process;
+
+      /**
+       * MPI communicator.
+       */
+      const MPI_Comm &comm;
+
+      /**
+       * Rank of this process.
+       */
+      const unsigned int my_rank;
+
+      /**
+       * Number of processes in the communicator.
+       */
+      const unsigned int n_procs;
+    };
+
+    /**
+     * This class implements ConsensusAlgorithm, using only point-to-point
+     * communications and a single IBarrier.
+     *
+     * @note This class closely follows the paper Hoefner et. al. "Scalable
+     *       Communication Protocols for Dynamic Sparse Data Exchange".
+     *       Since the algorithm shown there is not considering payloads, the
+     *       algorithm has been  modified here in such a way that synchronous
+     *       sends (Issend) have been replaced by equivalent Isend/Irecv, where
+     *       Irecv receives the answer to a request (with payload).
+     *
+     * @tparam T1 the type of the elements of the vector to sent
+     * @tparam T2 the type of the elements of the vector to received
+     *
+     * @author Peter Munch, 2019
+     */
+    template <typename T1, typename T2>
+    class ConsensusAlgorithm_NBX : public ConsensusAlgorithm<T1, T2>
+    {
+    public:
+      // Unique tags to be used during Isend and Irecv
+      static const unsigned int tag_request  = 12;
+      static const unsigned int tag_delivery = 13;
+
+      /**
+       * Constructor.
+       *
+       * @param process Process to be run during consensus algorithm.
+       * @param comm MPI Communicator
+       */
+      ConsensusAlgorithm_NBX(ConsensusAlgorithmProcess<T1, T2> &process,
+                             const MPI_Comm &                   comm);
+
+      /**
+       * Destructor.
+       */
+      virtual ~ConsensusAlgorithm_NBX() = default;
+
+      /**
+       * Run consensus algorithm.
+       */
+      virtual void
+      run() override;
+
+    private:
+#ifdef DEAL_II_WITH_MPI
+      /**
+       * List of processes this process wants to send requests to.
+       */
+      std::vector<unsigned int> targets;
+
+      /**
+       * Buffers for sending requests.
+       */
+      std::vector<std::vector<T1>> send_buffers;
+
+      /**
+       * Requests for sending requests.
+       */
+      std::vector<MPI_Request> send_requests;
+
+      /**
+       * Buffers for receiving answers to requests.
+       */
+      std::vector<std::vector<T2>> recv_buffers;
+
+
+      /**
+       * Requests for receiving answers to requests.
+       */
+      std::vector<MPI_Request> recv_requests;
+
+      /**
+       * Buffers for sending answers to requests.
+       */
+      std::vector<std::vector<T2>> request_buffers;
+
+      /**
+       * Requests for sending answers to requests.
+       */
+      std::vector<std::shared_ptr<MPI_Request>> request_requests;
+
+      // request for barrier
+      MPI_Request barrier_request;
+#endif
+
+#ifdef DEBUG
+      /**
+       * List of processes who have made a request to this process.
+       */
+      std::set<unsigned int> requesting_processes;
+#endif
+
+      /**
+       * Check if all request answers have been received by this rank.
+       */
+      bool
+      check_own_state();
+
+      /**
+       * Signal to all other ranks that this rank has received all request
+       * answers via entering IBarrier.
+       */
+      void
+      signal_finish();
+
+      /**
+       * Check if all ranks have received all their request answers, i.e.
+       * all ranks have reached the IBarrier.
+       */
+      bool
+      check_global_state();
+
+      /**
+       * A request message from another rank has been received: process the
+       * request and send an answer.
+       */
+      void
+      process_requests();
+
+      /**
+       * Start to send all requests via ISend and post IRecvs for the incoming
+       * answer messages.
+       */
+      void
+      start_communication();
+
+      /**
+       * After all rank has received all answers, the MPI data structures can be
+       * freed and the received answers can be processed.
+       */
+      void
+      clean_up_and_end_communication();
+    };
+
+    /**
+     * This class implements ConsensusAlgorithm, using a two step approach. In
+     * the first step the source ranks are determined and in the second step
+     * a static sparse data exchange is performed.
+     *
+     * @note In contrast to ConsensusAlgorithm_NBX, this class splits the same
+     *       task into two distinct steps. In the first step, all processes are
+     *       identified who want to send a request to this process. In the
+     *       second step, the data is exchanged. However, since - in the second
+     *       step - now it is clear how many requests have to be answered, i.e.
+     *       when this process can stop waiting for requests, no IBarrier is
+     *       needed.
+     *
+     * @note The function compute_point_to_point_communication_pattern() is used
+     *       to determine the source processes, which implements a
+     *       PEX-algorithm from Hoefner et. al. "Scalable Communication
+     *       Protocols for Dynamic Sparse Data Exchange"
+     *
+     * @tparam T1 the type of the elements of the vector to sent
+     * @tparam T2 the type of the elements of the vector to received
+     *
+     * @author Peter Munch, 2019
+     */
+    template <typename T1, typename T2>
+    class ConsensusAlgorithm_PEX : public ConsensusAlgorithm<T1, T2>
+    {
+    public:
+      // Unique tags to be used during Isend and Irecv
+      static const unsigned int tag_request  = 14;
+      static const unsigned int tag_delivery = 15;
+
+      /**
+       * Constructor.
+       *
+       * @param process Process to be run during consensus algorithm.
+       * @param comm MPI Communicator
+       */
+      ConsensusAlgorithm_PEX(ConsensusAlgorithmProcess<T1, T2> &process,
+                             const MPI_Comm &                   comm);
+
+      /**
+       * Destructor.
+       */
+      virtual ~ConsensusAlgorithm_PEX() = default;
+
+      /**
+       * Run consensus algorithm.
+       */
+      virtual void
+      run() override;
+
+    private:
+#ifdef DEAL_II_WITH_MPI
+      /**
+       * List of ranks of processes this processes wants to send a request to.
+       */
+      std::vector<unsigned int> targets;
+
+      /**
+       * List of ranks of processes wanting to send a request to this process.
+       */
+      std::vector<unsigned int> sources;
+
+      // data structures to send and receive requests
+
+      /**
+       * Buffers for sending requests.
+       */
+      std::vector<std::vector<T1>> send_buffers;
+
+      /**
+       * Buffers for receiving answers to requests.
+       */
+      std::vector<std::vector<T2>> recv_buffers;
+
+      /**
+       * Requests for sending requests and receiving answers to requests.
+       */
+      std::vector<MPI_Request> send_and_recv_buffers;
+
+      /**
+       * Buffers for sending answers to requests.
+       */
+      std::vector<std::vector<T2>> requests_buffers;
+
+      /**
+       * Requests for sending answers to requests.
+       */
+      std::vector<MPI_Request> requests_answers;
+#endif
+
+      /**
+       * The ith request message from another rank has been received: process
+       * the request and send an answer.
+       */
+      void
+      process_requests(int index);
+
+      /**
+       * Start to send all requests via ISend and post IRecvs for the incoming
+       * answer messages.
+       */
+      unsigned int
+      start_communication();
+
+      /**
+       * After all answers have been exchanged, the MPI data structures can be
+       * freed and the received answers can be processed.
+       */
+      void
+      clean_up_and_end_communication();
+    };
+
+    /**
+     * A class which delegates its task to other ConsensusAlgorithm
+     * implementations depending on the number of processes in the
+     * MPI communicator. For a small number of processes it uses
+     * ConsensusAlgorithm_PEX and for large number of processes
+     * ConsensusAlgorithm_NBX. The threshold depends if the program is
+     * compiled in debug or release mode.
+     *
+     * @tparam T1 the type of the elements of the vector to sent
+     * @tparam T2 the type of the elements of the vector to received
+     *
+     * @author Peter Munch, 2019
+     */
+    template <typename T1, typename T2>
+    class ConsensusAlgorithmSelector : public ConsensusAlgorithm<T1, T2>
+    {
+    public:
+      /**
+       * Constructor.
+       *
+       * @param process Process to be run during consensus algorithm.
+       * @param comm MPI Communicator.
+       */
+      ConsensusAlgorithmSelector(ConsensusAlgorithmProcess<T1, T2> &process,
+                                 const MPI_Comm &                   comm);
+
+      /**
+       * Destructor.
+       */
+      virtual ~ConsensusAlgorithmSelector() = default;
+
+      /**
+       * Run consensus algorithm. The function call is delegated to another
+       * ConsensusAlgorithm implementation.
+       */
+      virtual void
+      run() override;
+
+    private:
+      // Pointer to the actual ConsensusAlgorithm implementation.
+      std::shared_ptr<ConsensusAlgorithm<T1, T2>> consensus_algo;
+    };
+
+    /**
+     * Given a partitioned index set space, compute the owning MPI process rank
+     * of each element of a second index set according to the partitioned index
+     * set. A natural usage of this function is to compute for each ghosted
+     * degree of freedom the MPI rank of the process owning that index.
+     *
+     * One might think: "But we know which rank a ghost DoF belongs to based on
+     * the subdomain id of the cell it is on". But this heuristic fails for DoFs
+     * on interfaces between ghost cells with different subdomain_ids, or
+     * between a ghost cell and an artificial cell. Furthermore, this class
+     * enables a completely abstract exchange of information without the help of
+     * the grid in terms of neighbors.
+     *
+     * The first argument passed to this function, @p owned_indices, must
+     * uniquely partition an index space between all processes.
+     * Otherwise, there are no limitations on this argument: In particular,
+     * there is no need in partitioning
+     * the index space into contiguous subsets. Furthermore, there are no
+     * limitations
+     * on the second index set @p indices_to_look_up as long as the size matches
+     * the first one. It can be chosen arbitrarily and independently on each
+     * process. In the case that the second index set also contains locally
+     * owned indices, these indices will be treated correctly and the rank of
+     * this process is returned for those entries.
+     *
+     * @note This is a collective operation: all processes within the given
+     * communicator have to call this function. Since this function does not
+     * use MPI_Alltoall or MPI_Allgather, but instead uses non-blocking
+     * point-to-point communication instead, and only a single non-blocking
+     * barrier, it reduces the memory consumption significantly. This function
+     * is suited for large-scale simulations with >100k MPI ranks.
+     *
+     * @param[in] owned_indices Index set with indices locally owned by this
+     *            process.
+     * @param[in] indices_to_look_up Index set containing indices of which the
+     *            user is interested the rank of the owning process.
+     * @param[in] comm MPI communicator.
+     *
+     * @return List containing the MPI process rank for each entry in the index
+     *         set @p indices_to_look_up. The order coincides with the order
+     *         within the ElementIterator.
+     *
+     * @author Peter Munch, 2019
+     */
+    std::vector<unsigned int>
+    compute_index_owner(const IndexSet &owned_indices,
+                        const IndexSet &indices_to_look_up,
+                        const MPI_Comm &comm);
 
 #ifndef DOXYGEN
     // declaration for an internal function that lives in mpi.templates.h

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -233,56 +233,32 @@ namespace Utilities
             }
         }
 
-      // Allocate memory for data that will be exported
-      std::vector<types::global_dof_index> expanded_ghost_indices(
-        n_ghost_indices_data);
       unsigned int n_ghost_targets = 0;
-      if (n_ghost_indices_data > 0)
-        {
-          // Create first a vector of ghost_targets from the list of ghost
-          // indices and then push back new values. When we are done, copy the
-          // data to that field of the partitioner. This way, the variable
-          // ghost_targets will have exactly the size we need, whereas the
-          // vector filled with emplace_back might actually be too long.
-          unsigned int current_proc = 0;
-          ghost_indices_data.fill_index_vector(expanded_ghost_indices);
-          types::global_dof_index current_index = expanded_ghost_indices[0];
-          while (current_index >= first_index[current_proc + 1])
-            current_proc++;
-          AssertIndexRange(current_proc, n_procs);
+      {
+        const auto index_owner =
+          Utilities::MPI::compute_index_owner(this->locally_owned_range_data,
+                                              this->ghost_indices_data,
+                                              this->communicator);
 
-          // since DoFs are contiguous, populate a vector which stores
-          // a process rank and the number of ghosts
-          std::vector<std::pair<unsigned int, unsigned int>> ghost_targets_temp(
-            1, std::pair<unsigned int, unsigned int>(current_proc, 0));
-          n_ghost_targets++;
+        ghost_targets_data.clear();
 
-          // find which process is the owner of other indices:
-          for (unsigned int iterator = 1; iterator < n_ghost_indices_data;
-               ++iterator)
-            {
-              current_index = expanded_ghost_indices[iterator];
-              while (current_index >= first_index[current_proc + 1])
-                current_proc++;
-              AssertIndexRange(current_proc, n_procs);
-              // if we found a new target (i.e. higher rank) then adjust the
-              // pair.second in the last element so that it stores the total
-              // number of ghosts owned by pair.first
-              if (ghost_targets_temp[n_ghost_targets - 1].first < current_proc)
-                {
-                  ghost_targets_temp[n_ghost_targets - 1].second =
-                    iterator - ghost_targets_temp[n_ghost_targets - 1].second;
-                  ghost_targets_temp.emplace_back(current_proc, iterator);
-                  n_ghost_targets++;
-                }
-            }
-          // adjust the last element so that pair.second stores the number of
-          // elements
-          ghost_targets_temp[n_ghost_targets - 1].second =
-            n_ghost_indices_data -
-            ghost_targets_temp[n_ghost_targets - 1].second;
-          ghost_targets_data = ghost_targets_temp;
-        }
+        if (index_owner.size() > 0)
+          {
+            ghost_targets_data.emplace_back(index_owner[0], 0);
+            for (auto i : index_owner)
+              {
+                Assert(i >= ghost_targets_data.back().first,
+                       ExcInternalError(
+                         "Expect result of compute_index_owner to be sorted"));
+                if (i == ghost_targets_data.back().first)
+                  ghost_targets_data.back().second++;
+                else
+                  ghost_targets_data.emplace_back(i, 1);
+              }
+          }
+
+        n_ghost_targets = ghost_targets_data.size();
+      }
       // find the processes that want to import to me
       {
         std::vector<int> send_buffer(n_procs, 0);
@@ -316,9 +292,9 @@ namespace Utilities
       // now that we know how many indices each process will receive from
       // ghosts, send and receive indices for import data. non-blocking receives
       // and blocking sends
-      std::vector<types::global_dof_index> expanded_import_indices(
-        n_import_indices_data);
       {
+        std::vector<types::global_dof_index> expanded_import_indices(
+          n_import_indices_data);
         unsigned int             current_index_start = 0;
         std::vector<MPI_Request> import_requests(import_targets_data.size() +
                                                  n_ghost_targets);
@@ -339,6 +315,10 @@ namespace Utilities
 
         // use non-blocking send for ghost indices stored in
         // expanded_ghost_indices
+        std::vector<types::global_dof_index> expanded_ghost_indices;
+        if (n_ghost_indices_data > 0)
+          ghost_indices_data.fill_index_vector(expanded_ghost_indices);
+
         current_index_start = 0;
         for (unsigned int i = 0; i < n_ghost_targets; i++)
           {

--- a/tests/multigrid/transfer_matrix_free_06.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=15.output
+++ b/tests/multigrid/transfer_matrix_free_06.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=15.output
@@ -1,0 +1,178 @@
+
+DEAL::FE: FESystem<2>[FE_Q<2>(1)^2]
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0.00000
+DEAL::Diff prolongate   l2: 0.00000
+DEAL::Diff prolongate   l3: 9.61481e-17
+DEAL::Diff prolongate   l4: 2.54384e-16
+DEAL::Diff prolongate   l5: 2.97645e-16
+DEAL::Diff prolongate   l6: 3.06884e-16
+DEAL::Diff restrict     l1: 0.00000
+DEAL::Diff restrict add l1: 0.00000
+DEAL::Diff restrict     l2: 0.00000
+DEAL::Diff restrict add l2: 0.00000
+DEAL::Diff restrict     l3: 1.04148e-15
+DEAL::Diff restrict add l3: 8.88178e-16
+DEAL::Diff restrict     l4: 9.55050e-16
+DEAL::Diff restrict add l4: 9.42055e-16
+DEAL::Diff restrict     l5: 1.42178e-15
+DEAL::Diff restrict add l5: 1.60119e-15
+DEAL::Diff restrict     l6: 1.33227e-15
+DEAL::Diff restrict add l6: 1.50598e-15
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 5.55112e-17
+DEAL::Diff prolongate   l2: 2.71948e-16
+DEAL::Diff prolongate   l3: 5.75552e-16
+DEAL::Diff prolongate   l4: 6.31096e-16
+DEAL::Diff prolongate   l5: 7.90669e-16
+DEAL::Diff prolongate   l6: 1.02785e-15
+DEAL::Diff restrict     l1: 8.30815e-16
+DEAL::Diff restrict add l1: 8.88178e-16
+DEAL::Diff restrict     l2: 1.42178e-15
+DEAL::Diff restrict add l2: 1.77636e-15
+DEAL::Diff restrict     l3: 3.87307e-15
+DEAL::Diff restrict add l3: 4.02752e-15
+DEAL::Diff restrict     l4: 3.21773e-15
+DEAL::Diff restrict add l4: 3.74196e-15
+DEAL::Diff restrict     l5: 3.55098e-15
+DEAL::Diff restrict add l5: 4.13027e-15
+DEAL::Diff restrict     l6: 4.89947e-15
+DEAL::Diff restrict add l6: 5.45706e-15
+DEAL::
+DEAL::FE: FESystem<2>[FE_Q<2>(3)^2]
+DEAL::no. cells: 88
+DEAL::Diff prolongate   l1: 4.25485e-16
+DEAL::Diff prolongate   l2: 1.29017e-15
+DEAL::Diff prolongate   l3: 2.00231e-15
+DEAL::Diff prolongate   l4: 2.31946e-15
+DEAL::Diff prolongate   l5: 1.85168e-15
+DEAL::Diff restrict     l1: 7.69185e-16
+DEAL::Diff restrict add l1: 7.69185e-16
+DEAL::Diff restrict     l2: 2.67435e-15
+DEAL::Diff restrict add l2: 2.85221e-15
+DEAL::Diff restrict     l3: 4.72265e-15
+DEAL::Diff restrict add l3: 5.11185e-15
+DEAL::Diff restrict     l4: 5.29601e-15
+DEAL::Diff restrict add l4: 6.06877e-15
+DEAL::Diff restrict     l5: 4.22786e-15
+DEAL::Diff restrict add l5: 4.66822e-15
+DEAL::
+DEAL::no. cells: 510
+DEAL::Diff prolongate   l1: 1.95148e-15
+DEAL::Diff prolongate   l2: 4.10380e-15
+DEAL::Diff prolongate   l3: 3.44413e-15
+DEAL::Diff prolongate   l4: 4.64940e-15
+DEAL::Diff prolongate   l5: 5.43550e-15
+DEAL::Diff restrict     l1: 5.04518e-15
+DEAL::Diff restrict add l1: 5.79447e-15
+DEAL::Diff restrict     l2: 1.14867e-14
+DEAL::Diff restrict add l2: 1.25214e-14
+DEAL::Diff restrict     l3: 1.02271e-14
+DEAL::Diff restrict add l3: 1.09412e-14
+DEAL::Diff restrict     l4: 1.17679e-14
+DEAL::Diff restrict add l4: 1.32526e-14
+DEAL::Diff restrict     l5: 1.38716e-14
+DEAL::Diff restrict add l5: 1.55288e-14
+DEAL::
+DEAL::FE: FESystem<3>[FE_Q<3>(1)^2]
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0.00000
+DEAL::Diff prolongate   l2: 0.00000
+DEAL::Diff restrict     l1: 0.00000
+DEAL::Diff restrict add l1: 0.00000
+DEAL::Diff restrict     l2: 0.00000
+DEAL::Diff restrict add l2: 0.00000
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 2.41669e-16
+DEAL::Diff prolongate   l2: 3.91794e-16
+DEAL::Diff prolongate   l3: 1.01512e-15
+DEAL::Diff prolongate   l4: 1.55516e-15
+DEAL::Diff restrict     l1: 2.51215e-15
+DEAL::Diff restrict add l1: 2.17558e-15
+DEAL::Diff restrict     l2: 2.94575e-15
+DEAL::Diff restrict add l2: 2.94575e-15
+DEAL::Diff restrict     l3: 6.51541e-15
+DEAL::Diff restrict add l3: 7.00761e-15
+DEAL::Diff restrict     l4: 9.59492e-15
+DEAL::Diff restrict add l4: 1.07043e-14
+DEAL::
+DEAL::FE: FESystem<3>[FE_Q<3>(3)^2]
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 223
+DEAL::Diff prolongate   l1: 6.16822e-15
+DEAL::Diff prolongate   l2: 9.02624e-15
+DEAL::Diff prolongate   l3: 6.05143e-15
+DEAL::Diff restrict     l1: 2.49384e-14
+DEAL::Diff restrict add l1: 2.64056e-14
+DEAL::Diff restrict     l2: 3.99229e-14
+DEAL::Diff restrict add l2: 4.12483e-14
+DEAL::Diff restrict     l3: 3.05119e-14
+DEAL::Diff restrict add l3: 3.08762e-14
+DEAL::
+DEAL::FE: FESystem<2>[FE_Q<2>(2)^2]
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 4.16500e-08
+DEAL::Diff prolongate   l2: 1.14933e-07
+DEAL::Diff prolongate   l3: 4.36323e-07
+DEAL::Diff prolongate   l4: 4.56555e-07
+DEAL::Diff prolongate   l5: 6.44943e-07
+DEAL::Diff prolongate   l6: 6.88182e-07
+DEAL::Diff restrict     l1: 1.30930e-07
+DEAL::Diff restrict add l1: 1.61321e-07
+DEAL::Diff restrict     l2: 3.31534e-07
+DEAL::Diff restrict add l2: 3.70787e-07
+DEAL::Diff restrict     l3: 9.06752e-07
+DEAL::Diff restrict add l3: 1.06748e-06
+DEAL::Diff restrict     l4: 1.12259e-06
+DEAL::Diff restrict add l4: 1.27800e-06
+DEAL::Diff restrict     l5: 1.32543e-06
+DEAL::Diff restrict add l5: 1.66341e-06
+DEAL::Diff restrict     l6: 1.39826e-06
+DEAL::Diff restrict add l6: 1.79262e-06
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 3.33987e-07
+DEAL::Diff prolongate   l2: 7.05824e-07
+DEAL::Diff prolongate   l3: 1.48105e-06
+DEAL::Diff prolongate   l4: 1.34450e-06
+DEAL::Diff prolongate   l5: 1.51185e-06
+DEAL::Diff prolongate   l6: 1.87422e-06
+DEAL::Diff restrict     l1: 6.89860e-07
+DEAL::Diff restrict add l1: 9.08311e-07
+DEAL::Diff restrict     l2: 1.47143e-06
+DEAL::Diff restrict add l2: 1.75614e-06
+DEAL::Diff restrict     l3: 3.26568e-06
+DEAL::Diff restrict add l3: 3.98218e-06
+DEAL::Diff restrict     l4: 2.87348e-06
+DEAL::Diff restrict add l4: 3.39202e-06
+DEAL::Diff restrict     l5: 3.24632e-06
+DEAL::Diff restrict add l5: 3.95530e-06
+DEAL::Diff restrict     l6: 3.95620e-06
+DEAL::Diff restrict add l6: 4.98782e-06
+DEAL::
+DEAL::FE: FESystem<3>[FE_Q<3>(2)^2]
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 1.41616e-07
+DEAL::Diff prolongate   l2: 2.80670e-07
+DEAL::Diff restrict     l1: 6.42811e-07
+DEAL::Diff restrict add l1: 6.42811e-07
+DEAL::Diff restrict     l2: 1.11616e-06
+DEAL::Diff restrict add l2: 1.15446e-06
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 1.19894e-06
+DEAL::Diff prolongate   l2: 1.53705e-06
+DEAL::Diff prolongate   l3: 2.59694e-06
+DEAL::Diff prolongate   l4: 3.66785e-06
+DEAL::Diff restrict     l1: 3.54901e-06
+DEAL::Diff restrict add l1: 3.80668e-06
+DEAL::Diff restrict     l2: 4.41015e-06
+DEAL::Diff restrict add l2: 4.66617e-06
+DEAL::Diff restrict     l3: 7.02679e-06
+DEAL::Diff restrict add l3: 7.83739e-06
+DEAL::Diff restrict     l4: 9.56069e-06
+DEAL::Diff restrict add l4: 1.05378e-05
+DEAL::


### PR DESCRIPTION
The function `Utilities::MPI::compute_index_owner()` provides the owner of the ghost degrees of freedom relative to a set of locally owned ones. This function is used `Utilities::MPI::Partitioner` to avoid global all-to-all communication, speeding up computations on many MPI ranks.

I will also apply this new function in `internal::MGTransfer::fill_copy_indices`. However, this is still work in progress.

Relates to #8293 and #8298 .