### PR TITLE
Fix doxygen documentation

### DIFF
--- a/source/lac/full_matrix.cc
+++ b/source/lac/full_matrix.cc
@@ -21,11 +21,13 @@ DEAL_II_NAMESPACE_OPEN
 
 #include "full_matrix.inst"
 
-#ifndef DEAL_II_WITH_COMPLEX_VALUES
+#ifndef DOXYGEN
+
+#  ifndef DEAL_II_WITH_COMPLEX_VALUES
 // instantiate for std::complex<double> because we use it internally in
 // FESeries.
 template class FullMatrix<std::complex<double>>;
-#endif
+#  endif
 
 // instantiate for long double manually because we use it in a few places
 // inside the library
@@ -66,19 +68,21 @@ FullMatrix<long double>::add<long double>(const long double,
 // arguments is covered by the default copy constructor and copy operator that
 // is declared separately)
 
-#define TEMPL_OP_EQ(S1, S2) \
-  template FullMatrix<S1> &FullMatrix<S1>::operator=(const FullMatrix<S2> &)
+#  define TEMPL_OP_EQ(S1, S2) \
+    template FullMatrix<S1> &FullMatrix<S1>::operator=(const FullMatrix<S2> &)
 
 TEMPL_OP_EQ(double, float);
 TEMPL_OP_EQ(float, double);
 
-#ifdef DEAL_II_WITH_COMPLEX_VALUES
+#  ifdef DEAL_II_WITH_COMPLEX_VALUES
 TEMPL_OP_EQ(std::complex<double>, std::complex<float>);
 TEMPL_OP_EQ(std::complex<float>, std::complex<double>);
 TEMPL_OP_EQ(std::complex<double>, double);
 TEMPL_OP_EQ(std::complex<float>, float);
-#endif
+#  endif
 
-#undef TEMPL_OP_EQ
+#  undef TEMPL_OP_EQ
+
+#endif
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Hi, The documentation of `FullMatrix` is confusing.

For example, here there should not be a `long double`:
```c++
template void FullMatrix< number >::mmult< long double > ( FullMatrix< number2 > &, const FullMatrix< number2 > & ,
const bool  adding = false)  const
```

This patch fixes this.

