### PR TITLE
Introduced CellDataTransfer.

### DIFF
--- a/doc/news/changes/incompatibilities/20190606Fehling
+++ b/doc/news/changes/incompatibilities/20190606Fehling
@@ -4,4 +4,5 @@ The least dominant element of their children will be picked, according to
 hp::FECollection::find_dominated_fe_extended(). This affects the implementations
 of SolutionTransfer, parallel::distributed::SolutionTransfer, parallel::CellWeights,
 and hp::DoFHandler.
+<br>
 (Marc Fehling, 2019/06/06)

--- a/doc/news/changes/incompatibilities/20190626Fehling
+++ b/doc/news/changes/incompatibilities/20190626Fehling
@@ -1,0 +1,10 @@
+Changed: The CoarseningStrategies struct has been moved out of the
+parallel::distributed::CellDataTransfer class into a separate header and
+is now treated as a namespace. Its static member functions are now free
+functions and only take a `std::vector` as a parameter that contains all
+the data from the children. Therefore, the `coarsening_strategy`
+parameter for the constructor of the
+parallel::distributed::CellDataTransfer class has to be adjusted
+accordingly as well.
+<br>
+(Marc Fehling, 2019/06/26)

--- a/doc/news/changes/minor/20190626Fehling
+++ b/doc/news/changes/minor/20190626Fehling
@@ -1,0 +1,4 @@
+New: Class CellDataTransfer has been introduced to transfer cell by cell
+data across meshes in case of refinement/serialization.
+<br>
+(Marc Fehling, 2019/06/26)

--- a/include/deal.II/distributed/cell_data_transfer.templates.h
+++ b/include/deal.II/distributed/cell_data_transfer.templates.h
@@ -37,23 +37,33 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-namespace
+namespace internal
 {
-  template <typename VectorType>
-  void
-  post_refinement_action(std::vector<VectorType *> &all_out)
+  namespace parallel
   {
-    for (auto &out : all_out)
-      out->compress(::dealii::VectorOperation::insert);
-  }
+    namespace distributed
+    {
+      namespace CellDataTransferImplementation
+      {
+        template <typename VectorType>
+        void
+        post_unpack_action(std::vector<VectorType *> &all_out)
+        {
+          for (auto &out : all_out)
+            out->compress(::dealii::VectorOperation::insert);
+        }
 
-  template <typename ValueType>
-  void
-  post_refinement_action(std::vector<std::vector<ValueType> *> &)
-  {
-    // Do nothing for std::vector as VectorType.
-  }
-} // namespace
+        template <typename value_type>
+        void
+        post_unpack_action(std::vector<std::vector<value_type> *> &)
+        {
+          // Do nothing for std::vector as VectorType.
+        }
+      } // namespace CellDataTransferImplementation
+    }   // namespace distributed
+  }     // namespace parallel
+} // namespace internal
+
 
 
 namespace parallel
@@ -212,7 +222,8 @@ namespace parallel
                   std::placeholders::_3,
                   std::ref(all_out)));
 
-      post_refinement_action(all_out);
+      dealii::internal::parallel::distributed::CellDataTransferImplementation::
+        post_unpack_action(all_out);
 
       input_vectors.clear();
     }

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3556,6 +3556,18 @@ public:
                  << "The given boundary_id " << arg1
                  << " is not defined in this Triangulation!");
 
+  /**
+   * Exception
+   *
+   * @ingroup Exceptions
+   */
+  DeclExceptionMsg(
+    ExcInconsistentCoarseningFlags,
+    "A cell is flagged for coarsening, but either not all of its siblings "
+    "are active or flagged for coarsening as well. Please clean up all "
+    "coarsen flags on your triangulation via "
+    "Triangulation::prepare_coarsening_and_refinement() beforehand!");
+
   /*
    * @}
    */

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -26,8 +26,6 @@
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/template_constraints.h>
 
-#include <deal.II/distributed/cell_data_transfer.templates.h>
-
 #include <deal.II/dofs/deprecated_function_map.h>
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_iterator_selector.h>
@@ -46,6 +44,15 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 class Triangulation;
+
+namespace parallel
+{
+  namespace distributed
+  {
+    template <int dim, int spacedim, typename VectorType>
+    class CellDataTransfer;
+  }
+} // namespace parallel
 
 namespace internal
 {

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -768,11 +768,31 @@ namespace hp
     BlockMask
     block_mask(const ComponentMask &component_mask) const;
 
+    /**
+     * @name Exceptions
+     * @{
+     */
 
     /**
      * Exception
+     *
+     * @ingroup Exceptions
      */
     DeclException0(ExcNoFiniteElements);
+
+    /**
+     * Exception
+     *
+     * @ingroup Exceptions
+     */
+    DeclExceptionMsg(
+      ExcNoDominatedFiniteElementAmongstChildren,
+      "No FiniteElement has been found in your FECollection that is "
+      "dominated by all children of a cell you are trying to coarsen!");
+
+    /**
+     * @}
+     */
 
   private:
     /**

--- a/include/deal.II/numerics/cell_data_transfer.h
+++ b/include/deal.II/numerics/cell_data_transfer.h
@@ -1,0 +1,206 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_cell_data_transfer_h
+#define dealii_cell_data_transfer_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/smartpointer.h>
+
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/numerics/coarsening_strategies.h>
+
+#include <algorithm>
+#include <functional>
+#include <set>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * Transfer data that is associated with each active cell (like error
+ * indicators) while refining and/or coarsening a triangulation.
+ *
+ * This class therefore does for cell-related information what
+ * SolutionTransfer does for the values of degrees of freedom defined on a
+ * Triangulation.
+ *
+ * A non-distributed container (like Vector or `std::vector`) has to be
+ * provided, which holds the cell-wise data in the same order as active cells
+ * are traversed. In other words, each entry corresponds to the cell with the
+ * same index CellAccessor::active_cell_index(), and the container has to be of
+ * size Triangulation::n_active_cells().
+ *
+ * <h3>Transferring cell-wise data</h3>
+ *
+ * The following code snippet demonstrates how to transfer cell-related data
+ * across refinement/coarsening of the registered triangulation.
+ *
+ * @code
+ * // prepare the triangulation,
+ * triangulation.prepare_coarsening_and_refinement();
+ *
+ * // prepare the CellDataTransfer object for coarsening and refinement
+ * // and give the cell data vector that we intend to unpack later,
+ * Vector<double> data_to_transfer(triangulation.n_active_cells());
+ * //[fill data_to_transfer with cell-wise values...]
+ *
+ * CellDataTransfer<dim, spacedim, Vector<double>>
+ *   cell_data_trans(triangulation);
+ * cell_data_trans.prepare_for_coarsening_and_refinement();
+ *
+ * // actually execute the refinement,
+ * triangulation.execute_coarsening_and_refinement();
+ *
+ * // unpack transferred data,
+ * Vector<double> transferred_data(triangulation.n_active_cells());
+ * cell_data_trans.unpack(data_to_transfer, transferred_data);
+ * @endcode
+ *
+ * When using a parallel::shared::Triangulation, we need to ensure that we have
+ * the global data available in our local vector before refinement happened. We
+ * can achieve this as follows:
+ *
+ * @code
+ * Vector<double> data_to_transfer(triangulation.n_active_cells());
+ * //[fill data_to_transfer with cell-wise values...]
+ *
+ * PETScWrappers::MPI::Vector
+ * distributed_data_to_transfer(mpi_communicator,
+ *                              triangulation.n_active_cells(),
+ *                              triangulation.n_locally_owned_active_cells());
+ * for (const auto &cell : triangulation.active_cell_iterators())
+ *   if (cell->is_locally_owned())
+ *     {
+ *       const unsigned int index = cell->active_cell_index();
+ *       distributed_data_to_transfer(index) = data_to_transfer(index);
+ *     }
+ * distributed_data_to_transfer.compress(VectorOperation::insert);
+ *
+ * data_to_transfer = distributed_data_to_transfer;
+ * @endcode
+ *
+ * For the parallel distributed case, a designated class
+ * parallel::distributed::CellDataTransfer is available. Please refer to this
+ * particular class when using a parallel::distributed::Triangulation.
+ *
+ * @note See the documentation of SolutionTransfer for matching code snippets
+ *   for transfer.
+ *
+ * @ingroup numerics
+ * @author Marc Fehling, 2019
+ */
+template <int dim, int spacedim = dim, typename VectorType = Vector<double>>
+class CellDataTransfer
+{
+private:
+  /**
+   * An alias that defines the data type of provided container template.
+   */
+  using value_type = typename VectorType::value_type;
+
+public:
+  /**
+   * Constructor.
+   *
+   * @param[in] triangulation The triangulation on which all operations will
+   *   happen. At the time when this constructor is called, the refinement
+   *   in question has not happened yet.
+   * @param[in] coarsening_strategy Function deciding which data to store on
+   *   a cell whose children will get coarsened into.
+   */
+  CellDataTransfer(
+    const Triangulation<dim, spacedim> &                triangulation,
+    const std::function<value_type(
+      const std::vector<value_type> &children_indices)> coarsening_strategy =
+      &CoarseningStrategies::check_equality<value_type>);
+
+  /**
+   * Prepare the current object for coarsening and refinement.
+   *
+   * Stores the active_cell_indices of all active cells on the associated
+   * triangulation and attribute them to either persisting, refined or coarsened
+   * cells.
+   */
+  void
+  prepare_for_coarsening_and_refinement();
+
+  /**
+   * Transfer the information from the previous mesh to the updated one.
+   *
+   * Data from the previous mesh supplied by @p in will be transferred to the updated
+   * mesh and stored in @p out. @p out has to provide enough space to hold the
+   * transferred data, i.e. has to be of size `triangulation.n_active_cells()`.
+   */
+  void
+  unpack(const VectorType &in, VectorType &out);
+
+private:
+  /**
+   * Pointer to the triangulation to work with.
+   */
+  SmartPointer<const Triangulation<dim, spacedim>,
+               CellDataTransfer<dim, spacedim, VectorType>>
+    triangulation;
+
+  /**
+   * Function deciding on how to process data from children to be stored on the
+   * parent cell.
+   */
+  const std::function<value_type(
+    const std::vector<value_type> &children_indices)>
+    coarsening_strategy;
+
+  /**
+   * Container to temporarily store the iterator and active cell index
+   * of cells that persist.
+   */
+  std::map<const typename Triangulation<dim, spacedim>::cell_iterator,
+           const unsigned int>
+    persisting_cells_active_index;
+
+  /**
+   * Container to temporarily store the iterator and active cell index
+   * of cells that will be refined.
+   */
+  std::map<const typename Triangulation<dim, spacedim>::cell_iterator,
+           const unsigned int>
+    refined_cells_active_index;
+
+  /**
+   * Container to temporarily store the iterator of parent cells that will
+   * remain after coarsening along with the active cell indices of the
+   * corresponding children cells.
+   */
+  std::map<const typename Triangulation<dim, spacedim>::cell_iterator,
+           const std::set<unsigned int>>
+    coarsened_cells_active_index;
+
+  /**
+   * Number of active cells on the initial triangulation that has not been
+   * refined yet.
+   *
+   * It will be set in prepare_for_coarsening_and_refinement() and used to
+   * validate user inputs after refinement happened (only in debug mode).
+   */
+  unsigned int n_active_cells_pre;
+};
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif /* dealii_cell_data_transfer_h */

--- a/include/deal.II/numerics/cell_data_transfer.templates.h
+++ b/include/deal.II/numerics/cell_data_transfer.templates.h
@@ -1,0 +1,197 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_cell_data_transfer_templates_h
+#define dealii_cell_data_transfer_templates_h
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/numerics/cell_data_transfer.h>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+
+namespace internal
+{
+  namespace CellDataTransferImplementation
+  {
+    template <typename VectorType>
+    void
+    post_unpack_action(VectorType &out)
+    {
+      out.compress(::dealii::VectorOperation::insert);
+    }
+
+    template <typename value_type>
+    void
+    post_unpack_action(std::vector<value_type> &)
+    {
+      // Do nothing for std::vector as VectorType.
+    }
+  } // namespace CellDataTransferImplementation
+} // namespace internal
+
+
+
+template <int dim, int spacedim, typename VectorType>
+CellDataTransfer<dim, spacedim, VectorType>::CellDataTransfer(
+  const Triangulation<dim, spacedim> &                triangulation,
+  const std::function<value_type(
+    const std::vector<value_type> &children_indices)> coarsening_strategy)
+  : triangulation(&triangulation, typeid(*this).name())
+  , coarsening_strategy(coarsening_strategy)
+  , n_active_cells_pre(numbers::invalid_unsigned_int)
+{
+  Assert(
+    (dynamic_cast<const parallel::distributed::Triangulation<dim, spacedim> *>(
+       &triangulation) == nullptr),
+    ExcMessage("You are calling the CellDataTransfer class "
+               "with a parallel::distributed::Triangulation. "
+               "You probably want to use the "
+               "parallel::distributed::CellDataTransfer class."));
+}
+
+
+
+template <int dim, int spacedim, typename VectorType>
+void
+CellDataTransfer<dim, spacedim, VectorType>::
+  prepare_for_coarsening_and_refinement()
+{
+  // Cleanup previous indices.
+  refined_cells_active_index.clear();
+  coarsened_cells_active_index.clear();
+  persisting_cells_active_index.clear();
+
+  for (const auto &cell : triangulation->active_cell_iterators())
+    {
+      // Store iterator and active cell index of cells that will be refined.
+      if (cell->refine_flag_set())
+        {
+          refined_cells_active_index.insert({cell, cell->active_cell_index()});
+        }
+      else if (cell->coarsen_flag_set())
+        {
+          // Gather the iterator to the parent cell of cells that will be
+          // coarsened. Store it together with the active cell indices of all
+          // its children.
+          Assert(cell->level() > 0, ExcInternalError());
+          const auto &parent = cell->parent();
+
+          // Check if the active_cell_indices for the current cell have
+          // been determined already.
+          if (coarsened_cells_active_index.find(parent) ==
+              coarsened_cells_active_index.end())
+            {
+              std::set<unsigned int> indices_children;
+              for (unsigned int child_index = 0;
+                   child_index < parent->n_children();
+                   ++child_index)
+                {
+                  const auto sibling = parent->child(child_index);
+                  Assert(sibling->active() && sibling->coarsen_flag_set(),
+                         typename dealii::Triangulation<
+                           dim>::ExcInconsistentCoarseningFlags());
+
+                  indices_children.insert(sibling->active_cell_index());
+                }
+              AssertDimension(indices_children.size(), parent->n_children());
+
+              coarsened_cells_active_index.insert({parent, indices_children});
+            }
+        }
+      else
+        {
+          // Store iterator and active cell index of all other cells.
+          persisting_cells_active_index.insert(
+            {cell, cell->active_cell_index()});
+        }
+    }
+
+#ifdef DEBUG
+  n_active_cells_pre = triangulation->n_active_cells();
+#else
+  (void)n_active_cells_pre;
+#endif
+}
+
+
+
+template <int dim, int spacedim, typename VectorType>
+void
+CellDataTransfer<dim, spacedim, VectorType>::unpack(const VectorType &in,
+                                                    VectorType &      out)
+{
+#ifdef DEBUG
+  Assert(in.size() == n_active_cells_pre,
+         ExcDimensionMismatch(in.size(), n_active_cells_pre));
+  Assert(out.size() == triangulation->n_active_cells(),
+         ExcDimensionMismatch(out.size(), triangulation->n_active_cells()));
+#else
+  (void)n_active_cells_pre;
+#endif
+
+  // Transfer data of persisting cells.
+  for (const auto &persisting : persisting_cells_active_index)
+    {
+      Assert(persisting.first->active(), ExcInternalError());
+      out[persisting.first->active_cell_index()] = in[persisting.second];
+    }
+
+  // Transfer data of the parent cell to all of its children that it has been
+  // refined to.
+  for (const auto &refined : refined_cells_active_index)
+    for (unsigned int child_index = 0;
+         child_index < refined.first->n_children();
+         ++child_index)
+      {
+        const auto child = refined.first->child(child_index);
+        Assert(child->active(), ExcInternalError());
+        out[child->active_cell_index()] = in[refined.second];
+      }
+
+  // Transfer data from the former children to the cell that they have been
+  // coarsened to.
+  std::vector<value_type> children_values;
+  for (const auto &coarsened : coarsened_cells_active_index)
+    {
+      // Get previous values of former children.
+      children_values.resize(coarsened.second.size());
+
+      auto indices_it = coarsened.second.cbegin();
+      auto values_it  = children_values.begin();
+      for (; indices_it != coarsened.second.cend(); ++indices_it, ++values_it)
+        *values_it = in[*indices_it];
+      Assert(values_it == children_values.end(), ExcInternalError());
+
+      // Decide how to handle the previous data.
+      const value_type parent_value = coarsening_strategy(children_values);
+
+      // Set value for the parent cell.
+      Assert(coarsened.first->active(), ExcInternalError());
+      out[coarsened.first->active_cell_index()] = parent_value;
+    }
+
+  internal::CellDataTransferImplementation::post_unpack_action(out);
+}
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif /* dealii_cell_data_transfer_templates_h */

--- a/include/deal.II/numerics/coarsening_strategies.h
+++ b/include/deal.II/numerics/coarsening_strategies.h
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_coarsening_strategies_h
+#define dealii_coarsening_strategies_h
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exceptions.h>
+
+#include <algorithm>
+#include <numeric>
+#include <typeinfo>
+#include <vector>
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * When data is transferred during coarsening, it is not trivial to decide
+ * how to handle data of child cells which will be coarsened. Or in other
+ * words, which data should be stored in the corresponding parent cell.
+ *
+ * In this namespace, we offer a few strategies that cope with this
+ * problem. Such strategies can be passed to the CellDataTransfer and
+ * parallel::distributed::CellDataTransfer constructors.
+ *
+ * @author Marc Fehling, 2019
+ */
+namespace CoarseningStrategies
+{
+  /**
+   * Check if data on all children match, and return that value.
+   */
+  template <typename value_type>
+  value_type
+  check_equality(const std::vector<value_type> &children_values);
+
+  /**
+   * Return sum of data on all children.
+   */
+  template <typename value_type>
+  value_type
+  sum(const std::vector<value_type> &children_values);
+
+  /**
+   * Return mean value of data on all children.
+   */
+  template <typename value_type>
+  value_type
+  mean(const std::vector<value_type> &children_values);
+
+  /**
+   * Return maximum value of data on all children.
+   */
+  template <typename value_type>
+  value_type
+  max(const std::vector<value_type> &children_values);
+} // namespace CoarseningStrategies
+
+
+
+/* ---------------- template functions ---------------- */
+
+#ifndef DOXYGEN
+
+namespace CoarseningStrategies
+{
+  template <typename value_type>
+  value_type
+  check_equality(const std::vector<value_type> &children_values)
+  {
+    Assert(!children_values.empty(), ExcInternalError());
+
+    const auto first_child = children_values.cbegin();
+    for (auto other_child = first_child + 1;
+         other_child != children_values.cend();
+         ++other_child)
+      Assert(*first_child == *other_child,
+             ExcMessage(
+               "Values on cells that will be coarsened are not equal!"));
+
+    return *first_child;
+  }
+
+
+
+  template <typename value_type>
+  value_type
+  sum(const std::vector<value_type> &children_values)
+  {
+    static_assert(std::is_arithmetic<value_type>::value &&
+                    !std::is_same<value_type, bool>::value,
+                  "The provided value_type may not meet the requirements "
+                  "of this function.");
+
+    Assert(!children_values.empty(), ExcInternalError());
+    return std::accumulate(children_values.cbegin(),
+                           children_values.cend(),
+                           static_cast<value_type>(0));
+  }
+
+
+
+  template <typename value_type>
+  value_type
+  mean(const std::vector<value_type> &children_values)
+  {
+    return sum<value_type>(children_values) / children_values.size();
+  }
+
+
+
+  template <typename value_type>
+  value_type
+  max(const std::vector<value_type> &children_values)
+  {
+    Assert(!children_values.empty(), ExcInternalError());
+    return *std::max_element(children_values.cbegin(), children_values.cend());
+  }
+} // namespace CoarseningStrategies
+
+#endif
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif /* dealii_coarsening_strategies_h */

--- a/source/distributed/cell_data_transfer.inst.in
+++ b/source/distributed/cell_data_transfer.inst.in
@@ -15,16 +15,13 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     SCALAR : REAL_SCALARS)
   {
 #if deal_II_dimension <= deal_II_space_dimension
     template class parallel::distributed::CellDataTransfer<
       deal_II_dimension,
       deal_II_space_dimension,
-      Vector<double>>;
-    template class parallel::distributed::CellDataTransfer<
-      deal_II_dimension,
-      deal_II_space_dimension,
-      Vector<float>>;
+      Vector<SCALAR>>;
 #endif
   }

