### PR TITLE
Null pointer check added to CellDagaStorage::get_data()

### DIFF
--- a/doc/news/changes/minor/20190806RezaRastak
+++ b/doc/news/changes/minor/20190806RezaRastak
@@ -1,0 +1,4 @@
+Improved: CellDataStorage::get_data(cell) now checks whether we are retriving
+using a data type that matches the type we used to initialize the cell data.
+<br>
+(Reza Rastak, 2019/08/06)

--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -163,6 +163,13 @@ private:
    * A map to store a vector of data on a cell.
    */
   std::map<CellIteratorType, std::vector<std::shared_ptr<DataType>>> map;
+
+  /**
+   * @addtogroup Exceptions
+   */
+  DeclExceptionMsg(
+    ExcCellDataTypeMismatch,
+    "Cell data is being retrieved with a type which is different than the type used to initialize it");
 };
 
 
@@ -617,7 +624,10 @@ CellDataStorage<CellIteratorType, DataType>::get_data(
   // the T==DataType:
   std::vector<std::shared_ptr<T>> res(it->second.size());
   for (unsigned int q = 0; q < res.size(); q++)
-    res[q] = std::dynamic_pointer_cast<T>(it->second[q]);
+    {
+      res[q] = std::dynamic_pointer_cast<T>(it->second[q]);
+      Assert(res[q], ExcCellDataTypeMismatch());
+    }
   return res;
 }
 
@@ -640,7 +650,10 @@ CellDataStorage<CellIteratorType, DataType>::get_data(
   // does not modify the content of QP objects
   std::vector<std::shared_ptr<const T>> res(it->second.size());
   for (unsigned int q = 0; q < res.size(); q++)
-    res[q] = std::dynamic_pointer_cast<const T>(it->second[q]);
+    {
+      res[q] = std::dynamic_pointer_cast<const T>(it->second[q]);
+      Assert(res[q], ExcCellDataTypeMismatch());
+    }
   return res;
 }
 


### PR DESCRIPTION
When we initialize the cell history data using 
```c++
cell_data_storage.template initialize<T>(cell, n_data_points_per_cell)
```
and retrieve the data using
```c++
std::vector<std::shared_ptr<T>> data_vector = cell_data_storage.template get_data<T>(cell);
```
The type T used to initialize the cell data must be the same T that is used to retrieve it. If there is a type mismatch, `get_data` returns a vector of null pointers and it leads to catastrophic segfault when it is dereferenced.

I added an assert statement that checks this conditions and provides an understandable error message.