### PR TITLE
CMake: Update CTest configuration

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -20,9 +20,17 @@
 SET(CTEST_PROJECT_NAME "deal.II")
 
 SET(CTEST_DROP_METHOD "http")
-SET(CTEST_DROP_SITE "cdash.kyomu.43-1.org")
+SET(CTEST_DROP_SITE "cdash.43-1.org")
 SET(CTEST_DROP_LOCATION "/submit.php?project=deal.II")
 SET(CTEST_DROP_SITE_CDASH TRUE)
+
+#
+# We use the CTEST_UPDATE routine to query information about the repository
+# but we don't want to actually perform an update. Thus, replace the update
+# by a noop:
+#
+SET(CTEST_GIT_COMMAND "git")
+SET(CTEST_UPDATE_VERSION_ONLY true)
 
 SET(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS   100)
 SET(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 300)

--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -504,6 +504,9 @@ ENDIF()
 
 CTEST_START(Experimental TRACK ${TRACK})
 
+MESSAGE("-- Running CTEST_UPDATE() to query git information")
+CTEST_UPDATE(SOURCE ${CTEST_SOURCE_DIRECTORY})
+
 MESSAGE("-- Running CTEST_CONFIGURE()")
 CTEST_CONFIGURE(OPTIONS "${_options}" RETURN_VALUE _res)
 
@@ -573,18 +576,6 @@ Unable to determine test submission files from TAG. Bailing out.
 "
     )
 ENDIF()
-
-FILE(WRITE ${_path}/Update.xml
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<Update mode=\"Client\" Generator=\"ctest-${CTEST_VERSION}\">
-<Site>${CTEST_SITE}</Site>
-<BuildName>${CTEST_BUILD_NAME}</BuildName>
-<BuildStamp>${_tag}-${TRACK}</BuildStamp>
-<UpdateType>GIT</UpdateType>
-<Revision>${_git_WC_SHORTREV}</Revision>
-<Path>${_git_WC_BRANCH}</Path>
-</Update>"
-  )
 
 #
 # And finally submit:


### PR DESCRIPTION
* Change server name to the new variant ctest.43-1.org

 * Use the CTEST_UPDATE mechanism instead of handwriting an Update.xml.
   This is necessary for cdash-2.6.0 support...