### PR TITLE
indent: check for bad usernames and emails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,60 @@
+# This file is up-to-date if the command git log --format="%aN <%aE>" | sort -u
+# gives no duplicates.
+
+# Format:
+# Proper Name <good.email@address>
+# Proper Name <good@email.address> <old.or.incorrect@email.address>
+#
+# You can have several lines for the same person if more than one incorrect
+# email address is in use.
+#
+# Also see https://git-scm.com/docs/git-check-mailmap
+
+
+# adam4130 <adam4130@users.noreply.github.com>
+Adam Lee <adam4130@users.noreply.github.com>
+
+# tcclevenger <tcleven@clemson.edu>
+Thomas C. Clevenger <tcleven@clemson.edu>
+
+# Roland <roland.richter@ntnu.no>
+Roland Richter <roland.richter@ntnu.no>
+
+# saratro <sara.tro@colorado.edu>
+Sara Tro <sara.tro@colorado.edu>
+
+# rfildes <rfildes@ucdavis.edu>
+Rebecca Fildes <rfildes@ucdavis.edu>
+
+# notxor <pmnotxor@gmx.at>
+Daniel Jodlbauer <pmnotxor@gmx.at>
+
+# marcfehling <marc.fehling@gmx.net>
+Marc Fehling <marc.fehling@gmx.net>
+
+# rebeccampereira <rpereira2@umassd.edu>
+Rebecca Pereira <rpereira2@umassd.edu>
+
+# peterrum <peterrmuench@gmail.com>
+Peter Munch <peterrmuench@gmail.com>
+
+# ManaswineeB <bezba004@umn.edu>
+Manaswinee Bezbaruah <bezba004@umn.edu>
+
+# blaisb <blais.bruno@gmail.com>
+Bruno Blais <blais.bruno@gmail.com>
+
+# grahambenharper <grahambenharper@gmail.com>
+Graham Harper <grahambenharper@gmail.com>
+
+# kirana-bergstrom <kirana.bergstrom@ucdenver.edu>
+Kirana Bergstrom <kirana.bergstrom@ucdenver.edu>
+
+# luz.paz <luzpaz@users.noreply.github.com>
+unknown luzpaz <luzpaz@users.noreply.github.com>
+
+# zhuoranwang@ZhuorandeMacBook-Pro.local
+Zhuoran Wang <zhrwang@rams.colostate.edu> <zhuoranwang@ZhuorandeMacBook-Pro.local>
+
+# Wolfgang Bangerth <bangerth@gluon.math.colostate.edu>
+Wolfgang Bangerth <bangerth@colostate.edu> <bangerth@gluon.math.colostate.edu>

--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -66,6 +66,43 @@ checks() {
     echo "***   to install a compatible binary into './contrib/utilities/programs'."
     exit 1
   fi
+
+
+  # check formatting of usernames and email addresses, examples that will be detected:
+  # not-using-a-name <a@b.com>
+  # John Doe <doe@macbook.local>
+  # Jane Doe <a@nodomain>
+  #
+  # For commits already in the history, please see .mailmap in the root directory.
+  #
+  # Note that we currently allow email addresses of the form
+  # Luca Heltai <luca-heltai@users.noreply.github.com>
+  # as these are generated when using the website to commit.
+  #
+  # Finally, to stay sane, just go back until the beginning of 2019 for now.
+  #
+  # first user names:
+  git log --since "2019-01-01" --format="%aN" | sort -u | while read name ; do
+      words=($name)
+      if [ "${#words[@]}" -lt "2" ]; then
+	  echo "invalid author '$name' without firstname and lastname"
+	  exit 2
+      fi
+  done
+
+  # now emails:
+  git log --since "2019-01-01" --format="%aE" | sort -u | while read email ; do
+      words=($name)
+      if ! echo "$email" | grep -q "\."; then
+	  echo "invalid email '$email'"
+	  exit 3
+      fi
+      if ! echo "$email" | grep -q -v -e "\.local$"; then
+	  echo "invalid email '$email'"
+	  exit 3
+      fi
+  done
+
 }
 
 #

--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -88,7 +88,7 @@ checks() {
 	  echo "invalid author '$name' without firstname and lastname"
 	  exit 2
       fi
-  done
+  done || exit 2
 
   # now emails:
   git log --since "2019-01-01" --format="%aE" | sort -u | while read email ; do
@@ -101,7 +101,7 @@ checks() {
 	  echo "invalid email '$email'"
 	  exit 3
       fi
-  done
+  done || exit 3
 
 }
 


### PR DESCRIPTION
For compiling the list of contributors for each release, we rely on
useful names and email addresses. We also regularly generate statistics
about number of contributors, which requires identifying unique authors.

This PR does the following:
1. Enforce in `indent` that users have a sensible name set that consists
of at least two words (git config --global user.name)
2. Enforce in `indent` that users have sensible email addresses set by
blocking some common invalid ones.
3. Add a .mailmap file that corrects a collection of invalid
names/addresses already part of the history. This is a standard git
file, which will replace output of `git log` and similar commands.

Step 3 is necessary to make ./indent pass on master.