### PR TITLE
doc: no doxygen for friend declarations

### DIFF
--- a/include/deal.II/base/process_grid.h
+++ b/include/deal.II/base/process_grid.h
@@ -62,9 +62,7 @@ namespace Utilities
     class ProcessGrid
     {
     public:
-      /**
-       * Declare class ScaLAPACK as friend to provide access to private members.
-       */
+      // Declare class ScaLAPACK as friend to provide access to private members.
       template <typename NumberType>
       friend class dealii::ScaLAPACKMatrix;
 

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -674,9 +674,7 @@ protected:
    */
   TableIndices<N> table_size;
 
-  /**
-   * Make all other table classes friends.
-   */
+  // Make all other table classes friends.
   template <int, typename>
   friend class TableBase;
 };
@@ -955,14 +953,10 @@ namespace MatrixTableIterators
     void
     assert_valid_linear_index() const;
 
-    /**
-     * Make the const version a friend for copying.
-     */
+    // Make the const version a friend for copying.
     friend class AccessorBase<TableType, true, storage_order>;
 
-    /**
-     * Make the underlying iterator class a friend.
-     */
+    // Make the underlying iterator class a friend.
     friend class LinearIndexIterator<
       Iterator<TableType, Constness, storage_order>,
       Accessor<TableType, Constness, storage_order>>;
@@ -1352,19 +1346,15 @@ protected:
   typename AlignedVector<T>::const_reference
   el(const size_type i, const size_type j) const;
 
-  /**
-   * Make the AccessorBase class a friend so that it may directly index into
-   * the array.
-   */
+  // Make the AccessorBase class a friend so that it may directly index into
+  // the array.
   friend class MatrixTableIterators::
     AccessorBase<Table<2, T>, true, MatrixTableIterators::Storage::row_major>;
   friend class MatrixTableIterators::
     AccessorBase<Table<2, T>, false, MatrixTableIterators::Storage::row_major>;
 
-  /**
-   * Make the mutable accessor class a friend so that we can write to array
-   * entries with iterators.
-   */
+  // Make the mutable accessor class a friend so that we can write to array
+  // entries with iterators.
   friend class MatrixTableIterators::
     Accessor<Table<2, T>, false, MatrixTableIterators::Storage::row_major>;
 };
@@ -2084,10 +2074,8 @@ protected:
   const_reference
   el(const size_type i, const size_type j) const;
 
-  /**
-   * Make the AccessorBase class a friend so that it may directly index into
-   * the array.
-   */
+  // Make the AccessorBase class a friend so that it may directly index into
+  // the array.
   friend class MatrixTableIterators::AccessorBase<
     TransposeTable<T>,
     true,
@@ -2097,10 +2085,8 @@ protected:
     false,
     MatrixTableIterators::Storage::column_major>;
 
-  /**
-   * Make the mutable accessor class a friend so that we can write to array
-   * entries with iterators.
-   */
+  // Make the mutable accessor class a friend so that we can write to array
+  // entries with iterators.
   friend class MatrixTableIterators::Accessor<
     TransposeTable<T>,
     false,

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -475,9 +475,7 @@ private:
     return res;
   }
 
-  /**
-   * Make a few functions friends.
-   */
+  // Make a few functions friends.
   template <typename Number2, int width2>
   friend VectorizedArray<Number2, width2>
   std::sqrt(const VectorizedArray<Number2, width2> &);
@@ -900,9 +898,7 @@ private:
     return res;
   }
 
-  /**
-   * Make a few functions friends.
-   */
+  // Make a few functions friends.
   template <typename Number2, int width2>
   friend VectorizedArray<Number2, width2>
   std::sqrt(const VectorizedArray<Number2, width2> &);
@@ -1321,9 +1317,7 @@ private:
     return res;
   }
 
-  /**
-   * Make a few functions friends.
-   */
+  // Make a few functions friends.
   template <typename Number2, int width2>
   friend VectorizedArray<Number2, width2>
   std::sqrt(const VectorizedArray<Number2, width2> &);
@@ -1784,9 +1778,7 @@ private:
     return res;
   }
 
-  /**
-   * Make a few functions friends.
-   */
+  // Make a few functions friends.
   template <typename Number2, int width2>
   friend VectorizedArray<Number2, width2>
   std::sqrt(const VectorizedArray<Number2, width2> &);
@@ -2174,9 +2166,7 @@ private:
     return res;
   }
 
