### PR TITLE
Add functionality to support multiple mappings per element in FE_PolyTensor

### DIFF
--- a/doc/news/changes/minor/20190712GrahamHarper
+++ b/doc/news/changes/minor/20190712GrahamHarper
@@ -1,0 +1,7 @@
+Improved: FE_PolyTensor now supports finite elements with different mapping 
+types for each shape function. The member variable mapping_type is now of 
+type std::vector<MappingType>. If the vector contains only one MappingType, 
+then the same mapping is applied to every shape function. If a list of 
+MappingTypes is provided, mapping_type[i] will be applied to shape function i.
+<br>
+(Graham Harper, 2019/07/12)

--- a/include/deal.II/fe/fe_dg_vector.templates.h
+++ b/include/deal.II/fe/fe_dg_vector.templates.h
@@ -43,7 +43,7 @@ FE_DGVector<PolynomialType, dim, spacedim>::FE_DGVector(const unsigned int deg,
       std::vector<ComponentMask>(PolynomialType::compute_n_pols(deg),
                                  ComponentMask(dim, true)))
 {
-  this->mapping_type                   = map;
+  this->mapping_type                   = {map};
   const unsigned int polynomial_degree = this->tensor_degree();
 
   QGauss<dim> quadrature(polynomial_degree + 1);

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -216,6 +216,18 @@ protected:
    */
   std::vector<MappingType> mapping_type;
 
+  /**
+   * Returns a boolean that is true when the finite element uses a single
+   * mapping and false when the finite element uses multiple mappings.
+   */
+  bool
+  single_mapping() const;
+
+  /**
+   * Returns MappingType @p i for the finite element.
+   */
+  MappingType
+  get_mapping_type(unsigned int i) const;
 
   /* NOTE: The following function has its definition inlined into the class
      declaration because we otherwise run into a compiler error with MS Visual
@@ -254,19 +266,17 @@ protected:
     // allocate memory
 
     const bool update_transformed_shape_values =
-      (std::find_if(this->mapping_type.begin(),
-                    this->mapping_type.end(),
-                    [](const MappingType t) { return t != mapping_none; }) !=
-       this->mapping_type.end());
+      std::any_of(this->mapping_type.begin(),
+                  this->mapping_type.end(),
+                  [](const MappingType t) { return t != mapping_none; });
 
     const bool update_transformed_shape_grads =
-      (std::find_if(this->mapping_type.begin(),
-                    this->mapping_type.end(),
-                    [](const MappingType t) {
-                      return (t == mapping_raviart_thomas ||
-                              t == mapping_piola || t == mapping_nedelec ||
-                              t == mapping_contravariant);
-                    }) != this->mapping_type.end());
+      std::any_of(this->mapping_type.begin(),
+                  this->mapping_type.end(),
+                  [](const MappingType t) {
+                    return (t == mapping_raviart_thomas || t == mapping_piola ||
+                            t == mapping_nedelec || t == mapping_contravariant);
+                  });
 
     const bool update_transformed_shape_hessian_tensors =
       update_transformed_shape_values;

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -129,11 +129,13 @@ DEAL_II_NAMESPACE_OPEN
  * transformations can be selected from the set MappingType and stored in
  * #mapping_type. Therefore, each constructor should contain a line like:
  * @code
- * this->mapping_type = mapping_none;
+ * this->mapping_type = {mapping_none};
  * @endcode
  * (in case no mapping is required) or using whatever value among
  * the ones defined in MappingType is appropriate for the element you
- * are implementing.
+ * are implementing. If each shape function may be mapped by different
+ * mappings, then @p mapping_type may be a vector with the same number
+ * of elements as there are shape functions.
  *
  * @see PolynomialsBDM, PolynomialsRaviartThomas
  * @ingroup febase

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -207,9 +207,12 @@ public:
 protected:
   /**
    * The mapping type to be used to map shape functions from the reference
-   * cell to the mesh cell.
+   * cell to the mesh cell. If this vector is length one, the same mapping
+   * will be applied to all shape functions. If the vector size is equal to
+   * the finite element dofs per cell, then each shape function will be mapped
+   * according to the corresponding entry in the vector.
    */
-  MappingType mapping_type;
+  std::vector<MappingType> mapping_type;
 
 
   /* NOTE: The following function has its definition inlined into the class
@@ -247,11 +250,30 @@ protected:
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
+
+    const bool update_transformed_shape_values =
+      (std::find_if(this->mapping_type.begin(),
+                    this->mapping_type.end(),
+                    [](const MappingType t) { return t != mapping_none; }) !=
+       this->mapping_type.end());
+
+    const bool update_transformed_shape_grads =
+      (std::find_if(this->mapping_type.begin(),
+                    this->mapping_type.end(),
+                    [](const MappingType t) {
+                      return (t == mapping_raviart_thomas ||
+                              t == mapping_piola || t == mapping_nedelec ||
+                              t == mapping_contravariant);
+                    }) != this->mapping_type.end());
+
+    const bool update_transformed_shape_hessian_tensors =
+      update_transformed_shape_values;
+
     if (update_flags & update_values)
       {
         values.resize(this->dofs_per_cell);
         data.shape_values.reinit(this->dofs_per_cell, n_q_points);
-        if (mapping_type != mapping_none)
+        if (update_transformed_shape_values)
           data.transformed_shape_values.resize(n_q_points);
       }
 
@@ -261,10 +283,7 @@ protected:
         data.shape_grads.reinit(this->dofs_per_cell, n_q_points);
         data.transformed_shape_grads.resize(n_q_points);
 
-        if ((mapping_type == mapping_raviart_thomas) ||
-            (mapping_type == mapping_piola) ||
-            (mapping_type == mapping_nedelec) ||
-            (mapping_type == mapping_contravariant))
+        if (update_transformed_shape_grads)
           data.untransformed_shape_grads.resize(n_q_points);
       }
 
@@ -273,7 +292,7 @@ protected:
         grad_grads.resize(this->dofs_per_cell);
         data.shape_grad_grads.reinit(this->dofs_per_cell, n_q_points);
         data.transformed_shape_hessians.resize(n_q_points);
-        if (mapping_type != mapping_none)
+        if (update_transformed_shape_hessian_tensors)
           data.untransformed_shape_hessian_tensors.resize(n_q_points);
       }
 

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -60,7 +60,7 @@ FE_ABF<dim>::FE_ABF(const unsigned int deg)
   Assert(dim >= 2, ExcImpossibleInDim(dim));
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = mapping_raviart_thomas;
+  this->mapping_type = {mapping_raviart_thomas};
   // First, initialize the
   // generalized support points and
   // quadrature weights, since they

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -56,7 +56,7 @@ FE_BDM<dim>::FE_BDM(const unsigned int deg)
 
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = mapping_bdm;
+  this->mapping_type = {mapping_bdm};
   // These must be done first, since
   // they change the evaluation of
   // basis functions

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -55,7 +55,7 @@ FE_BernardiRaugel<dim>::FE_BernardiRaugel(const unsigned int p)
 
   // const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = mapping_none;
+  this->mapping_type = {mapping_none};
   // These must be done first, since
   // they change the evaluation of
   // basis functions

--- a/source/fe/fe_dg_vector.cc
+++ b/source/fe/fe_dg_vector.cc
@@ -27,7 +27,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 FE_DGNedelec<dim, spacedim>::FE_DGNedelec(const unsigned int p)
-  : FE_DGVector<PolynomialsNedelec<dim>, dim, spacedim>(p, mapping_nedelec)
+  : FE_DGVector<PolynomialsNedelec<dim>, dim, spacedim>(p, {mapping_nedelec})
 {}
 
 
@@ -52,7 +52,7 @@ template <int dim, int spacedim>
 FE_DGRaviartThomas<dim, spacedim>::FE_DGRaviartThomas(const unsigned int p)
   : FE_DGVector<PolynomialsRaviartThomas<dim>, dim, spacedim>(
       p,
-      mapping_raviart_thomas)
+      {mapping_raviart_thomas})
 {}
 
 
@@ -77,7 +77,7 @@ FE_DGRaviartThomas<dim, spacedim>::get_name() const
 
 template <int dim, int spacedim>
 FE_DGBDM<dim, spacedim>::FE_DGBDM(const unsigned int p)
-  : FE_DGVector<PolynomialsBDM<dim>, dim, spacedim>(p, mapping_bdm)
+  : FE_DGVector<PolynomialsBDM<dim>, dim, spacedim>(p, {mapping_bdm})
 {}
 
 

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -87,7 +87,7 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
 
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = mapping_nedelec;
+  this->mapping_type = {mapping_nedelec};
   // First, initialize the
   // generalized support points and
   // quadrature weights, since they

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -158,7 +158,8 @@ namespace internal
         // TODO: This is probably only going to work for those elements for
         // which all dofs are face dofs
         for (unsigned int l = 0; l < GeometryInfo<dim>::lines_per_cell; ++l)
-          if (!(cell->line_orientation(l)) & mapping_type[0] == mapping_nedelec)
+          if (!(cell->line_orientation(l)) &&
+              mapping_type[0] == mapping_nedelec)
             face_sign[l] = -1.0;
       }
     } // namespace
@@ -189,6 +190,28 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::FE_PolyTensor(
   // the component itself
   for (unsigned int comp = 0; comp < this->n_components(); ++comp)
     this->component_to_base_table[comp].first.second = comp;
+}
+
+
+
+template <class PolynomialType, int dim, int spacedim>
+bool
+FE_PolyTensor<PolynomialType, dim, spacedim>::single_mapping() const
+{
+  return mapping_type.size() == 1;
+}
+
+
+
+template <class PolynomialType, int dim, int spacedim>
+MappingType
+FE_PolyTensor<PolynomialType, dim, spacedim>::get_mapping_type(
+  unsigned int i) const
+{
+  if (single_mapping())
+    return mapping_type[0];
+  Assert(i < mapping_type.size(), ExcIndexRange(i, 0, mapping_type.size()));
+  return mapping_type[i];
 }
 
 
@@ -392,9 +415,7 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::fill_fe_values(
 
   for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
     {
-      MappingType mapping_type =
-        (this->mapping_type.size() > 1 ? this->mapping_type[i] :
-                                         this->mapping_type[0]);
+      const MappingType mapping_type = get_mapping_type(i);
 
       const unsigned int first =
         output_data.shape_function_to_row_table[i * this->n_components() +
@@ -972,9 +993,7 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::fill_fe_face_values(
 
   for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
     {
-      const MappingType mapping_type =
-        (this->mapping_type.size() > 1 ? this->mapping_type[i] :
-                                         this->mapping_type[0]);
+      const MappingType mapping_type = get_mapping_type(i);
 
       const unsigned int first =
         output_data.shape_function_to_row_table[i * this->n_components() +
@@ -1604,9 +1623,7 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::fill_fe_subface_values(
 
   for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
     {
-      MappingType mapping_type =
-        (this->mapping_type.size() > 1 ? this->mapping_type[i] :
-                                         this->mapping_type[0]);
+      const MappingType mapping_type = get_mapping_type(i);
 
       const unsigned int first =
         output_data.shape_function_to_row_table[i * this->n_components() +
@@ -2170,9 +2187,7 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::requires_update_flags(
 
   for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
     {
-      MappingType mapping_type =
-        (this->mapping_type.size() > 1 ? this->mapping_type[i] :
-                                         this->mapping_type[0]);
+      const MappingType mapping_type = get_mapping_type(i);
 
       switch (mapping_type)
         {

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -49,29 +49,28 @@ namespace internal
        * implements an algorithm that determines those DoFs that need this
        * sign change for a given cell.
        */
+      template <int spacedim>
       void
       get_face_sign_change_rt(const dealii::Triangulation<1>::cell_iterator &,
-                              const unsigned int,
-                              std::vector<double> &face_sign)
+                              const FiniteElement<1, spacedim> &,
+                              const std::vector<MappingType> &,
+                              std::vector<double> &)
       {
         // nothing to do in 1d
-        std::fill(face_sign.begin(), face_sign.end(), 1.0);
       }
 
 
 
