### PR TITLE
Add two new methods to VectorizedArray

### DIFF
--- a/doc/news/changes/minor/20190729PeterMunch
+++ b/doc/news/changes/minor/20190729PeterMunch
@@ -1,0 +1,4 @@
+New: Amend VectorizedArray with a default constructor and 
+a constructor taking a scalar value.
+<br>
+(Peter Munch, 2019/07/29)

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -3536,16 +3536,7 @@ operator*(const SymmetricTensor<rank_, dim, Number> &t,
   // (as well as with switched arguments and double<->float).
   using product_type = typename ProductType<Number, OtherNumber>::type;
   SymmetricTensor<rank_, dim, product_type> tt(t);
-  // we used to shorten the following by 'tt *= product_type(factor);'
-  // which requires that a converting constructor
-  // 'product_type::product_type(const OtherNumber) is defined.
-  // however, a user-defined constructor is not allowed for aggregates,
-  // e.g. VectorizedArray. therefore, we work around this issue using a
-  // copy-assignment operator 'product_type::operator=(const OtherNumber)'
-  // which we assume to be defined.
-  product_type new_factor;
-  new_factor = factor;
-  tt *= new_factor;
+  tt *= product_type(factor);
   return tt;
 }
 

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -225,6 +225,20 @@ public:
   // and copy functions (the standard is somewhat relaxed in C++2011, though).
 
   /**
+   * Default empty constructor, leaving the data in an uninitialized state
+   * similar to float/double.
+   */
+  VectorizedArray() = default;
+
+  /**
+   * Construct an array with the given scalar broadcast to all lanes
+   */
+  VectorizedArray(const Number scalar)
+  {
+    this->operator=(scalar);
+  }
+
+  /**
    * This function assigns a scalar to this class.
    */
   DEAL_II_ALWAYS_INLINE
@@ -667,6 +681,20 @@ public:
   static const unsigned int n_array_elements = 8;
 
   /**
+   * Default empty constructor, leaving the data in an uninitialized state
+   * similar to float/double.
+   */
+  VectorizedArray() = default;
+
+  /**
+   * Construct an array with the given scalar broadcast to all lanes
+   */
+  VectorizedArray(const double scalar)
+  {
+    this->operator=(scalar);
+  }
+
+  /**
    * This function can be used to set all data fields to a given scalar.
    */
   DEAL_II_ALWAYS_INLINE
@@ -1084,6 +1112,20 @@ public:
    * This gives the number of vectors collected in this class.
    */
   static const unsigned int n_array_elements = 16;
+
+  /**
+   * Default empty constructor, leaving the data in an uninitialized state
+   * similar to float/double.
+   */
+  VectorizedArray() = default;
+
+  /**
+   * Construct an array with the given scalar broadcast to all lanes
+   */
+  VectorizedArray(const float scalar)
+  {
+    this->operator=(scalar);
+  }
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -1556,6 +1598,20 @@ public:
   static const unsigned int n_array_elements = 4;
 
   /**
+   * Default empty constructor, leaving the data in an uninitialized state
+   * similar to float/double.
+   */
+  VectorizedArray() = default;
+
+  /**
+   * Construct an array with the given scalar broadcast to all lanes
+   */
+  VectorizedArray(const double scalar)
+  {
+    this->operator=(scalar);
+  }
+
+  /**
    * This function can be used to set all data fields to a given scalar.
    */
   DEAL_II_ALWAYS_INLINE
@@ -1942,6 +1998,20 @@ public:
    * This gives the number of vectors collected in this class.
    */
   static const unsigned int n_array_elements = 8;
+
+  /**
+   * Default empty constructor, leaving the data in an uninitialized state
+   * similar to float/double.
+   */
+  VectorizedArray() = default;
+
+  /**
+   * Construct an array with the given scalar broadcast to all lanes
+   */
+  VectorizedArray(const float scalar)
+  {
+    this->operator=(scalar);
+  }
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -2353,6 +2423,20 @@ public:
   static const unsigned int n_array_elements = 2;
 
   /**
+   * Default empty constructor, leaving the data in an uninitialized state
+   * similar to float/double.
+   */
+  VectorizedArray() = default;
+
+  /**
+   * Construct an array with the given scalar broadcast to all lanes
+   */
+  VectorizedArray(const double scalar)
+  {
+    this->operator=(scalar);
+  }
+
+  /**
    * This function can be used to set all data fields to a given scalar.
    */
   DEAL_II_ALWAYS_INLINE
@@ -2702,6 +2786,20 @@ public:
   /**
    * This function can be used to set all data fields to a given scalar.
    */
+
+  /**
+   * Default empty constructor, leaving the data in an uninitialized state
+   * similar to float/double.
+   */
+  VectorizedArray() = default;
+
+  /**
+   * Construct an array with the given scalar broadcast to all lanes
+   */
+  VectorizedArray(const float scalar)
+  {
+    this->operator=(scalar);
+  }
 
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -3068,6 +3166,20 @@ public:
   static const unsigned int n_array_elements = 2;
 
   /**
+   * Default empty constructor, leaving the data in an uninitialized state
+   * similar to float/double.
+   */
+  VectorizedArray() = default;
+
+  /**
+   * Construct an array with the given scalar broadcast to all lanes
+   */
+  VectorizedArray(const double scalar)
+  {
+    this->operator=(scalar);
+  }
+
+  /**
    * This function assigns a scalar to this class.
    */
   DEAL_II_ALWAYS_INLINE
@@ -3284,6 +3396,20 @@ public:
    * This gives the number of vectors collected in this class.
    */
   static const unsigned int n_array_elements = 4;
