### PR TITLE
Change all uses of MappingType and mapping_type

### DIFF
--- a/doc/news/changes/incompatibilities/20190806GrahamHarper
+++ b/doc/news/changes/incompatibilities/20190806GrahamHarper
@@ -1,0 +1,7 @@
+Changed: mapping.h referred to different kinds of mappings in an enum 
+MappingType; however, since it's an enum, MappingType is a misleading name. 
+All instances of MappingType and mapping_type have been changed to 
+MappingKind and mapping_kind, respectively. The documentation has been 
+updated in order to reflect these changes as well.
+<br>
+(Graham Harper, 2019/08/06)

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -2289,7 +2289,7 @@ public:
    *   the node functionals of the element applied to the given function.
    *
    * @note It is safe to call this function for (transformed) values on the
-   * real cell only for elements with trivial MappingType. For all other
+   * real cell only for elements with trivial MappingKind. For all other
    * elements (for example for H(curl), or H(div) conforming elements)
    * vector values have to be transformed to the reference cell first.
    *

--- a/include/deal.II/fe/fe_dg_vector.h
+++ b/include/deal.II/fe/fe_dg_vector.h
@@ -58,7 +58,7 @@ public:
   /**
    * Constructor for the vector element of degree @p p.
    */
-  FE_DGVector(const unsigned int p, MappingType m);
+  FE_DGVector(const unsigned int p, MappingKind m);
 
   /**
    * Return a string that uniquely identifies a finite element. This class

--- a/include/deal.II/fe/fe_dg_vector.templates.h
+++ b/include/deal.II/fe/fe_dg_vector.templates.h
@@ -32,7 +32,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <class PolynomialType, int dim, int spacedim>
 FE_DGVector<PolynomialType, dim, spacedim>::FE_DGVector(const unsigned int deg,
-                                                        MappingType        map)
+                                                        MappingKind        map)
   : FE_PolyTensor<PolynomialType, dim, spacedim>(
       deg,
       FiniteElementData<dim>(get_dpo_vector(deg),
@@ -43,7 +43,7 @@ FE_DGVector<PolynomialType, dim, spacedim>::FE_DGVector(const unsigned int deg,
       std::vector<ComponentMask>(PolynomialType::compute_n_pols(deg),
                                  ComponentMask(dim, true)))
 {
-  this->mapping_type                   = {map};
+  this->mapping_kind                   = {map};
   const unsigned int polynomial_degree = this->tensor_degree();
 
   QGauss<dim> quadrature(polynomial_degree + 1);

--- a/include/deal.II/fe/fe_nedelec_sz.h
+++ b/include/deal.II/fe/fe_nedelec_sz.h
@@ -137,7 +137,7 @@ public:
 
   /**
    * Given <tt>flags</tt>, determines the values which must be computed only
-   * for the reference cell. Make sure, that #mapping_type is set by the
+   * for the reference cell. Make sure, that #mapping_kind is set by the
    * derived class, such that this function can operate correctly.
    */
   UpdateFlags
@@ -145,7 +145,7 @@ public:
 
   /**
    * Given <tt>flags</tt>, determines the values which must be computed in
-   * each cell cell. Make sure, that #mapping_type is set by the derived
+   * each cell cell. Make sure, that #mapping_kind is set by the derived
    * class, such that this function can operate correctly.
    */
   UpdateFlags
@@ -153,10 +153,10 @@ public:
 
 protected:
   /**
-   * The mapping type to be used to map shape functions from the reference
+   * The mapping kind to be used to map shape functions from the reference
    * cell to the mesh cell.
    */
-  MappingType mapping_type;
+  MappingKind mapping_kind;
 
   virtual std::unique_ptr<
     typename dealii::FiniteElement<dim, spacedim>::InternalDataBase>

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -62,7 +62,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * Similarly, in many cases, node functionals depend on the shape of the mesh
  * cell, since they evaluate normal or tangential components on the faces. In
- * order to allow for a set of transformations, the variable #mapping_type has
+ * order to allow for a set of transformations, the variable #mapping_kind has
  * been introduced. It should needs be set in the constructor of a derived
  * class.
  *
@@ -126,15 +126,15 @@ DEAL_II_NAMESPACE_OPEN
  *
  * In most cases, vector valued basis functions must be transformed when
  * mapped from the reference cell to the actual grid cell. These
- * transformations can be selected from the set MappingType and stored in
- * #mapping_type. Therefore, each constructor should contain a line like:
+ * transformations can be selected from the set MappingKind and stored in
+ * #mapping_kind. Therefore, each constructor should contain a line like:
  * @code
- * this->mapping_type = {mapping_none};
+ * this->mapping_kind = {mapping_none};
  * @endcode
  * (in case no mapping is required) or using whatever value among