--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -145,18 +145,23 @@ namespace parallel
             std::set<unsigned int> fe_indices_children;
             for (unsigned int child_index = 0; child_index < cell->n_children();
                  ++child_index)
-              fe_indices_children.insert(
-                cell->child(child_index)->future_fe_index());
+              {
+                const auto child = cell->child(child_index);
+                Assert(child->active() && child->coarsen_flag_set(),
+                       typename dealii::Triangulation<
+                         dim>::ExcInconsistentCoarseningFlags());
+
+                fe_indices_children.insert(child->future_fe_index());
+              }
+            Assert(!fe_indices_children.empty(), ExcInternalError());
 
             fe_index =
               dof_handler->get_fe_collection().find_dominated_fe_extended(
                 fe_indices_children, /*codim=*/0);
 
             Assert(fe_index != numbers::invalid_unsigned_int,
-                   ExcMessage(
-                     "No FiniteElement has been found in your FECollection "
-                     "that is dominated by all children of a cell you are "
-                     "trying to coarsen!"));
+                   typename dealii::hp::FECollection<
+                     dim>::ExcNoDominatedFiniteElementAmongstChildren());
           }
           break;
 

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -266,19 +266,23 @@ namespace parallel
                   for (unsigned int child_index = 0;
                        child_index < cell->n_children();
                        ++child_index)
-                    fe_indices_children.insert(
-                      cell->child(child_index)->future_fe_index());
+                    {
+                      const auto child = cell->child(child_index);
+                      Assert(child->active() && child->coarsen_flag_set(),
+                             typename dealii::Triangulation<
+                               dim>::ExcInconsistentCoarseningFlags());
+
+                      fe_indices_children.insert(child->future_fe_index());
+                    }
+                  Assert(!fe_indices_children.empty(), ExcInternalError());
 
                   fe_index =
                     dof_handler->get_fe_collection().find_dominated_fe_extended(
                       fe_indices_children, /*codim=*/0);
 
-                  Assert(
-                    fe_index != numbers::invalid_unsigned_int,
-                    ExcMessage(
-                      "No FiniteElement has been found in your FECollection "
-                      "that is dominated by all children of a cell you are "
-                      "trying to coarsen!"));
+                  Assert(fe_index != numbers::invalid_unsigned_int,
+                         typename dealii::hp::FECollection<
+                           dim>::ExcNoDominatedFiniteElementAmongstChildren());
 
                   break;
                 }

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -991,10 +991,10 @@ namespace internal
         communicate_active_fe_indices(
           dealii::hp::DoFHandler<dim, spacedim> &dof_handler)
         {
-          if (const parallel::shared::Triangulation<dim, spacedim> *tr =
+          if (const dealii::parallel::shared::Triangulation<dim, spacedim> *tr =
                 dynamic_cast<
-                  const parallel::shared::Triangulation<dim, spacedim> *>(
-                  &dof_handler.get_triangulation()))
+                  const dealii::parallel::shared::Triangulation<dim, spacedim>
+                    *>(&dof_handler.get_triangulation()))
             {
               // we have a shared triangulation. in this case, every processor
               // knows about all cells, but every processor only has knowledge
@@ -1029,10 +1029,11 @@ namespace internal
                     cell->index(),
                     active_fe_indices[cell->active_cell_index()]);
             }
-          else if (const parallel::distributed::Triangulation<dim, spacedim>
-                     *tr = dynamic_cast<
-                       const parallel::distributed::Triangulation<dim, spacedim>
-                         *>(&dof_handler.get_triangulation()))
+          else if (const dealii::parallel::distributed::Triangulation<dim,
+                                                                      spacedim>
+                     *tr = dynamic_cast<const dealii::parallel::distributed::
+                                          Triangulation<dim, spacedim> *>(
+                       &dof_handler.get_triangulation()))
             {
               // For completely distributed meshes, use the function that is
               // able to move data from locally owned cells on one processor to
@@ -1068,10 +1069,10 @@ namespace internal
           else
             {
               // a sequential triangulation. there is nothing we need to do here
-              Assert(
-                (dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
-                   &dof_handler.get_triangulation()) == nullptr),
-                ExcInternalError());
+              Assert((dynamic_cast<
+                        const dealii::parallel::Triangulation<dim, spacedim> *>(
+                        &dof_handler.get_triangulation()) == nullptr),
+                     ExcInternalError());
             }
         }
 

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -18,6 +18,7 @@
 #include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/thread_management.h>
 
+#include <deal.II/distributed/cell_data_transfer.templates.h>
 #include <deal.II/distributed/shared_tria.h>
 #include <deal.II/distributed/tria.h>
 
@@ -35,6 +36,8 @@
 #include <deal.II/hp/dof_faces.h>
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/dof_level.h>
+
+#include <deal.II/numerics/coarsening_strategies.h>
 
 #include <boost/serialization/array.hpp>
 
@@ -1120,6 +1123,7 @@ namespace internal
                     // particular cell has a parent at all.
                     Assert(cell->level() > 0, ExcInternalError());
                     const auto &parent = cell->parent();
+
                     // Check if the active_fe_index for the current cell has
                     // been determined already.
                     if (fe_transfer->coarsened_cells_fe_index.find(parent) ==
@@ -1134,11 +1138,14 @@ namespace internal
                              child_index < parent->n_children();
                              ++child_index)
                           {
-                            Assert(parent->child(child_index)->active(),
-                                   ExcInternalError());
+                            const auto sibling = parent->child(child_index);
+                            Assert(sibling->active() &&
+                                     sibling->coarsen_flag_set(),
+                                   typename dealii::Triangulation<
+                                     dim>::ExcInconsistentCoarseningFlags());
 
                             fe_indices_children.insert(
-                              parent->child(child_index)->future_fe_index());
+                              sibling->future_fe_index());
                           }
                         Assert(!fe_indices_children.empty(),
                                ExcInternalError());
@@ -1147,12 +1154,9 @@ namespace internal
                           dof_handler.fe_collection.find_dominated_fe_extended(
                             fe_indices_children, /*codim=*/0);
 
-                        Assert(
-                          fe_index != numbers::invalid_unsigned_int,
-                          ExcMessage(
-                            "No FiniteElement has been found in your FECollection "
-                            "that is dominated by all children of a cell you are "
-                            "trying to coarsen!"));
+                        Assert(fe_index != numbers::invalid_unsigned_int,
+                               typename dealii::hp::FECollection<dim>::
+                                 ExcNoDominatedFiniteElementAmongstChildren());
 
                         fe_transfer->coarsened_cells_fe_index.insert(
                           {parent, fe_index});
@@ -1184,22 +1188,22 @@ namespace internal
           const auto &fe_transfer = dof_handler.active_fe_index_transfer;
 
           // Set active_fe_indices on persisting cells.
-          for (const auto &pair : fe_transfer->persisting_cells_fe_index)
+          for (const auto &persist : fe_transfer->persisting_cells_fe_index)
             {
-              const auto &cell = pair.first;
+              const auto &cell = persist.first;
 
               if (cell->is_locally_owned())
                 {
                   Assert(cell->active(), ExcInternalError());
-                  cell->set_active_fe_index(pair.second);
+                  cell->set_active_fe_index(persist.second);
                 }
             }
 
           // Distribute active_fe_indices from all refined cells on their
           // respective children.
-          for (const auto &pair : fe_transfer->refined_cells_fe_index)
+          for (const auto &refine : fe_transfer->refined_cells_fe_index)
             {
-              const auto &parent = pair.first;
+              const auto &parent = refine.first;
 
               for (unsigned int child_index = 0;
                    child_index < parent->n_children();
@@ -1208,18 +1212,18 @@ namespace internal
                   const auto &child = parent->child(child_index);
                   Assert(child->is_locally_owned() && child->active(),
                          ExcInternalError());
-                  child->set_active_fe_index(pair.second);
+                  child->set_active_fe_index(refine.second);
                 }
             }
 
           // Set active_fe_indices on coarsened cells that have been determined
           // before the actual coarsening happened.
-          for (const auto &pair : fe_transfer->coarsened_cells_fe_index)
+          for (const auto &coarsen : fe_transfer->coarsened_cells_fe_index)
             {
-              const auto &cell = pair.first;
+              const auto &cell = coarsen.first;
               Assert(cell->is_locally_owned() && cell->active(),
                      ExcInternalError());
-              cell->set_active_fe_index(pair.second);
+              cell->set_active_fe_index(coarsen.second);
             }
         }
       };
@@ -2085,10 +2089,7 @@ namespace hp
             CellDataTransfer<dim, spacedim, std::vector<unsigned int>>>(
           *distributed_tria,
           /*transfer_variable_size_data=*/false,
-          &parallel::distributed::CellDataTransfer<
-            dim,
-            spacedim,
-            std::vector<unsigned int>>::CoarseningStrategies::check_equality);
+          &CoarseningStrategies::check_equality<unsigned int>);
 
         active_fe_index_transfer->cell_data_transfer
           ->prepare_for_coarsening_and_refinement(
@@ -2191,10 +2192,7 @@ namespace hp
             CellDataTransfer<dim, spacedim, std::vector<unsigned int>>>(
           *distributed_tria,
           /*transfer_variable_size_data=*/false,
-          &parallel::distributed::CellDataTransfer<
-            dim,
-            spacedim,
-            std::vector<unsigned int>>::CoarseningStrategies::check_equality);
+          &CoarseningStrategies::check_equality<unsigned int>);
 
         // If we work on a p::d::Triangulation, we have to transfer all
         // active fe indices since ownership of cells may change.
