### PR TITLE
Use MPI_Exscan instead of MPI_Scan.

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7946,8 +7946,7 @@ DataOutBase::write_hdf5_parallel(
   hid_t pt_data_dataspace, pt_data_dataset, pt_data_file_dataspace,
     pt_data_memory_dataspace;
   herr_t status;
-  unsigned int local_node_cell_count[2], global_node_cell_count[2],
-    global_node_cell_offsets[2];
+  unsigned int local_node_cell_count[2];
   hsize_t count[2], offset[2], node_ds_dim[2], cell_ds_dim[2];
   std::vector<double> node_data_vec;
   std::vector<unsigned int> cell_data_vec;
@@ -7980,6 +7979,10 @@ DataOutBase::write_hdf5_parallel(
 
   // Compute the global total number of nodes/cells and determine the offset of
   // the data for this process
+
+  unsigned int global_node_cell_count[2] = {0, 0};
+  unsigned int global_node_cell_offsets[2] = {0, 0};
+
 #  ifdef DEAL_II_WITH_MPI
   ierr = MPI_Allreduce(local_node_cell_count,
                        global_node_cell_count,
@@ -7988,15 +7991,13 @@ DataOutBase::write_hdf5_parallel(
                        MPI_SUM,
                        comm);
   AssertThrowMPI(ierr);
-  ierr = MPI_Scan(local_node_cell_count,
-                  global_node_cell_offsets,
-                  2,
-                  MPI_UNSIGNED,
-                  MPI_SUM,
-                  comm);
+  ierr = MPI_Exscan(local_node_cell_count,
+                    global_node_cell_offsets,
+                    2,
+                    MPI_UNSIGNED,
+                    MPI_SUM,
+                    comm);
   AssertThrowMPI(ierr);
-  global_node_cell_offsets[0] -= local_node_cell_count[0];
-  global_node_cell_offsets[1] -= local_node_cell_count[1];
 #  else
   global_node_cell_count[0] = local_node_cell_count[0];
   global_node_cell_count[1] = local_node_cell_count[1];


### PR DESCRIPTION
Prompted by #8577.

I'm writing this on my laptop, which is too weak to test this. I *think* it looks right. Does the tester check parallel features like this?