### PR TITLE
Add frobenius_norm method to BlockMatrixBase

### DIFF
--- a/doc/news/changes/minor/20190806JonathanRobey
+++ b/doc/news/changes/minor/20190806JonathanRobey
@@ -1,0 +1,2 @@
+New: Added frobenius_norm method to BlockMatrixBase
+(Jonathan Robey, 2019/08/06)

--- a/doc/news/changes/minor/20190806JonathanRobey
+++ b/doc/news/changes/minor/20190806JonathanRobey
@@ -1,2 +1,2 @@
-New: Added frobenius_norm method to BlockMatrixBase
+New: Added frobenius_norm method to BlockMatrixBase.
 (Jonathan Robey, 2019/08/06)

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -2414,7 +2414,6 @@ BlockMatrixBase<MatrixType>::frobenius_norm() const
 {
   value_type norm_sqr = 0;
 
-
   // For each block, get the Frobenius norm, and add the square to the
   // accumulator for the full matrix
   for (unsigned int row = 0; row < n_block_rows(); ++row)

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -699,6 +699,13 @@ public:
   matrix_norm_square(const BlockVectorType &v) const;
 
   /**
+   * Return the frobenius norm of the matrix, i.e. the square root of the sum
+   * of squares of all entries in the matrix.
+   */
+  value_type
+  frobenius_norm() const;
+
+  /**
    * Compute the matrix scalar product $\left(u,Mv\right)$.
    */
   template <class BlockVectorType>
@@ -2397,6 +2404,29 @@ BlockMatrixBase<MatrixType>::matrix_norm_square(const BlockVectorType &v) const
         norm_sqr +=
           block(row, col).matrix_scalar_product(v.block(row), v.block(col));
   return norm_sqr;
+}
+
+
+
+template <class MatrixType>
+typename BlockMatrixBase<MatrixType>::value_type
+BlockMatrixBase<MatrixType>::frobenius_norm() const
+{
+  value_type norm_sqr = 0;
+
+
+  // For each block, get the Frobenius norm, and add the square to the
+  // accumulator for the full matrix
+  for (unsigned int row = 0; row < n_block_rows(); ++row)
+    {
+      for (unsigned int col = 0; col < n_block_cols(); ++col)
+        {
+          const value_type block_norm = block(row, col).frobenius_norm();
+          norm_sqr += block_norm * block_norm;
+        }
+    }
+
+  return std::sqrt(norm_sqr);
 }
 
 

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -360,6 +360,7 @@ public:
    * library containers.
    */
   using value_type      = typename BlockType::value_type;
+  using real_type       = typename numbers::NumberTraits<value_type>::real_type;
   using pointer         = value_type *;
   using const_pointer   = const value_type *;
   using reference       = value_type &;
@@ -702,7 +703,7 @@ public:
    * Return the frobenius norm of the matrix, i.e. the square root of the sum
    * of squares of all entries in the matrix.
    */
