### PR TITLE
Introduce parallel::DistributedTriangulationBase

### DIFF
--- a/doc/news/changes/minor/20190817PeterMunch
+++ b/doc/news/changes/minor/20190817PeterMunch
@@ -1,0 +1,4 @@
+New: Introduce new class parallel::DistributedTriangulationBase 
+between parallel::TriangulationBase and parallel::distributed::Triangulation.
+<br>
+(Peter Munch, 2019/08/17)

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -249,7 +249,7 @@ namespace parallel
      */
     template <int dim, int spacedim = dim>
     class Triangulation
-      : public dealii::parallel::TriangulationBase<dim, spacedim>
+      : public dealii::parallel::DistributedTriangulationBase<dim, spacedim>
     {
     public:
       /**
@@ -382,6 +382,12 @@ namespace parallel
        */
       virtual void
       clear() override;
+
+      /**
+       * Return if multilevel hierarchy is supported and has been constructed.
+       */
+      bool
+      is_multilevel_hierarchy_constructed() const override;
 
       /**
        * Implementation of the same function as in the base class.
@@ -1247,7 +1253,7 @@ namespace parallel
      */
     template <int spacedim>
     class Triangulation<1, spacedim>
-      : public dealii::parallel::TriangulationBase<1, spacedim>
+      : public dealii::parallel::DistributedTriangulationBase<1, spacedim>
     {
     public:
       /**
@@ -1334,6 +1340,9 @@ namespace parallel
        */
       void
       save(const std::string &filename) const;
+
+      bool
+      is_multilevel_hierarchy_constructed() const override;
 
       /**
        * This function is not implemented, but needs to be present for the

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -246,6 +246,32 @@ namespace parallel
   template <int dim, int spacedim = dim>
   using Triangulation DEAL_II_DEPRECATED = TriangulationBase<dim, spacedim>;
 
+  /**
+   * A base class for distributed triangulations. It can be used to test
+   * (via <tt>dynamic_cast</tt>) whether a particular triangulation object
+   * is able to distribute meshes between processes.
+   */
+  template <int dim, int spacedim = dim>
+  class DistributedTriangulationBase
+    : public dealii::parallel::TriangulationBase<dim, spacedim>
+  {
+  public:
+    /**
+     * Constructor.
+     */
+    DistributedTriangulationBase(
+      MPI_Comm mpi_communicator,
+      const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
+                 smooth_grid = (dealii::Triangulation<dim, spacedim>::none),
+      const bool check_for_distorted_cells = false);
+
+    /**
+     * Return if multilevel hierarchy is supported and has been constructed.
+     */
+    virtual bool
+    is_multilevel_hierarchy_constructed() const = 0;
+  };
+
 } // namespace parallel
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -215,7 +215,7 @@ namespace internal
 
       /**
        * This class implements the policy for operations when we use a
-       * parallel::distributed::Triangulation object.
+       * parallel::DistributedTriangulationBase object.
        */
       template <class DoFHandlerType>
       class ParallelDistributed

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2127,7 +2127,7 @@ namespace parallel
       : // Do not check for distorted cells.
         // For multigrid, we need limit_level_difference_at_vertices
         // to make sure the transfer operators only need to consider two levels.
-      dealii::parallel::TriangulationBase<dim, spacedim>(
+      dealii::parallel::DistributedTriangulationBase<dim, spacedim>(
         mpi_communicator,
         (settings_ & construct_multigrid_hierarchy) ?
           static_cast<
@@ -2593,6 +2593,16 @@ namespace parallel
       dealii::Triangulation<dim, spacedim>::clear();
 
       this->update_number_cache();
+    }
+
+
+
+    template <int dim, int spacedim>
+    bool
+    Triangulation<dim, spacedim>::is_multilevel_hierarchy_constructed() const
+    {
+      return settings &
+             Triangulation<dim, spacedim>::construct_multigrid_hierarchy;
     }
 
 
@@ -4967,9 +4977,10 @@ namespace parallel
       const typename dealii::Triangulation<1, spacedim>::MeshSmoothing
         smooth_grid,
       const Settings /*settings*/)
-      : dealii::parallel::TriangulationBase<1, spacedim>(mpi_communicator,
-                                                         smooth_grid,
-                                                         false)
+      : dealii::parallel::DistributedTriangulationBase<1, spacedim>(
+          mpi_communicator,
+          smooth_grid,
+          false)
     {
       Assert(false, ExcNotImplemented());
     }
@@ -5102,6 +5113,16 @@ namespace parallel
     Triangulation<1, spacedim>::save(const std::string &) const
     {
       Assert(false, ExcNotImplemented());
+    }
+
+
+
+    template <int spacedim>
+    bool
+    Triangulation<1, spacedim>::is_multilevel_hierarchy_constructed() const
+    {
+      Assert(false, ExcNotImplemented());
+      return false;
     }
 
   } // namespace distributed

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -392,6 +392,18 @@ namespace parallel
     return result;
   }
 
