### PR TITLE
Fourier::calculate only works with double

### DIFF
--- a/source/fe/fe_series_fourier.cc
+++ b/source/fe/fe_series_fourier.cc
@@ -209,7 +209,8 @@ namespace FESeries
 
     for (unsigned int i = 0; i < unrolled_coefficients.size(); i++)
       for (unsigned int j = 0; j < local_dof_values.size(); j++)
-        unrolled_coefficients[i] += matrix[i][j] * local_dof_values[j];
+        unrolled_coefficients[i] +=
+          matrix[i][j] * static_cast<double>(local_dof_values[j]);
 
     fourier_coefficients.fill(unrolled_coefficients.begin());
   }


### PR DESCRIPTION
I don't know why it works with most compiler but if you look at [this line](https://github.com/dealii/dealii/compare/master...Rombur:fe_series?expand=1#diff-ca3f80c49e696f0c490c9e4dd93bcfd3R211) `matrix[i][j]` is of type `std::complex<double>` and `local_dof_values[j]` is of type `Number` but this only works if `Number` is a `double`

Part of #7821 