### PR TITLE
Remove PolynomialType Template Argument from FE_PolyTensor

### DIFF
--- a/include/deal.II/fe/fe_abf.h
+++ b/include/deal.II/fe/fe_abf.h
@@ -100,7 +100,7 @@ DEAL_II_NAMESPACE_OPEN
  * Kanschat and Wolfgang Bangerth
  */
 template <int dim>
-class FE_ABF : public FE_PolyTensor<PolynomialsABF<dim>, dim>
+class FE_ABF : public FE_PolyTensor<dim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_bdm.h
+++ b/include/deal.II/fe/fe_bdm.h
@@ -56,7 +56,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup fe
  */
 template <int dim>
-class FE_BDM : public FE_PolyTensor<PolynomialsBDM<dim>, dim>
+class FE_BDM : public FE_PolyTensor<dim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_bernardi_raugel.h
+++ b/include/deal.II/fe/fe_bernardi_raugel.h
@@ -84,8 +84,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  */
 template <int dim>
-class FE_BernardiRaugel
-  : public FE_PolyTensor<PolynomialsBernardiRaugel<dim>, dim>
+class FE_BernardiRaugel : public FE_PolyTensor<dim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_dg_vector.h
+++ b/include/deal.II/fe/fe_dg_vector.h
@@ -52,7 +52,7 @@ DEAL_II_NAMESPACE_OPEN
  * @date 2010
  */
 template <class PolynomialType, int dim, int spacedim = dim>
-class FE_DGVector : public FE_PolyTensor<PolynomialType, dim, spacedim>
+class FE_DGVector : public FE_PolyTensor<dim, spacedim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_dg_vector.templates.h
+++ b/include/deal.II/fe/fe_dg_vector.templates.h
@@ -33,8 +33,8 @@ DEAL_II_NAMESPACE_OPEN
 template <class PolynomialType, int dim, int spacedim>
 FE_DGVector<PolynomialType, dim, spacedim>::FE_DGVector(const unsigned int deg,
                                                         MappingKind        map)
