### PR TITLE
Change Polynomial Classes to Derive from TensorPolynomialsBase

### DIFF
--- a/include/deal.II/base/polynomials_abf.h
+++ b/include/deal.II/base/polynomials_abf.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_polynomials_base.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 #include <deal.II/base/thread_management.h>
 
@@ -51,7 +52,7 @@ DEAL_II_NAMESPACE_OPEN
  * @date 2006
  */
 template <int dim>
-class PolynomialsABF
+class PolynomialsABF : public TensorPolynomialsBase<dim>
 {
 public:
   /**
@@ -82,26 +83,13 @@ public:
           std::vector<Tensor<2, dim>> &grads,
           std::vector<Tensor<3, dim>> &grad_grads,
           std::vector<Tensor<4, dim>> &third_derivatives,
-          std::vector<Tensor<5, dim>> &fourth_derivatives) const;
-
-  /**
-   * Return the number of ABF polynomials.
-   */
-  unsigned int
-  n() const;
-
-  /**
-   * Return the degree of the ABF space, which is two less than the highest
-   * polynomial degree.
-   */
-  unsigned int
-  degree() const;
+          std::vector<Tensor<5, dim>> &fourth_derivatives) const override;
 
   /**
    * Return the name of the space, which is <tt>ABF</tt>.
    */
   std::string
-  name() const;
+  name() const override;
 
   /**
    * Return the number of polynomials in the space <tt>RT(degree)</tt> without
@@ -111,23 +99,19 @@ public:
   static unsigned int
   compute_n_pols(unsigned int degree);
 
-private:
   /**
-   * The degree of this object as given to the constructor.
+   * @copydoc TensorPolynomialsBase<dim>::clone()
    */
-  const unsigned int my_degree;
+  virtual std::unique_ptr<TensorPolynomialsBase<dim>>
+  clone() const override;
 
+private:
   /**
    * An object representing the polynomial space for a single component. We
    * can re-use it for the other vector components by rotating the
    * coordinates of the evaluation point.
    */
   const AnisotropicPolynomials<dim> polynomial_space;
-
-  /**
-   * Number of Raviart-Thomas polynomials.
-   */
-  unsigned int n_pols;
 
   /**
    * A mutex that guards the following scratch arrays.
@@ -159,22 +143,6 @@ private:
    */
   mutable std::vector<Tensor<4, dim>> p_fourth_derivatives;
 };
-
-
-template <int dim>
-inline unsigned int
-PolynomialsABF<dim>::n() const
-{
-  return n_pols;
-}
-
-
-template <int dim>
-inline unsigned int
-PolynomialsABF<dim>::degree() const
-{
-  return my_degree;
-}
 
 
 template <int dim>

--- a/include/deal.II/base/polynomials_bdm.h
+++ b/include/deal.II/base/polynomials_bdm.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_polynomials_base.h>
 #include <deal.II/base/thread_management.h>
 
 #include <vector>
@@ -97,7 +98,7 @@ DEAL_II_NAMESPACE_OPEN
  * @date 2003, 2005, 2009
  */
 template <int dim>
-class PolynomialsBDM
+class PolynomialsBDM : public TensorPolynomialsBase<dim>
 {
 public:
   /**
@@ -128,13 +129,7 @@ public:
           std::vector<Tensor<2, dim>> &grads,
           std::vector<Tensor<3, dim>> &grad_grads,
           std::vector<Tensor<4, dim>> &third_derivatives,
-          std::vector<Tensor<5, dim>> &fourth_derivatives) const;
-
-  /**
-   * Return the number of BDM polynomials.
-   */
-  unsigned int
-  n() const;
+          std::vector<Tensor<5, dim>> &fourth_derivatives) const override;
 
   /**
    * Return the degree of the BDM space, which is one less than the highest
@@ -147,7 +142,7 @@ public:
    * Return the name of the space, which is <tt>BDM</tt>.
    */
   std::string
-  name() const;
+  name() const override;
 
   /**
    * Return the number of polynomials in the space <tt>BDM(degree)</tt>
@@ -156,6 +151,12 @@ public:
    */
   static unsigned int
   compute_n_pols(unsigned int degree);
