### PR TITLE
Add a space between sentences in ExcNumberNotFinite

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -683,7 +683,7 @@ namespace StandardExceptions
     << "finite, but that the actual error that computed the number "
     << "may have happened far earlier. To find this location, you "
     << "may want to add checks for finiteness in places of your "
-    << "program visited before the place where this error is produced."
+    << "program visited before the place where this error is produced. "
     << "One way to check for finiteness is to use the 'AssertIsFinite' "
     << "macro.");
 


### PR DESCRIPTION
In my adventures I came across a space between words that was missing. I figured it was worth a quick pull request, even though it's an extremely small detail.

Previously ExcNumberNotFinite had a paragraph that was missing a space between two sentences:
> ..."before the place where this error is produced.One way to check for finiteness is to use the 'AssertIsFinite' macro"...

Now it should read:
> ,,,"before the place where this error is produced. One way to check for finiteness is to use the 'AssertIsFinite' macro"...

