### PR TITLE
Add workload imbalance function

### DIFF
--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -279,6 +279,19 @@ namespace MGTools
   template <int dim, int spacedim>
   unsigned int
   max_level_for_coarse_mesh(const Triangulation<dim, spacedim> &tria);
+
+  /**
+   * Return the imbalance of the parallel distribution of the multigrid
+   * mesh hierarchy. Ideally this value is equal to 1 (every processor owns
+   * the same number of cells on each level, approximately true for most
+   * globally refined meshes). Values greater than 1 estimate the slowdown
+   * one should see in a geometric multigrid v-cycle as compared with the same
+   * computation on a perfectly distributed mesh hierarchy.
+   */
+  template <int dim, int spacedim>
+  double
+  workload_imbalance(const Triangulation<dim, spacedim> &tria);
+
 } // namespace MGTools
 
 /* @} */

--- a/source/multigrid/mg_tools.inst.in
+++ b/source/multigrid/mg_tools.inst.in
@@ -162,6 +162,10 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
       template unsigned int
       max_level_for_coarse_mesh(
         const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria);
+
+      template double
+      workload_imbalance(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria);
 #endif
     \}
   }

--- a/tests/multigrid/workload_imbalance.cc
+++ b/tests/multigrid/workload_imbalance.cc
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2006 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// check function MGTools::workload_imbalance()
+
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/grid_refinement.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/multigrid/mg_constrained_dofs.h>
+#include <deal.II/multigrid/multigrid.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(
+    MPI_COMM_WORLD,
+    Triangulation<dim>::limit_level_difference_at_vertices,
+    parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+  GridGenerator::hyper_cube(tria, 0, 1);
+  tria.refine_global(1);
+
+  unsigned int counter = 0;
+  for (auto cell : tria.active_cell_iterators())
+    {
+      cell->set_refine_flag();
+      ++counter;
+
+      if (dim == 2 && counter == 1)
+        break;
+      if (dim == 3 && counter == 4)
+        break;
+    }
+  tria.execute_coarsening_and_refinement();
+
+  const double workload_imbalance = MGTools::workload_imbalance(tria);
+  deallog << "Workload imbalance: " << workload_imbalance << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    all;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/multigrid/workload_imbalance.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/multigrid/workload_imbalance.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,14 @@
+
+DEAL:0:2d::Workload imbalance: 2.66667
+DEAL:0:3d::Workload imbalance: 1.60976
+DEAL:0::OK
+
+DEAL:1:2d::Workload imbalance: 2.66667
+DEAL:1:3d::Workload imbalance: 1.60976
+DEAL:1::OK
+
+
+DEAL:2:2d::Workload imbalance: 2.66667
+DEAL:2:3d::Workload imbalance: 1.60976
+DEAL:2::OK
+


### PR DESCRIPTION
Function which computes the workload imbalance of the multigrid mesh partition as discussed in:
https://arxiv.org/abs/1904.03317

For me, this function would be useful to have inside deal.II. Also the paper above contains a lengthy discussion of the return value of this function.