### PR TITLE
Fix compilation on MSVS 2017

### DIFF
--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -1972,8 +1972,8 @@ namespace FEValuesViews
    * @author Luca Heltai, 2019.
    */
   template <int dim, int spacedim, typename Extractor>
-  using View =
-    typename internal::FEValuesViews::ViewType<dim, spacedim, Extractor>::type;
+  using View = typename dealii::internal::FEValuesViews::
+    ViewType<dim, spacedim, Extractor>::type;
 } // namespace FEValuesViews
 
 


### PR DESCRIPTION
Added namespace `dealii::` in front of `internal`.

This should fix #7928 