### PR TITLE
Remove unused variable warning

### DIFF
--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -61,7 +61,10 @@ namespace
                   const unsigned int               dofs_per_cell)
   {
     for (const auto &values : dof_values)
-      AssertDimension(values.size(), dofs_per_cell);
+      {
+        AssertDimension(values.size(), dofs_per_cell);
+        (void)values;
+      }
 
     const std::size_t bytes_per_entry = sizeof(value_type) * dofs_per_cell;
 


### PR DESCRIPTION
This removes the following warning:
```c++
dealii/source/distributed/solution_transfer.cc:63:22: warning: unused variable 'values' [-Wunused-variable]
    for (const auto &values : dof_values)
```

Probably related to #8641