### PR TITLE
Make particle iterators const references in range-based for loops.

### DIFF
--- a/tests/particles/particle_handler_01.cc
+++ b/tests/particles/particle_handler_01.cc
@@ -76,14 +76,12 @@ test()
     deallog << "Particle number: " << particle_handler.n_global_particles()
             << std::endl;
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
+    for (const auto &particle : particle_handler)
       {
-        deallog << "Particle location: " << particle->get_location()
+        deallog << "Particle location: " << particle.get_location()
                 << std::endl;
         deallog << "Particle reference location: "
-                << particle->get_reference_location() << std::endl;
+                << particle.get_reference_location() << std::endl;
       }
   }
 

--- a/tests/particles/particle_handler_02.cc
+++ b/tests/particles/particle_handler_02.cc
@@ -94,14 +94,12 @@ test()
     deallog << "Max particles per cell: "
             << particle_handler.n_global_max_particles_per_cell() << std::endl;
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
+    for (const auto &particle : particle_handler)
       {
-        deallog << "Particle location: " << particle->get_location()
+        deallog << "Particle location: " << particle.get_location()
                 << std::endl;
         deallog << "Particle reference location: "
-                << particle->get_reference_location() << std::endl;
+                << particle.get_reference_location() << std::endl;
       }
   }
 

--- a/tests/particles/particle_handler_03.cc
+++ b/tests/particles/particle_handler_03.cc
@@ -67,20 +67,16 @@ test()
     particle_handler.insert_particle(particle1, cell1);
     particle_handler.insert_particle(particle2, cell2);
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "Before sort particle id " << particle->get_id()
-              << " is in cell " << particle->get_surrounding_cell(tr)
+    for (const auto &particle : particle_handler)
+      deallog << "Before sort particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
               << std::endl;
 
     particle_handler.sort_particles_into_subdomains_and_cells();
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "After sort particle id " << particle->get_id()
-              << " is in cell " << particle->get_surrounding_cell(tr)
+    for (const auto &particle : particle_handler)
+      deallog << "After sort particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
               << std::endl;
 
     // Move all points up by 0.5. This will change cell for particle 1, and will
@@ -88,17 +84,13 @@ test()
     // coordinate dim-1 despite having a spacedim point.
     Point<spacedim> shift;
     shift(dim - 1) = 0.5;
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      particle->set_location(particle->get_location() + shift);
+    for (auto &particle : particle_handler)
+      particle.set_location(particle.get_location() + shift);
 
     particle_handler.sort_particles_into_subdomains_and_cells();
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "After shift particle id " << particle->get_id()
-              << " is in cell " << particle->get_surrounding_cell(tr)
+    for (const auto &particle : particle_handler)
+      deallog << "After shift particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
               << std::endl;
   }
 

--- a/tests/particles/particle_handler_04.cc
+++ b/tests/particles/particle_handler_04.cc
@@ -72,11 +72,9 @@ test()
         particle_handler.insert_particle(particle1, cell1);
         particle_handler.insert_particle(particle2, cell2);
 
-        for (auto particle = particle_handler.begin();
-             particle != particle_handler.end();
-             ++particle)
-          deallog << "Before sort particle id " << particle->get_id()
-                  << " is in cell " << particle->get_surrounding_cell(tr)
+        for (const auto &particle : particle_handler)
+          deallog << "Before sort particle id " << particle.get_id()
+                  << " is in cell " << particle.get_surrounding_cell(tr)
                   << " on process "
                   << Utilities::MPI::this_mpi_process(tr.get_communicator())
                   << std::flush << std::endl;
@@ -86,11 +84,9 @@ test()
 
     particle_handler.sort_particles_into_subdomains_and_cells();
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "After sort particle id " << particle->get_id()
-              << " is in cell " << particle->get_surrounding_cell(tr)
+    for (const auto &particle : particle_handler)
+      deallog << "After sort particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
               << " on process "
               << Utilities::MPI::this_mpi_process(tr.get_communicator())
               << std::flush << std::endl;
@@ -100,17 +96,13 @@ test()
     // coordinate dim-1 despite having a spacedim point.
     Point<spacedim> shift;
     shift(dim - 1) = 0.5;
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      particle->set_location(particle->get_location() + shift);
+    for (auto &particle : particle_handler)
+      particle.set_location(particle.get_location() + shift);
 
     particle_handler.sort_particles_into_subdomains_and_cells();
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "After shift particle id " << particle->get_id()
-              << " is in cell " << particle->get_surrounding_cell(tr)
+    for (const auto &particle : particle_handler)
+      deallog << "After shift particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
               << " on process "
               << Utilities::MPI::this_mpi_process(tr.get_communicator())
               << std::flush << std::endl;

--- a/tests/particles/particle_handler_05.cc
+++ b/tests/particles/particle_handler_05.cc
@@ -116,21 +116,17 @@ test()
 
     create_regular_particle_distribution(particle_handler, tr);
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "Before refinement particle id " << particle->get_id()
-              << " is in cell " << particle->get_surrounding_cell(tr)
+    for (const auto &particle : particle_handler)
+      deallog << "Before refinement particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
               << std::endl;
 
     // Check that all particles are moved to children
     tr.refine_global(1);
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "After refinement particle id " << particle->get_id()
-              << " is in cell " << particle->get_surrounding_cell(tr)
+    for (const auto &particle : particle_handler)
+      deallog << "After refinement particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
               << std::endl;
 
     // Reverse the refinement and check again
@@ -139,11 +135,9 @@ test()
 
     tr.execute_coarsening_and_refinement();
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "After coarsening particle id " << particle->get_id()
-              << " is in cell " << particle->get_surrounding_cell(tr)
+    for (const auto &particle : particle_handler)
+      deallog << "After coarsening particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
               << std::endl;
   }
 


### PR DESCRIPTION
I didn't convert them all so we can continue to test both ways to write a loop.