### PR TITLE
fixed the representation of the decrement operator -- in doxygen

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -104,8 +104,8 @@ struct EnableIfScalar<VectorizedArray<Number, width>>
  * respectively (this corresponds to the SSE/SSE2 data sets) when compiling
  * deal.II on 64-bit operating systems. On Intel Sandy Bridge processors and
  * newer or AMD Bulldozer processors and newer, four doubles or eight floats
- * are used when deal.II is configured using gcc with --with-cpu=native
- * or --with-cpu=corei7-avx. On compilations with AVX-512 support (e.g.,
+ * are used when deal.II is configured using gcc with \--with-cpu=native
+ * or \--with-cpu=corei7-avx. On compilations with AVX-512 support (e.g.,
  * Intel Skylake Server from 2017), eight doubles or sixteen floats are used.
  *
  * This behavior of this class is made similar to the basic data types double

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -107,7 +107,7 @@ namespace internal
  * triangulation data. These iterators are built on top of those of the
  * Triangulation class, but offer the additional information on degrees of
  * freedom functionality compared to pure triangulation iterators. The order
- * in which dof iterators are presented by the <tt>++</tt> and <tt>--</tt>
+ * in which dof iterators are presented by the <tt>++</tt> and <tt>\--</tt>
  * operators is the same as that for the corresponding iterators traversing
  * the triangulation on which this DoFHandler is constructed.
  *

--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -341,7 +341,7 @@ namespace IteratorFilters
  * filter (called a <em>predicate</em>, following the notation of the C++
  * standard library). Once initialized with a predicate and a value for the
  * iterator, a filtered iterator hops to the next or previous element that
- * satisfies the predicate if operators ++ or -- are invoked. Intermediate
+ * satisfies the predicate if operators ++ or \-- are invoked. Intermediate
  * iterator values that lie in between but do not satisfy the predicate are
  * skipped. It is thus very simple to write loops over a certain class of
  * objects without the need to explicitly write down the condition they have

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -114,7 +114,7 @@ class TriaActiveIterator;
  * anyway. Most iterator and accessor functions are inlined.
  *
  * The main functionality of iterators, resides in the <tt>++</tt> and
- * <tt>--</tt> operators. These move the iterator forward or backward just as
+ * <tt>\--</tt> operators. These move the iterator forward or backward just as
  * if it were a pointer into an array. Here, this operation is not so easy,
  * since it may include skipping some elements and the transition between the
  * triangulation levels. This is completely hidden from the user, though you
@@ -151,7 +151,7 @@ class TriaActiveIterator;
  * member function <tt>bool used()</tt>, for the latter a member function
  * <tt>bool active()</tt>.
  *
- * <li> It must have void operators <tt>++</tt> and <tt>--</tt>.
+ * <li> It must have void operators <tt>++</tt> and <tt>\--</tt>.
  *
  * <li> It must declare a local alias <tt>AccessorData</tt> which states the
  * data type the accessor expects to get passed as fourth constructor
@@ -450,14 +450,14 @@ public:
   operator++(int);
 
   /**
-   * Prefix @p -- operator: @p --iterator. This operator moves the iterator to
+   * Prefix @p \-- operator: @p \--iterator. This operator moves the iterator to
    * the previous element and returns a reference to <tt>*this</tt>.
    */
   TriaRawIterator &
   operator--();
 
   /**
-   * Postfix @p -- operator: @p iterator--. This operator moves the iterator
+   * Postfix @p \-- operator: @p iterator\--. This operator moves the iterator
    * to the previous element, but returns an iterator to the element
    * previously pointed to.
    *
@@ -714,14 +714,14 @@ public:
   operator++(int);
 
   /**
-   * Prefix @p -- operator: @p --i. This operator advances the iterator to the
+   * Prefix @p \-- operator: @p \--i. This operator advances the iterator to the
    * previous used element and returns a reference to <tt>*this</tt>.
    */
   TriaIterator<Accessor> &
   operator--();
 
   /**
-   * Postfix @p -- operator: @p i--.
+   * Postfix @p \-- operator: @p i\--.
    */
   TriaIterator<Accessor>
   operator--(int);
@@ -915,14 +915,14 @@ public:
   operator++(int);
 
   /**
-   * Prefix @p -- operator: @p --i. This operator advances the iterator to the
+   * Prefix @p \-- operator: @p \--i. This operator advances the iterator to the
    * previous active element and returns a reference to <tt>*this</tt>.
    */
   TriaActiveIterator<Accessor> &
   operator--();
 
   /**
-   * Postfix @p -- operator: @p i--.
+   * Postfix @p \-- operator: @p i\--.
    */
   TriaActiveIterator<Accessor>
   operator--(int);

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -669,7 +669,7 @@ namespace PETScWrappers
   /**
    * A class that implements the interface to use the BoomerAMG algebraic
    * multigrid preconditioner from the HYPRE suite. Note that PETSc has to be
-   * configured with HYPRE (e.g. with --download-hypre=1).
+   * configured with HYPRE (e.g. with \--download-hypre=1).
    *
    * The preconditioner does support parallel distributed computations. See
    * step-40 for an example.
@@ -791,7 +791,7 @@ namespace PETScWrappers
   /**
    * A class that implements the interface to use the ParaSails sparse
    * approximate inverse preconditioner from the HYPRE suite. Note that PETSc
-   * has to be configured with HYPRE (e.g. with --download-hypre=1).
+   * has to be configured with HYPRE (e.g. with \--download-hypre=1).
    *
    * ParaSails uses least-squares minimization to compute a sparse approximate
    * inverse. The sparsity pattern used is the pattern of a power of a

--- a/include/deal.II/particles/particle_iterator.h
+++ b/include/deal.II/particles/particle_iterator.h
@@ -107,7 +107,7 @@ namespace Particles
     operator++(int);
 
     /**
-     * Prefix <tt>--</tt> operator: <tt>--iterator</tt>. This operator moves
+     * Prefix <tt>\--</tt> operator: <tt>\--iterator</tt>. This operator moves
      * the iterator to the previous element and returns a reference to
      * <tt>*this</tt>.
      */
@@ -115,7 +115,7 @@ namespace Particles
     operator--();
 
     /**
-     * Postfix <tt>--</tt> operator: <tt>iterator--</tt>. This operator moves
+     * Postfix <tt>\--</tt> operator: <tt>iterator\--</tt>. This operator moves
      * the iterator to the previous element, but returns an iterator to the
      * element previously pointed to.
      */


### PR DESCRIPTION
In certain places in the documentation we have to replace `--` with `\--` because otherwise it will show up in the documentation as a long dash. [more info](http://www.doxygen.nl/manual/commands.html#cmdndash)