### PR TITLE
Hanging nodes: Loosen assertion for artificial cells.

### DIFF
--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -840,8 +840,10 @@ namespace DoFTools
                        ExcInternalError());
                 for (unsigned int c = 0; c < cell->face(face)->n_children();
                      ++c)
-                  AssertDimension(
-                    cell->face(face)->child(c)->n_active_fe_indices(), 1);
+                  if (!cell->neighbor_child_on_subface(face, c)
+                         ->is_artificial())
+                    AssertDimension(
+                      cell->face(face)->child(c)->n_active_fe_indices(), 1);
 
                 // right now, all that is implemented is the case that both
                 // sides use the same fe, and not only that but also that all
@@ -1115,8 +1117,11 @@ namespace DoFTools
                        ExcInternalError());
                 for (unsigned int c = 0; c < cell->face(face)->n_children();
                      ++c)
-                  Assert(cell->face(face)->child(c)->n_active_fe_indices() == 1,
-                         ExcInternalError());
+                  if (!cell->neighbor_child_on_subface(face, c)
+                         ->is_artificial())
+                    Assert(cell->face(face)->child(c)->n_active_fe_indices() ==
+                             1,
+                           ExcInternalError());
 
                 // first find out whether we can constrain each of the subfaces
                 // to the mother face. in the lingo of the hp paper, this would

--- a/tests/mpi/hp_hanging_node_constraints.cc
+++ b/tests/mpi/hp_hanging_node_constraints.cc
@@ -1,0 +1,102 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// this test failed at some stage:
+// DoFTools::make_hanging_node_constraints() has not worked with an
+// hp::DoFHandler on ghost cells that neighbor artificial cells.
+//
+// Geometry in 2D divided on two subdomains:
+// Subdomain0:          Subdomain1:
+// +-------+-------+    +-------+-------+
+// |       |       |    |       |       |
+// |   g   |   g   |    |   o   |   o   |
+// |       |       |    |       |       |
+// +---+---+---+!!!+    +---+---+---+---+
+// | o | o | g | a |    | g | g | o | o |
+// +---+---+---+---+    +---+---+---+---+
+// | o | o | g | a |    | a | g | o | o |
+// +---+---+---+---+    +---+---+---+---+
+
+
+#include <deal.II/base/index_set.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/hp/dof_handler.h>
+#include <deal.II/hp/fe_collection.h>
+
+#include <deal.II/lac/affine_constraints.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  // setup triangulation
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(1);
+
+  // refine half of all cells
+  unsigned int i = 0;
+  for (const auto &cell : tria.active_cell_iterators())
+    if (i++ < .5 * tria.n_active_cells())
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+
+  // setup finite elemets
+  hp::FECollection<dim> fes;
+  fes.push_back(FE_Q<dim>(1));
+
+  hp::DoFHandler<dim> dh(tria);
+  dh.distribute_dofs(fes);
+
+  // make constraints
+  IndexSet locally_relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+
+  AffineConstraints<double> constraints;
+  constraints.reinit(locally_relevant_dofs);
+  DoFTools::make_hanging_node_constraints(dh, constraints);
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+  MPI_Barrier(MPI_COMM_WORLD);
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/mpi/hp_hanging_node_constraints.with_p4est=true.mpirun=2.output
+++ b/tests/mpi/hp_hanging_node_constraints.with_p4est=true.mpirun=2.output
@@ -1,0 +1,7 @@
+
+DEAL:0:2d::OK
+DEAL:0:3d::OK
+
+DEAL:1:2d::OK
+DEAL:1:3d::OK
+


### PR DESCRIPTION
While preparing a parallel distributed version of `step-27`, the following assertion gets triggered when calling `DoFTools::make_hanging_node_constraints()`:
https://github.com/dealii/dealii/blob/223d9d0be2498114bd5429bbce51271f16a031e5/source/dofs/dof_tools_constraints.cc#L1118

This assertion gets triggered whenever a ghost cell neighbors an artificial one which lives on a different level: Since no finite element is assigned to artificial cells, `n_active_fe_indices()` returns `0` on those.
```
Subdomain 0:         Subdomain 1:
+-------+-------+    +-------+-------+    o = locally owned
|       |       |    |       |       |    g = ghost
|   g   |   g   |    |   o   |   o   |    a = artificial
|       |       |    |       |       |
+---+---+---+!!!+    +---+---+---+---+
| o | o | g | a |    | g | g | o | o |
+---+---+---+---+    +---+---+---+---+
| o | o | g | a |    | a | g | o | o |
+---+---+---+---+    +---+---+---+---+
```

Judging the lines following this particular assertion, I assume that the case for artificial cells has already been considered in the implementation. Thus, I've loosened the assertion in a way that we exclude artificial cells for this particular check. At least for now, this seems to solve my problem.