### PR TITLE
ranged-for documentation fix

### DIFF
--- a/doc/doxygen/headers/c++11.h
+++ b/doc/doxygen/headers/c++11.h
@@ -40,7 +40,7 @@
  * @code
  *   Triangulation<dim> triangulation;
  *   ...
- *   for (auto cell : triangulation.active_cell_iterators())
+ *   for (auto &cell : triangulation.active_cell_iterators())
  *     cell->set_refine_flag();
  * @endcode
  * This relies on functions such as Triangulation::active_cell_iterators(),

--- a/include/deal.II/base/iterator_range.h
+++ b/include/deal.II/base/iterator_range.h
@@ -52,7 +52,7 @@ class IteratorOverIterators;
  * @code
  *   Triangulation<dim> triangulation;
  *   ...
- *   for (auto & cell : triangulation.active_cell_iterators())
+ *   for (auto &cell : triangulation.active_cell_iterators())
  *     cell->set_user_flag();
  * @endcode
  * In other words, the <code>cell</code> objects are iterators, and the range

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -1081,7 +1081,7 @@ namespace Differentiation
      *   Vector<double> cell_rhs (...);
      *
      *   // Assembly loop:
-     *   for (auto & cell : ...)
+     *   for (auto &cell : ...)
      *   {
      *     cell->get_dof_indices(local_dof_indices);
      *     const unsigned int n_independent_variables =
@@ -1384,7 +1384,7 @@ namespace Differentiation
      *   Vector<double> cell_rhs (...);
      *
      *   // Assembly loop:
-     *   for (auto & cell : ...)
+     *   for (auto &cell : ...)
      *   {
      *     cell->get_dof_indices(local_dof_indices);
      *     const unsigned int n_independent_variables


### PR DESCRIPTION
Since we seek to unify the style of range-based cell loops (#8107), the documentation should be fixed (especially `c++11.h`)

Related question: Has anyone measured the speed difference between
```c++
for (auto cell : triangulation.active_cell_iterators())
```
and
```c++
for (const auto &cell : triangulation.active_cell_iterators())
```
?