### PR TITLE
Add to LinearAlgebra::distributed::Vector documentation 

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -251,6 +251,9 @@ namespace LinearAlgebra
 
       /**
        * Copy constructor. Uses the parallel partitioning of @p in_vector.
+       * It should be noted that this constructor automatically sets ghost
+       * values to zero. Call @p update_ghost_values() directly following
+       * construction if a ghosted vector is required.
        */
       Vector(const Vector<Number, MemorySpace> &in_vector);
 


### PR DESCRIPTION
Spend quite some time hunting why my computations were all of a sudden slow. Realized that I had copied a ghosted vector in some of my recent changes, but the copy was not ghosted. @tjhei suggested I added to the documentation. I agree that it would be helpful. 