### PR TITLE
Introduced DoFCellAccessor:get_future_fe().

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -1947,6 +1947,28 @@ public:
    */
 
   /**
+   * Return the finite element that will be assigned to this cell next time the
+   * triangulation gets refined and coarsened. If no future finite element has
+   * been specified for this cell via the set_future_fe_index() function, the
+   * active one will remain unchanged, in which case the active finite element
+   * will be returned.
+   *
+   * For non-hp DoF handlers, this is of course always the same element,
+   * independent of the cell we are presently on, but for hp DoF handlers, this
+   * may change from cell to cell.
+   *
+   * @note Since degrees of freedom only exist on active cells for
+   * hp::DoFHandler (i.e., there is currently no implementation of multilevel
+   * hp::DoFHandler objects), it does not make sense to query the finite
+   * element on non-active cells since they do not have finite element spaces
+   * associated with them without having any degrees of freedom. Consequently,
+   * this function will produce an exception when called on non-active cells.
+   */
+  const FiniteElement<DoFHandlerType::dimension,
+                      DoFHandlerType::space_dimension> &
+  get_future_fe() const;
+
+  /**
    * Return the fe_index of the finite element that will be assigned to this
    * cell next time the triangulation gets refined and coarsened. If no future
    * finite element has been specified for this cell via the

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -3974,6 +3974,7 @@ inline const FiniteElement<DoFHandlerType::dimension,
                            DoFHandlerType::space_dimension> &
 DoFCellAccessor<DoFHandlerType, level_dof_access>::get_fe() const
 {
+  Assert(this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
   Assert(
     (dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,
                                            DoFHandlerType::space_dimension> *>(
@@ -3982,7 +3983,6 @@ DoFCellAccessor<DoFHandlerType, level_dof_access>::get_fe() const
     ExcMessage("In hp::DoFHandler objects, finite elements are only associated "
                "with active cells. Consequently, you can not ask for the "
                "active finite element on cells with children."));
-  Assert(this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
 
   return this->dof_handler->get_fe(active_fe_index());
 }
@@ -4044,6 +4044,26 @@ DoFCellAccessor<DoFHandlerType, level_dof_access>::set_active_fe_index(
 
   dealii::internal::DoFCellAccessorImplementation::Implementation::
     set_active_fe_index(*this, i);
+}
+
+
+
+template <typename DoFHandlerType, bool level_dof_access>
+inline const FiniteElement<DoFHandlerType::dimension,
+                           DoFHandlerType::space_dimension> &
+DoFCellAccessor<DoFHandlerType, level_dof_access>::get_future_fe() const
+{
+  Assert(this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
+  Assert(
+    (dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,
+                                           DoFHandlerType::space_dimension> *>(
+       this->dof_handler) != nullptr) ||
+      (this->has_children() == false),
+    ExcMessage("In hp::DoFHandler objects, finite elements are only associated "
+               "with active cells. Consequently, you can not ask for the "
+               "future finite element on cells with children."));
+
+  return this->dof_handler->get_fe(future_fe_index());
 }
 
 

--- a/tests/hp/future_fe_indices.cc
+++ b/tests/hp/future_fe_indices.cc
@@ -52,20 +52,15 @@ test()
   auto cell = dh.begin_active();
   cell->set_future_fe_index(1);
 
-  // try to set future index to an invalid one
-  try
-    {
-      (++cell)->set_future_fe_index(2);
-    }
-  catch (const ExcIndexRange &)
-    {
-      deallog << "Set to 2 failed" << std::endl;
-    }
-
   // verify flags
   for (const auto &cell : dh.active_cell_iterators())
-    deallog << "cell:" << cell->id().to_string()
-            << ", future_fe:" << cell->future_fe_index() << std::endl;
+    {
+      deallog << "cell:" << cell->id().to_string()
+              << ", future_fe:" << cell->future_fe_index() << std::endl;
+      Assert(&(dh.get_fe(cell->future_fe_index())) == &(cell->get_future_fe()),
+             ExcMessage(
+               "DoFCellAccessor::get_future_fe() returns the wrong object."));
+    }
 
   // clear all flags and check if all were cleared
   for (const auto &cell : dh.active_cell_iterators())

--- a/tests/hp/future_fe_indices.output
+++ b/tests/hp/future_fe_indices.output
@@ -1,12 +1,12 @@
 
 DEAL:1D::cell:0_1:0, future_fe:1
-DEAL:1D::cell:0_1:1, future_fe:2
+DEAL:1D::cell:0_1:1, future_fe:0
 DEAL:2D::cell:0_1:0, future_fe:1
-DEAL:2D::cell:0_1:1, future_fe:2
+DEAL:2D::cell:0_1:1, future_fe:0
 DEAL:2D::cell:0_1:2, future_fe:0
 DEAL:2D::cell:0_1:3, future_fe:0
 DEAL:3D::cell:0_1:0, future_fe:1
-DEAL:3D::cell:0_1:1, future_fe:2
+DEAL:3D::cell:0_1:1, future_fe:0
 DEAL:3D::cell:0_1:2, future_fe:0
 DEAL:3D::cell:0_1:3, future_fe:0
 DEAL:3D::cell:0_1:4, future_fe:0


### PR DESCRIPTION
This function does exactly what `get_fe()` does for `active_fe_indices` and is thus basically a copy of it. This will be useful for an upcoming rework of the `p::d::CellWeights` class.

We don't check if an active/future index is valid until we actually access the corresponding finite element via the `dof_handler` object. Thus I removed the `try-catch` block in the corresponding test.