- * the ones defined in MappingType is appropriate for the element you
+ * the ones defined in MappingKind is appropriate for the element you
  * are implementing. If each shape function may be mapped by different
- * mappings, then @p mapping_type may be a vector with the same number
+ * mappings, then @p mapping_kind may be a vector with the same number
  * of elements as there are shape functions.
  *
  * @see PolynomialsBDM, PolynomialsRaviartThomas
@@ -214,20 +214,20 @@ protected:
    * the finite element dofs per cell, then each shape function will be mapped
    * according to the corresponding entry in the vector.
    */
-  std::vector<MappingType> mapping_type;
+  std::vector<MappingKind> mapping_kind;
 
   /**
    * Returns a boolean that is true when the finite element uses a single
    * mapping and false when the finite element uses multiple mappings.
    */
   bool
-  single_mapping_type() const;
+  single_mapping_kind() const;
 
   /**
-   * Returns MappingType @p i for the finite element.
+   * Returns MappingKind @p i for the finite element.
    */
-  MappingType
-  get_mapping_type(const unsigned int i) const;
+  MappingKind
+  get_mapping_kind(const unsigned int i) const;
 
   /* NOTE: The following function has its definition inlined into the class
      declaration because we otherwise run into a compiler error with MS Visual
@@ -266,14 +266,14 @@ protected:
     // allocate memory
 
     const bool update_transformed_shape_values =
-      std::any_of(this->mapping_type.begin(),
-                  this->mapping_type.end(),
-                  [](const MappingType t) { return t != mapping_none; });
+      std::any_of(this->mapping_kind.begin(),
+                  this->mapping_kind.end(),
+                  [](const MappingKind t) { return t != mapping_none; });
 
     const bool update_transformed_shape_grads =
-      std::any_of(this->mapping_type.begin(),
-                  this->mapping_type.end(),
-                  [](const MappingType t) {
+      std::any_of(this->mapping_kind.begin(),
+                  this->mapping_kind.end(),
+                  [](const MappingKind t) {
                     return (t == mapping_raviart_thomas || t == mapping_piola ||
                             t == mapping_nedelec || t == mapping_contravariant);
                   });

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -48,7 +48,7 @@ class FESubfaceValues;
 
 
 /**
- * The transformation type used for the Mapping::transform() functions.
+ * The transformation kind used for the Mapping::transform() functions.
  *
  * Special finite elements may need special Mapping from the reference cell to
  * the actual mesh cell. In order to be most flexible, this enum provides an
@@ -58,7 +58,7 @@ class FESubfaceValues;
  *
  * @ingroup mapping
  */
