### PR TITLE
Only allow floating point types in complex_overloads.h

### DIFF
--- a/doc/news/changes/incompatibilities/20190821DanielArndt
+++ b/doc/news/changes/incompatibilities/20190821DanielArndt
@@ -1,0 +1,4 @@
+Changed: The complex operator overloads for multiplication and division are
+restricted to floating point types.
+<br>
+(Daniel Arndt, 2019/08/21)

--- a/include/deal.II/base/complex_overloads.h
+++ b/include/deal.II/base/complex_overloads.h
@@ -24,8 +24,6 @@ DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
 #ifndef DOXYGEN
-template <typename T>
-struct EnableIfScalar;
 template <typename T, typename U>
 struct ProductType;
 #endif
@@ -39,7 +37,9 @@ struct ProductType;
  * @relatesalso ProductType
  */
 template <typename T, typename U>
-inline typename ProductType<std::complex<T>, std::complex<U>>::type
+inline typename std::enable_if<
+  std::is_floating_point<T>::value && std::is_floating_point<U>::value,
+  typename ProductType<std::complex<T>, std::complex<U>>::type>::type
 operator*(const std::complex<T> &left, const std::complex<U> &right)
 {
   using result_type =
@@ -55,7 +55,9 @@ operator*(const std::complex<T> &left, const std::complex<U> &right)
  * @relatesalso ProductType
  */
 template <typename T, typename U>
-inline typename ProductType<std::complex<T>, std::complex<U>>::type
+inline typename std::enable_if<
+  std::is_floating_point<T>::value && std::is_floating_point<U>::value,
+  typename ProductType<std::complex<T>, std::complex<U>>::type>::type
 operator/(const std::complex<T> &left, const std::complex<U> &right)
 {
   using result_type =
@@ -68,12 +70,13 @@ operator/(const std::complex<T> &left, const std::complex<U> &right)
  * floating point type with a different real floating point type. Annoyingly,
  * the standard library does not provide such an operator...
  *
- * @relatesalso EnableIfScalar
  * @relatesalso ProductType
  */
 template <typename T, typename U>
 inline
-  typename ProductType<std::complex<T>, typename EnableIfScalar<U>::type>::type
+  typename std::enable_if<std::is_floating_point<T>::value &&
+                            std::is_floating_point<U>::value,
+                          typename ProductType<std::complex<T>, U>::type>::type
   operator*(const std::complex<T> &left, const U &right)
 {
   using result_type = typename ProductType<std::complex<T>, U>::type;
@@ -85,12 +88,13 @@ inline
  * floating point type with a different real floating point type. Annoyingly,
  * the standard library does not provide such an operator...
  *
- * @relatesalso EnableIfScalar
  * @relatesalso ProductType
  */
 template <typename T, typename U>
 inline
-  typename ProductType<std::complex<T>, typename EnableIfScalar<U>::type>::type
+  typename std::enable_if<std::is_floating_point<T>::value &&
+                            std::is_floating_point<U>::value,
+                          typename ProductType<std::complex<T>, U>::type>::type
   operator/(const std::complex<T> &left, const U &right)
 {
   using result_type = typename ProductType<std::complex<T>, U>::type;
@@ -102,15 +106,17 @@ inline
  * floating point type with a different complex floating point type.
  * Annoyingly, the standard library does not provide such an operator...
  *
- * @relatesalso EnableIfScalar
  * @relatesalso ProductType
  */
 template <typename T, typename U>
-inline
-  typename ProductType<typename EnableIfScalar<T>::type, std::complex<U>>::type
+inline typename
+
+  std::enable_if<std::is_floating_point<T>::value &&
+                   std::is_floating_point<U>::value,
+                 typename ProductType<T, std::complex<U>>::type>::type
   operator*(const T &left, const std::complex<U> &right)
 {
-  using result_type = typename ProductType<std::complex<T>, U>::type;
+  using result_type = typename ProductType<T, std::complex<U>>::type;
   return static_cast<result_type>(left) * static_cast<result_type>(right);
 }
 
@@ -119,15 +125,16 @@ inline
  * floating point type with a different complex floating point type.
  * Annoyingly, the standard library does not provide such an operator...
  *
- * @relatesalso EnableIfScalar
  * @relatesalso ProductType
  */
 template <typename T, typename U>
 inline
-  typename ProductType<typename EnableIfScalar<T>::type, std::complex<U>>::type
+  typename std::enable_if<std::is_floating_point<T>::value &&
+                            std::is_floating_point<U>::value,
+                          typename ProductType<T, std::complex<U>>::type>::type
   operator/(const T &left, const std::complex<U> &right)
 {
-  using result_type = typename ProductType<std::complex<T>, U>::type;
+  using result_type = typename ProductType<T, std::complex<U>>::type;
   return static_cast<result_type>(left) / static_cast<result_type>(right);
 }
 #endif /* DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS */


### PR DESCRIPTION
Fixes #8607. This appears simpler than I expected. At least, I could compile and all the `symengine` (apart from the one addressed in #8602), `tensor` and `complex` tests pass.