### PR TITLE
Let step-1 output SVG instead of EPS.

### DIFF
--- a/doc/news/changes/minor/20190803Bangerth-1
+++ b/doc/news/changes/minor/20190803Bangerth-1
@@ -1,0 +1,4 @@
+Changed: The step-1 program no longer uses EPS to output the meshes,
+but the far more modern SVG format.
+<br>
+(Wolfgang Bangerth, 2019/08/03)

--- a/examples/step-1/doc/results.dox
+++ b/examples/step-1/doc/results.dox
@@ -1,27 +1,37 @@
 <h1>Results</h1>
 
-Running the program produces graphics of two grids (grid-1.eps and grid-2.eps). They look like this:
+Running the program produces graphics of two grids (grid-1.svg and grid-2.svg). 
+You can open these with most every web browser -- in the simplest case,
+just open the current directory in your file system explorer and click
+on the file. If you like working on the command line, you call your
+web browser with the file: `firefox grid-1.svg`, `google-chrome grid-1.svg`,
+or whatever the name of your browser is. If you do this, the two meshes
+should look like this:
 
 <table width="60%" align="center">
   <tr>
     <td align="center">
-      <img src="https://www.dealii.org/images/steps/developer/step-1.grid-1.png" alt="">
+      <img src="https://www.dealii.org/images/steps/developer/step-1.grid-1-r9.2.png" alt="">
     </td>
     <td align="center">
-      <img src="https://www.dealii.org/images/steps/developer/step-1.grid-2r2.png" alt="">
+      <img src="https://www.dealii.org/images/steps/developer/step-1.grid-2-r9.2.png" alt="">
     </td>
   </tr>
 </table>
 
 The left one, well, is not very exciting. The right one is &mdash; at least
-&mdash; unconventional.
+&mdash; unconventional. The pictures color-code the "refinement level" of each
+cell: How many times did a coarse mesh cell have to be subdivided to obtain
+the given cell. In the left image, this is boring since the mesh was
+refined globally a number of times, i.e., <i>every</i> cell was
+refined the same number of times.
 
-While the second mesh is entirely artificial and made-up, and
+(While the second mesh is entirely artificial and made-up, and
 certainly not very practical in applications, to everyone's surprise it
 has found its way into the literature: see the paper by M. Mu
 titled "PDE.MART: A network-based problem-solving environment", ACM
 Trans. Math. Software, vol. 31, pp. 508-531, 2005. Apparently it is
-good for some things at least.
+good for some things at least.)
 
 
 <h3> Possible extensions </h3>
@@ -90,3 +100,18 @@ possible. It will be time well invested.
 Questions (FAQ) page linked to from the top-level <a
 href="http://www.dealii.org/">deal.II webpage</a> also provides a good number
 of hints on debugging deal.II programs.
+
+
+<h4> More about graphical output </h4>
+
+It is often useful to include meshes into your theses or publications.
+For this, it may not be very useful to color-code the cells by
+refinement level, and to print the cell number onto each cell. But
+it doesn't have to be that way -- the GridOut class allows setting flags
+for each possible output format (see the classes in the GridOutFlags
+namespace) that control how exactly a mesh is plotted. You can of
+course also choose other output file formats such as VTK or VTU; this
+is particularly useful for 3d meshes where a 2d format such as SVG
+is not particular useful because it fixes a particular viewpoint onto
+the 3d object. As a consequence, you might want to explore other
+options in the GridOut class.

--- a/examples/step-1/step-1.cc
+++ b/examples/step-1/step-1.cc
@@ -68,11 +68,12 @@ void first_grid()
 
   // Now we want to write a graphical representation of the mesh to an output
   // file. The GridOut class of deal.II can do that in a number of different
-  // output formats; here, we choose encapsulated postscript (eps) format:
-  std::ofstream out("grid-1.eps");
+  // output formats; here, we choose scalable vector graphics (SVG) format
+  // that you can visualize using the web browser of your choice:
+  std::ofstream out("grid-1.svg");
   GridOut       grid_out;
-  grid_out.write_eps(triangulation, out);
-  std::cout << "Grid written to grid-1.eps" << std::endl;
+  grid_out.write_svg(triangulation, out);
+  std::cout << "Grid written to grid-1.svg" << std::endl;
 }
 
 
@@ -238,13 +239,13 @@ void second_grid()
 
 
   // Finally, after these five iterations of refinement, we want to again
-  // write the resulting mesh to a file, again in eps format. This works just
+  // write the resulting mesh to a file, again in SVG format. This works just
   // as above:
-  std::ofstream out("grid-2.eps");
+  std::ofstream out("grid-2.svg");
   GridOut       grid_out;
-  grid_out.write_eps(triangulation, out);
+  grid_out.write_svg(triangulation, out);
 
-  std::cout << "Grid written to grid-2.eps" << std::endl;
+  std::cout << "Grid written to grid-2.svg" << std::endl;
 }
 
 


### PR DESCRIPTION
EPS is just an outdated format.

I've already put these pictures online, but they look like this:
![step-1 grid-1-r9 2](https://user-images.githubusercontent.com/7504421/62422909-48305000-b677-11e9-9fec-822ea3c63245.png)
![step-1 grid-2r2](https://user-images.githubusercontent.com/7504421/62422911-4c5c6d80-b677-11e9-9822-923099a1820c.png)
