### PR TITLE
Add new make_vectorized_array function

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -522,6 +522,29 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
 
 
 /**
+ * Create a vectorized array of given type and broadcast the scalar value
+ * to all array elements.
+ *
+ *  @relatesalso VectorizedArray
+ */
+template <typename VectorizedArrayType>
+inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
+                             make_vectorized_array(const typename VectorizedArrayType::value_type &u)
+{
+  static_assert(
+    std::is_same<VectorizedArrayType,
+                 VectorizedArray<typename VectorizedArrayType::value_type,
+                                 VectorizedArrayType::n_array_elements>>::value,
+    "VectorizedArrayType is not a VectorizedArray.");
+
+  VectorizedArrayType result;
+  result = u;
+  return result;
+}
+
+
+
+/**
  * This method loads VectorizedArray::n_array_elements data streams from the
  * given array @p in. The offsets to the input array are given by the array @p
  * offsets. From each stream, n_entries are read. The data is then transposed

--- a/tests/base/vectorization_make_vectorized_array_01.cc
+++ b/tests/base/vectorization_make_vectorized_array_01.cc
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// test make_vectorized_array function for all possible value_types and vector
+// lengths
+
+#include <deal.II/base/vectorization.h>
+
+#include <limits>
+
+#include "../tests.h"
+
+
+template <typename VectorizedArrayType>
+void
+do_test(const VectorizedArrayType                      array,
+        const typename VectorizedArrayType::value_type number)
+{
+  deallog << "  test " << VectorizedArrayType::n_array_elements
+          << " array elements" << std::endl;
+  for (unsigned int i = 0; i < VectorizedArrayType::n_array_elements; i++)
+    if (array[i] != number)
+      deallog << "  problem in element " << i << std::endl;
+}
+
+
+template <typename Number>
+struct Tester
+{
+  static void
+  test()
+  {}
+};
+
+template <>
+struct Tester<double>
+{
+  static void
+  test()
+  {
+    do_test(make_vectorized_array<double>(2.0), 2.0);
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
+    do_test(make_vectorized_array<VectorizedArray<double, 8>>(2.0), 2.0);
+#endif
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
+    do_test(make_vectorized_array<VectorizedArray<double, 4>>(2.0), 2.0);
+#endif
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
+    do_test(make_vectorized_array<VectorizedArray<double, 2>>(2.0), 2.0);
+#endif
+
+    do_test(make_vectorized_array<VectorizedArray<double, 1>>(2.0), 2.0);
+  }
+};
+
+template <>
+struct Tester<float>
+{
+  static void
+  test()
+  {
+    do_test(make_vectorized_array<float>(2.0), 2.0);
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
+    do_test(make_vectorized_array<VectorizedArray<float, 16>>(2.0), 2.0);
+#endif
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
+    do_test(make_vectorized_array<VectorizedArray<float, 8>>(2.0), 2.0);
+#endif
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
+    do_test(make_vectorized_array<VectorizedArray<float, 4>>(2.0), 2.0);
+#endif
+
+    do_test(make_vectorized_array<VectorizedArray<float, 1>>(2.0), 2.0);
+  }
+};
+
+
+int
+main()
+{
+  initlog();
+
+  deallog << "double:" << std::endl;
+  Tester<double>::test();
+
+  deallog << "float:" << std::endl;
+  Tester<float>::test();
+}

--- a/tests/base/vectorization_make_vectorized_array_01.output
+++ b/tests/base/vectorization_make_vectorized_array_01.output
@@ -1,0 +1,7 @@
+
+DEAL::double:
+DEAL::  test 1 array elements
+DEAL::  test 1 array elements
+DEAL::float:
+DEAL::  test 1 array elements
+DEAL::  test 1 array elements

--- a/tests/base/vectorization_make_vectorized_array_01.output.avx
+++ b/tests/base/vectorization_make_vectorized_array_01.output.avx
@@ -1,0 +1,11 @@
+
+DEAL::double:
+DEAL::  test 4 array elements
+DEAL::  test 4 array elements
+DEAL::  test 2 array elements
+DEAL::  test 1 array elements
+DEAL::float:
+DEAL::  test 8 array elements
+DEAL::  test 8 array elements
+DEAL::  test 4 array elements
+DEAL::  test 1 array elements

--- a/tests/base/vectorization_make_vectorized_array_01.output.avx512
+++ b/tests/base/vectorization_make_vectorized_array_01.output.avx512
@@ -1,0 +1,13 @@
+
+DEAL::double:
+DEAL::  test 8 array elements
+DEAL::  test 8 array elements
+DEAL::  test 4 array elements
+DEAL::  test 2 array elements
+DEAL::  test 1 array elements
+DEAL::float:
+DEAL::  test 16 array elements
+DEAL::  test 16 array elements
+DEAL::  test 8 array elements
+DEAL::  test 4 array elements
+DEAL::  test 1 array elements

--- a/tests/base/vectorization_make_vectorized_array_01.output.sse2
+++ b/tests/base/vectorization_make_vectorized_array_01.output.sse2
@@ -1,0 +1,9 @@
+
+DEAL::double:
+DEAL::  test 2 array elements
+DEAL::  test 2 array elements
+DEAL::  test 1 array elements
+DEAL::float:
+DEAL::  test 4 array elements
+DEAL::  test 4 array elements
+DEAL::  test 1 array elements


### PR DESCRIPTION
During using the features form PR #8348, I realized that it would be nice to have a new utility function:
```cpp
template <typename VectorizedArrayType>
VectorizedArrayType
make_vectorized_array(const typename VectorizedArrayType::value_type &u);
```
