### PR TITLE
Automated template instantiation for VectorizedArray

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -8,6 +8,10 @@ BOOL            := { true; false }
 // real scalar floating point types
 REAL_SCALARS    := { double; float }
 
+// real scalar floating point types (vectorized)
+REAL_SCALARS_VECTORIZED    := { @DEAL_II_EXPAND_REAL_SCALARS_VECTORIZED@; }
+FLOAT_VECTORIZED           := { @DEAL_II_EXPAND_FLOAT_VECTORIZED@; }
+
 // complex scalar types
 COMPLEX_SCALARS := { 
     @DEAL_II_EXPAND_COMPLEX_SCALARS@;

--- a/cmake/configure/configure_vectorization.cmake
+++ b/cmake/configure/configure_vectorization.cmake
@@ -1,0 +1,40 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2019 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE.md at
+## the top level directory of deal.II.
+##
+## ---------------------------------------------------------------------
+ 
+#
+# Configuration for real scalar vectorization
+#
+
+
+SET(DEAL_II_EXPAND_REAL_SCALARS_VECTORIZED "VectorizedArray<double,1>" "VectorizedArray<float,1>")
+SET(DEAL_II_EXPAND_FLOAT_VECTORIZED "VectorizedArray<float,1>")
+
+IF(${DEAL_II_COMPILER_VECTORIZATION_LEVEL} GREATER 0)
+   SET(DEAL_II_EXPAND_REAL_SCALARS_VECTORIZED 
+      "${DEAL_II_EXPAND_REAL_SCALARS_VECTORIZED}" "VectorizedArray<double,2>" "VectorizedArray<float,4>")
+   SET(DEAL_II_EXPAND_FLOAT_VECTORIZED  "${DEAL_II_EXPAND_FLOAT_VECTORIZED}" "VectorizedArray<float,4>")
+ENDIF()
+
+IF((${DEAL_II_COMPILER_VECTORIZATION_LEVEL} GREATER 1) AND ( DEAL_II_HAVE_AVX OR DEAL_II_HAVE_ALTIVEC))
+   SET(DEAL_II_EXPAND_REAL_SCALARS_VECTORIZED 
+      "${DEAL_II_EXPAND_REAL_SCALARS_VECTORIZED}" "VectorizedArray<double,4>" "VectorizedArray<float,8>")
+   SET(DEAL_II_EXPAND_FLOAT_VECTORIZED  "${DEAL_II_EXPAND_FLOAT_VECTORIZED}" "VectorizedArray<float,8>")
+ENDIF()
+
+IF((${DEAL_II_COMPILER_VECTORIZATION_LEVEL} GREATER 2) AND DEAL_II_HAVE_AVX512)
+   SET(DEAL_II_EXPAND_REAL_SCALARS_VECTORIZED 
+      "${DEAL_II_EXPAND_REAL_SCALARS_VECTORIZED}" "VectorizedArray<double,8>" "VectorizedArray<float,16>")
+   SET(DEAL_II_EXPAND_FLOAT_VECTORIZED  "${DEAL_II_EXPAND_FLOAT_VECTORIZED}" "VectorizedArray<float,16>")
+ENDIF()

--- a/doc/news/changes/minor/20190713PeterMunch
+++ b/doc/news/changes/minor/20190713PeterMunch
@@ -1,0 +1,4 @@
+New: Provide a list of all possible VectorizedArray<Number, width> instances for a given
+hardware and optimization level. The list can be used during template instantiation.
+<br>
+(Peter Munch, 2019/07/13)

--- a/source/matrix_free/mapping_info.inst.in
+++ b/source/matrix_free/mapping_info.inst.in
@@ -14,202 +14,38 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS;
+     deal_II_scalar_vectorized : REAL_SCALARS_VECTORIZED)
   {
-    template struct internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 1>>;
-    template struct internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 1>>;
+    template struct internal::MatrixFreeFunctions::MappingInfo<
+      deal_II_dimension,
+      deal_II_scalar_vectorized::value_type,
+      deal_II_scalar_vectorized>;
 
     template struct internal::MatrixFreeFunctions::MappingInfoStorage<
       deal_II_dimension,
       deal_II_dimension,
-      double,
-      VectorizedArray<double, 1>>;
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension,
-      deal_II_dimension,
-      float,
-      VectorizedArray<float, 1>>;
+      deal_II_scalar_vectorized::value_type,
+      deal_II_scalar_vectorized>;
+
 #if deal_II_dimension > 1
     template struct internal::MatrixFreeFunctions::MappingInfoStorage<
       deal_II_dimension - 1,
       deal_II_dimension,
-      double,
-      VectorizedArray<double, 1>>;
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension - 1,
-      deal_II_dimension,
-      float,
-      VectorizedArray<float, 1>>;
+      deal_II_scalar_vectorized::value_type,
+      deal_II_scalar_vectorized>;
 #endif
 
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 1>>::
-        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
-          const;
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 1>>::
-        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
-                                                     const TaskInfo &) const;
-
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 1>>::
-        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
-          const;
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 1>>::
-        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
-                                                     const TaskInfo &) const;
-
-
-
-#if (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)) || \
-  (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__))
-    template struct internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 2>>;
-    template struct internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 4>>;
-
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
+    template void internal::MatrixFreeFunctions::MappingInfo<
       deal_II_dimension,