-  /**
-   * Make a few functions friends.
-   */
+  // Make a few functions friends.
   template <typename Number2, int width2>
   friend VectorizedArray<Number2, width2>
   std::sqrt(const VectorizedArray<Number2, width2> &);
@@ -2571,9 +2561,7 @@ private:
     return res;
   }
 
-  /**
-   * Make a few functions friends.
-   */
+  // Make a few functions friends.
   template <typename Number2, int width2>
   friend VectorizedArray<Number2, width2>
   std::sqrt(const VectorizedArray<Number2, width2> &);
@@ -2920,9 +2908,7 @@ private:
     return res;
   }
 
-  /**
-   * Make a few functions friends.
-   */
+  // Make a few functions friends.
   template <typename Number2, int width2>
   friend VectorizedArray<Number2, width2>
   std::sqrt(const VectorizedArray<Number2, width2> &);
@@ -3243,9 +3229,7 @@ private:
     return res;
   }
 
-  /**
-   * Make a few functions friends.
-   */
+  // Make a few functions friends.
   template <typename Number2, int width2>
   friend VectorizedArray<Number2, width2>
   std::sqrt(const VectorizedArray<Number2, width2> &);
@@ -3463,9 +3447,7 @@ private:
     return res;
   }
 
-  /**
-   * Make a few functions friends.
-   */
+  // Make a few functions friends.
   template <typename Number2, int width2>
   friend VectorizedArray<Number2, width2>
   std::sqrt(const VectorizedArray<Number2, width2> &);

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -729,20 +729,16 @@ protected:
     const types::global_dof_index index,
     const unsigned int fe_index = DoFHandlerType::default_fe_index) const;
 
-  /**
-   * Iterator classes need to be friends because they need to access
-   * operator== and operator!=.
-   */
+  // Iterator classes need to be friends because they need to access
+  // operator== and operator!=.
   template <typename>
   friend class TriaRawIterator;
   template <int, class, bool>
   friend class DoFAccessor;
 
 private:
-  /**
-   * Make the DoFHandler class a friend so that it can call the set_xxx()
-   * functions.
-   */
+  // Make the DoFHandler class a friend so that it can call the set_xxx()
+  // functions.
   template <int dim, int spacedim>
   friend class DoFHandler;
   template <int dim, int spacedim>
@@ -1206,18 +1202,14 @@ protected:
     const types::global_dof_index index,
     const unsigned int fe_index = AccessorData::default_fe_index) const;
 
-  /**
-   * Iterator classes need to be friends because they need to access
-   * operator== and operator!=.
-   */
+  // Iterator classes need to be friends because they need to access
+  // operator== and operator!=.
   template <typename>
   friend class TriaRawIterator;
 
 
-  /**
-   * Make the DoFHandler class a friend so that it can call the set_xxx()
-   * functions.
-   */
+  // Make the DoFHandler class a friend so that it can call the set_xxx()
+  // functions.
   template <int, int>
   friend class DoFHandler;
   template <int, int>
@@ -2008,10 +2000,8 @@ public:
    */
 
 private:
-  /**
-   * Make the DoFHandler class a friend so that it can call the
-   * update_cell_dof_indices_cache() function
-   */
+  // Make the DoFHandler class a friend so that it can call the
+  // update_cell_dof_indices_cache() function
   template <int dim, int spacedim>
   friend class DoFHandler;
   friend struct dealii::internal::DoFCellAccessorImplementation::Implementation;

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1418,9 +1418,7 @@ private:
   std::unique_ptr<dealii::internal::DoFHandlerImplementation::DoFFaces<dim>>
     mg_faces;
 
-  /**
-   * Make accessor objects friends.
-   */
+  // Make accessor objects friends.
   template <int, class, bool>
   friend class DoFAccessor;
   template <class, bool>

--- a/include/deal.II/dofs/dof_objects.h
+++ b/include/deal.II/dofs/dof_objects.h
@@ -149,10 +149,8 @@ namespace internal
       void
       serialize(Archive &ar, const unsigned int version);
 
-      /**
-       * Declare the classes that store levels and faces of DoFs friends so
-       * that they can resize arrays.
-       */
+      // Declare the classes that store levels and faces of DoFs friends so
+      // that they can resize arrays.
       template <int>
       friend class DoFLevel;
       template <int>

--- a/include/deal.II/fe/fe_abf.h
+++ b/include/deal.II/fe/fe_abf.h
@@ -244,9 +244,7 @@ private:
   Table<3, double> interior_weights_abf;
 
 
