### PR TITLE
Avoid initializing a numbered list in step-28 documentation

### DIFF
--- a/examples/step-28/doc/intro.dox
+++ b/examples/step-28/doc/intro.dox
@@ -89,8 +89,8 @@ processes:
 </ul>
 
 For realistic simulations in reactor analysis, one may want to split the
-continuous spectrum of neutron energies into many energy groups, often up to
-100. However, if neutron energy spectra are known well enough for some type of
+continuous spectrum of neutron energies into many energy groups, often up to 100.
+However, if neutron energy spectra are known well enough for some type of
 reactor (for example Pressurized Water Reactors, PWR), it is possible to obtain
 satisfactory results with only 2 energy groups.
 


### PR DESCRIPTION
Doxygen interprets this line as the first item of a numbered list. This is not what we want.