### PR TITLE
Fix clang-tidy complaints for Symengine

### DIFF
--- a/include/deal.II/differentiation/sd/symengine_number_types.h
+++ b/include/deal.II/differentiation/sd/symengine_number_types.h
@@ -517,7 +517,7 @@ namespace Differentiation
        * to that of the @p rhs object.
        */
       Expression &
-      operator=(Expression &&rhs);
+      operator=(Expression &&rhs) noexcept;
 
       /**
        * Addition assignment.

--- a/include/deal.II/differentiation/sd/symengine_product_types.h
+++ b/include/deal.II/differentiation/sd/symengine_product_types.h
@@ -36,7 +36,7 @@ DEAL_II_NAMESPACE_OPEN
 template <>
 struct EnableIfScalar<Differentiation::SD::Expression>
 {
-  typedef Differentiation::SD::Expression type;
+  using type = Differentiation::SD::Expression;
 };
 
 
@@ -69,7 +69,7 @@ namespace internal
       Differentiation::SD::Expression,
       typename std::enable_if<std::is_arithmetic<T>::value>::type>
     {
-      typedef Differentiation::SD::Expression type;
+      using type = Differentiation::SD::Expression;
     };
 
     template <typename T>
@@ -80,7 +80,7 @@ namespace internal
         boost::is_complex<T>::value &&
         std::is_arithmetic<typename T::value_type>::value>::type>
     {
-      typedef Differentiation::SD::Expression type;
+      using type = Differentiation::SD::Expression;
     };
 
   } // namespace SD
@@ -90,26 +90,22 @@ namespace internal
   struct ProductTypeImpl<Differentiation::SD::Expression,
                          Differentiation::SD::Expression>
   {
-    typedef Differentiation::SD::Expression type;
+    using type = Differentiation::SD::Expression;
   };
 
 
   template <typename T>
   struct ProductTypeImpl<T, Differentiation::SD::Expression>
   {
-    typedef
-      typename SD::GeneralProductTypeImpl<T,
-                                          Differentiation::SD::Expression>::type
-        type;
+    using type = typename SD::
+      GeneralProductTypeImpl<T, Differentiation::SD::Expression>::type;
   };
 
   template <typename T>
   struct ProductTypeImpl<Differentiation::SD::Expression, T>
   {
-    typedef
-      typename SD::GeneralProductTypeImpl<T,
-                                          Differentiation::SD::Expression>::type
-        type;
+    using type = typename SD::
+      GeneralProductTypeImpl<T, Differentiation::SD::Expression>::type;
   };
 
 } // namespace internal

--- a/source/differentiation/sd/symengine_number_types.cc
+++ b/source/differentiation/sd/symengine_number_types.cc
@@ -317,7 +317,7 @@ namespace Differentiation
 
 
     Expression &
-    Expression::operator=(Expression &&rhs)
+    Expression::operator=(Expression &&rhs) noexcept
     {
       if (this != &rhs)
         this->expression = std::move(rhs.expression);

--- a/source/differentiation/sd/symengine_scalar_operations.cc
+++ b/source/differentiation/sd/symengine_scalar_operations.cc
@@ -239,7 +239,7 @@ namespace Differentiation
                 }
 
               // Compute and store the hash of the new object
-              hash_old = std::move(hash_new);
+              hash_old = hash_new;
               hash_new = out.get_RCP()->hash();
               AssertThrow(
                 iter < size,

--- a/source/differentiation/sd/symengine_utilities.cc
+++ b/source/differentiation/sd/symengine_utilities.cc
@@ -59,11 +59,8 @@ namespace Differentiation
         SD::types::symbol_vector symbols;
         symbols.reserve(substitution_values.size());
 
-        for (typename SD::types::substitution_map::const_iterator it =
-               substitution_values.begin();
-             it != substitution_values.end();
-             ++it)
-          symbols.push_back(it->first);
+        for (const auto &substitution : substitution_values)
+          symbols.push_back(substitution.first);
 
         return symbols;
       }


### PR DESCRIPTION
It seems that we never ran `clang-tidy` on a build with the `Symengine` dependency enabled.

The full output was
```
clang-tidy-6.0 -header-filter=/home/darndt/dealii-new/include/*/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_number_types.h:520:7: error: move assignment operators should be marked noexcept [performance-noexcept-move-constructor,-warnings-as-errors]
/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_number_types.h:520:7: error: move assignment operators should be marked noexcept [performance-noexcept-move-constructor,-warnings-as-errors]
/home/darndt/dealii-new/source/differentiation/sd/symengine_scalar_operations.cc:242:26: error: std::move of the variable 'hash_new' of the trivially-copyable type 'SE::hash_t' (aka 'unsigned long') has no effect; remove std::move() [performance-move-const-arg,-warnings-as-errors]
/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_number_types.h:520:7: error: move assignment operators should be marked noexcept [performance-noexcept-move-constructor,-warnings-as-errors]
/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_product_types.h:39:3: error: use 'using' instead of 'typedef' [modernize-use-using,-warnings-as-errors]
/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_product_types.h:72:7: error: use 'using' instead of 'typedef' [modernize-use-using,-warnings-as-errors]
/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_product_types.h:83:7: error: use 'using' instead of 'typedef' [modernize-use-using,-warnings-as-errors]
/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_product_types.h:93:5: error: use 'using' instead of 'typedef' [modernize-use-using,-warnings-as-errors]
/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_product_types.h:100:5: error: use 'using' instead of 'typedef' [modernize-use-using,-warnings-as-errors]
/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_product_types.h:109:5: error: use 'using' instead of 'typedef' [modernize-use-using,-warnings-as-errors]
/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_number_types.h:520:7: error: move assignment operators should be marked noexcept [performance-noexcept-move-constructor,-warnings-as-errors]
/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_number_types.h:520:7: error: move assignment operators should be marked noexcept [performance-noexcept-move-constructor,-warnings-as-errors]
/home/darndt/dealii-new/source/differentiation/sd/symengine_utilities.cc:62:9: error: use range-based for loop instead [modernize-loop-convert,-warnings-as-errors]
clang-tidy-6.0 -header-filter=/home/darndt/dealii-new/include/* -p=. -quiet /home/darndt/dealii-new/source/non_matching/immersed_surfa/home/darndt/dealii-new/include/deal.II/differentiation/sd/symengine_number_types.h:520:7: error: move assignment operators should be marked noexcept [performance-noexcept-move-constructor,-warnings-as-errors]
/home/darndt/dealii-new/source/differentiation/sd/symengine_number_types.cc:320:17: error: move assignment operators should be marked noexcept [performance-noexcept-move-constructor,-warnings-as-errors]
```