-  /**
-   * Allow access from other dimensions.
-   */
+  // Allow access from other dimensions.
   template <int dim1>
   friend class FE_ABF;
 };

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -579,9 +579,7 @@ private:
    */
   const PolynomialSpace<dim> polynomial_space;
 
-  /**
-   * Allow access from other dimensions.
-   */
+  // Allow access from other dimensions.
   template <int, int>
   friend class FE_DGPNonparametric;
 };

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -377,15 +377,11 @@ private:
    */
   mutable Threads::Mutex mutex;
 
-  /**
-   * Allow access from other dimensions.
-   */
+  // Allow access from other dimensions.
   template <int dim1, int spacedim1>
   friend class FE_DGQ;
 
-  /**
-   * Allow @p MappingQ class to access to build_renumbering function.
-   */
+  // Allow @p MappingQ class to access to build_renumbering function.
   template <int dim1, int spacedim1>
   friend class MappingQ;
 };

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -323,14 +323,12 @@ private:
    */
   Table<2, double> boundary_weights;
 
-  /*
+  /**
    * Mutex for protecting initialization of restriction and embedding matrix.
    */
   mutable Threads::Mutex mutex;
 
-  /**
-   * Allow access from other dimensions.
-   */
+  // Allow access from other dimensions.
   template <int dim1>
   friend class FE_Nedelec;
 };

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -330,18 +330,16 @@ protected:
    */
   struct Implementation;
 
-  /*
-   * Declare implementation friend.
-   */
+  // Declare implementation friend.
   friend struct FE_Q_Base<PolynomialType, dim, spacedim>::Implementation;
 
 private:
-  /*
+  /**
    * Mutex for protecting initialization of restriction and embedding matrix.
    */
   mutable Threads::Mutex mutex;
 
-  /*
+  /**
    * The highest polynomial degree of the underlying tensor product space
    * without any enrichment. For FE_Q*(p) this is p. Note that enrichments
    * may lead to a difference to degree.

--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -785,12 +785,10 @@ private:
    */
   const std::vector<unsigned int> face_renumber;
 
-  /**
-   * Allow access from other dimensions. We need this since we want to call
-   * the functions @p get_dpo_vector and @p
-   * lexicographic_to_hierarchic_numbering for the faces of the finite element
-   * of dimension dim+1.
-   */
+  // Allow access from other dimensions. We need this since we want to call
+  // the functions @p get_dpo_vector and @p
+  // lexicographic_to_hierarchic_numbering for the faces of the finite element
+  // of dimension dim+1.
   template <int dim1>
   friend class FE_Q_Hierarchical;
 };

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -197,9 +197,7 @@ private:
    */
   Table<3, double> interior_weights;
 
-  /**
-   * Allow access from other dimensions.
-   */
+  // Allow access from other dimensions.
   template <int dim1>
   friend class FE_RaviartThomas;
 };

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -1226,7 +1226,7 @@ private:
       base_fe_output_objects;
   };
 
-  /*
+  /**
    * Mutex for protecting initialization of restriction and embedding matrix.
    */
   mutable Threads::Mutex mutex;

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -3468,10 +3468,8 @@ private:
    */
   dealii::internal::FEValuesViews::Cache<dim, spacedim> fe_values_views_cache;
 
-  /**
-   * Make the view classes friends of this class, since they access internal
-   * data.
-   */
+  // Make the view classes friends of this class, since they access internal
+  // data.
   template <int, int>
   friend class FEValuesViews::Scalar;
   template <int, int>

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -1233,10 +1233,8 @@ public:
    */
 
 
-  /**
-   * Give class @p FEValues access to the private <tt>get_...data</tt> and
-   * <tt>fill_fe_...values</tt> functions.
-   */
+  // Give class @p FEValues access to the private <tt>get_...data</tt> and
+  // <tt>fill_fe_...values</tt> functions.
   friend class FEValuesBase<dim, spacedim>;
   friend class FEValues<dim, spacedim>;
   friend class FEFaceValues<dim, spacedim>;

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -618,9 +618,7 @@ private:
                     InternalData &         data) const;
 
 
-  /**
-   * Declare other MappingFEField classes friends.
-   */
+  // Declare other MappingFEField classes friends.
   template <int, int, class, class>
   friend class MappingFEField;
 };

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -732,17 +732,13 @@ protected:
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     std::vector<Point<spacedim>> &                              a) const;
 