+
+  /**
+   * @copydoc TensorPolynomialsBase<dim>::clone()
+   */
+  virtual std::unique_ptr<TensorPolynomialsBase<dim>>
+  clone() const override;
 
 private:
   /**
@@ -169,11 +170,6 @@ private:
    * <i>k</i>. In 3D, we need all polynomials from degree zero to <i>k</i>.
    */
   std::vector<Polynomials::Polynomial<double>> monomials;
-
-  /**
-   * Number of BDM polynomials.
-   */
-  unsigned int n_pols;
 
   /**
    * A mutex that guards the following scratch arrays.
@@ -205,14 +201,6 @@ private:
    */
   mutable std::vector<Tensor<4, dim>> p_fourth_derivatives;
 };
-
-
-template <int dim>
-inline unsigned int
-PolynomialsBDM<dim>::n() const
-{
-  return n_pols;
-}
 
 
 template <int dim>

--- a/include/deal.II/base/polynomials_bernardi_raugel.h
+++ b/include/deal.II/base/polynomials_bernardi_raugel.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_polynomials_base.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
 #include <vector>
@@ -81,7 +82,7 @@ DEAL_II_NAMESPACE_OPEN
  * @date 2018
  */
 template <int dim>
-class PolynomialsBernardiRaugel
+class PolynomialsBernardiRaugel : public TensorPolynomialsBase<dim>
 {
 public:
   /**
@@ -94,25 +95,10 @@ public:
   PolynomialsBernardiRaugel(const unsigned int k);
 
   /**
-   * Return the number of Bernardi-Raugel polynomials.
-   */
-  unsigned int
-  n() const;
-
-
-  /**
-   * Return the degree of Bernardi-Raugel polynomials.
-   * Since the bubble functions are quadratic in at least one variable,
-   * the degree of the Bernardi-Raugel polynomials is two.
-   */
-  unsigned int
-  degree() const;
-
-  /**
    * Return the name of the space, which is <tt>BernardiRaugel</tt>.
    */
   std::string
-  name() const;
+  name() const override;
 
   /**
    * Compute the value and derivatives of each Bernardi-Raugel
@@ -132,7 +118,7 @@ public:
           std::vector<Tensor<2, dim>> &grads,
           std::vector<Tensor<3, dim>> &grad_grads,
           std::vector<Tensor<4, dim>> &third_derivatives,
-          std::vector<Tensor<5, dim>> &fourth_derivatives) const;
+          std::vector<Tensor<5, dim>> &fourth_derivatives) const override;
 
   /**
    * Return the number of polynomials in the space <tt>BR(degree)</tt> without
@@ -142,17 +128,13 @@ public:
   static unsigned int
   compute_n_pols(const unsigned int k);
 
+  /**
+   * @copydoc TensorPolynomialsBase<dim>::clone()
+   */
+  virtual std::unique_ptr<TensorPolynomialsBase<dim>>
+  clone() const override;
+
 private:
-  /**
-   * The degree of this object given to the constructor (must be 1).
-   */
-  const unsigned int my_degree;
-
-  /**
-   * The number of Bernardi-Raugel polynomials.
-   */
-  const unsigned int n_pols;
-
   /**
    * An object representing the polynomial space of Q
    * functions which forms the <tt>BR</tt> polynomials through
@@ -182,24 +164,6 @@ private:
   static std::vector<std::vector<Polynomials::Polynomial<double>>>
   create_polynomials_bubble();
 };
-
-
-template <int dim>
-inline unsigned int
-PolynomialsBernardiRaugel<dim>::n() const
-{
-  return n_pols;
-}
-
-
-
-template <int dim>
-inline unsigned int
-PolynomialsBernardiRaugel<dim>::degree() const
-{
-  return 2;
-}
-
 
 
 template <int dim>

--- a/include/deal.II/base/polynomials_nedelec.h
+++ b/include/deal.II/base/polynomials_nedelec.h
@@ -25,6 +25,7 @@
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_polynomials_base.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
 #include <vector>
@@ -49,7 +50,7 @@ DEAL_II_NAMESPACE_OPEN
  * @date 2009, 2010
  */
 template <int dim>
-class PolynomialsNedelec
+class PolynomialsNedelec : public TensorPolynomialsBase<dim>
 {
 public:
   /**
@@ -79,26 +80,13 @@ public:
           std::vector<Tensor<2, dim>> &grads,
           std::vector<Tensor<3, dim>> &grad_grads,
           std::vector<Tensor<4, dim>> &third_derivatives,
-          std::vector<Tensor<5, dim>> &fourth_derivatives) const;
-
-  /**
-   * Return the number of Nédélec polynomials.
-   */
-  unsigned int
-  n() const;
-
-  /**
-   * Return the degree of the Nédélec space, which is one less than the
-   * highest polynomial degree.
-   */
-  unsigned int
-  degree() const;
+          std::vector<Tensor<5, dim>> &fourth_derivatives) const override;
 
   /**
    * Return the name of the space, which is <tt>Nedelec</tt>.
    */
   std::string
-  name() const;
+  name() const override;
 
   /**
    * Return the number of polynomials in the space <tt>N(degree)</tt> without
@@ -108,22 +96,18 @@ public:
   static unsigned int
   compute_n_pols(unsigned int degree);
 
-private:
   /**
-   * The degree of this object as given to the constructor.
+   * @copydoc TensorPolynomialsBase<dim>::clone()
    */
-  const unsigned int my_degree;
+  virtual std::unique_ptr<TensorPolynomialsBase<dim>>
+  clone() const override;
 
+private:
   /**
    * An object representing the polynomial space for a single component. We
    * can re-use it by rotating the coordinates of the evaluation point.
    */
   const AnisotropicPolynomials<dim> polynomial_space;
-
-  /**
-   * Number of Nédélec polynomials.
-   */
-  const unsigned int n_pols;
 
   /**
    * A static member function that creates the polynomial space we use to
@@ -132,22 +116,6 @@ private:
   static std::vector<std::vector<Polynomials::Polynomial<double>>>
   create_polynomials(const unsigned int k);
 };
-
-
-template <int dim>
-inline unsigned int
-PolynomialsNedelec<dim>::n() const
-{
-  return n_pols;
-}
-
-
-template <int dim>
-inline unsigned int
-PolynomialsNedelec<dim>::degree() const
-{
-  return my_degree;
-}
 
 
 template <int dim>

--- a/include/deal.II/base/polynomials_raviart_thomas.h
+++ b/include/deal.II/base/polynomials_raviart_thomas.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_polynomials_base.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
 #include <vector>
@@ -46,7 +47,7 @@ DEAL_II_NAMESPACE_OPEN
  * @date 2005
  */
 template <int dim>
-class PolynomialsRaviartThomas
+class PolynomialsRaviartThomas : public TensorPolynomialsBase<dim>
 {
 public:
   /**
@@ -77,26 +78,13 @@ public:
           std::vector<Tensor<2, dim>> &grads,
           std::vector<Tensor<3, dim>> &grad_grads,
           std::vector<Tensor<4, dim>> &third_derivatives,
-          std::vector<Tensor<5, dim>> &fourth_derivatives) const;
-
-  /**
-   * Return the number of Raviart-Thomas polynomials.
-   */
-  unsigned int
-  n() const;
-
-  /**
-   * Return the degree of the Raviart-Thomas space, which is one less than
-   * the highest polynomial degree.
-   */
-  unsigned int
-  degree() const;
+          std::vector<Tensor<5, dim>> &fourth_derivatives) const override;
 
   /**
    * Return the name of the space, which is <tt>RaviartThomas</tt>.
    */
   std::string
-  name() const;
+  name() const override;
 
   /**
    * Return the number of polynomials in the space <tt>RT(degree)</tt> without
@@ -106,22 +94,18 @@ public:
   static unsigned int
   compute_n_pols(unsigned int degree);
 
-private:
   /**
-   * The degree of this object as given to the constructor.
+   * @copydoc TensorPolynomialsBase<dim>::clone()
    */
-  const unsigned int my_degree;
+  virtual std::unique_ptr<TensorPolynomialsBase<dim>>
+  clone() const override;
 
+private:
   /**
    * An object representing the polynomial space for a single component. We
    * can re-use it by rotating the coordinates of the evaluation point.
    */
   const AnisotropicPolynomials<dim> polynomial_space;
-
-  /**
-   * Number of Raviart-Thomas polynomials.
-   */
-  const unsigned int n_pols;
 
   /**
    * A static member function that creates the polynomial space we use to
@@ -130,25 +114,6 @@ private:
   static std::vector<std::vector<Polynomials::Polynomial<double>>>
   create_polynomials(const unsigned int k);
 };
-
-
-
-template <int dim>
-inline unsigned int
-PolynomialsRaviartThomas<dim>::n() const
-{
-  return n_pols;
-}
-
-
-
-template <int dim>
-inline unsigned int
-PolynomialsRaviartThomas<dim>::degree() const
-{
-  return my_degree;
-}
-
 
 
 template <int dim>

--- a/include/deal.II/base/polynomials_rt_bubbles.h
+++ b/include/deal.II/base/polynomials_rt_bubbles.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_raviart_thomas.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_polynomials_base.h>
 
 #include <vector>
 
@@ -84,7 +85,7 @@ DEAL_II_NAMESPACE_OPEN
  */
 
 template <int dim>
-class PolynomialsRT_Bubbles
+class PolynomialsRT_Bubbles : public TensorPolynomialsBase<dim>
 {
 public:
   /**
@@ -111,26 +112,13 @@ public:
           std::vector<Tensor<2, dim>> &grads,
           std::vector<Tensor<3, dim>> &grad_grads,
           std::vector<Tensor<4, dim>> &third_derivatives,
-          std::vector<Tensor<5, dim>> &fourth_derivatives) const;
-
-  /**
-   * Returns the number of enhanced Raviart-Thomas polynomials.
-   */
-  unsigned int
-  n() const;
-
-  /**
-   * Returns the degree of the RT_bubble space, which is one less than the
-   * highest polynomial degree.
-   */
-  unsigned int
-  degree() const;
+          std::vector<Tensor<5, dim>> &fourth_derivatives) const override;
 
   /**
    * Return the name of the space, which is <tt>RT_Bubbles</tt>.
    */
   std::string
-  name() const;
+  name() const override;
 
   /**
    * Return the number of polynomials in the space <tt>RT_Bubbles(degree)</tt>
@@ -140,12 +128,13 @@ public:
   static unsigned int
   compute_n_pols(const unsigned int degree);
 
-private:
   /**
-   * The degree of this object as given to the constructor.
+   * @copydoc TensorPolynomialsBase<dim>::clone()
    */
-  const unsigned int my_degree;
+  virtual std::unique_ptr<TensorPolynomialsBase<dim>>
+  clone() const override;
 
+private:
   /**
    * An object representing the Raviart-Thomas part of the space
    */
@@ -156,31 +145,7 @@ private:
    * to <i>k+1</i>.
    */
   std::vector<Polynomials::Polynomial<double>> monomials;
-
-  /**
-   * Number of RT_Bubbles polynomials.
-   */
-  unsigned int n_pols;
 };
