### PR TITLE
Change polynomial classes to derive from ScalarPolynomialsBase

### DIFF
--- a/include/deal.II/base/polynomials_rannacher_turek.h
+++ b/include/deal.II/base/polynomials_rannacher_turek.h
@@ -18,6 +18,7 @@
 #define dealii_polynomials_rannacher_turek_h
 
 #include <deal.II/base/point.h>
+#include <deal.II/base/scalar_polynomials_base.h>
 #include <deal.II/base/tensor.h>
 
 #include <vector>
@@ -38,7 +39,7 @@ DEAL_II_NAMESPACE_OPEN
  * @date 2015
  */
 template <int dim>
-class PolynomialsRannacherTurek
+class PolynomialsRannacherTurek : public ScalarPolynomialsBase<dim>
 {
 public:
   /**
@@ -85,12 +86,24 @@ public:
    * zero. A size of zero means that we are not computing the vector entries.
    */
   void
-  compute(const Point<dim> &           unit_point,
-          std::vector<double> &        values,
-          std::vector<Tensor<1, dim>> &grads,
-          std::vector<Tensor<2, dim>> &grad_grads,
-          std::vector<Tensor<3, dim>> &third_derivatives,
-          std::vector<Tensor<4, dim>> &fourth_derivatives) const;
+  evaluate(const Point<dim> &           unit_point,
+           std::vector<double> &        values,
+           std::vector<Tensor<1, dim>> &grads,
+           std::vector<Tensor<2, dim>> &grad_grads,
+           std::vector<Tensor<3, dim>> &third_derivatives,
+           std::vector<Tensor<4, dim>> &fourth_derivatives) const override;
+
+  /**
+   * Return the name of the space, which is <tt>RannacherTurek</tt>.
+   */
+  std::string
+  name() const override;
+
+  /**
+   * @copydoc ScalarPolynomialsBase<dim>::clone()
+   */
+  virtual std::unique_ptr<ScalarPolynomialsBase<dim>>
+  clone() const override;
 };
 
 
