### PR TITLE
Fix include to intrinsics

### DIFF
--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -70,10 +70,7 @@ ENDIF()
 #
 CHECK_CXX_SOURCE_COMPILES(
   "
-  #include <emmintrin.h>
-#ifdef __AVX512F__
-  #include <immintrin.h>
-#endif
+  #include <x86intrin.h>
   int main()
   {
     __m128d a, b;


### PR DESCRIPTION
We previously switched from version-specific intrinsics headers to `#include <x86intrin.h>` in #8128 but we forgot one spot. This makes the selection (and whether we enable any of these features) consistent with a single header.