### PR TITLE
Enable MappingFEField on multigrid levels

### DIFF
--- a/doc/news/changes/minor/20190722MartinKronbichlerJohannesHeinz
+++ b/doc/news/changes/minor/20190722MartinKronbichlerJohannesHeinz
@@ -1,0 +1,4 @@
+New: MappingFEField can now also be initialized on multigrid levels by handing
+in an appropriately sized vector of position vectors for the levels.
+<br>
+(Martin Kronbichler, Johannes Heinz, 2019/07/22)

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mg_level_object.h>
 #include <deal.II/base/thread_management.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -117,6 +118,31 @@ public:
   MappingFEField(const DoFHandlerType &euler_dof_handler,
                  const VectorType &    euler_vector,
                  const ComponentMask & mask = ComponentMask());
+
+  /**
+   * Constructor taking vectors on the multigrid levels rather than the active
+   * cells only. The vector of vectors is expected to have as many entries as
+   * there are levels in the triangulation and provide valid data on each
+   * level, i.e., be of compatible length DoFHandler::n_dofs(level). Apart
+   * from the source of the vectors, the same arguments as in the other
+   * constructor need to be provided.
+   */
+  MappingFEField(const DoFHandlerType &         euler_dof_handler,
+                 const std::vector<VectorType> &euler_vector,
+                 const ComponentMask &          mask = ComponentMask());
+
+  /**
+   * Constructor taking vectors on the multigrid levels rather than the active
+   * cells only, variant with MGLevelObject instead of std::vector. The vector
+   * of vectors is expected to have as many entries as there are levels in the
+   * triangulation and provide valid data on each level, i.e., be of
+   * compatible length DoFHandler::n_dofs(level). Apart from the source of the
+   * vectors, the same arguments as in the other constructor need to be
+   * provided.
+   */
+  MappingFEField(const DoFHandlerType &           euler_dof_handler,
+                 const MGLevelObject<VectorType> &euler_vector,
+                 const ComponentMask &            mask = ComponentMask());
 
   /**
    * Copy constructor.
@@ -504,12 +530,18 @@ private:
    * @}
    */
 
+  /**
+   * Specifies whether we access unknowns on the active dofs (with a single
+   * Euler vector) or on the level dofs (via a vector of Euler vectors).
+   */
+  const bool uses_level_dofs;
 
   /**
    * Reference to the vector of shifts.
    */