-enum MappingType
+enum MappingKind
 {
   /**
    * No mapping, i.e., shape functions are not mapped from a reference cell
@@ -106,7 +106,7 @@ enum MappingType
    * The mapping used for Nedelec elements.
    *
    * Curl-conforming elements are mapped as covariant vectors. Nevertheless,
-   * we introduce a separate mapping type, such that we can use the same flag
+   * we introduce a separate mapping kind, such that we can use the same flag
    * for the vector and its gradient (see Mapping::transform() for details).
    */
   mapping_nedelec = 0x0200,
@@ -229,7 +229,7 @@ enum MappingType
  * The differential forms <b>A</b> and <b>B</b> are determined by the kind of
  * object being transformed. These transformations are performed through the
  * transform() functions, and the type of object being transformed is
- * specified by their MappingType argument. See the documentation there for
+ * specified by their MappingKind argument. See the documentation there for
  * possible choices.
  *
  * <h4>Derivatives of the mapping</h4>
@@ -950,14 +950,14 @@ public:
 
   /**
    * Transform a field of vectors or 1-differential forms according to the
-   * selected MappingType.
+   * selected MappingKind.
    *
    * @note Normally, this function is called by a finite element, filling
    * FEValues objects. For this finite element, there should be an alias
-   * MappingType like @p mapping_bdm, @p mapping_nedelec, etc. This alias
-   * should be preferred to using the types below.
+   * MappingKind like @p mapping_bdm, @p mapping_nedelec, etc. This alias
+   * should be preferred to using the kinds below.
    *
-   * The mapping types currently implemented by derived classes are:
+   * The mapping kinds currently implemented by derived classes are:
    * <ul>
    * <li> @p mapping_contravariant: maps a vector field on the reference cell
    * to the physical cell through the Jacobian:
@@ -998,7 +998,7 @@ public:
    *
    * @param[in] input An array (or part of an array) of input objects that
    * should be mapped.
-   * @param[in] type The kind of mapping to be applied.
+   * @param[in] kind The kind of mapping to be applied.
    * @param[in] internal A pointer to an object of type
    * Mapping::InternalDataBase that contains information previously stored by
    * the mapping. The object pointed to was created by the get_data(),
@@ -1013,7 +1013,7 @@ public:
    */
   virtual void
   transform(const ArrayView<const Tensor<1, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<1, spacedim>> &output) const = 0;
 
@@ -1021,7 +1021,7 @@ public:
    * Transform a field of differential forms from the reference cell to the
    * physical cell.  It is useful to think of $\mathbf{T} = \nabla \mathbf u$
    * and $\hat{\mathbf  T} = \hat \nabla \hat{\mathbf  u}$, with $\mathbf u$ a
-   * vector field.  The mapping types currently implemented by derived classes
+   * vector field.  The mapping kinds currently implemented by derived classes
    * are:
    * <ul>
    * <li> @p mapping_covariant: maps a field of forms on the reference cell to
@@ -1051,7 +1051,7 @@ public:
    *
    * @param[in] input An array (or part of an array) of input objects that
    * should be mapped.
-   * @param[in] type The kind of mapping to be applied.
+   * @param[in] kind The kind of mapping to be applied.
    * @param[in] internal A pointer to an object of type
    * Mapping::InternalDataBase that contains information previously stored by
    * the mapping. The object pointed to was created by the get_data(),
@@ -1066,7 +1066,7 @@ public:
    */
   virtual void
   transform(const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const = 0;
 
@@ -1074,7 +1074,7 @@ public:
    * Transform a tensor field from the reference cell to the physical cell.
    * These tensors are usually the Jacobians in the reference cell of vector
    * fields that have been pulled back from the physical cell.  The mapping
-   * types currently implemented by derived classes are:
+   * kinds currently implemented by derived classes are:
    * <ul>
    * <li> @p mapping_contravariant_gradient: it assumes $\mathbf u(\mathbf x)
    * = J \hat{\mathbf  u}$ so that
@@ -1109,7 +1109,7 @@ public:
    *
    * @param[in] input An array (or part of an array) of input objects that
    * should be mapped.
-   * @param[in] type The kind of mapping to be applied.
+   * @param[in] kind The kind of mapping to be applied.
    * @param[in] internal A pointer to an object of type
    * Mapping::InternalDataBase that contains information previously stored by
    * the mapping. The object pointed to was created by the get_data(),
@@ -1124,7 +1124,7 @@ public:
    */
   virtual void
   transform(const ArrayView<const Tensor<2, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const = 0;
 
@@ -1133,7 +1133,7 @@ public:
    * This tensors are most of times the hessians in the reference cell of
    * vector fields that have been pulled back from the physical cell.
    *
-   * The mapping types currently implemented by derived classes are:
+   * The mapping kinds currently implemented by derived classes are:
    * <ul>
    * <li> @p mapping_covariant_gradient: maps a field of forms on the
    * reference cell to a field of forms on the physical cell. Mathematically,
@@ -1156,7 +1156,7 @@ public:
    *
    * @param[in] input An array (or part of an array) of input objects that
    * should be mapped.
-   * @param[in] type The kind of mapping to be applied.
+   * @param[in] kind The kind of mapping to be applied.
    * @param[in] internal A pointer to an object of type
    * Mapping::InternalDataBase that contains information previously stored by
    * the mapping. The object pointed to was created by the get_data(),
@@ -1171,7 +1171,7 @@ public:
    */
   virtual void
   transform(const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const = 0;
 
@@ -1181,7 +1181,7 @@ public:
    * \mathbf u_i$ and $\mathbf{\hat T}_{IJK} = \hat D^2_{JK} \mathbf{\hat
    * u}_I$, with $\mathbf u_i$ a vector field.
    *
-   * The mapping types currently implemented by derived classes are:
+   * The mapping kinds currently implemented by derived classes are:
    * <ul>
    * <li> @p mapping_contravariant_hessian: it assumes $\mathbf u_i(\mathbf x)
    * = J_{iI} \hat{\mathbf  u}_I$ so that
@@ -1210,7 +1210,7 @@ public:
    *
    * @param[in] input An array (or part of an array) of input objects that
    * should be mapped.
-   * @param[in] type The kind of mapping to be applied.
+   * @param[in] kind The kind of mapping to be applied.
    * @param[in] internal A pointer to an object of type
    * Mapping::InternalDataBase that contains information previously stored by
    * the mapping. The object pointed to was created by the get_data(),
@@ -1224,7 +1224,7 @@ public:
    */
   virtual void
   transform(const ArrayView<const Tensor<3, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const = 0;
 

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -101,35 +101,35 @@ public:
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<1, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<1, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<2, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<3, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const override;
 

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -204,35 +204,35 @@ public:
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<1, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<1, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<2, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<3, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const override;
 

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -110,35 +110,35 @@ public:
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<1, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<1, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<2, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<3, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const override;
 

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -160,35 +160,35 @@ public:
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<1, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<1, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<2, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<3, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const override;
 

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -195,35 +195,35 @@ public:
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<1, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<1, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<2, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<2, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const override;
 
   // for documentation, see the Mapping base class
   virtual void
   transform(const ArrayView<const Tensor<3, dim>> &                  input,
-            const MappingType                                        type,
+            const MappingKind                                        kind,
             const typename Mapping<dim, spacedim>::InternalDataBase &internal,
             const ArrayView<Tensor<3, spacedim>> &output) const override;
 

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -111,7 +111,7 @@ namespace VectorTools
     // FIXME: This should be refactored into the mapping (i.e.
     // implement the inverse function of Mapping<dim, spacedim>::transform).
     // Further, the finite element should make the information about
-    // the correct mapping directly accessible (i.e. which MappingType
+    // the correct mapping directly accessible (i.e. which MappingKind
     // should be used). Using fe.conforming_space might be a bit of a
     // problem because we only support doing nothing, Hcurl, and Hdiv
     // conforming mappings.

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -60,7 +60,7 @@ FE_ABF<dim>::FE_ABF(const unsigned int deg)
   Assert(dim >= 2, ExcImpossibleInDim(dim));
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = {mapping_raviart_thomas};
+  this->mapping_kind = {mapping_raviart_thomas};
   // First, initialize the
   // generalized support points and
   // quadrature weights, since they

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -56,7 +56,7 @@ FE_BDM<dim>::FE_BDM(const unsigned int deg)
 
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = {mapping_bdm};
+  this->mapping_kind = {mapping_bdm};
   // These must be done first, since
   // they change the evaluation of
   // basis functions

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -55,7 +55,7 @@ FE_BernardiRaugel<dim>::FE_BernardiRaugel(const unsigned int p)
 
   // const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = {mapping_none};
+  this->mapping_kind = {mapping_none};
   // These must be done first, since
   // they change the evaluation of
   // basis functions

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -87,7 +87,7 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
 
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = {mapping_nedelec};
+  this->mapping_kind = {mapping_nedelec};
   // First, initialize the
   // generalized support points and
   // quadrature weights, since they

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -33,7 +33,7 @@ FE_NedelecSZ<dim, spacedim>::FE_NedelecSZ(const unsigned int degree)
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
 
-  this->mapping_type = mapping_nedelec;
+  this->mapping_kind = mapping_nedelec;
   // Set up the table converting components to base components. Since we have
   // only one base element, everything remains zero except the component in the
   // base, which is the component itself.
@@ -2170,7 +2170,7 @@ template <int dim, int spacedim>
 UpdateFlags
 FE_NedelecSZ<dim, spacedim>::update_once(const UpdateFlags flags) const
 {
-  const bool values_once = (mapping_type == mapping_none);
+  const bool values_once = (mapping_kind == mapping_none);
 
   UpdateFlags out = update_default;
   if (values_once && (flags & update_values))

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -60,7 +60,7 @@ FE_RaviartThomas<dim>::FE_RaviartThomas(const unsigned int deg)
   Assert(dim >= 2, ExcImpossibleInDim(dim));
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = {mapping_raviart_thomas};
+  this->mapping_kind = {mapping_raviart_thomas};
   // First, initialize the
   // generalized support points and
   // quadrature weights, since they

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -52,7 +52,7 @@ FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int deg)
   Assert(dim >= 2, ExcImpossibleInDim(dim));
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = {mapping_raviart_thomas};
+  this->mapping_kind = {mapping_raviart_thomas};
   // First, initialize the
   // generalized support points and
   // quadrature weights, since they

--- a/source/fe/fe_rt_bubbles.cc
+++ b/source/fe/fe_rt_bubbles.cc
@@ -55,7 +55,7 @@ FE_RT_Bubbles<dim>::FE_RT_Bubbles(const unsigned int deg)
       "Lowest order RT_Bubbles element is degree 1, but you requested for degree 0"));
   const unsigned int n_dofs = this->dofs_per_cell;
 
-  this->mapping_type = {mapping_raviart_thomas};
+  this->mapping_kind = {mapping_raviart_thomas};
   // Initialize support points and quadrature weights
   initialize_support_points(deg);
   // Compute the inverse node matrix to get

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -670,7 +670,7 @@ template <int dim, int spacedim>
 void
 MappingCartesian<dim, spacedim>::transform(
   const ArrayView<const Tensor<1, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<1, spacedim>> &                   output) const
 {
@@ -679,7 +679,7 @@ MappingCartesian<dim, spacedim>::transform(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_covariant:
         {
@@ -730,7 +730,7 @@ template <int dim, int spacedim>
 void
 MappingCartesian<dim, spacedim>::transform(
   const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<2, spacedim>> &                   output) const
 {
@@ -739,7 +739,7 @@ MappingCartesian<dim, spacedim>::transform(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_covariant:
         {
@@ -840,7 +840,7 @@ template <int dim, int spacedim>
 void
 MappingCartesian<dim, spacedim>::transform(
   const ArrayView<const Tensor<2, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<2, spacedim>> &                   output) const
 {
@@ -849,7 +849,7 @@ MappingCartesian<dim, spacedim>::transform(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_covariant:
         {
@@ -949,7 +949,7 @@ template <int dim, int spacedim>
 void
 MappingCartesian<dim, spacedim>::transform(
   const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<3, spacedim>> &                   output) const
 {
@@ -958,7 +958,7 @@ MappingCartesian<dim, spacedim>::transform(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_covariant_gradient:
         {
@@ -986,7 +986,7 @@ template <int dim, int spacedim>
 void
 MappingCartesian<dim, spacedim>::transform(
   const ArrayView<const Tensor<3, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<3, spacedim>> &                   output) const
 {
@@ -995,7 +995,7 @@ MappingCartesian<dim, spacedim>::transform(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_contravariant_hessian:
         {

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -1965,7 +1965,7 @@ namespace internal
       void
       transform_fields(
         const ArrayView<const Tensor<rank, dim>> &               input,
-        const MappingType                                        mapping_type,
+        const MappingKind                                        mapping_kind,
         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
         const ArrayView<Tensor<rank, spacedim>> &                output)
       {
@@ -1984,7 +1984,7 @@ namespace internal
               MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::
                 InternalData &>(mapping_data);
 
-        switch (mapping_type)
+        switch (mapping_kind)
           {
             case mapping_contravariant:
               {
@@ -2051,7 +2051,7 @@ namespace internal
       void
       transform_differential_forms(
         const ArrayView<const DerivativeForm<rank, dim, spacedim>> &input,
-        const MappingType                                        mapping_type,
+        const MappingKind                                        mapping_kind,
         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
         const ArrayView<Tensor<rank + 1, spacedim>> &            output)
       {
@@ -2070,7 +2070,7 @@ namespace internal
               MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::
                 InternalData &>(mapping_data);
 
-        switch (mapping_type)
+        switch (mapping_kind)
           {
             case mapping_covariant:
               {
@@ -2098,7 +2098,7 @@ template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 void
 MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::transform(
   const ArrayView<const Tensor<1, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<1, spacedim>> &                   output) const
 {
@@ -2106,7 +2106,7 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::transform(
 
   internal::MappingFEFieldImplementation::
     transform_fields<dim, spacedim, 1, VectorType, DoFHandlerType>(input,
-                                                                   mapping_type,
+                                                                   mapping_kind,
                                                                    mapping_data,
                                                                    output);
 }
@@ -2117,7 +2117,7 @@ template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 void
 MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::transform(
   const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<2, spacedim>> &                   output) const
 {
@@ -2125,7 +2125,7 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::transform(
 
   internal::MappingFEFieldImplementation::
     transform_differential_forms<dim, spacedim, 1, VectorType, DoFHandlerType>(
-      input, mapping_type, mapping_data, output);
+      input, mapping_kind, mapping_data, output);
 }
 
 
@@ -2134,7 +2134,7 @@ template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 void
 MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::transform(
   const ArrayView<const Tensor<2, dim>> &input,
-  const MappingType,
+  const MappingKind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<2, spacedim>> &                   output) const
 {
@@ -2152,7 +2152,7 @@ template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 void
 MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::transform(
   const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<3, spacedim>> &                   output) const
 {
@@ -2161,7 +2161,7 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::transform(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_covariant_gradient:
         {
@@ -2200,7 +2200,7 @@ template <int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 void
 MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::transform(
   const ArrayView<const Tensor<3, dim>> &input,
-  const MappingType /*mapping_type*/,
+  const MappingKind /*mapping_kind*/,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<3, spacedim>> &                   output) const
 {

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -871,7 +871,7 @@ namespace internal
       void
       transform_fields(
         const ArrayView<const Tensor<rank, dim>> &               input,
-        const MappingType                                        mapping_type,
+        const MappingKind                                        mapping_kind,
         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
         const ArrayView<Tensor<rank, spacedim>> &                output)
       {
@@ -885,7 +885,7 @@ namespace internal
             static_cast<const typename dealii::MappingManifold<dim, spacedim>::
                           InternalData &>(mapping_data);
 
-        switch (mapping_type)
+        switch (mapping_kind)
           {
             case mapping_contravariant:
               {
@@ -949,7 +949,7 @@ namespace internal
       void
       transform_gradients(
         const ArrayView<const Tensor<rank, dim>> &               input,
-        const MappingType                                        mapping_type,
+        const MappingKind                                        mapping_kind,
         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
         const ArrayView<Tensor<rank, spacedim>> &                output)
       {
@@ -963,7 +963,7 @@ namespace internal
             static_cast<const typename dealii::MappingManifold<dim, spacedim>::
                           InternalData &>(mapping_data);
 
-        switch (mapping_type)
+        switch (mapping_kind)
           {
             case mapping_contravariant_gradient:
               {
@@ -1051,7 +1051,7 @@ namespace internal
       void
       transform_hessians(
         const ArrayView<const Tensor<3, dim>> &                  input,
-        const MappingType                                        mapping_type,
+        const MappingKind                                        mapping_kind,
         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
         const ArrayView<Tensor<3, spacedim>> &                   output)
       {
@@ -1065,7 +1065,7 @@ namespace internal
             static_cast<const typename dealii::MappingManifold<dim, spacedim>::
                           InternalData &>(mapping_data);
 
-        switch (mapping_type)
+        switch (mapping_kind)
           {
             case mapping_contravariant_hessian:
               {
@@ -1220,7 +1220,7 @@ namespace internal
       void
       transform_differential_forms(
         const ArrayView<const DerivativeForm<rank, dim, spacedim>> &input,
-        const MappingType                                        mapping_type,
+        const MappingKind                                        mapping_kind,
         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
         const ArrayView<Tensor<rank + 1, spacedim>> &            output)
       {
@@ -1234,7 +1234,7 @@ namespace internal
             static_cast<const typename dealii::MappingManifold<dim, spacedim>::
                           InternalData &>(mapping_data);
 
-        switch (mapping_type)
+        switch (mapping_kind)
           {
             case mapping_covariant:
               {
@@ -1329,12 +1329,12 @@ template <int dim, int spacedim>
 void
 MappingManifold<dim, spacedim>::transform(
   const ArrayView<const Tensor<1, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<1, spacedim>> &                   output) const
 {
   internal::MappingManifoldImplementation::transform_fields(input,
-                                                            mapping_type,
+                                                            mapping_kind,
                                                             mapping_data,
                                                             output);
 }
@@ -1345,12 +1345,12 @@ template <int dim, int spacedim>
 void
 MappingManifold<dim, spacedim>::transform(
   const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<2, spacedim>> &                   output) const
 {
   internal::MappingManifoldImplementation::transform_differential_forms(
-    input, mapping_type, mapping_data, output);
+    input, mapping_kind, mapping_data, output);
 }
 
 
@@ -1359,15 +1359,15 @@ template <int dim, int spacedim>
 void
 MappingManifold<dim, spacedim>::transform(
   const ArrayView<const Tensor<2, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<2, spacedim>> &                   output) const
 {
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_contravariant:
         internal::MappingManifoldImplementation::transform_fields(input,
-                                                                  mapping_type,
+                                                                  mapping_kind,
                                                                   mapping_data,
                                                                   output);
         return;
@@ -1376,7 +1376,7 @@ MappingManifold<dim, spacedim>::transform(
       case mapping_contravariant_gradient:
       case mapping_covariant_gradient:
         internal::MappingManifoldImplementation::transform_gradients(
-          input, mapping_type, mapping_data, output);
+          input, mapping_kind, mapping_data, output);
         return;
       default:
         Assert(false, ExcNotImplemented());
@@ -1389,7 +1389,7 @@ template <int dim, int spacedim>
 void
 MappingManifold<dim, spacedim>::transform(
   const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<3, spacedim>> &                   output) const
 {
@@ -1398,7 +1398,7 @@ MappingManifold<dim, spacedim>::transform(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_covariant_gradient:
         {
@@ -1438,17 +1438,17 @@ template <int dim, int spacedim>
 void
 MappingManifold<dim, spacedim>::transform(
   const ArrayView<const Tensor<3, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<3, spacedim>> &                   output) const
 {
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_piola_hessian:
       case mapping_contravariant_hessian:
       case mapping_covariant_hessian:
         internal::MappingManifoldImplementation::transform_hessians(
-          input, mapping_type, mapping_data, output);
+          input, mapping_kind, mapping_data, output);
         return;
       default:
         Assert(false, ExcNotImplemented());

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -384,7 +384,7 @@ template <int dim, int spacedim>
 void
 MappingQ<dim, spacedim>::transform(
   const ArrayView<const Tensor<1, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<1, spacedim>> &                   output) const
 {
@@ -395,10 +395,10 @@ MappingQ<dim, spacedim>::transform(
 
   // check whether we should in fact work on the Q1 portion of it
   if (data->use_mapping_q1_on_current_cell)
-    q1_mapping->transform(input, mapping_type, *data->mapping_q1_data, output);
+    q1_mapping->transform(input, mapping_kind, *data->mapping_q1_data, output);
   else
     // otherwise use the full mapping
-    qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
+    qp_mapping->transform(input, mapping_kind, *data->mapping_qp_data, output);
 }
 
 
@@ -407,7 +407,7 @@ template <int dim, int spacedim>
 void
 MappingQ<dim, spacedim>::transform(
   const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<2, spacedim>> &                   output) const
 {
@@ -419,10 +419,10 @@ MappingQ<dim, spacedim>::transform(
 
   // check whether we should in fact work on the Q1 portion of it
   if (data->use_mapping_q1_on_current_cell)
-    q1_mapping->transform(input, mapping_type, *data->mapping_q1_data, output);
+    q1_mapping->transform(input, mapping_kind, *data->mapping_q1_data, output);
   else
     // otherwise use the full mapping
-    qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
+    qp_mapping->transform(input, mapping_kind, *data->mapping_qp_data, output);
 }
 
 
@@ -431,7 +431,7 @@ template <int dim, int spacedim>
 void
 MappingQ<dim, spacedim>::transform(
   const ArrayView<const Tensor<2, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<2, spacedim>> &                   output) const
 {
@@ -443,10 +443,10 @@ MappingQ<dim, spacedim>::transform(
 
   // check whether we should in fact work on the Q1 portion of it
   if (data->use_mapping_q1_on_current_cell)
-    q1_mapping->transform(input, mapping_type, *data->mapping_q1_data, output);
+    q1_mapping->transform(input, mapping_kind, *data->mapping_q1_data, output);
   else
     // otherwise use the full mapping
-    qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
+    qp_mapping->transform(input, mapping_kind, *data->mapping_qp_data, output);
 }
 
 
@@ -455,7 +455,7 @@ template <int dim, int spacedim>
 void
 MappingQ<dim, spacedim>::transform(
   const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<3, spacedim>> &                   output) const
 {
@@ -467,10 +467,10 @@ MappingQ<dim, spacedim>::transform(
 
   // check whether we should in fact work on the Q1 portion of it
   if (data->use_mapping_q1_on_current_cell)
-    q1_mapping->transform(input, mapping_type, *data->mapping_q1_data, output);
+    q1_mapping->transform(input, mapping_kind, *data->mapping_q1_data, output);
   else
     // otherwise use the full mapping
-    qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
+    qp_mapping->transform(input, mapping_kind, *data->mapping_qp_data, output);
 }
 
 
@@ -479,7 +479,7 @@ template <int dim, int spacedim>
 void
 MappingQ<dim, spacedim>::transform(
   const ArrayView<const Tensor<3, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<3, spacedim>> &                   output) const
 {
@@ -491,10 +491,10 @@ MappingQ<dim, spacedim>::transform(
 
   // check whether we should in fact work on the Q1 portion of it
   if (data->use_mapping_q1_on_current_cell)
-    q1_mapping->transform(input, mapping_type, *data->mapping_q1_data, output);
+    q1_mapping->transform(input, mapping_kind, *data->mapping_q1_data, output);
   else
     // otherwise use the full mapping
-    qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
+    qp_mapping->transform(input, mapping_kind, *data->mapping_qp_data, output);
 }
 
 

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -3354,7 +3354,7 @@ namespace internal
       void
       transform_fields(
         const ArrayView<const Tensor<rank, dim>> &               input,
-        const MappingType                                        mapping_type,
+        const MappingKind                                        mapping_kind,
         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
         const ArrayView<Tensor<rank, spacedim>> &                output)
       {
@@ -3368,7 +3368,7 @@ namespace internal
             static_cast<const typename dealii::MappingQGeneric<dim, spacedim>::
                           InternalData &>(mapping_data);
 
-        switch (mapping_type)
+        switch (mapping_kind)
           {
             case mapping_contravariant:
               {
@@ -3432,7 +3432,7 @@ namespace internal
       void
       transform_gradients(
         const ArrayView<const Tensor<rank, dim>> &               input,
-        const MappingType                                        mapping_type,
+        const MappingKind                                        mapping_kind,
         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
         const ArrayView<Tensor<rank, spacedim>> &                output)
       {
@@ -3446,7 +3446,7 @@ namespace internal
             static_cast<const typename dealii::MappingQGeneric<dim, spacedim>::
                           InternalData &>(mapping_data);
 
-        switch (mapping_type)
+        switch (mapping_kind)
           {
             case mapping_contravariant_gradient:
               {
@@ -3534,7 +3534,7 @@ namespace internal
       void
       transform_hessians(
         const ArrayView<const Tensor<3, dim>> &                  input,
-        const MappingType                                        mapping_type,
+        const MappingKind                                        mapping_kind,
         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
         const ArrayView<Tensor<3, spacedim>> &                   output)
       {
@@ -3548,7 +3548,7 @@ namespace internal
             static_cast<const typename dealii::MappingQGeneric<dim, spacedim>::
                           InternalData &>(mapping_data);
 
-        switch (mapping_type)
+        switch (mapping_kind)
           {
             case mapping_contravariant_hessian:
               {
@@ -3703,7 +3703,7 @@ namespace internal
       void
       transform_differential_forms(
         const ArrayView<const DerivativeForm<rank, dim, spacedim>> &input,
-        const MappingType                                        mapping_type,
+        const MappingKind                                        mapping_kind,
         const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
         const ArrayView<Tensor<rank + 1, spacedim>> &            output)
       {
@@ -3717,7 +3717,7 @@ namespace internal
             static_cast<const typename dealii::MappingQGeneric<dim, spacedim>::
                           InternalData &>(mapping_data);
 
-        switch (mapping_type)
+        switch (mapping_kind)
           {
             case mapping_covariant:
               {
@@ -3745,12 +3745,12 @@ template <int dim, int spacedim>
 void
 MappingQGeneric<dim, spacedim>::transform(
   const ArrayView<const Tensor<1, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<1, spacedim>> &                   output) const
 {
   internal::MappingQGenericImplementation::transform_fields(input,
-                                                            mapping_type,
+                                                            mapping_kind,
                                                             mapping_data,
                                                             output);
 }
@@ -3761,12 +3761,12 @@ template <int dim, int spacedim>
 void
 MappingQGeneric<dim, spacedim>::transform(
   const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<2, spacedim>> &                   output) const
 {
   internal::MappingQGenericImplementation::transform_differential_forms(
-    input, mapping_type, mapping_data, output);
+    input, mapping_kind, mapping_data, output);
 }
 
 
@@ -3775,15 +3775,15 @@ template <int dim, int spacedim>
 void
 MappingQGeneric<dim, spacedim>::transform(
   const ArrayView<const Tensor<2, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<2, spacedim>> &                   output) const
 {
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_contravariant:
         internal::MappingQGenericImplementation::transform_fields(input,
-                                                                  mapping_type,
+                                                                  mapping_kind,
                                                                   mapping_data,
                                                                   output);
         return;
@@ -3792,7 +3792,7 @@ MappingQGeneric<dim, spacedim>::transform(
       case mapping_contravariant_gradient:
       case mapping_covariant_gradient:
         internal::MappingQGenericImplementation::transform_gradients(
-          input, mapping_type, mapping_data, output);
+          input, mapping_kind, mapping_data, output);
         return;
       default:
         Assert(false, ExcNotImplemented());
@@ -3805,7 +3805,7 @@ template <int dim, int spacedim>
 void
 MappingQGeneric<dim, spacedim>::transform(
   const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<3, spacedim>> &                   output) const
 {
@@ -3814,7 +3814,7 @@ MappingQGeneric<dim, spacedim>::transform(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_covariant_gradient:
         {
@@ -3854,17 +3854,17 @@ template <int dim, int spacedim>
 void
 MappingQGeneric<dim, spacedim>::transform(
   const ArrayView<const Tensor<3, dim>> &                  input,
-  const MappingType                                        mapping_type,
+  const MappingKind                                        mapping_kind,
   const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   const ArrayView<Tensor<3, spacedim>> &                   output) const
 {
-  switch (mapping_type)
+  switch (mapping_kind)
     {
       case mapping_piola_hessian:
       case mapping_contravariant_hessian:
       case mapping_covariant_hessian:
         internal::MappingQGenericImplementation::transform_hessians(
-          input, mapping_type, mapping_data, output);
+          input, mapping_kind, mapping_data, output);
         return;
       default:
         Assert(false, ExcNotImplemented());


### PR DESCRIPTION
I've heard the use of MappingType in mapping.h is a little confusing since it's not actually a type.

To fix that, I've changed all instances of MappingType to MappingKind, all instances of mapping_type to mapping_kind, and then updated as much documentation as I could find to accordingly match. Please let me know if I missed anything.

I'm running a build on my end now to verify nothing was broken but it may take awhile on my laptop :cry: 