### PR TITLE
Add initializing constructor to DiagonalMatrix

### DIFF
--- a/doc/news/changes/minor/20190823DanielArndt
+++ b/doc/news/changes/minor/20190823DanielArndt
@@ -1,0 +1,4 @@
+New: There is a new constructor for DiagonalMatrix that immediately initializes
+the underlying vector.
+<br>
+(Daniel Arndt, 2019/08/23)

--- a/include/deal.II/lac/diagonal_matrix.h
+++ b/include/deal.II/lac/diagonal_matrix.h
@@ -52,9 +52,15 @@ public:
   using size_type  = typename VectorType::size_type;
 
   /**
-   * Constructor.
+   * Default constructor. The object needs still to be reinitialized to be
+   * usable.
    */
   DiagonalMatrix() = default;
+
+  /**
+   * Constructor immediately initializing the object properly.
+   */
+  explicit DiagonalMatrix(const VectorType &vec);
 
   /**
    * Initialize with a given vector by copying the content of the vector
@@ -214,6 +220,13 @@ private:
 /* ---------------------------------- Inline functions ------------------- */
 
 #ifndef DOXYGEN
+
+template <typename VectorType>
+DiagonalMatrix<VectorType>::DiagonalMatrix(const VectorType &vec)
+  : diagonal(vec)
+{}
+
+
 
 template <typename VectorType>
 void

--- a/include/deal.II/lac/diagonal_matrix.h
+++ b/include/deal.II/lac/diagonal_matrix.h
@@ -58,7 +58,9 @@ public:
   DiagonalMatrix() = default;
 
   /**
-   * Constructor immediately initializing the object properly.
+   * Constructor initializing this object as a diagonal matrix of size `n x n`
+   * where `n` is the size of the vector, and with diagonal entries equal to the
+   * elements of @p vec.
    */
   explicit DiagonalMatrix(const VectorType &vec);
 

--- a/tests/lac/diagonal_matrix_02.cc
+++ b/tests/lac/diagonal_matrix_02.cc
@@ -100,12 +100,10 @@ test(const bool hanging_nodes = true)
     sparse_matrix.reinit(csp);
   }
 
-  DiagonalMatrix<LinearAlgebra::distributed::Vector<double>> diagonal_matrix;
-  {
-    LinearAlgebra::distributed::Vector<double> dummy;
-    dummy.reinit(owned_set, relevant_set, MPI_COMM_WORLD);
-    diagonal_matrix.reinit(dummy);
-  }
+  DiagonalMatrix<LinearAlgebra::distributed::Vector<double>> diagonal_matrix(
+    LinearAlgebra::distributed::Vector<double>(owned_set,
+                                               relevant_set,
+                                               MPI_COMM_WORLD));
 
   {
     QGauss<dim> quadrature_formula(fe_degree + 1);


### PR DESCRIPTION
So far constructing a  `DiagonalMatrix` object required to use intermediate which seems to be really unnecessary. This pull request introduces a constructor that immediately initializes the underlying vector.