### PR TITLE
Fix a few gcc-9 warninigs in tests

### DIFF
--- a/tests/mpi/periodicity_06.cc
+++ b/tests/mpi/periodicity_06.cc
@@ -134,7 +134,7 @@ test(const unsigned numRefinementLevels = 2)
               if (dist < 1e-08)
                 cell->set_refine_flag();
             }
-          catch (typename MappingQ1<dim>::ExcTransformationFailed)
+          catch (const typename MappingQ1<dim>::ExcTransformationFailed &)
             {}
         }
       triangulation.execute_coarsening_and_refinement();

--- a/tests/mpi/periodicity_07.cc
+++ b/tests/mpi/periodicity_07.cc
@@ -107,7 +107,7 @@ test(const unsigned numRefinementLevels = 2)
               if (dist < 1e-08)
                 cell->set_refine_flag();
             }
-          catch (typename MappingQ1<dim>::ExcTransformationFailed)
+          catch (const typename MappingQ1<dim>::ExcTransformationFailed &)
             {}
         }
       triangulation.execute_coarsening_and_refinement();


### PR DESCRIPTION
Running the test suite with `-Werror` only really gave these two warnings.