### PR TITLE
Add compression options to pack and use default parameters

### DIFF
--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1215,7 +1215,7 @@ namespace Utilities
             boost::iostreams::filtering_ostream out;
             out.push(
               boost::iostreams::gzip_compressor(boost::iostreams::gzip_params(
-                boost::iostreams::gzip::best_compression)));
+                boost::iostreams::gzip::default_compression)));
             out.push(boost::iostreams::back_inserter(dest_buffer));
 
             boost::archive::binary_oarchive archive(out);

--- a/tests/base/utilities_pack_unpack_07.cc
+++ b/tests/base/utilities_pack_unpack_07.cc
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// tests the influence of different compression options for
+// Utilities::pack/unpack
+// (based upon "utilities_pack_unpack_06")
+
+
+#include <deal.II/base/point.h>
+#include <deal.II/base/timer.h>
+#include <deal.II/base/utilities.h>
+
+#include <random>
+
+#include "../tests.h"
+
+using namespace dealii;
+
+
+template <int N>
+void
+check(const double (&array)[N])
+{
+  // ----- PACK -----
+  std::vector<char> array_compressed, array_uncompressed;
+
+  TimerOutput computing_timer(std::cout,
+                              TimerOutput::never,
+                              TimerOutput::wall_times);
+
+#ifdef DEAL_II_WITH_ZLIB
+  // default option should work for compression
+  {
+    TimerOutput::Scope timer_section(computing_timer, "Pack compressed");
+    Utilities::pack(array, array_compressed, true);
+  }
+#endif
+
+  {
+    TimerOutput::Scope timer_section(computing_timer, "Pack uncompressed");
+    Utilities::pack(array, array_uncompressed, false);
+  }
+
+  // computing_timer.print_summary();
+
+  // check if compression has been invoked by comparing sizes
+  deallog << "unpacked array: " << sizeof(array) << std::endl;
+
+  deallog << "packed array without compression: " << array_uncompressed.size()
+          << std::endl;
+
+#ifdef DEAL_II_WITH_ZLIB
+  deallog << "packed array with compression: " << array_compressed.size()
+          << std::endl;
+#endif
+}
+
+
+void
+test()
+{
+  // pick large data types and arrays that could be compressed,
+  // and check for both compression options
+  const unsigned int N = 10000;
+  double             x2[N];
+
+  std::default_random_engine             generator(0);
+  std::uniform_real_distribution<double> distribution(0.0, 1.0);
+
+  // Test easily compressible data.
+  // Default compression is much faster than best compression.
+  for (unsigned int i = 0; i < N; ++i)
+    {
+      x2[i] = i;
+    }
+
+  check(x2);
+
+  // Test random data, which is nearly incompressible.
+  // Default compression is equally fast as best compression.
+  for (unsigned int i = 0; i < N; ++i)
+    {
+      x2[i] = distribution(generator);
+    }
+
+  check(x2);
+
+  deallog << "OK!" << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  test();
+}

--- a/tests/base/utilities_pack_unpack_07.with_zlib=off.output
+++ b/tests/base/utilities_pack_unpack_07.with_zlib=off.output
@@ -1,0 +1,6 @@
+
+DEAL::unpacked array: 80000
+DEAL::packed array without compression: 80048
+DEAL::unpacked array: 80000
+DEAL::packed array without compression: 80048
+DEAL::OK!

--- a/tests/base/utilities_pack_unpack_07.with_zlib=on.debug.output
+++ b/tests/base/utilities_pack_unpack_07.with_zlib=on.debug.output
@@ -1,0 +1,8 @@
+
+DEAL::unpacked array: 80000
+DEAL::packed array without compression: 80048
+DEAL::packed array with compression: 14697
+DEAL::unpacked array: 80000
+DEAL::packed array without compression: 80048
+DEAL::packed array with compression: 75558
+DEAL::OK!

--- a/tests/base/utilities_pack_unpack_07.with_zlib=on.release.output
+++ b/tests/base/utilities_pack_unpack_07.with_zlib=on.release.output
@@ -1,0 +1,8 @@
+
+DEAL::unpacked array: 80000
+DEAL::packed array without compression: 80048
+DEAL::packed array with compression: 14697
+DEAL::unpacked array: 80000
+DEAL::packed array without compression: 80048
+DEAL::packed array with compression: 75550
+DEAL::OK!


### PR DESCRIPTION
In my tests with the Utilities::pack function it turns out that we use the `best_compression` setting for the gzip compressor that is used to compress the data. This setting is vastly more expensive and (at least for my test data) only marginally more effective than the default setting. This PR does two things:
1. Use the default settings instead of best_compression.
2. Add a new optional argument that allows to use other compression settings (by request from @marcfehling).

This is sample output from my timing test that compares different compression settings. `pack particles` is a hand written function that does not use the Utilities::pack function or the boost::archive functionality at all. For the size information keep in mind that I use very regular (easily compressible) data, the compression will be much worse for arbitrary data, random doubles don't compress well:
```
Size of uncompressed: 69861605
Size of default compressed: 2436266
Size of best compressed: 2435962
Size of pack particles: 50455548

+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |      6.19s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Pack best compressed            |         1 |      2.71s |        44% |
| Pack default compressed         |         1 |     0.962s |        16% |
| Pack uncompressed               |         1 |     0.636s |        10% |
| Pack particles                  |         1 |    0.0221s |      0.36% |
+---------------------------------+-----------+------------+------------+
```