@@ -2267,10 +2265,7 @@ namespace hp
             CellDataTransfer<dim, spacedim, std::vector<unsigned int>>>(
           *distributed_tria,
           /*transfer_variable_size_data=*/false,
-          &parallel::distributed::CellDataTransfer<
-            dim,
-            spacedim,
-            std::vector<unsigned int>>::CoarseningStrategies::check_equality);
+          &CoarseningStrategies::check_equality<unsigned int>);
 
         // Unpack active_fe_indices.
         active_fe_index_transfer->active_fe_indices.resize(

--- a/source/numerics/CMakeLists.txt
+++ b/source/numerics/CMakeLists.txt
@@ -35,6 +35,7 @@ SET(_unity_include_src
   )
 
 SET(_separate_src
+  cell_data_transfer.cc
   data_out_dof_data.cc
   data_out_dof_data_inst2.cc
   data_out_dof_data_codim.cc
@@ -73,6 +74,7 @@ SETUP_SOURCE_LIST("${_unity_include_src}"
   )
 
 SET(_inst
+  cell_data_transfer.inst.in
   data_out_dof_data.inst.in
   data_out_dof_data_codim.inst.in
   data_out_faces.inst.in

--- a/source/numerics/cell_data_transfer.cc
+++ b/source/numerics/cell_data_transfer.cc
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/numerics/cell_data_transfer.templates.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+// explicit instantiations
+#include "cell_data_transfer.inst"
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/numerics/cell_data_transfer.inst.in
+++ b/source/numerics/cell_data_transfer.inst.in
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     SCALAR : REAL_SCALARS)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+    template class CellDataTransfer<deal_II_dimension,
+                                    deal_II_space_dimension,
+                                    Vector<SCALAR>>;
+#endif
+  }

--- a/tests/mpi/cell_data_transfer_03.cc
+++ b/tests/mpi/cell_data_transfer_03.cc
@@ -29,13 +29,10 @@
 #include "../tests.h"
 
 
-template <int dim, int spacedim>
 std::vector<int>
-get_data_of_first_child(const typename parallel::distributed::
-                          Triangulation<dim, spacedim>::cell_iterator &parent,
-                        const std::vector<std::vector<int>> &input_vector)
+get_data_of_first_child(const std::vector<std::vector<int>> &children_values)
 {
-  return input_vector[parent->child(0)->active_cell_index()];
+  return children_values[0];
 }
 
 
@@ -89,10 +86,9 @@ test()
   // ----- transfer -----
   parallel::distributed::
     CellDataTransfer<dim, spacedim, std::vector<std::vector<int>>>
-      cell_data_transfer(
-        tria,
-        /*transfer_variable_size_data=*/true,
-        /*coarsening_strategy=*/&get_data_of_first_child<dim, spacedim>);
+      cell_data_transfer(tria,
+                         /*transfer_variable_size_data=*/true,
+                         /*coarsening_strategy=*/&get_data_of_first_child);
 
   cell_data_transfer.prepare_for_coarsening_and_refinement(cell_data);
   tria.execute_coarsening_and_refinement();

--- a/tests/numerics/cell_data_transfer.cc
+++ b/tests/numerics/cell_data_transfer.cc
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// CellDataTransfer test by refinement
+// for sequential Triangulation
+
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/numerics/cell_data_transfer.templates.h>
+
+#include <string>
+
+#include "../tests.h"
+
+
+template <int dim, int spacedim>
+void
+test()
+{
+  // ------ setup ------
+  Triangulation<dim, spacedim> tria;
+
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+  tria.refine_global(1);
+  deallog << "cells before: " << tria.n_global_active_cells() << std::endl;
+
+  // ----- prepare -----
+  // set refinement/coarsening flags
+  for (auto &cell : tria.active_cell_iterators())
+    {
+      if (cell->id().to_string() == "0_1:0")
+        cell->set_refine_flag();
+      else if (((dim == 1) && (cell->parent()->id().to_string() == "1_0:")) ||
+               ((dim == 2) && (cell->parent()->id().to_string() == "3_0:")) ||
+               ((dim == 3) && (cell->parent()->id().to_string() == "7_0:")))
+        cell->set_coarsen_flag();
+    }
+
+  // ----- gather -----
+  // store parent id of all cells
+  std::vector<unsigned int> cell_ids_pre(tria.n_active_cells());
+  for (auto &cell : tria.active_cell_iterators())
+    {
+      const std::string  parent_cellid = cell->parent()->id().to_string();
+      const unsigned int parent_coarse_cell_id =
+        static_cast<unsigned int>(std::stoul(parent_cellid));
+      cell_ids_pre[cell->active_cell_index()] = parent_coarse_cell_id;
+
+      deallog << "cellid=" << cell->id()
+              << " parentid=" << cell_ids_pre[cell->active_cell_index()];
+      if (cell->coarsen_flag_set())
+        deallog << " coarsening";
+      else if (cell->refine_flag_set())
+        deallog << " refining";
+      deallog << std::endl;
+    }
+
+  // ----- transfer -----
+  CellDataTransfer<dim, spacedim, std::vector<unsigned int>> cell_data_transfer(
+    tria);
+
+  cell_data_transfer.prepare_for_coarsening_and_refinement();
+  tria.execute_coarsening_and_refinement();
+  deallog << "cells after: " << tria.n_global_active_cells() << std::endl;
+
+  std::vector<unsigned int> cell_ids_post(tria.n_active_cells());
+  cell_data_transfer.unpack(cell_ids_pre, cell_ids_post);
+
+  // ------ verify ------
+  // check if all children adopted the correct id
+  for (auto &cell : tria.active_cell_iterators())
+    deallog << "cellid=" << cell->id()
+            << " parentid=" << cell_ids_post[(cell->active_cell_index())]
+            << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  initlog();
+
+  deallog.push("1d");
+  test<1, 1>();
+  deallog.pop();
+  deallog.push("2d");
+  test<2, 2>();
+  deallog.pop();
+  deallog.push("3d");
+  test<3, 3>();
+  deallog.pop();
+}

--- a/tests/numerics/cell_data_transfer.output
+++ b/tests/numerics/cell_data_transfer.output
@@ -1,0 +1,178 @@
+
+DEAL:1d::cells before: 4
+DEAL:1d::cellid=0_1:0 parentid=0 refining
+DEAL:1d::cellid=0_1:1 parentid=0
+DEAL:1d::cellid=1_1:0 parentid=1 coarsening
+DEAL:1d::cellid=1_1:1 parentid=1 coarsening
+DEAL:1d::cells after: 4
+DEAL:1d::cellid=1_0: parentid=1
+DEAL:1d::cellid=0_1:1 parentid=0
+DEAL:1d::cellid=0_2:00 parentid=0
+DEAL:1d::cellid=0_2:01 parentid=0
+DEAL:1d::OK
+DEAL:2d::cells before: 16
+DEAL:2d::cellid=0_1:0 parentid=0 refining
+DEAL:2d::cellid=0_1:1 parentid=0
+DEAL:2d::cellid=0_1:2 parentid=0
+DEAL:2d::cellid=0_1:3 parentid=0
+DEAL:2d::cellid=1_1:0 parentid=1
+DEAL:2d::cellid=1_1:1 parentid=1
+DEAL:2d::cellid=1_1:2 parentid=1
+DEAL:2d::cellid=1_1:3 parentid=1
+DEAL:2d::cellid=2_1:0 parentid=2
+DEAL:2d::cellid=2_1:1 parentid=2
+DEAL:2d::cellid=2_1:2 parentid=2
+DEAL:2d::cellid=2_1:3 parentid=2
+DEAL:2d::cellid=3_1:0 parentid=3 coarsening
+DEAL:2d::cellid=3_1:1 parentid=3 coarsening
+DEAL:2d::cellid=3_1:2 parentid=3 coarsening
+DEAL:2d::cellid=3_1:3 parentid=3 coarsening
+DEAL:2d::cells after: 16
+DEAL:2d::cellid=3_0: parentid=3
+DEAL:2d::cellid=0_1:1 parentid=0
+DEAL:2d::cellid=0_1:2 parentid=0
+DEAL:2d::cellid=0_1:3 parentid=0
+DEAL:2d::cellid=1_1:0 parentid=1
+DEAL:2d::cellid=1_1:1 parentid=1
+DEAL:2d::cellid=1_1:2 parentid=1
+DEAL:2d::cellid=1_1:3 parentid=1
+DEAL:2d::cellid=2_1:0 parentid=2
+DEAL:2d::cellid=2_1:1 parentid=2
+DEAL:2d::cellid=2_1:2 parentid=2
+DEAL:2d::cellid=2_1:3 parentid=2
+DEAL:2d::cellid=0_2:00 parentid=0
+DEAL:2d::cellid=0_2:01 parentid=0
+DEAL:2d::cellid=0_2:02 parentid=0
+DEAL:2d::cellid=0_2:03 parentid=0
+DEAL:2d::OK
+DEAL:3d::cells before: 64
+DEAL:3d::cellid=0_1:0 parentid=0 refining
+DEAL:3d::cellid=0_1:1 parentid=0
+DEAL:3d::cellid=0_1:2 parentid=0
+DEAL:3d::cellid=0_1:3 parentid=0
+DEAL:3d::cellid=0_1:4 parentid=0
+DEAL:3d::cellid=0_1:5 parentid=0
+DEAL:3d::cellid=0_1:6 parentid=0
+DEAL:3d::cellid=0_1:7 parentid=0
+DEAL:3d::cellid=1_1:0 parentid=1
+DEAL:3d::cellid=1_1:1 parentid=1
+DEAL:3d::cellid=1_1:2 parentid=1
+DEAL:3d::cellid=1_1:3 parentid=1
+DEAL:3d::cellid=1_1:4 parentid=1
+DEAL:3d::cellid=1_1:5 parentid=1
+DEAL:3d::cellid=1_1:6 parentid=1
+DEAL:3d::cellid=1_1:7 parentid=1
+DEAL:3d::cellid=2_1:0 parentid=2
+DEAL:3d::cellid=2_1:1 parentid=2
+DEAL:3d::cellid=2_1:2 parentid=2
+DEAL:3d::cellid=2_1:3 parentid=2
+DEAL:3d::cellid=2_1:4 parentid=2
+DEAL:3d::cellid=2_1:5 parentid=2
+DEAL:3d::cellid=2_1:6 parentid=2
+DEAL:3d::cellid=2_1:7 parentid=2
+DEAL:3d::cellid=3_1:0 parentid=3
+DEAL:3d::cellid=3_1:1 parentid=3
+DEAL:3d::cellid=3_1:2 parentid=3
+DEAL:3d::cellid=3_1:3 parentid=3
+DEAL:3d::cellid=3_1:4 parentid=3
+DEAL:3d::cellid=3_1:5 parentid=3
+DEAL:3d::cellid=3_1:6 parentid=3
+DEAL:3d::cellid=3_1:7 parentid=3
+DEAL:3d::cellid=4_1:0 parentid=4
+DEAL:3d::cellid=4_1:1 parentid=4
+DEAL:3d::cellid=4_1:2 parentid=4
+DEAL:3d::cellid=4_1:3 parentid=4
+DEAL:3d::cellid=4_1:4 parentid=4
+DEAL:3d::cellid=4_1:5 parentid=4
+DEAL:3d::cellid=4_1:6 parentid=4
+DEAL:3d::cellid=4_1:7 parentid=4
+DEAL:3d::cellid=5_1:0 parentid=5
+DEAL:3d::cellid=5_1:1 parentid=5
+DEAL:3d::cellid=5_1:2 parentid=5
+DEAL:3d::cellid=5_1:3 parentid=5
+DEAL:3d::cellid=5_1:4 parentid=5
+DEAL:3d::cellid=5_1:5 parentid=5
+DEAL:3d::cellid=5_1:6 parentid=5
+DEAL:3d::cellid=5_1:7 parentid=5
+DEAL:3d::cellid=6_1:0 parentid=6
+DEAL:3d::cellid=6_1:1 parentid=6
+DEAL:3d::cellid=6_1:2 parentid=6
+DEAL:3d::cellid=6_1:3 parentid=6
+DEAL:3d::cellid=6_1:4 parentid=6
+DEAL:3d::cellid=6_1:5 parentid=6
+DEAL:3d::cellid=6_1:6 parentid=6
+DEAL:3d::cellid=6_1:7 parentid=6
+DEAL:3d::cellid=7_1:0 parentid=7 coarsening
+DEAL:3d::cellid=7_1:1 parentid=7 coarsening
+DEAL:3d::cellid=7_1:2 parentid=7 coarsening
+DEAL:3d::cellid=7_1:3 parentid=7 coarsening
+DEAL:3d::cellid=7_1:4 parentid=7 coarsening
+DEAL:3d::cellid=7_1:5 parentid=7 coarsening
+DEAL:3d::cellid=7_1:6 parentid=7 coarsening
+DEAL:3d::cellid=7_1:7 parentid=7 coarsening
+DEAL:3d::cells after: 64
+DEAL:3d::cellid=7_0: parentid=7
+DEAL:3d::cellid=0_1:1 parentid=0
+DEAL:3d::cellid=0_1:2 parentid=0
+DEAL:3d::cellid=0_1:3 parentid=0
+DEAL:3d::cellid=0_1:4 parentid=0
+DEAL:3d::cellid=0_1:5 parentid=0
+DEAL:3d::cellid=0_1:6 parentid=0
+DEAL:3d::cellid=0_1:7 parentid=0
+DEAL:3d::cellid=1_1:0 parentid=1
+DEAL:3d::cellid=1_1:1 parentid=1
+DEAL:3d::cellid=1_1:2 parentid=1
+DEAL:3d::cellid=1_1:3 parentid=1
+DEAL:3d::cellid=1_1:4 parentid=1
+DEAL:3d::cellid=1_1:5 parentid=1
+DEAL:3d::cellid=1_1:6 parentid=1
+DEAL:3d::cellid=1_1:7 parentid=1
+DEAL:3d::cellid=2_1:0 parentid=2
+DEAL:3d::cellid=2_1:1 parentid=2
+DEAL:3d::cellid=2_1:2 parentid=2
+DEAL:3d::cellid=2_1:3 parentid=2
+DEAL:3d::cellid=2_1:4 parentid=2
+DEAL:3d::cellid=2_1:5 parentid=2
+DEAL:3d::cellid=2_1:6 parentid=2
+DEAL:3d::cellid=2_1:7 parentid=2
+DEAL:3d::cellid=3_1:0 parentid=3
+DEAL:3d::cellid=3_1:1 parentid=3
+DEAL:3d::cellid=3_1:2 parentid=3
+DEAL:3d::cellid=3_1:3 parentid=3
+DEAL:3d::cellid=3_1:4 parentid=3
+DEAL:3d::cellid=3_1:5 parentid=3
+DEAL:3d::cellid=3_1:6 parentid=3
+DEAL:3d::cellid=3_1:7 parentid=3
+DEAL:3d::cellid=4_1:0 parentid=4
+DEAL:3d::cellid=4_1:1 parentid=4
+DEAL:3d::cellid=4_1:2 parentid=4
+DEAL:3d::cellid=4_1:3 parentid=4
+DEAL:3d::cellid=4_1:4 parentid=4
+DEAL:3d::cellid=4_1:5 parentid=4
+DEAL:3d::cellid=4_1:6 parentid=4
+DEAL:3d::cellid=4_1:7 parentid=4
+DEAL:3d::cellid=5_1:0 parentid=5
+DEAL:3d::cellid=5_1:1 parentid=5
+DEAL:3d::cellid=5_1:2 parentid=5
+DEAL:3d::cellid=5_1:3 parentid=5
+DEAL:3d::cellid=5_1:4 parentid=5
+DEAL:3d::cellid=5_1:5 parentid=5
+DEAL:3d::cellid=5_1:6 parentid=5
+DEAL:3d::cellid=5_1:7 parentid=5
+DEAL:3d::cellid=6_1:0 parentid=6
+DEAL:3d::cellid=6_1:1 parentid=6
+DEAL:3d::cellid=6_1:2 parentid=6
+DEAL:3d::cellid=6_1:3 parentid=6
+DEAL:3d::cellid=6_1:4 parentid=6
+DEAL:3d::cellid=6_1:5 parentid=6
+DEAL:3d::cellid=6_1:6 parentid=6
+DEAL:3d::cellid=6_1:7 parentid=6
+DEAL:3d::cellid=0_2:00 parentid=0
+DEAL:3d::cellid=0_2:01 parentid=0
+DEAL:3d::cellid=0_2:02 parentid=0
+DEAL:3d::cellid=0_2:03 parentid=0
+DEAL:3d::cellid=0_2:04 parentid=0
+DEAL:3d::cellid=0_2:05 parentid=0
+DEAL:3d::cellid=0_2:06 parentid=0
+DEAL:3d::cellid=0_2:07 parentid=0
+DEAL:3d::OK

--- a/tests/sharedtria/cell_data_transfer_01.cc
+++ b/tests/sharedtria/cell_data_transfer_01.cc
@@ -1,0 +1,138 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// CellDataTransfer test by refinement
+// for parallel::shared::Triangulation without artificial cells
+
+
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/vector.templates.h>
+
+#include <deal.II/numerics/cell_data_transfer.templates.h>
+
+#include <string>
+
+#include "../tests.h"
+
+
+template <int dim, int spacedim>
+void
+test()
+{
+  // ------ setup ------
+  MPI_Comm                             mpi_communicator(MPI_COMM_WORLD);
+  parallel::shared::Triangulation<dim> tria(mpi_communicator,
+                                            ::Triangulation<dim>::none,
+                                            false);
+
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+  tria.refine_global(1);
+  deallog << "cells before: " << tria.n_global_active_cells() << std::endl;
+
+  // ----- prepare -----
+  // set refinement/coarsening flags
+  for (auto &cell : tria.active_cell_iterators())
+    {
+      if (cell->id().to_string() == "0_1:0")
+        cell->set_refine_flag();
+      else if (((dim == 1) && (cell->parent()->id().to_string() == "1_0:")) ||
+               ((dim == 2) && (cell->parent()->id().to_string() == "3_0:")) ||
+               ((dim == 3) && (cell->parent()->id().to_string() == "7_0:")))
+        cell->set_coarsen_flag();
+    }
+
+  // ----- gather -----
+  // store parent id of all locally owned cells
+  Vector<unsigned int> cell_ids_pre(tria.n_active_cells());
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        const std::string  parent_cellid = cell->parent()->id().to_string();
+        const unsigned int parent_coarse_cell_id =
+          static_cast<unsigned int>(std::stoul(parent_cellid));
+        cell_ids_pre(cell->active_cell_index()) = parent_coarse_cell_id;
+      }
+
+  // distribute local vector (as presented in step-18)
+  PETScWrappers::MPI::Vector distributed_cell_ids_pre(
+    mpi_communicator,
+    tria.n_active_cells(),
+    tria.n_locally_owned_active_cells());
+
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      distributed_cell_ids_pre(cell->active_cell_index()) =
+        cell_ids_pre(cell->active_cell_index());
+  distributed_cell_ids_pre.compress(VectorOperation::insert);
+
+  cell_ids_pre = distributed_cell_ids_pre;
+
+  // output initial situation
+  for (const auto &cell : tria.active_cell_iterators())
+    {
+      deallog << "cellid=" << cell->id()
+              << " parentid=" << cell_ids_pre(cell->active_cell_index());
+      if (cell->coarsen_flag_set())
+        deallog << " coarsening";
+      else if (cell->refine_flag_set())
+        deallog << " refining";
+      deallog << std::endl;
+    }
+
+  // ----- transfer -----
+  CellDataTransfer<dim, spacedim, Vector<unsigned int>> cell_data_transfer(
+    tria);
+
+  cell_data_transfer.prepare_for_coarsening_and_refinement();
+  tria.execute_coarsening_and_refinement();
+  deallog << "cells after: " << tria.n_global_active_cells() << std::endl;
+
+  Vector<unsigned int> cell_ids_post(tria.n_active_cells());
+  cell_data_transfer.unpack(cell_ids_pre, cell_ids_post);
+
+  // ------ verify ------
+  // check if all children adopted the correct id
+  for (auto &cell : tria.active_cell_iterators())
+    deallog << "cellid=" << cell->id()
+            << " parentid=" << cell_ids_post(cell->active_cell_index())
+            << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("1d");
+  test<1, 1>();
+  deallog.pop();
+  deallog.push("2d");
+  test<2, 2>();
+  deallog.pop();
+  deallog.push("3d");
+  test<3, 3>();
+  deallog.pop();
+}

