### PR TITLE
Add boost files

### DIFF
--- a/bundled/boost-1.70.0/include/boost/type_traits/detail/is_function_cxx_03.hpp
+++ b/bundled/boost-1.70.0/include/boost/type_traits/detail/is_function_cxx_03.hpp
@@ -1,0 +1,108 @@
+
+//  Copyright 2000 John Maddock (john@johnmaddock.co.uk)
+//  Copyright 2002 Aleksey Gurtovoy (agurtovoy@meta-comm.com)
+//
+//  Use, modification and distribution are subject to the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt).
+//
+//  See http://www.boost.org/libs/type_traits for most recent version including documentation.
+
+#ifndef BOOST_TT_IS_FUNCTION_CXX_03_HPP_INCLUDED
+#define BOOST_TT_IS_FUNCTION_CXX_03_HPP_INCLUDED
+
+#include <boost/type_traits/is_reference.hpp>
+
+#if !defined(BOOST_TT_TEST_MS_FUNC_SIGS)
+#   include <boost/type_traits/detail/is_function_ptr_helper.hpp>
+#else
+#   include <boost/type_traits/detail/is_function_ptr_tester.hpp>
+#   include <boost/type_traits/detail/yes_no_type.hpp>
+#endif
+
+// is a type a function?
+// Please note that this implementation is unnecessarily complex:
+// we could just use !is_convertible<T*, const volatile void*>::value,
+// except that some compilers erroneously allow conversions from
+// function pointers to void*.
+
+namespace boost {
+
+#if !defined( __CODEGEARC__ )
+
+namespace detail {
+
+#if !defined(BOOST_TT_TEST_MS_FUNC_SIGS)
+template<bool is_ref = true>
+struct is_function_chooser
+{
+   template< typename T > struct result_
+      : public false_type {};
+};
+
+template <>
+struct is_function_chooser<false>
+{
+    template< typename T > struct result_
+        : public ::boost::type_traits::is_function_ptr_helper<T*> {};
+};
+
+template <typename T>
+struct is_function_impl
+    : public is_function_chooser< ::boost::is_reference<T>::value >
+        ::BOOST_NESTED_TEMPLATE result_<T>
+{
+};
+
+#else
+
+template <typename T>
+struct is_function_impl
+{
+#if BOOST_WORKAROUND(BOOST_MSVC_FULL_VER, >= 140050000)
+#pragma warning(push)
+#pragma warning(disable:6334)
+#endif
+    static T* t;
+    BOOST_STATIC_CONSTANT(
+        bool, value = sizeof(::boost::type_traits::is_function_ptr_tester(t))
+        == sizeof(::boost::type_traits::yes_type)
+        );
+#if BOOST_WORKAROUND(BOOST_MSVC_FULL_VER, >= 140050000)
+#pragma warning(pop)
+#endif
+};
+
+template <typename T>
+struct is_function_impl<T&> : public false_type
+{};
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+template <typename T>
+struct is_function_impl<T&&> : public false_type
+{};
+#endif
+
+#endif
+
+} // namespace detail
+
+#endif // !defined( __CODEGEARC__ )
+
+#if defined( __CODEGEARC__ )
+template <class T> struct is_function : integral_constant<bool, __is_function(T)> {};
+#else
+template <class T> struct is_function : integral_constant<bool, ::boost::detail::is_function_impl<T>::value> {};
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+template <class T> struct is_function<T&&> : public false_type {};
+#endif
+#if !BOOST_WORKAROUND(BOOST_MSVC, <= 1600)
+template <class T> struct is_function<T&> : public false_type {};
+#endif
+#endif
+} // namespace boost
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && defined(BOOST_MSVC) && BOOST_WORKAROUND(BOOST_MSVC, <= 1700)
+#include <boost/type_traits/detail/is_function_msvc10_fix.hpp>
+#endif
+
+#endif // BOOST_TT_IS_FUNCTION_CXX_03_HPP_INCLUDED

