### PR TITLE
Fix typo in link for the step-17 introduction

### DIFF
--- a/examples/step-17/doc/intro.dox
+++ b/examples/step-17/doc/intro.dox
@@ -72,7 +72,7 @@ In general, to be truly able to scale to large numbers of processors, one
 needs to split between the available processors <i>every</i> data structure
 whose size scales with the size of the overall problem. (For a definition
 of what it means for a program to "scale", see 
-@ref GlossParallelScaling "this glossary entry.) This includes, for
+@ref GlossParallelScaling "this glossary entry".) This includes, for
 example, the triangulation, the matrix, and all global vectors (solution, right
 hand side). If one doesn't split all of these objects, one of those will be
 replicated on all processors and will eventually simply become too large


### PR DESCRIPTION
The missing marks make doxygen render the whole line as the link, which is certainly not what we want.