### PR TITLE
Fix AffineConstraints::set_zero for MemorySpace::CUDA

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1905,6 +1905,7 @@ namespace internal
     {
       Assert(shift == 0, ExcNotImplemented());
       std::vector<size_type> constrained_local_dofs_host;
+      constrained_local_dofs_host.reserve(cm.size());
 
       for (const auto global_index : cm)
         if (vec.in_local_range(global_index))

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1904,17 +1904,14 @@ namespace internal
       size_type                                                      shift = 0)
     {
       Assert(shift == 0, ExcNotImplemented());
-      const int              n_constraints = cm.size();
-      std::vector<size_type> constrained_local_dofs_host(n_constraints);
+      std::vector<size_type> constrained_local_dofs_host;
 
-      std::transform(cm.begin(),
-                     cm.end(),
-                     constrained_local_dofs_host.begin(),
-                     [&vec](const size_type global_index) {
-                       return vec.get_partitioner()->global_to_local(
-                         global_index);
-                     });
+      for (const auto global_index : cm)
+        if (vec.in_local_range(global_index))
+          constrained_local_dofs_host.push_back(
+            vec.get_partitioner()->global_to_local(global_index));
 
+      const int  n_constraints = constrained_local_dofs_host.size();
       size_type *constrained_local_dofs_device;
       Utilities::CUDA::malloc(constrained_local_dofs_device, n_constraints);
       Utilities::CUDA::copy_to_dev(constrained_local_dofs_host,
@@ -1922,7 +1919,7 @@ namespace internal
 
       const int n_blocks = 1 + (n_constraints - 1) / CUDAWrappers::block_size;
       set_zero_kernel<<<n_blocks, CUDAWrappers::block_size>>>(
-        constrained_local_dofs_device, cm.size(), vec.get_values());
+        constrained_local_dofs_device, n_constraints, vec.get_values());
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
       AssertCuda(cudaGetLastError());

--- a/tests/cuda/affine_constraints_set_zero.mpirun=2.output
+++ b/tests/cuda/affine_constraints_set_zero.mpirun=2.output
@@ -1,31 +1,51 @@
 
-DEAL:0::vector before:
+DEAL:0::CM:
+    1 = 0
+    2 = 0
+DEAL:0::ghosted vector before:
 Process #0
 Local range: [0, 2), global size: 4
 Vector data:
 1.000e+00 2.000e+00 
-DEAL:0::
-DEAL:0::CM:
-    1 = 0
-DEAL:0::vector after:
+DEAL:0::ghosted vector after:
+Process #0
+Local range: [0, 2), global size: 4
+Vector data:
+1.000e+00 0.000e+00 
+DEAL:0::distributed vector before:
+Process #0
+Local range: [0, 2), global size: 4
+Vector data:
+1.000e+00 2.000e+00 
+DEAL:0::distributed vector after:
 Process #0
 Local range: [0, 2), global size: 4
 Vector data:
 1.000e+00 0.000e+00 
 DEAL:0::OK
 
-DEAL:1::vector before:
+DEAL:1::CM:
+    1 = 0
+    2 = 0
+DEAL:1::ghosted vector before:
 Process #1
 Local range: [2, 4), global size: 4
 Vector data:
 3.000e+00 4.000e+00 
-DEAL:1::
-DEAL:1::CM:
-    3 = 0
-DEAL:1::vector after:
+DEAL:1::ghosted vector after:
 Process #1
 Local range: [2, 4), global size: 4
 Vector data:
-3.000e+00 0.000e+00 
+0.000e+00 4.000e+00 
+DEAL:1::distributed vector before:
+Process #1
+Local range: [2, 4), global size: 4
+Vector data:
+3.000e+00 4.000e+00 
+DEAL:1::distributed vector after:
+Process #1
+Local range: [2, 4), global size: 4
+Vector data:
+0.000e+00 4.000e+00 
 DEAL:1::OK
 


### PR DESCRIPTION
We need to make sure not to ask the partitioner for the local dof index of global dofs that are not stored. This happens in particular for distributed vectors when the `AffineConstraints` object also contains locally relevant dofs.