-  SmartPointer<const VectorType,
-               MappingFEField<dim, spacedim, VectorType, DoFHandlerType>>
+  std::vector<
+    SmartPointer<const VectorType,
+                 MappingFEField<dim, spacedim, VectorType, DoFHandlerType>>>
     euler_vector;
 
   /**

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -122,23 +122,22 @@ public:
   /**
    * Constructor taking vectors on the multigrid levels rather than the active
    * cells only. The vector of vectors is expected to have as many entries as
-   * there are levels in the triangulation and provide valid data on each
-   * level, i.e., be of compatible length DoFHandler::n_dofs(level). Apart
-   * from the source of the vectors, the same arguments as in the other
-   * constructor need to be provided.
+   * there are global levels in the triangulation and provide valid data on
+   * each level, i.e., be of compatible length DoFHandler::n_dofs(level). A
+   * prerequisite of this constructor is that DoFHandler::distribute_mg_dofs()
+   * has been called. Apart from the level vectors, the same arguments as in
+   * the other constructor need to be provided.
    */
   MappingFEField(const DoFHandlerType &         euler_dof_handler,
                  const std::vector<VectorType> &euler_vector,
                  const ComponentMask &          mask = ComponentMask());
 
   /**
-   * Constructor taking vectors on the multigrid levels rather than the active
-   * cells only, variant with MGLevelObject instead of std::vector. The vector
-   * of vectors is expected to have as many entries as there are levels in the
-   * triangulation and provide valid data on each level, i.e., be of
-   * compatible length DoFHandler::n_dofs(level). Apart from the source of the
-   * vectors, the same arguments as in the other constructor need to be
-   * provided.
+   * Constructor with MGLevelObject instead of std::vector, otherwise the same
+   * as above. It is required that `euler_vector.max_level()+1` equals the
+   * global number of levels in the triangulation. The minimum level may be
+   * zero or more &mdash; it only needs to be consistent between what is set
+   * here and later used for evaluation of the mapping.
    */
   MappingFEField(const DoFHandlerType &           euler_dof_handler,
                  const MGLevelObject<VectorType> &euler_vector,

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -240,7 +240,8 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::MappingFEField(
   const DoFHandlerType &euler_dof_handler,
   const VectorType &    euler_vector,
   const ComponentMask & mask)
-  : euler_vector(&euler_vector)
+  : uses_level_dofs(false)
+  , euler_vector({&euler_vector})
   , euler_dof_handler(&euler_dof_handler)
   , fe_mask(mask.size() ?
               mask :
@@ -262,10 +263,92 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::MappingFEField(
 }
 
 
+
+template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
+MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::MappingFEField(
+  const DoFHandlerType &         euler_dof_handler,
+  const std::vector<VectorType> &euler_vector,
+  const ComponentMask &          mask)
+  : uses_level_dofs(true)
+  , euler_dof_handler(&euler_dof_handler)
+  , fe_mask(mask.size() ?
+              mask :
+              ComponentMask(
+                euler_dof_handler.get_fe().get_nonzero_components(0).size(),
+                true))
+  , fe_to_real(fe_mask.size(), numbers::invalid_unsigned_int)
+  , fe_values(this->euler_dof_handler->get_fe(),
+              get_vertex_quadrature<dim>(),
+              update_values)
+{
+  unsigned int size = 0;
+  for (unsigned int i = 0; i < fe_mask.size(); ++i)
+    {
+      if (fe_mask[i])
+        fe_to_real[i] = size++;
+    }
+  AssertDimension(size, spacedim);
+
+  Assert(euler_dof_handler.has_level_dofs(),
+         ExcMessage("The underlying did not call distribute_mg_dofs(). "
+                    "In this case, the construction via level vectors does not "
+                    "make sense."));
+  AssertDimension(euler_vector.size(),
+                  euler_dof_handler.get_triangulation().n_global_levels());
+  this->euler_vector.clear();
+  this->euler_vector.resize(euler_vector.size());
+  for (unsigned int i = 0; i < euler_vector.size(); ++i)
+    this->euler_vector[i] = &euler_vector[i];
+}
+
+
+
+template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
+MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::MappingFEField(
+  const DoFHandlerType &           euler_dof_handler,
+  const MGLevelObject<VectorType> &euler_vector,
+  const ComponentMask &            mask)
+  : uses_level_dofs(true)
+  , euler_dof_handler(&euler_dof_handler)
+  , fe_mask(mask.size() ?
+              mask :
+              ComponentMask(
+                euler_dof_handler.get_fe().get_nonzero_components(0).size(),
+                true))
+  , fe_to_real(fe_mask.size(), numbers::invalid_unsigned_int)
+  , fe_values(this->euler_dof_handler->get_fe(),
+              get_vertex_quadrature<dim>(),
+              update_values)
+{
+  unsigned int size = 0;
+  for (unsigned int i = 0; i < fe_mask.size(); ++i)
+    {
+      if (fe_mask[i])
+        fe_to_real[i] = size++;
+    }
+  AssertDimension(size, spacedim);
+
+  Assert(euler_dof_handler.has_level_dofs(),
+         ExcMessage("The underlying did not call distribute_mg_dofs(). "
+                    "In this case, the construction via level vectors does not "
+                    "make sense."));
+  AssertDimension(euler_vector.max_level() + 1 - euler_vector.min_level(),
+                  euler_dof_handler.get_triangulation().n_global_levels());
+  this->euler_vector.clear();
+  this->euler_vector.resize(
+    euler_dof_handler.get_triangulation().n_global_levels());
+  for (unsigned int i = euler_vector.min_level(); i <= euler_vector.max_level();
+       ++i)
+    this->euler_vector[i - euler_vector.min_level()] = &euler_vector[i];
+}
+
+
+
 template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::MappingFEField(
   const MappingFEField<dim, spacedim, VectorType, DoFHandlerType> &mapping)
-  : euler_vector(mapping.euler_vector)
+  : uses_level_dofs(mapping.uses_level_dofs)
+  , euler_vector(mapping.euler_vector)
   , euler_dof_handler(mapping.euler_dof_handler)
   , fe_mask(mapping.fe_mask)
   , fe_to_real(mapping.fe_to_real)
@@ -311,28 +394,42 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::get_vertices(
   const typename DoFHandler<dim, spacedim>::cell_iterator dof_cell(
     *cell, euler_dof_handler);
 
-  Assert(dof_cell->active() == true, ExcInactiveCell());
+  Assert(uses_level_dofs || dof_cell->active() == true, ExcInactiveCell());
   AssertDimension(GeometryInfo<dim>::vertices_per_cell,
                   fe_values.n_quadrature_points);
   AssertDimension(fe_to_real.size(),
                   euler_dof_handler->get_fe().n_components());
 
-  std::vector<Vector<typename VectorType::value_type>> values(
-    fe_values.n_quadrature_points,
-    Vector<typename VectorType::value_type>(
-      euler_dof_handler->get_fe().n_components()));
-
   {
     std::lock_guard<std::mutex> lock(fe_values_mutex);
     fe_values.reinit(dof_cell);
-    fe_values.get_function_values(*euler_vector, values);
   }
-  std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell> vertices;
+  const unsigned int dofs_per_cell = euler_dof_handler->get_fe().dofs_per_cell;
+  std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
+  if (uses_level_dofs)
+    dof_cell->get_mg_dof_indices(dof_indices);
+  else
+    dof_cell->get_dof_indices(dof_indices);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
-    for (unsigned int j = 0; j < fe_to_real.size(); ++j)
-      if (fe_to_real[j] != numbers::invalid_unsigned_int)
-        vertices[i][fe_to_real[j]] = values[i][j];
+  const VectorType &vector =
+    uses_level_dofs ? *euler_vector[cell->level()] : *euler_vector[0];
+  std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell> vertices;
+  for (unsigned int i = 0; i < dofs_per_cell; ++i)
+    {
+      const unsigned int comp = fe_to_real
+        [euler_dof_handler->get_fe().system_to_component_index(i).first];
+      if (comp != numbers::invalid_unsigned_int)
+        {
+          typename VectorType::value_type value =
+            internal::ElementAccess<VectorType>::get(vector, dof_indices[i]);
+          if (euler_dof_handler->get_fe().is_primitive(i))
+            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
+                 ++v)
+              vertices[v][comp] += fe_values.shape_value(i, v) * value;
+          else
+            Assert(false, ExcNotImplemented());
+        }
+    }
 
   return vertices;
 }
@@ -2349,13 +2446,18 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::update_internal_dofs(
          ExcMessage("euler_dof_handler is empty"));
 
   typename DoFHandlerType::cell_iterator dof_cell(*cell, euler_dof_handler);
-  Assert(dof_cell->active() == true, ExcInactiveCell());
+  Assert(uses_level_dofs || dof_cell->active() == true, ExcInactiveCell());
 
-  dof_cell->get_dof_indices(data.local_dof_indices);
+  if (uses_level_dofs)
+    dof_cell->get_mg_dof_indices(data.local_dof_indices);
+  else
+    dof_cell->get_dof_indices(data.local_dof_indices);
 
+  const VectorType &vector =
+    uses_level_dofs ? *euler_vector[cell->level()] : *euler_vector[0];
   for (unsigned int i = 0; i < data.local_dof_values.size(); ++i)
     data.local_dof_values[i] =
-      internal::ElementAccess<VectorType>::get(*euler_vector,
+      internal::ElementAccess<VectorType>::get(vector,
                                                data.local_dof_indices[i]);
 }
 

--- a/tests/mappings/mapping_fe_field_04.cc
+++ b/tests/mappings/mapping_fe_field_04.cc
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// check MappingFEField when initialized on all multigrid levels
+
+#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_fe_field.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  Triangulation<dim, spacedim> tria(
+    Triangulation<dim, spacedim>::limit_level_difference_at_vertices);
+  GridGenerator::hyper_cube(tria);
+
+  tria.refine_global(2);
+
+  FESystem<dim, spacedim>   fe(FE_Q<dim, spacedim>(2), spacedim);
+  DoFHandler<dim, spacedim> dh(tria);
+
+  dh.distribute_dofs(fe);
+  dh.distribute_mg_dofs();
+
+  deallog << "dim, spacedim: " << dim << ", " << spacedim << std::endl
+          << "cells: " << tria.n_active_cells() << ", dofs: " << dh.n_dofs()
+          << std::endl;
+
+  // Create a Mapping
+  LinearAlgebra::distributed::Vector<double> map_vector(dh.n_dofs());
+  VectorTools::get_position_vector(dh, map_vector);
+  MGLevelObject<LinearAlgebra::distributed::Vector<double>> level_vectors(
+    0, tria.n_global_levels() - 1);
+  for (unsigned int level = 0; level < tria.n_global_levels(); ++level)
+    level_vectors[level].reinit(dh.n_dofs(level));
+
+  MGTransferMatrixFree<dim, double> transfer;
+  transfer.build(dh);
+  transfer.interpolate_to_mg(dh, level_vectors, map_vector);
+  MappingFEField<dim,
+                 spacedim,
+                 LinearAlgebra::distributed::Vector<double>,
+                 DoFHandler<dim>>
+    mapping(dh, level_vectors);
+
+  QGauss<dim>   quad(1);
+  FEValues<dim> fe_values_ref(fe,
+                              quad,
+                              update_jacobians | update_quadrature_points);
+  FEValues<dim> fe_values(mapping,
+                          fe,
+                          quad,
+                          update_jacobians | update_quadrature_points);
+
+  for (const auto &cell : tria.cell_iterators())
+    {
+      fe_values_ref.reinit(cell);
+      fe_values.reinit(cell);
+
+      if (fe_values_ref.quadrature_point(0).distance(
+            fe_values.quadrature_point(0)) > 1e-12)
+        deallog << "Mapped point should be "
+                << fe_values_ref.quadrature_point(0) << " and is "
+                << fe_values.quadrature_point(0) << std::endl;
+      Tensor<2, dim> jac_ref = fe_values_ref.jacobian(0),
+                     jac     = fe_values.jacobian(0);
+      if ((jac_ref - jac).norm() > 1e-12)
+        deallog << "Jacobian should be " << jac_ref << " and is " << jac
+                << std::endl;
+    }
+  deallog << "OK" << std::endl;
+}
+
+using namespace dealii;
+int
+main()
+{
+  initlog();
+  test<2, 2>();
+  test<3, 3>();
+}

