### PR TITLE
Fix documentation of Chebyshev iteration

### DIFF
--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -879,7 +879,7 @@ private:
  *  x^{n+1} = x^{n} + \rho_n \rho_{n-1} (x^{n} - x^{n-1}) +
  *     \frac{\rho_n}{\lambda_{\max{}}-\lambda_{\min{}}} P^{-1} (b-Ax^n).
  * @f]
- * where the parameter $\rho_0$ is set to $\rho_0 =
+ * where the parameter $\rho_0$ is set to $\rho_0 = 2
  * \frac{\lambda_{\max{}}-\lambda_{\min{}}}{\lambda_{\max{}}+\lambda_{\min{}}}$
  * for the maximal eigenvalue $\lambda_{\max{}}$ and updated via $\rho_n =
  * \left(2\frac{\lambda_{\max{}}+\lambda_{\min{}}}
@@ -910,9 +910,9 @@ private:
  *
  * The Chebyshev method relies on an estimate of the eigenvalues of the matrix
  * which are computed during the first invocation of vmult(). The algorithm
- * invokes a conjugate gradient solver so symmetry and positive definiteness
- * of the (preconditioned) matrix system are requirements. The eigenvalue
- * algorithm can be controlled by
+ * invokes a conjugate gradient solver (i.e., Lanczos iteration) so symmetry
+ * and positive definiteness of the (preconditioned) matrix system are
+ * requirements. The eigenvalue algorithm can be controlled by
  * PreconditionChebyshev::AdditionalData::eig_cg_n_iterations specifying how
  * many iterations should be performed. The iterations are started from an
  * initial vector that depends on the vector type. For the classes


### PR DESCRIPTION
There was another mistake in the documentation of `PreconditionChebyshev` that I overlooked in #8333: The initial step `rho_0` is set to `1./theta` [here](https://github.com/dealii/dealii/blob/master/include/deal.II/lac/precondition.h#L2338) and theta is set to `1/2 * (lambda_max + lambda_min)` [here](https://github.com/dealii/dealii/blob/master/include/deal.II/lac/precondition.h#L2293). Combine with how we spell the formula of the iteration [here](https://github.com/dealii/dealii/blob/master/include/deal.II/lac/precondition.h#L880) we must set a factor 2.