--- a/bundled/boost-1.70.0/include/boost/type_traits/detail/is_member_function_pointer_cxx_03.hpp
+++ b/bundled/boost-1.70.0/include/boost/type_traits/detail/is_member_function_pointer_cxx_03.hpp
@@ -1,0 +1,117 @@
+
+//  (C) Copyright Dave Abrahams, Steve Cleary, Beman Dawes, Howard
+//  Hinnant & John Maddock 2000.  
+//  Use, modification and distribution are subject to the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt).
+//
+//  See http://www.boost.org/libs/type_traits for most recent version including documentation.
+
+
+#ifndef BOOST_TT_IS_MEMBER_FUNCTION_POINTER_CXX_03_HPP_INCLUDED
+#define BOOST_TT_IS_MEMBER_FUNCTION_POINTER_CXX_03_HPP_INCLUDED
+
+#if !BOOST_WORKAROUND(__BORLANDC__, < 0x600) && !defined(BOOST_TT_TEST_MS_FUNC_SIGS)
+   //
+   // Note: we use the "workaround" version for MSVC because it works for 
+   // __stdcall etc function types, where as the partial specialisation
+   // version does not do so.
+   //
+#   include <boost/type_traits/detail/is_mem_fun_pointer_impl.hpp>
+#   include <boost/type_traits/remove_cv.hpp>
+#   include <boost/type_traits/integral_constant.hpp>
+#else
+#   include <boost/type_traits/is_reference.hpp>
+#   include <boost/type_traits/is_array.hpp>
+#   include <boost/type_traits/detail/yes_no_type.hpp>
+#   include <boost/type_traits/detail/is_mem_fun_pointer_tester.hpp>
+#endif
+
+namespace boost {
+
+#if defined( __CODEGEARC__ )
+template <class T> struct is_member_function_pointer : public integral_constant<bool, __is_member_function_pointer( T )> {};
+#elif !BOOST_WORKAROUND(__BORLANDC__, < 0x600) && !defined(BOOST_TT_TEST_MS_FUNC_SIGS)
+
+template <class T> struct is_member_function_pointer 
+   : public ::boost::integral_constant<bool, ::boost::type_traits::is_mem_fun_pointer_impl<typename remove_cv<T>::type>::value>{};
+
+#else
+
+namespace detail {
+
+#ifndef __BORLANDC__
+
+template <bool>
+struct is_mem_fun_pointer_select
+{
+   template <class T> struct result_ : public false_type{};
+};
+
+template <>
+struct is_mem_fun_pointer_select<false>
+{
+    template <typename T> struct result_
+    {
+#if BOOST_WORKAROUND(BOOST_MSVC_FULL_VER, >= 140050000)
+#pragma warning(push)
+#pragma warning(disable:6334)
+#endif
+        static T* make_t;
+        typedef result_<T> self_type;
+
+        BOOST_STATIC_CONSTANT(
+            bool, value = (
+                1 == sizeof(::boost::type_traits::is_mem_fun_pointer_tester(self_type::make_t))
+            ));
+#if BOOST_WORKAROUND(BOOST_MSVC_FULL_VER, >= 140050000)
+#pragma warning(pop)
+#endif
+    };
+};
+
+template <typename T>
+struct is_member_function_pointer_impl
+    : public is_mem_fun_pointer_select< 
+      ::boost::is_reference<T>::value || ::boost::is_array<T>::value>::template result_<T>{};
+
+template <typename T>
+struct is_member_function_pointer_impl<T&> : public false_type{};
+
+#else // Borland C++
+
+template <typename T>
+struct is_member_function_pointer_impl
+{
+   static T* m_t;
+   BOOST_STATIC_CONSTANT(
+              bool, value =
+               (1 == sizeof(type_traits::is_mem_fun_pointer_tester(m_t))) );
+};
+
+template <typename T>
+struct is_member_function_pointer_impl<T&>
+{
+   BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+#endif
+
+template<> struct is_member_function_pointer_impl<void> : public false_type{};
+#ifndef BOOST_NO_CV_VOID_SPECIALIZATIONS
+template<> struct is_member_function_pointer_impl<void const> : public false_type{};
+template<> struct is_member_function_pointer_impl<void const volatile> : public false_type{};
+template<> struct is_member_function_pointer_impl<void volatile> : public false_type{};
+#endif
+
+} // namespace detail
+
+template <class T>
+struct is_member_function_pointer
+   : public integral_constant<bool, ::boost::detail::is_member_function_pointer_impl<T>::value>{};
+
+#endif
+
+} // namespace boost
+
+#endif // BOOST_TT_IS_MEMBER_FUNCTION_POINTER_HPP_INCLUDED


### PR DESCRIPTION
The following files are necessary in order to compile deal.II with boost 1.70 and clang 3.9:
```
is_function_cxx_03.hpp
is_member_function_pointer_cxx_03.hpp
```
This fixes #8440