### PR TITLE
Change GridOut::write_svg() defaults

### DIFF
--- a/doc/news/changes/incompatibilities/20190805Bangerth
+++ b/doc/news/changes/incompatibilities/20190805Bangerth
@@ -1,0 +1,8 @@
+Changed: The GridOut::write_svg() function now no longer outputs the
+cell level and number by default; this also obviates the need for the
+colorbar and the caption. This is achieved by changing the defaults in
+the constructor of the GridOutFlags::Svg structure. This likely comes
+closer to what most users want to see from this function -- namely,
+just the mesh for inclusion into text.
+<br>
+(Wolfgang Bangerth, 2019/08/05)

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -672,42 +672,67 @@ namespace GridOutFlags
    */
   struct Svg
   {
-    /// Height of the plot in SVG units, computed from width if zero. Defaults
-    /// to 1000
+    /**
+     *  Height of the plot in SVG units, computed from width if zero. Defaults
+     *  to 1000.
+     */
     unsigned int height;
-    /// The width of the plot. Computed automatically from height if zero
-    /// (default)
+
+    /**
+     *  The width of the plot. Computed automatically from height if zero
+     *  (default).
+     */
     unsigned int width;
-    /// Thickness of the lines between cells
+
+    /**
+     *  Thickness of the lines between cells.
+     */
     unsigned int line_thickness;
-    /// Thickness of lines at the boundary
+    /**
+     * Thickness of lines at the boundary.
+     */
     unsigned int boundary_line_thickness;
 
-    /// Margin around the plotted area
+    /**
+     *  Margin around the plotted area.
+     */
     bool margin;
 
     /**
-     * Background style.
+     * An `enum` describing all possible background styles.
      */
     enum Background
     {
-      /// Use transparent value of SVG
+      /**
+       * Use transparent value of SVG.
+       */
       transparent,
-      /// Use white background
+
+      /**
+       * Use white background.
+       */
       white,
-      /// Use a gradient from white (top) to steelblue (bottom), and add date
-      /// and time plus a deal.II logo. Automatically draws a margin.
+
+      /**
+       * Use a gradient from white (top) to steelblue (bottom), and add date
+       * and time plus a deal.II logo. Automatically draws a margin.
+       */
       dealii
     };
 
+    /**
+     * The style used for the background of the mesh.
+     */
     Background background;
 
     // View angles for the perspective view of the grid; Default is 0, 0 (top
     // view).
+
     /**
      * The azimuth angle measured from ??? in degrees. Default is 0.
      */
     int azimuth_angle;
+
     /**
      * The angle from vertically above the xy-plane. Default is 0.
      */
@@ -736,28 +761,51 @@ namespace GridOutFlags
     /// (useful in the perspective view).
     bool convert_level_number_to_height;
 
-    /// The factor determining the vertical distance between levels (default =
-    /// 0.3)
+    /**
+     * The factor determining the vertical distance between levels (default =
+     * 0.3.
+     */
     float level_height_factor;
 
-    /// Scaling of the font for cell annotations. Defaults to 1.
+    /**
+     * Scaling of the font for cell annotations. Defaults to 1.
+     */
     float cell_font_scaling;
-    /// Write level number into each cell. Defaults to true
+    /**
+     * Write level number into each cell. Defaults to true.
+     */
     bool label_level_number;
-    /// Write cell index into each cell. Defaults to true
+
+    /**
+     * Write cell index into each cell. Defaults to true.
+     */
     bool label_cell_index;
-    /// Write material id of each cell. Defaults to false
+
+    /**
+     * Write material id of each cell. Defaults to false.
+     */
     bool label_material_id;
-    /// Write subdomain id of each cell. Defaults to false
+
+    /**
+     * Write subdomain id of each cell. Defaults to false.
+     */
     bool label_subdomain_id;
-    /// Write level subdomain id of each cell. Defaults to false
+
+    /**
+     * Write level subdomain id of each cell. Defaults to false.
+     */
     bool label_level_subdomain_id;
 
-    /// Draw a colorbar next to the plotted grid with respect to the chosen
-    /// coloring of the cells
+    /**
+     * Draw a colorbar next to the plotted grid with respect to the chosen
+     * coloring of the cells.
+     */
     bool draw_colorbar;
-    /// Draw a legend next to the plotted grid, explaining the label of the
-    /// cells
+
+    /**
+     * Draw a legend next to the plotted grid, explaining the label of the
+     * cells.
+     */
     bool draw_legend;
 
     /**
@@ -765,7 +813,7 @@ namespace GridOutFlags
      */
     Svg(const unsigned int line_thickness                 = 2,
         const unsigned int boundary_line_thickness        = 4,
-        bool               margin                         = true,
+        const bool         margin                         = true,
         const Background   background                     = white,
         const int          azimuth_angle                  = 0,
         const int          polar_angle                    = 0,

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -819,12 +819,12 @@ namespace GridOutFlags
         const int          polar_angle                    = 0,
         const Coloring     coloring                       = level_number,
         const bool         convert_level_number_to_height = false,
-        const bool         label_level_number             = true,
-        const bool         label_cell_index               = true,
+        const bool         label_level_number             = false,
+        const bool         label_cell_index               = false,
         const bool         label_material_id              = false,
         const bool         label_subdomain_id             = false,
-        const bool         draw_colorbar                  = true,
-        const bool         draw_legend                    = true);
+        const bool         draw_colorbar                  = false,
+        const bool         draw_legend                    = false);
   };
 
   /**

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -1159,7 +1159,9 @@ public:
    * further possible in order to visualize a certain property of the cells
    * such as their level or material id. A colorbar can be drawn to encode the
    * chosen coloring.  Moreover, a cell label can be added, showing level
-   * index, etc.
+   * index, etc. Indeed, by using the set_flags() with an appropriately
+   * generated object of type GridOutFlags::Svg, many aspects of how and
+   * what is being visualized by this function can be customized.
    *
    * @note This function is currently only implemented for two-dimensional
    * grids in two space dimensions.

--- a/tests/grid/get_finest_common_cells_04.cc
+++ b/tests/grid/get_finest_common_cells_04.cc
@@ -58,8 +58,10 @@ test()
       std::string tria_1_out =
         "tria-1-" + std::to_string(Utilities::MPI::this_mpi_process(MPI_COMM_WORLD)) + ".svg";
       std::ofstream tria_1_out_stream(tria_1_out);
-      GridOut().write_svg(tria_0, tria_0_out_stream);
-      GridOut().write_svg(tria_1, tria_1_out_stream);
+      GridOut go;
+      go.set_flags (GridOutFlags::Svg(2, 4, true, GridOutFlags::Svg::white, 0, 0, GridOutFlags::Svg::level_number, false, true, true));
+      go.write_svg(tria_0, tria_0_out_stream);
+      go.write_svg(tria_1, tria_1_out_stream);
     }
 
   deallog << "tria 0 cells:" << std::endl;

--- a/tests/grid/grid_out_svg_01.cc
+++ b/tests/grid/grid_out_svg_01.cc
@@ -73,9 +73,13 @@ main()
   GridOut           grid_out;
   GridOutFlags::Svg svg_flags;
 
-  svg_flags.coloring          = GridOutFlags::Svg::level_number;
-  svg_flags.label_material_id = true;
-  svg_flags.background        = GridOutFlags::Svg::transparent;
+  svg_flags.coloring           = GridOutFlags::Svg::level_number;
+  svg_flags.label_material_id  = true;
+  svg_flags.background         = GridOutFlags::Svg::transparent;
+  svg_flags.label_level_number = true;
+  svg_flags.label_cell_index   = true;
+  svg_flags.draw_legend        = true;
+  svg_flags.draw_colorbar      = true;
 
   grid_out.set_flags(svg_flags);
   grid_out.write_svg(create_grid(), deallog.get_file_stream());

--- a/tests/grid/grid_out_svg_02.cc
+++ b/tests/grid/grid_out_svg_02.cc
@@ -86,6 +86,11 @@ main()
   svg_flags.level_height_factor            = .5;
   svg_flags.height                         = 0;
   svg_flags.width                          = 2000;
+  svg_flags.label_level_number             = true;
+  svg_flags.label_cell_index               = true;
+  svg_flags.draw_legend                    = true;
+  svg_flags.draw_colorbar                  = true;
+
   grid_out.set_flags(svg_flags);
   grid_out.write_svg(create_grid(), deallog.get_file_stream());
 


### PR DESCRIPTION
The GridOut::write_svg() function now no longer outputs the
cell level and number by default; this also obviates the need for the
colorbar and the caption. This is achieved by changing the defaults in
the constructor of the GridOutFlags::Svg structure. This likely comes
closer to what most users want to see from this function -- namely,
just the mesh for inclusion into text.

It might be easiest to read the four commits individually.