### PR TITLE
Avoid warning regarding VectorizedArray: no-user provided constructor

### DIFF
--- a/include/deal.II/base/tensor_accessors.h
+++ b/include/deal.II/base/tensor_accessors.h
@@ -714,12 +714,22 @@ namespace TensorAccessors
       {
         // Some auto-differentiable numbers need explicit
         // zero initialization.
-        T1 result = dealii::internal::NumberType<T1>::value(0.0);
-        for (unsigned int i = 0; i < dim; ++i)
-          result +=
-            Contract2<no_contr - 1, dim>::template contract2<T1>(left[i],
-                                                                 right[i]);
-        return result;
+        if (dim == 0)
+          {
+            T1 result = dealii::internal::NumberType<T1>::value(0.0);
+            return result;
+          }
+        else
+          {
+            T1 result =
+              Contract2<no_contr - 1, dim>::template contract2<T1>(left[0],
+                                                                   right[0]);
+            for (unsigned int i = 1; i < dim; ++i)
+              result +=
+                Contract2<no_contr - 1, dim>::template contract2<T1>(left[i],
+                                                                     right[i]);
+            return result;
+          }
       }
     };
 


### PR DESCRIPTION
When compiling code that involved `operator*` of two `Tensor<1,dim,VectorizedArray>` objects, I got the warning
```
/home/kronbichler/deal/deal.II/include/deal.II/base/tensor.h: In instantiation of 
‘constexpr typename dealii::Tensor<((rank_1 + rank_2) - 2), dim,
typename dealii::ProductType<Number, OtherNumber>::type>::tensor_type
dealii::operator*(const dealii::Tensor<rank_1, dim, Number>&,
const dealii::Tensor<rank_2, dim, OtherNumber>&)
[with int rank_1 = 1; int rank_2 = 1; int dim = 2;
Number = dealii::VectorizedArray<double>;
OtherNumber = dealii::VectorizedArray<double>;
typename dealii::Tensor<((rank_1 + rank_2) - 2), dim, typename
dealii::ProductType<Number, OtherNumber>::type>::tensor_type
= dealii::VectorizedArray<double>]’:
...
/home/kronbichler/deal/deal.II/include/deal.II/base/vectorization.h:1548:7: note:
 ‘using tensor_type = class dealii::VectorizedArray<double>’ {aka ‘class 
dealii::VectorizedArray<double>’} has no user-provided default constructor
 class VectorizedArray<double, 4>
       ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kronbichler/deal/deal.II/include/deal.II/base/vectorization.h:1565:3: note:
constructor is not user-provided because it is explicitly defaulted in the class body
   VectorizedArray() = default;
   ^~~~~~~~~~~~~~~
/home/kronbichler/deal/deal.II/include/deal.II/base/vectorization.h:1762:11: note:
and the implicitly-defined constructor does not initialize ‘__m256d 
dealii::VectorizedArray<double>::data’
   __m256d data;
           ^~~~
```

This came from the uninitialized field `result` that is passed by reference into some functions. For some reasons, the compiler did not understand that this variable will always be overwritten at some point, so it does no harm. However, the part that issues the warnings seems to come before the optimization pass that inlines everything and makes sure that data is valid.

Worried about a possible performance penalty of zeroing another variable in a register, I stumbled over the (what I believe) working loop of `operator*` which does an initial zero operation anyway. While I have not yet had the time to look into the generated assembler code yet, I believe that the zeroing operation will be absorbed by some peephole optimization pass (or it was there before anyway), so this should be fine.

Relates to #8406 (it fixes another variant of that warning; now that only appears when explicitly working with vectorized arrays).

I ran the full test suite locally and have not seen failures apart from those that already fail on master right now.