### PR TITLE
Matrix free atomic

### DIFF
--- a/doc/news/changes/minor/20190808BrunoTurcksin
+++ b/doc/news/changes/minor/20190808BrunoTurcksin
@@ -1,0 +1,5 @@
+New: Add a new parameter to CUDAWrappers::MatrixFree::AdditionalData to choose
+between graph coloring and atomics in CUDAWrappers::MatrixFree::cell_loop().
+The atomic implementation is faster on Pascal and newer architectures.
+<br>
+(Bruno Turcksin, 2019/08/08)

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -91,14 +91,19 @@ namespace CUDAWrappers
       parallel_over_elem
     };
 
+    /**
+     * Standardized data struct to pipe additional data to MatrixFree.
+     */
     struct AdditionalData
     {
       AdditionalData(
         const ParallelizationScheme parallelization_scheme = parallel_in_elem,
         const UpdateFlags           mapping_update_flags   = update_gradients |
-                                                 update_JxW_values)
+                                                 update_JxW_values,
+        const bool use_coloring = false)
         : parallelization_scheme(parallelization_scheme)
         , mapping_update_flags(mapping_update_flags)
+        , use_coloring(use_coloring)
       {}
 
       /**
@@ -120,6 +125,13 @@ namespace CUDAWrappers
        * must be specified by this field.
        */
       UpdateFlags mapping_update_flags;
+
+      /**
+       * If true, use graph coloring. Otherwise, use atomic operations. Graph
+       * coloring ensures bitwise reproducibility but is slower on Pascal and
+       * newer architectures.
+       */
+      bool use_coloring;
     };
 
     /**
@@ -136,6 +148,7 @@ namespace CUDAWrappers
       unsigned int             padding_length;
       unsigned int             row_start;
       unsigned int *           constraint_mask;
+      bool                     use_coloring;
     };
 
     /**
@@ -376,6 +389,13 @@ namespace CUDAWrappers
      * over cells.
      */
     ParallelizationScheme parallelization_scheme;
+
+    /**
+     * If true, use graph coloring. Otherwise, use atomic operations. Graph
+     * coloring ensures bitwise reproducibility but is slower on Pascal and
+     * newer architectures.
+     */
+    bool use_coloring;
 
     /**
      * Total number of degrees of freedom.

--- a/tests/cuda/matrix_free_matrix_vector_03b.cu
+++ b/tests/cuda/matrix_free_matrix_vector_03b.cu
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// this function tests the correctness of the implementation of matrix free
+// matrix-vector products by comparing with the result of deal.II sparse
+// matrix. The mesh uses a hypercube mesh with hanging nodes (created by
+// randomly refining some cells) and zero Dirichlet conditions. Same as test
+// matrix_free_matrix_vector_03b but use coloring instead of atomics
+
+#include <deal.II/base/function.h>
+
+#include "../tests.h"
+
+std::ofstream logfile("output");
+
+#include "matrix_vector_common.h"
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
+                                                    endc = tria.end();
+  if (dim < 3 || fe_degree < 2)
+    tria.refine_global(2);
+  else
+    tria.refine_global(1);
+  tria.begin(tria.n_levels() - 1)->set_refine_flag();
+  tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  cell = tria.begin_active();
+  for (unsigned int i = 0; i < 10 - 3 * dim; ++i)
+    {
+      cell                 = tria.begin_active();
+      unsigned int counter = 0;
+      for (; cell != endc; ++cell, ++counter)
+        if (counter % (7 - i) == 0)
+          cell->set_refine_flag();
+      tria.execute_coarsening_and_refinement();
+    }
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+
+  VectorTools::interpolate_boundary_values(dof,
+                                           0,
+                                           Functions::ZeroFunction<dim>(),
+                                           constraints);
+  constraints.close();
+
+  // Skip 2D tests with even fe_degree
+  if ((dim == 3) || ((fe_degree % 2) == 1))
+    do_test<dim,
+            fe_degree,
+            double,
+            LinearAlgebra::CUDAWrappers::Vector<double>,
+            fe_degree + 1>(dof, constraints, tria.n_active_cells(), true, true);
+}

--- a/tests/cuda/matrix_free_matrix_vector_03b.output
+++ b/tests/cuda/matrix_free_matrix_vector_03b.output
@@ -1,0 +1,16 @@
+
+DEAL:2d::Testing FE_Q<2>(1)
+DEAL:2d::Norm of difference: 0.
+DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(3)
+DEAL:2d::Norm of difference: 0.
+DEAL:2d::
+DEAL:3d::Testing FE_Q<3>(1)
+DEAL:3d::Norm of difference: 0.
+DEAL:3d::
+DEAL:3d::Testing FE_Q<3>(2)
+DEAL:3d::Norm of difference: 0.
+DEAL:3d::
+DEAL:3d::Testing FE_Q<3>(3)
+DEAL:3d::Norm of difference: 0.
+DEAL:3d::

--- a/tests/cuda/matrix_vector_common.h
+++ b/tests/cuda/matrix_vector_common.h
@@ -78,7 +78,8 @@ void
 do_test(const DoFHandler<dim> &          dof,
         const AffineConstraints<double> &constraints,
         const unsigned int               n_locally_owned_cells,
-        const bool                       constant_coefficient = true)
+        const bool                       constant_coefficient = true,
+        const bool                       coloring             = false)
 {
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
 
@@ -89,6 +90,7 @@ do_test(const DoFHandler<dim> &          dof,
   additional_data.mapping_update_flags = update_values | update_gradients |
                                          update_JxW_values |
                                          update_quadrature_points;
+  additional_data.use_coloring = coloring;
   const QGauss<1> quad(n_q_points_1d);
   mf_data.reinit(mapping, dof, constraints, quad, additional_data);
 


### PR DESCRIPTION
This allows cuda matrix-free to use atomics instead of graph coloring. Atomics are extremely fast on newer architectures, so I switched the default behavior to use atomics. All the tests have been switched to atomics so I added one test that uses graph coloring.

Relates to #7037 