### PR TITLE
Enable Ginkgo when building doxygen

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -181,6 +181,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_WITH_CXX17=1 \
                          DEAL_II_WITH_CUDA=1 \
                          DEAL_II_COMPILER_CUDA_AWARE=1 \
+                         DEAL_II_WITH_GINKGO=1 \
                          DEAL_II_WITH_GSL=1 \
                          DEAL_II_WITH_GMSH=1 \
                          DEAL_II_WITH_HDF5=1 \


### PR DESCRIPTION
The ginkgo wrappers don't show up in doxygen otherwise