### PR TITLE
Documentation typos fixed in theta_timestepping.h and newton.h

### DIFF
--- a/include/deal.II/algorithms/newton.h
+++ b/include/deal.II/algorithms/newton.h
@@ -147,7 +147,7 @@ namespace Algorithms
      * A flag used to decide how many stepsize iteration should be made.
      * Default is the original value of 21.
      *
-     * Enter zero here to turn of stepsize control.
+     * Enter zero here to turn off stepsize control.
      *
      * @note Controlled by <tt>Stepsize iterations</tt> in parameter file
      */

--- a/include/deal.II/algorithms/theta_timestepping.h
+++ b/include/deal.II/algorithms/theta_timestepping.h
@@ -134,14 +134,16 @@ namespace Algorithms
    * use a SmartPointer here, since the TimestepData will be destroyed before
    * the operator.
    *
-   * @skip class Explicit @until End of declarations
+   * @skip class Explicit
+   * @until End of declarations
    *
    * These operators will be implemented after the main program. But let us
    * look first at how they get used. First, let us define a matrix to be used
    * for our system and also an OutputOperator in order to write the data of
    * each timestep to a file.
    *
-   * @skipline main @until out.initialize
+   * @skipline main
+   * @until out.initialize
    *
    * Now we create objects for the implicit and explicit parts of the steps as
    * well as the ThetaTimestepping itself. We initialize the timestepping with
@@ -163,10 +165,13 @@ namespace Algorithms
    *
    * @until }
    *
+   * Besides the main function, we need to define the members functions
+   * of the implicit and explicit operators.
    * First the constructor, which simply copies the system matrix into the
    * member pointer for later use.
    *
-   * @skip Explicit:: @until }
+   * @skip Explicit::
+   * @until }
    *
    * Now we need to study the application of the implicit and explicit
    * operator. We assume that the pointer <code>matrix</code> points to the
@@ -178,15 +183,19 @@ namespace Algorithms
    * off the notifications, we clear them, such that the matrix is only
    * generated when necessary.
    *
-   * @skipline void @until clear
+   * @skipline void
+   * @until clear
    *
    * Now we multiply the input vector with the new matrix and store on output.
    *
-   * @until } The code for the implicit operator is almost the same, except
-   * that we change the sign in front of the timestep and use the inverse of t
-   * he matrix.
+   * @until }
    *
-   * @until vmult @until }
+   * The code for the implicit operator is almost the same, except
+   * that we change the sign in front of the timestep and use the inverse of
+   * the matrix.
+   *
+   * @until vmult
+   * @until }
    * @author Guido Kanschat
    * @date 2010
    */


### PR DESCRIPTION
The example mentioned in the documentation of `theta_timestepping.h` was not properly formatted. I fixed it.