@@ -201,6 +214,15 @@ PolynomialsRannacherTurek<dim>::compute_derivative(const unsigned int i,
 {
   return internal::PolynomialsRannacherTurekImplementation::compute_derivative<
     order>(i, p);
+}
+
+
+
+template <int dim>
+inline std::string
+PolynomialsRannacherTurek<dim>::name() const
+{
+  return "RannacherTurek";
 }
 
 

--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -118,12 +118,12 @@ public:
    * over all tensor product polynomials.
    */
   void
-  compute(const Point<dim> &           unit_point,
-          std::vector<double> &        values,
-          std::vector<Tensor<1, dim>> &grads,
-          std::vector<Tensor<2, dim>> &grad_grads,
-          std::vector<Tensor<3, dim>> &third_derivatives,
-          std::vector<Tensor<4, dim>> &fourth_derivatives) const;
+  evaluate(const Point<dim> &           unit_point,
+           std::vector<double> &        values,
+           std::vector<Tensor<1, dim>> &grads,
+           std::vector<Tensor<2, dim>> &grad_grads,
+           std::vector<Tensor<3, dim>> &third_derivatives,
+           std::vector<Tensor<4, dim>> &fourth_derivatives) const;
 
   /**
    * Compute the value of the <tt>i</tt>th tensor product polynomial at

--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -69,12 +69,12 @@ public:
    * over all tensor product polynomials.
    */
   void
-  compute(const Point<dim> &           unit_point,
-          std::vector<double> &        values,
-          std::vector<Tensor<1, dim>> &grads,
-          std::vector<Tensor<2, dim>> &grad_grads,
-          std::vector<Tensor<3, dim>> &third_derivatives,
-          std::vector<Tensor<4, dim>> &fourth_derivatives) const;
+  evaluate(const Point<dim> &           unit_point,
+           std::vector<double> &        values,
+           std::vector<Tensor<1, dim>> &grads,
+           std::vector<Tensor<2, dim>> &grad_grads,
+           std::vector<Tensor<3, dim>> &third_derivatives,
+           std::vector<Tensor<4, dim>> &fourth_derivatives) const;
 
   /**
    * Compute the value of the <tt>i</tt>th tensor product polynomial at

--- a/include/deal.II/base/tensor_product_polynomials_const.h
+++ b/include/deal.II/base/tensor_product_polynomials_const.h
@@ -75,12 +75,12 @@ public:
    * over all tensor product polynomials.
    */
   void
-  compute(const Point<dim> &           unit_point,
-          std::vector<double> &        values,
-          std::vector<Tensor<1, dim>> &grads,
-          std::vector<Tensor<2, dim>> &grad_grads,
-          std::vector<Tensor<3, dim>> &third_derivatives,
-          std::vector<Tensor<4, dim>> &fourth_derivatives) const;
+  evaluate(const Point<dim> &           unit_point,
+           std::vector<double> &        values,
+           std::vector<Tensor<1, dim>> &grads,
+           std::vector<Tensor<2, dim>> &grad_grads,
+           std::vector<Tensor<3, dim>> &third_derivatives,
+           std::vector<Tensor<4, dim>> &fourth_derivatives) const;
 
   /**
    * Compute the value of the <tt>i</tt>th tensor product polynomial at

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -40,12 +40,12 @@ DEAL_II_NAMESPACE_OPEN
  * @code
  *  static const unsigned int dimension;
  *
- *  void compute (const Point<dim>            &unit_point,
- *                std::vector<double>         &values,
- *                std::vector<Tensor<1,dim> > &grads,
- *                std::vector<Tensor<2,dim> > &grad_grads,
- *                std::vector<Tensor<3,dim> > &third_derivatives,
- *                std::vector<Tensor<4,dim> > &fourth_derivatives) const;
+ *  void evaluate (const Point<dim>            &unit_point,
+ *                 std::vector<double>         &values,
+ *                 std::vector<Tensor<1,dim> > &grads,
+ *                 std::vector<Tensor<2,dim> > &grad_grads,
+ *                 std::vector<Tensor<3,dim> > &third_derivatives,
+ *                 std::vector<Tensor<4,dim> > &fourth_derivatives) const;
  *
  *  double compute_value (const unsigned int i,
  *                        const Point<dim> &p) const;
@@ -303,12 +303,12 @@ protected:
                         update_3rd_derivatives))
       for (unsigned int i = 0; i < n_q_points; ++i)
         {
-          poly_space.compute(quadrature.point(i),
-                             values,
-                             grads,
-                             grad_grads,
-                             third_derivatives,
-                             fourth_derivatives);
+          poly_space.evaluate(quadrature.point(i),
+                              values,
+                              grads,
+                              grad_grads,
+                              third_derivatives,
+                              fourth_derivatives);
 
           // the values of shape functions at quadrature points don't change.
           // consequently, write these values right into the output array if

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -133,12 +133,12 @@ protected:
                                  std::vector<double>(n_q_points));
         for (unsigned int i = 0; i < n_q_points; ++i)
           {
-            poly_space.compute(quadrature.point(i),
-                               values,
-                               grads,
-                               grad_grads,
-                               empty_vector_of_3rd_order_tensors,
-                               empty_vector_of_4th_order_tensors);
+            poly_space.evaluate(quadrature.point(i),
+                                values,
+                                grads,
+                                grad_grads,
+                                empty_vector_of_3rd_order_tensors,
+                                empty_vector_of_4th_order_tensors);
 
             for (unsigned int k = 0; k < poly_space.n(); ++k)
               data.shape_values[k][i] = values[k];

--- a/source/base/polynomial_space.cc
+++ b/source/base/polynomial_space.cc
@@ -15,6 +15,7 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/polynomial_space.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/table.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -200,7 +201,7 @@ PolynomialSpace<dim>::compute_grad_grad(const unsigned int i,
 
 template <int dim>
 void
-PolynomialSpace<dim>::compute(
+PolynomialSpace<dim>::evaluate(
   const Point<dim> &           p,
   std::vector<double> &        values,
   std::vector<Tensor<1, dim>> &grads,
@@ -210,41 +211,42 @@ PolynomialSpace<dim>::compute(
 {
   const unsigned int n_1d = polynomials.size();
 
-  Assert(values.size() == n_pols || values.size() == 0,
-         ExcDimensionMismatch2(values.size(), n_pols, 0));
-  Assert(grads.size() == n_pols || grads.size() == 0,
-         ExcDimensionMismatch2(grads.size(), n_pols, 0));
-  Assert(grad_grads.size() == n_pols || grad_grads.size() == 0,
-         ExcDimensionMismatch2(grad_grads.size(), n_pols, 0));
-  Assert(third_derivatives.size() == n_pols || third_derivatives.size() == 0,
-         ExcDimensionMismatch2(third_derivatives.size(), n_pols, 0));
-  Assert(fourth_derivatives.size() == n_pols || fourth_derivatives.size() == 0,
-         ExcDimensionMismatch2(fourth_derivatives.size(), n_pols, 0));
+  Assert(values.size() == this->n() || values.size() == 0,
+         ExcDimensionMismatch2(values.size(), this->n(), 0));
+  Assert(grads.size() == this->n() || grads.size() == 0,
+         ExcDimensionMismatch2(grads.size(), this->n(), 0));
+  Assert(grad_grads.size() == this->n() || grad_grads.size() == 0,
+         ExcDimensionMismatch2(grad_grads.size(), this->n(), 0));
+  Assert(third_derivatives.size() == this->n() || third_derivatives.size() == 0,
+         ExcDimensionMismatch2(third_derivatives.size(), this->n(), 0));
+  Assert(fourth_derivatives.size() == this->n() ||
+           fourth_derivatives.size() == 0,
+         ExcDimensionMismatch2(fourth_derivatives.size(), this->n(), 0));
 
   unsigned int v_size = 0;
   bool update_values = false, update_grads = false, update_grad_grads = false;
   bool update_3rd_derivatives = false, update_4th_derivatives = false;
-  if (values.size() == n_pols)
+  if (values.size() == this->n())
     {
       update_values = true;
       v_size        = 1;
     }
-  if (grads.size() == n_pols)
+  if (grads.size() == this->n())
     {
       update_grads = true;
       v_size       = 2;
     }
-  if (grad_grads.size() == n_pols)
+  if (grad_grads.size() == this->n())
     {
       update_grad_grads = true;
       v_size            = 3;
     }
-  if (third_derivatives.size() == n_pols)
+  if (third_derivatives.size() == this->n())
     {
       update_3rd_derivatives = true;
       v_size                 = 4;
     }
-  if (fourth_derivatives.size() == n_pols)
+  if (fourth_derivatives.size() == this->n())
     {
       update_4th_derivatives = true;
       v_size                 = 5;
@@ -393,6 +395,15 @@ PolynomialSpace<dim>::compute(
                       }
             }
     }
+}
+
+
+
+template <int dim>
+std::unique_ptr<ScalarPolynomialsBase<dim>>
+PolynomialSpace<dim>::clone() const
+{
+  return std_cxx14::make_unique<PolynomialSpace<dim>>(*this);
 }
 
 

--- a/source/base/polynomials_bdm.cc
+++ b/source/base/polynomials_bdm.cc
@@ -98,12 +98,12 @@ PolynomialsBDM<dim>::evaluate(
     // will have first all polynomials
     // in the x-component, then y and
     // z.
-    polynomial_space.compute(unit_point,
-                             p_values,
-                             p_grads,
-                             p_grad_grads,
-                             p_third_derivatives,
-                             p_fourth_derivatives);
+    polynomial_space.evaluate(unit_point,
+                              p_values,
+                              p_grads,
+                              p_grad_grads,
+                              p_third_derivatives,
+                              p_fourth_derivatives);
 
     std::fill(values.begin(), values.end(), Tensor<1, dim>());
     for (unsigned int i = 0; i < p_values.size(); ++i)

--- a/source/base/polynomials_rannacher_turek.cc
+++ b/source/base/polynomials_rannacher_turek.cc
@@ -16,12 +16,14 @@
 
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/polynomials_rannacher_turek.h>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim>
 PolynomialsRannacherTurek<dim>::PolynomialsRannacherTurek()
+  : ScalarPolynomialsBase<dim>(2, dealii::GeometryInfo<dim>::faces_per_cell)
 {
   Assert(dim == 2, ExcNotImplemented());
 }
@@ -141,7 +143,7 @@ PolynomialsRannacherTurek<dim>::compute_grad_grad(
 
 template <int dim>
 void
-PolynomialsRannacherTurek<dim>::compute(
+PolynomialsRannacherTurek<dim>::evaluate(
   const Point<dim> &           unit_point,
   std::vector<double> &        values,
   std::vector<Tensor<1, dim>> &grads,
@@ -149,7 +151,7 @@ PolynomialsRannacherTurek<dim>::compute(
   std::vector<Tensor<3, dim>> &third_derivatives,
   std::vector<Tensor<4, dim>> &fourth_derivatives) const
 {
-  const unsigned int n_pols = dealii::GeometryInfo<dim>::faces_per_cell;
+  const unsigned int n_pols = this->n();
   Assert(values.size() == n_pols || values.size() == 0,
          ExcDimensionMismatch(values.size(), n_pols));
   Assert(grads.size() == n_pols || grads.size() == 0,
@@ -184,6 +186,15 @@ PolynomialsRannacherTurek<dim>::compute(
           fourth_derivatives[i] = compute_derivative<4>(i, unit_point);
         }
     }
+}
+
+
+
+template <int dim>
+std::unique_ptr<ScalarPolynomialsBase<dim>>
+PolynomialsRannacherTurek<dim>::clone() const
+{
+  return std_cxx14::make_unique<PolynomialsRannacherTurek<dim>>(*this);
 }
 
 

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -241,7 +241,7 @@ TensorProductPolynomials<dim, PolynomialType>::compute_grad_grad(
 
 template <int dim, typename PolynomialType>
 void
-TensorProductPolynomials<dim, PolynomialType>::compute(
+TensorProductPolynomials<dim, PolynomialType>::evaluate(
   const Point<dim> &           p,
   std::vector<double> &        values,
   std::vector<Tensor<1, dim>> &grads,

--- a/source/base/tensor_product_polynomials_bubbles.cc
+++ b/source/base/tensor_product_polynomials_bubbles.cc
@@ -215,7 +215,7 @@ TensorProductPolynomialsBubbles<dim>::compute_grad_grad(
 
 template <int dim>
 void
-TensorProductPolynomialsBubbles<dim>::compute(
+TensorProductPolynomialsBubbles<dim>::evaluate(
   const Point<dim> &           p,
   std::vector<double> &        values,
   std::vector<Tensor<1, dim>> &grads,
@@ -273,7 +273,7 @@ TensorProductPolynomialsBubbles<dim>::compute(
       do_4th_derivatives = true;
     }
 
-  this->TensorProductPolynomials<dim>::compute(
+  this->TensorProductPolynomials<dim>::evaluate(
     p, values, grads, grad_grads, third_derivatives, fourth_derivatives);
 
   for (unsigned int i = this->n_tensor_pols;

--- a/source/base/tensor_product_polynomials_const.cc
+++ b/source/base/tensor_product_polynomials_const.cc
@@ -86,7 +86,7 @@ TensorProductPolynomialsConst<dim>::compute_grad_grad(const unsigned int i,
 
 template <int dim>
 void
-TensorProductPolynomialsConst<dim>::compute(
+TensorProductPolynomialsConst<dim>::evaluate(
   const Point<dim> &           p,
   std::vector<double> &        values,
   std::vector<Tensor<1, dim>> &grads,
@@ -141,7 +141,7 @@ TensorProductPolynomialsConst<dim>::compute(
       do_4th_derivatives = true;
     }
 
-  this->TensorProductPolynomials<dim>::compute(
+  this->TensorProductPolynomials<dim>::evaluate(
     p, values, grads, grad_grads, third_derivatives, fourth_derivatives);
 
   // for dgq node: values =1, grads=0, grads_grads=0, third_derivatives=0,

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -294,12 +294,12 @@ namespace internal
         for (unsigned int k = 0; k < quadrature.size(); ++k)
           {
             test_values[k].resize(poly.n());
-            poly.compute(quadrature.point(k),
-                         test_values[k],
-                         dummy1,
-                         dummy2,
-                         dummy3,
-                         dummy4);
+            poly.evaluate(quadrature.point(k),
+                          test_values[k],
+                          dummy1,
+                          dummy2,
+                          dummy3,
+                          dummy4);
             for (unsigned int i = 0; i < poly.n(); ++i)
               {
                 test_values[k][i] *= quadrature.weight(k);

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -332,12 +332,12 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
   if (fe_internal.update_each & (update_values | update_gradients))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
-        polynomial_space.compute(mapping_data.quadrature_points[i],
-                                 values,
-                                 grads,
-                                 grad_grads,
-                                 empty_vector_of_3rd_order_tensors,
-                                 empty_vector_of_4th_order_tensors);
+        polynomial_space.evaluate(mapping_data.quadrature_points[i],
+                                  values,
+                                  grads,
+                                  grad_grads,
+                                  empty_vector_of_3rd_order_tensors,
+                                  empty_vector_of_4th_order_tensors);
 
         if (fe_internal.update_each & update_values)
           for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
@@ -388,12 +388,12 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
   if (fe_internal.update_each & (update_values | update_gradients))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
-        polynomial_space.compute(mapping_data.quadrature_points[i],
-                                 values,
-                                 grads,
-                                 grad_grads,
-                                 empty_vector_of_3rd_order_tensors,
-                                 empty_vector_of_4th_order_tensors);
+        polynomial_space.evaluate(mapping_data.quadrature_points[i],
+                                  values,
+                                  grads,
+                                  grad_grads,
+                                  empty_vector_of_3rd_order_tensors,
+                                  empty_vector_of_4th_order_tensors);
 
         if (fe_internal.update_each & update_values)
           for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
@@ -445,12 +445,12 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
   if (fe_internal.update_each & (update_values | update_gradients))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
-        polynomial_space.compute(mapping_data.quadrature_points[i],
-                                 values,
-                                 grads,
-                                 grad_grads,
-                                 empty_vector_of_3rd_order_tensors,
-                                 empty_vector_of_4th_order_tensors);
+        polynomial_space.evaluate(mapping_data.quadrature_points[i],
+                                  values,
+                                  grads,
+                                  grad_grads,
+                                  empty_vector_of_3rd_order_tensors,
+                                  empty_vector_of_4th_order_tensors);
 
         if (fe_internal.update_each & update_values)
           for (unsigned int k = 0; k < this->dofs_per_cell; ++k)

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -296,7 +296,7 @@ namespace internal
             data.shape_fourth_derivatives.size() != 0)
           for (unsigned int point = 0; point < n_points; ++point)
             {
-              tensor_pols.compute(
+              tensor_pols.evaluate(
                 unit_points[point], values, grads, grad2, grad3, grad4);
 
               if (data.shape_values.size() != 0)

--- a/tests/base/anisotropic_1.cc
+++ b/tests/base/anisotropic_1.cc
@@ -42,7 +42,7 @@ check_poly(const Point<dim> &     x,
   std::vector<Tensor<3, dim>> third1(n), third2(n);
   std::vector<Tensor<4, dim>> fourth1(n), fourth2(n);
 
-  p.compute(x, values1, gradients1, second1, third1, fourth1);
+  p.evaluate(x, values1, gradients1, second1, third1, fourth1);
   q.compute(x, values2, gradients2, second2, third2, fourth2);
 
   for (unsigned int k = 0; k < n; ++k)

--- a/tests/base/polynomial_test.cc
+++ b/tests/base/polynomial_test.cc
@@ -41,7 +41,7 @@ check_poly(const Point<dim> &x, const PolynomialType &p)
   std::vector<Tensor<3, dim>> third(n);
   std::vector<Tensor<4, dim>> fourth(n);
 
-  p.compute(x, values, gradients, second, third, fourth);
+  p.evaluate(x, values, gradients, second, third, fourth);
 
   for (unsigned int k = 0; k < n; ++k)
     {


### PR DESCRIPTION
This is a WIP at the moment. I did a bit of work in related files to make all of this consistent with #8619 as well.

I believe it compiles in its current form, but some of these classes have their own derived classes and I need to check that things are inherited and implemented properly in the derived classes, so we shouldn't test it just yet.

As far as answering #1973, this will complete step 5/6
1. [x] Implement the TensorPolynomialsBase class
2. [x] Change tensor polynomial classes to derive from it
3. [x] Remove the class template argument from FE_PolyTensor
4. [x] Implement the ScalarPolynomialsBase class
5. [x] Change scalar polynomial classes to derive from it
6. [ ] Remove the class template argument from FE_Poly