### PR TITLE
Extend MatrixFree with a second template argument to control vectorization

### DIFF
--- a/doc/news/changes/minor/20190706PeterMunch
+++ b/doc/news/changes/minor/20190706PeterMunch
@@ -1,0 +1,5 @@
+New: An additional optional template parameter VectorizedArrayType has been 
+added to the MatrixFree framework. It lets the user switch between no 
+vectorization (only auto vectorization) and vectorization over elements.
+<br>
+(Peter Munch, 2019/07/06)

--- a/doc/news/changes/minor/20190710PeterMunch
+++ b/doc/news/changes/minor/20190710PeterMunch
@@ -1,0 +1,4 @@
+New: It is possible to access value type Number of VectorizedArray<Number,width> 
+directly via VectorizedArray<Number, width>::value_type.
+<br>
+(Peter Munch, 2019/07/10)

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -207,6 +207,11 @@ class VectorizedArray
 {
 public:
   /**
+   * This gives the type of the array elements.
+   */
+  using value_type = Number;
+
+  /**
    * This gives the number of elements collected in this class. In the general
    * case, there is only one element. Specializations use SIMD intrinsics and
    * can work on multiple elements at the same time.
@@ -631,6 +636,11 @@ class VectorizedArray<double, 8>
 {
 public:
   /**
+   * This gives the type of the array elements.
+   */
+  using value_type = double;
+
+  /**
    * This gives the number of vectors collected in this class.
    */
   static const unsigned int n_array_elements = 8;
@@ -1046,6 +1056,11 @@ template <>
 class VectorizedArray<float, 16>
 {
 public:
+  /**
+   * This gives the type of the array elements.
+   */
+  using value_type = float;
+
   /**
    * This gives the number of vectors collected in this class.
    */
@@ -1514,6 +1529,11 @@ class VectorizedArray<double, 4>
 {
 public:
   /**
+   * This gives the type of the array elements.
+   */
+  using value_type = double;
+
+  /**
    * This gives the number of vectors collected in this class.
    */
   static const unsigned int n_array_elements = 4;
@@ -1898,6 +1918,11 @@ template <>
 class VectorizedArray<float, 8>
 {
 public:
+  /**
+   * This gives the type of the array elements.
+   */
+  using value_type = float;
+
   /**
    * This gives the number of vectors collected in this class.
    */
@@ -2305,6 +2330,11 @@ class VectorizedArray<double, 2>
 {
 public:
   /**
+   * This gives the type of the array elements.
+   */
+  using value_type = double;
+
+  /**
    * This gives the number of vectors collected in this class.
    */
   static const unsigned int n_array_elements = 2;
@@ -2648,6 +2678,11 @@ template <>
 class VectorizedArray<float, 4>
 {
 public:
+  /**
+   * This gives the type of the array elements.
+   */
+  using value_type = float;
+
   /**
    * This gives the number of vectors collected in this class.
    */
@@ -3014,6 +3049,11 @@ class VectorizedArray<double, 2>
 {
 public:
   /**
+   * This gives the type of the array elements.
+   */
+  using value_type = double;
+
+  /**
    * This gives the number of vectors collected in this class.
    */
   static const unsigned int n_array_elements = 2;
@@ -3228,6 +3268,11 @@ template <>
 class VectorizedArray<float, 4>
 {
 public:
+  /**
+   * This gives the type of the array elements.
+   */
+  using value_type = float;
+
   /**
    * This gives the number of vectors collected in this class.
    */

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -374,7 +374,7 @@ namespace internal
        * cells batched together. As opposed to the other classes which are
        * templated on the number type, this class as a pure index container is
        * not templated, so we need to keep the information otherwise contained
-       * in VectorizedArray<Number>::n_array_elements.
+       * in VectorizedArrayType::n_array_elements.
        */
       unsigned int vectorization_length;
 

--- a/include/deal.II/matrix_free/mapping_data_on_the_fly.h
+++ b/include/deal.II/matrix_free/mapping_data_on_the_fly.h
@@ -58,9 +58,13 @@ namespace internal
      *
      * @author Martin Kronbichler, 2014
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number, typename VectorizedArrayType>
     class MappingDataOnTheFly
     {
+      static_assert(
+        std::is_same<Number, typename VectorizedArrayType::value_type>::value,
+        "Type of Number and of VectorizedArrayType do not match.");
+
     public:
       /**
        * Constructor, similar to FEValues. Since this class only evaluates the
@@ -114,7 +118,7 @@ namespace internal
        * MappingInfo. This ensures compatibility with the precomputed data
        * fields in the MappingInfo class.
        */
-      const MappingInfoStorage<dim, dim, Number> &
+      const MappingInfoStorage<dim, dim, Number, VectorizedArrayType> &
       get_data_storage() const;
 
       /**
@@ -150,21 +154,24 @@ namespace internal
        * The storage part created for a single cell and held in analogy to
        * MappingInfo.
        */
-      MappingInfoStorage<dim, dim, Number> mapping_info_storage;
+      MappingInfoStorage<dim, dim, Number, VectorizedArrayType>
+        mapping_info_storage;
     };
 
 
     /*-------------------------- Inline functions ---------------------------*/
 
-    template <int dim, typename Number>
-    inline MappingDataOnTheFly<dim, Number>::MappingDataOnTheFly(
-      const Mapping<dim> & mapping,
-      const Quadrature<1> &quadrature,
-      const UpdateFlags    update_flags)
-      : fe_values(mapping,
-                  fe_dummy,
-                  Quadrature<dim>(quadrature),
-                  MappingInfo<dim, Number>::compute_update_flags(update_flags))
+    template <int dim, typename Number, typename VectorizedArrayType>
+    inline MappingDataOnTheFly<dim, Number, VectorizedArrayType>::
+      MappingDataOnTheFly(const Mapping<dim> & mapping,
+                          const Quadrature<1> &quadrature,
+                          const UpdateFlags    update_flags)
+      : fe_values(
+          mapping,
+          fe_dummy,
+          Quadrature<dim>(quadrature),
+          MappingInfo<dim, Number, VectorizedArrayType>::compute_update_flags(
+            update_flags))
       , quadrature_1d(quadrature)
     {
       mapping_info_storage.descriptor.resize(1);
@@ -191,10 +198,10 @@ namespace internal
 
 
 
-    template <int dim, typename Number>
-    inline MappingDataOnTheFly<dim, Number>::MappingDataOnTheFly(
-      const Quadrature<1> &quadrature,
-      const UpdateFlags    update_flags)
+    template <int dim, typename Number, typename VectorizedArrayType>
+    inline MappingDataOnTheFly<dim, Number, VectorizedArrayType>::
+      MappingDataOnTheFly(const Quadrature<1> &quadrature,
+                          const UpdateFlags    update_flags)
       : MappingDataOnTheFly(::dealii::StaticMappingQ1<dim, dim>::mapping,
                             quadrature,
                             update_flags)
@@ -202,9 +209,9 @@ namespace internal
 
 
 
-    template <int dim, typename Number>
+    template <int dim, typename Number, typename VectorizedArrayType>
     inline void
-    MappingDataOnTheFly<dim, Number>::reinit(
+    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::reinit(
       typename dealii::Triangulation<dim>::cell_iterator cell)
     {
       if (present_cell == cell)
@@ -241,9 +248,10 @@ namespace internal
 
 
 
-    template <int dim, typename Number>
+    template <int dim, typename Number, typename VectorizedArrayType>
     inline bool
-    MappingDataOnTheFly<dim, Number>::is_initialized() const
+    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::is_initialized()
+      const
     {
       return present_cell !=
              typename dealii::Triangulation<dim>::cell_iterator();
@@ -251,36 +259,38 @@ namespace internal
 
 
 
-    template <int dim, typename Number>
+    template <int dim, typename Number, typename VectorizedArrayType>
     inline typename dealii::Triangulation<dim>::cell_iterator
-    MappingDataOnTheFly<dim, Number>::get_cell() const
+    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::get_cell() const
     {
       return fe_values.get_cell();
     }
 
 
 
-    template <int dim, typename Number>
+    template <int dim, typename Number, typename VectorizedArrayType>
     inline const dealii::FEValues<dim> &
-    MappingDataOnTheFly<dim, Number>::get_fe_values() const
+    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::get_fe_values() const
     {
       return fe_values;
     }
 
 
 
-    template <int dim, typename Number>
-    inline const MappingInfoStorage<dim, dim, Number> &
-    MappingDataOnTheFly<dim, Number>::get_data_storage() const
+    template <int dim, typename Number, typename VectorizedArrayType>
+    inline const MappingInfoStorage<dim, dim, Number, VectorizedArrayType> &
+    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::get_data_storage()
+      const
     {
       return mapping_info_storage;
     }
 
 
 
-    template <int dim, typename Number>
+    template <int dim, typename Number, typename VectorizedArrayType>
     inline const Quadrature<1> &
-    MappingDataOnTheFly<dim, Number>::get_quadrature() const
+    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::get_quadrature()
+      const
     {
       return quadrature_1d;
     }

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -47,9 +47,9 @@ namespace internal
       return a;
     }
 
-    template <typename Number>
+    template <typename Number, int width>
     Number
-    get_first_array_element(const VectorizedArray<Number> a)
+    get_first_array_element(const VectorizedArray<Number, width> a)
     {
       return a[0];
     }

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -44,7 +44,7 @@ template <int dim>
 class Quadrature;
 template <int dim>
 class QGauss;
-template <int dim, typename number>
+template <int dim, typename number, typename VectorizedArrayType>
 class MatrixFree;
 
 template <typename number>
@@ -1007,15 +1007,18 @@ namespace VectorTools
    */
   template <int dim, typename VectorType>
   void
-  project(std::shared_ptr<
-            const MatrixFree<dim, typename VectorType::value_type>> data,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const unsigned int      n_q_points_1d,
-          const std::function<VectorizedArray<typename VectorType::value_type>(
-            const unsigned int,
-            const unsigned int)> &func,
-          VectorType &            vec_result,
-          const unsigned int      fe_component = 0);
+  project(
+    std::shared_ptr<
+      const MatrixFree<dim,
+                       typename VectorType::value_type,
+                       VectorizedArray<typename VectorType::value_type>>> data,
+    const AffineConstraints<typename VectorType::value_type> &constraints,
+    const unsigned int                                        n_q_points_1d,
+    const std::function<VectorizedArray<typename VectorType::value_type>(
+      const unsigned int,
+      const unsigned int)> &                                  func,
+    VectorType &                                              vec_result,
+    const unsigned int                                        fe_component = 0);
 
   /**
    * Same as above but for <code>n_q_points_1d =
@@ -1023,14 +1026,17 @@ namespace VectorTools
    */
   template <int dim, typename VectorType>
   void
-  project(std::shared_ptr<
-            const MatrixFree<dim, typename VectorType::value_type>> data,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const std::function<VectorizedArray<typename VectorType::value_type>(
-            const unsigned int,
-            const unsigned int)> &                                  func,
-          VectorType &                                              vec_result,
-          const unsigned int fe_component = 0);
+  project(
+    std::shared_ptr<
+      const MatrixFree<dim,
+                       typename VectorType::value_type,
+                       VectorizedArray<typename VectorType::value_type>>> data,
+    const AffineConstraints<typename VectorType::value_type> &constraints,
+    const std::function<VectorizedArray<typename VectorType::value_type>(
+      const unsigned int,
+      const unsigned int)> &                                  func,
+    VectorType &                                              vec_result,
+    const unsigned int                                        fe_component = 0);
 
   /**
    * Compute Dirichlet boundary conditions.  This function makes up a map of

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -1723,8 +1723,10 @@ namespace VectorTools
 
   template <int dim, typename VectorType>
   void
-  project(std::shared_ptr<
-            const MatrixFree<dim, typename VectorType::value_type>> matrix_free,
+  project(std::shared_ptr<const MatrixFree<
+            dim,
+            typename VectorType::value_type,
+            VectorizedArray<typename VectorType::value_type>>>      matrix_free,
           const AffineConstraints<typename VectorType::value_type> &constraints,
           const unsigned int      n_q_points_1d,
           const std::function<VectorizedArray<typename VectorType::value_type>(
@@ -1764,8 +1766,10 @@ namespace VectorTools
 
   template <int dim, typename VectorType>
   void
-  project(std::shared_ptr<
-            const MatrixFree<dim, typename VectorType::value_type>> matrix_free,
+  project(std::shared_ptr<const MatrixFree<
+            dim,
+            typename VectorType::value_type,
+            VectorizedArray<typename VectorType::value_type>>>      matrix_free,
           const AffineConstraints<typename VectorType::value_type> &constraints,
           const std::function<VectorizedArray<typename VectorType::value_type>(
             const unsigned int,

--- a/source/matrix_free/mapping_info.cc
+++ b/source/matrix_free/mapping_info.cc
@@ -25,7 +25,31 @@ DEAL_II_NAMESPACE_OPEN
 
 #include "mapping_info.inst"
 
-template struct internal::MatrixFreeFunctions::FPArrayComparator<double>;
-template struct internal::MatrixFreeFunctions::FPArrayComparator<float>;
+template struct internal::MatrixFreeFunctions::
+  FPArrayComparator<double, VectorizedArray<double, 1>>;
+template struct internal::MatrixFreeFunctions::
+  FPArrayComparator<float, VectorizedArray<float, 1>>;
+
+#if (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)) || \
+  (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__))
+template struct internal::MatrixFreeFunctions::
+  FPArrayComparator<double, VectorizedArray<double, 2>>;
+template struct internal::MatrixFreeFunctions::
+  FPArrayComparator<float, VectorizedArray<float, 4>>;
+#endif
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
+template struct internal::MatrixFreeFunctions::
+  FPArrayComparator<double, VectorizedArray<double, 4>>;
+template struct internal::MatrixFreeFunctions::
+  FPArrayComparator<float, VectorizedArray<float, 8>>;
+#endif
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
+template struct internal::MatrixFreeFunctions::
+  FPArrayComparator<double, VectorizedArray<double, 8>>;
+template struct internal::MatrixFreeFunctions::
+  FPArrayComparator<float, VectorizedArray<float, 16>>;
+#endif
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/matrix_free/mapping_info.inst.in
+++ b/source/matrix_free/mapping_info.inst.in
@@ -17,37 +17,199 @@
 for (deal_II_dimension : DIMENSIONS)
   {
     template struct internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double>;
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 1>>;
     template struct internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float>;
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 1>>;
 
-    template struct internal::MatrixFreeFunctions::
-      MappingInfoStorage<deal_II_dimension, deal_II_dimension, double>;
-    template struct internal::MatrixFreeFunctions::
-      MappingInfoStorage<deal_II_dimension, deal_II_dimension, float>;
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension,
+      deal_II_dimension,
+      double,
+      VectorizedArray<double, 1>>;
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension,
+      deal_II_dimension,
+      float,
+      VectorizedArray<float, 1>>;
 #if deal_II_dimension > 1
-    template struct internal::MatrixFreeFunctions::
-      MappingInfoStorage<deal_II_dimension - 1, deal_II_dimension, double>;
-    template struct internal::MatrixFreeFunctions::
-      MappingInfoStorage<deal_II_dimension - 1, deal_II_dimension, float>;
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension - 1,
+      deal_II_dimension,
+      double,
+      VectorizedArray<double, 1>>;
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension - 1,
+      deal_II_dimension,
+      float,
+      VectorizedArray<float, 1>>;
 #endif
 
-    template void internal::MatrixFreeFunctions::MappingInfo<
-      deal_II_dimension,
-      double>::print_memory_consumption<std::ostream>(std::ostream &,
-                                                      const TaskInfo &) const;
-    template void
-    internal::MatrixFreeFunctions::MappingInfo<deal_II_dimension, double>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
-                                                   const TaskInfo &) const;
-
-    template void internal::MatrixFreeFunctions::MappingInfo<
-      deal_II_dimension,
-      float>::print_memory_consumption<std::ostream>(std::ostream &,
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 1>>::
+        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
+          const;
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 1>>::
+        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
                                                      const TaskInfo &) const;
-    template void internal::MatrixFreeFunctions::MappingInfo<
+
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 1>>::
+        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
+          const;
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 1>>::
+        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
+                                                     const TaskInfo &) const;
+
+
+
+#if (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)) || \
+  (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__))
+    template struct internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 2>>;
+    template struct internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 4>>;
+
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
       deal_II_dimension,
-      float>::print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
-                                                           const TaskInfo &)
-      const;
+      deal_II_dimension,
+      double,
+      VectorizedArray<double, 2>>;
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension,
+      deal_II_dimension,
+      float,
+      VectorizedArray<float, 4>>;
+#  if deal_II_dimension > 1
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension - 1,
+      deal_II_dimension,
+      double,
+      VectorizedArray<double, 2>>;
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension - 1,
+      deal_II_dimension,
+      float,
+      VectorizedArray<float, 4>>;
+#  endif
+
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 2>>::
+        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
+          const;
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 2>>::
+        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
+                                                     const TaskInfo &) const;
+
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 4>>::
+        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
+          const;
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 4>>::
+        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
+                                                     const TaskInfo &) const;
+#endif
+
+
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
+    template struct internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 4>>;
+    template struct internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 8>>;
+
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension,
+      deal_II_dimension,
+      double,
+      VectorizedArray<double, 4>>;
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension,
+      deal_II_dimension,
+      float,
+      VectorizedArray<float, 8>>;
+#  if deal_II_dimension > 1
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension - 1,
+      deal_II_dimension,
+      double,
+      VectorizedArray<double, 4>>;
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension - 1,
+      deal_II_dimension,
+      float,
+      VectorizedArray<float, 8>>;
+#  endif
+
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 4>>::
+        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
+          const;
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 4>>::
+        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
+                                                     const TaskInfo &) const;
+
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 8>>::
+        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
+          const;
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 8>>::
+        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
+                                                     const TaskInfo &) const;
+#endif
+
+
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
+    template struct internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 8>>;
+    template struct internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 16>>;
+
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension,
+      deal_II_dimension,
+      double,
+      VectorizedArray<double, 8>>;
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension,
+      deal_II_dimension,
+      float,
+      VectorizedArray<float, 16>>;
+#  if deal_II_dimension > 1
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension - 1,
+      deal_II_dimension,
+      double,
+      VectorizedArray<double, 8>>;
+    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+      deal_II_dimension - 1,
+      deal_II_dimension,
+      float,
+      VectorizedArray<float, 16>>;
+#  endif
+
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 8>>::
+        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
+          const;
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 8>>::
+        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
+                                                     const TaskInfo &) const;
+
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 16>>::
+        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
+          const;
+    template void internal::MatrixFreeFunctions::
+      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 16>>::
+        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
+                                                     const TaskInfo &) const;
+#endif
   }

--- a/source/matrix_free/matrix_free.inst.in
+++ b/source/matrix_free/matrix_free.inst.in
@@ -16,72 +16,6 @@
 
 for (deal_II_dimension : DIMENSIONS)
   {
-    template class MatrixFree<deal_II_dimension, double>;
-    template class MatrixFree<deal_II_dimension, float>;
-
-    template void
-    MatrixFree<deal_II_dimension,
-               double>::print_memory_consumption<std::ostream>(std::ostream &)
-      const;
-    template void MatrixFree<deal_II_dimension, double>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension,
-               float>::print_memory_consumption<std::ostream>(std::ostream &)
-      const;
-
-    template void MatrixFree<deal_II_dimension, float>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
-
-    template void MatrixFree<deal_II_dimension, double>::internal_reinit<
-      double>(const Mapping<deal_II_dimension> &,
-              const std::vector<const DoFHandler<deal_II_dimension> *> &,
-              const std::vector<const AffineConstraints<double> *> &,
-              const std::vector<IndexSet> &,
-              const std::vector<hp::QCollection<1>> &,
-              const AdditionalData &);
-
-    template void MatrixFree<deal_II_dimension, double>::internal_reinit<
-      double>(const Mapping<deal_II_dimension> &,
-              const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-              const std::vector<const AffineConstraints<double> *> &,
-              const std::vector<IndexSet> &,
-              const std::vector<hp::QCollection<1>> &,
-              const AdditionalData &);
-
-    template void MatrixFree<deal_II_dimension, float>::internal_reinit<double>(
-      const Mapping<deal_II_dimension> &,
-      const std::vector<const DoFHandler<deal_II_dimension> *> &,
-      const std::vector<const AffineConstraints<double> *> &,
-      const std::vector<IndexSet> &,
-      const std::vector<hp::QCollection<1>> &,
-      const AdditionalData &);
-
-    template void MatrixFree<deal_II_dimension, float>::internal_reinit<double>(
-      const Mapping<deal_II_dimension> &,
-      const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-      const std::vector<const AffineConstraints<double> *> &,
-      const std::vector<IndexSet> &,
-      const std::vector<hp::QCollection<1>> &,
-      const AdditionalData &);
-
-    template void MatrixFree<deal_II_dimension, float>::internal_reinit<float>(
-      const Mapping<deal_II_dimension> &,
-      const std::vector<const DoFHandler<deal_II_dimension> *> &,
-      const std::vector<const AffineConstraints<float> *> &,
-      const std::vector<IndexSet> &,
-      const std::vector<hp::QCollection<1>> &,
-      const AdditionalData &);
-
-    template void MatrixFree<deal_II_dimension, float>::internal_reinit<float>(
-      const Mapping<deal_II_dimension> &,
-      const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-      const std::vector<const AffineConstraints<float> *> &,
-      const std::vector<IndexSet> &,
-      const std::vector<hp::QCollection<1>> &,
-      const AdditionalData &);
-
     template void
     internal::MatrixFreeFunctions::ShapeInfo<double>::reinit<deal_II_dimension>(
       const Quadrature<1> &,
@@ -93,27 +27,486 @@ for (deal_II_dimension : DIMENSIONS)
       const Quadrature<1> &,
       const FiniteElement<deal_II_dimension, deal_II_dimension> &,
       const unsigned int);
+  }
+
+
+
+for (deal_II_dimension : DIMENSIONS)
+  {
+    template class MatrixFree<deal_II_dimension,
+                              double,
+                              VectorizedArray<double, 1>>;
+    template class MatrixFree<deal_II_dimension,
+                              float,
+                              VectorizedArray<float, 1>>;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 1>>::
+      print_memory_consumption<std::ostream>(std::ostream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 1>>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
+      print_memory_consumption<std::ostream>(std::ostream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 1>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 1>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
+      internal_reinit<float>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<float> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
+      internal_reinit<float>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<float> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
 
     template void internal::MatrixFreeFunctions::
-      ShapeInfo<VectorizedArray<double>>::reinit<deal_II_dimension>(
+      ShapeInfo<VectorizedArray<double, 1>>::reinit<deal_II_dimension>(
         const Quadrature<1> &,
         const FiniteElement<deal_II_dimension, deal_II_dimension> &,
         const unsigned int);
 
     template void internal::MatrixFreeFunctions::
-      ShapeInfo<VectorizedArray<float>>::reinit<deal_II_dimension>(
+      ShapeInfo<VectorizedArray<float, 1>>::reinit<deal_II_dimension>(
         const Quadrature<1> &,
         const FiniteElement<deal_II_dimension, deal_II_dimension> &,
         const unsigned int);
   }
 
+
+
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension <= deal_II_space_dimension
-    template bool MatrixFree<deal_II_dimension, double>::is_supported(
-      const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+    template bool
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 1>>::
+      is_supported(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
 
-    template bool MatrixFree<deal_II_dimension, float>::is_supported(
-      const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+    template bool
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
+      is_supported(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+#endif
+  }
+
+
+
+for (deal_II_dimension : DIMENSIONS)
+  {
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
+    template class MatrixFree<deal_II_dimension,
+                              double,
+                              VectorizedArray<double, 4>>;
+    template class MatrixFree<deal_II_dimension,
+                              float,
+                              VectorizedArray<float, 8>>;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 4>>::
+      print_memory_consumption<std::ostream>(std::ostream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 4>>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
+      print_memory_consumption<std::ostream>(std::ostream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 4>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 4>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
+      internal_reinit<float>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<float> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
+      internal_reinit<float>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<float> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void internal::MatrixFreeFunctions::
+      ShapeInfo<VectorizedArray<double, 4>>::reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
+
+    template void internal::MatrixFreeFunctions::
+      ShapeInfo<VectorizedArray<float, 8>>::reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
+#endif
+  }
+
+
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
+#  if deal_II_dimension <= deal_II_space_dimension
+    template bool
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 4>>::
+      is_supported(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+
+    template bool
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
+      is_supported(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+#  endif
+#endif
+  }
+
+
+
+for (deal_II_dimension : DIMENSIONS)
+  {
+#if (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)) || \
+  (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__))
+    template class MatrixFree<deal_II_dimension,
+                              double,
+                              VectorizedArray<double, 2>>;
+    template class MatrixFree<deal_II_dimension,
+                              float,
+                              VectorizedArray<float, 4>>;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 2>>::
+      print_memory_consumption<std::ostream>(std::ostream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 2>>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
+      print_memory_consumption<std::ostream>(std::ostream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 2>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 2>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
+      internal_reinit<float>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<float> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
+      internal_reinit<float>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<float> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void internal::MatrixFreeFunctions::
+      ShapeInfo<VectorizedArray<double, 2>>::reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
+
+    template void internal::MatrixFreeFunctions::
+      ShapeInfo<VectorizedArray<float, 4>>::reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
+#endif
+  }
+
+
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+#if (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)) || \
+  (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__))
+#  if deal_II_dimension <= deal_II_space_dimension
+    template bool
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 2>>::
+      is_supported(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+
+    template bool
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
+      is_supported(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+#  endif
+#endif
+  }
+
+
+
+for (deal_II_dimension : DIMENSIONS)
+  {
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
+    template class MatrixFree<deal_II_dimension,
+                              double,
+                              VectorizedArray<double, 8>>;
+    template class MatrixFree<deal_II_dimension,
+                              float,
+                              VectorizedArray<float, 16>>;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 8>>::
+      print_memory_consumption<std::ostream>(std::ostream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 8>>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
+      print_memory_consumption<std::ostream>(std::ostream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 8>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 8>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
+      internal_reinit<float>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<float> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
+      internal_reinit<float>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<float> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void internal::MatrixFreeFunctions::
+      ShapeInfo<VectorizedArray<double, 8>>::reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
+
+    template void internal::MatrixFreeFunctions::
+      ShapeInfo<VectorizedArray<float, 16>>::reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
+#endif
+  }
+
+
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
+#  if deal_II_dimension <= deal_II_space_dimension
+    template bool
+    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 8>>::
+      is_supported(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+
+    template bool
+    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
+      is_supported(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+#  endif
 #endif
   }

--- a/source/numerics/vector_tools_project_qpmf.inst.in
+++ b/source/numerics/vector_tools_project_qpmf.inst.in
@@ -19,10 +19,11 @@ for (VEC : REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
   {
     namespace VectorTools
     \{
-
       template void
       project<deal_II_dimension, VEC>(
-        std::shared_ptr<const MatrixFree<deal_II_dimension, VEC::value_type>>
+        std::shared_ptr<const MatrixFree<deal_II_dimension,
+                                         VEC::value_type,
+                                         VectorizedArray<VEC::value_type>>>
                                                   matrix_free,
         const AffineConstraints<VEC::value_type> &constraints,
         const std::function<VectorizedArray<
@@ -32,7 +33,9 @@ for (VEC : REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
 
       template void
       project<deal_II_dimension, VEC>(
-        std::shared_ptr<const MatrixFree<deal_II_dimension, VEC::value_type>>
+        std::shared_ptr<const MatrixFree<deal_II_dimension,
+                                         VEC::value_type,
+                                         VectorizedArray<VEC::value_type>>>
                                                   matrix_free,
         const AffineConstraints<VEC::value_type> &constraints,
         const unsigned int,
@@ -40,6 +43,7 @@ for (VEC : REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
           VEC::value_type>(const unsigned int, const unsigned int)> &,
         VEC &,
         const unsigned int);
+
 
     \}
   }

--- a/tests/matrix_free/matrix_vector_faces_26.cc
+++ b/tests/matrix_free/matrix_vector_faces_26.cc
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// tests matrix-free face evaluation, matrix-vector products as compared to
+// the same implementation with MeshWorker. This example uses a hypercube mesh
+// without any hanging nodes
+
+#include <deal.II/base/function.h>
+
+#include <deal.II/fe/fe_dgq.h>
+
+#include "../tests.h"
+
+std::ofstream logfile("output");
+
+#include "matrix_vector_faces_common.h"
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(5 - dim);
+
+  FE_DGQ<dim>     fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  do_test<dim, fe_degree, fe_degree + 1, double, VectorizedArray<double, 1>>(
+    dof, constraints, true);
+
+#if (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)) || \
+  (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__))
+  do_test<dim, fe_degree, fe_degree + 1, double, VectorizedArray<double, 2>>(
+    dof, constraints, true);
+#endif
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
+  do_test<dim, fe_degree, fe_degree + 1, double, VectorizedArray<double, 4>>(
+    dof, constraints, true);
+#endif
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
+  do_test<dim, fe_degree, fe_degree + 1, double, VectorizedArray<double, 8>>(
+    dof, constraints, true);
+#endif
+}

--- a/tests/matrix_free/matrix_vector_faces_26.output
+++ b/tests/matrix_free/matrix_vector_faces_26.output
@@ -1,0 +1,17 @@
+
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::

--- a/tests/matrix_free/matrix_vector_faces_26.output.avx
+++ b/tests/matrix_free/matrix_vector_faces_26.output.avx
@@ -1,0 +1,49 @@
+
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::

--- a/tests/matrix_free/matrix_vector_faces_26.output.avx512
+++ b/tests/matrix_free/matrix_vector_faces_26.output.avx512
@@ -1,0 +1,65 @@
+
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::

--- a/tests/matrix_free/matrix_vector_faces_26.output.sse2
+++ b/tests/matrix_free/matrix_vector_faces_26.output.sse2
@@ -1,0 +1,33 @@
+
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::Norm of difference parallel: 0
+DEAL:2d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::Norm of difference parallel: 0
+DEAL:3d::


### PR DESCRIPTION
This PR adds an optional template argument to the `MatrixFree` framework. This template argument controls 1) on which data type internally should be worked on and 2) which data type should be returned (by `FEEvaluation`).

For the time being, we only intend to support `VectorizedArray<Number, width>` with different widths (see: PR #8342). Almost all explicit uses of `VectorizedArray<Number>` in the matrix_free folder are removed: it is only used as default parameter to guarantee backwards compatibility. 

The affected classes are:
```cpp
template<dim, Number, VectorizedArrayType>
MatrixFree;

template<dim, fe_degree, n_q_points_1d, n_components, Number, VectorizedArrayType>
FEEvaluation;

template<dim, fe_degree, n_q_points_1d, n_components, Number, VectorizedArrayType>
FEFaceEvaluation;
```

This PR is part of the effort to introduce new vectorization strategies in the `MatrixFree` framework: no vectorization, vectorization over quadrature points, vectorization over elements. This PR enables to switch between no vectorization and vectorization over elements. Vectorization over quadrature points will be targeted in a next PR: it only requires modifications to the initialization of the internal data structures within `MatrixFree` related i.a. to mapping.