### PR TITLE
Add std::complex support to DataPostprocessor

### DIFF
--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -213,7 +213,7 @@ namespace internal
      *
      * @author Wolfgang Bangerth, 2004
      */
-    template <typename DoFHandlerType>
+    template <typename DoFHandlerType, typename Number = double>
     class DataEntryBase
     {
     public:
@@ -233,9 +233,9 @@ namespace internal
        * case, the names and vector declarations are going to be acquired from
        * the postprocessor.
        */
-      DataEntryBase(const DoFHandlerType *dofs,
-                    const DataPostprocessor<DoFHandlerType::space_dimension>
-                      *data_postprocessor);
+      DataEntryBase(const DoFHandlerType *           dofs,
+                    const DataPostprocessor<DoFHandlerType::space_dimension,
+                                            Number> *data_postprocessor);
 
       /**
        * Destructor made virtual.
@@ -366,8 +366,8 @@ namespace internal
        * Pointer to a DataPostprocessing object which shall be applied to this
        * data vector.
        */
-      SmartPointer<
-        const dealii::DataPostprocessor<DoFHandlerType::space_dimension>>
+      SmartPointer<const dealii::
+                     DataPostprocessor<DoFHandlerType::space_dimension, Number>>
         postprocessor;
 
       /**
@@ -593,7 +593,8 @@ namespace internal
  */
 template <typename DoFHandlerType,
           int patch_dim,
-          int patch_space_dim = patch_dim>
+          int patch_space_dim = patch_dim,
+          typename Number     = double>
 class DataOut_DoFData : public DataOutInterface<patch_dim, patch_space_dim>
 {
 public:
@@ -836,7 +837,8 @@ public:
   template <class VectorType>
   void
   add_data_vector(const VectorType &data,
-                  const DataPostprocessor<DoFHandlerType::space_dimension>
+                  const DataPostprocessor<DoFHandlerType::space_dimension,
+                                          typename VectorType::value_type>
                     &data_postprocessor);
 
   /**
@@ -849,7 +851,8 @@ public:
   void
   add_data_vector(const DoFHandlerType &dof_handler,
                   const VectorType &    data,
-                  const DataPostprocessor<DoFHandlerType::space_dimension>
+                  const DataPostprocessor<DoFHandlerType::space_dimension,
+                                          typename VectorType::value_type>
                     &data_postprocessor);
 
   /**
@@ -941,14 +944,14 @@ protected:
    * List of data elements with vectors of values for each degree of freedom.
    */
   std::vector<std::shared_ptr<
-    internal::DataOutImplementation::DataEntryBase<DoFHandlerType>>>
+    internal::DataOutImplementation::DataEntryBase<DoFHandlerType, Number>>>
     dof_data;
 
   /**
    * List of data elements with vectors of values for each cell.
    */
   std::vector<std::shared_ptr<
-    internal::DataOutImplementation::DataEntryBase<DoFHandlerType>>>
+    internal::DataOutImplementation::DataEntryBase<DoFHandlerType, Number>>>
     cell_data;
 
   /**
@@ -994,7 +997,7 @@ protected:
 
   // Make all template siblings friends. Needed for the merge_patches()
   // function.
-  template <class, int, int>
+  template <class, int, int, class>
   friend class DataOut_DoFData;
 
 private:
@@ -1016,15 +1019,19 @@ private:
 
 
 // -------------------- template and inline functions ------------------------
-template <typename DoFHandlerType, int patch_dim, int patch_space_dim>
+template <typename DoFHandlerType,
+          int patch_dim,
+          int patch_space_dim,
+          typename Number>
 template <typename VectorType>
 void
-DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
-  const VectorType &   vec,
-  const std::string &  name,
-  const DataVectorType type,
-  const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    &data_component_interpretation)
+DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim, Number>::
+  add_data_vector(
+    const VectorType &   vec,
+    const std::string &  name,
+    const DataVectorType type,
+    const std::vector<DataComponentInterpretation::DataComponentInterpretation>
+      &data_component_interpretation)
 {
   Assert(triangulation != nullptr,
          Exceptions::DataOutImplementation::ExcNoTriangulationSelected());
@@ -1035,15 +1042,19 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
 
 
 
-template <typename DoFHandlerType, int patch_dim, int patch_space_dim>
+template <typename DoFHandlerType,
+          int patch_dim,
+          int patch_space_dim,
+          typename Number>
 template <typename VectorType>
 void
-DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
-  const VectorType &              vec,
-  const std::vector<std::string> &names,
-  const DataVectorType            type,
-  const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    &data_component_interpretation)
+DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim, Number>::
+  add_data_vector(
+    const VectorType &              vec,
+    const std::vector<std::string> &names,
+    const DataVectorType            type,
+    const std::vector<DataComponentInterpretation::DataComponentInterpretation>
+      &data_component_interpretation)
 {
   Assert(triangulation != nullptr,
          Exceptions::DataOutImplementation::ExcNoTriangulationSelected());
@@ -1053,15 +1064,19 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
 
 
 
-template <typename DoFHandlerType, int patch_dim, int patch_space_dim>
+template <typename DoFHandlerType,
+          int patch_dim,
+          int patch_space_dim,
+          typename Number>
 template <typename VectorType>
 void
-DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
-  const DoFHandlerType &dof_handler,
-  const VectorType &    data,
-  const std::string &   name,
-  const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    &data_component_interpretation)
+DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim, Number>::
+  add_data_vector(
+    const DoFHandlerType &dof_handler,
+    const VectorType &    data,
+    const std::string &   name,
+    const std::vector<DataComponentInterpretation::DataComponentInterpretation>
+      &data_component_interpretation)
 {
   std::vector<std::string> names(1, name);
   add_data_vector_internal(&dof_handler,
@@ -1074,15 +1089,19 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
 
 
 
-template <typename DoFHandlerType, int patch_dim, int patch_space_dim>
+template <typename DoFHandlerType,
+          int patch_dim,
+          int patch_space_dim,
+          typename Number>
 template <typename VectorType>
 void
-DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
-  const DoFHandlerType &          dof_handler,
-  const VectorType &              data,
-  const std::vector<std::string> &names,
-  const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    &data_component_interpretation)
+DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim, Number>::
+  add_data_vector(
+    const DoFHandlerType &          dof_handler,
+    const VectorType &              data,
+    const std::vector<std::string> &names,
+    const std::vector<DataComponentInterpretation::DataComponentInterpretation>
+      &data_component_interpretation)
 {
   add_data_vector_internal(&dof_handler,
                            data,
@@ -1094,12 +1113,17 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
 
 
 
-template <typename DoFHandlerType, int patch_dim, int patch_space_dim>
+template <typename DoFHandlerType,
+          int patch_dim,
+          int patch_space_dim,
+          typename Number>
 template <typename VectorType>
 void
-DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
-  const VectorType &                                        vec,
-  const DataPostprocessor<DoFHandlerType::space_dimension> &data_postprocessor)
+DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim, Number>::
+  add_data_vector(const VectorType &vec,
+                  const DataPostprocessor<DoFHandlerType::space_dimension,
+                                          typename VectorType::value_type>
+                    &data_postprocessor)
 {
   Assert(dofs != nullptr,
          Exceptions::DataOutImplementation::ExcNoDoFHandlerSelected());
@@ -1108,12 +1132,16 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
 
 
 
-template <typename DoFHandlerType, int patch_dim, int patch_space_dim>
+template <typename DoFHandlerType,
+          int patch_dim,
+          int patch_space_dim,
+          typename Number>
 template <typename DoFHandlerType2>
 void
-DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::merge_patches(
-  const DataOut_DoFData<DoFHandlerType2, patch_dim, patch_space_dim> &source,
-  const Point<patch_space_dim> &                                      shift)
+DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim, Number>::
+  merge_patches(
+    const DataOut_DoFData<DoFHandlerType2, patch_dim, patch_space_dim> &source,
+    const Point<patch_space_dim> &                                      shift)
 {
   const std::vector<Patch> &source_patches = source.get_patches();
   Assert((patches.size() != 0) && (source_patches.size() != 0),

--- a/include/deal.II/numerics/data_postprocessor.h
+++ b/include/deal.II/numerics/data_postprocessor.h
@@ -227,7 +227,7 @@ namespace DataPostprocessorInputs
    *
    * @author Wolfgang Bangerth, 2016
    */
-  template <int spacedim>
+  template <int spacedim, typename Number = double>
   struct Scalar : public CommonInputs<spacedim>
   {
     /**
@@ -235,7 +235,7 @@ namespace DataPostprocessorInputs
      * points used to create graphical output from one cell, face, or other
      * object.
      */
-    std::vector<double> solution_values;
+    std::vector<Number> solution_values;
 
     /**
      * An array of gradients of the (scalar) solution at each of the evaluation
@@ -250,7 +250,7 @@ namespace DataPostprocessorInputs
      * or DataPostprocessorTensor may pass this flag to the constructor of
      * these three classes.
      */
-    std::vector<Tensor<1, spacedim>> solution_gradients;
+    std::vector<Tensor<1, spacedim, Number>> solution_gradients;
 
     /**
      * An array of second derivatives of the (scalar) solution at each of the
@@ -265,7 +265,7 @@ namespace DataPostprocessorInputs
      * or DataPostprocessorTensor may pass this flag to the constructor of
      * these three classes.
      */
-    std::vector<Tensor<2, spacedim>> solution_hessians;
+    std::vector<Tensor<2, spacedim, Number>> solution_hessians;
   };
 
 
@@ -283,7 +283,7 @@ namespace DataPostprocessorInputs
    *
    * @author Wolfgang Bangerth, 2016
    */
-  template <int spacedim>
+  template <int spacedim, typename Number = double>
   struct Vector : public CommonInputs<spacedim>
   {
     /**
@@ -295,7 +295,7 @@ namespace DataPostprocessorInputs
      * vector runs over the components of the finite element field for which
      * output will be generated.
      */
-    std::vector<dealii::Vector<double>> solution_values;
+    std::vector<dealii::Vector<Number>> solution_values;
 
     /**
      * An array of gradients of a vector-valued solution at each of the
@@ -314,7 +314,7 @@ namespace DataPostprocessorInputs
      * or DataPostprocessorTensor may pass this flag to the constructor of
      * these three classes.
      */
-    std::vector<std::vector<Tensor<1, spacedim>>> solution_gradients;
+    std::vector<std::vector<Tensor<1, spacedim, Number>>> solution_gradients;
 
     /**
      * An array of second derivatives of a vector-valued solution at each of the
@@ -333,7 +333,7 @@ namespace DataPostprocessorInputs
      * or DataPostprocessorTensor may pass this flag to the constructor of
      * these three classes.
      */
-    std::vector<std::vector<Tensor<2, spacedim>>> solution_hessians;
+    std::vector<std::vector<Tensor<2, spacedim, Number>>> solution_hessians;
   };
 
 } // namespace DataPostprocessorInputs
@@ -425,7 +425,7 @@ namespace DataPostprocessorInputs
  * @ingroup output
  * @author Tobias Leicht, 2007, Wolfgang Bangerth, 2016
  */
-template <int dim>
+template <int dim, typename Number = double>
 class DataPostprocessor : public Subscriptor
 {
 public:
@@ -456,8 +456,9 @@ public:
    * component.
    */
   virtual void
-  evaluate_scalar_field(const DataPostprocessorInputs::Scalar<dim> &input_data,
-                        std::vector<Vector<double>> &computed_quantities) const;
+  evaluate_scalar_field(
+    const DataPostprocessorInputs::Scalar<dim, Number> &input_data,
+    std::vector<Vector<Number>> &computed_quantities) const;
 
   /**
    * Same as the evaluate_scalar_field() function, but this
@@ -465,8 +466,9 @@ public:
    * i.e. the finite element in use has multiple vector components.
    */
   virtual void
-  evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
-                        std::vector<Vector<double>> &computed_quantities) const;
+  evaluate_vector_field(
+    const DataPostprocessorInputs::Vector<dim, Number> &input_data,
+    std::vector<Vector<Number>> &computed_quantities) const;
 
   /**
    * Return the vector of strings describing the names of the computed
@@ -535,8 +537,8 @@ public:
  * @ingroup output
  * @author Wolfgang Bangerth, 2011
  */
-template <int dim>
-class DataPostprocessorScalar : public DataPostprocessor<dim>
+template <int dim, typename Number = double>
+class DataPostprocessorScalar : public DataPostprocessor<dim, Number>
 {
 public:
   /**
@@ -774,8 +776,8 @@ private:
  * @ingroup output
  * @author Wolfgang Bangerth, 2011, 2017
  */
-template <int dim>
-class DataPostprocessorVector : public DataPostprocessor<dim>
+template <int dim, typename Number = double>
+class DataPostprocessorVector : public DataPostprocessor<dim, Number>
 {
 public:
   /**
@@ -1019,8 +1021,8 @@ private:
  * @ingroup output
  * @author Wolfgang Bangerth, 2017
  */
-template <int dim>
-class DataPostprocessorTensor : public DataPostprocessor<dim>
+template <int dim, typename Number = double>
+class DataPostprocessorTensor : public DataPostprocessor<dim, Number>
 {
 public:
   /**

--- a/source/numerics/data_out_dof_data.inst.in
+++ b/source/numerics/data_out_dof_data.inst.in
@@ -36,7 +36,8 @@ for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DH<deal_II_dimension, deal_II_dimension> &,
         const VEC &,
         const DataPostprocessor<
-          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension,
+          typename VEC::value_type> &);
 
 
 
@@ -61,7 +62,8 @@ for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DH<deal_II_dimension, deal_II_dimension> &,
         const VEC &,
         const DataPostprocessor<
-          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension,
+          typename VEC::value_type> &);
 
 
 
@@ -87,7 +89,8 @@ for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DH<deal_II_dimension, deal_II_dimension> &,
         const VEC &,
         const DataPostprocessor<
-          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension,
+          typename VEC::value_type> &);
 #endif
   }
 

--- a/source/numerics/data_out_dof_data_codim.inst.in
+++ b/source/numerics/data_out_dof_data_codim.inst.in
@@ -39,7 +39,8 @@ for (VEC : REAL_VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
       add_data_vector<VEC>(
         const VEC &,
         const DataPostprocessor<
-          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension> &);
+          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension,
+          typename VEC::value_type> &);
 
     template void
     DataOut_DoFData<DH<deal_II_dimension, deal_II_space_dimension>,
@@ -49,7 +50,8 @@ for (VEC : REAL_VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DH<deal_II_dimension, deal_II_space_dimension> &,
         const VEC &,
         const DataPostprocessor<
-          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension> &);
+          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension,
+          typename VEC::value_type> &);
 #endif
   }
 

--- a/source/numerics/data_postprocessor.cc
+++ b/source/numerics/data_postprocessor.cc
@@ -21,31 +21,31 @@ DEAL_II_NAMESPACE_OPEN
 
 // -------------------------- DataPostprocessor ---------------------------
 
-template <int dim>
+template <int dim, typename Number>
 void
-DataPostprocessor<dim>::evaluate_scalar_field(
-  const DataPostprocessorInputs::Scalar<dim> &,
-  std::vector<Vector<double>> &) const
+DataPostprocessor<dim, Number>::evaluate_scalar_field(
+  const DataPostprocessorInputs::Scalar<dim, Number> &,
+  std::vector<Vector<Number>> &) const
 {
   AssertThrow(false, ExcPureFunctionCalled());
 }
 
 
 
-template <int dim>
+template <int dim, typename Number>
 void
-DataPostprocessor<dim>::evaluate_vector_field(
-  const DataPostprocessorInputs::Vector<dim> &,
-  std::vector<Vector<double>> &) const
+DataPostprocessor<dim, Number>::evaluate_vector_field(
+  const DataPostprocessorInputs::Vector<dim, Number> &,
+  std::vector<Vector<Number>> &) const
 {
   AssertThrow(false, ExcPureFunctionCalled());
 }
 
 
 
-template <int dim>
+template <int dim, typename Number>
 std::vector<DataComponentInterpretation::DataComponentInterpretation>
-DataPostprocessor<dim>::get_data_component_interpretation() const
+DataPostprocessor<dim, Number>::get_data_component_interpretation() const
 {
   // default implementation assumes that all
   // components are independent scalars
@@ -56,8 +56,8 @@ DataPostprocessor<dim>::get_data_component_interpretation() const
 
 // -------------------------- DataPostprocessorScalar -------------------------
 
-template <int dim>
-DataPostprocessorScalar<dim>::DataPostprocessorScalar(
+template <int dim, typename Number>
+DataPostprocessorScalar<dim, Number>::DataPostprocessorScalar(
   const std::string &name,
   const UpdateFlags  update_flags)
   : name(name)
@@ -66,27 +66,27 @@ DataPostprocessorScalar<dim>::DataPostprocessorScalar(
 
 
 
-template <int dim>
+template <int dim, typename Number>
 std::vector<std::string>
-DataPostprocessorScalar<dim>::get_names() const
+DataPostprocessorScalar<dim, Number>::get_names() const
 {
   return std::vector<std::string>(1, name);
 }
 
 
 
-template <int dim>
+template <int dim, typename Number>
 std::vector<DataComponentInterpretation::DataComponentInterpretation>
-DataPostprocessorScalar<dim>::get_data_component_interpretation() const
+DataPostprocessorScalar<dim, Number>::get_data_component_interpretation() const
 {
   return std::vector<DataComponentInterpretation::DataComponentInterpretation>(
     1, DataComponentInterpretation::component_is_scalar);
 }
 
 
-template <int dim>
+template <int dim, typename Number>
 UpdateFlags
-DataPostprocessorScalar<dim>::get_needed_update_flags() const
+DataPostprocessorScalar<dim, Number>::get_needed_update_flags() const
 {
   return update_flags;
 }
@@ -95,8 +95,8 @@ DataPostprocessorScalar<dim>::get_needed_update_flags() const
 
 // -------------------------- DataPostprocessorVector -------------------------
 
-template <int dim>
-DataPostprocessorVector<dim>::DataPostprocessorVector(
+template <int dim, typename Number>
+DataPostprocessorVector<dim, Number>::DataPostprocessorVector(
   const std::string &name,
   const UpdateFlags  update_flags)
   : name(name)
@@ -105,27 +105,27 @@ DataPostprocessorVector<dim>::DataPostprocessorVector(
 
 
 
-template <int dim>
+template <int dim, typename Number>
 std::vector<std::string>
-DataPostprocessorVector<dim>::get_names() const
+DataPostprocessorVector<dim, Number>::get_names() const
 {
   return std::vector<std::string>(dim, name);
 }
 
 
 
-template <int dim>
+template <int dim, typename Number>
 std::vector<DataComponentInterpretation::DataComponentInterpretation>
-DataPostprocessorVector<dim>::get_data_component_interpretation() const
+DataPostprocessorVector<dim, Number>::get_data_component_interpretation() const
 {
   return std::vector<DataComponentInterpretation::DataComponentInterpretation>(
     dim, DataComponentInterpretation::component_is_part_of_vector);
 }
 
 
-template <int dim>
+template <int dim, typename Number>
 UpdateFlags
-DataPostprocessorVector<dim>::get_needed_update_flags() const
+DataPostprocessorVector<dim, Number>::get_needed_update_flags() const
 {
   return update_flags;
 }
@@ -134,8 +134,8 @@ DataPostprocessorVector<dim>::get_needed_update_flags() const
 
 // -------------------------- DataPostprocessorTensor -------------------------
 
-template <int dim>
-DataPostprocessorTensor<dim>::DataPostprocessorTensor(
+template <int dim, typename Number>
+DataPostprocessorTensor<dim, Number>::DataPostprocessorTensor(
   const std::string &name,
   const UpdateFlags  update_flags)
   : name(name)
@@ -144,9 +144,9 @@ DataPostprocessorTensor<dim>::DataPostprocessorTensor(
 
 
 
-template <int dim>
+template <int dim, typename Number>
 std::vector<std::string>
-DataPostprocessorTensor<dim>::get_names() const
+DataPostprocessorTensor<dim, Number>::get_names() const
 {
   static_assert(dim <= 3,
                 "The following variable needs to be expanded for dim>3");
@@ -161,18 +161,18 @@ DataPostprocessorTensor<dim>::get_names() const
 
 
 
-template <int dim>
+template <int dim, typename Number>
 std::vector<DataComponentInterpretation::DataComponentInterpretation>
-DataPostprocessorTensor<dim>::get_data_component_interpretation() const
+DataPostprocessorTensor<dim, Number>::get_data_component_interpretation() const
 {
   return std::vector<DataComponentInterpretation::DataComponentInterpretation>(
     dim * dim, DataComponentInterpretation::component_is_scalar);
 }
 
 
-template <int dim>
+template <int dim, typename Number>
 UpdateFlags
-DataPostprocessorTensor<dim>::get_needed_update_flags() const
+DataPostprocessorTensor<dim, Number>::get_needed_update_flags() const
 {
   return update_flags;
 }

--- a/source/numerics/data_postprocessor.inst.in
+++ b/source/numerics/data_postprocessor.inst.in
@@ -16,8 +16,17 @@
 
 for (deal_II_dimension : DIMENSIONS)
   {
-    template class DataPostprocessor<deal_II_dimension>;
-    template class DataPostprocessorScalar<deal_II_dimension>;
-    template class DataPostprocessorVector<deal_II_dimension>;
-    template class DataPostprocessorTensor<deal_II_dimension>;
+    template class DataPostprocessor<deal_II_dimension, double>;
+    template class DataPostprocessorScalar<deal_II_dimension, double>;
+    template class DataPostprocessorVector<deal_II_dimension, double>;
+    template class DataPostprocessorTensor<deal_II_dimension, double>;
+#ifdef DEAL_II_WITH_COMPLEX_VALUES
+    template class DataPostprocessor<deal_II_dimension, std::complex<double>>;
+    template class DataPostprocessorScalar<deal_II_dimension,
+                                           std::complex<double>>;
+    template class DataPostprocessorVector<deal_II_dimension,
+                                           std::complex<double>>;
+    template class DataPostprocessorTensor<deal_II_dimension,
+                                           std::complex<double>>;
+#endif
   }


### PR DESCRIPTION
Hi, I would like to add support for a vector valued `std::complex` DataPostprocessor but I think that I took the wrong approach.

Could you give me a hint :) ?

I think that it should be feasible because the machinery to write a vector valued `std::complex` solution is already in place.

The members in `DataPostprocessor` are `double` and I have the feeling that `add_data_vector()` converts any `Vector<number>` to `Vector<double>`. That is a problem because `std::complex` can not be converted to double.