### PR TITLE
improved documentation for grid generator

### DIFF
--- a/doc/news/changes/minor/20190807MJayadharan
+++ b/doc/news/changes/minor/20190807MJayadharan
@@ -1,0 +1,3 @@
+Changed: Improved the documentation about GridGenerator::subdivided_hyper_cube().
+<br>
+(Manu Jayadharan, 2019/08/07)

--- a/doc/news/changes/minor/20190808MJayadharan
+++ b/doc/news/changes/minor/20190808MJayadharan
@@ -1,0 +1,3 @@
+Debug: There were two functions in GridTools::Cache class (in source/grid/grid_tools_cache.cc), namely get_used_vertices_rtree() and get_cell_bounding_boxes_rtree where the update flag is not cleared. Fixed that by adding a line to both functions at the end of if loop checking the flag.
+<br>
+(Manu Jayadharan, 2019/08/08)

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -135,6 +135,16 @@ namespace GridGenerator
    * <tt>Triangulation@<2,3@></tt> will be a square in the xy plane with z=0.
    *
    * @note The triangulation passed as argument needs to be empty when calling this function.
+   *
+   * @param tria The Triangulation to create. It needs to be empty upon
+   * calling this function.
+   *
+   * @param repetitions A vector of @p dim positive values denoting the number
+   * of cells to generate in that direction.
+   *
+   * @param left Lower bound for the interval used to create the hyper cube.
+   *
+   * @param right Upper bound for the interval used to create the hyper cube.
    */
   template <int dim, int spacedim>
   void
@@ -176,6 +186,8 @@ namespace GridGenerator
    * z=0, defined by the two opposing corners @p p1 and @p p2.
    *
    * @note The triangulation passed as argument needs to be empty when calling this function.
+
+ 
    */
   template <int dim, int spacedim>
   void

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -140,7 +140,8 @@ namespace GridGenerator
    * calling this function.
    *
    * @param repetitions A vector of @p dim positive values denoting the number
-   * of cells to generate in that direction.
+   * of cells to generate in that direction. FOr example, first component of the vector specifies the number of cells
+   * in the x-direction, second component specifies that for the y-direction for dim=2.
    *
    * @param left Lower bound for the interval used to create the hyper cube.
    *
@@ -186,8 +187,6 @@ namespace GridGenerator
    * z=0, defined by the two opposing corners @p p1 and @p p2.
    *
    * @note The triangulation passed as argument needs to be empty when calling this function.
-
- 
    */
   template <int dim, int spacedim>
   void

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -114,6 +114,7 @@ namespace GridTools
         for (const auto &it : used_vertices)
           vertices[i++] = std::make_pair(it.second, it.first);
         used_vertices_rtree = pack_rtree(vertices);
+        update_flags = update_flags & ~update_used_vertices_rtree;
       }
     return used_vertices_rtree;
   }
@@ -137,6 +138,7 @@ namespace GridTools
           boxes[i++] = std::make_pair(mapping->get_bounding_box(cell), cell);
 
         cell_bounding_boxes_rtree = pack_rtree(boxes);
+        update_flags = update_flags & ~update_cell_bounding_boxes_rtree;
       }
     return cell_bounding_boxes_rtree;
   }


### PR DESCRIPTION
Parameter description was missing from the documentation for GridGenerator::subdivided_hyper_cube. Documentation is changed to add the parameter description. This is basically an exercise on first pull request. 