### PR TITLE
Fix compiling with CUDA

### DIFF
--- a/cmake/checks/check_01_cpu_features.cmake
+++ b/cmake/checks/check_01_cpu_features.cmake
@@ -290,6 +290,15 @@ IF(DEAL_II_HAVE_ALTIVEC)
   SET(DEAL_II_COMPILER_VECTORIZATION_LEVEL 1)
 ENDIF()
 
+#
+# We need to disable SIMD vectorization for CUDA device code.
+# Otherwise, nvcc compilers from version 9 on will emit an error message like:
+# "[...] contains a vector, which is not supported in device code"
+#
+
+IF(DEAL_II_WITH_CUDA)
+  SET(DEAL_II_COMPILER_VECTORIZATION_LEVEL 0)
+ENDIF()
 
 #
 # If we have OpenMP SIMD support (i.e. DEAL_II_HAVE_OPENMP_SIMD is true)

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -116,14 +116,7 @@
  */
 
 #cmakedefine DEAL_II_WORDS_BIGENDIAN
-// We need to disable SIMD vectorization for CUDA device code.
-// Otherwise, nvcc compilers from version 9 on will emit an error message like:
-// "[...] contains a vector, which is not supported in device code"
-#ifdef DEAL_II_WITH_CUDA
-#  define DEAL_II_COMPILER_VECTORIZATION_LEVEL 0
-#else
-#  define DEAL_II_COMPILER_VECTORIZATION_LEVEL @DEAL_II_COMPILER_VECTORIZATION_LEVEL@
-#endif
+#define DEAL_II_COMPILER_VECTORIZATION_LEVEL @DEAL_II_COMPILER_VECTORIZATION_LEVEL@
 #define DEAL_II_OPENMP_SIMD_PRAGMA @DEAL_II_OPENMP_SIMD_PRAGMA@
 
 


### PR DESCRIPTION
Currently, compiling with `CUDA` fails (see https://cdash.43-1.org/viewBuildError.php?buildid=537) since the update to `DEAL_II_COMPILER_VECTORIZATION_LEVEL` (in `include/deal.II/base/config.h.in`) is not reflected in the `CMake` variable. We can move this restriction to the place where we define the `CMake` variable instead.