### PR TITLE
Choose a more appropriate tolerance for vector add_and_dot

### DIFF
--- a/tests/lac/la_parallel_vector_add_and_dot_complex.cc
+++ b/tests/lac/la_parallel_vector_add_and_dot_complex.cc
@@ -61,14 +61,18 @@ check()
         }
 
       deallog << "Add and dot is ";
-      if (std::abs(prod - prod_check) <
-          4. * std::numeric_limits<number>::epsilon() *
-            std::sqrt(static_cast<number>(size)) * size)
+      // check tolerance with respect to the expected size of result which is
+      // ~ size^2 including the roundoff error ~ sqrt(size) we expect
+      const number tolerance = 4. * std::numeric_limits<number>::epsilon() *
+                               std::sqrt(static_cast<number>(size)) * size *
+                               size;
+      if (std::abs(prod - prod_check) < tolerance)
         deallog << "correct" << std::endl;
       else
-        deallog << "wrong; should be " << prod / static_cast<number>(size)
-                << ", is " << prod_check / static_cast<number>(size)
-                << std::endl;
+        deallog << "wrong by " << std::abs(prod - prod_check)
+                << " with tolerance " << tolerance << "; should be "
+                << prod / static_cast<number>(size) << ", is "
+                << prod_check / static_cast<number>(size) << std::endl;
     }
 }
 

--- a/tests/lac/la_vector_add_and_dot_complex.cc
+++ b/tests/lac/la_vector_add_and_dot_complex.cc
@@ -58,14 +58,18 @@ check()
         }
 
       deallog << "Add and dot is ";
-      if (std::abs(prod - prod_check) <
-          4. * std::numeric_limits<number>::epsilon() *
-            std::sqrt(static_cast<number>(size)) * size)
+      // check tolerance with respect to the expected size of result which is
+      // ~ size^2 including the roundoff error ~ sqrt(size) we expect
+      const number tolerance = 4. * std::numeric_limits<number>::epsilon() *
+                               std::sqrt(static_cast<number>(size)) * size *
+                               size;
+      if (std::abs(prod - prod_check) < tolerance)
         deallog << "correct" << std::endl;
       else
-        deallog << "wrong; should be " << prod / static_cast<number>(size)
-                << ", is " << prod_check / static_cast<number>(size)
-                << std::endl;
+        deallog << "wrong by " << std::abs(prod - prod_check)
+                << " with tolerance " << tolerance << "; should be "
+                << prod / static_cast<number>(size) << ", is "
+                << prod_check / static_cast<number>(size) << std::endl;
     }
 }
 

--- a/tests/lac/vector_add_and_dot_complex.cc
+++ b/tests/lac/vector_add_and_dot_complex.cc
@@ -55,14 +55,18 @@ check()
         }
 
       deallog << "Add and dot is ";
-      if (std::abs(prod - prod_check) <
-          4. * std::abs(std::numeric_limits<number>::epsilon()) *
-            std::sqrt(static_cast<double>(size)) * size)
+      // check tolerance with respect to the expected size of result which is
+      // ~ size^2 including the roundoff error ~ sqrt(size) we expect
+      const number tolerance = 4. * std::numeric_limits<number>::epsilon() *
+                               std::sqrt(static_cast<number>(size)) * size *
+                               size;
+      if (std::abs(prod - prod_check) < tolerance)
         deallog << "correct" << std::endl;
       else
-        deallog << "wrong; should be " << prod / static_cast<number>(size)
-                << ", is " << prod_check / static_cast<number>(size)
-                << std::endl;
+        deallog << "wrong by " << std::abs(prod - prod_check)
+                << " with tolerance " << tolerance << "; should be "
+                << prod / static_cast<number>(size) << ", is "
+                << prod_check / static_cast<number>(size) << std::endl;
     }
 }
 


### PR DESCRIPTION
It turned out that I was too optimistic about the tolerances in #8391 as the expected size of the inner product is `size^2`, not `size` as I expected. I also added a bit more output in case the test fails to more easily see what happens why.