### PR TITLE
Instantiate for all dimensions GridOut::write_svg

### DIFF
--- a/source/grid/grid_out.inst.in
+++ b/source/grid/grid_out.inst.in
@@ -24,6 +24,11 @@ for (deal_II_dimension : DIMENSIONS)
       const Triangulation<deal_II_dimension> &, std::ostream &) const;
 #endif
 
+#if deal_II_dimension != 2
+    template void GridOut::write_svg(const Triangulation<deal_II_dimension> &,
+                                     std::ostream &) const;
+#endif
+
     template void GridOut::write_msh(const Triangulation<deal_II_dimension> &,
                                      std::ostream &) const;
 
@@ -68,6 +73,13 @@ for (deal_II_dimension : DIMENSIONS)
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension < deal_II_space_dimension
+
+#  if deal_II_dimension != 2
+    template void GridOut::write_svg(
+      const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+      std::ostream &) const;
+#  endif
+
     template void GridOut::write_msh(
       const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
       std::ostream &) const;


### PR DESCRIPTION
Motivated by @bangerth (#8447), I wanted to try out `GridOut::write_svg` for `parallel::fullydistributed::Triangulation` (see #8418). During that I noticed that it is not instantiated for all dimensions, although the documentation says so:
```
Declaration of the same function as above for all other dimensions and space 
dimensions. This function is not currently implemented and is only declared to exist 
to support dimension independent programming.
```