--- a/tests/sharedtria/cell_data_transfer_01.with_mpi=true.with_petsc=true.mpirun=1.output
+++ b/tests/sharedtria/cell_data_transfer_01.with_mpi=true.with_petsc=true.mpirun=1.output
@@ -1,0 +1,178 @@
+
+DEAL:0:1d::cells before: 4
+DEAL:0:1d::cellid=0_1:0 parentid=0 refining
+DEAL:0:1d::cellid=0_1:1 parentid=0
+DEAL:0:1d::cellid=1_1:0 parentid=1 coarsening
+DEAL:0:1d::cellid=1_1:1 parentid=1 coarsening
+DEAL:0:1d::cells after: 4
+DEAL:0:1d::cellid=1_0: parentid=1
+DEAL:0:1d::cellid=0_1:1 parentid=0
+DEAL:0:1d::cellid=0_2:00 parentid=0
+DEAL:0:1d::cellid=0_2:01 parentid=0
+DEAL:0:1d::OK
+DEAL:0:2d::cells before: 16
+DEAL:0:2d::cellid=0_1:0 parentid=0 refining
+DEAL:0:2d::cellid=0_1:1 parentid=0
+DEAL:0:2d::cellid=0_1:2 parentid=0
+DEAL:0:2d::cellid=0_1:3 parentid=0
+DEAL:0:2d::cellid=1_1:0 parentid=1
+DEAL:0:2d::cellid=1_1:1 parentid=1
+DEAL:0:2d::cellid=1_1:2 parentid=1
+DEAL:0:2d::cellid=1_1:3 parentid=1
+DEAL:0:2d::cellid=2_1:0 parentid=2
+DEAL:0:2d::cellid=2_1:1 parentid=2
+DEAL:0:2d::cellid=2_1:2 parentid=2
+DEAL:0:2d::cellid=2_1:3 parentid=2
+DEAL:0:2d::cellid=3_1:0 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:1 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:2 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:3 parentid=3 coarsening
+DEAL:0:2d::cells after: 16
+DEAL:0:2d::cellid=3_0: parentid=3
+DEAL:0:2d::cellid=0_1:1 parentid=0
+DEAL:0:2d::cellid=0_1:2 parentid=0
+DEAL:0:2d::cellid=0_1:3 parentid=0
+DEAL:0:2d::cellid=1_1:0 parentid=1
+DEAL:0:2d::cellid=1_1:1 parentid=1
+DEAL:0:2d::cellid=1_1:2 parentid=1
+DEAL:0:2d::cellid=1_1:3 parentid=1
+DEAL:0:2d::cellid=2_1:0 parentid=2
+DEAL:0:2d::cellid=2_1:1 parentid=2
+DEAL:0:2d::cellid=2_1:2 parentid=2
+DEAL:0:2d::cellid=2_1:3 parentid=2
+DEAL:0:2d::cellid=0_2:00 parentid=0
+DEAL:0:2d::cellid=0_2:01 parentid=0
+DEAL:0:2d::cellid=0_2:02 parentid=0
+DEAL:0:2d::cellid=0_2:03 parentid=0
+DEAL:0:2d::OK
+DEAL:0:3d::cells before: 64
+DEAL:0:3d::cellid=0_1:0 parentid=0 refining
+DEAL:0:3d::cellid=0_1:1 parentid=0
+DEAL:0:3d::cellid=0_1:2 parentid=0
+DEAL:0:3d::cellid=0_1:3 parentid=0
+DEAL:0:3d::cellid=0_1:4 parentid=0
+DEAL:0:3d::cellid=0_1:5 parentid=0
+DEAL:0:3d::cellid=0_1:6 parentid=0
+DEAL:0:3d::cellid=0_1:7 parentid=0
+DEAL:0:3d::cellid=1_1:0 parentid=1
+DEAL:0:3d::cellid=1_1:1 parentid=1
+DEAL:0:3d::cellid=1_1:2 parentid=1
+DEAL:0:3d::cellid=1_1:3 parentid=1
+DEAL:0:3d::cellid=1_1:4 parentid=1
+DEAL:0:3d::cellid=1_1:5 parentid=1
+DEAL:0:3d::cellid=1_1:6 parentid=1
+DEAL:0:3d::cellid=1_1:7 parentid=1
+DEAL:0:3d::cellid=2_1:0 parentid=2
+DEAL:0:3d::cellid=2_1:1 parentid=2
+DEAL:0:3d::cellid=2_1:2 parentid=2
+DEAL:0:3d::cellid=2_1:3 parentid=2
+DEAL:0:3d::cellid=2_1:4 parentid=2
+DEAL:0:3d::cellid=2_1:5 parentid=2
+DEAL:0:3d::cellid=2_1:6 parentid=2
+DEAL:0:3d::cellid=2_1:7 parentid=2
+DEAL:0:3d::cellid=3_1:0 parentid=3
+DEAL:0:3d::cellid=3_1:1 parentid=3
+DEAL:0:3d::cellid=3_1:2 parentid=3
+DEAL:0:3d::cellid=3_1:3 parentid=3
+DEAL:0:3d::cellid=3_1:4 parentid=3
+DEAL:0:3d::cellid=3_1:5 parentid=3
+DEAL:0:3d::cellid=3_1:6 parentid=3
+DEAL:0:3d::cellid=3_1:7 parentid=3
+DEAL:0:3d::cellid=4_1:0 parentid=4
+DEAL:0:3d::cellid=4_1:1 parentid=4
+DEAL:0:3d::cellid=4_1:2 parentid=4
+DEAL:0:3d::cellid=4_1:3 parentid=4
+DEAL:0:3d::cellid=4_1:4 parentid=4
+DEAL:0:3d::cellid=4_1:5 parentid=4
+DEAL:0:3d::cellid=4_1:6 parentid=4
+DEAL:0:3d::cellid=4_1:7 parentid=4
+DEAL:0:3d::cellid=5_1:0 parentid=5
+DEAL:0:3d::cellid=5_1:1 parentid=5
+DEAL:0:3d::cellid=5_1:2 parentid=5
+DEAL:0:3d::cellid=5_1:3 parentid=5
+DEAL:0:3d::cellid=5_1:4 parentid=5
+DEAL:0:3d::cellid=5_1:5 parentid=5
+DEAL:0:3d::cellid=5_1:6 parentid=5
+DEAL:0:3d::cellid=5_1:7 parentid=5
+DEAL:0:3d::cellid=6_1:0 parentid=6
+DEAL:0:3d::cellid=6_1:1 parentid=6
+DEAL:0:3d::cellid=6_1:2 parentid=6
+DEAL:0:3d::cellid=6_1:3 parentid=6
+DEAL:0:3d::cellid=6_1:4 parentid=6
+DEAL:0:3d::cellid=6_1:5 parentid=6
+DEAL:0:3d::cellid=6_1:6 parentid=6
+DEAL:0:3d::cellid=6_1:7 parentid=6
+DEAL:0:3d::cellid=7_1:0 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:1 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:2 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:3 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:4 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:5 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:6 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:7 parentid=7 coarsening
+DEAL:0:3d::cells after: 64
+DEAL:0:3d::cellid=7_0: parentid=7
+DEAL:0:3d::cellid=0_1:1 parentid=0
+DEAL:0:3d::cellid=0_1:2 parentid=0
+DEAL:0:3d::cellid=0_1:3 parentid=0
+DEAL:0:3d::cellid=0_1:4 parentid=0
+DEAL:0:3d::cellid=0_1:5 parentid=0
+DEAL:0:3d::cellid=0_1:6 parentid=0
+DEAL:0:3d::cellid=0_1:7 parentid=0
+DEAL:0:3d::cellid=1_1:0 parentid=1
+DEAL:0:3d::cellid=1_1:1 parentid=1
+DEAL:0:3d::cellid=1_1:2 parentid=1
+DEAL:0:3d::cellid=1_1:3 parentid=1
+DEAL:0:3d::cellid=1_1:4 parentid=1
+DEAL:0:3d::cellid=1_1:5 parentid=1
+DEAL:0:3d::cellid=1_1:6 parentid=1
+DEAL:0:3d::cellid=1_1:7 parentid=1
+DEAL:0:3d::cellid=2_1:0 parentid=2
+DEAL:0:3d::cellid=2_1:1 parentid=2
+DEAL:0:3d::cellid=2_1:2 parentid=2
+DEAL:0:3d::cellid=2_1:3 parentid=2
+DEAL:0:3d::cellid=2_1:4 parentid=2
+DEAL:0:3d::cellid=2_1:5 parentid=2
+DEAL:0:3d::cellid=2_1:6 parentid=2
+DEAL:0:3d::cellid=2_1:7 parentid=2
+DEAL:0:3d::cellid=3_1:0 parentid=3
+DEAL:0:3d::cellid=3_1:1 parentid=3
+DEAL:0:3d::cellid=3_1:2 parentid=3
+DEAL:0:3d::cellid=3_1:3 parentid=3
+DEAL:0:3d::cellid=3_1:4 parentid=3
+DEAL:0:3d::cellid=3_1:5 parentid=3
+DEAL:0:3d::cellid=3_1:6 parentid=3
+DEAL:0:3d::cellid=3_1:7 parentid=3
+DEAL:0:3d::cellid=4_1:0 parentid=4
+DEAL:0:3d::cellid=4_1:1 parentid=4
+DEAL:0:3d::cellid=4_1:2 parentid=4
+DEAL:0:3d::cellid=4_1:3 parentid=4
+DEAL:0:3d::cellid=4_1:4 parentid=4
+DEAL:0:3d::cellid=4_1:5 parentid=4
+DEAL:0:3d::cellid=4_1:6 parentid=4
+DEAL:0:3d::cellid=4_1:7 parentid=4
+DEAL:0:3d::cellid=5_1:0 parentid=5
+DEAL:0:3d::cellid=5_1:1 parentid=5
+DEAL:0:3d::cellid=5_1:2 parentid=5
+DEAL:0:3d::cellid=5_1:3 parentid=5
+DEAL:0:3d::cellid=5_1:4 parentid=5
+DEAL:0:3d::cellid=5_1:5 parentid=5
+DEAL:0:3d::cellid=5_1:6 parentid=5
+DEAL:0:3d::cellid=5_1:7 parentid=5
+DEAL:0:3d::cellid=6_1:0 parentid=6
+DEAL:0:3d::cellid=6_1:1 parentid=6
+DEAL:0:3d::cellid=6_1:2 parentid=6
+DEAL:0:3d::cellid=6_1:3 parentid=6
+DEAL:0:3d::cellid=6_1:4 parentid=6
+DEAL:0:3d::cellid=6_1:5 parentid=6
+DEAL:0:3d::cellid=6_1:6 parentid=6
+DEAL:0:3d::cellid=6_1:7 parentid=6
+DEAL:0:3d::cellid=0_2:00 parentid=0
+DEAL:0:3d::cellid=0_2:01 parentid=0
+DEAL:0:3d::cellid=0_2:02 parentid=0
+DEAL:0:3d::cellid=0_2:03 parentid=0
+DEAL:0:3d::cellid=0_2:04 parentid=0
+DEAL:0:3d::cellid=0_2:05 parentid=0
+DEAL:0:3d::cellid=0_2:06 parentid=0
+DEAL:0:3d::cellid=0_2:07 parentid=0
+DEAL:0:3d::OK