--- a/tests/mappings/mapping_fe_field_04.output
+++ b/tests/mappings/mapping_fe_field_04.output
@@ -1,0 +1,7 @@
+
+DEAL::dim, spacedim: 2, 2
+DEAL::cells: 16, dofs: 162
+DEAL::OK
+DEAL::dim, spacedim: 3, 3
+DEAL::cells: 64, dofs: 2187
+DEAL::OK

--- a/tests/mappings/mapping_fe_field_05.cc
+++ b/tests/mappings/mapping_fe_field_05.cc
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// check MappingFEField when initialized on all multigrid levels
+
+#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_fe_field.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  Triangulation<dim, spacedim> tria(
+    Triangulation<dim, spacedim>::limit_level_difference_at_vertices);
+  GridGenerator::hyper_ball(tria);
+
+  tria.refine_global(1);
+
+  FESystem<dim, spacedim>   fe(FE_Q<dim, spacedim>(2), spacedim);
+  DoFHandler<dim, spacedim> dh(tria);
+
+  dh.distribute_dofs(fe);
+  dh.distribute_mg_dofs();
+
+  deallog << "dim, spacedim: " << dim << ", " << spacedim << std::endl
+          << "cells: " << tria.n_active_cells() << ", dofs: " << dh.n_dofs()
+          << std::endl;
+
+  // Create a Mapping
+  LinearAlgebra::distributed::Vector<double> map_vector(dh.n_dofs());
+  VectorTools::get_position_vector(dh, map_vector);
+  MGLevelObject<LinearAlgebra::distributed::Vector<double>> level_vectors(
+    0, tria.n_global_levels() - 1);
+  for (unsigned int level = 0; level < tria.n_global_levels(); ++level)
+    level_vectors[level].reinit(dh.n_dofs(level));
+
+  MGTransferMatrixFree<dim, double> transfer;
+  transfer.build(dh);
+  transfer.interpolate_to_mg(dh, level_vectors, map_vector);
+  MappingFEField<dim,
+                 spacedim,
+                 LinearAlgebra::distributed::Vector<double>,
+                 DoFHandler<dim>>
+                       mapping(dh, level_vectors);
+  MappingQGeneric<dim> mapping_ref(fe.degree);
+
+  QGauss<dim>   quad(1);
+  FEValues<dim> fe_values_ref(mapping_ref,
+                              fe,
+                              quad,
+                              update_jacobians | update_quadrature_points);
+  FEValues<dim> fe_values(mapping,
+                          fe,
+                          quad,
+                          update_jacobians | update_quadrature_points);
+
+  for (const auto &cell : tria.cell_iterators())
+    {
+      fe_values_ref.reinit(cell);
+      fe_values.reinit(cell);
+
+      if (fe_values_ref.quadrature_point(0).distance(
+            fe_values.quadrature_point(0)) > 1e-12)
+        deallog << "Mapped point should be "
+                << fe_values_ref.quadrature_point(0) << " and is "
+                << fe_values.quadrature_point(0) << std::endl;
+      Tensor<2, dim> jac_ref = fe_values_ref.jacobian(0),
+                     jac     = fe_values.jacobian(0);
+      if ((jac_ref - jac).norm() > 1e-12)
+        deallog << "Jacobian should be " << jac_ref << " and is " << jac
+                << std::endl;
+    }
+  deallog << "OK" << std::endl;
+}
+
+using namespace dealii;
+int
+main()
+{
+  initlog();
+  test<2, 2>();
+  test<3, 3>();
+}

