### PR TITLE
Initialize particle locations with invalid numbers.

### DIFF
--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -13,6 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/signaling_nan.h>
+
 #include <deal.II/particles/particle.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -21,8 +23,8 @@ namespace Particles
 {
   template <int dim, int spacedim>
   Particle<dim, spacedim>::Particle()
-    : location()
-    , reference_location()
+    : location(numbers::signaling_nan<Point<spacedim>>())
+    , reference_location(numbers::signaling_nan<Point<dim>>())
     , id(0)
     , property_pool(nullptr)
     , properties(PropertyPool::invalid_handle)

--- a/tests/particles/particle_01.cc
+++ b/tests/particles/particle_01.cc
@@ -29,8 +29,6 @@ test()
   {
     Particles::Particle<dim> particle;
 
-    deallog << "Particle location: " << particle.get_location() << std::endl;
-
     Point<dim> position;
     position(0) = 1.0;
     particle.set_location(position);

--- a/tests/particles/particle_01.output
+++ b/tests/particles/particle_01.output
@@ -1,7 +1,5 @@
 
-DEAL::Particle location: 0.00000 0.00000
 DEAL::Particle location: 1.00000 0.00000
 DEAL::OK
-DEAL::Particle location: 0.00000 0.00000 0.00000
 DEAL::Particle location: 1.00000 0.00000 0.00000
 DEAL::OK


### PR DESCRIPTION
The previous version just put the particle onto the origin, but that seems as arbitrary as any other way. So just give it an invalid location and throw a SIGFPE if it is accessed.

I also like the idea of instantiating a particle in nirvana, with no actual location. Setting the location then yields actually instantiates the particle in real life.

@gassmoeller -- FYI.