-  /**
-   * Make MappingQ a friend since it needs to call the fill_fe_values()
-   * functions on its MappingQGeneric(1) sub-object.
-   */
+  // Make MappingQ a friend since it needs to call the fill_fe_values()
+  // functions on its MappingQGeneric(1) sub-object.
   template <int, int>
   friend class MappingQ;
 
-  /**
-   * Make MappingQCache a friend since it needs to call the
-   * compute_mapping_support_points() function.
-   */
+  // Make MappingQCache a friend since it needs to call the
+  // compute_mapping_support_points() function.
   template <int, int>
   friend class MappingQCache;
 };

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -548,15 +548,13 @@ protected:
   Accessor accessor;
 
 
-  /**
-   * Make all other iterator class templates friends of this class. This is
-   * necessary for the implementation of conversion constructors.
-   *
-   * In fact, we would not need them to be friends if they were for different
-   * dimensions, but the compiler dislikes giving a fixed dimension and
-   * variable accessor since then it says that would be a partial
-   * specialization.
-   */
+  // Make all other iterator class templates friends of this class. This is
+  // necessary for the implementation of conversion constructors.
+  //
+  // In fact, we would not need them to be friends if they were for different
+  // dimensions, but the compiler dislikes giving a fixed dimension and
+  // variable accessor since then it says that would be a partial
+  // specialization.
   template <typename SomeAccessor>
   friend class TriaRawIterator;
   template <typename SomeAccessor>

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -1355,9 +1355,7 @@ namespace hp
      */
     std::vector<boost::signals2::connection> tria_listeners;
 
-    /**
-     * Make accessor objects friends.
-     */
+    // Make accessor objects friends.
     template <int, class, bool>
     friend class dealii::DoFAccessor;
     template <class, bool>
@@ -1366,10 +1364,8 @@ namespace hp
     friend struct dealii::internal::DoFCellAccessorImplementation::
       Implementation;
 
-    /**
-     * Likewise for DoFLevel objects since they need to access the vertex dofs
-     * in the functions that set and retrieve vertex dof indices.
-     */
+    // Likewise for DoFLevel objects since they need to access the vertex dofs
+    // in the functions that set and retrieve vertex dof indices.
     template <int>
     friend class dealii::internal::hp::DoFIndicesOnFacesOrEdges;
     friend struct dealii::internal::hp::DoFHandlerImplementation::

--- a/include/deal.II/hp/dof_level.h
+++ b/include/deal.II/hp/dof_level.h
@@ -365,10 +365,8 @@ namespace internal
       normalize_active_fe_indices();
 
 
-      /**
-       * Make hp::DoFHandler and its auxiliary class a friend since it is the
-       * class that needs to create these data structures.
-       */
+      // Make hp::DoFHandler and its auxiliary class a friend since it is the
+      // class that needs to create these data structures.
       template <int, int>
       friend class dealii::hp::DoFHandler;
       friend struct dealii::internal::hp::DoFHandlerImplementation::

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -99,9 +99,7 @@ namespace BlockMatrixIterators
      */
     unsigned int col_block;
 
-    /**
-     * Let the iterator class be a friend.
-     */
+    // Let the iterator class be a friend.
     template <typename>
     friend class MatrixIterator;
   };
@@ -280,9 +278,7 @@ namespace BlockMatrixIterators
     bool
     operator==(const Accessor &a) const;
 
-    /**
-     * Let the iterator class be a friend.
-     */
+    // Let the iterator class be a friend.
     template <typename>
     friend class dealii::MatrixIterator;
   };
@@ -1060,10 +1056,8 @@ private:
    */
   TemporaryData temporary_data;
 
-  /**
-   * Make the iterator class a friend. We have to work around a compiler bug
-   * here again.
-   */
+  // Make the iterator class a friend. We have to work around a compiler bug
+  // here again.
   template <typename, bool>
   friend class BlockMatrixIterators::Accessor;
 

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -377,10 +377,8 @@ private:
    */
   std::vector<std::vector<size_type>> block_column_indices;
 
-  /**
-   * Make the block sparse matrix a friend, so that it can use our
-   * #row_indices and #column_indices objects.
-   */
+  // Make the block sparse matrix a friend, so that it can use our
+  // #row_indices and #column_indices objects.
   template <typename number>
   friend class BlockSparseMatrix;
 };

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -398,10 +398,7 @@ namespace internal
       void
       move_backward();
 
