### PR TITLE
Use std::free instead of free to avoid name collision when using hipcc

### DIFF
--- a/include/deal.II/base/memory_space.h
+++ b/include/deal.II/base/memory_space.h
@@ -85,7 +85,7 @@ namespace MemorySpace
     /**
      * Pointer to data on the host.
      */
-    std::unique_ptr<Number[], decltype(&free)> values;
+    std::unique_ptr<Number[], decltype(&std::free)> values;
 
     /**
      * Pointer to data on the device.
@@ -114,7 +114,7 @@ namespace MemorySpace
   struct MemorySpaceData<Number, Host>
   {
     MemorySpaceData()
-      : values(nullptr, &free)
+      : values(nullptr, &std::free)
     {}
 
     void
@@ -129,7 +129,7 @@ namespace MemorySpace
       std::copy(begin, begin + n_elements, values.get());
     }
 
-    std::unique_ptr<Number[], decltype(&free)> values;
+    std::unique_ptr<Number[], decltype(&std::free)> values;
 
     // This is not used but it allows to simplify the code until we start using
     // CUDA-aware MPI.
@@ -153,7 +153,7 @@ namespace MemorySpace
   struct MemorySpaceData<Number, CUDA>
   {
     MemorySpaceData()
-      : values(nullptr, &free)
+      : values(nullptr, &std::free)
       , values_dev(nullptr, Utilities::CUDA::delete_device_data<Number>)
     {}
 
@@ -179,8 +179,8 @@ namespace MemorySpace
       AssertCuda(cuda_error_code);
     }
 
-    std::unique_ptr<Number[], decltype(&free)>    values;
-    std::unique_ptr<Number[], void (*)(Number *)> values_dev;
+    std::unique_ptr<Number[], decltype(&std::free)> values;
+    std::unique_ptr<Number[], void (*)(Number *)>   values_dev;
   };
 
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -701,7 +701,7 @@ namespace LinearAlgebra
     /**
      * Pointer to the array of local elements of this vector.
      */
-    std::unique_ptr<Number[], decltype(free) *> values;
+    std::unique_ptr<Number[], decltype(std::free) *> values;
 
     /**
      * For parallel loops with TBB, this member variable stores the affinity


### PR DESCRIPTION
I have started work to make deal.II work on AMD GPU. `hipcc` defines its own `free` functions and it confuses the compiler, so make it clear that we want `free` from `std`

Part of #7821