### PR TITLE
Add assert to Utilities::MPI::compute_index_owner

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -1724,6 +1724,10 @@ namespace Utilities
       Assert(owned_indices.size() == indices_to_look_up.size(),
              ExcMessage("IndexSets have to have the same sizes."));
 
+      Assert(
+        owned_indices.size() == Utilities::MPI::max(owned_indices.size(), comm),
+        ExcMessage("IndexSets have to have the same size on all processes."));
+
       std::vector<unsigned int> owning_ranks(indices_to_look_up.n_elements());
 
       // Step 1: setup dictionary


### PR DESCRIPTION
This PR adds an assert to `Utilities::MPI::compute_index_owner` (see PR #8300) to check the equality of the size of the index sets on all processes. 