+      deal_II_scalar_vectorized::value_type,
+      deal_II_scalar_vectorized>::
+      print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
+        const;
+    template void internal::MatrixFreeFunctions::MappingInfo<
       deal_II_dimension,
-      double,
-      VectorizedArray<double, 2>>;
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension,
-      deal_II_dimension,
-      float,
-      VectorizedArray<float, 4>>;
-#  if deal_II_dimension > 1
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension - 1,
-      deal_II_dimension,
-      double,
-      VectorizedArray<double, 2>>;
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension - 1,
-      deal_II_dimension,
-      float,
-      VectorizedArray<float, 4>>;
-#  endif
-
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 2>>::
-        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
-          const;
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 2>>::
-        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
-                                                     const TaskInfo &) const;
-
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 4>>::
-        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
-          const;
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 4>>::
-        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
-                                                     const TaskInfo &) const;
-#endif
-
-
-
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
-    template struct internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 4>>;
-    template struct internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 8>>;
-
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension,
-      deal_II_dimension,
-      double,
-      VectorizedArray<double, 4>>;
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension,
-      deal_II_dimension,
-      float,
-      VectorizedArray<float, 8>>;
-#  if deal_II_dimension > 1
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension - 1,
-      deal_II_dimension,
-      double,
-      VectorizedArray<double, 4>>;
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension - 1,
-      deal_II_dimension,
-      float,
-      VectorizedArray<float, 8>>;
-#  endif
-
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 4>>::
-        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
-          const;
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 4>>::
-        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
-                                                     const TaskInfo &) const;
-
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 8>>::
-        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
-          const;
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 8>>::
-        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
-                                                     const TaskInfo &) const;
-#endif
-
-
-
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
-    template struct internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 8>>;
-    template struct internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 16>>;
-
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension,
-      deal_II_dimension,
-      double,
-      VectorizedArray<double, 8>>;
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension,
-      deal_II_dimension,
-      float,
-      VectorizedArray<float, 16>>;
-#  if deal_II_dimension > 1
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension - 1,
-      deal_II_dimension,
-      double,
-      VectorizedArray<double, 8>>;
-    template struct internal::MatrixFreeFunctions::MappingInfoStorage<
-      deal_II_dimension - 1,
-      deal_II_dimension,
-      float,
-      VectorizedArray<float, 16>>;
-#  endif
-
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 8>>::
-        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
-          const;
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, double, VectorizedArray<double, 8>>::
-        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
-                                                     const TaskInfo &) const;
-
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 16>>::
-        print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
-          const;
-    template void internal::MatrixFreeFunctions::
-      MappingInfo<deal_II_dimension, float, VectorizedArray<float, 16>>::
-        print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
-                                                     const TaskInfo &) const;
-#endif
+      deal_II_scalar_vectorized::value_type,
+      deal_II_scalar_vectorized>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
+                                                   const TaskInfo &) const;
   }