--- a/tests/sharedtria/cell_data_transfer_01.with_mpi=true.with_petsc=true.mpirun=2.output
+++ b/tests/sharedtria/cell_data_transfer_01.with_mpi=true.with_petsc=true.mpirun=2.output
@@ -1,0 +1,357 @@
+
+DEAL:0:1d::cells before: 4
+DEAL:0:1d::cellid=0_1:0 parentid=0 refining
+DEAL:0:1d::cellid=0_1:1 parentid=0
+DEAL:0:1d::cellid=1_1:0 parentid=1 coarsening
+DEAL:0:1d::cellid=1_1:1 parentid=1 coarsening
+DEAL:0:1d::cells after: 4
+DEAL:0:1d::cellid=1_0: parentid=1
+DEAL:0:1d::cellid=0_1:1 parentid=0
+DEAL:0:1d::cellid=0_2:00 parentid=0
+DEAL:0:1d::cellid=0_2:01 parentid=0
+DEAL:0:1d::OK
+DEAL:0:2d::cells before: 16
+DEAL:0:2d::cellid=0_1:0 parentid=0 refining
+DEAL:0:2d::cellid=0_1:1 parentid=0
+DEAL:0:2d::cellid=0_1:2 parentid=0
+DEAL:0:2d::cellid=0_1:3 parentid=0
+DEAL:0:2d::cellid=1_1:0 parentid=1
+DEAL:0:2d::cellid=1_1:1 parentid=1
+DEAL:0:2d::cellid=1_1:2 parentid=1
+DEAL:0:2d::cellid=1_1:3 parentid=1
+DEAL:0:2d::cellid=2_1:0 parentid=2
+DEAL:0:2d::cellid=2_1:1 parentid=2
+DEAL:0:2d::cellid=2_1:2 parentid=2
+DEAL:0:2d::cellid=2_1:3 parentid=2
+DEAL:0:2d::cellid=3_1:0 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:1 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:2 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:3 parentid=3 coarsening
+DEAL:0:2d::cells after: 16
+DEAL:0:2d::cellid=3_0: parentid=3
+DEAL:0:2d::cellid=0_1:1 parentid=0
+DEAL:0:2d::cellid=0_1:2 parentid=0
+DEAL:0:2d::cellid=0_1:3 parentid=0
+DEAL:0:2d::cellid=1_1:0 parentid=1
+DEAL:0:2d::cellid=1_1:1 parentid=1
+DEAL:0:2d::cellid=1_1:2 parentid=1
+DEAL:0:2d::cellid=1_1:3 parentid=1
+DEAL:0:2d::cellid=2_1:0 parentid=2
+DEAL:0:2d::cellid=2_1:1 parentid=2
+DEAL:0:2d::cellid=2_1:2 parentid=2
+DEAL:0:2d::cellid=2_1:3 parentid=2
+DEAL:0:2d::cellid=0_2:00 parentid=0
+DEAL:0:2d::cellid=0_2:01 parentid=0
+DEAL:0:2d::cellid=0_2:02 parentid=0
+DEAL:0:2d::cellid=0_2:03 parentid=0
+DEAL:0:2d::OK
+DEAL:0:3d::cells before: 64
+DEAL:0:3d::cellid=0_1:0 parentid=0 refining
+DEAL:0:3d::cellid=0_1:1 parentid=0
+DEAL:0:3d::cellid=0_1:2 parentid=0
+DEAL:0:3d::cellid=0_1:3 parentid=0
+DEAL:0:3d::cellid=0_1:4 parentid=0
+DEAL:0:3d::cellid=0_1:5 parentid=0
+DEAL:0:3d::cellid=0_1:6 parentid=0
+DEAL:0:3d::cellid=0_1:7 parentid=0
+DEAL:0:3d::cellid=1_1:0 parentid=1
+DEAL:0:3d::cellid=1_1:1 parentid=1
+DEAL:0:3d::cellid=1_1:2 parentid=1
+DEAL:0:3d::cellid=1_1:3 parentid=1
+DEAL:0:3d::cellid=1_1:4 parentid=1
+DEAL:0:3d::cellid=1_1:5 parentid=1
+DEAL:0:3d::cellid=1_1:6 parentid=1
+DEAL:0:3d::cellid=1_1:7 parentid=1
+DEAL:0:3d::cellid=2_1:0 parentid=2
+DEAL:0:3d::cellid=2_1:1 parentid=2
+DEAL:0:3d::cellid=2_1:2 parentid=2
+DEAL:0:3d::cellid=2_1:3 parentid=2
+DEAL:0:3d::cellid=2_1:4 parentid=2
+DEAL:0:3d::cellid=2_1:5 parentid=2
+DEAL:0:3d::cellid=2_1:6 parentid=2
+DEAL:0:3d::cellid=2_1:7 parentid=2
+DEAL:0:3d::cellid=3_1:0 parentid=3
+DEAL:0:3d::cellid=3_1:1 parentid=3
+DEAL:0:3d::cellid=3_1:2 parentid=3
+DEAL:0:3d::cellid=3_1:3 parentid=3
+DEAL:0:3d::cellid=3_1:4 parentid=3
+DEAL:0:3d::cellid=3_1:5 parentid=3
+DEAL:0:3d::cellid=3_1:6 parentid=3
+DEAL:0:3d::cellid=3_1:7 parentid=3
+DEAL:0:3d::cellid=4_1:0 parentid=4
+DEAL:0:3d::cellid=4_1:1 parentid=4
+DEAL:0:3d::cellid=4_1:2 parentid=4
+DEAL:0:3d::cellid=4_1:3 parentid=4
+DEAL:0:3d::cellid=4_1:4 parentid=4
+DEAL:0:3d::cellid=4_1:5 parentid=4
+DEAL:0:3d::cellid=4_1:6 parentid=4
+DEAL:0:3d::cellid=4_1:7 parentid=4
+DEAL:0:3d::cellid=5_1:0 parentid=5
+DEAL:0:3d::cellid=5_1:1 parentid=5
+DEAL:0:3d::cellid=5_1:2 parentid=5
+DEAL:0:3d::cellid=5_1:3 parentid=5
+DEAL:0:3d::cellid=5_1:4 parentid=5
+DEAL:0:3d::cellid=5_1:5 parentid=5
+DEAL:0:3d::cellid=5_1:6 parentid=5
+DEAL:0:3d::cellid=5_1:7 parentid=5
+DEAL:0:3d::cellid=6_1:0 parentid=6
+DEAL:0:3d::cellid=6_1:1 parentid=6
+DEAL:0:3d::cellid=6_1:2 parentid=6
+DEAL:0:3d::cellid=6_1:3 parentid=6
+DEAL:0:3d::cellid=6_1:4 parentid=6
+DEAL:0:3d::cellid=6_1:5 parentid=6
+DEAL:0:3d::cellid=6_1:6 parentid=6
+DEAL:0:3d::cellid=6_1:7 parentid=6
+DEAL:0:3d::cellid=7_1:0 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:1 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:2 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:3 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:4 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:5 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:6 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:7 parentid=7 coarsening
+DEAL:0:3d::cells after: 64
+DEAL:0:3d::cellid=7_0: parentid=7
+DEAL:0:3d::cellid=0_1:1 parentid=0
+DEAL:0:3d::cellid=0_1:2 parentid=0
+DEAL:0:3d::cellid=0_1:3 parentid=0
+DEAL:0:3d::cellid=0_1:4 parentid=0
+DEAL:0:3d::cellid=0_1:5 parentid=0
+DEAL:0:3d::cellid=0_1:6 parentid=0
+DEAL:0:3d::cellid=0_1:7 parentid=0
+DEAL:0:3d::cellid=1_1:0 parentid=1
+DEAL:0:3d::cellid=1_1:1 parentid=1
+DEAL:0:3d::cellid=1_1:2 parentid=1
+DEAL:0:3d::cellid=1_1:3 parentid=1
+DEAL:0:3d::cellid=1_1:4 parentid=1
+DEAL:0:3d::cellid=1_1:5 parentid=1
+DEAL:0:3d::cellid=1_1:6 parentid=1
+DEAL:0:3d::cellid=1_1:7 parentid=1
+DEAL:0:3d::cellid=2_1:0 parentid=2
+DEAL:0:3d::cellid=2_1:1 parentid=2
+DEAL:0:3d::cellid=2_1:2 parentid=2
+DEAL:0:3d::cellid=2_1:3 parentid=2
+DEAL:0:3d::cellid=2_1:4 parentid=2
+DEAL:0:3d::cellid=2_1:5 parentid=2
+DEAL:0:3d::cellid=2_1:6 parentid=2
+DEAL:0:3d::cellid=2_1:7 parentid=2
+DEAL:0:3d::cellid=3_1:0 parentid=3
+DEAL:0:3d::cellid=3_1:1 parentid=3
+DEAL:0:3d::cellid=3_1:2 parentid=3
+DEAL:0:3d::cellid=3_1:3 parentid=3
+DEAL:0:3d::cellid=3_1:4 parentid=3
+DEAL:0:3d::cellid=3_1:5 parentid=3
+DEAL:0:3d::cellid=3_1:6 parentid=3
+DEAL:0:3d::cellid=3_1:7 parentid=3
+DEAL:0:3d::cellid=4_1:0 parentid=4
+DEAL:0:3d::cellid=4_1:1 parentid=4
+DEAL:0:3d::cellid=4_1:2 parentid=4
+DEAL:0:3d::cellid=4_1:3 parentid=4
+DEAL:0:3d::cellid=4_1:4 parentid=4
+DEAL:0:3d::cellid=4_1:5 parentid=4
+DEAL:0:3d::cellid=4_1:6 parentid=4
+DEAL:0:3d::cellid=4_1:7 parentid=4
+DEAL:0:3d::cellid=5_1:0 parentid=5
+DEAL:0:3d::cellid=5_1:1 parentid=5
+DEAL:0:3d::cellid=5_1:2 parentid=5
+DEAL:0:3d::cellid=5_1:3 parentid=5
+DEAL:0:3d::cellid=5_1:4 parentid=5
+DEAL:0:3d::cellid=5_1:5 parentid=5
+DEAL:0:3d::cellid=5_1:6 parentid=5
+DEAL:0:3d::cellid=5_1:7 parentid=5
+DEAL:0:3d::cellid=6_1:0 parentid=6
+DEAL:0:3d::cellid=6_1:1 parentid=6
+DEAL:0:3d::cellid=6_1:2 parentid=6
+DEAL:0:3d::cellid=6_1:3 parentid=6
+DEAL:0:3d::cellid=6_1:4 parentid=6
+DEAL:0:3d::cellid=6_1:5 parentid=6
+DEAL:0:3d::cellid=6_1:6 parentid=6
+DEAL:0:3d::cellid=6_1:7 parentid=6
+DEAL:0:3d::cellid=0_2:00 parentid=0
+DEAL:0:3d::cellid=0_2:01 parentid=0
+DEAL:0:3d::cellid=0_2:02 parentid=0
+DEAL:0:3d::cellid=0_2:03 parentid=0
+DEAL:0:3d::cellid=0_2:04 parentid=0
+DEAL:0:3d::cellid=0_2:05 parentid=0
+DEAL:0:3d::cellid=0_2:06 parentid=0
+DEAL:0:3d::cellid=0_2:07 parentid=0
+DEAL:0:3d::OK
+
+DEAL:1:1d::cells before: 4
+DEAL:1:1d::cellid=0_1:0 parentid=0 refining
+DEAL:1:1d::cellid=0_1:1 parentid=0
+DEAL:1:1d::cellid=1_1:0 parentid=1 coarsening
+DEAL:1:1d::cellid=1_1:1 parentid=1 coarsening
+DEAL:1:1d::cells after: 4
+DEAL:1:1d::cellid=1_0: parentid=1
+DEAL:1:1d::cellid=0_1:1 parentid=0
+DEAL:1:1d::cellid=0_2:00 parentid=0
+DEAL:1:1d::cellid=0_2:01 parentid=0
+DEAL:1:1d::OK
+DEAL:1:2d::cells before: 16
+DEAL:1:2d::cellid=0_1:0 parentid=0 refining
+DEAL:1:2d::cellid=0_1:1 parentid=0
+DEAL:1:2d::cellid=0_1:2 parentid=0
+DEAL:1:2d::cellid=0_1:3 parentid=0
+DEAL:1:2d::cellid=1_1:0 parentid=1
+DEAL:1:2d::cellid=1_1:1 parentid=1
+DEAL:1:2d::cellid=1_1:2 parentid=1
+DEAL:1:2d::cellid=1_1:3 parentid=1
+DEAL:1:2d::cellid=2_1:0 parentid=2
+DEAL:1:2d::cellid=2_1:1 parentid=2
+DEAL:1:2d::cellid=2_1:2 parentid=2
+DEAL:1:2d::cellid=2_1:3 parentid=2
+DEAL:1:2d::cellid=3_1:0 parentid=3 coarsening
+DEAL:1:2d::cellid=3_1:1 parentid=3 coarsening
+DEAL:1:2d::cellid=3_1:2 parentid=3 coarsening
+DEAL:1:2d::cellid=3_1:3 parentid=3 coarsening
+DEAL:1:2d::cells after: 16
+DEAL:1:2d::cellid=3_0: parentid=3
+DEAL:1:2d::cellid=0_1:1 parentid=0
+DEAL:1:2d::cellid=0_1:2 parentid=0
+DEAL:1:2d::cellid=0_1:3 parentid=0
+DEAL:1:2d::cellid=1_1:0 parentid=1
+DEAL:1:2d::cellid=1_1:1 parentid=1
+DEAL:1:2d::cellid=1_1:2 parentid=1
+DEAL:1:2d::cellid=1_1:3 parentid=1
+DEAL:1:2d::cellid=2_1:0 parentid=2
+DEAL:1:2d::cellid=2_1:1 parentid=2
+DEAL:1:2d::cellid=2_1:2 parentid=2
+DEAL:1:2d::cellid=2_1:3 parentid=2
+DEAL:1:2d::cellid=0_2:00 parentid=0
+DEAL:1:2d::cellid=0_2:01 parentid=0
+DEAL:1:2d::cellid=0_2:02 parentid=0
+DEAL:1:2d::cellid=0_2:03 parentid=0
+DEAL:1:2d::OK
+DEAL:1:3d::cells before: 64
+DEAL:1:3d::cellid=0_1:0 parentid=0 refining
+DEAL:1:3d::cellid=0_1:1 parentid=0
+DEAL:1:3d::cellid=0_1:2 parentid=0
+DEAL:1:3d::cellid=0_1:3 parentid=0
+DEAL:1:3d::cellid=0_1:4 parentid=0
+DEAL:1:3d::cellid=0_1:5 parentid=0
+DEAL:1:3d::cellid=0_1:6 parentid=0
+DEAL:1:3d::cellid=0_1:7 parentid=0
+DEAL:1:3d::cellid=1_1:0 parentid=1
+DEAL:1:3d::cellid=1_1:1 parentid=1
+DEAL:1:3d::cellid=1_1:2 parentid=1
+DEAL:1:3d::cellid=1_1:3 parentid=1
+DEAL:1:3d::cellid=1_1:4 parentid=1
+DEAL:1:3d::cellid=1_1:5 parentid=1
+DEAL:1:3d::cellid=1_1:6 parentid=1
+DEAL:1:3d::cellid=1_1:7 parentid=1
+DEAL:1:3d::cellid=2_1:0 parentid=2
+DEAL:1:3d::cellid=2_1:1 parentid=2
+DEAL:1:3d::cellid=2_1:2 parentid=2
+DEAL:1:3d::cellid=2_1:3 parentid=2
+DEAL:1:3d::cellid=2_1:4 parentid=2
+DEAL:1:3d::cellid=2_1:5 parentid=2
+DEAL:1:3d::cellid=2_1:6 parentid=2
+DEAL:1:3d::cellid=2_1:7 parentid=2
+DEAL:1:3d::cellid=3_1:0 parentid=3
+DEAL:1:3d::cellid=3_1:1 parentid=3
+DEAL:1:3d::cellid=3_1:2 parentid=3
+DEAL:1:3d::cellid=3_1:3 parentid=3
+DEAL:1:3d::cellid=3_1:4 parentid=3
+DEAL:1:3d::cellid=3_1:5 parentid=3
+DEAL:1:3d::cellid=3_1:6 parentid=3
+DEAL:1:3d::cellid=3_1:7 parentid=3
+DEAL:1:3d::cellid=4_1:0 parentid=4
+DEAL:1:3d::cellid=4_1:1 parentid=4
+DEAL:1:3d::cellid=4_1:2 parentid=4
+DEAL:1:3d::cellid=4_1:3 parentid=4
+DEAL:1:3d::cellid=4_1:4 parentid=4
+DEAL:1:3d::cellid=4_1:5 parentid=4
+DEAL:1:3d::cellid=4_1:6 parentid=4
+DEAL:1:3d::cellid=4_1:7 parentid=4
+DEAL:1:3d::cellid=5_1:0 parentid=5
+DEAL:1:3d::cellid=5_1:1 parentid=5
+DEAL:1:3d::cellid=5_1:2 parentid=5
+DEAL:1:3d::cellid=5_1:3 parentid=5
+DEAL:1:3d::cellid=5_1:4 parentid=5
+DEAL:1:3d::cellid=5_1:5 parentid=5
+DEAL:1:3d::cellid=5_1:6 parentid=5
+DEAL:1:3d::cellid=5_1:7 parentid=5
+DEAL:1:3d::cellid=6_1:0 parentid=6
+DEAL:1:3d::cellid=6_1:1 parentid=6
+DEAL:1:3d::cellid=6_1:2 parentid=6
+DEAL:1:3d::cellid=6_1:3 parentid=6
+DEAL:1:3d::cellid=6_1:4 parentid=6
+DEAL:1:3d::cellid=6_1:5 parentid=6
+DEAL:1:3d::cellid=6_1:6 parentid=6
+DEAL:1:3d::cellid=6_1:7 parentid=6
+DEAL:1:3d::cellid=7_1:0 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:1 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:2 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:3 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:4 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:5 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:6 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:7 parentid=7 coarsening
+DEAL:1:3d::cells after: 64
+DEAL:1:3d::cellid=7_0: parentid=7
+DEAL:1:3d::cellid=0_1:1 parentid=0
+DEAL:1:3d::cellid=0_1:2 parentid=0
+DEAL:1:3d::cellid=0_1:3 parentid=0
+DEAL:1:3d::cellid=0_1:4 parentid=0
+DEAL:1:3d::cellid=0_1:5 parentid=0
+DEAL:1:3d::cellid=0_1:6 parentid=0
+DEAL:1:3d::cellid=0_1:7 parentid=0
+DEAL:1:3d::cellid=1_1:0 parentid=1
+DEAL:1:3d::cellid=1_1:1 parentid=1
+DEAL:1:3d::cellid=1_1:2 parentid=1
+DEAL:1:3d::cellid=1_1:3 parentid=1
+DEAL:1:3d::cellid=1_1:4 parentid=1
+DEAL:1:3d::cellid=1_1:5 parentid=1
+DEAL:1:3d::cellid=1_1:6 parentid=1
+DEAL:1:3d::cellid=1_1:7 parentid=1
+DEAL:1:3d::cellid=2_1:0 parentid=2
+DEAL:1:3d::cellid=2_1:1 parentid=2
+DEAL:1:3d::cellid=2_1:2 parentid=2
+DEAL:1:3d::cellid=2_1:3 parentid=2
+DEAL:1:3d::cellid=2_1:4 parentid=2
+DEAL:1:3d::cellid=2_1:5 parentid=2
+DEAL:1:3d::cellid=2_1:6 parentid=2
+DEAL:1:3d::cellid=2_1:7 parentid=2
+DEAL:1:3d::cellid=3_1:0 parentid=3
+DEAL:1:3d::cellid=3_1:1 parentid=3
+DEAL:1:3d::cellid=3_1:2 parentid=3
+DEAL:1:3d::cellid=3_1:3 parentid=3
+DEAL:1:3d::cellid=3_1:4 parentid=3
+DEAL:1:3d::cellid=3_1:5 parentid=3
+DEAL:1:3d::cellid=3_1:6 parentid=3
+DEAL:1:3d::cellid=3_1:7 parentid=3
+DEAL:1:3d::cellid=4_1:0 parentid=4
+DEAL:1:3d::cellid=4_1:1 parentid=4
+DEAL:1:3d::cellid=4_1:2 parentid=4
+DEAL:1:3d::cellid=4_1:3 parentid=4
+DEAL:1:3d::cellid=4_1:4 parentid=4
+DEAL:1:3d::cellid=4_1:5 parentid=4
+DEAL:1:3d::cellid=4_1:6 parentid=4
+DEAL:1:3d::cellid=4_1:7 parentid=4
+DEAL:1:3d::cellid=5_1:0 parentid=5
+DEAL:1:3d::cellid=5_1:1 parentid=5
+DEAL:1:3d::cellid=5_1:2 parentid=5
+DEAL:1:3d::cellid=5_1:3 parentid=5
+DEAL:1:3d::cellid=5_1:4 parentid=5
+DEAL:1:3d::cellid=5_1:5 parentid=5
+DEAL:1:3d::cellid=5_1:6 parentid=5
+DEAL:1:3d::cellid=5_1:7 parentid=5
+DEAL:1:3d::cellid=6_1:0 parentid=6
+DEAL:1:3d::cellid=6_1:1 parentid=6
+DEAL:1:3d::cellid=6_1:2 parentid=6
+DEAL:1:3d::cellid=6_1:3 parentid=6
+DEAL:1:3d::cellid=6_1:4 parentid=6
+DEAL:1:3d::cellid=6_1:5 parentid=6
+DEAL:1:3d::cellid=6_1:6 parentid=6
+DEAL:1:3d::cellid=6_1:7 parentid=6
+DEAL:1:3d::cellid=0_2:00 parentid=0
+DEAL:1:3d::cellid=0_2:01 parentid=0
+DEAL:1:3d::cellid=0_2:02 parentid=0
+DEAL:1:3d::cellid=0_2:03 parentid=0
+DEAL:1:3d::cellid=0_2:04 parentid=0
+DEAL:1:3d::cellid=0_2:05 parentid=0
+DEAL:1:3d::cellid=0_2:06 parentid=0
+DEAL:1:3d::cellid=0_2:07 parentid=0
+DEAL:1:3d::OK
+

