### PR TITLE
 Epetra: fix SparsityPattern::compress() with 64 bit

### DIFF
--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -27,6 +27,7 @@
 #    include <deal.II/lac/exceptions.h>
 #    include <deal.II/lac/full_matrix.h>
 #    include <deal.II/lac/trilinos_epetra_vector.h>
+#    include <deal.II/lac/trilinos_index_access.h>
 #    include <deal.II/lac/trilinos_tpetra_vector.h>
 #    include <deal.II/lac/trilinos_vector.h>
 #    include <deal.II/lac/vector_memory.h>
@@ -3132,11 +3133,7 @@ namespace TrilinosWrappers
     // sparsity pattern), it does not know about the number of columns so we
     // must always take this from the additional column space map
     Assert(column_space_map.get() != nullptr, ExcInternalError());
-#      ifndef DEAL_II_WITH_64BIT_INDICES
-    return column_space_map->NumGlobalElements();
-#      else
-    return column_space_map->NumGlobalElements64();
-#      endif
+    return n_global_elements(*column_space_map);
   }
 
 

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -792,7 +792,7 @@ namespace TrilinosWrappers
       {
         if (nonlocal_graph->IndicesAreGlobal() == false &&
             nonlocal_graph->RowMap().NumMyElements() > 0 &&
-            column_space_map->NumGlobalElements() > 0)
+            n_global_elements(*column_space_map) > 0)
           {
             // Insert dummy element at (row, column) that corresponds to row 0
             // in local index counting.
@@ -814,7 +814,7 @@ namespace TrilinosWrappers
             AssertThrow(ierr == 0, ExcTrilinosError(ierr));
           }
         Assert(nonlocal_graph->RowMap().NumMyElements() == 0 ||
-                 column_space_map->NumGlobalElements() == 0 ||
+                 n_global_elements(*column_space_map) == 0 ||
                  nonlocal_graph->IndicesAreGlobal() == true,
                ExcInternalError());
 


### PR DESCRIPTION
NumGlobalElements is only available if the Epetra map was created with a
32 bit int for the dimension, which is not true if we compile with 64
bit enabled. Fix this using the helper functions we already have.