### PR TITLE
Rename the Poly*::compute_n_pols() function to ::n_polynomials().

### DIFF
--- a/doc/news/changes/incompatibilities/20190822Bangerth
+++ b/doc/news/changes/incompatibilities/20190822Bangerth
@@ -1,0 +1,7 @@
+Changed: A number of classes implementing tensor-valued polynomials
+had a member function called `compute_n_pols()`. This name has now
+been changed to `n_polynomials()`, better reflecting our usual naming
+scheme as well as what the function does -- which in many cases is not
+actually computing but just returning something.
+<br>
+(Wolfgang Bangerth, 2019/08/2)

--- a/include/deal.II/base/polynomial_space.h
+++ b/include/deal.II/base/polynomial_space.h
@@ -214,7 +214,7 @@ public:
    * onedimensional polynomials, thus the degree plus one.
    */
   static unsigned int
-  compute_n_pols(const unsigned int n);
+  n_polynomials(const unsigned int n);
 
 protected:
   /**
@@ -271,7 +271,7 @@ template <int dim>
 template <class Pol>
 PolynomialSpace<dim>::PolynomialSpace(const std::vector<Pol> &pols)
   : polynomials(pols.begin(), pols.end())
-  , n_pols(compute_n_pols(polynomials.size()))
+  , n_pols(n_polynomials(polynomials.size()))
   , index_map(n_pols)
   , index_map_inverse(n_pols)
 {

--- a/include/deal.II/base/polynomials_abf.h
+++ b/include/deal.II/base/polynomials_abf.h
@@ -97,7 +97,7 @@ public:
    * FiniteElement classes.
    */
   static unsigned int
-  n_polynomials(unsigned int degree);
+  n_polynomials(const unsigned int degree);
 
   /**
    * @copydoc TensorPolynomialsBase<dim>::clone()

--- a/include/deal.II/base/polynomials_abf.h
+++ b/include/deal.II/base/polynomials_abf.h
@@ -97,7 +97,7 @@ public:
    * FiniteElement classes.
    */
   static unsigned int
-  compute_n_pols(unsigned int degree);
+  n_polynomials(unsigned int degree);
 
   /**
    * @copydoc TensorPolynomialsBase<dim>::clone()

--- a/include/deal.II/base/polynomials_bdm.h
+++ b/include/deal.II/base/polynomials_bdm.h
@@ -150,7 +150,7 @@ public:
    * by the FiniteElement classes.
    */
   static unsigned int
-  compute_n_pols(unsigned int degree);
+  n_polynomials(unsigned int degree);
 
   /**
    * @copydoc TensorPolynomialsBase<dim>::clone()

--- a/include/deal.II/base/polynomials_bdm.h
+++ b/include/deal.II/base/polynomials_bdm.h
@@ -150,7 +150,7 @@ public:
    * by the FiniteElement classes.
    */
   static unsigned int
-  n_polynomials(unsigned int degree);
+  n_polynomials(const unsigned int degree);
 
   /**
    * @copydoc TensorPolynomialsBase<dim>::clone()

--- a/include/deal.II/base/polynomials_bernardi_raugel.h
+++ b/include/deal.II/base/polynomials_bernardi_raugel.h
@@ -126,7 +126,7 @@ public:
    * required by the FiniteElement classes.
    */
   static unsigned int
-  compute_n_pols(const unsigned int k);
+  n_polynomials(const unsigned int k);
 
   /**
    * @copydoc TensorPolynomialsBase<dim>::clone()

--- a/include/deal.II/base/polynomials_nedelec.h
+++ b/include/deal.II/base/polynomials_nedelec.h
@@ -94,7 +94,7 @@ public:
    * the FiniteElement classes.
    */
   static unsigned int
-  compute_n_pols(unsigned int degree);
+  n_polynomials(unsigned int degree);
 
   /**
    * @copydoc TensorPolynomialsBase<dim>::clone()

--- a/include/deal.II/base/polynomials_nedelec.h
+++ b/include/deal.II/base/polynomials_nedelec.h
@@ -94,7 +94,7 @@ public:
    * the FiniteElement classes.
    */
   static unsigned int
-  n_polynomials(unsigned int degree);
+  n_polynomials(const unsigned int degree);
 
   /**
    * @copydoc TensorPolynomialsBase<dim>::clone()

--- a/include/deal.II/base/polynomials_raviart_thomas.h
+++ b/include/deal.II/base/polynomials_raviart_thomas.h
@@ -92,7 +92,7 @@ public:
    * required by the FiniteElement classes.
    */
   static unsigned int
