### PR TITLE
Modify the definition of CellId

### DIFF
--- a/doc/news/changes/minor/20190813PeterMunch
+++ b/doc/news/changes/minor/20190813PeterMunch
@@ -1,0 +1,4 @@
+New: The definition of CellID has been modified so that it depends on the 
+unique coarse-cell id and no longer on the coarse-cell index.
+<br>
+(Peter Munch, 2019/08/13)

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3502,7 +3502,7 @@ public:
    * Translate the index of coarse cell to its unique id.
    *
    * @note: See the note of the method
-   * translate_coarse_cell_id_to_coarse_cell_index().
+   * coarse_cell_id_to_coarse_cell_index().
    *
    * @param coarse_cell_index Index of the coarse cell.
    * @return Id of the coarse cell.

--- a/source/grid/cell_id.cc
+++ b/source/grid/cell_id.cc
@@ -158,9 +158,8 @@ template <int dim, int spacedim>
 typename Triangulation<dim, spacedim>::cell_iterator
 CellId::to_cell(const Triangulation<dim, spacedim> &tria) const
 {
-  typename Triangulation<dim, spacedim>::cell_iterator cell(&tria,
-                                                            0,
-                                                            coarse_cell_id);
+  typename Triangulation<dim, spacedim>::cell_iterator cell(
+    &tria, 0, tria.coarse_cell_id_to_coarse_cell_index(coarse_cell_id));
 
   for (unsigned int i = 0; i < n_child_indices; ++i)
     cell = cell->child(static_cast<unsigned int>(child_indices[i]));

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2179,7 +2179,9 @@ CellAccessor<dim, spacedim>::id() const
   Assert(ptr.level() == 0, ExcInternalError());
   const unsigned int coarse_index = ptr.index();
 
-  return {coarse_index, n_child_indices, id.data()};
+  return {this->tria->coarse_cell_index_to_coarse_cell_id(coarse_index),
+          n_child_indices,
+          id.data()};
 }
 
 


### PR DESCRIPTION
This PR is part of the effort to introduce the new `parallel::fullydistributed::Triangulation` (see #8558).

In this PR, the definition of a `CellId` is modified in the sense that it depends now on the coarse-cell id, in contrast to the coarse-cell (level) index. Both have been the same till now, however, cannot be the same in the fully distributed case.

I have introduced in the `Triangulation` class two new methods to translate the ids and the indices:
```cpp
  virtual unsigned int
  translate_coarse_cell_id_to_coarse_cell_index(
    const unsigned int coarse_cell_id) const;

  virtual unsigned int
  translate_coarse_cell_index_to_coarse_cell_id(
    const unsigned int coarse_cell_index) const;
```
These methods are at the moment very boring: they simply return the input value... However, will be overridden in coming PRs. In the case of `p:d:t`, they will access `coarse_cell_to_p4est_tree_permutation` and `p4est_tree_to_coarse_cell_permutation`. In the case of `p:f:t`, id will become global id and index a local id. 