-
-      /**
-       * Mark all other instances of this template as friends.
-       */
+      // Mark all other instances of this template as friends.
       template <typename, bool>
       friend class Iterator;
     };
@@ -971,9 +968,7 @@ protected:
    */
   BlockIndices block_indices;
 
-  /**
-   * Make the iterator class a friend.
-   */
+  // Make the iterator class a friend.
   template <typename N, bool C>
   friend class dealii::internal::BlockVectorIterators::Iterator;
 

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -141,9 +141,7 @@ namespace ChunkSparseMatrixIterators
      */
     using ChunkSparsityPatternIterators::Accessor::advance;
 
-    /**
-     * Make iterator class a friend.
-     */
+    // Make iterator class a friend.
     template <typename, bool>
     friend class Iterator;
   };
@@ -274,9 +272,7 @@ namespace ChunkSparseMatrixIterators
      */
     using ChunkSparsityPatternIterators::Accessor::advance;
 
-    /**
-     * Make iterator class a friend.
-     */
+    // Make iterator class a friend.
     template <typename, bool>
     friend class Iterator;
   };
@@ -1409,9 +1405,7 @@ private:
   template <typename somenumber>
   friend class ChunkSparseMatrix;
 
-  /**
-   * Also give access to internal details to the iterator/accessor classes.
-   */
+  // Also give access to internal details to the iterator/accessor classes.
   template <typename, bool>
   friend class ChunkSparseMatrixIterators::Iterator;
   template <typename, bool>

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -155,9 +155,7 @@ namespace ChunkSparsityPatternIterators
     void
     advance();
 
-    /**
-     * Grant access to iterator class.
-     */
+    // Grant access to iterator class.
     friend class Iterator;
   };
 
@@ -852,15 +850,11 @@ private:
    */
   SparsityPattern sparsity_pattern;
 
-  /**
-   * Make all the chunk sparse matrix kinds friends.
-   */
+  // Make all the chunk sparse matrix kinds friends.
   template <typename>
   friend class ChunkSparseMatrix;
 
-  /**
-   * Make the accessor class a friend.
-   */
+  // Make the accessor class a friend.
   friend class ChunkSparsityPatternIterators::Accessor;
 };
 

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -155,9 +155,7 @@ namespace DynamicSparsityPatternIterators
     void
     advance();
 
-    /**
-     * Grant access to iterator class.
-     */
+    // Grant access to iterator class.
     friend class Iterator;
   };
 

--- a/include/deal.II/lac/filtered_matrix.h
+++ b/include/deal.II/lac/filtered_matrix.h
@@ -252,10 +252,8 @@ public:
      * Current row number.
      */
     size_type index;
-    /*
-     * Make enclosing class a
-     * friend.
-     */
+
+    // Make enclosing class a friend.
     friend class const_iterator;
   };
 
@@ -563,9 +561,7 @@ private:
   post_filter(const VectorType &in, VectorType &out) const;
 
   friend class Accessor;
-  /**
-   * FilteredMatrixBlock accesses pre_filter() and post_filter().
-   */
+  // FilteredMatrixBlock accesses pre_filter() and post_filter().
   friend class FilteredMatrixBlock<VectorType>;
 };
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1385,15 +1385,11 @@ namespace LinearAlgebra
       void
       resize_val(const size_type new_allocated_size);
 
-      /*
-       * Make all other vector types friends.
-       */
+      // Make all other vector types friends.
       template <typename Number2, typename MemorySpace2>
       friend class Vector;
 
-      /**
-       * Make BlockVector type friends.
-       */
+      // Make BlockVector type friends.
       template <typename Number2>
       friend class BlockVector;
     };

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -411,9 +411,7 @@ namespace LinearAlgebra
 
     friend class boost::serialization::access;
 
-    /**
-     * Make all other ReadWriteVector types friends.
-     */
+    // Make all other ReadWriteVector types friends.
     template <typename Number2>
     friend class Vector;
   };

--- a/include/deal.II/lac/matrix_iterator.h
+++ b/include/deal.II/lac/matrix_iterator.h
@@ -118,9 +118,7 @@ private:
    */
   ACCESSOR accessor;
 
-  /**
-   * Allow other iterators access to private data.
-   */
+  // Allow other iterators access to private data.
   template <class OtherAccessor>
   friend class MatrixIterator;
 };

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -167,9 +167,7 @@ namespace PETScWrappers
         void
         visit_present_row();
 
