### PR TITLE
Fixed markdown in a step-1 tutorial comment.

### DIFF
--- a/examples/step-1/step-1.cc
+++ b/examples/step-1/step-1.cc
@@ -31,7 +31,7 @@
 // This is needed for C++ output:
 #include <iostream>
 #include <fstream>
-// And this for the declarations of the `sqrt' and `fabs' functions:
+// And this for the declarations of the `sqrt` and `fabs` functions:
 #include <cmath>
 
 // The final step in importing deal.II is this: All deal.II functions and


### PR DESCRIPTION
Most function names in the comments of step 1 are written with backticks so that they appear in a typewriter font on the tutorial page, but one line uses a different format. I'm pretty sure this is an unintentional inconsistency.