+      //      template<int spacedim>
       void
       get_face_sign_change_rt(
         const dealii::Triangulation<2>::cell_iterator &cell,
-        const unsigned int                             dofs_per_face,
+        const FiniteElement<2, 2> &                    fe,
+        const std::vector<MappingType> &               mapping_type,
         std::vector<double> &                          face_sign)
       {
         const unsigned int dim      = 2;
         const unsigned int spacedim = 2;
-
-        // Default is no sign
-        // change. I.e. multiply by one.
-        std::fill(face_sign.begin(), face_sign.end(), 1.0);
 
         for (unsigned int f = GeometryInfo<dim>::faces_per_cell / 2;
              f < GeometryInfo<dim>::faces_per_cell;
@@ -84,14 +83,24 @@ namespace internal
                 const unsigned int nn = cell->neighbor_face_no(f);
 
                 if (nn < GeometryInfo<dim>::faces_per_cell / 2)
-                  for (unsigned int j = 0; j < dofs_per_face; ++j)
+                  for (unsigned int j = 0; j < fe.dofs_per_face; ++j)
                     {
-                      Assert(f * dofs_per_face + j < face_sign.size(),
+                      const unsigned int cell_j = fe.face_to_cell_index(j, f);
+                      // something in FiniteElement or FiniteElementData base
+                      // classes
+
+                      Assert(f * fe.dofs_per_face + j < face_sign.size(),
+                             ExcInternalError());
+                      Assert(mapping_type.size() == 1 ||
+                               cell_j < mapping_type.size(),
                              ExcInternalError());
 
                       // TODO: This is probably only going to work for those
                       // elements for which all dofs are face dofs
-                      face_sign[f * dofs_per_face + j] = -1.0;
+                      if ((mapping_type.size() > 1 ?
+                             mapping_type[cell_j] :
+                             mapping_type[0]) == mapping_raviart_thomas)
+                        face_sign[f * fe.dofs_per_face + j] = -1.0;
                     }
               }
           }
@@ -99,51 +108,57 @@ namespace internal
 
 
 
+      template <int spacedim>
       void
       get_face_sign_change_rt(
         const dealii::Triangulation<3>::cell_iterator & /*cell*/,
-        const unsigned int /*dofs_per_face*/,
-        std::vector<double> &face_sign)
+        const FiniteElement<3, spacedim> & /*fe*/,
+        const std::vector<MappingType> & /*mapping_type*/,
+        std::vector<double> & /*face_sign*/)
       {
-        std::fill(face_sign.begin(), face_sign.end(), 1.0);
         // TODO: think about what it would take here
       }
 