-
-
-
-template <int dim>
-inline unsigned int
-PolynomialsRT_Bubbles<dim>::n() const
-{
-  return n_pols;
-}
-
-
-
-template <int dim>
-inline unsigned int
-PolynomialsRT_Bubbles<dim>::degree() const
-{
-  return my_degree;
-}
-
 
 
 template <int dim>

--- a/source/base/polynomials_abf.cc
+++ b/source/base/polynomials_abf.cc
@@ -16,6 +16,7 @@
 
 #include <deal.II/base/polynomials_abf.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/std_cxx14/memory.h>
 
 #include <iomanip>
 #include <iostream>
@@ -47,9 +48,8 @@ namespace
 
 template <int dim>
 PolynomialsABF<dim>::PolynomialsABF(const unsigned int k)
-  : my_degree(k)
+  : TensorPolynomialsBase<dim>(k, compute_n_pols(k))
   , polynomial_space(get_abf_polynomials<dim>(k))
-  , n_pols(compute_n_pols(k))
 {
   // check that the dimensions match. we only store one of the 'dim'
   // anisotropic polynomials that make up the vector-valued space, so
@@ -69,16 +69,17 @@ PolynomialsABF<dim>::compute(
   std::vector<Tensor<4, dim>> &third_derivatives,
   std::vector<Tensor<5, dim>> &fourth_derivatives) const
 {
-  Assert(values.size() == n_pols || values.size() == 0,
-         ExcDimensionMismatch(values.size(), n_pols));
-  Assert(grads.size() == n_pols || grads.size() == 0,
-         ExcDimensionMismatch(grads.size(), n_pols));
-  Assert(grad_grads.size() == n_pols || grad_grads.size() == 0,
-         ExcDimensionMismatch(grad_grads.size(), n_pols));
-  Assert(third_derivatives.size() == n_pols || third_derivatives.size() == 0,
-         ExcDimensionMismatch(third_derivatives.size(), n_pols));
-  Assert(fourth_derivatives.size() == n_pols || fourth_derivatives.size() == 0,
-         ExcDimensionMismatch(fourth_derivatives.size(), n_pols));
+  Assert(values.size() == this->n() || values.size() == 0,
+         ExcDimensionMismatch(values.size(), this->n()));
+  Assert(grads.size() == this->n() || grads.size() == 0,
+         ExcDimensionMismatch(grads.size(), this->n()));
+  Assert(grad_grads.size() == this->n() || grad_grads.size() == 0,
+         ExcDimensionMismatch(grad_grads.size(), this->n()));
+  Assert(third_derivatives.size() == this->n() || third_derivatives.size() == 0,
+         ExcDimensionMismatch(third_derivatives.size(), this->n()));
+  Assert(fourth_derivatives.size() == this->n() ||
+           fourth_derivatives.size() == 0,
+         ExcDimensionMismatch(fourth_derivatives.size(), this->n()));
 
   const unsigned int n_sub = polynomial_space.n();
   // guard access to the scratch
@@ -177,6 +178,14 @@ PolynomialsABF<dim>::compute_n_pols(const unsigned int k)
     }
 
   return 0;
+}
+
+
+template <int dim>
+std::unique_ptr<TensorPolynomialsBase<dim>>
+PolynomialsABF<dim>::clone() const
+{
+  return std_cxx14::make_unique<PolynomialsABF<dim>>(*this);
 }
 
 

