### PR TITLE
Exclude MacOS self-generated files from untracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,16 @@ CMakeLists.txt.user
 # temporary and backup files
 *~
 *#
+*.swp
+
+# MacOS self-generated files
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
 
 # configuration, executable, and output files from examples
 examples/step-*/*dat


### PR DESCRIPTION
I don't know if this change could be useful for other Mac users, but this avoids seeing the hidden files generated by MacOS in the untracked files.

ping @luca-heltai 