--- a/tests/sharedtria/cell_data_transfer_02.cc
+++ b/tests/sharedtria/cell_data_transfer_02.cc
@@ -1,0 +1,138 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// CellDataTransfer test by refinement
+// for parallel::shared::Triangulation with artificial cells
+
+
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/vector.templates.h>
+
+#include <deal.II/numerics/cell_data_transfer.templates.h>
+
+#include <string>
+
+#include "../tests.h"
+
+
+template <int dim, int spacedim>
+void
+test()
+{
+  // ------ setup ------
+  MPI_Comm                             mpi_communicator(MPI_COMM_WORLD);
+  parallel::shared::Triangulation<dim> tria(mpi_communicator,
+                                            ::Triangulation<dim>::none,
+                                            true);
+
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+  tria.refine_global(1);
+  deallog << "cells before: " << tria.n_global_active_cells() << std::endl;
+
+  // ----- prepare -----
+  // set refinement/coarsening flags
+  for (auto &cell : tria.active_cell_iterators())
+    {
+      if (cell->id().to_string() == "0_1:0")
+        cell->set_refine_flag();
+      else if (((dim == 1) && (cell->parent()->id().to_string() == "1_0:")) ||
+               ((dim == 2) && (cell->parent()->id().to_string() == "3_0:")) ||
+               ((dim == 3) && (cell->parent()->id().to_string() == "7_0:")))
+        cell->set_coarsen_flag();
+    }
+
+  // ----- gather -----
+  // store parent id of all locally owned cells
+  Vector<unsigned int> cell_ids_pre(tria.n_active_cells());
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        const std::string  parent_cellid = cell->parent()->id().to_string();
+        const unsigned int parent_coarse_cell_id =
+          static_cast<unsigned int>(std::stoul(parent_cellid));
+        cell_ids_pre(cell->active_cell_index()) = parent_coarse_cell_id;
+      }
+
+  // distribute local vector (as presented in step-18)
+  PETScWrappers::MPI::Vector distributed_cell_ids_pre(
+    mpi_communicator,
+    tria.n_active_cells(),
+    tria.n_locally_owned_active_cells());
+
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      distributed_cell_ids_pre(cell->active_cell_index()) =
+        cell_ids_pre(cell->active_cell_index());
+  distributed_cell_ids_pre.compress(VectorOperation::insert);
+
+  cell_ids_pre = distributed_cell_ids_pre;
+
+  // output initial situation
+  for (const auto &cell : tria.active_cell_iterators())
+    {
+      deallog << "cellid=" << cell->id()
+              << " parentid=" << cell_ids_pre(cell->active_cell_index());
+      if (cell->coarsen_flag_set())
+        deallog << " coarsening";
+      else if (cell->refine_flag_set())
+        deallog << " refining";
+      deallog << std::endl;
+    }
+
+  // ----- transfer -----
+  CellDataTransfer<dim, spacedim, Vector<unsigned int>> cell_data_transfer(
+    tria);
+
+  cell_data_transfer.prepare_for_coarsening_and_refinement();
+  tria.execute_coarsening_and_refinement();
+  deallog << "cells after: " << tria.n_global_active_cells() << std::endl;
+
+  Vector<unsigned int> cell_ids_post(tria.n_active_cells());
+  cell_data_transfer.unpack(cell_ids_pre, cell_ids_post);
+
+  // ------ verify ------
+  // check if all children adopted the correct id
+  for (auto &cell : tria.active_cell_iterators())
+    deallog << "cellid=" << cell->id()
+            << " parentid=" << cell_ids_post(cell->active_cell_index())
+            << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("1d");
+  test<1, 1>();
+  deallog.pop();
+  deallog.push("2d");
+  test<2, 2>();
+  deallog.pop();
+  deallog.push("3d");
+  test<3, 3>();
+  deallog.pop();
+}