--- a/source/matrix_free/matrix_free.inst.in
+++ b/source/matrix_free/matrix_free.inst.in
@@ -14,116 +14,10 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_scalar : REAL_SCALARS)
   {
-    template void
-    internal::MatrixFreeFunctions::ShapeInfo<double>::reinit<deal_II_dimension>(
-      const Quadrature<1> &,
-      const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-      const unsigned int);
-
-    template void
-    internal::MatrixFreeFunctions::ShapeInfo<float>::reinit<deal_II_dimension>(
-      const Quadrature<1> &,
-      const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-      const unsigned int);
-  }
-
-
-
-for (deal_II_dimension : DIMENSIONS)
-  {
-    template class MatrixFree<deal_II_dimension,
-                              double,
-                              VectorizedArray<double, 1>>;
-    template class MatrixFree<deal_II_dimension,
-                              float,
-                              VectorizedArray<float, 1>>;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 1>>::
-      print_memory_consumption<std::ostream>(std::ostream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 1>>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
-      print_memory_consumption<std::ostream>(std::ostream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 1>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 1>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
-      internal_reinit<float>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<float> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
-      internal_reinit<float>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<float> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<VectorizedArray<double, 1>>::reinit<deal_II_dimension>(
-        const Quadrature<1> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
-
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<VectorizedArray<float, 1>>::reinit<deal_II_dimension>(
+    template void internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar>::
+      reinit<deal_II_dimension>(
         const Quadrature<1> &,
         const FiniteElement<deal_II_dimension, deal_II_dimension> &,
         const unsigned int);
@@ -131,382 +25,90 @@ for (deal_II_dimension : DIMENSIONS)
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS;
+     deal_II_scalar_vectorized : REAL_SCALARS_VECTORIZED)
+  {
+    template class MatrixFree<deal_II_dimension,
+                              deal_II_scalar_vectorized::value_type,
+                              deal_II_scalar_vectorized>;
+
+    template void MatrixFree<deal_II_dimension,
+                             deal_II_scalar_vectorized::value_type,
+                             deal_II_scalar_vectorized>::
+      print_memory_consumption<std::ostream>(std::ostream &) const;
+
+    template void MatrixFree<deal_II_dimension,
+                             deal_II_scalar_vectorized::value_type,
+                             deal_II_scalar_vectorized>::
+      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
+
+    template void MatrixFree<deal_II_dimension,
+                             deal_II_scalar_vectorized::value_type,
+                             deal_II_scalar_vectorized>::
+      internal_reinit<deal_II_scalar_vectorized::value_type>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<
+          const AffineConstraints<deal_II_scalar_vectorized::value_type> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void MatrixFree<deal_II_dimension,
+                             deal_II_scalar_vectorized::value_type,
+                             deal_II_scalar_vectorized>::
+      internal_reinit<deal_II_scalar_vectorized::value_type>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<
+          const AffineConstraints<deal_II_scalar_vectorized::value_type> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void internal::MatrixFreeFunctions::
+      ShapeInfo<deal_II_scalar_vectorized>::reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
+  }
+
+
+for (deal_II_dimension : DIMENSIONS;
+     deal_II_float_vectorized : FLOAT_VECTORIZED)
+  {
+    template void MatrixFree<deal_II_dimension,
+                             deal_II_float_vectorized::value_type,
+                             deal_II_float_vectorized>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+
+    template void MatrixFree<deal_II_dimension,
+                             deal_II_float_vectorized::value_type,
+                             deal_II_float_vectorized>::
+      internal_reinit<double>(
+        const Mapping<deal_II_dimension> &,
+        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
+        const std::vector<const AffineConstraints<double> *> &,
+        const std::vector<IndexSet> &,
+        const std::vector<hp::QCollection<1>> &,
+        const AdditionalData &);
+  }
+
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     deal_II_scalar_vectorized : REAL_SCALARS_VECTORIZED)
   {
 #if deal_II_dimension <= deal_II_space_dimension
-    template bool
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 1>>::
+    template bool MatrixFree<deal_II_dimension,
+                             deal_II_scalar_vectorized::value_type,
+                             deal_II_scalar_vectorized>::
       is_supported(
         const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
-
-    template bool
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 1>>::
-      is_supported(
-        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
-#endif
-  }
-
-
-
-for (deal_II_dimension : DIMENSIONS)
-  {
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
-    template class MatrixFree<deal_II_dimension,
-                              double,
-                              VectorizedArray<double, 4>>;
-    template class MatrixFree<deal_II_dimension,
-                              float,
-                              VectorizedArray<float, 8>>;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 4>>::
-      print_memory_consumption<std::ostream>(std::ostream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 4>>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
-      print_memory_consumption<std::ostream>(std::ostream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 4>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 4>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
-      internal_reinit<float>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<float> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
-      internal_reinit<float>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<float> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<VectorizedArray<double, 4>>::reinit<deal_II_dimension>(
-        const Quadrature<1> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
-
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<VectorizedArray<float, 8>>::reinit<deal_II_dimension>(
-        const Quadrature<1> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
-#endif
-  }
-
-
-
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-  {
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
-#  if deal_II_dimension <= deal_II_space_dimension
-    template bool
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 4>>::
-      is_supported(
-        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
-
-    template bool
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 8>>::
-      is_supported(
-        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
-#  endif
-#endif
-  }
-
-
-
-for (deal_II_dimension : DIMENSIONS)
-  {
-#if (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)) || \
-  (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__))
-    template class MatrixFree<deal_II_dimension,
-                              double,
-                              VectorizedArray<double, 2>>;
-    template class MatrixFree<deal_II_dimension,
-                              float,
-                              VectorizedArray<float, 4>>;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 2>>::
-      print_memory_consumption<std::ostream>(std::ostream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 2>>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
-      print_memory_consumption<std::ostream>(std::ostream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 2>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 2>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
-      internal_reinit<float>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<float> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
-      internal_reinit<float>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<float> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<VectorizedArray<double, 2>>::reinit<deal_II_dimension>(
-        const Quadrature<1> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
-
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<VectorizedArray<float, 4>>::reinit<deal_II_dimension>(
-        const Quadrature<1> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
-#endif
-  }
-
-
-
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-  {
-#if (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)) || \
-  (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__))
-#  if deal_II_dimension <= deal_II_space_dimension
-    template bool
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 2>>::
-      is_supported(
-        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
-
-    template bool
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 4>>::
-      is_supported(
-        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
-#  endif
-#endif
-  }
-
-
-
-for (deal_II_dimension : DIMENSIONS)
-  {
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
-    template class MatrixFree<deal_II_dimension,
-                              double,
-                              VectorizedArray<double, 8>>;
-    template class MatrixFree<deal_II_dimension,
-                              float,
-                              VectorizedArray<float, 16>>;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 8>>::
-      print_memory_consumption<std::ostream>(std::ostream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 8>>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
-      print_memory_consumption<std::ostream>(std::ostream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
-      print_memory_consumption<ConditionalOStream>(ConditionalOStream &) const;
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 8>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 8>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
-      internal_reinit<double>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<double> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
-      internal_reinit<float>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<float> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
-      internal_reinit<float>(
-        const Mapping<deal_II_dimension> &,
-        const std::vector<const hp::DoFHandler<deal_II_dimension> *> &,
-        const std::vector<const AffineConstraints<float> *> &,
-        const std::vector<IndexSet> &,
-        const std::vector<hp::QCollection<1>> &,
-        const AdditionalData &);
-
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<VectorizedArray<double, 8>>::reinit<deal_II_dimension>(
-        const Quadrature<1> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
-
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<VectorizedArray<float, 16>>::reinit<deal_II_dimension>(
-        const Quadrature<1> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
-#endif
-  }
-
-
-
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-  {
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
-#  if deal_II_dimension <= deal_II_space_dimension
-    template bool
-    MatrixFree<deal_II_dimension, double, VectorizedArray<double, 8>>::
-      is_supported(
-        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
-
-    template bool
-    MatrixFree<deal_II_dimension, float, VectorizedArray<float, 16>>::
-      is_supported(
-        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
-#  endif
 #endif
   }


### PR DESCRIPTION
This PR is related to issue #8364 and has been discussed there and in person with @kronbichler .

In PR #8342, I have introduced a second template parameter to VectorizedArray<Number, width>, such that the user can specify the length of the array. The width cannot be selected arbitrarily, but is fixed for the given processor architecture (`__SSE2__`, ` __AVX__`, `__AVX512F__`) and the optimization level (`DEAL_II_COMPILER_VECTORIZATION_LEVEL`). 

In PR #8348, I have added `VectorizedArrayType` to the MatrixFree-classes as an additional template parameter to be able to control the vectorization strategies used. Currently, `VectorizedArrayType` is assuming that `VectorizedArray<Number, width>` is passed.

In that commit, different `MatrixFree`-classes (in which `VectorizationArrayType` is a template argument) have been instantiated for all possible `VectorizedArray`-types via copy-and-paste and a lot of `ifdefs` for different processor and compiler optimization configurations.

This PR introduces in  `cmake/configuration/configure_vectorization.cmake` and  `cmake/config/template-arguments.in` new lists containing all possible `VectorizedArray`-types available on the given hardware for a specified optimization level. The usage of this new list simplifies the instantiation of `MatrixFree`-classes significantly and removes duplicate lines of code.  