-  value_type
+  real_type
   frobenius_norm() const;
 
   /**
@@ -2409,7 +2410,7 @@ BlockMatrixBase<MatrixType>::matrix_norm_square(const BlockVectorType &v) const
 
 
 template <class MatrixType>
-typename BlockMatrixBase<MatrixType>::value_type
+typename BlockMatrixBase<MatrixType>::real_type
 BlockMatrixBase<MatrixType>::frobenius_norm() const
 {
   value_type norm_sqr = 0;

--- a/tests/lac/block_matrices_05.cc
+++ b/tests/lac/block_matrices_05.cc
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/lac/block_sparse_matrix.h>
+#include <deal.II/lac/block_sparsity_pattern.h>
+#include <deal.II/lac/block_vector.h>
+
+#include <algorithm>
+
+#include "../tests.h"
+
+
+
+int
+main()
+{
+  std::ofstream logfile("output");
+  deallog << std::fixed;
+  deallog << std::setprecision(2);
+  deallog.attach(logfile);
+
+  BlockSparsityPattern bsp(2, 2);
+  // set sizes
+  for (unsigned int i = 0; i < 2; ++i)
+    for (unsigned int j = 0; j < 2; ++j)
+      bsp.block(i, j).reinit(5, 5, 5);
+  bsp.collect_sizes();
+
+  // make a full matrix
+  for (unsigned int row = 0; row < 10; ++row)
+    for (unsigned int i = 0; i < 10; ++i)
+      bsp.add(row, i);
+  bsp.compress();
+
+  BlockSparseMatrix<double> bsm(bsp);
+
+  for (unsigned int i = 0; i < bsm.m(); ++i)
+    for (unsigned int j = 0; j < bsm.n(); ++j)
+    {
+      bsm.add(i, j,  1.0);
+    }
+
+  const double accuracy = 1e-12;
+  const double correct_frob_norm = 10.0;
+  const double frob_norm = bsm.frobenius_norm();
+
+  Assert(std::fabs(frob_norm - correct_frob_norm) < accuracy, ExcInternalError());
+
+  deallog << "OK" << std::endl;
+  deallog << std::flush;
+
+  return 0;
+}

--- a/tests/lac/block_matrices_05.cc
+++ b/tests/lac/block_matrices_05.cc
@@ -15,7 +15,7 @@
 
 
 // Test that the frobenius_norm function returns the correct value
-// for a block matrix
+// for a block matrix.
 
 
 #include <deal.II/lac/block_sparse_matrix.h>
@@ -31,10 +31,7 @@
 int
 main()
 {
-  std::ofstream logfile("output");
-  deallog << std::fixed;
-  deallog << std::setprecision(2);
-  deallog.attach(logfile);
+  initlog();
 
   BlockSparsityPattern bsp(2, 2);
   // set sizes
@@ -65,7 +62,6 @@ main()
          ExcInternalError());
 
   deallog << "OK" << std::endl;
-  deallog << std::flush;
 
   return 0;
 }

--- a/tests/lac/block_matrices_05.cc
+++ b/tests/lac/block_matrices_05.cc
@@ -13,6 +13,11 @@
 //
 // ---------------------------------------------------------------------
 
+
+// Test that the frobenius_norm function returns the correct value
+// for a block matrix
+
+
 #include <deal.II/lac/block_sparse_matrix.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/block_vector.h>

--- a/tests/lac/block_matrices_05.cc
+++ b/tests/lac/block_matrices_05.cc
@@ -53,15 +53,16 @@ main()
 
   for (unsigned int i = 0; i < bsm.m(); ++i)
     for (unsigned int j = 0; j < bsm.n(); ++j)
-    {
-      bsm.add(i, j,  1.0);
-    }
+      {
+        bsm.add(i, j, 1.0);
+      }
 
-  const double accuracy = 1e-12;
+  const double accuracy          = 1e-12;
   const double correct_frob_norm = 10.0;
-  const double frob_norm = bsm.frobenius_norm();
+  const double frob_norm         = bsm.frobenius_norm();
 
-  Assert(std::fabs(frob_norm - correct_frob_norm) < accuracy, ExcInternalError());
+  Assert(std::fabs(frob_norm - correct_frob_norm) < accuracy,
+         ExcInternalError());
 
   deallog << "OK" << std::endl;
   deallog << std::flush;

--- a/tests/lac/block_matrices_05.output
+++ b/tests/lac/block_matrices_05.output
@@ -1,3 +1,2 @@
 
 DEAL::OK
-DEAL::

--- a/tests/lac/block_matrices_05.output
+++ b/tests/lac/block_matrices_05.output
@@ -1,0 +1,3 @@
+
+DEAL::OK
+DEAL::


### PR DESCRIPTION
Fix to #7629

I could not find any tests in `tests/lac/` which used the `BlockMatrixBase::matrix_norm_square` function, so while I would like to add a test for this new functionality, I do not see an obvious place to insert it.