-  n_polynomials(unsigned int degree);
+  n_polynomials(const unsigned int degree);
 
   /**
    * @copydoc TensorPolynomialsBase<dim>::clone()

--- a/include/deal.II/base/polynomials_raviart_thomas.h
+++ b/include/deal.II/base/polynomials_raviart_thomas.h
@@ -92,7 +92,7 @@ public:
    * required by the FiniteElement classes.
    */
   static unsigned int
-  compute_n_pols(unsigned int degree);
+  n_polynomials(unsigned int degree);
 
   /**
    * @copydoc TensorPolynomialsBase<dim>::clone()

--- a/include/deal.II/base/polynomials_rt_bubbles.h
+++ b/include/deal.II/base/polynomials_rt_bubbles.h
@@ -126,7 +126,7 @@ public:
    * required by the FiniteElement classes.
    */
   static unsigned int
-  compute_n_pols(const unsigned int degree);
+  n_polynomials(const unsigned int degree);
 
   /**
    * @copydoc TensorPolynomialsBase<dim>::clone()

--- a/include/deal.II/fe/fe_dg_vector.templates.h
+++ b/include/deal.II/fe/fe_dg_vector.templates.h
@@ -39,8 +39,8 @@ FE_DGVector<PolynomialType, dim, spacedim>::FE_DGVector(const unsigned int deg,
                              dim,
                              deg + 1,
                              FiniteElementData<dim>::L2),
-      std::vector<bool>(PolynomialType::compute_n_pols(deg), true),
-      std::vector<ComponentMask>(PolynomialType::compute_n_pols(deg),
+      std::vector<bool>(PolynomialType::n_polynomials(deg), true),
+      std::vector<ComponentMask>(PolynomialType::n_polynomials(deg),
                                  ComponentMask(dim, true)))
 {
   this->mapping_kind                   = {map};
@@ -81,7 +81,7 @@ FE_DGVector<PolynomialType, dim, spacedim>::get_dpo_vector(
   const unsigned int deg)
 {
   std::vector<unsigned int> dpo(dim + 1);
-  dpo[dim] = PolynomialType::compute_n_pols(deg);
+  dpo[dim] = PolynomialType::n_polynomials(deg);
 
   return dpo;
 }

--- a/source/base/polynomial_space.cc
+++ b/source/base/polynomial_space.cc
@@ -22,7 +22,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 unsigned int
-PolynomialSpace<dim>::compute_n_pols(const unsigned int n)
+PolynomialSpace<dim>::n_polynomials(const unsigned int n)
 {
   unsigned int n_pols = n;
   for (unsigned int i = 1; i < dim; ++i)
@@ -36,7 +36,7 @@ PolynomialSpace<dim>::compute_n_pols(const unsigned int n)
 
 template <>
 unsigned int
-PolynomialSpace<0>::compute_n_pols(const unsigned int)
+PolynomialSpace<0>::n_polynomials(const unsigned int)
 {
   return 0;
 }

--- a/source/base/polynomials_abf.cc
+++ b/source/base/polynomials_abf.cc
@@ -48,13 +48,13 @@ namespace
 
 template <int dim>
 PolynomialsABF<dim>::PolynomialsABF(const unsigned int k)
-  : TensorPolynomialsBase<dim>(k, compute_n_pols(k))
+  : TensorPolynomialsBase<dim>(k, n_polynomials(k))
   , polynomial_space(get_abf_polynomials<dim>(k))
 {
   // check that the dimensions match. we only store one of the 'dim'
   // anisotropic polynomials that make up the vector-valued space, so
   // multiply by 'dim'
-  Assert(dim * polynomial_space.n() == compute_n_pols(k), ExcInternalError());
+  Assert(dim * polynomial_space.n() == n_polynomials(k), ExcInternalError());
 }
 
 
@@ -155,7 +155,7 @@ PolynomialsABF<dim>::compute(
 
 template <int dim>
 unsigned int
-PolynomialsABF<dim>::compute_n_pols(const unsigned int k)
+PolynomialsABF<dim>::n_polynomials(const unsigned int k)
 {
   switch (dim)
     {

--- a/source/base/polynomials_bdm.cc
+++ b/source/base/polynomials_bdm.cc
@@ -429,7 +429,7 @@ square for (unsigned int j=0;j<moment_weight.size();++j)
 
 template <int dim>
 unsigned int
-PolynomialsBDM<dim>::n_polynomials(unsigned int k)
+PolynomialsBDM<dim>::n_polynomials(const unsigned int k)
 {
   if (dim == 1)
     return k + 1;

--- a/source/base/polynomials_bdm.cc
+++ b/source/base/polynomials_bdm.cc
@@ -28,7 +28,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 PolynomialsBDM<dim>::PolynomialsBDM(const unsigned int k)
-  : TensorPolynomialsBase<dim>(k, compute_n_pols(k))
+  : TensorPolynomialsBase<dim>(k, n_polynomials(k))
   , polynomial_space(Polynomials::Legendre::generate_complete_basis(k))
   , monomials((dim == 2) ? (1) : (k + 2))
   , p_values(polynomial_space.n())
@@ -429,7 +429,7 @@ square for (unsigned int j=0;j<moment_weight.size();++j)
 
 template <int dim>
 unsigned int
-PolynomialsBDM<dim>::compute_n_pols(unsigned int k)
+PolynomialsBDM<dim>::n_polynomials(unsigned int k)
 {
   if (dim == 1)
     return k + 1;

--- a/source/base/polynomials_bernardi_raugel.cc
+++ b/source/base/polynomials_bernardi_raugel.cc
@@ -22,7 +22,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 PolynomialsBernardiRaugel<dim>::PolynomialsBernardiRaugel(const unsigned int k)
-  : TensorPolynomialsBase<dim>(k + 1, compute_n_pols(k))
+  : TensorPolynomialsBase<dim>(k + 1, n_polynomials(k))
   , polynomial_space_Q(create_polynomials_Q())
   , polynomial_space_bubble(create_polynomials_bubble())
 {}
@@ -236,7 +236,7 @@ PolynomialsBernardiRaugel<dim>::compute(
 
 template <int dim>
 unsigned int
-PolynomialsBernardiRaugel<dim>::compute_n_pols(const unsigned int k)
+PolynomialsBernardiRaugel<dim>::n_polynomials(const unsigned int k)
 {
   (void)k;
   Assert(k == 1, ExcNotImplemented());

--- a/source/base/polynomials_nedelec.cc
+++ b/source/base/polynomials_nedelec.cc
@@ -1486,7 +1486,7 @@ PolynomialsNedelec<dim>::compute(
 
 template <int dim>
 unsigned int
-PolynomialsNedelec<dim>::n_polynomials(unsigned int k)
+PolynomialsNedelec<dim>::n_polynomials(const unsigned int k)
 {
   switch (dim)
     {

--- a/source/base/polynomials_nedelec.cc
+++ b/source/base/polynomials_nedelec.cc
@@ -27,7 +27,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 PolynomialsNedelec<dim>::PolynomialsNedelec(const unsigned int k)
-  : TensorPolynomialsBase<dim>(k, compute_n_pols(k))
+  : TensorPolynomialsBase<dim>(k, n_polynomials(k))
   , polynomial_space(create_polynomials(k))
 {}
 
@@ -1486,7 +1486,7 @@ PolynomialsNedelec<dim>::compute(
 
 template <int dim>
 unsigned int
-PolynomialsNedelec<dim>::compute_n_pols(unsigned int k)
+PolynomialsNedelec<dim>::n_polynomials(unsigned int k)
 {
   switch (dim)
     {

--- a/source/base/polynomials_raviart_thomas.cc
+++ b/source/base/polynomials_raviart_thomas.cc
@@ -170,7 +170,7 @@ PolynomialsRaviartThomas<dim>::compute(
 
 template <int dim>
 unsigned int
-PolynomialsRaviartThomas<dim>::n_polynomials(unsigned int k)
+PolynomialsRaviartThomas<dim>::n_polynomials(const unsigned int k)
 {
   if (dim == 1)
     return k + 1;

--- a/source/base/polynomials_raviart_thomas.cc
+++ b/source/base/polynomials_raviart_thomas.cc
@@ -36,7 +36,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 PolynomialsRaviartThomas<dim>::PolynomialsRaviartThomas(const unsigned int k)
-  : TensorPolynomialsBase<dim>(k, compute_n_pols(k))
+  : TensorPolynomialsBase<dim>(k, n_polynomials(k))
   , polynomial_space(create_polynomials(k))
 {}
 
@@ -170,7 +170,7 @@ PolynomialsRaviartThomas<dim>::compute(
 
 template <int dim>
 unsigned int
-PolynomialsRaviartThomas<dim>::compute_n_pols(unsigned int k)
+PolynomialsRaviartThomas<dim>::n_polynomials(unsigned int k)
 {
   if (dim == 1)
     return k + 1;

--- a/source/base/polynomials_rt_bubbles.cc
+++ b/source/base/polynomials_rt_bubbles.cc
@@ -28,7 +28,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 PolynomialsRT_Bubbles<dim>::PolynomialsRT_Bubbles(const unsigned int k)
-  : TensorPolynomialsBase<dim>(k, compute_n_pols(k))
+  : TensorPolynomialsBase<dim>(k, n_polynomials(k))
   , raviart_thomas_space(k - 1)
   , monomials(k + 2)
 {
@@ -835,7 +835,7 @@ PolynomialsRT_Bubbles<dim>::compute(
 
 template <int dim>
 unsigned int
-PolynomialsRT_Bubbles<dim>::compute_n_pols(const unsigned int k)
+PolynomialsRT_Bubbles<dim>::n_polynomials(const unsigned int k)
 {
   if (dim == 1 || dim == 2 || dim == 3)
     return dim * Utilities::fixed_power<dim>(k + 1);

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -52,8 +52,8 @@ FE_ABF<dim>::FE_ABF(const unsigned int deg)
                              dim,
                              deg + 2,
                              FiniteElementData<dim>::Hdiv),
-      std::vector<bool>(PolynomialsABF<dim>::compute_n_pols(deg), true),
-      std::vector<ComponentMask>(PolynomialsABF<dim>::compute_n_pols(deg),
+      std::vector<bool>(PolynomialsABF<dim>::n_polynomials(deg), true),
+      std::vector<ComponentMask>(PolynomialsABF<dim>::n_polynomials(deg),
                                  std::vector<bool>(dim, true)))
   , rt_order(deg)
 {

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -45,7 +45,7 @@ FE_BDM<dim>::FE_BDM(const unsigned int deg)
                              deg + 1,
                              FiniteElementData<dim>::Hdiv),
       get_ria_vector(deg),
-      std::vector<ComponentMask>(PolynomialsBDM<dim>::compute_n_pols(deg),
+      std::vector<ComponentMask>(PolynomialsBDM<dim>::n_polynomials(deg),
                                  std::vector<bool>(dim, true)))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
@@ -222,12 +222,12 @@ FE_BDM<dim>::get_dpo_vector(const unsigned int deg)
   // the element is face-based and we have as many degrees of freedom
   // on the faces as there are polynomials of degree up to
   // deg. Observe the odd convention of
-  // PolynomialSpace::compute_n_pols()!
+  // PolynomialSpace::n_polynomials()!
 
   std::vector<unsigned int> dpo(dim + 1, 0u);
   dpo[dim] =
-    (deg > 1 ? dim * PolynomialSpace<dim>::compute_n_pols(deg - 1) : 0u);
-  dpo[dim - 1] = PolynomialSpace<dim - 1>::compute_n_pols(deg + 1);
+    (deg > 1 ? dim * PolynomialSpace<dim>::n_polynomials(deg - 1) : 0u);
+  dpo[dim - 1] = PolynomialSpace<dim - 1>::n_polynomials(deg + 1);
 
   return dpo;
 }
@@ -244,9 +244,9 @@ FE_BDM<dim>::get_ria_vector(const unsigned int deg)
       return std::vector<bool>();
     }
 
-  const unsigned int dofs_per_cell = PolynomialsBDM<dim>::compute_n_pols(deg);
+  const unsigned int dofs_per_cell = PolynomialsBDM<dim>::n_polynomials(deg);
   const unsigned int dofs_per_face =
-    PolynomialSpace<dim - 1>::compute_n_pols(deg + 1);
+    PolynomialSpace<dim - 1>::n_polynomials(deg + 1);
 
   Assert(GeometryInfo<dim>::faces_per_cell * dofs_per_face <= dofs_per_cell,
          ExcInternalError());

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -44,9 +44,8 @@ FE_BernardiRaugel<dim>::FE_BernardiRaugel(const unsigned int p)
                              dim,
                              2,
                              FiniteElementData<dim>::Hdiv),
-      std::vector<bool>(PolynomialsBernardiRaugel<dim>::compute_n_pols(p),
-                        true),
-      std::vector<ComponentMask>(PolynomialsBernardiRaugel<dim>::compute_n_pols(
+      std::vector<bool>(PolynomialsBernardiRaugel<dim>::n_polynomials(p), true),
+      std::vector<ComponentMask>(PolynomialsBernardiRaugel<dim>::n_polynomials(
                                    p),
                                  std::vector<bool>(dim, true)))
 {

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -75,8 +75,8 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
                              dim,
                              order + 1,
                              FiniteElementData<dim>::Hcurl),
-      std::vector<bool>(PolynomialsNedelec<dim>::compute_n_pols(order), true),
-      std::vector<ComponentMask>(PolynomialsNedelec<dim>::compute_n_pols(order),
+      std::vector<bool>(PolynomialsNedelec<dim>::n_polynomials(order), true),
+      std::vector<ComponentMask>(PolynomialsNedelec<dim>::n_polynomials(order),
                                  std::vector<bool>(dim, true)))
 {
 #ifdef DEBUG_NEDELEC
@@ -2003,7 +2003,7 @@ FE_Nedelec<dim>::get_dpo_vector(const unsigned int degree, bool dg)
 
   if (dg)
     {
-      dpo[dim] = PolynomialsNedelec<dim>::compute_n_pols(degree);
+      dpo[dim] = PolynomialsNedelec<dim>::n_polynomials(degree);
     }
   else
     {

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -51,9 +51,9 @@ FE_RaviartThomas<dim>::FE_RaviartThomas(const unsigned int deg)
                              dim,
                              deg + 1,
                              FiniteElementData<dim>::Hdiv),
-      std::vector<bool>(PolynomialsRaviartThomas<dim>::compute_n_pols(deg),
+      std::vector<bool>(PolynomialsRaviartThomas<dim>::n_polynomials(deg),
                         true),
-      std::vector<ComponentMask>(PolynomialsRaviartThomas<dim>::compute_n_pols(
+      std::vector<ComponentMask>(PolynomialsRaviartThomas<dim>::n_polynomials(
                                    deg),
                                  std::vector<bool>(dim, true)))
 {

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -45,7 +45,7 @@ FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int deg)
                                               FiniteElementData<dim>::Hdiv),
                        get_ria_vector(deg),
                        std::vector<ComponentMask>(
-                         PolynomialsRaviartThomas<dim>::compute_n_pols(deg),
+                         PolynomialsRaviartThomas<dim>::n_polynomials(deg),
                          std::vector<bool>(dim, true)))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
@@ -253,7 +253,7 @@ std::vector<bool>
 FE_RaviartThomasNodal<dim>::get_ria_vector(const unsigned int deg)
 {
   const unsigned int dofs_per_cell =
-    PolynomialsRaviartThomas<dim>::compute_n_pols(deg);
+    PolynomialsRaviartThomas<dim>::n_polynomials(deg);
   unsigned int dofs_per_face = deg + 1;
   for (unsigned int d = 2; d < dim; ++d)
     dofs_per_face *= deg + 1;

--- a/source/fe/fe_rt_bubbles.cc
+++ b/source/fe/fe_rt_bubbles.cc
@@ -37,15 +37,15 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 FE_RT_Bubbles<dim>::FE_RT_Bubbles(const unsigned int deg)
-  : FE_PolyTensor<dim>(PolynomialsRT_Bubbles<dim>(deg),
-                       FiniteElementData<dim>(get_dpo_vector(deg),
-                                              dim,
-                                              deg + 1,
-                                              FiniteElementData<dim>::Hdiv),
-                       get_ria_vector(deg),
-                       std::vector<ComponentMask>(
-                         PolynomialsRT_Bubbles<dim>::compute_n_pols(deg),
-                         std::vector<bool>(dim, true)))
+  : FE_PolyTensor<dim>(
+      PolynomialsRT_Bubbles<dim>(deg),
+      FiniteElementData<dim>(get_dpo_vector(deg),
+                             dim,
+                             deg + 1,
+                             FiniteElementData<dim>::Hdiv),
+      get_ria_vector(deg),
+      std::vector<ComponentMask>(PolynomialsRT_Bubbles<dim>::n_polynomials(deg),
+                                 std::vector<bool>(dim, true)))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
   Assert(
@@ -239,7 +239,7 @@ std::vector<bool>
 FE_RT_Bubbles<dim>::get_ria_vector(const unsigned int deg)
 {
   const unsigned int dofs_per_cell =
-    PolynomialsRT_Bubbles<dim>::compute_n_pols(deg);
+    PolynomialsRT_Bubbles<dim>::n_polynomials(deg);
   unsigned int dofs_per_face = deg + 1;
   for (unsigned int d = 2; d < dim; ++d)
     dofs_per_face *= deg + 1;


### PR DESCRIPTION
This more accurately reflects the purpose of the function, which may or may not
actually compute anything -- oftentimes it just returns something already
computed. The new name also more closely follows our usual naming convention.

Part of #1973. @GrahamBenHarper -- FYI.