### PR TITLE
added #ifndef DOXYGEN to forward declarations

### DIFF
--- a/doc/news/changes/minor/20190816RezaRastak
+++ b/doc/news/changes/minor/20190816RezaRastak
@@ -1,0 +1,4 @@
+Fixed: Forward declarations in header files are prevented from confusing
+doxygen.
+<br>
+(Reza Rastak, 2019/08/16)

--- a/include/deal.II/algorithms/newton.h
+++ b/include/deal.II/algorithms/newton.h
@@ -26,7 +26,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 class ParameterHandler;
+#endif
 
 namespace Algorithms
 {

--- a/include/deal.II/algorithms/theta_timestepping.h
+++ b/include/deal.II/algorithms/theta_timestepping.h
@@ -24,7 +24,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 class ParameterHandler;
+#endif
 
 namespace Algorithms
 {

--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -26,7 +26,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 class ParameterHandler;
+#endif
 
 namespace Algorithms
 {

--- a/include/deal.II/base/complex_overloads.h
+++ b/include/deal.II/base/complex_overloads.h
@@ -23,10 +23,12 @@
 DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
+#ifndef DOXYGEN
 template <typename T>
 struct EnableIfScalar;
 template <typename T, typename U>
 struct ProductType;
+#endif
 
 #ifndef DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS
 /**

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -47,9 +47,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
+// Forward declarations
+#ifndef DOXYGEN
 class ParameterHandler;
 class XDMFEntry;
+#endif
 
 /**
  * This is a base class for output of data on meshes of very general form.

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -31,11 +31,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
+// Forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class Vector;
 template <int rank, int dim, typename Number>
 class TensorFunction;
+#endif
 
 /**
  * This class is a model for a general function that, given a point at which

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -36,10 +36,11 @@ namespace mu
 
 DEAL_II_NAMESPACE_OPEN
 
-
+// Forward declaration
+#ifndef DOXYGEN
 template <typename>
 class Vector;
-
+#endif
 
 /**
  * This class implements a function object that gets its value by parsing a

--- a/include/deal.II/base/incremental_function.h
+++ b/include/deal.II/base/incremental_function.h
@@ -22,8 +22,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <typename number>
 class Vector;
+#endif
 
 namespace Functions
 {

--- a/include/deal.II/base/iterator_range.h
+++ b/include/deal.II/base/iterator_range.h
@@ -27,10 +27,11 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-// Forward declarations
+// Forward declaration
+#ifndef DOXYGEN
 template <typename Iterator>
 class IteratorOverIterators;
-
+#endif
 
 
 /**

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -87,6 +87,7 @@ DEAL_II_NAMESPACE_OPEN
 
 
 // Forward type declarations to allow MPI sums over tensorial types
+#ifndef DOXYGEN
 template <int rank, int dim, typename Number>
 class Tensor;
 template <int rank, int dim, typename Number>
@@ -94,6 +95,7 @@ class SymmetricTensor;
 template <typename Number>
 class SparseMatrix;
 class IndexSet;
+#endif
 
 namespace Utilities
 {

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -126,12 +126,14 @@ namespace internal
 } // namespace internal
 
 // forward declarations to support abs or sqrt operations on VectorizedArray
+#ifndef DOXYGEN
 template <typename Number,
           int width =
             internal::VectorizedArrayWidthSpecifier<Number>::max_width>
 class VectorizedArray;
 template <typename T>
 struct EnableIfScalar;
+#endif
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -36,8 +36,10 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations for interfaces and friendship
+#ifndef DOXYGEN
 class LogStream;
 class MultipleParameterLoop;
+#endif
 
 /**
  * The ParameterHandler class provides a standard interface to an input file

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -54,10 +54,12 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations for interfaces and friendship
+#ifndef DOXYGEN
 class LogStream;
 class MultipleParameterLoop;
 template <int dim>
 class FunctionParser;
+#endif
 
 /**
  * Namespace for a few classes that act as patterns for the ParameterHandler

--- a/include/deal.II/base/process_grid.h
+++ b/include/deal.II/base/process_grid.h
@@ -27,9 +27,10 @@ DEAL_II_NAMESPACE_OPEN
 
 
 // Forward declaration of class ScaLAPACKMatrix for ProcessGrid
+#  ifndef DOXYGEN
 template <typename NumberType>
 class ScaLAPACKMatrix;
-
+#  endif
 
 namespace Utilities
 {

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -28,8 +28,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <int rank, int dim, typename Number = double>
 class SymmetricTensor;
+#endif
 
 template <int dim, typename Number>
 DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE SymmetricTensor<2, dim, Number>

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -31,6 +31,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declaration
+#ifndef DOXYGEN
 template <int N, typename T>
 class TableBase;
 template <int N, typename T>
@@ -49,6 +50,7 @@ template <typename T>
 class Table<5, T>;
 template <typename T>
 class Table<6, T>;
+#endif
 
 
 

--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -36,7 +36,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 class TableHandler;
+#endif
 
 namespace internal
 {

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -38,13 +38,14 @@
 DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations:
-
+#ifndef DOXYGEN
 template <int dim, typename Number>
 class Point;
 template <int rank_, int dim, typename Number = double>
 class Tensor;
 template <typename Number>
 class Vector;
+#endif
 
 #ifndef DOXYGEN
 // Overload invalid tensor types of negative rank that come up during

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -61,8 +61,10 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 DEAL_II_NAMESPACE_OPEN
 
 // forward declare Point
+#ifndef DOXYGEN
 template <int dim, typename Number>
 class Point;
+#endif
 
 /**
  * A namespace for utility functions that are not particularly specific to

--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -38,6 +38,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#  ifndef DOXYGEN
 namespace parallel
 {
   namespace distributed
@@ -46,7 +48,7 @@ namespace parallel
     class Triangulation;
   }
 } // namespace parallel
-
+#  endif
 
 namespace internal
 {

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -56,6 +56,8 @@ DEAL_II_NAMESPACE_OPEN
 
 #ifdef DEAL_II_WITH_P4EST
 
+// Forward declarations
+#  ifndef DOXYGEN
 namespace internal
 {
   namespace DoFHandlerImplementation
@@ -83,6 +85,7 @@ namespace GridTools
   template <typename CellIterator>
   struct PeriodicFacePair;
 }
+#  endif
 
 namespace parallel
 {

--- a/include/deal.II/dofs/block_info.h
+++ b/include/deal.II/dofs/block_info.h
@@ -26,7 +26,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
-
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class DoFHandler;
 namespace hp
@@ -34,6 +34,7 @@ namespace hp
   template <int dim, int spacedim>
   class DoFHandler;
 }
+#endif
 
 
 /**

--- a/include/deal.II/dofs/deprecated_function_map.h
+++ b/include/deal.II/dofs/deprecated_function_map.h
@@ -22,9 +22,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <int spacedim, typename RangeNumberType>
 class Function;
-
+#endif
 
 
 /**

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -29,6 +29,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class FullMatrix;
 template <typename number>
@@ -41,7 +43,6 @@ class TriaRawIterator;
 
 template <int, int>
 class FiniteElement;
-
 
 namespace internal
 {
@@ -67,6 +68,7 @@ namespace internal
     }
   } // namespace hp
 } // namespace internal
+#endif
 
 // note: the file dof_accessor.templates.h is included at the end of
 // this file.  this includes a lot of templates and thus makes

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -44,6 +44,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class FiniteElement;
 template <int dim, int spacedim>
@@ -73,7 +75,7 @@ namespace internal
     struct Implementation;
   }
 } // namespace internal
-
+#endif
 
 /**
  * Given a triangulation and a description of a finite element, this

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -32,9 +32,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#  ifndef DOXYGEN
 template <int, int>
 class DoFHandler;
-
+#  endif
 
 namespace internal
 {

--- a/include/deal.II/dofs/dof_iterator_selector.h
+++ b/include/deal.II/dofs/dof_iterator_selector.h
@@ -21,6 +21,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int, int, int>
 class DoFInvalidAccessor;
 
@@ -35,6 +37,7 @@ template <typename Accessor>
 class TriaIterator;
 template <typename Accessor>
 class TriaActiveIterator;
+#endif
 
 namespace internal
 {

--- a/include/deal.II/dofs/dof_objects.h
+++ b/include/deal.II/dofs/dof_objects.h
@@ -25,18 +25,22 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int, int>
 class DoFHandler;
+#endif
 
 namespace internal
 {
   namespace DoFHandlerImplementation
   {
+#ifndef DOXYGEN
     template <int>
     class DoFLevel;
     template <int>
     class DoFFaces;
-
+#endif
 
     /**
      * Store the indices of the degrees of freedom which are located on

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -39,6 +39,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 class BlockMask;
 template <int dim, typename RangeNumberType>
 class Function;
@@ -66,7 +68,7 @@ namespace GridTools
   template <typename CellIterator>
   struct PeriodicFacePair;
 }
-
+#endif
 
 /**
  * This is a collection of functions operating on, and manipulating the

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -25,10 +25,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class MappingQ;
 template <int dim>
 class Quadrature;
+#endif
 
 /*!@addtogroup fe */
 /*@{*/

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -35,9 +35,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#  ifndef DOXYGEN
 template <int dim, int spacedim>
 class FE_Enriched;
-
+#  endif
 
 /**
  * This class provides an interface to group several elements together into

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -39,6 +39,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class FullMatrix;
 template <int dim>
@@ -51,7 +53,7 @@ template <int dim>
 class FiniteElementData;
 template <typename number>
 class AffineConstraints;
-
+#endif
 
 
 /*!@addtogroup feall */

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -29,9 +29,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <int, int>
 class FiniteElement;
-
+#endif
 
 /*!@addtogroup feaccess */
 /*@{*/

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -53,8 +53,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <int dim, int spacedim = dim>
 class FEValuesBase;
+#endif
 
 namespace internal
 {

--- a/include/deal.II/grid/cell_id.h
+++ b/include/deal.II/grid/cell_id.h
@@ -31,8 +31,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int, int>
 class Triangulation;
+#endif
 
 /**
  * A class to represent a unique ID for a cell in a Triangulation. It is

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -29,10 +29,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int dim, int space_dim>
 class Triangulation;
 template <int dim>
 struct CellData;
+#endif
 
 /**
  * This class implements an input mechanism for grid data. It allows to read a

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -28,11 +28,14 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 class ParameterHandler;
 template <int dim, int spacedim>
 class Triangulation;
 template <int dim, int spacedim>
 class Mapping;
+#endif
 
 
 /**

--- a/include/deal.II/grid/grid_refinement.h
+++ b/include/deal.II/grid/grid_refinement.h
@@ -26,10 +26,12 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class Triangulation;
 template <typename Number>
 class Vector;
+#endif
 
 /**
  * This namespace provides a collection of functions that aid in refinement

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -62,6 +62,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#  ifndef DOXYGEN
 namespace parallel
 {
   namespace distributed
@@ -78,6 +80,7 @@ namespace hp
 }
 
 class SparsityPattern;
+#  endif
 
 namespace internal
 {

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -33,8 +33,10 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declaration
+#ifndef DOXYGEN
 template <int, typename>
 class Table;
+#endif
 
 /**
  * We collect here some helper functions used in the Manifold<dim,spacedim>

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -44,6 +44,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class Manifold;
 
@@ -91,7 +93,7 @@ namespace hp
   template <int dim, int spacedim>
   class DoFHandler;
 }
-
+#endif
 
 /*------------------------------------------------------------------------*/
 

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -33,6 +33,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class Triangulation;
 template <typename Accessor>
@@ -44,7 +46,7 @@ class TriaActiveIterator;
 
 template <int dim, int spacedim>
 class Manifold;
-
+#endif
 
 namespace internal
 {

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -35,11 +35,14 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 namespace parallel
 {
   template <int, int>
   class Triangulation;
 }
+#endif
 
 
 /*--------------------- Functions: TriaAccessorBase -------------------------*/

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -32,6 +32,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#  ifndef DOXYGEN
 template <int dim, int spacedim>
 class Triangulation;
 template <int, int, int>
@@ -41,6 +43,7 @@ template <typename>
 class TriaIterator;
 template <typename>
 class TriaActiveIterator;
+#  endif
 
 
 

--- a/include/deal.II/grid/tria_iterator_selector.h
+++ b/include/deal.II/grid/tria_iterator_selector.h
@@ -21,6 +21,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class CellAccessor;
 template <int, int, int>
@@ -35,6 +37,7 @@ template <typename Accessor>
 class TriaIterator;
 template <typename Accessor>
 class TriaActiveIterator;
+#endif
 
 namespace internal
 {

--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -39,12 +39,15 @@ DEAL_II_NAMESPACE_OPEN
 // bool and then an integer and then a double, etc. Verify that this is
 // actually the case.
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class Triangulation;
 template <class Accessor>
 class TriaRawIterator;
 template <int, int, int>
 class TriaAccessor;
+#endif
 
 namespace internal
 {

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -42,6 +42,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class Triangulation;
 
@@ -91,7 +93,7 @@ namespace internal
     struct Implementation;
   }
 } // namespace internal
-
+#endif
 
 
 namespace hp

--- a/include/deal.II/hp/dof_level.h
+++ b/include/deal.II/hp/dof_level.h
@@ -26,6 +26,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 namespace hp
 {
   template <int, int>
@@ -49,6 +51,7 @@ namespace internal
     struct Implementation;
   }
 } // namespace internal
+#endif
 
 
 namespace internal

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -30,9 +30,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class FiniteElement;
-
+#endif
 
 
 namespace internal

--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -24,6 +24,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
+#ifndef DOXYGEN
 template <typename Number>
 class Vector;
 
@@ -32,6 +33,7 @@ namespace hp
   template <int dim, int spacedim>
   class DoFHandler;
 }
+#endif
 
 namespace hp
 {

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -35,6 +35,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <typename>
 class FullMatrix;
 class SparsityPattern;
@@ -55,6 +57,7 @@ namespace internals
 
 template <typename number>
 class AffineConstraints;
+#endif
 
 /**
  * ConstraintMatrix has been renamed to AffineConstraints. Provide a

--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -26,7 +26,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations:
-
+#ifndef DOXYGEN
 namespace internal
 {
   namespace BlockLinearOperatorImplementation
@@ -45,6 +45,7 @@ template <typename Range  = BlockVector<double>,
           typename BlockPayload =
             internal::BlockLinearOperatorImplementation::EmptyBlockPayload<>>
 class BlockLinearOperator;
+#endif
 
 template <typename Range  = BlockVector<double>,
           typename Domain = Range,

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -37,9 +37,11 @@
 DEAL_II_NAMESPACE_OPEN
 
 
+// Forward declaration
+#ifndef DOXYGEN
 template <typename>
 class MatrixIterator;
-
+#endif
 
 
 /*! @addtogroup Matrix1

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -34,8 +34,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <typename Number>
 class BlockVector;
+#endif
 
 /*! @addtogroup Matrix1
  *@{

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -31,10 +31,12 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
+// Forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class BlockSparseMatrix;
 class BlockDynamicSparsityPattern;
+#endif
 
 /*! @addtogroup Sparsity
  *@{

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -32,7 +32,9 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-#ifdef DEAL_II_WITH_TRILINOS
+// Forward declaration
+#ifndef DOXYGEN
+#  ifdef DEAL_II_WITH_TRILINOS
 namespace TrilinosWrappers
 {
   namespace MPI
@@ -40,6 +42,7 @@ namespace TrilinosWrappers
     class BlockVector;
   }
 } // namespace TrilinosWrappers
+#  endif
 #endif
 
 

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -41,9 +41,11 @@ DEAL_II_NAMESPACE_OPEN
  *@{
  */
 
+// Forward declaration
+#ifndef DOXYGEN
 template <typename>
 class BlockVectorBase;
-
+#endif
 
 /**
  * A class that can be used to determine whether a given type is a block

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -31,10 +31,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#  ifndef DOXYGEN
 template <typename number>
 class Vector;
 template <typename number>
 class FullMatrix;
+#  endif
 
 /*! @addtogroup Matrix1
  *@{

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -30,9 +30,11 @@
 DEAL_II_NAMESPACE_OPEN
 
 
+// Forward declaration
+#ifndef DOXYGEN
 template <typename>
 class ChunkSparseMatrix;
-
+#endif
 
 /*! @addtogroup Sparsity
  *@{

--- a/include/deal.II/lac/communication_pattern_base.h
+++ b/include/deal.II/lac/communication_pattern_base.h
@@ -22,7 +22,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 class IndexSet;
+#endif
 
 namespace LinearAlgebra
 {

--- a/include/deal.II/lac/cuda_precondition.h
+++ b/include/deal.II/lac/cuda_precondition.h
@@ -28,6 +28,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward-definition
+#  ifndef DOXYGEN
 namespace LinearAlgebra
 {
   namespace CUDAWrappers
@@ -36,6 +37,7 @@ namespace LinearAlgebra
     class Vector;
   }
 } // namespace LinearAlgebra
+#  endif
 
 namespace CUDAWrappers
 {

--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -28,9 +28,12 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#  ifndef DOXYGEN
 class CommunicationPatternBase;
 template <typename Number>
 class ReadWriteVector;
+#  endif
 
 namespace LinearAlgebra
 {

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -31,7 +31,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 class DynamicSparsityPattern;
+#endif
 
 /*! @addtogroup Sparsity
  *@{

--- a/include/deal.II/lac/filtered_matrix.h
+++ b/include/deal.II/lac/filtered_matrix.h
@@ -32,8 +32,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#  ifndef DOXYGEN
 template <class VectorType>
 class FilteredMatrixBlock;
+#  endif
 
 /*! @addtogroup Matrix2
  *@{

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -36,11 +36,12 @@ DEAL_II_NAMESPACE_OPEN
 
 
 // forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class Vector;
 template <typename number>
 class LAPACKFullMatrix;
-
+#endif
 
 /*! @addtogroup Matrix1
  *@{

--- a/include/deal.II/lac/householder.h
+++ b/include/deal.II/lac/householder.h
@@ -29,9 +29,10 @@ DEAL_II_NAMESPACE_OPEN
 
 
 // forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class Vector;
-
+#endif
 
 /*! @addtogroup Matrix2
  *@{

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -33,7 +33,9 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-#ifdef DEAL_II_WITH_PETSC
+// Forward declarations
+#ifndef DOXYGEN
+#  ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   namespace MPI
@@ -41,9 +43,9 @@ namespace PETScWrappers
     class BlockVector;
   }
 } // namespace PETScWrappers
-#endif
+#  endif
 
-#ifdef DEAL_II_WITH_TRILINOS
+#  ifdef DEAL_II_WITH_TRILINOS
 namespace TrilinosWrappers
 {
   namespace MPI
@@ -51,6 +53,7 @@ namespace TrilinosWrappers
     class BlockVector;
   }
 } // namespace TrilinosWrappers
+#  endif
 #endif
 
 namespace LinearAlgebra

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -31,8 +31,10 @@ DEAL_II_NAMESPACE_OPEN
 // Forward type declaration to have special treatment of
 // LAPACKFullMatrix<number>
 // in multivector_inner_product()
+#ifndef DOXYGEN
 template <typename Number>
 class LAPACKFullMatrix;
+#endif
 
 namespace LinearAlgebra
 {

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -33,6 +33,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 namespace LinearAlgebra
 {
   /**
@@ -48,7 +50,7 @@ namespace LinearAlgebra
   class ReadWriteVector;
 } // namespace LinearAlgebra
 
-#ifdef DEAL_II_WITH_PETSC
+#  ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   namespace MPI
@@ -56,9 +58,9 @@ namespace PETScWrappers
     class Vector;
   }
 } // namespace PETScWrappers
-#endif
+#  endif
 
-#ifdef DEAL_II_WITH_TRILINOS
+#  ifdef DEAL_II_WITH_TRILINOS
 namespace TrilinosWrappers
 {
   namespace MPI
@@ -66,6 +68,7 @@ namespace TrilinosWrappers
     class Vector;
   }
 } // namespace TrilinosWrappers
+#  endif
 #endif
 
 namespace LinearAlgebra

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -33,6 +33,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class Vector;
 template <typename number>
@@ -41,7 +42,7 @@ template <typename number>
 class FullMatrix;
 template <typename number>
 class SparseMatrix;
-
+#endif
 
 /**
  * A variant of FullMatrix using LAPACK functions wherever possible. In order

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -29,7 +29,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations:
-
+#ifndef DOXYGEN
 namespace internal
 {
   namespace LinearOperatorImplementation
@@ -48,6 +48,7 @@ template <typename Range  = Vector<double>,
           typename Payload =
             internal::LinearOperatorImplementation::EmptyPayload>
 class LinearOperator;
+#endif
 
 template <
   typename Range   = Vector<double>,

--- a/include/deal.II/lac/matrix_block.h
+++ b/include/deal.II/lac/matrix_block.h
@@ -34,8 +34,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <typename MatrixType>
 class MatrixBlock;
+#endif
 
 namespace internal
 {

--- a/include/deal.II/lac/matrix_lib.h
+++ b/include/deal.II/lac/matrix_lib.h
@@ -23,12 +23,15 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class Vector;
 template <typename number>
 class BlockVector;
 template <typename number>
 class SparseMatrix;
+#endif
 
 /*! @addtogroup Matrix2
  *@{

--- a/include/deal.II/lac/packaged_operation.h
+++ b/include/deal.II/lac/packaged_operation.h
@@ -27,12 +27,14 @@
 DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations:
+#ifndef DOXYGEN
 template <typename Number>
 class Vector;
 template <typename Range, typename Domain, typename Payload>
 class LinearOperator;
 template <typename Range = Vector<double>>
 class PackagedOperation;
+#endif
 
 
 /**

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -37,8 +37,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#    ifndef DOXYGEN
 template <typename Matrix>
 class BlockMatrixBase;
+#    endif
 
 
 namespace PETScWrappers

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -32,10 +32,11 @@ DEAL_II_NAMESPACE_OPEN
 namespace PETScWrappers
 {
   // forward declarations
+#    ifndef DOXYGEN
   class MatrixBase;
   class VectorBase;
   class SolverBase;
-
+#    endif
 
   /**
    * Base class for preconditioner classes using the PETSc functionality. The

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -34,20 +34,25 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-#    ifdef DEAL_II_WITH_SLEPC
+// Forward declarations
+#    ifndef DOXYGEN
+#      ifdef DEAL_II_WITH_SLEPC
 namespace SLEPcWrappers
 {
   // forward declarations
   class TransformationBase;
 } // namespace SLEPcWrappers
+#      endif
 #    endif
 
 namespace PETScWrappers
 {
   // forward declarations
+#    ifndef DOXYGEN
   class MatrixBase;
   class VectorBase;
   class PreconditionerBase;
+#    endif
 
 
   /**

--- a/include/deal.II/lac/petsc_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_sparse_matrix.h
@@ -29,9 +29,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 // forward declaration
+#    ifndef DOXYGEN
 template <typename MatrixType>
 class BlockMatrixBase;
-
+#    endif
 
 namespace PETScWrappers
 {

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -36,9 +36,15 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declaration
+#    ifndef DOXYGEN
 template <typename number>
 class Vector;
 
+namespace PETScWrappers
+{
+  class VectorBase;
+}
+#    endif
 
 /**
  * A namespace in which wrapper classes for PETSc objects reside.
@@ -49,9 +55,6 @@ class Vector;
  */
 namespace PETScWrappers
 {
-  // forward declaration
-  class VectorBase;
-
   /**
    * @cond internal
    */

--- a/include/deal.II/lac/pointer_matrix.h
+++ b/include/deal.II/lac/pointer_matrix.h
@@ -24,6 +24,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <typename VectorType>
 class VectorMemory;
 
@@ -44,6 +46,7 @@ template <typename number>
 class TridiagonalMatrix;
 template <typename number, typename BlockVectorType>
 class BlockMatrixArray;
+#endif
 
 /*! @addtogroup Matrix2
  *@{

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -34,7 +34,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
-
+#ifndef DOXYGEN
 template <typename number>
 class Vector;
 template <typename number>
@@ -47,7 +47,7 @@ namespace LinearAlgebra
     class Vector;
   } // namespace distributed
 } // namespace LinearAlgebra
-
+#endif
 
 
 /*! @addtogroup Preconditioners

--- a/include/deal.II/lac/precondition_block_base.h
+++ b/include/deal.II/lac/precondition_block_base.h
@@ -31,10 +31,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class FullMatrix;
 template <typename number>
 class Vector;
+#endif
 
 /**
  * A class storing the inverse diagonal blocks for block preconditioners and

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -26,10 +26,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <class number>
 class Vector;
 template <class number>
 class SparseMatrix;
+#endif
 
 
 /*! @addtogroup Preconditioners

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -43,6 +43,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 namespace LinearAlgebra
 {
   class CommunicationPatternBase;
@@ -53,7 +55,7 @@ namespace LinearAlgebra
   } // namespace distributed
 } // namespace LinearAlgebra
 
-#ifdef DEAL_II_WITH_PETSC
+#  ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   namespace MPI
@@ -61,9 +63,9 @@ namespace PETScWrappers
     class Vector;
   }
 } // namespace PETScWrappers
-#endif
+#  endif
 
-#ifdef DEAL_II_WITH_TRILINOS
+#  ifdef DEAL_II_WITH_TRILINOS
 namespace TrilinosWrappers
 {
   namespace MPI
@@ -71,9 +73,9 @@ namespace TrilinosWrappers
     class Vector;
   }
 } // namespace TrilinosWrappers
-#endif
+#  endif
 
-#ifdef DEAL_II_WITH_CUDA
+#  ifdef DEAL_II_WITH_CUDA
 namespace LinearAlgebra
 {
   namespace CUDAWrappers
@@ -82,6 +84,7 @@ namespace LinearAlgebra
     class Vector;
   }
 } // namespace LinearAlgebra
+#  endif
 #endif
 
 namespace LinearAlgebra

--- a/include/deal.II/lac/slepc_spectral_transformation.h
+++ b/include/deal.II/lac/slepc_spectral_transformation.h
@@ -33,11 +33,14 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#    ifndef DOXYGEN
 namespace PETScWrappers
 {
   // forward declarations
   class SolverBase;
 } // namespace PETScWrappers
+#    endif
 
 namespace SLEPcWrappers
 {

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -28,8 +28,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <typename number>
 class Vector;
+#endif
 
 /**
  * A base class for iterative linear solvers. This class provides interfaces

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -32,7 +32,9 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declaration
+#ifndef DOXYGEN
 class PreconditionIdentity;
+#endif
 
 
 /*!@addtogroup Solvers */

--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -25,7 +25,9 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifndef DOXYGEN
 class ParameterHandler;
+#endif
 
 /*!@addtogroup Solvers */
 /*@{*/

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -35,6 +35,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#  ifndef DOXYGEN
 template <typename number>
 class Vector;
 template <typename number>
@@ -43,7 +45,7 @@ template <typename Matrix>
 class BlockMatrixBase;
 template <typename number>
 class SparseILU;
-#  ifdef DEAL_II_WITH_MPI
+#    ifdef DEAL_II_WITH_MPI
 namespace Utilities
 {
   namespace MPI
@@ -53,13 +55,14 @@ namespace Utilities
     sum(const SparseMatrix<Number> &, const MPI_Comm &, SparseMatrix<Number> &);
   }
 } // namespace Utilities
-#  endif
+#    endif
 
-#  ifdef DEAL_II_WITH_TRILINOS
+#    ifdef DEAL_II_WITH_TRILINOS
 namespace TrilinosWrappers
 {
   class SparseMatrix;
 }
+#    endif
 #  endif
 
 /**

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -28,10 +28,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#  ifndef DOXYGEN
 template <typename number>
 class Vector;
 template <typename number>
 class FullMatrix;
+#  endif
 
 /**
  * @addtogroup Matrix1

--- a/include/deal.II/lac/sparse_vanka.h
+++ b/include/deal.II/lac/sparse_vanka.h
@@ -28,6 +28,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class FullMatrix;
 template <typename number>
@@ -39,6 +41,7 @@ template <typename number>
 class SparseVanka;
 template <typename number>
 class SparseBlockVanka;
+#endif
 
 /*! @addtogroup Preconditioners
  *@{

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -41,6 +41,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 class SparsityPattern;
 class SparsityPatternBase;
 class DynamicSparsityPattern;
@@ -58,7 +60,7 @@ namespace ChunkSparsityPatternIterators
 {
   class Accessor;
 }
-
+#endif
 
 /*! @addtogroup Sparsity
  *@{

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -28,10 +28,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <typename>
 class Vector;
 template <typename>
 class FullMatrix;
+#endif
 
 /**
  * This is an abstract base class used for a special matrix class, namely the

--- a/include/deal.II/lac/tridiagonal_matrix.h
+++ b/include/deal.II/lac/tridiagonal_matrix.h
@@ -28,9 +28,10 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
+#ifndef DOXYGEN
 template <typename number>
 class Vector;
-
+#endif
 
 /*! @addtogroup Matrix1
  *@{

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -34,10 +34,11 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
+#  ifndef DOXYGEN
 class BlockSparsityPattern;
 template <typename number>
 class BlockSparseMatrix;
-
+#  endif
 
 namespace TrilinosWrappers
 {

--- a/include/deal.II/lac/trilinos_linear_operator.h
+++ b/include/deal.II/lac/trilinos_linear_operator.h
@@ -28,6 +28,7 @@ DEAL_II_NAMESPACE_OPEN
 namespace TrilinosWrappers
 {
   // Forward declarations:
+#  ifndef DOXYGEN
   class SparseMatrix;
   class PreconditionBase;
   class BlockSparseMatrix;
@@ -45,7 +46,7 @@ namespace TrilinosWrappers
       class TrilinosBlockPayload;
     }
   } // namespace internal
-
+#  endif
 
   /**
    * @name Creation of a LinearOperator

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -31,12 +31,9 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declaration
+#  ifndef DOXYGEN
 template <typename Number>
 class BlockVectorBase;
-
-/*! @addtogroup TrilinosWrappers
- *@{
- */
 
 namespace TrilinosWrappers
 {
@@ -46,8 +43,15 @@ namespace TrilinosWrappers
     class BlockVector;
   }
   class BlockSparseMatrix;
+} // namespace TrilinosWrappers
+#  endif
 
+/*! @addtogroup TrilinosWrappers
+ *@{
+ */
 
+namespace TrilinosWrappers
+{
   namespace MPI
   {
     /**

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -40,22 +40,25 @@
 #    include <Teuchos_ParameterList.hpp>
 
 // forward declarations
+#    ifndef DOXYGEN
 class Ifpack_Preconditioner;
 class Ifpack_Chebyshev;
 namespace ML_Epetra
 {
   class MultiLevelPreconditioner;
 }
-
+#    endif
 
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
+#    ifndef DOXYGEN
 template <typename number>
 class SparseMatrix;
 template <typename number>
 class Vector;
 class SparsityPattern;
+#    endif
 
 /*! @addtogroup TrilinosWrappers
  *@{

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -39,8 +39,10 @@ DEAL_II_NAMESPACE_OPEN
 namespace TrilinosWrappers
 {
   // forward declarations
+#    ifndef DOXYGEN
   class SparseMatrix;
   class PreconditionBase;
+#    endif
 
 
   /**

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -55,6 +55,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
+#    ifndef DOXYGEN
 template <typename MatrixType>
 class BlockMatrixBase;
 
@@ -63,23 +64,26 @@ class SparseMatrix;
 class SparsityPattern;
 class DynamicSparsityPattern;
 
-
-
 namespace TrilinosWrappers
 {
-  // forward declarations
   class SparseMatrix;
   class SparsityPattern;
 
+  namespace SparseMatrixIterators
+  {
+    template <bool Constness>
+    class Iterator;
+  }
+} // namespace TrilinosWrappers
+#    endif
+
+namespace TrilinosWrappers
+{
   /**
    * Iterators for Trilinos matrices
    */
   namespace SparseMatrixIterators
   {
-    // forward declaration
-    template <bool Constness>
-    class Iterator;
-
     /**
      * Exception
      */

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -43,20 +43,26 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
+#    ifndef DOXYGEN
 class SparsityPattern;
 class DynamicSparsityPattern;
 
 namespace TrilinosWrappers
 {
-  // forward declarations
   class SparsityPattern;
   class SparseMatrix;
 
   namespace SparsityPatternIterators
   {
-    // forward declaration
     class Iterator;
+  }
+} // namespace TrilinosWrappers
+#    endif
 
+namespace TrilinosWrappers
+{
+  namespace SparsityPatternIterators
+  {
     /**
      * Accessor class for iterators into sparsity patterns. This class is also
      * the base class for both const and non-const accessor classes into

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -43,8 +43,10 @@ DEAL_II_NAMESPACE_OPEN
 namespace LinearAlgebra
 {
   // Forward declaration
+#  ifndef DOXYGEN
   template <typename Number>
   class ReadWriteVector;
+#  endif
 
   namespace TpetraWrappers
   {

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -47,12 +47,15 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#  ifndef DOXYGEN
 namespace LinearAlgebra
 {
   // Forward declaration
   template <typename Number>
   class ReadWriteVector;
 } // namespace LinearAlgebra
+#  endif
 
 /**
  * @addtogroup TrilinosWrappers

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -41,14 +41,16 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-#ifdef DEAL_II_WITH_PETSC
+// Forward declarations
+#ifndef DOXYGEN
+#  ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   class VectorBase;
 }
-#endif
+#  endif
 
-#ifdef DEAL_II_WITH_TRILINOS
+#  ifdef DEAL_II_WITH_TRILINOS
 namespace TrilinosWrappers
 {
   namespace MPI
@@ -56,7 +58,7 @@ namespace TrilinosWrappers
     class Vector;
   }
 } // namespace TrilinosWrappers
-#endif
+#  endif
 
 template <typename number>
 class LAPACKFullMatrix;
@@ -71,7 +73,7 @@ namespace parallel
     class TBBPartitioner;
   }
 } // namespace parallel
-
+#endif
 
 
 /*! @addtogroup Vectors

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -27,6 +27,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 class IndexSet;
 namespace LinearAlgebra
 {
@@ -34,6 +36,7 @@ namespace LinearAlgebra
   template <typename Number>
   class ReadWriteVector;
 } // namespace LinearAlgebra
+#endif
 
 namespace LinearAlgebra
 {

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -41,11 +41,13 @@ DEAL_II_NAMESPACE_OPEN
 namespace CUDAWrappers
 {
   // forward declaration
+#  ifndef DOXYGEN
   namespace internal
   {
     template <int dim, typename Number>
     class ReinitHelper;
   }
+#  endif
 
   /**
    * This class collects all the data that is stored for the matrix free

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -40,8 +40,11 @@ namespace internal
 {
   namespace MatrixFreeFunctions
   {
+    // Forward declaration
+#ifndef DOXYGEN
     template <typename Number>
     struct ConstraintValues;
+#endif
 
     /**
      * The class that stores the indices of the degrees of freedom for all the

--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -34,9 +34,11 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace MeshWorker
 {
+  // Forward declaration
+#ifndef DOXYGEN
   template <int dim, class DOFINFO>
   class DoFInfoBox;
-
+#endif
 
   /**
    * A class containing information on geometry and degrees of freedom of a

--- a/include/deal.II/meshworker/local_integrator.h
+++ b/include/deal.II/meshworker/local_integrator.h
@@ -29,10 +29,13 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace MeshWorker
 {
+  // Forward declarations
+#ifndef DOXYGEN
   template <int dim, int spacedim, typename number>
   class DoFInfo;
   template <int dim, int spacedim>
   class IntegrationInfo;
+#endif
 
   /**
    * A local integrator object, which can be used to simplify the call of

--- a/include/deal.II/meshworker/local_results.h
+++ b/include/deal.II/meshworker/local_results.h
@@ -30,7 +30,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 class BlockIndices;
+#endif
 
 /**
  * A collection of functions and classes for the mesh loops that are an

--- a/include/deal.II/meshworker/loop.h
+++ b/include/deal.II/meshworker/loop.h
@@ -33,8 +33,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <typename>
 class TriaActiveIterator;
+#endif
 
 namespace internal
 {

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -36,8 +36,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <typename>
 class TriaActiveIterator;
+#endif
 
 namespace MeshWorker
 {

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -25,8 +25,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <int, int>
 class FEValuesBase;
+#endif
 
 namespace MeshWorker
 {

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -29,8 +29,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class DoFHandler;
+#endif
 
 
 /**

--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -29,9 +29,12 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class DoFHandler;
 class MGConstrainedDoFs;
+#endif
 
 /* !@addtogroup mg */
 /* @{ */

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -37,8 +37,11 @@
 DEAL_II_NAMESPACE_OPEN
 
 
+// Forward declaration
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class DoFHandler;
+#endif
 
 /*
  * MGTransferBase is defined in mg_base.h

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -38,9 +38,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
+// Forward declaration
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class DoFHandler;
+#endif
 
 /*
  * MGTransferBase is defined in mg_base.h

--- a/include/deal.II/numerics/data_out_stack.h
+++ b/include/deal.II/numerics/data_out_stack.h
@@ -31,8 +31,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class DoFHandler;
+#endif
 
 /**
  * This class is used to stack the output from several computations into one

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -30,7 +30,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
+// Forward declarations
+#ifndef DOXYGEN
 template <int, int>
 class Mapping;
 template <int>
@@ -41,7 +42,7 @@ namespace hp
   template <int>
   class QCollection;
 }
-
+#endif
 
 
 /**

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -35,10 +35,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declaration
+#ifndef DOXYGEN
 namespace VectorTools
 {
   class ExcPointNotAvailableHere;
 }
+#endif
 
 namespace Functions
 {

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -37,6 +37,7 @@ DEAL_II_NAMESPACE_OPEN
 
 
 // forward declarations
+#ifndef DOXYGEN
 template <int dim>
 class Quadrature;
 
@@ -69,7 +70,7 @@ namespace hp
 } // namespace hp
 
 
-#ifdef DEAL_II_WITH_PETSC
+#  ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   class MatrixBase;
@@ -80,9 +81,9 @@ namespace PETScWrappers
     class BlockVector;
   } // namespace MPI
 } // namespace PETScWrappers
-#endif
+#  endif
 
-#ifdef DEAL_II_WITH_TRILINOS
+#  ifdef DEAL_II_WITH_TRILINOS
 namespace TrilinosWrappers
 {
   class SparseMatrix;
@@ -93,6 +94,7 @@ namespace TrilinosWrappers
     class BlockVector;
   } // namespace MPI
 } // namespace TrilinosWrappers
+#  endif
 #endif
 
 

--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -32,11 +32,13 @@
 DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
+#  ifndef DOXYGEN
 class TimeStepBase;
 template <typename number>
 class Vector;
 template <int dim, int spacedim>
 class Triangulation;
+#  endif
 
 /**
  * This class provides an abstract interface to time dependent problems in

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -38,6 +38,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+#ifndef DOXYGEN
 template <int dim, typename RangeNumberType>
 class Function;
 template <int dim>
@@ -62,7 +64,7 @@ namespace hp
 }
 template <typename number>
 class AffineConstraints;
-
+#endif
 
 // TODO: Move documentation of functions to the functions!
 

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -26,10 +26,13 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace Particles
 {
+  // Forward declarations
+#ifndef DOXYGEN
   template <int, int>
   class ParticleIterator;
   template <int, int>
   class ParticleHandler;
+#endif
 
   /**
    * Accessor class used by ParticleIterator to access particle data.

--- a/include/deal.II/particles/particle_iterator.h
+++ b/include/deal.II/particles/particle_iterator.h
@@ -24,8 +24,11 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace Particles
 {
+  // Forward declaration
+#ifndef DOXYGEN
   template <int, int>
   class ParticleHandler;
+#endif
 
   /**
    * A class that is used to iterate over particles. Together with the


### PR DESCRIPTION
Forward declarations cause doxygen to report an incorrect location for the definition of a class/struct.   For example, at the end of the documentation of `SymmetricTensor` it says
> Definition at line 93 of file mpi.h.

instead of
> Definition at line 555 of file symmetric_tensor.h.

This PR attempts to fix it. My first commit is a proof of concept that fixes this issue for the documentation of `Tensor` and `SymmetricTensor`. If you agree with these changes, I will add apply the same modifications to all forward declarations of all header files.

In my observation, the issue is seen only for forward-declared classes/structs. doxygen does not have a problem with forward-declared functions.