-        /**
-         * Make enclosing class a friend.
-         */
+        // Make enclosing class a friend.
         friend class const_iterator;
       };
 
@@ -1068,9 +1066,7 @@ namespace PETScWrappers
     mutable std::vector<PetscScalar> column_values;
 
 
-    /**
-     * To allow calling protected prepare_add() and prepare_set().
-     */
+    // To allow calling protected prepare_add() and prepare_set().
     template <class>
     friend class dealii::BlockMatrixBase;
   };

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -111,10 +111,8 @@ namespace PETScWrappers
      */
     operator Mat() const;
 
-    /**
-     * Make the solver class a friend, since it needs to call the conversion
-     * operator.
-     */
+    // Make the solver class a friend, since it needs to call the conversion
+    // operator.
     friend class SolverBase;
   };
 

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -247,10 +247,8 @@ namespace PETScWrappers
     std::unique_ptr<SolverData> solver_data;
 
 #    ifdef DEAL_II_WITH_SLEPC
-    /**
-     * Make the transformation class a friend, since it needs to set the KSP
-     * solver.
-     */
+    // Make the transformation class a friend, since it needs to set the KSP
+    // solver.
     friend class SLEPcWrappers::TransformationBase;
 #    endif
   };

--- a/include/deal.II/lac/petsc_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_sparse_matrix.h
@@ -280,9 +280,7 @@ namespace PETScWrappers
     do_reinit(const SparsityPatternType &sparsity_pattern,
               const bool                 preset_nonzero_locations);
 
-    /**
-     * To allow calling protected prepare_add() and prepare_set().
-     */
+    // To allow calling protected prepare_add() and prepare_set().
     friend class BlockMatrixBase<SparseMatrix>;
   };
 
@@ -756,9 +754,7 @@ namespace PETScWrappers
                 const IndexSet &           local_columns,
                 const SparsityPatternType &sparsity_pattern);
 
-      /**
-       * To allow calling protected prepare_add() and prepare_set().
-       */
+      // To allow calling protected prepare_add() and prepare_set().
       friend class BlockMatrixBase<SparseMatrix>;
     };
 

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -198,10 +198,8 @@ namespace PETScWrappers
        */
       const size_type index;
 
-      /**
-       * Make the vector class a friend, so that it can create objects of the
-       * present type.
-       */
+      // Make the vector class a friend, so that it can create objects of the
+      // present type.
       friend class ::dealii::PETScWrappers::VectorBase;
     };
   } // namespace internal
@@ -791,9 +789,7 @@ namespace PETScWrappers
      */
     mutable VectorOperation::values last_action;
 
-    /**
-     * Make the reference class a friend.
-     */
+    // Make the reference class a friend.
     friend class internal::VectorReference;
 
     /**

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -458,9 +458,7 @@ public:
        */
       typename FullMatrix<inverse_type>::const_iterator b_end;
 
-      /**
-       * Make enclosing class a friend.
-       */
+      // Make enclosing class a friend.
       friend class const_iterator;
     };
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -707,9 +707,7 @@ namespace LinearAlgebra
     mutable std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
       thread_loop_partitioner;
 
-    /**
-     * Make all other ReadWriteVector types friends.
-     */
+    // Make all other ReadWriteVector types friends.
     template <typename Number2>
     friend class ReadWriteVector;
 

--- a/include/deal.II/lac/slepc_spectral_transformation.h
+++ b/include/deal.II/lac/slepc_spectral_transformation.h
@@ -106,10 +106,8 @@ namespace SLEPcWrappers
      */
     ST st;
 
-    /**
-     * Make the solver class a friend, since it needs to set spectral
-     * transformation object.
-     */
+    // Make the solver class a friend, since it needs to set spectral
+    // transformation object.
     friend class SolverBase;
   };
 
@@ -192,10 +190,8 @@ namespace SLEPcWrappers
      */
     const AdditionalData additional_data;
 
-    /**
-     * Make the solver class a friend, since it may need to set target
-     * equal the provided shift value.
-     */
+    // Make the solver class a friend, since it may need to set target
+    // equal the provided shift value.
     friend class SolverBase;
   };
 

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -173,9 +173,7 @@ namespace SparseMatrixIterators
      */
     using SparsityPatternIterators::Accessor::advance;
 
-    /**
-     * Make iterator class a friend.
-     */
+    // Make iterator class a friend.
     template <typename, bool>
     friend class Iterator;
   };
