### PR TITLE
Avoid explicit template arguments in std::make_pair

### DIFF
--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -1263,8 +1263,7 @@ namespace internal
     std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>, unsigned int>
     promote_to_fe_pair(const FiniteElement<dim, spacedim> &fe)
     {
-      return std::make_pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
-                            unsigned int>(std::move(fe.clone()), 1u);
+      return std::make_pair(std::move(fe.clone()), 1u);
     }
 
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -234,7 +234,7 @@ namespace Particles
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
   {
     const internal::LevelInd level_index =
-      std::make_pair<int, int>(cell->level(), cell->index());
+      std::make_pair(cell->level(), cell->index());
 
     if (cell->is_ghost())
       {
@@ -410,7 +410,7 @@ namespace Particles
     const
   {
     const internal::LevelInd found_cell =
-      std::make_pair<int, int>(cell->level(), cell->index());
+      std::make_pair(cell->level(), cell->index());
 
     if (cell->is_locally_owned())
       return particles.count(found_cell);


### PR DESCRIPTION
Fixes a few `CodeFactor` complains (https://www.codefactor.io/repository/github/dealii/dealii/issues?category=Style&groupId=845).