### PR TITLE
Implement output operator for VectorizedArray 

### DIFF
--- a/doc/news/changes/minor/20190729DanielArndt
+++ b/doc/news/changes/minor/20190729DanielArndt
@@ -1,0 +1,4 @@
+New: The content of a VectorizedArray object can be printed
+using the output operator.
+<br>
+(Daniel Arndt, 2019/07/29)

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -3841,9 +3841,24 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
   return VectorizedArray<Number, width>() - u;
 }
 
+/**
+ * Output operator for vectorized array.
+ *
+ * @relatesalso VectorizedArray
+ */
+template <typename Number, int width>
+inline std::ostream &
+operator<<(std::ostream &out, const VectorizedArray<Number, width> &p)
+{
+  constexpr unsigned int n = VectorizedArray<Number, width>::n_array_elements;
+  for (unsigned int i = 0; i < n - 1; ++i)
+    out << p[i] << ' ';
+  out << p[n - 1];
+
+  return out;
+}
 
 DEAL_II_NAMESPACE_CLOSE
-
 
 /**
  * Implementation of functions from cmath on VectorizedArray. These functions

--- a/tests/base/vectorization_12.cc
+++ b/tests/base/vectorization_12.cc
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// test printing a VectorizedArray object
+
+#include <deal.II/base/vectorization.h>
+
+#include <sstream>
+
+#include "../tests.h"
+
+
+template <typename Number>
+void
+test()
+{
+  constexpr unsigned int n = VectorizedArray<Number>::n_array_elements;
+
+  VectorizedArray<Number> a;
+  std::stringstream       test_stream;
+  for (unsigned int i = 0; i < n; ++i)
+    a[i] = (i + 1);
+  test_stream << a;
+
+  std::stringstream reference_stream;
+  for (unsigned int i = 0; i < n - 1; ++i)
+    {
+      reference_stream << Number(i + 1) << " ";
+    }
+  reference_stream << Number(n);
+
+  if (reference_stream.str() != test_stream.str())
+    {
+      deallog << "Error: " << test_stream.str() << " should be "
+              << reference_stream.str() << std::endl;
+      AssertThrow(false, ExcInternalError());
+    }
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  deallog << "Test double: ";
+  test<double>();
+  deallog << "Test int: ";
+  test<int>();
+}

--- a/tests/base/vectorization_12.output
+++ b/tests/base/vectorization_12.output
@@ -1,0 +1,3 @@
+
+DEAL::Test double: OK
+DEAL::Test int: OK


### PR DESCRIPTION
It always annoyed me that it is hard to view the content of a `VectorizedArray` object and I ended up writing the same simple code for it over and over. Let's just define an output operator in the library and be done with it.