@@ -308,9 +306,7 @@ namespace SparseMatrixIterators
      */
     using SparsityPatternIterators::Accessor::advance;
 
-    /**
-     * Make iterator class a friend.
-     */
+    // Make iterator class a friend.
     template <typename, bool>
     friend class Iterator;
   };
@@ -1733,24 +1729,18 @@ private:
   template <typename>
   friend class SparseILU;
 
-  /**
-   * To allow it calling private prepare_add() and prepare_set().
-   */
+  // To allow it calling private prepare_add() and prepare_set().
   template <typename>
   friend class BlockMatrixBase;
 
-  /**
-   * Also give access to internal details to the iterator/accessor classes.
-   */
+  // Also give access to internal details to the iterator/accessor classes.
   template <typename, bool>
   friend class SparseMatrixIterators::Iterator;
   template <typename, bool>
   friend class SparseMatrixIterators::Accessor;
 
 #  ifdef DEAL_II_WITH_MPI
-  /**
-   * Give access to internal datastructures to perform MPI operations.
-   */
+  // Give access to internal datastructures to perform MPI operations.
   template <typename Number>
   friend void
   Utilities::MPI::sum(const SparseMatrix<Number> &,

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -232,9 +232,7 @@ public:
        */
       unsigned short a_index;
 
-      /**
-       * Make enclosing class a friend.
-       */
+      // Make enclosing class a friend.
       friend class const_iterator;
     };
 
@@ -285,14 +283,6 @@ public:
      * Store an object of the accessor class.
      */
     Accessor accessor;
-
-    /**
-     * Make the enclosing class a friend. This is only necessary since icc7
-     * otherwise wouldn't allow us to make const_iterator::Accessor a friend,
-     * stating that it can't access this class -- this is of course bogus,
-     * since granting friendship doesn't need access to the class being
-     * granted friendship...
-     */
   };
 
   /**

--- a/include/deal.II/lac/sparse_vanka.h
+++ b/include/deal.II/lac/sparse_vanka.h
@@ -365,18 +365,16 @@ private:
   void
   compute_inverse(const size_type row, std::vector<size_type> &local_indices);
 
-  /**
-   * Make the derived class a friend. This seems silly, but is actually
-   * necessary, since derived classes can only access non-public members
-   * through their @p this pointer, but not access these members as member
-   * functions of other objects of the type of this base class (i.e. like
-   * <tt>x.f()</tt>, where @p x is an object of the base class, and @p f one
-   * of it's non-public member functions).
-   *
-   * Now, in the case of the @p SparseBlockVanka class, we would like to take
-   * the address of a function of the base class in order to call it through
-   * the multithreading framework, so the derived class has to be a friend.
-   */
+  // Make the derived class a friend. This seems silly, but is actually
+  // necessary, since derived classes can only access non-public members
+  // through their @p this pointer, but not access these members as member
+  // functions of other objects of the type of this base class (i.e. like
+  // <tt>x.f()</tt>, where @p x is an object of the base class, and @p f one
+  // of it's non-public member functions).
+  //
+  // Now, in the case of the @p SparseBlockVanka class, we would like to take
+  // the address of a function of the base class in order to call it through
+  // the multithreading framework, so the derived class has to be a friend.
   template <typename T>
   friend class SparseBlockVanka;
 };

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -243,14 +243,10 @@ namespace SparsityPatternIterators
     void
     advance();
 
-    /**
-     * Grant access to iterator class.
-     */
+    // Grant access to iterator class.
     friend class LinearIndexIterator<Iterator, Accessor>;
 
-    /**
-     * Grant access to accessor class of ChunkSparsityPattern.
-     */
+    // Grant access to accessor class of ChunkSparsityPattern.
     friend class ChunkSparsityPatternIterators::Accessor;
   };
 
@@ -803,9 +799,7 @@ protected:
    */
   bool compressed;
 
-  /**
-   * Make all sparse matrices friends of this class.
-   */
+  // Make all sparse matrices friends of this class.
   template <typename number>
   friend class SparseMatrix;
   template <typename number>
@@ -818,9 +812,7 @@ protected:
   friend class ChunkSparsityPattern;
   friend class DynamicSparsityPattern;
 
-  /**
-   * Also give access to internal details to the iterator/accessor classes.
-   */
+  // Also give access to internal details to the iterator/accessor classes.
   friend class SparsityPatternIterators::Iterator;
   friend class SparsityPatternIterators::Accessor;
   friend class ChunkSparsityPatternIterators::Accessor;