+
+
+      template <int spacedim>
       void
       get_face_sign_change_nedelec(
         const dealii::Triangulation<1>::cell_iterator & /*cell*/,
-        const unsigned int /*dofs_per_face*/,
-        std::vector<double> &face_sign)
+        const FiniteElement<1, spacedim> & /*fe*/,
+        const std::vector<MappingType> & /*mapping_type*/,
+        std::vector<double> & /*face_sign*/)
       {
         // nothing to do in 1d
-        std::fill(face_sign.begin(), face_sign.end(), 1.0);
       }
 
 
 
+      template <int spacedim>
       void
       get_face_sign_change_nedelec(
         const dealii::Triangulation<2>::cell_iterator & /*cell*/,
-        const unsigned int /*dofs_per_face*/,
-        std::vector<double> &face_sign)
+        const FiniteElement<2, spacedim> & /*fe*/,
+        const std::vector<MappingType> & /*mapping_type*/,
+        std::vector<double> & /*face_sign*/)
       {
-        std::fill(face_sign.begin(), face_sign.end(), 1.0);
         // TODO: think about what it would take here
       }
 
 
+      template <int spacedim>
       void
       get_face_sign_change_nedelec(
         const dealii::Triangulation<3>::cell_iterator &cell,
-        const unsigned int /*dofs_per_face*/,
-        std::vector<double> &face_sign)
+        const FiniteElement<3, spacedim> & /*fe*/,
+        const std::vector<MappingType> &mapping_type,
+        std::vector<double> &           face_sign)
       {
         const unsigned int dim = 3;
-        std::fill(face_sign.begin(), face_sign.end(), 1.0);
         // TODO: This is probably only going to work for those elements for
         // which all dofs are face dofs
         for (unsigned int l = 0; l < GeometryInfo<dim>::lines_per_cell; ++l)
-          if (!(cell->line_orientation(l)))
+          if (!(cell->line_orientation(l)) & mapping_type[0] == mapping_nedelec)
             face_sign[l] = -1.0;
       }
     } // namespace