--- a/tests/sharedtria/cell_data_transfer_02.with_mpi=true.with_petsc=true.mpirun=1.output
+++ b/tests/sharedtria/cell_data_transfer_02.with_mpi=true.with_petsc=true.mpirun=1.output
@@ -1,0 +1,178 @@
+
+DEAL:0:1d::cells before: 4
+DEAL:0:1d::cellid=0_1:0 parentid=0 refining
+DEAL:0:1d::cellid=0_1:1 parentid=0
+DEAL:0:1d::cellid=1_1:0 parentid=1 coarsening
+DEAL:0:1d::cellid=1_1:1 parentid=1 coarsening
+DEAL:0:1d::cells after: 4
+DEAL:0:1d::cellid=1_0: parentid=1
+DEAL:0:1d::cellid=0_1:1 parentid=0
+DEAL:0:1d::cellid=0_2:00 parentid=0
+DEAL:0:1d::cellid=0_2:01 parentid=0
+DEAL:0:1d::OK
+DEAL:0:2d::cells before: 16
+DEAL:0:2d::cellid=0_1:0 parentid=0 refining
+DEAL:0:2d::cellid=0_1:1 parentid=0
+DEAL:0:2d::cellid=0_1:2 parentid=0
+DEAL:0:2d::cellid=0_1:3 parentid=0
+DEAL:0:2d::cellid=1_1:0 parentid=1
+DEAL:0:2d::cellid=1_1:1 parentid=1
+DEAL:0:2d::cellid=1_1:2 parentid=1
+DEAL:0:2d::cellid=1_1:3 parentid=1
+DEAL:0:2d::cellid=2_1:0 parentid=2
+DEAL:0:2d::cellid=2_1:1 parentid=2
+DEAL:0:2d::cellid=2_1:2 parentid=2
+DEAL:0:2d::cellid=2_1:3 parentid=2
+DEAL:0:2d::cellid=3_1:0 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:1 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:2 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:3 parentid=3 coarsening
+DEAL:0:2d::cells after: 16
+DEAL:0:2d::cellid=3_0: parentid=3
+DEAL:0:2d::cellid=0_1:1 parentid=0
+DEAL:0:2d::cellid=0_1:2 parentid=0
+DEAL:0:2d::cellid=0_1:3 parentid=0
+DEAL:0:2d::cellid=1_1:0 parentid=1
+DEAL:0:2d::cellid=1_1:1 parentid=1
+DEAL:0:2d::cellid=1_1:2 parentid=1
+DEAL:0:2d::cellid=1_1:3 parentid=1
+DEAL:0:2d::cellid=2_1:0 parentid=2
+DEAL:0:2d::cellid=2_1:1 parentid=2
+DEAL:0:2d::cellid=2_1:2 parentid=2
+DEAL:0:2d::cellid=2_1:3 parentid=2
+DEAL:0:2d::cellid=0_2:00 parentid=0
+DEAL:0:2d::cellid=0_2:01 parentid=0
+DEAL:0:2d::cellid=0_2:02 parentid=0
+DEAL:0:2d::cellid=0_2:03 parentid=0
+DEAL:0:2d::OK
+DEAL:0:3d::cells before: 64
+DEAL:0:3d::cellid=0_1:0 parentid=0 refining
+DEAL:0:3d::cellid=0_1:1 parentid=0
+DEAL:0:3d::cellid=0_1:2 parentid=0
+DEAL:0:3d::cellid=0_1:3 parentid=0
+DEAL:0:3d::cellid=0_1:4 parentid=0
+DEAL:0:3d::cellid=0_1:5 parentid=0
+DEAL:0:3d::cellid=0_1:6 parentid=0
+DEAL:0:3d::cellid=0_1:7 parentid=0
+DEAL:0:3d::cellid=1_1:0 parentid=1
+DEAL:0:3d::cellid=1_1:1 parentid=1
+DEAL:0:3d::cellid=1_1:2 parentid=1
+DEAL:0:3d::cellid=1_1:3 parentid=1
+DEAL:0:3d::cellid=1_1:4 parentid=1
+DEAL:0:3d::cellid=1_1:5 parentid=1
+DEAL:0:3d::cellid=1_1:6 parentid=1
+DEAL:0:3d::cellid=1_1:7 parentid=1
+DEAL:0:3d::cellid=2_1:0 parentid=2
+DEAL:0:3d::cellid=2_1:1 parentid=2
+DEAL:0:3d::cellid=2_1:2 parentid=2
+DEAL:0:3d::cellid=2_1:3 parentid=2
+DEAL:0:3d::cellid=2_1:4 parentid=2
+DEAL:0:3d::cellid=2_1:5 parentid=2
+DEAL:0:3d::cellid=2_1:6 parentid=2
+DEAL:0:3d::cellid=2_1:7 parentid=2
+DEAL:0:3d::cellid=3_1:0 parentid=3
+DEAL:0:3d::cellid=3_1:1 parentid=3
+DEAL:0:3d::cellid=3_1:2 parentid=3
+DEAL:0:3d::cellid=3_1:3 parentid=3
+DEAL:0:3d::cellid=3_1:4 parentid=3
+DEAL:0:3d::cellid=3_1:5 parentid=3
+DEAL:0:3d::cellid=3_1:6 parentid=3
+DEAL:0:3d::cellid=3_1:7 parentid=3
+DEAL:0:3d::cellid=4_1:0 parentid=4
+DEAL:0:3d::cellid=4_1:1 parentid=4
+DEAL:0:3d::cellid=4_1:2 parentid=4
+DEAL:0:3d::cellid=4_1:3 parentid=4
+DEAL:0:3d::cellid=4_1:4 parentid=4
+DEAL:0:3d::cellid=4_1:5 parentid=4
+DEAL:0:3d::cellid=4_1:6 parentid=4
+DEAL:0:3d::cellid=4_1:7 parentid=4
+DEAL:0:3d::cellid=5_1:0 parentid=5
+DEAL:0:3d::cellid=5_1:1 parentid=5
+DEAL:0:3d::cellid=5_1:2 parentid=5
+DEAL:0:3d::cellid=5_1:3 parentid=5
+DEAL:0:3d::cellid=5_1:4 parentid=5
+DEAL:0:3d::cellid=5_1:5 parentid=5
+DEAL:0:3d::cellid=5_1:6 parentid=5
+DEAL:0:3d::cellid=5_1:7 parentid=5
+DEAL:0:3d::cellid=6_1:0 parentid=6
+DEAL:0:3d::cellid=6_1:1 parentid=6
+DEAL:0:3d::cellid=6_1:2 parentid=6
+DEAL:0:3d::cellid=6_1:3 parentid=6
+DEAL:0:3d::cellid=6_1:4 parentid=6
+DEAL:0:3d::cellid=6_1:5 parentid=6
+DEAL:0:3d::cellid=6_1:6 parentid=6
+DEAL:0:3d::cellid=6_1:7 parentid=6
+DEAL:0:3d::cellid=7_1:0 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:1 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:2 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:3 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:4 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:5 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:6 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:7 parentid=7 coarsening
+DEAL:0:3d::cells after: 64
+DEAL:0:3d::cellid=7_0: parentid=7
+DEAL:0:3d::cellid=0_1:1 parentid=0
+DEAL:0:3d::cellid=0_1:2 parentid=0
+DEAL:0:3d::cellid=0_1:3 parentid=0
+DEAL:0:3d::cellid=0_1:4 parentid=0
+DEAL:0:3d::cellid=0_1:5 parentid=0
+DEAL:0:3d::cellid=0_1:6 parentid=0
+DEAL:0:3d::cellid=0_1:7 parentid=0
+DEAL:0:3d::cellid=1_1:0 parentid=1
+DEAL:0:3d::cellid=1_1:1 parentid=1
+DEAL:0:3d::cellid=1_1:2 parentid=1
+DEAL:0:3d::cellid=1_1:3 parentid=1
+DEAL:0:3d::cellid=1_1:4 parentid=1
+DEAL:0:3d::cellid=1_1:5 parentid=1
+DEAL:0:3d::cellid=1_1:6 parentid=1
+DEAL:0:3d::cellid=1_1:7 parentid=1
+DEAL:0:3d::cellid=2_1:0 parentid=2
+DEAL:0:3d::cellid=2_1:1 parentid=2
+DEAL:0:3d::cellid=2_1:2 parentid=2
+DEAL:0:3d::cellid=2_1:3 parentid=2
+DEAL:0:3d::cellid=2_1:4 parentid=2
+DEAL:0:3d::cellid=2_1:5 parentid=2
+DEAL:0:3d::cellid=2_1:6 parentid=2
+DEAL:0:3d::cellid=2_1:7 parentid=2
+DEAL:0:3d::cellid=3_1:0 parentid=3
+DEAL:0:3d::cellid=3_1:1 parentid=3
+DEAL:0:3d::cellid=3_1:2 parentid=3
+DEAL:0:3d::cellid=3_1:3 parentid=3
+DEAL:0:3d::cellid=3_1:4 parentid=3
+DEAL:0:3d::cellid=3_1:5 parentid=3
+DEAL:0:3d::cellid=3_1:6 parentid=3
+DEAL:0:3d::cellid=3_1:7 parentid=3
+DEAL:0:3d::cellid=4_1:0 parentid=4
+DEAL:0:3d::cellid=4_1:1 parentid=4
+DEAL:0:3d::cellid=4_1:2 parentid=4
+DEAL:0:3d::cellid=4_1:3 parentid=4
+DEAL:0:3d::cellid=4_1:4 parentid=4
+DEAL:0:3d::cellid=4_1:5 parentid=4
+DEAL:0:3d::cellid=4_1:6 parentid=4
+DEAL:0:3d::cellid=4_1:7 parentid=4
+DEAL:0:3d::cellid=5_1:0 parentid=5
+DEAL:0:3d::cellid=5_1:1 parentid=5
+DEAL:0:3d::cellid=5_1:2 parentid=5
+DEAL:0:3d::cellid=5_1:3 parentid=5
+DEAL:0:3d::cellid=5_1:4 parentid=5
+DEAL:0:3d::cellid=5_1:5 parentid=5
+DEAL:0:3d::cellid=5_1:6 parentid=5
+DEAL:0:3d::cellid=5_1:7 parentid=5
+DEAL:0:3d::cellid=6_1:0 parentid=6
+DEAL:0:3d::cellid=6_1:1 parentid=6
+DEAL:0:3d::cellid=6_1:2 parentid=6
+DEAL:0:3d::cellid=6_1:3 parentid=6
+DEAL:0:3d::cellid=6_1:4 parentid=6
+DEAL:0:3d::cellid=6_1:5 parentid=6
+DEAL:0:3d::cellid=6_1:6 parentid=6
+DEAL:0:3d::cellid=6_1:7 parentid=6
+DEAL:0:3d::cellid=0_2:00 parentid=0
+DEAL:0:3d::cellid=0_2:01 parentid=0
+DEAL:0:3d::cellid=0_2:02 parentid=0
+DEAL:0:3d::cellid=0_2:03 parentid=0
+DEAL:0:3d::cellid=0_2:04 parentid=0
+DEAL:0:3d::cellid=0_2:05 parentid=0
+DEAL:0:3d::cellid=0_2:06 parentid=0
+DEAL:0:3d::cellid=0_2:07 parentid=0
+DEAL:0:3d::OK

