### PR TITLE
fixed misrepresentation of "*" in documentation of tutorials

### DIFF
--- a/examples/step-18/doc/intro.dox
+++ b/examples/step-18/doc/intro.dox
@@ -497,8 +497,7 @@ for (unsigned int i=0; i<dofs_per_cell; ++i)
           eps_phi_j = get_strain (fe_values, j, q_point);
 
         cell_matrix(i,j)
-          += (eps_phi_i * stress_strain_tensor * eps_phi_j
-              *
+          += (eps_phi_i * stress_strain_tensor * eps_phi_j *
               fe_values.JxW (q_point));
       }
   @endcode
@@ -542,8 +541,7 @@ for (unsigned int i=0; i<dofs_per_cell; ++i)
                         fe_values.shape_value (i,q_point)
                         -
                         old_stress *
-                        get_strain (fe_values,i,q_point))
-                       *
+                        get_strain (fe_values,i,q_point)) *
                        fe_values.JxW (q_point);
       }
   }

--- a/examples/step-20/doc/intro.dox
+++ b/examples/step-20/doc/intro.dox
@@ -228,8 +228,7 @@ If we implemented this, we would get code like this:
                               k_inverse_values[q][1][1] *
                               fe_values.shape_value_component(i,q,1) *
                               fe_values.shape_value_component(j,q,1)
-                             )
-                             *
+                             ) *
                              fe_values.JxW(q);
 @endcode
 


### PR DESCRIPTION
For some reason that I don't know, any line containing a single asterisk within a code block within doxygen is not displayed in the documentation. I searched the tutorial files and I found 3 lines of code that must be slightly reformatted to properly show the multiplication sign `*`