+  template <int dim, int spacedim>
+  DistributedTriangulationBase<dim, spacedim>::DistributedTriangulationBase(
+    MPI_Comm mpi_communicator,
+    const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
+               smooth_grid,
+    const bool check_for_distorted_cells)
+    : dealii::parallel::TriangulationBase<dim, spacedim>(
+        mpi_communicator,
+        smooth_grid,
+        check_for_distorted_cells)
+  {}
+
 } // end namespace parallel
 
 

--- a/source/distributed/tria_base.inst.in
+++ b/source/distributed/tria_base.inst.in
@@ -28,5 +28,15 @@ for (deal_II_dimension : DIMENSIONS)
       template class TriangulationBase<deal_II_dimension,
                                        deal_II_dimension + 2>;
 #endif
+
+      template class DistributedTriangulationBase<deal_II_dimension>;
+#if deal_II_dimension < 3
+      template class DistributedTriangulationBase<deal_II_dimension,
+                                                  deal_II_dimension + 1>;
+#endif
+#if deal_II_dimension < 2
+      template class DistributedTriangulationBase<deal_II_dimension,
+                                                  deal_II_dimension + 2>;
+#endif
     \}
   }

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1446,7 +1446,7 @@ namespace internal
           std::vector<bool> include_vertex(
             dof_handler.get_triangulation().n_vertices(), false);
           if (dynamic_cast<
-                const parallel::distributed::Triangulation<dim, spacedim> *>(
+                const parallel::DistributedTriangulationBase<dim, spacedim> *>(
                 &dof_handler.get_triangulation()) != nullptr)
             for (const auto &cell : dof_handler.active_cell_iterators())
               if (cell->is_ghost())
@@ -3616,7 +3616,7 @@ namespace internal
         /**
          * level subdomain association. Similar to the above function only
          * for level meshes. This function assigns boundary dofs in
-         * the same way as parallel::distributed::Triangulation (proc with
+         * the same way as parallel::DistributedTriangulationBase (proc with
          * smallest index) instead of the coin flip method above.
          */
         template <class DoFHandlerType>
@@ -4366,7 +4366,7 @@ namespace internal
         template <int dim, int spacedim>
         void
         get_mg_dofindices_recursively(
-          const parallel::distributed::Triangulation<dim, spacedim> &tria,
+          const parallel::DistributedTriangulationBase<dim, spacedim> &tria,
           const typename dealii::internal::p4est::types<dim>::quadrant
             &p4est_cell,
           const typename DoFHandler<dim, spacedim>::level_cell_iterator
@@ -4420,7 +4420,7 @@ namespace internal
         template <int dim, int spacedim>
         void
         find_marked_mg_ghost_cells_recursively(
-          const typename parallel::distributed::Triangulation<dim, spacedim>
+          const typename parallel::DistributedTriangulationBase<dim, spacedim>
             &                tria,
           const unsigned int tree_index,
           const typename DoFHandler<dim, spacedim>::level_cell_iterator
@@ -4465,7 +4465,7 @@ namespace internal
         template <int dim, int spacedim>
         void
         set_mg_dofindices_recursively(
-          const parallel::distributed::Triangulation<dim, spacedim> &tria,
+          const parallel::DistributedTriangulationBase<dim, spacedim> &tria,
           const typename dealii::internal::p4est::types<dim>::quadrant
             &p4est_cell,
           const typename DoFHandler<dim, spacedim>::level_cell_iterator
@@ -4536,7 +4536,7 @@ namespace internal
         template <int dim, int spacedim, class DoFHandlerType>
         void
         communicate_mg_ghost_cells(
-          const typename parallel::distributed::Triangulation<dim, spacedim>
+          const typename parallel::DistributedTriangulationBase<dim, spacedim>
             &             tria,
           DoFHandlerType &dof_handler)
         {
@@ -4961,7 +4961,7 @@ namespace internal
           // barrier is negligible compared to everything else we do
           // here
           if (const auto *triangulation = dynamic_cast<
-                const parallel::distributed::Triangulation<dim, spacedim> *>(
+                const parallel::DistributedTriangulationBase<dim, spacedim> *>(
                 &dof_handler.get_triangulation()))
             {
               const int ierr = MPI_Barrier(triangulation->get_communicator());
@@ -5004,10 +5004,10 @@ namespace internal
         const unsigned int dim      = DoFHandlerType::dimension;
         const unsigned int spacedim = DoFHandlerType::space_dimension;
 
-        parallel::distributed::Triangulation<dim, spacedim> *triangulation =
-          (dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
-            const_cast<dealii::Triangulation<dim, spacedim> *>(
-              &dof_handler->get_triangulation())));
+        parallel::DistributedTriangulationBase<dim, spacedim> *triangulation =
+          (dynamic_cast<parallel::DistributedTriangulationBase<dim, spacedim>
+                          *>(const_cast<dealii::Triangulation<dim, spacedim> *>(
+            &dof_handler->get_triangulation())));
         Assert(triangulation != nullptr, ExcInternalError());
 
         const types::subdomain_id subdomain_id =
@@ -5241,15 +5241,13 @@ namespace internal
         const unsigned int dim      = DoFHandlerType::dimension;
         const unsigned int spacedim = DoFHandlerType::space_dimension;
 
-        parallel::distributed::Triangulation<dim, spacedim> *triangulation =
-          (dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
-            const_cast<dealii::Triangulation<dim, spacedim> *>(
-              &dof_handler->get_triangulation())));
+        parallel::DistributedTriangulationBase<dim, spacedim> *triangulation =
+          (dynamic_cast<parallel::DistributedTriangulationBase<dim, spacedim>
+                          *>(const_cast<dealii::Triangulation<dim, spacedim> *>(
+            &dof_handler->get_triangulation())));
         Assert(triangulation != nullptr, ExcInternalError());
 
-        AssertThrow((triangulation->settings &
-                     parallel::distributed::Triangulation<dim, spacedim>::
-                       construct_multigrid_hierarchy),
+        AssertThrow((triangulation->is_multilevel_hierarchy_constructed()),
                     ExcMessage(
                       "Multigrid DoFs can only be distributed on a parallel "
                       "Triangulation if the flag construct_multigrid_hierarchy "
@@ -5470,10 +5468,10 @@ namespace internal
         const unsigned int dim      = DoFHandlerType::dimension;
         const unsigned int spacedim = DoFHandlerType::space_dimension;
 
-        parallel::distributed::Triangulation<dim, spacedim> *triangulation =
-          (dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
-            const_cast<dealii::Triangulation<dim, spacedim> *>(
-              &dof_handler->get_triangulation())));
+        parallel::DistributedTriangulationBase<dim, spacedim> *triangulation =
+          (dynamic_cast<parallel::DistributedTriangulationBase<dim, spacedim>
+                          *>(const_cast<dealii::Triangulation<dim, spacedim> *>(
+            &dof_handler->get_triangulation())));
         Assert(triangulation != nullptr, ExcInternalError());
 
 


### PR DESCRIPTION
This PR is part of the effort to introduce the new parallel::fullydistributed::Triangulation (see #8558) and is a follow-up to PR #8587.

This PR introduces a new virtual class `parallel::DistributedTrinagulationBase` between `parallel::Trinagulation` and `parallel::distributed::Trinagulation`. This class will be also the parent class of `p:f:t`.

*Note*: Please only consider the last commit, since all other commits will be removed from this PR once  PR #8587 is merged.

*Ping*: @bangerth @tjhei 