### PR TITLE
Avoid unused variable in dof_handler_policy.cc

### DIFF
--- a/doc/news/changes/incompatibilities/20190603MartinKronbichler
+++ b/doc/news/changes/incompatibilities/20190603MartinKronbichler
@@ -1,9 +1,11 @@
 Changed: The functions DoFHandler::n_locally_owned_dofs_per_processor(),
 DoFHandler::locally_owned_dofs_per_processor() and
-DoFHandler::locally_owned_mg_dofs_per_processor() previously return a
+DoFHandler::locally_owned_mg_dofs_per_processor() previously returned a
 reference to an internally stored array of index sets on all processors. As
 this cannot scale to large processor counts, these functions have been marked
-deprecated and only populate the internal vectors on the first demand. Use the
+deprecated and only populate the internal vectors on the first demand. This
+means that the first call must be a collective call on all MPI ranks to ensure
+that the underlying MPI_Allgather function completes. Use the
 new functions DoFHandler::compute_n_locally_owned_dofs_per_processor(),
 DoFHandler::compute_locally_owned_dofs_per_processor() and
 DoFHandler::compute_locally_owned_mg_dofs_per_processor() instead or, even

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -5753,6 +5753,8 @@ namespace internal
         // general case
         const IndexSet index_set = dof_handler->locally_owned_mg_dofs(level);
 
+#ifdef DEAL_II_WITH_MPI
+
         constexpr int dim      = DoFHandlerType::dimension;
         constexpr int spacedim = DoFHandlerType::space_dimension;
         const parallel::Triangulation<dim, spacedim> *tr =
@@ -5760,7 +5762,6 @@ namespace internal
             &this->dof_handler->get_triangulation()));
         Assert(tr != nullptr, ExcInternalError());
 
-#ifdef DEAL_II_WITH_MPI
         const unsigned int my_rank =
           Utilities::MPI::this_mpi_process(tr->get_communicator());
 


### PR DESCRIPTION
The cdash instance [1] complains about an unused variables due to my changes in #8298. This PR moves the offending code block into the `DEAL_II_WITH_MPI` block.

Furthermore, I slightly extended the changelog entry describing the incompatibility as it was not entirely clear what is incompatible and what is merely deprecated.

[1] http://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=10343 [minimal_bundled build, no MPI]