### PR TITLE
Changes to enclosed_hyper_cube and moebius documentation 

### DIFF
--- a/doc/news/changes/minor/20190807ManaswineeBezbaruah
+++ b/doc/news/changes/minor/20190807ManaswineeBezbaruah
@@ -1,3 +1,6 @@
+Improved: Changes in grid_generator.h
 The original documentation of enclosed_hyper_cube said 'first two parameters' in the second line, which was a bit unclear. 
 I made that more specific. The coloring scheme was also unclear, especially with the use of bitwise OR as a verb.
 The moebius function had a pi outside of math mode, not a huge error.
+<br>
+(Manaswinee Bezbaruah, 2019/08/05)

--- a/doc/news/changes/minor/20190807ManaswineeBezbaruah
+++ b/doc/news/changes/minor/20190807ManaswineeBezbaruah
@@ -1,0 +1,3 @@
+The original documentation of enclosed_hyper_cube said 'first two parameters' in the second line, which was a bit unclear. 
+I made that more specific. The coloring scheme was also unclear, especially with the use of bitwise OR as a verb.
+The moebius function had a pi outside of math mode, not a huge error.

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1224,7 +1224,7 @@ namespace GridGenerator
    * @param tria        The triangulation to be worked on.
    * @param n_cells     The number of cells in the loop. Must be greater than
    * 4.
-   * @param n_rotations The number of rotations ($\pi$/2 each) to be performed
+   * @param n_rotations The number of rotations ($\pi/2$ each) to be performed
    * before gluing the loop together.
    * @param R           The radius of the circle, which forms the middle line
    * of the torus containing the loop of cells. Must be greater than @p r.


### PR DESCRIPTION
The original documentation of enclosed_hyper_cube said 'first two parameters' in the second line, which was a bit unclear. I made that more specific. The coloring scheme was also unclear, especially with the use of bitwise OR as a verb.
The moebius function had a pi outside of math mode, not a huge error.
Added a document for the minor change