### PR TITLE
Add a push_back member function to Quadrature<dim>.

### DIFF
--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -197,6 +197,15 @@ public:
              const std::vector<double> &    weights);
 
   /**
+   * Extend the given formula by an additional quadrature point.
+   *
+   * @note This function should only be used during construction of the
+   * quadrature formula.
+   */
+  void
+  push_back(const Point<dim> &point, const double weight);
+
+  /**
    * Number of quadrature points.
    */
   unsigned int

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -58,6 +58,16 @@ Quadrature<dim>::initialize(const std::vector<Point<dim>> &p,
 
 
 template <int dim>
+void
+Quadrature<dim>::push_back(const Point<dim> &point, const double weight)
+{
+  quadrature_points.push_back(point);
+  weights.push_back(weight);
+}
+
+
+
+template <int dim>
 Quadrature<dim>::Quadrature(const std::vector<Point<dim>> &points,
                             const std::vector<double> &    weights)
   : quadrature_points(points)

--- a/tests/base/quadrature_push_back.cc
+++ b/tests/base/quadrature_push_back.cc
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+#include <deal.II/base/quadrature.h>
+
+#include "../tests.h"
+
+/*
+ * Test that it is possible to add a point to the quadrature formula using the
+ * push_back function.
+ */
+template <int dim>
+void
+test_push_back()
+{
+  Quadrature<dim>  quadrature;
+  const Point<dim> point  = Point<dim>::unit_vector(0);
+  const double     weight = .5;
+  quadrature.push_back(point, weight);
+
+  AssertThrow(1 == quadrature.size(), ExcInternalError());
+  deallog << "point: " << quadrature.point(0) << std::endl;
+  deallog << "weight: " << quadrature.weight(0) << std::endl;
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+  test_push_back<1>();
+  test_push_back<2>();
+  test_push_back<3>();
+}

--- a/tests/base/quadrature_push_back.output
+++ b/tests/base/quadrature_push_back.output
@@ -1,0 +1,10 @@
+
+DEAL::point: 1.00000
+DEAL::weight: 0.500000
+DEAL::OK
+DEAL::point: 1.00000 0.00000
+DEAL::weight: 0.500000
+DEAL::OK
+DEAL::point: 1.00000 0.00000 0.00000
+DEAL::weight: 0.500000
+DEAL::OK


### PR DESCRIPTION
Immersed quadrature rules are complicated to construct. It is often
done in several steps over different parts of a cell. The
implementation of the algorithm generating immersed quadratures will be
simplified if we can pass around a reference to a Quadrature<dim> and
push back quadrature points on it consecutively.