### PR TITLE
Fix a bug with cuda and hanging nodes

### DIFF
--- a/doc/news/changes/minor/20190831BrunoTurcksin
+++ b/doc/news/changes/minor/20190831BrunoTurcksin
@@ -1,0 +1,4 @@
+Fixed: CUDAWrappers::MatrixFree::cell_loop() now works on adapted mesh even in
+two dimensions with finite elements of even degree.
+<br>
+(Bruno Turcksin, 2019/08/31)

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -177,11 +177,6 @@ namespace CUDAWrappers
       , fe_degree(fe_degree)
       , dof_handler(dof_handler)
     {
-      AssertThrow(
-        (dim == 3) || ((fe_degree % 2) == 1),
-        ExcMessage(
-          "This function is not implemented when dim = 2 and fe_degree is even."));
-
       // Set up line-to-cell mapping for edge constraints (only if dim = 3)
       setup_line_to_cell();
 
@@ -787,6 +782,7 @@ namespace CUDAWrappers
           ((direction == 1) && ((constraint_mask & internal::constr_type_x) ?
                                   (x_idx == 0) :
                                   (x_idx == fe_degree)));
+        __syncthreads();
         if (constrained_face && constrained_dof)
           {
             const bool type = constraint_mask & this_type;
@@ -901,6 +897,7 @@ namespace CUDAWrappers
            ((constraint_mask & face2) && on_face2) ||
            ((constraint_mask & edge) && on_face1 && on_face2));
 
+        __syncthreads();
         if (constrained_face && constrained_dof)
           {
             const bool type = constraint_mask & this_type;

--- a/tests/cuda/matrix_free_matrix_vector_01.output
+++ b/tests/cuda/matrix_free_matrix_vector_01.output
@@ -2,6 +2,9 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Norm of difference: 0
 DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(2)
+DEAL:2d::Norm of difference: 0
+DEAL:2d::
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Norm of difference: 0
 DEAL:2d::

--- a/tests/cuda/matrix_free_matrix_vector_02.output
+++ b/tests/cuda/matrix_free_matrix_vector_02.output
@@ -2,6 +2,9 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Norm of difference: 0
 DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(2)
+DEAL:2d::Norm of difference: 0
+DEAL:2d::
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Norm of difference: 0
 DEAL:2d::

--- a/tests/cuda/matrix_free_matrix_vector_03.cu
+++ b/tests/cuda/matrix_free_matrix_vector_03.cu
@@ -66,11 +66,9 @@ test()
                                            constraints);
   constraints.close();
 
-  // Skip 2D tests with even fe_degree
-  if ((dim == 3) || ((fe_degree % 2) == 1))
-    do_test<dim,
-            fe_degree,
-            double,
-            LinearAlgebra::CUDAWrappers::Vector<double>,
-            fe_degree + 1>(dof, constraints, tria.n_active_cells());
+  do_test<dim,
+          fe_degree,
+          double,
+          LinearAlgebra::CUDAWrappers::Vector<double>,
+          fe_degree + 1>(dof, constraints, tria.n_active_cells());
 }

--- a/tests/cuda/matrix_free_matrix_vector_03.output
+++ b/tests/cuda/matrix_free_matrix_vector_03.output
@@ -2,6 +2,9 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Norm of difference: 0.
 DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(2)
+DEAL:2d::Norm of difference: 0.
+DEAL:2d::
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Norm of difference: 0.
 DEAL:2d::

--- a/tests/cuda/matrix_free_matrix_vector_03b.cu
+++ b/tests/cuda/matrix_free_matrix_vector_03b.cu
@@ -67,11 +67,9 @@ test()
                                            constraints);
   constraints.close();
 
-  // Skip 2D tests with even fe_degree
-  if ((dim == 3) || ((fe_degree % 2) == 1))
-    do_test<dim,
-            fe_degree,
-            double,
-            LinearAlgebra::CUDAWrappers::Vector<double>,
-            fe_degree + 1>(dof, constraints, tria.n_active_cells(), true, true);
+  do_test<dim,
+          fe_degree,
+          double,
+          LinearAlgebra::CUDAWrappers::Vector<double>,
+          fe_degree + 1>(dof, constraints, tria.n_active_cells(), true, true);
 }

--- a/tests/cuda/matrix_free_matrix_vector_03b.output
+++ b/tests/cuda/matrix_free_matrix_vector_03b.output
@@ -2,6 +2,9 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Norm of difference: 0.
 DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(2)
+DEAL:2d::Norm of difference: 0.
+DEAL:2d::
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Norm of difference: 0.
 DEAL:2d::

--- a/tests/cuda/matrix_free_matrix_vector_04.output
+++ b/tests/cuda/matrix_free_matrix_vector_04.output
@@ -2,6 +2,9 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Norm of difference: 0
 DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(2)
+DEAL:2d::Norm of difference: 0
+DEAL:2d::
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Norm of difference: 0
 DEAL:2d::

--- a/tests/cuda/matrix_free_matrix_vector_05.cu
+++ b/tests/cuda/matrix_free_matrix_vector_05.cu
@@ -76,11 +76,9 @@ test()
   DoFTools::make_hanging_node_constraints(dof, constraints);
   constraints.close();
 
-  // Skip 2D tests with even fe_degree
-  if ((dim == 3) || ((fe_degree % 2) == 1))
-    do_test<dim,
-            fe_degree,
-            double,
-            LinearAlgebra::CUDAWrappers::Vector<double>,
-            fe_degree + 1>(dof, constraints, tria.n_active_cells());
+  do_test<dim,
+          fe_degree,
+          double,
+          LinearAlgebra::CUDAWrappers::Vector<double>,
+          fe_degree + 1>(dof, constraints, tria.n_active_cells());
 }

--- a/tests/cuda/matrix_free_matrix_vector_05.output
+++ b/tests/cuda/matrix_free_matrix_vector_05.output
@@ -2,6 +2,9 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Norm of difference: 0
 DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(2)
+DEAL:2d::Norm of difference: 0
+DEAL:2d::
 DEAL:2d::Testing FE_Q<2>(3)
 DEAL:2d::Norm of difference: 0
 DEAL:2d::

--- a/tests/cuda/matrix_vector_common.h
+++ b/tests/cuda/matrix_vector_common.h
@@ -198,7 +198,7 @@ main()
   {
     deallog.push("2d");
     test<2, 1>();
-    // test<2, 2>();
+    test<2, 2>();
     test<2, 3>();
     deallog.pop();
     deallog.push("3d");


### PR DESCRIPTION
Right now we can't use cuda matrix-free on an adapted mesh if `dim=2` and `fe_degree` is even. There is also a test failing on the cuda tester when using atomics in release mode. Going back to Karl's code, I realized that I was missing some synchronization barriers.