### PR TITLE
Be more conservative in clearing the cache of MappingQCache

### DIFF
--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -42,8 +42,12 @@ MappingQCache<dim, spacedim>::MappingQCache(
 template <int dim, int spacedim>
 MappingQCache<dim, spacedim>::~MappingQCache()
 {
-  if (clear_signal.connected())
-    clear_signal.disconnect();
+  // When this object goes out of scope, we want the cache to get cleared and
+  // free its memory before the signal is disconnected in order to not work on
+  // invalid memory that has been left back by freeing an object of this
+  // class.
+  support_point_cache.reset();
+  clear_signal.disconnect();
 }
 
 


### PR DESCRIPTION
I observed a failure when running `tests/mappings/mapping_q_cache_03.debug` on a machine (no full submitted results, unfortunately) in terms of read-after-free. This can be avoided by always resetting the cache and not relying on the signal in the destructor.