--- a/source/base/polynomials_bernardi_raugel.cc
+++ b/source/base/polynomials_bernardi_raugel.cc
@@ -15,14 +15,14 @@
 
 
 #include <deal.II/base/polynomials_bernardi_raugel.h>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim>
 PolynomialsBernardiRaugel<dim>::PolynomialsBernardiRaugel(const unsigned int k)
-  : my_degree(k)
-  , n_pols(compute_n_pols(k))
+  : TensorPolynomialsBase<dim>(k + 1, compute_n_pols(k))
   , polynomial_space_Q(create_polynomials_Q())
   , polynomial_space_bubble(create_polynomials_bubble())
 {}
@@ -75,16 +75,17 @@ PolynomialsBernardiRaugel<dim>::compute(
   std::vector<Tensor<4, dim>> &third_derivatives,
   std::vector<Tensor<5, dim>> &fourth_derivatives) const
 {
-  Assert(values.size() == n_pols || values.size() == 0,
-         ExcDimensionMismatch(values.size(), n_pols));
-  Assert(grads.size() == n_pols || grads.size() == 0,
-         ExcDimensionMismatch(grads.size(), n_pols));
-  Assert(grad_grads.size() == n_pols || grad_grads.size() == 0,
-         ExcDimensionMismatch(grad_grads.size(), n_pols));
-  Assert(third_derivatives.size() == n_pols || third_derivatives.size() == 0,
-         ExcDimensionMismatch(third_derivatives.size(), n_pols));
-  Assert(fourth_derivatives.size() == n_pols || fourth_derivatives.size() == 0,
-         ExcDimensionMismatch(fourth_derivatives.size(), n_pols));
+  Assert(values.size() == this->n() || values.size() == 0,
+         ExcDimensionMismatch(values.size(), this->n()));
+  Assert(grads.size() == this->n() || grads.size() == 0,
+         ExcDimensionMismatch(grads.size(), this->n()));
+  Assert(grad_grads.size() == this->n() || grad_grads.size() == 0,
+         ExcDimensionMismatch(grad_grads.size(), this->n()));
+  Assert(third_derivatives.size() == this->n() || third_derivatives.size() == 0,
+         ExcDimensionMismatch(third_derivatives.size(), this->n()));
+  Assert(fourth_derivatives.size() == this->n() ||
+           fourth_derivatives.size() == 0,
+         ExcDimensionMismatch(fourth_derivatives.size(), this->n()));
 
   std::vector<double>         Q_values;
   std::vector<Tensor<1, dim>> Q_grads;
@@ -246,6 +247,14 @@ PolynomialsBernardiRaugel<dim>::compute_n_pols(const unsigned int k)
 
   Assert(false, ExcNotImplemented());
   return 0;
+}
+
+
+template <int dim>
+std::unique_ptr<TensorPolynomialsBase<dim>>
+PolynomialsBernardiRaugel<dim>::clone() const
+{
+  return std_cxx14::make_unique<PolynomialsBernardiRaugel<dim>>(*this);
 }
 
 template class PolynomialsBernardiRaugel<1>; // to prevent errors