--- a/tests/mappings/mapping_fe_field_05.output
+++ b/tests/mappings/mapping_fe_field_05.output
@@ -1,0 +1,7 @@
+
+DEAL::dim, spacedim: 2, 2
+DEAL::cells: 20, dofs: 178
+DEAL::OK
+DEAL::dim, spacedim: 3, 3
+DEAL::cells: 56, dofs: 1551
+DEAL::OK

--- a/tests/mappings/mapping_fe_field_06.cc
+++ b/tests/mappings/mapping_fe_field_06.cc
@@ -1,0 +1,172 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// check MappingFEField when initialized manually on levels on a distributed
+// triangulation
+
+#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_fe_field.h>
+#include <deal.II/fe/mapping_q_generic.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim, spacedim> tria(
+    MPI_COMM_WORLD,
+    Triangulation<dim, spacedim>::limit_level_difference_at_vertices,
+    parallel::distributed::Triangulation<dim, spacedim>::
+      construct_multigrid_hierarchy);
+  GridGenerator::hyper_ball(tria);
+
+  tria.refine_global(2);
+  if (tria.begin_active()->is_locally_owned())
+    tria.begin_active()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+
+  FESystem<dim, spacedim>   fe(FE_Q<dim, spacedim>(2), spacedim);
+  DoFHandler<dim, spacedim> dh(tria);
+
+  dh.distribute_dofs(fe);
+  dh.distribute_mg_dofs();
+
+  deallog << "dim, spacedim: " << dim << ", " << spacedim << std::endl
+          << "cells: " << tria.n_active_cells() << ", dofs: " << dh.n_dofs()
+          << std::endl;
+
+  // Create a Mapping
+  std::vector<LinearAlgebra::distributed::Vector<double>> level_vectors(
+    tria.n_global_levels());
+  MappingQGeneric<dim, spacedim> mapping_ref(fe.degree);
+  FEValues<dim>                  fe_values_setup(mapping_ref,
+                                dh.get_fe(),
+                                Quadrature<dim>(
+                                  dh.get_fe().get_unit_support_points()),
+                                update_quadrature_points);
+  for (unsigned int level = 0; level < tria.n_global_levels(); ++level)
+    {
+      IndexSet relevant_dofs;
+      DoFTools::extract_locally_relevant_level_dofs(dh, level, relevant_dofs);
+      level_vectors[level].reinit(dh.locally_owned_mg_dofs(level),
+                                  relevant_dofs,
+                                  tria.get_communicator());
+      std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
+      for (const auto &cell : dh.mg_cell_iterators_on_level(level))
+        if (cell->level_subdomain_id() != numbers::artificial_subdomain_id)
+          {
+            fe_values_setup.reinit(cell);
+            cell->get_active_or_mg_dof_indices(dof_indices);
+            for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+              {
+                const unsigned int coordinate_direction =
+                  fe.system_to_component_index(i).first;
+                const Point<dim> point = fe_values_setup.quadrature_point(i);
+                level_vectors[level](dof_indices[i]) =
+                  point[coordinate_direction];
+              }
+          }
+      level_vectors[level].update_ghost_values();
+    }
+
+  MappingFEField<dim,
+                 spacedim,
+                 LinearAlgebra::distributed::Vector<double>,
+                 DoFHandler<dim>>
+    mapping(dh, level_vectors);
+
+  QGauss<dim>   quad(1);
+  FEValues<dim> fe_values_ref(mapping_ref,
+                              fe,
+                              quad,
+                              update_jacobians | update_quadrature_points);
+  FEValues<dim> fe_values(mapping,
+                          fe,
+                          quad,
+                          update_jacobians | update_quadrature_points);
+
+  for (const auto &cell : tria.cell_iterators())
+    if (cell->level_subdomain_id() != numbers::artificial_subdomain_id)
+      {
+        fe_values_ref.reinit(cell);
+        fe_values.reinit(cell);
+
+        if (fe_values_ref.quadrature_point(0).distance(
+              fe_values.quadrature_point(0)) > 1e-12)
+          deallog << "Mapped point should be "
+                  << fe_values_ref.quadrature_point(0) << " and is "
+                  << fe_values.quadrature_point(0) << std::endl;
+        Tensor<2, dim> jac_ref = fe_values_ref.jacobian(0),
+                       jac     = fe_values.jacobian(0);
+        if ((jac_ref - jac).norm() > 1e-12)
+          deallog << "Jacobian should be " << jac_ref << " and is " << jac
+                  << std::endl;
+      }
+
+  // shift the Euler vectors and check whether the result is still correct
+  for (unsigned int level = 0; level < tria.n_global_levels(); ++level)
+    level_vectors[level].add(1.1);
+
+  for (const auto &cell : tria.cell_iterators())
+    if (cell->level_subdomain_id() != numbers::artificial_subdomain_id)
+      {
+        fe_values_ref.reinit(cell);
+        fe_values.reinit(cell);
+
+        Point<dim> shift;
+        for (unsigned int d = 0; d < dim; ++d)
+          shift[d] = 1.1;
+        if ((fe_values_ref.quadrature_point(0) + shift)
+              .distance(fe_values.quadrature_point(0)) > 1e-12)
+          deallog << "Mapped point should be "
+                  << fe_values_ref.quadrature_point(0) + shift << " and is "
+                  << fe_values.quadrature_point(0) << std::endl;
+        Tensor<2, dim> jac_ref = fe_values_ref.jacobian(0),
+                       jac     = fe_values.jacobian(0);
+        if ((jac_ref - jac).norm() > 1e-12)
+          deallog << "Jacobian should be " << jac_ref << " and is " << jac
+                  << std::endl;
+      }
+  deallog << "OK" << std::endl;
+}
+
+using namespace dealii;
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc,
+                                            argv,
+                                            testing_max_num_threads());
+  MPILogInitAll                    log;
+  test<2, 2>();
+  test<3, 3>();
+}

--- a/tests/mappings/mapping_fe_field_06.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/mappings/mapping_fe_field_06.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,23 @@
+
+DEAL:0::dim, spacedim: 2, 2
+DEAL:0::cells: 65, dofs: 674
+DEAL:0::OK
+DEAL:0::dim, spacedim: 3, 3
+DEAL:0::cells: 392, dofs: 11451
+DEAL:0::OK
+
+DEAL:1::dim, spacedim: 2, 2
+DEAL:1::cells: 74, dofs: 674
+DEAL:1::OK
+DEAL:1::dim, spacedim: 3, 3
+DEAL:1::cells: 448, dofs: 11451
+DEAL:1::OK
+
+
+DEAL:2::dim, spacedim: 2, 2
+DEAL:2::cells: 65, dofs: 674
+DEAL:2::OK
+DEAL:2::dim, spacedim: 3, 3
+DEAL:2::cells: 420, dofs: 11451
+DEAL:2::OK
+


### PR DESCRIPTION
This commit enables `MappingFEField` on the multigrid levels of a triangulation.

The vector can be generated either by `MGTransferMatrixFree::interpolate_to_mg` (see the `_04` and `_05` tests) or filled manually on all levels (see the `_06` test). This works both in serial and in parallel.