@@ -161,7 +176,7 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::FE_PolyTensor(
   : FiniteElement<dim, spacedim>(fe_data,
                                  restriction_is_additive_flags,
                                  nonzero_components)
-  , mapping_type(MappingType::mapping_none)
+  , mapping_type({MappingType::mapping_none})
   , poly_space(PolynomialType(degree))
 {
   cached_point(0) = -1;
@@ -364,18 +379,23 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::fill_fe_values(
   // between two faces.
   std::fill(fe_data.sign_change.begin(), fe_data.sign_change.end(), 1.0);
 
-  if (mapping_type == mapping_raviart_thomas)
-    internal::FE_PolyTensor::get_face_sign_change_rt(cell,
-                                                     this->dofs_per_face,
-                                                     fe_data.sign_change);
-  else if (mapping_type == mapping_nedelec)
-    internal::FE_PolyTensor::get_face_sign_change_nedelec(cell,
-                                                          this->dofs_per_face,
-                                                          fe_data.sign_change);
+  internal::FE_PolyTensor::get_face_sign_change_rt(cell,
+                                                   *this,
+                                                   this->mapping_type,
+                                                   fe_data.sign_change);
+
+  internal::FE_PolyTensor::get_face_sign_change_nedelec(cell,
+                                                        *this,
+                                                        this->mapping_type,
+                                                        fe_data.sign_change);
 
 
   for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
     {
+      MappingType mapping_type =
+        (this->mapping_type.size() > 1 ? this->mapping_type[i] :
+                                         this->mapping_type[0]);
+
       const unsigned int first =
         output_data.shape_function_to_row_table[i * this->n_components() +
                                                 this->get_nonzero_components(i)
@@ -940,18 +960,22 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::fill_fe_face_values(
   // on the neighborhood between two faces.
   std::fill(fe_data.sign_change.begin(), fe_data.sign_change.end(), 1.0);
 
-  if (mapping_type == mapping_raviart_thomas)
-    internal::FE_PolyTensor::get_face_sign_change_rt(cell,
-                                                     this->dofs_per_face,
-                                                     fe_data.sign_change);
+  internal::FE_PolyTensor::get_face_sign_change_rt(cell,
+                                                   *this,
+                                                   this->mapping_type,
+                                                   fe_data.sign_change);
 
-  else if (mapping_type == mapping_nedelec)
-    internal::FE_PolyTensor::get_face_sign_change_nedelec(cell,
-                                                          this->dofs_per_face,
-                                                          fe_data.sign_change);
+  internal::FE_PolyTensor::get_face_sign_change_nedelec(cell,
+                                                        *this,
+                                                        this->mapping_type,
+                                                        fe_data.sign_change);
 
   for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
     {
+      const MappingType mapping_type =
+        (this->mapping_type.size() > 1 ? this->mapping_type[i] :
+                                         this->mapping_type[0]);
+
       const unsigned int first =
         output_data.shape_function_to_row_table[i * this->n_components() +
                                                 this->get_nonzero_components(i)
@@ -1568,18 +1592,22 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::fill_fe_subface_values(
   // on the neighborhood between two faces.
   std::fill(fe_data.sign_change.begin(), fe_data.sign_change.end(), 1.0);
 
-  if (mapping_type == mapping_raviart_thomas)
-    internal::FE_PolyTensor::get_face_sign_change_rt(cell,
-                                                     this->dofs_per_face,
-                                                     fe_data.sign_change);
+  internal::FE_PolyTensor::get_face_sign_change_rt(cell,
+                                                   *this,
+                                                   this->mapping_type,
+                                                   fe_data.sign_change);
 
-  else if (mapping_type == mapping_nedelec)
-    internal::FE_PolyTensor::get_face_sign_change_nedelec(cell,
-                                                          this->dofs_per_face,
-                                                          fe_data.sign_change);
+  internal::FE_PolyTensor::get_face_sign_change_nedelec(cell,
+                                                        *this,
+                                                        this->mapping_type,
+                                                        fe_data.sign_change);
 
   for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
     {
+      MappingType mapping_type =
+        (this->mapping_type.size() > 1 ? this->mapping_type[i] :
+                                         this->mapping_type[0]);
+
       const unsigned int first =
         output_data.shape_function_to_row_table[i * this->n_components() +
                                                 this->get_nonzero_components(i)
@@ -2140,88 +2168,95 @@ FE_PolyTensor<PolynomialType, dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = update_default;
 
-  switch (mapping_type)
+  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
     {
-      case mapping_none:
+      MappingType mapping_type =
+        (this->mapping_type.size() > 1 ? this->mapping_type[i] :
+                                         this->mapping_type[0]);
+
+      switch (mapping_type)
         {
-          if (flags & update_values)
-            out |= update_values;
+          case mapping_none:
+            {
+              if (flags & update_values)
+                out |= update_values;
 
-          if (flags & update_gradients)
-            out |= update_gradients | update_values |
-                   update_jacobian_pushed_forward_grads;
+              if (flags & update_gradients)
+                out |= update_gradients | update_values |
+                       update_jacobian_pushed_forward_grads;
 
-          if (flags & update_hessians)
-            out |= update_hessians | update_values | update_gradients |
-                   update_jacobian_pushed_forward_grads |
-                   update_jacobian_pushed_forward_2nd_derivatives;
-          break;
-        }
+              if (flags & update_hessians)
+                out |= update_hessians | update_values | update_gradients |
+                       update_jacobian_pushed_forward_grads |
+                       update_jacobian_pushed_forward_2nd_derivatives;
+              break;
+            }
+          case mapping_raviart_thomas:
+          case mapping_piola:
+            {
+              if (flags & update_values)
+                out |= update_values | update_piola;
 
-      case mapping_raviart_thomas:
-      case mapping_piola:
-        {
-          if (flags & update_values)
-            out |= update_values | update_piola;
+              if (flags & update_gradients)
+                out |= update_gradients | update_values | update_piola |
+                       update_jacobian_pushed_forward_grads |
+                       update_covariant_transformation |
+                       update_contravariant_transformation;
 
-          if (flags & update_gradients)
-            out |= update_gradients | update_values | update_piola |
-                   update_jacobian_pushed_forward_grads |
-                   update_covariant_transformation |
-                   update_contravariant_transformation;
+              if (flags & update_hessians)
+                out |= update_hessians | update_piola | update_values |
+                       update_gradients | update_jacobian_pushed_forward_grads |
+                       update_jacobian_pushed_forward_2nd_derivatives |
+                       update_covariant_transformation;
 
-          if (flags & update_hessians)
-            out |= update_hessians | update_piola | update_values |
-                   update_gradients | update_jacobian_pushed_forward_grads |
-                   update_jacobian_pushed_forward_2nd_derivatives |
-                   update_covariant_transformation;
+              break;
+            }
 
-          break;
-        }
 
-      case mapping_contravariant:
-        {
-          if (flags & update_values)
-            out |= update_values | update_piola;
+          case mapping_contravariant:
+            {
+              if (flags & update_values)
+                out |= update_values | update_piola;
 
-          if (flags & update_gradients)
-            out |= update_gradients | update_values |
-                   update_jacobian_pushed_forward_grads |
-                   update_covariant_transformation |
-                   update_contravariant_transformation;
+              if (flags & update_gradients)
+                out |= update_gradients | update_values |
+                       update_jacobian_pushed_forward_grads |
+                       update_covariant_transformation |
+                       update_contravariant_transformation;
 
-          if (flags & update_hessians)
-            out |= update_hessians | update_piola | update_values |
-                   update_gradients | update_jacobian_pushed_forward_grads |
-                   update_jacobian_pushed_forward_2nd_derivatives |
-                   update_covariant_transformation;
+              if (flags & update_hessians)
+                out |= update_hessians | update_piola | update_values |
+                       update_gradients | update_jacobian_pushed_forward_grads |
+                       update_jacobian_pushed_forward_2nd_derivatives |
+                       update_covariant_transformation;
 
-          break;
-        }
+              break;
+            }
 
-      case mapping_nedelec:
-      case mapping_covariant:
-        {
-          if (flags & update_values)
-            out |= update_values | update_covariant_transformation;
+          case mapping_nedelec:
+          case mapping_covariant:
+            {
+              if (flags & update_values)
+                out |= update_values | update_covariant_transformation;
 
-          if (flags & update_gradients)
-            out |= update_gradients | update_values |
-                   update_jacobian_pushed_forward_grads |
-                   update_covariant_transformation;
+              if (flags & update_gradients)
+                out |= update_gradients | update_values |
+                       update_jacobian_pushed_forward_grads |
+                       update_covariant_transformation;
 
-          if (flags & update_hessians)
-            out |= update_hessians | update_values | update_gradients |
-                   update_jacobian_pushed_forward_grads |
-                   update_jacobian_pushed_forward_2nd_derivatives |
-                   update_covariant_transformation;
+              if (flags & update_hessians)
+                out |= update_hessians | update_values | update_gradients |
+                       update_jacobian_pushed_forward_grads |
+                       update_jacobian_pushed_forward_2nd_derivatives |
+                       update_covariant_transformation;
 
-          break;
-        }
+              break;
+            }
 
-      default:
-        {
-          Assert(false, ExcNotImplemented());
+          default:
+            {
+              Assert(false, ExcNotImplemented());
+            }
         }
     }
 

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -60,7 +60,7 @@ FE_RaviartThomas<dim>::FE_RaviartThomas(const unsigned int deg)
   Assert(dim >= 2, ExcImpossibleInDim(dim));
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = mapping_raviart_thomas;
+  this->mapping_type = {mapping_raviart_thomas};
   // First, initialize the
   // generalized support points and
   // quadrature weights, since they

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -52,7 +52,7 @@ FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int deg)
   Assert(dim >= 2, ExcImpossibleInDim(dim));
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = mapping_raviart_thomas;
+  this->mapping_type = {mapping_raviart_thomas};
   // First, initialize the
   // generalized support points and
   // quadrature weights, since they

--- a/source/fe/fe_rt_bubbles.cc
+++ b/source/fe/fe_rt_bubbles.cc
@@ -55,7 +55,7 @@ FE_RT_Bubbles<dim>::FE_RT_Bubbles(const unsigned int deg)
       "Lowest order RT_Bubbles element is degree 1, but you requested for degree 0"));
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = mapping_raviart_thomas;
+  this->mapping_type = {mapping_raviart_thomas};
   // Initialize support points and quadrature weights
   initialize_support_points(deg);
   // Compute the inverse node matrix to get


### PR DESCRIPTION
These changes to `FE_PolyTensor` generalize it so that derived classes may support different mapping types for each shape function.

The motivation for this is the existence of many different kinds of "enriched" finite elements, where some vector fields may be mapped with no mapping (such as the Q_1^d vector field), but others may be mapped so that the vector field remains normal to the element (such as bubble functions). This way future implementation of finite element classes will not be restricted.

I've run a build and most of the tests and everything comes back clean so far. I also experimented with the `FE_BernardiRaugel` class and changing the mappings to
```
this->mapping_type = 
{mapping_none, mapping_none, mapping_none, mapping_none,
 mapping_none, mapping_none, mapping_none, mapping_none,
 mapping_piola, mapping_piola, mapping_piola, mapping_piola}
```
in 2D (3D case used 24 mapping_nones and 6 mapping_piolas). The shape functions evaluate correctly when this is done, and also when `mapping_contravariant` is used instead of `mapping_piola`.

The only case that didn't pass my own testing is `mapping_covariant`, but I'm fairly certain that `FE_PolyTensor` in its current form does not support mapping vector fields with `mapping_covariant` in the first place. I raised an issue so that can also be discussed as needed #8351.

I tried squashing all the commits down as much as I could, but then I forgot a couple minor things. Please remind me later, and I can squash commits down again, but I would need to be reminded which git commands I need to use in order to do so.

I look forward to your feedback!