### PR TITLE
Cell id is the key

### DIFF
--- a/doc/news/changes/incompatibilities/20190808RezaRastak
+++ b/doc/news/changes/incompatibilities/20190808RezaRastak
@@ -1,0 +1,5 @@
+Improved: CellDataStorage stores a reference to a single unique triangulation
+to ensure that cells from other triangulations cannot store any data on the
+current object.
+<br>
+(Reza Rastak, 2019/08/08)

--- a/doc/news/changes/minor/20190807RezaRastakPeterMunch
+++ b/doc/news/changes/minor/20190807RezaRastakPeterMunch
@@ -1,0 +1,4 @@
+Fixed: Bug in CellDataStorage that produced error when applying adaptive
+refinement in multi-material grids.
+<br>
+(Reza Rastak, Peter Munch, 2019/08/07)

--- a/tests/base/cell_data_storage_03.cc
+++ b/tests/base/cell_data_storage_03.cc
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// It checks whether the cell_data_storage, specifically the methods
+// initialize() and get_data(), works with two different materials
+// types storing two different data structures.
+// It makes sure the results are not affected during local refinement and
+// and coarsening.
+
+#include <deal.II/base/quadrature_point_data.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include "../tests.h"
+
+// history structs for each material
+struct MaterialBase
+{
+  virtual ~MaterialBase()
+  {}
+};
+struct Mat0 : MaterialBase
+{
+  double x{5.};
+};
+struct Mat1 : MaterialBase
+{
+  double y{8.};
+};
+constexpr unsigned int n_data_points_per_cell = 4;
+
+
+void setup_history(
+  Triangulation<2> &tria,
+  CellDataStorage<typename Triangulation<2>::active_cell_iterator, MaterialBase>
+    &storage)
+{
+  deallog << "initializing history" << std::endl;
+  for (auto cell : tria.active_cell_iterators())
+    {
+      deallog << "initializing cell " << cell->id() << std::endl;
+      if (cell->material_id() == 0)
+        storage.template initialize<Mat0>(cell, n_data_points_per_cell);
+      else if (cell->material_id() == 1)
+        storage.template initialize<Mat1>(cell, n_data_points_per_cell);
+    }
+}
+
+void read_history(
+  Triangulation<2> &tria,
+  CellDataStorage<typename Triangulation<2>::active_cell_iterator, MaterialBase>
+    &storage)
+{
+  deallog << "reading history" << std::endl;
+  for (auto cell : tria.active_cell_iterators())
+    {
+      if (cell->material_id() == 0)
+        {
+          auto data_vec = storage.template get_data<Mat0>(cell);
+          deallog << "Cell with material id = 0 contains the data "
+                  << data_vec[0]->x << std::endl;
+        }
+      else if (cell->material_id() == 1)
+        {
+          auto data_vec = storage.template get_data<Mat1>(cell);
+          deallog << "Cell with material id = 1 contains the data "
+                  << data_vec[0]->y << std::endl;
+        }
+    }
+}
+
+int
+main()
+{
+  initlog();
+
+  // create a mesh with two cells
+  Triangulation<2> tria;
+  GridGenerator::subdivided_hyper_rectangle(tria,
+                                            /*repetitions*/ {2, 1},
+                                            /*point1*/ {0., 0.},
+                                            /*point2*/ {2., 1.});
+
+  // assign material ids
+  auto cell0 = tria.begin_active();
+  cell0->set_material_id(0);
+  auto cell1 = cell0;
+  ++cell1;
+  cell1->set_material_id(1);
+
+  // refine one cell
+  cell0->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  deallog << "first refinement done" << std::endl;
+
+  // create a history structure and populate it
+  CellDataStorage<typename Triangulation<2>::active_cell_iterator, MaterialBase>
+    storage;
+  setup_history(tria, storage);
+  read_history(tria, storage);
+
+  // coarsen the cell and refine the other cell
+  for (auto cell : tria.cell_iterators_on_level(1))
+    cell->set_coarsen_flag();
+  cell1->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  deallog << "second refinement done" << std::endl;
+
+  // initialize history for newly created cells
+  setup_history(tria, storage);
+  read_history(tria, storage);
+
+  deallog << "OK" << std::endl;
+
+  return 0;
+}

--- a/tests/base/cell_data_storage_03.output
+++ b/tests/base/cell_data_storage_03.output
@@ -1,0 +1,28 @@
+
+DEAL::first refinement done
+DEAL::initializing history
+DEAL::initializing cell 1_0:
+DEAL::initializing cell 0_1:0
+DEAL::initializing cell 0_1:1
+DEAL::initializing cell 0_1:2
+DEAL::initializing cell 0_1:3
+DEAL::reading history
+DEAL::Cell with material id = 1 contains the data 8.00000
+DEAL::Cell with material id = 0 contains the data 5.00000
+DEAL::Cell with material id = 0 contains the data 5.00000
+DEAL::Cell with material id = 0 contains the data 5.00000
+DEAL::Cell with material id = 0 contains the data 5.00000
+DEAL::second refinement done
+DEAL::initializing history
+DEAL::initializing cell 0_0:
+DEAL::initializing cell 1_1:0
+DEAL::initializing cell 1_1:1
+DEAL::initializing cell 1_1:2
+DEAL::initializing cell 1_1:3
+DEAL::reading history
+DEAL::Cell with material id = 0 contains the data 5.00000
+DEAL::Cell with material id = 1 contains the data 8.00000
+DEAL::Cell with material id = 1 contains the data 8.00000
+DEAL::Cell with material id = 1 contains the data 8.00000
+DEAL::Cell with material id = 1 contains the data 8.00000
+DEAL::OK


### PR DESCRIPTION
CellDataStorage() uses `CellIteratorType` as the key of its internal `std::map` data structure. The issue is that when local refinement and coarsening is applied, the identity of cell iterators may change. The data assigned to a cell may be wrongfully assigned to a different cell.

To demonstrate that the current master branch contains this error, a test is added. We use two different materials with two different stored data structures. A simple refinement and coarsening step and a subsequent reinitialization of cell data structures introduces the error. Basically instead of initializing a data structures for newly refined cells, it assumes that these already exist and no initialization is performed. Now if we try to retrieve this data using the `get_data()` method, the exception `ExcCellDataTypeMismatch` is thrown (I proposed #8471 to appropriately present this obscure error). Note that this error is only thrown when we have two different material ids and two material data structures. Last week I found this bug and it took me around 12-16 hours to track the source of it because my code would randomly fail after 10 levels of refinement with a segfault.

To fix this error we change the key of the private data map to `CellId` because it uniquely represents cells even after refinement and coarsening steps.

@peterrum helped me considerably to reproduce this bug in a test and to solve it.