### PR TITLE
Mark DEAL_II_ALWAYS_INLINE function as inline

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2652,8 +2652,8 @@ constexpr DEAL_II_ALWAYS_INLINE Number
  * @author Wolfgang Bangerth, 2005
  */
 template <int dim, typename Number>
-DEAL_II_CONSTEXPR DEAL_II_ALWAYS_INLINE Number
-                                        trace(const SymmetricTensor<2, dim, Number> &d)
+DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE Number
+                                               trace(const SymmetricTensor<2, dim, Number> &d)
 {
   Number t = d.data[0];
   for (unsigned int i = 1; i < dim; ++i)


### PR DESCRIPTION
Silences `gcc-4.9.4` warnings in https://cdash.43-1.org/viewBuildError.php?type=1&buildid=687. The `gcc` [documentation](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html) says:
> Generally, functions are not inlined unless optimization is specified. For functions declared inline, this attribute inlines the function independent of any restrictions that otherwise apply to inlining. Failure to inline such a function is diagnosed as an error. Note that if such a function is called indirectly the compiler may or may not inline it depending on optimization level and a failure to inline an indirect call may or may not be diagnosed. 

