### PR TITLE
Remove unused code in CUDAWrappers::internal::HangingNodes

### DIFF
--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -900,7 +900,6 @@ namespace CUDAWrappers
           (((constraint_mask & face1) && on_face1) ||
            ((constraint_mask & face2) && on_face2) ||
            ((constraint_mask & edge) && on_face1 && on_face2));
-        (direction == 0) ? z_idx : (direction == 1) ? x_idx : y_idx;
 
         if (constrained_face && constrained_dof)
           {


### PR DESCRIPTION
This code line has no effect and seems to be duplicated from https://github.com/dealii/dealii/blob/master/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h#L890 while restructuring the code in https://github.com/dealii/dealii/pull/8337.