@@ -1293,9 +1285,7 @@ private:
    */
   bool store_diagonal_first_in_row;
 
-  /**
-   * Make all sparse matrices friends of this class.
-   */
+  // Make all sparse matrices friends of this class.
   template <typename number>
   friend class SparseMatrix;
   template <typename number>
@@ -1308,9 +1298,7 @@ private:
   friend class ChunkSparsityPattern;
   friend class DynamicSparsityPattern;
 
-  /**
-   * Also give access to internal details to the iterator/accessor classes.
-   */
+  // Also give access to internal details to the iterator/accessor classes.
   friend class SparsityPatternIterators::Iterator;
   friend class SparsityPatternIterators::Accessor;
   friend class ChunkSparsityPatternIterators::Accessor;

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -245,9 +245,7 @@ namespace TrilinosWrappers
       value() const;
 
     private:
-      /**
-       * Make iterator class a friend.
-       */
+      // Make iterator class a friend.
       template <bool>
       friend class Iterator;
     };
@@ -329,14 +327,11 @@ namespace TrilinosWrappers
       value() const;
 
     private:
-      /**
-       * Make iterator class a friend.
-       */
+      // Make iterator class a friend.
       template <bool>
       friend class Iterator;
-      /**
-       * Make Reference object a friend.
-       */
+
+      // Make Reference object a friend.
       friend class Reference;
     };
 
@@ -2149,9 +2144,7 @@ namespace TrilinosWrappers
      */
     bool compressed;
 
-    /**
-     * To allow calling protected prepare_add() and prepare_set().
-     */
+    // To allow calling protected prepare_add() and prepare_set().
     friend class BlockMatrixBase<SparseMatrix>;
   };
 

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -158,9 +158,7 @@ namespace TrilinosWrappers
       void
       visit_present_row();
 
-      /**
-       * Make enclosing class a friend.
-       */
+      // Make enclosing class a friend.
       friend class Iterator;
     };
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -179,10 +179,8 @@ namespace TrilinosWrappers
        */
       const size_type index;
 
-      /**
-       * Make the vector class a friend, so that it can create objects of the
-       * present type.
-       */
+      // Make the vector class a friend, so that it can create objects of the
+      // present type.
       friend class ::dealii::TrilinosWrappers::MPI::Vector;
     };
   } // namespace internal
@@ -1335,9 +1333,7 @@ namespace TrilinosWrappers
        */
       IndexSet owned_elements;
 
-      /**
-       * Make the reference class a friend.
-       */
+      // Make the reference class a friend.
       friend class internal::VectorReference;
     };
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1036,9 +1036,7 @@ private:
   mutable std::shared_ptr<parallel::internal::TBBPartitioner>
     thread_loop_partitioner;
 
-  /**
-   * Make all other vector types friends.
-   */
+  // Make all other vector types friends.
   template <typename Number2>
   friend class Vector;
 };

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -1125,9 +1125,7 @@ private:
   void
   set_data_pointers();
 
-  /**
-   * Make other FEEvaluationBase as well as FEEvaluation objects friends.
-   */
+  // Make other FEEvaluationBase as well as FEEvaluation objects friends.
   template <int, int, typename, bool, typename>
   friend class FEEvaluationBase;
   template <int, int, int, int, typename, typename>

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -992,10 +992,8 @@ protected:
                DataComponentInterpretation::DataComponentInterpretation>>
   get_nonscalar_data_ranges() const override;
 
-  /**
-   * Make all template siblings friends. Needed for the merge_patches()
-   * function.
-   */
+  // Make all template siblings friends. Needed for the merge_patches()
+  // function.
   template <class, int, int>
   friend class DataOut_DoFData;
 

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -214,10 +214,8 @@ namespace Particles
     typename std::multimap<internal::LevelInd,
                            Particle<dim, spacedim>>::iterator particle;
 
-    /**
-     * Make ParticleIterator a friend to allow it constructing
-     * ParticleAccessors.
-     */
+    // Make ParticleIterator a friend to allow it constructing
+    // ParticleAccessors.
     template <int, int>
     friend class ParticleIterator;
     template <int, int>


### PR DESCRIPTION
It doesn't make sense to use doxygen format for friend declarations.
Even worse, it sometimes stops the correct documentation from showing
up.

As a bonus, this PR also has some hidden other fixes found while
replacing the comments.