+
+  /**
+   * Default empty constructor, leaving the data in an uninitialized state
+   * similar to float/double.
+   */
+  VectorizedArray() = default;
+
+  /**
+   * Construct an array with the given scalar broadcast to all lanes
+   */
+  VectorizedArray(const float scalar)
+  {
+    this->operator=(scalar);
+  }
 
   /**
    * This function assigns a scalar to this class.

--- a/tests/base/vectorization_11.cc
+++ b/tests/base/vectorization_11.cc
@@ -52,20 +52,25 @@ struct Tester<double>
   test()
   {
     do_test(make_vectorized_array<double>(2.0), 2.0);
+    do_test(VectorizedArray<double>(2.0), 2.0);
 
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
     do_test(make_vectorized_array<VectorizedArray<double, 8>>(2.0), 2.0);
+    do_test(VectorizedArray<double, 8>(2.0), 2.0);
 #endif
 
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
     do_test(make_vectorized_array<VectorizedArray<double, 4>>(2.0), 2.0);
+    do_test(VectorizedArray<double, 4>(2.0), 2.0);
 #endif
 
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
     do_test(make_vectorized_array<VectorizedArray<double, 2>>(2.0), 2.0);
+    do_test(VectorizedArray<double, 2>(2.0), 2.0);
 #endif
 
     do_test(make_vectorized_array<VectorizedArray<double, 1>>(2.0), 2.0);
+    do_test(VectorizedArray<double, 1>(2.0), 2.0);
   }
 };
 
@@ -76,20 +81,25 @@ struct Tester<float>
   test()
   {
     do_test(make_vectorized_array<float>(2.0), 2.0);
+    do_test(VectorizedArray<float>(2.0), 2.0);
 
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
     do_test(make_vectorized_array<VectorizedArray<float, 16>>(2.0), 2.0);
+    do_test(VectorizedArray<float, 16>(2.0), 2.0);
 #endif
 
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
     do_test(make_vectorized_array<VectorizedArray<float, 8>>(2.0), 2.0);
+    do_test(VectorizedArray<float, 8>(2.0), 2.0);
 #endif
 
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
     do_test(make_vectorized_array<VectorizedArray<float, 4>>(2.0), 2.0);
+    do_test(VectorizedArray<float, 4>(2.0), 2.0);
 #endif
 
     do_test(make_vectorized_array<VectorizedArray<float, 1>>(2.0), 2.0);
+    do_test(VectorizedArray<float, 1>(2.0), 2.0);
   }
 };
 

--- a/tests/base/vectorization_11.output
+++ b/tests/base/vectorization_11.output
@@ -2,6 +2,10 @@
 DEAL::double:
 DEAL::  test 1 array elements
 DEAL::  test 1 array elements
+DEAL::  test 1 array elements
+DEAL::  test 1 array elements
 DEAL::float:
+DEAL::  test 1 array elements
+DEAL::  test 1 array elements
 DEAL::  test 1 array elements
 DEAL::  test 1 array elements

--- a/tests/base/vectorization_11.output.avx
+++ b/tests/base/vectorization_11.output.avx
@@ -2,10 +2,18 @@
 DEAL::double:
 DEAL::  test 4 array elements
 DEAL::  test 4 array elements
+DEAL::  test 4 array elements
+DEAL::  test 4 array elements
 DEAL::  test 2 array elements
+DEAL::  test 2 array elements
+DEAL::  test 1 array elements
 DEAL::  test 1 array elements
 DEAL::float:
 DEAL::  test 8 array elements
 DEAL::  test 8 array elements
+DEAL::  test 8 array elements
+DEAL::  test 8 array elements
 DEAL::  test 4 array elements
+DEAL::  test 4 array elements
+DEAL::  test 1 array elements
 DEAL::  test 1 array elements

--- a/tests/base/vectorization_11.output.avx512
+++ b/tests/base/vectorization_11.output.avx512
@@ -2,12 +2,22 @@
 DEAL::double:
 DEAL::  test 8 array elements
 DEAL::  test 8 array elements
+DEAL::  test 8 array elements
+DEAL::  test 8 array elements
+DEAL::  test 4 array elements
 DEAL::  test 4 array elements
 DEAL::  test 2 array elements
+DEAL::  test 2 array elements
+DEAL::  test 1 array elements
 DEAL::  test 1 array elements
 DEAL::float:
 DEAL::  test 16 array elements
 DEAL::  test 16 array elements
+DEAL::  test 16 array elements
+DEAL::  test 16 array elements
+DEAL::  test 8 array elements
 DEAL::  test 8 array elements
 DEAL::  test 4 array elements
+DEAL::  test 4 array elements
+DEAL::  test 1 array elements
 DEAL::  test 1 array elements

--- a/tests/base/vectorization_11.output.sse2
+++ b/tests/base/vectorization_11.output.sse2
@@ -2,8 +2,14 @@
 DEAL::double:
 DEAL::  test 2 array elements
 DEAL::  test 2 array elements
+DEAL::  test 2 array elements
+DEAL::  test 2 array elements
+DEAL::  test 1 array elements
 DEAL::  test 1 array elements
 DEAL::float:
 DEAL::  test 4 array elements
 DEAL::  test 4 array elements
+DEAL::  test 4 array elements
+DEAL::  test 4 array elements
+DEAL::  test 1 array elements
 DEAL::  test 1 array elements


### PR DESCRIPTION
In PR #8400, we expressed to add two new methods to `VectorizedArray`:
- constructor:
```cpp
VectorizedArray(const Number scalar);
```
- broadcast function:
```cpp
void broadcast_from_scalar(const Number scalar);
```
This PR intends to add these two functions and remove existing workarounds that were needed due to the lack of these (e.g. #8064).

@masterleinad  @tjhei, @bangerth, @kronbichler ping