### PR TITLE
ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,10 @@ qtcreator/
 /.clang_complete
 /contrib/utilities/programs
 
-# emacs temporary and backup files
+# temporary and backup files
 *~
 *#
+.DS_Store
 
 # configuration, executable, and output files from examples
 examples/step-*/*dat


### PR DESCRIPTION
Not sure how people feel about this, but I nearly accepted a PR that contained one of these files. 

Also, there is probably other stuff that could be added (temp files like *~).