### PR TITLE
Avoid more boost warnings

### DIFF
--- a/bundled/boost-1.70.0/include/boost/archive/impl/basic_binary_iarchive.ipp
+++ b/bundled/boost-1.70.0/include/boost/archive/impl/basic_binary_iarchive.ipp
@@ -89,7 +89,7 @@ basic_binary_iarchive<Archive>::init(void){
     {
         int v = 0;
         v = this->This()->m_sb.sbumpc();
-        #if defined(BOOST_LITTLE_ENDIAN)
+        #if defined(BOOST_ENDIAN_LITTLE_BYTE)
         if(v < 6){
             ;
         }
@@ -111,7 +111,7 @@ basic_binary_iarchive<Archive>::init(void){
             // version 8+ followed by a zero
             this->This()->m_sb.sbumpc();
         }
-        #elif defined(BOOST_BIG_ENDIAN)
+        #elif defined(BOOST_ENDIAN_BIG_BYTE)
         if(v == 0)
             v = this->This()->m_sb.sbumpc();
         #endif

--- a/bundled/boost-1.70.0/include/boost/detail/endian.hpp
+++ b/bundled/boost-1.70.0/include/boost/detail/endian.hpp
@@ -6,6 +6,6 @@
 #define BOOST_DETAIL_ENDIAN_HPP
 
 // Use the Predef library for the detection of endianess.
-#include <boost/predef/detail/endian_compat.h>
+#include <boost/predef/other/endian.h>
 
 #endif


### PR DESCRIPTION
This avoids the warnings in https://cdash.43-1.org/viewBuildError.php?type=1&buildid=718. `BOOST_BIG_ENDIAN`, `BOOST_LITTLE_ENDIAN`, `BOOST_PDP_ENDIAN` and `BOOST_BYTE_ORDER` are nowhere else used.

