### PR TITLE
Bug in CellDataStorage::erase() fixed

### DIFF
--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -559,6 +559,8 @@ bool
 CellDataStorage<CellIteratorType, DataType>::erase(const CellIteratorType &cell)
 {
   const auto it = map.find(cell);
+  if (it == map.end())
+    return false;
   for (unsigned int i = 0; i < it->second.size(); i++)
     {
       Assert(

--- a/tests/base/cell_data_storage_02.cc
+++ b/tests/base/cell_data_storage_02.cc
@@ -102,6 +102,10 @@ test()
           fe_values.reinit(dof_cell);
           const std::vector<Point<dim>> &q_points =
             fe_values.get_quadrature_points();
+          // before initialization, you can erase it without any consequences
+          const bool erased_nonexisting_data = data_storage.erase(cell);
+          Assert(!erased_nonexisting_data, ExcInternalError());
+          // initialize
           data_storage.initialize(cell, rhs.size());
           {
             std::vector<std::shared_ptr<MyQData>> qpd =


### PR DESCRIPTION
The documentation of this function says:
> If no data is attached to the cell, this function will not do anything and returns false.

However, I observed that when no data is attached to the cell, it fails catastrophically (segfault). I fixed it by adding a simple check.