### PR TITLE
Update deprecated warning message in parallel_block_vector.h.

### DIFF
--- a/include/deal.II/lac/parallel_block_vector.h
+++ b/include/deal.II/lac/parallel_block_vector.h
@@ -21,7 +21,7 @@
 #include <deal.II/lac/la_parallel_block_vector.h>
 
 DEAL_II_WARNING(
-  "This file is deprecated. Use <deal.II/lac/la_block_vector.h> and LinearAlgebra::distributed::BlockVector instead.")
+  "This file is deprecated. Use <deal.II/lac/la_parallel_block_vector.h> and LinearAlgebra::distributed::BlockVector instead.")
 
 #include <cstring>
 #include <iomanip>


### PR DESCRIPTION
The warning suggests including a file which doesn't exist. Change the
message to the intended file.