-  : FE_PolyTensor<PolynomialType, dim, spacedim>(
-      deg,
+  : FE_PolyTensor<dim, spacedim>(
+      PolynomialType(deg),
       FiniteElementData<dim>(get_dpo_vector(deg),
                              dim,
                              deg + 1,
@@ -69,7 +69,7 @@ std::string
 FE_DGVector<PolynomialType, dim, spacedim>::get_name() const
 {
   std::ostringstream namebuf;
-  namebuf << "FE_DGVector_" << this->poly_space.name() << "<" << dim << ">("
+  namebuf << "FE_DGVector_" << this->poly_space->name() << "<" << dim << ">("
           << this->degree - 1 << ")";
   return namebuf.str();
 }

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -110,7 +110,7 @@ DEAL_II_NAMESPACE_OPEN
  * @date 2009, 2010, 2011
  */
 template <int dim>
-class FE_Nedelec : public FE_PolyTensor<PolynomialsNedelec<dim>, dim>
+class FE_Nedelec : public FE_PolyTensor<dim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -102,8 +102,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Guido Kanschat, 2005, based on previous work by Wolfgang Bangerth.
  */
 template <int dim>
-class FE_RaviartThomas
-  : public FE_PolyTensor<PolynomialsRaviartThomas<dim>, dim>
+class FE_RaviartThomas : public FE_PolyTensor<dim>
 {
 public:
   /**
@@ -244,8 +243,7 @@ private:
  * @author Guido Kanschat, 2005, Zhu Liang, 2008
  */
 template <int dim>
-class FE_RaviartThomasNodal
-  : public FE_PolyTensor<PolynomialsRaviartThomas<dim>, dim>
+class FE_RaviartThomasNodal : public FE_PolyTensor<dim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_rt_bubbles.h
+++ b/include/deal.II/fe/fe_rt_bubbles.h
@@ -87,7 +87,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Eldar Khattatov, 2018
  */
 template <int dim>
-class FE_RT_Bubbles : public FE_PolyTensor<PolynomialsRT_Bubbles<dim>, dim>
+class FE_RT_Bubbles : public FE_PolyTensor<dim>
 {
 public:
   /**

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -46,8 +46,8 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 FE_ABF<dim>::FE_ABF(const unsigned int deg)
-  : FE_PolyTensor<PolynomialsABF<dim>, dim>(
-      deg,
+  : FE_PolyTensor<dim>(
+      PolynomialsABF<dim>(deg),
       FiniteElementData<dim>(get_dpo_vector(deg),
                              dim,
                              deg + 2,

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -38,8 +38,8 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 FE_BDM<dim>::FE_BDM(const unsigned int deg)
-  : FE_PolyTensor<PolynomialsBDM<dim>, dim>(
-      deg,
+  : FE_PolyTensor<dim>(
+      PolynomialsBDM<dim>(deg),
       FiniteElementData<dim>(get_dpo_vector(deg),
                              dim,
                              deg + 1,

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -38,8 +38,8 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 FE_BernardiRaugel<dim>::FE_BernardiRaugel(const unsigned int p)
-  : FE_PolyTensor<PolynomialsBernardiRaugel<dim>, dim>(
-      p,
+  : FE_PolyTensor<dim>(
+      PolynomialsBernardiRaugel<dim>(p),
       FiniteElementData<dim>(get_dpo_vector(),
                              dim,
                              2,

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -69,8 +69,8 @@ namespace internal
 
 template <int dim>
 FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
-  : FE_PolyTensor<PolynomialsNedelec<dim>, dim>(
-      order,
+  : FE_PolyTensor<dim>(
+      PolynomialsNedelec<dim>(order),
       FiniteElementData<dim>(get_dpo_vector(order),
                              dim,
                              order + 1,

--- a/source/fe/fe_poly_tensor.inst.in
+++ b/source/fe/fe_poly_tensor.inst.in
@@ -17,16 +17,5 @@
 
 for (deal_II_dimension : DIMENSIONS)
   {
-    template class FE_PolyTensor<PolynomialsRaviartThomas<deal_II_dimension>,
-                                 deal_II_dimension>;
-    template class FE_PolyTensor<PolynomialsRT_Bubbles<deal_II_dimension>,
-                                 deal_II_dimension>;
-    template class FE_PolyTensor<PolynomialsABF<deal_II_dimension>,
-                                 deal_II_dimension>;
-    template class FE_PolyTensor<PolynomialsBernardiRaugel<deal_II_dimension>,
-                                 deal_II_dimension>;
-    template class FE_PolyTensor<PolynomialsBDM<deal_II_dimension>,
-                                 deal_II_dimension>;
-    template class FE_PolyTensor<PolynomialsNedelec<deal_II_dimension>,
-                                 deal_II_dimension>;
+    template class FE_PolyTensor<deal_II_dimension, deal_II_dimension>;
   }

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -45,8 +45,8 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 FE_RaviartThomas<dim>::FE_RaviartThomas(const unsigned int deg)
-  : FE_PolyTensor<PolynomialsRaviartThomas<dim>, dim>(
-      deg,
+  : FE_PolyTensor<dim>(
+      PolynomialsRaviartThomas<dim>(deg),
       FiniteElementData<dim>(get_dpo_vector(deg),
                              dim,
                              deg + 1,

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -38,16 +38,15 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int deg)
-  : FE_PolyTensor<PolynomialsRaviartThomas<dim>, dim>(
-      deg,
-      FiniteElementData<dim>(get_dpo_vector(deg),
-                             dim,
-                             deg + 1,
-                             FiniteElementData<dim>::Hdiv),
-      get_ria_vector(deg),
-      std::vector<ComponentMask>(PolynomialsRaviartThomas<dim>::compute_n_pols(
-                                   deg),
-                                 std::vector<bool>(dim, true)))
+  : FE_PolyTensor<dim>(PolynomialsRaviartThomas<dim>(deg),
+                       FiniteElementData<dim>(get_dpo_vector(deg),
+                                              dim,
+                                              deg + 1,
+                                              FiniteElementData<dim>::Hdiv),
+                       get_ria_vector(deg),
+                       std::vector<ComponentMask>(
+                         PolynomialsRaviartThomas<dim>::compute_n_pols(deg),
+                         std::vector<bool>(dim, true)))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
   const unsigned int n_dofs = this->dofs_per_cell;

--- a/source/fe/fe_rt_bubbles.cc
+++ b/source/fe/fe_rt_bubbles.cc
@@ -37,16 +37,15 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 FE_RT_Bubbles<dim>::FE_RT_Bubbles(const unsigned int deg)
-  : FE_PolyTensor<PolynomialsRT_Bubbles<dim>, dim>(
-      deg,
-      FiniteElementData<dim>(get_dpo_vector(deg),
-                             dim,
-                             deg + 1,
-                             FiniteElementData<dim>::Hdiv),
-      get_ria_vector(deg),
-      std::vector<ComponentMask>(PolynomialsRT_Bubbles<dim>::compute_n_pols(
-                                   deg),
-                                 std::vector<bool>(dim, true)))
+  : FE_PolyTensor<dim>(PolynomialsRT_Bubbles<dim>(deg),
+                       FiniteElementData<dim>(get_dpo_vector(deg),
+                                              dim,
+                                              deg + 1,
+                                              FiniteElementData<dim>::Hdiv),
+                       get_ria_vector(deg),
+                       std::vector<ComponentMask>(
+                         PolynomialsRT_Bubbles<dim>::compute_n_pols(deg),
+                         std::vector<bool>(dim, true)))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
   Assert(


### PR DESCRIPTION
This is step 3 in addressing #1973.

This is the hardest for me so far, so I need a little bit of advice. In the current state, most of the errors have been eliminated; however, I believe I'm doing something conceptually wrong. When I run a build, I receive the following error
```
                 from /home/graham/Programming/cpp/Deal.II/deal.II-master/source/fe/fe_bernardi_raugel.cc:17:
/usr/include/c++/7/bits/unique_ptr.h: In instantiation of ‘typename std::_MakeUniq<_Tp>::__single_object std::make_unique(_Args&& ...) [with _Tp = dealii::FE_BernardiRaugel<1>; _Args = {const dealii::FE_BernardiRaugel<1>&}; typename std::_MakeUniq<_Tp>::__single_object = std::unique_ptr<dealii::FE_BernardiRaugel<1>, std::default_delete<dealii::FE_BernardiRaugel<1> > >]’:
/home/graham/Programming/cpp/Deal.II/deal.II-master/source/fe/fe_bernardi_raugel.cc:87:56:   required from ‘std::unique_ptr<dealii::FiniteElement<dim, dim> > dealii::FE_BernardiRaugel<dim>::clone() const [with int dim = 1]’
/home/graham/Programming/cpp/Deal.II/deal.II-master/source/fe/fe_bernardi_raugel.cc:182:16:   required from here
/usr/include/c++/7/bits/unique_ptr.h:825:30: error: use of deleted function ‘dealii::FE_BernardiRaugel<1>::FE_BernardiRaugel(const dealii::FE_BernardiRaugel<1>&)’
     { return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...)); }
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/graham/Programming/cpp/Deal.II/deal.II-master/source/fe/fe_bernardi_raugel.cc:25:0:
/home/graham/Programming/cpp/Deal.II/deal.II-master/include/deal.II/fe/fe_bernardi_raugel.h:87:7: note: ‘dealii::FE_BernardiRaugel<1>::FE_BernardiRaugel(const dealii::FE_BernardiRaugel<1>&)’ is implicitly deleted because the default definition would be ill-formed:
 class FE_BernardiRaugel : public FE_PolyTensor<dim>
       ^~~~~~~~~~~~~~~~~
/home/graham/Programming/cpp/Deal.II/deal.II-master/include/deal.II/fe/fe_bernardi_raugel.h:87:7: error: use of deleted function ‘dealii::FE_PolyTensor<1, 1>::FE_PolyTensor(const dealii::FE_PolyTensor<1, 1>&)’
In file included from /home/graham/Programming/cpp/Deal.II/deal.II-master/include/deal.II/fe/fe_bernardi_raugel.h:27:0,
                 from /home/graham/Programming/cpp/Deal.II/deal.II-master/source/fe/fe_bernardi_raugel.cc:25:
/home/graham/Programming/cpp/Deal.II/deal.II-master/include/deal.II/fe/fe_poly_tensor.h:146:7: note: ‘dealii::FE_PolyTensor<1, 1>::FE_PolyTensor(const dealii::FE_PolyTensor<1, 1>&)’ is implicitly deleted because the default definition would be ill-formed:
 class FE_PolyTensor : public FiniteElement<dim, spacedim>
       ^~~~~~~~~~~~~
```
I think this is telling me that I'm using a move constructor when I shouldn't be, but I'm not sure where this is happening. My guess is that my new setup for the class isn't quite right. I have
 - `const std::unique_ptr<TensorPolynomialsBase> poly_space` as a member of `FE_PolyTensor`
 - On construction, `FE_PolyTensor` takes an argument `const TensorPolynomialsBase<dim> &polynomials` and uses its `clone()` to initialize `poly_space`.
 - Each FE class calls the `FE_PolyTensor` constructor and passes the respective polynomial space as an argument, i.e. `PolynomialsABF<dim>(deg)` for `FE_ABF`.

This is a WIP, but I believe this is the most difficult hurdle for these changes. I will also likely need to change the `fe_poly_tensor.inst.in` file to remove the templates for `PolynomialType`s, but I'm unsure if that's related to my current issue.