### PR TITLE
Add CHANGELOG.md and SUPPORT.md files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+Changes to deal.II between versions
+===================================
+
+The list of changes between versions of deal.II is maintained as part of the
+regular documentation. You can find it
+[here](https://www.dealii.org/developer/doxygen/deal.II/pages.html).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,6 @@
+In case of questions
+====================
+
+There are many ways to obtain support if you have questions about deal.II.
+Please see the [main project website](https://dealii.org/) for links to the
+web forum, links to the documentation, and much other information.


### PR DESCRIPTION
xSDK has added more recommended policies (see R7 at https://github.com/xsdk-project/xsdk-community-policies) that suggest having SUPPORT and CHANGELOG files. I find these a bit pointless, most of all the changelog file. We could just ignore the policy (it's "only" recommended), but it's also easy to add these files.

I have no intention of actually putting content in there, but we may just link to the places where we have that information.