--- a/source/base/polynomials_raviart_thomas.cc
+++ b/source/base/polynomials_raviart_thomas.cc
@@ -16,6 +16,7 @@
 
 #include <deal.II/base/polynomials_raviart_thomas.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/thread_management.h>
 
 #include <iomanip>
@@ -35,9 +36,8 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 PolynomialsRaviartThomas<dim>::PolynomialsRaviartThomas(const unsigned int k)
-  : my_degree(k)
+  : TensorPolynomialsBase<dim>(k, compute_n_pols(k))
   , polynomial_space(create_polynomials(k))
-  , n_pols(compute_n_pols(k))
 {}
 
 
@@ -69,16 +69,17 @@ PolynomialsRaviartThomas<dim>::compute(
   std::vector<Tensor<4, dim>> &third_derivatives,
   std::vector<Tensor<5, dim>> &fourth_derivatives) const
 {
-  Assert(values.size() == n_pols || values.size() == 0,
-         ExcDimensionMismatch(values.size(), n_pols));
-  Assert(grads.size() == n_pols || grads.size() == 0,
-         ExcDimensionMismatch(grads.size(), n_pols));
-  Assert(grad_grads.size() == n_pols || grad_grads.size() == 0,
-         ExcDimensionMismatch(grad_grads.size(), n_pols));
-  Assert(third_derivatives.size() == n_pols || third_derivatives.size() == 0,
-         ExcDimensionMismatch(third_derivatives.size(), n_pols));
-  Assert(fourth_derivatives.size() == n_pols || fourth_derivatives.size() == 0,
-         ExcDimensionMismatch(fourth_derivatives.size(), n_pols));
+  Assert(values.size() == this->n() || values.size() == 0,
+         ExcDimensionMismatch(values.size(), this->n()));
+  Assert(grads.size() == this->n() || grads.size() == 0,
+         ExcDimensionMismatch(grads.size(), this->n()));
+  Assert(grad_grads.size() == this->n() || grad_grads.size() == 0,
+         ExcDimensionMismatch(grad_grads.size(), this->n()));
+  Assert(third_derivatives.size() == this->n() || third_derivatives.size() == 0,
+         ExcDimensionMismatch(third_derivatives.size(), this->n()));
+  Assert(fourth_derivatives.size() == this->n() ||
+           fourth_derivatives.size() == 0,
+         ExcDimensionMismatch(fourth_derivatives.size(), this->n()));
 
   // have a few scratch
   // arrays. because we don't want to
@@ -180,6 +181,14 @@ PolynomialsRaviartThomas<dim>::compute_n_pols(unsigned int k)
 
   Assert(false, ExcNotImplemented());
   return 0;
+}
+
+
+template <int dim>
+std::unique_ptr<TensorPolynomialsBase<dim>>
+PolynomialsRaviartThomas<dim>::clone() const
+{
+  return std_cxx14::make_unique<PolynomialsRaviartThomas<dim>>(*this);
 }
 
 


### PR DESCRIPTION
This is step 2 in a multi-step process for addressing #1973.

This changes 6 polynomial classes to derive from the `TensorPolynomialsBase` class that was implemented in #8528.

The next thing I need to do (either as part of this PR or the next PR) is remove some function implementations from these derived classes so that they use the base class's functions and variables.