--- a/tests/sharedtria/cell_data_transfer_02.with_mpi=true.with_petsc=true.mpirun=2.output
+++ b/tests/sharedtria/cell_data_transfer_02.with_mpi=true.with_petsc=true.mpirun=2.output
@@ -1,0 +1,357 @@
+
+DEAL:0:1d::cells before: 4
+DEAL:0:1d::cellid=0_1:0 parentid=0 refining
+DEAL:0:1d::cellid=0_1:1 parentid=0
+DEAL:0:1d::cellid=1_1:0 parentid=1 coarsening
+DEAL:0:1d::cellid=1_1:1 parentid=1 coarsening
+DEAL:0:1d::cells after: 4
+DEAL:0:1d::cellid=1_0: parentid=1
+DEAL:0:1d::cellid=0_1:1 parentid=0
+DEAL:0:1d::cellid=0_2:00 parentid=0
+DEAL:0:1d::cellid=0_2:01 parentid=0
+DEAL:0:1d::OK
+DEAL:0:2d::cells before: 16
+DEAL:0:2d::cellid=0_1:0 parentid=0 refining
+DEAL:0:2d::cellid=0_1:1 parentid=0
+DEAL:0:2d::cellid=0_1:2 parentid=0
+DEAL:0:2d::cellid=0_1:3 parentid=0
+DEAL:0:2d::cellid=1_1:0 parentid=1
+DEAL:0:2d::cellid=1_1:1 parentid=1
+DEAL:0:2d::cellid=1_1:2 parentid=1
+DEAL:0:2d::cellid=1_1:3 parentid=1
+DEAL:0:2d::cellid=2_1:0 parentid=2
+DEAL:0:2d::cellid=2_1:1 parentid=2
+DEAL:0:2d::cellid=2_1:2 parentid=2
+DEAL:0:2d::cellid=2_1:3 parentid=2
+DEAL:0:2d::cellid=3_1:0 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:1 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:2 parentid=3 coarsening
+DEAL:0:2d::cellid=3_1:3 parentid=3 coarsening
+DEAL:0:2d::cells after: 16
+DEAL:0:2d::cellid=3_0: parentid=3
+DEAL:0:2d::cellid=0_1:1 parentid=0
+DEAL:0:2d::cellid=0_1:2 parentid=0
+DEAL:0:2d::cellid=0_1:3 parentid=0
+DEAL:0:2d::cellid=1_1:0 parentid=1
+DEAL:0:2d::cellid=1_1:1 parentid=1
+DEAL:0:2d::cellid=1_1:2 parentid=1
+DEAL:0:2d::cellid=1_1:3 parentid=1
+DEAL:0:2d::cellid=2_1:0 parentid=2
+DEAL:0:2d::cellid=2_1:1 parentid=2
+DEAL:0:2d::cellid=2_1:2 parentid=2
+DEAL:0:2d::cellid=2_1:3 parentid=2
+DEAL:0:2d::cellid=0_2:00 parentid=0
+DEAL:0:2d::cellid=0_2:01 parentid=0
+DEAL:0:2d::cellid=0_2:02 parentid=0
+DEAL:0:2d::cellid=0_2:03 parentid=0
+DEAL:0:2d::OK
+DEAL:0:3d::cells before: 64
+DEAL:0:3d::cellid=0_1:0 parentid=0 refining
+DEAL:0:3d::cellid=0_1:1 parentid=0
+DEAL:0:3d::cellid=0_1:2 parentid=0
+DEAL:0:3d::cellid=0_1:3 parentid=0
+DEAL:0:3d::cellid=0_1:4 parentid=0
+DEAL:0:3d::cellid=0_1:5 parentid=0
+DEAL:0:3d::cellid=0_1:6 parentid=0
+DEAL:0:3d::cellid=0_1:7 parentid=0
+DEAL:0:3d::cellid=1_1:0 parentid=1
+DEAL:0:3d::cellid=1_1:1 parentid=1
+DEAL:0:3d::cellid=1_1:2 parentid=1
+DEAL:0:3d::cellid=1_1:3 parentid=1
+DEAL:0:3d::cellid=1_1:4 parentid=1
+DEAL:0:3d::cellid=1_1:5 parentid=1
+DEAL:0:3d::cellid=1_1:6 parentid=1
+DEAL:0:3d::cellid=1_1:7 parentid=1
+DEAL:0:3d::cellid=2_1:0 parentid=2
+DEAL:0:3d::cellid=2_1:1 parentid=2
+DEAL:0:3d::cellid=2_1:2 parentid=2
+DEAL:0:3d::cellid=2_1:3 parentid=2
+DEAL:0:3d::cellid=2_1:4 parentid=2
+DEAL:0:3d::cellid=2_1:5 parentid=2
+DEAL:0:3d::cellid=2_1:6 parentid=2
+DEAL:0:3d::cellid=2_1:7 parentid=2
+DEAL:0:3d::cellid=3_1:0 parentid=3
+DEAL:0:3d::cellid=3_1:1 parentid=3
+DEAL:0:3d::cellid=3_1:2 parentid=3
+DEAL:0:3d::cellid=3_1:3 parentid=3
+DEAL:0:3d::cellid=3_1:4 parentid=3
+DEAL:0:3d::cellid=3_1:5 parentid=3
+DEAL:0:3d::cellid=3_1:6 parentid=3
+DEAL:0:3d::cellid=3_1:7 parentid=3
+DEAL:0:3d::cellid=4_1:0 parentid=4
+DEAL:0:3d::cellid=4_1:1 parentid=4
+DEAL:0:3d::cellid=4_1:2 parentid=4
+DEAL:0:3d::cellid=4_1:3 parentid=4
+DEAL:0:3d::cellid=4_1:4 parentid=4
+DEAL:0:3d::cellid=4_1:5 parentid=4
+DEAL:0:3d::cellid=4_1:6 parentid=4
+DEAL:0:3d::cellid=4_1:7 parentid=4
+DEAL:0:3d::cellid=5_1:0 parentid=5
+DEAL:0:3d::cellid=5_1:1 parentid=5
+DEAL:0:3d::cellid=5_1:2 parentid=5
+DEAL:0:3d::cellid=5_1:3 parentid=5
+DEAL:0:3d::cellid=5_1:4 parentid=5
+DEAL:0:3d::cellid=5_1:5 parentid=5
+DEAL:0:3d::cellid=5_1:6 parentid=5
+DEAL:0:3d::cellid=5_1:7 parentid=5
+DEAL:0:3d::cellid=6_1:0 parentid=6
+DEAL:0:3d::cellid=6_1:1 parentid=6
+DEAL:0:3d::cellid=6_1:2 parentid=6
+DEAL:0:3d::cellid=6_1:3 parentid=6
+DEAL:0:3d::cellid=6_1:4 parentid=6
+DEAL:0:3d::cellid=6_1:5 parentid=6
+DEAL:0:3d::cellid=6_1:6 parentid=6
+DEAL:0:3d::cellid=6_1:7 parentid=6
+DEAL:0:3d::cellid=7_1:0 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:1 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:2 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:3 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:4 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:5 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:6 parentid=7 coarsening
+DEAL:0:3d::cellid=7_1:7 parentid=7 coarsening
+DEAL:0:3d::cells after: 64
+DEAL:0:3d::cellid=7_0: parentid=7
+DEAL:0:3d::cellid=0_1:1 parentid=0
+DEAL:0:3d::cellid=0_1:2 parentid=0
+DEAL:0:3d::cellid=0_1:3 parentid=0
+DEAL:0:3d::cellid=0_1:4 parentid=0
+DEAL:0:3d::cellid=0_1:5 parentid=0
+DEAL:0:3d::cellid=0_1:6 parentid=0
+DEAL:0:3d::cellid=0_1:7 parentid=0
+DEAL:0:3d::cellid=1_1:0 parentid=1
+DEAL:0:3d::cellid=1_1:1 parentid=1
+DEAL:0:3d::cellid=1_1:2 parentid=1
+DEAL:0:3d::cellid=1_1:3 parentid=1
+DEAL:0:3d::cellid=1_1:4 parentid=1
+DEAL:0:3d::cellid=1_1:5 parentid=1
+DEAL:0:3d::cellid=1_1:6 parentid=1
+DEAL:0:3d::cellid=1_1:7 parentid=1
+DEAL:0:3d::cellid=2_1:0 parentid=2
+DEAL:0:3d::cellid=2_1:1 parentid=2
+DEAL:0:3d::cellid=2_1:2 parentid=2
+DEAL:0:3d::cellid=2_1:3 parentid=2
+DEAL:0:3d::cellid=2_1:4 parentid=2
+DEAL:0:3d::cellid=2_1:5 parentid=2
+DEAL:0:3d::cellid=2_1:6 parentid=2
+DEAL:0:3d::cellid=2_1:7 parentid=2
+DEAL:0:3d::cellid=3_1:0 parentid=3
+DEAL:0:3d::cellid=3_1:1 parentid=3
+DEAL:0:3d::cellid=3_1:2 parentid=3
+DEAL:0:3d::cellid=3_1:3 parentid=3
+DEAL:0:3d::cellid=3_1:4 parentid=3
+DEAL:0:3d::cellid=3_1:5 parentid=3
+DEAL:0:3d::cellid=3_1:6 parentid=3
+DEAL:0:3d::cellid=3_1:7 parentid=3
+DEAL:0:3d::cellid=4_1:0 parentid=4
+DEAL:0:3d::cellid=4_1:1 parentid=4
+DEAL:0:3d::cellid=4_1:2 parentid=4
+DEAL:0:3d::cellid=4_1:3 parentid=4
+DEAL:0:3d::cellid=4_1:4 parentid=4
+DEAL:0:3d::cellid=4_1:5 parentid=4
+DEAL:0:3d::cellid=4_1:6 parentid=4
+DEAL:0:3d::cellid=4_1:7 parentid=4
+DEAL:0:3d::cellid=5_1:0 parentid=5
+DEAL:0:3d::cellid=5_1:1 parentid=5
+DEAL:0:3d::cellid=5_1:2 parentid=5
+DEAL:0:3d::cellid=5_1:3 parentid=5
+DEAL:0:3d::cellid=5_1:4 parentid=5
+DEAL:0:3d::cellid=5_1:5 parentid=5
+DEAL:0:3d::cellid=5_1:6 parentid=5
+DEAL:0:3d::cellid=5_1:7 parentid=5
+DEAL:0:3d::cellid=6_1:0 parentid=6
+DEAL:0:3d::cellid=6_1:1 parentid=6
+DEAL:0:3d::cellid=6_1:2 parentid=6
+DEAL:0:3d::cellid=6_1:3 parentid=6
+DEAL:0:3d::cellid=6_1:4 parentid=6
+DEAL:0:3d::cellid=6_1:5 parentid=6
+DEAL:0:3d::cellid=6_1:6 parentid=6
+DEAL:0:3d::cellid=6_1:7 parentid=6
+DEAL:0:3d::cellid=0_2:00 parentid=0
+DEAL:0:3d::cellid=0_2:01 parentid=0
+DEAL:0:3d::cellid=0_2:02 parentid=0
+DEAL:0:3d::cellid=0_2:03 parentid=0
+DEAL:0:3d::cellid=0_2:04 parentid=0
+DEAL:0:3d::cellid=0_2:05 parentid=0
+DEAL:0:3d::cellid=0_2:06 parentid=0
+DEAL:0:3d::cellid=0_2:07 parentid=0
+DEAL:0:3d::OK
+
+DEAL:1:1d::cells before: 4
+DEAL:1:1d::cellid=0_1:0 parentid=0 refining
+DEAL:1:1d::cellid=0_1:1 parentid=0
+DEAL:1:1d::cellid=1_1:0 parentid=1 coarsening
+DEAL:1:1d::cellid=1_1:1 parentid=1 coarsening
+DEAL:1:1d::cells after: 4
+DEAL:1:1d::cellid=1_0: parentid=1
+DEAL:1:1d::cellid=0_1:1 parentid=0
+DEAL:1:1d::cellid=0_2:00 parentid=0
+DEAL:1:1d::cellid=0_2:01 parentid=0
+DEAL:1:1d::OK
+DEAL:1:2d::cells before: 16
+DEAL:1:2d::cellid=0_1:0 parentid=0 refining
+DEAL:1:2d::cellid=0_1:1 parentid=0
+DEAL:1:2d::cellid=0_1:2 parentid=0
+DEAL:1:2d::cellid=0_1:3 parentid=0
+DEAL:1:2d::cellid=1_1:0 parentid=1
+DEAL:1:2d::cellid=1_1:1 parentid=1
+DEAL:1:2d::cellid=1_1:2 parentid=1
+DEAL:1:2d::cellid=1_1:3 parentid=1
+DEAL:1:2d::cellid=2_1:0 parentid=2
+DEAL:1:2d::cellid=2_1:1 parentid=2
+DEAL:1:2d::cellid=2_1:2 parentid=2
+DEAL:1:2d::cellid=2_1:3 parentid=2
+DEAL:1:2d::cellid=3_1:0 parentid=3 coarsening
+DEAL:1:2d::cellid=3_1:1 parentid=3 coarsening
+DEAL:1:2d::cellid=3_1:2 parentid=3 coarsening
+DEAL:1:2d::cellid=3_1:3 parentid=3 coarsening
+DEAL:1:2d::cells after: 16
+DEAL:1:2d::cellid=3_0: parentid=3
+DEAL:1:2d::cellid=0_1:1 parentid=0
+DEAL:1:2d::cellid=0_1:2 parentid=0
+DEAL:1:2d::cellid=0_1:3 parentid=0
+DEAL:1:2d::cellid=1_1:0 parentid=1
+DEAL:1:2d::cellid=1_1:1 parentid=1
+DEAL:1:2d::cellid=1_1:2 parentid=1
+DEAL:1:2d::cellid=1_1:3 parentid=1
+DEAL:1:2d::cellid=2_1:0 parentid=2
+DEAL:1:2d::cellid=2_1:1 parentid=2
+DEAL:1:2d::cellid=2_1:2 parentid=2
+DEAL:1:2d::cellid=2_1:3 parentid=2
+DEAL:1:2d::cellid=0_2:00 parentid=0
+DEAL:1:2d::cellid=0_2:01 parentid=0
+DEAL:1:2d::cellid=0_2:02 parentid=0
+DEAL:1:2d::cellid=0_2:03 parentid=0
+DEAL:1:2d::OK
+DEAL:1:3d::cells before: 64
+DEAL:1:3d::cellid=0_1:0 parentid=0 refining
+DEAL:1:3d::cellid=0_1:1 parentid=0
+DEAL:1:3d::cellid=0_1:2 parentid=0
+DEAL:1:3d::cellid=0_1:3 parentid=0
+DEAL:1:3d::cellid=0_1:4 parentid=0
+DEAL:1:3d::cellid=0_1:5 parentid=0
+DEAL:1:3d::cellid=0_1:6 parentid=0
+DEAL:1:3d::cellid=0_1:7 parentid=0
+DEAL:1:3d::cellid=1_1:0 parentid=1
+DEAL:1:3d::cellid=1_1:1 parentid=1
+DEAL:1:3d::cellid=1_1:2 parentid=1
+DEAL:1:3d::cellid=1_1:3 parentid=1
+DEAL:1:3d::cellid=1_1:4 parentid=1
+DEAL:1:3d::cellid=1_1:5 parentid=1
+DEAL:1:3d::cellid=1_1:6 parentid=1
+DEAL:1:3d::cellid=1_1:7 parentid=1
+DEAL:1:3d::cellid=2_1:0 parentid=2
+DEAL:1:3d::cellid=2_1:1 parentid=2
+DEAL:1:3d::cellid=2_1:2 parentid=2
+DEAL:1:3d::cellid=2_1:3 parentid=2
+DEAL:1:3d::cellid=2_1:4 parentid=2
+DEAL:1:3d::cellid=2_1:5 parentid=2
+DEAL:1:3d::cellid=2_1:6 parentid=2
+DEAL:1:3d::cellid=2_1:7 parentid=2
+DEAL:1:3d::cellid=3_1:0 parentid=3
+DEAL:1:3d::cellid=3_1:1 parentid=3
+DEAL:1:3d::cellid=3_1:2 parentid=3
+DEAL:1:3d::cellid=3_1:3 parentid=3
+DEAL:1:3d::cellid=3_1:4 parentid=3
+DEAL:1:3d::cellid=3_1:5 parentid=3
+DEAL:1:3d::cellid=3_1:6 parentid=3
+DEAL:1:3d::cellid=3_1:7 parentid=3
+DEAL:1:3d::cellid=4_1:0 parentid=4
+DEAL:1:3d::cellid=4_1:1 parentid=4
+DEAL:1:3d::cellid=4_1:2 parentid=4
+DEAL:1:3d::cellid=4_1:3 parentid=4
+DEAL:1:3d::cellid=4_1:4 parentid=4
+DEAL:1:3d::cellid=4_1:5 parentid=4
+DEAL:1:3d::cellid=4_1:6 parentid=4
+DEAL:1:3d::cellid=4_1:7 parentid=4
+DEAL:1:3d::cellid=5_1:0 parentid=5
+DEAL:1:3d::cellid=5_1:1 parentid=5
+DEAL:1:3d::cellid=5_1:2 parentid=5
+DEAL:1:3d::cellid=5_1:3 parentid=5
+DEAL:1:3d::cellid=5_1:4 parentid=5
+DEAL:1:3d::cellid=5_1:5 parentid=5
+DEAL:1:3d::cellid=5_1:6 parentid=5
+DEAL:1:3d::cellid=5_1:7 parentid=5
+DEAL:1:3d::cellid=6_1:0 parentid=6
+DEAL:1:3d::cellid=6_1:1 parentid=6
+DEAL:1:3d::cellid=6_1:2 parentid=6
+DEAL:1:3d::cellid=6_1:3 parentid=6
+DEAL:1:3d::cellid=6_1:4 parentid=6
+DEAL:1:3d::cellid=6_1:5 parentid=6
+DEAL:1:3d::cellid=6_1:6 parentid=6
+DEAL:1:3d::cellid=6_1:7 parentid=6
+DEAL:1:3d::cellid=7_1:0 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:1 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:2 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:3 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:4 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:5 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:6 parentid=7 coarsening
+DEAL:1:3d::cellid=7_1:7 parentid=7 coarsening
+DEAL:1:3d::cells after: 64
+DEAL:1:3d::cellid=7_0: parentid=7
+DEAL:1:3d::cellid=0_1:1 parentid=0
+DEAL:1:3d::cellid=0_1:2 parentid=0
+DEAL:1:3d::cellid=0_1:3 parentid=0
+DEAL:1:3d::cellid=0_1:4 parentid=0
+DEAL:1:3d::cellid=0_1:5 parentid=0
+DEAL:1:3d::cellid=0_1:6 parentid=0
+DEAL:1:3d::cellid=0_1:7 parentid=0
+DEAL:1:3d::cellid=1_1:0 parentid=1
+DEAL:1:3d::cellid=1_1:1 parentid=1
+DEAL:1:3d::cellid=1_1:2 parentid=1
+DEAL:1:3d::cellid=1_1:3 parentid=1
+DEAL:1:3d::cellid=1_1:4 parentid=1
+DEAL:1:3d::cellid=1_1:5 parentid=1
+DEAL:1:3d::cellid=1_1:6 parentid=1
+DEAL:1:3d::cellid=1_1:7 parentid=1
+DEAL:1:3d::cellid=2_1:0 parentid=2
+DEAL:1:3d::cellid=2_1:1 parentid=2
+DEAL:1:3d::cellid=2_1:2 parentid=2
+DEAL:1:3d::cellid=2_1:3 parentid=2
+DEAL:1:3d::cellid=2_1:4 parentid=2
+DEAL:1:3d::cellid=2_1:5 parentid=2
+DEAL:1:3d::cellid=2_1:6 parentid=2
+DEAL:1:3d::cellid=2_1:7 parentid=2
+DEAL:1:3d::cellid=3_1:0 parentid=3
+DEAL:1:3d::cellid=3_1:1 parentid=3
+DEAL:1:3d::cellid=3_1:2 parentid=3
+DEAL:1:3d::cellid=3_1:3 parentid=3
+DEAL:1:3d::cellid=3_1:4 parentid=3
+DEAL:1:3d::cellid=3_1:5 parentid=3
+DEAL:1:3d::cellid=3_1:6 parentid=3
+DEAL:1:3d::cellid=3_1:7 parentid=3
+DEAL:1:3d::cellid=4_1:0 parentid=4
+DEAL:1:3d::cellid=4_1:1 parentid=4
+DEAL:1:3d::cellid=4_1:2 parentid=4
+DEAL:1:3d::cellid=4_1:3 parentid=4
+DEAL:1:3d::cellid=4_1:4 parentid=4
+DEAL:1:3d::cellid=4_1:5 parentid=4
+DEAL:1:3d::cellid=4_1:6 parentid=4
+DEAL:1:3d::cellid=4_1:7 parentid=4
+DEAL:1:3d::cellid=5_1:0 parentid=5
+DEAL:1:3d::cellid=5_1:1 parentid=5
+DEAL:1:3d::cellid=5_1:2 parentid=5
+DEAL:1:3d::cellid=5_1:3 parentid=5
+DEAL:1:3d::cellid=5_1:4 parentid=5
+DEAL:1:3d::cellid=5_1:5 parentid=5
+DEAL:1:3d::cellid=5_1:6 parentid=5
+DEAL:1:3d::cellid=5_1:7 parentid=5
+DEAL:1:3d::cellid=6_1:0 parentid=6
+DEAL:1:3d::cellid=6_1:1 parentid=6
+DEAL:1:3d::cellid=6_1:2 parentid=6
+DEAL:1:3d::cellid=6_1:3 parentid=6
+DEAL:1:3d::cellid=6_1:4 parentid=6
+DEAL:1:3d::cellid=6_1:5 parentid=6
+DEAL:1:3d::cellid=6_1:6 parentid=6
+DEAL:1:3d::cellid=6_1:7 parentid=6
+DEAL:1:3d::cellid=0_2:00 parentid=0
+DEAL:1:3d::cellid=0_2:01 parentid=0
+DEAL:1:3d::cellid=0_2:02 parentid=0
+DEAL:1:3d::cellid=0_2:03 parentid=0
+DEAL:1:3d::cellid=0_2:04 parentid=0
+DEAL:1:3d::cellid=0_2:05 parentid=0
+DEAL:1:3d::cellid=0_2:06 parentid=0
+DEAL:1:3d::cellid=0_2:07 parentid=0
+DEAL:1:3d::OK
+


### PR DESCRIPTION
This PR introduces the `CellDataTransfer` class for non-distributed triangulations. The distributed pendant has been introduced in #7537.

Similarly to the `SolutionTransfer` class, we store `active_cell_indices` on the unrefined mesh and use them to transfer data from the initial to the refined mesh.

We use the `CoarseningStrategy` struct to decide how to handle data during coarsening. However for `CellDataTransfer`, we need the values on all coarsened cells not before, but after coarsening, when the cells no longer exist. Thus, some changes were necessary.

For more flexibility, we moved the `CoarseningStrategy` struct out of the scope of the `p::d::CellDataTransfer` class. It is now an independent struct in the `dealii` namespace defined in `deal.II/numerics/cell_data_transfer.h`. Shall we introduce a separate header for this struct, e.g. `deal.II/numerics/coarsening_strategy.h`?
EDIT: Moved it to `grid/grid_tools.h` now.

Requested by #7515.