### PR TITLE
mpi/step-27: Check consistency of AffineConstraints.

### DIFF
--- a/tests/mpi/petsc_step-27.cc
+++ b/tests/mpi/petsc_step-27.cc
@@ -229,6 +229,19 @@ namespace Step27
                                              0,
                                              Functions::ZeroFunction<dim>(),
                                              constraints);
+#ifdef DEBUG
+    // We have not dealt with chains of constraints on ghost cells yet.
+    // Thus, we are content with verifying their consistency for now.
+    IndexSet locally_active_dofs;
+    DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+    AssertThrow(constraints.is_consistent_in_parallel(
+                  dof_handler.locally_owned_dofs_per_processor(),
+                  locally_active_dofs,
+                  mpi_communicator,
+                  /*verbose=*/true),
+                ExcMessage(
+                  "AffineConstraints object contains inconsistencies!"));
+#endif
     constraints.close();
 
     DynamicSparsityPattern dsp(locally_relevant_dofs);

--- a/tests/mpi/trilinos_step-27.cc
+++ b/tests/mpi/trilinos_step-27.cc
@@ -229,6 +229,19 @@ namespace Step27
                                              0,
                                              Functions::ZeroFunction<dim>(),
                                              constraints);
+#ifdef DEBUG
+    // We did not think about hp constraints on ghost cells yet.
+    // Thus, we are content with verifying their consistency for now.
+    IndexSet locally_active_dofs;
+    DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+    AssertThrow(constraints.is_consistent_in_parallel(
+                  dof_handler.locally_owned_dofs_per_processor(),
+                  locally_active_dofs,
+                  mpi_communicator,
+                  /*verbose=*/true),
+                ExcMessage(
+                  "AffineConstraints object contains inconsistencies!"));
+#endif
     constraints.close();
 
     DynamicSparsityPattern dsp(locally_relevant_dofs);


### PR DESCRIPTION
Follow-up to #8421.

@tjhei pointed out that we haven't thought about chains of constraints on ghost cells in the hp case yet. This PR ensures (for now) that at least our tests have consistent `AffineConstraint` objects.

For these exemplary tests, these constraints are consistent (at least for a number of processes up to 40).