### PR TITLE
 Add AffineConstraints::set_zero for MemorySpace::CUDA 

### DIFF
--- a/doc/news/changes/minor/20190728DanielArndt
+++ b/doc/news/changes/minor/20190728DanielArndt
@@ -1,0 +1,4 @@
+Fixed: AffineConstraints::set_zero() can be used with
+LinearAlgebra::distributed::Vector with MemorySpace::CUDA.
+<br>
+(Daniel Arndt, 2019/07/28)

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -65,6 +65,7 @@ IF(DEAL_II_WITH_CUDA)
   SET(_separate_src
     ${_separate_src}
     vector_memory.cu
+    affine_constraints.cu
     )
 ENDIF()
 

--- a/source/lac/affine_constraints.cu
+++ b/source/lac/affine_constraints.cu
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/lac/affine_constraints.templates.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+template void
+AffineConstraints<float>::set_zero<
+  LinearAlgebra::distributed::Vector<float, MemorySpace::CUDA>>(
+  LinearAlgebra::distributed::Vector<float, MemorySpace::CUDA> &) const;
+
+template void
+AffineConstraints<double>::set_zero<
+  LinearAlgebra::distributed::Vector<double, MemorySpace::CUDA>>(
+  LinearAlgebra::distributed::Vector<double, MemorySpace::CUDA> &) const;
+
+DEAL_II_NAMESPACE_CLOSE

--- a/tests/cuda/affine_constraints_set_zero.cu
+++ b/tests/cuda/affine_constraints_set_zero.cu
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check AffineConstraints<double>::set_zero(Vector) for parallel distributed
+// vectors
+
+#include <deal.II/base/cuda_size.h>
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include "../tests.h"
+
+
+__global__ void
+initialize_vector(double *vector, int local_size, int offset)
+{
+  const int index = threadIdx.x + blockIdx.x * blockDim.x;
+  if (index < local_size)
+    vector[index] = 1.0 + index + offset;
+}
+
+
+void
+test()
+{
+  unsigned int myid    = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  unsigned int numproc = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+
+  IndexSet local_active;
+  local_active.set_size(2 * numproc);
+  local_active.add_range(myid * numproc, (myid + 1) * numproc);
+
+  LinearAlgebra::distributed::Vector<double, MemorySpace::CUDA> v;
+  v.reinit(local_active, complete_index_set(2 * numproc), MPI_COMM_WORLD);
+
+  const int n_blocks = 1 + v.size() / CUDAWrappers::block_size;
+  initialize_vector<<<n_blocks, CUDAWrappers::block_size>>>(v.get_values(),
+                                                            numproc,
+                                                            myid * numproc);
+  v.compress(VectorOperation::insert);
+
+  AffineConstraints<double> cm;
+  cm.add_line(numproc * myid + 1);
+  cm.close();
+
+  deallog << "vector before:" << std::endl;
+  v.print(deallog.get_file_stream());
+
+  deallog << std::endl;
+  deallog << "CM:" << std::endl;
+  cm.print(deallog.get_file_stream());
+
+  cm.set_zero(v);
+
+  deallog << "vector after:" << std::endl;
+  v.print(deallog.get_file_stream());
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  init_cuda();
+
+  test();
+  return 0;
+}

--- a/tests/cuda/affine_constraints_set_zero.mpirun=2.output
+++ b/tests/cuda/affine_constraints_set_zero.mpirun=2.output
@@ -1,0 +1,31 @@
+
+DEAL:0::vector before:
+Process #0
+Local range: [0, 2), global size: 4
+Vector data:
+1.000e+00 2.000e+00 
+DEAL:0::
+DEAL:0::CM:
+    1 = 0
+DEAL:0::vector after:
+Process #0
+Local range: [0, 2), global size: 4
+Vector data:
+1.000e+00 0.000e+00 
+DEAL:0::OK
+
+DEAL:1::vector before:
+Process #1
+Local range: [2, 4), global size: 4
+Vector data:
+3.000e+00 4.000e+00 
+DEAL:1::
+DEAL:1::CM:
+    3 = 0
+DEAL:1::vector after:
+Process #1
+Local range: [2, 4), global size: 4
+Vector data:
+3.000e+00 0.000e+00 
+DEAL:1::OK
+


### PR DESCRIPTION
We need a separate implementation for AffineConstraints::set_zero in case the data resides on the `CUDA` device.