### PR TITLE
Make hp::FEvaluesBase non-internal.

### DIFF
--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -37,154 +37,147 @@ class FiniteElement;
 #endif
 
 
-namespace internal
+namespace hp
 {
-  namespace hp
+  /**
+   * Base class for the <tt>hp::FE*Values</tt> classes, storing the data
+   * that is common to them. The main task of this class is to provide a
+   * table where for every combination of finite element, mapping, and
+   * quadrature object from their corresponding collection objects there is
+   * a matching ::FEValues, ::FEFaceValues, or ::FESubfaceValues object. To
+   * make things more efficient, however, these FE*Values objects are only
+   * created once requested (lazy allocation).
+   *
+   * The first template parameter denotes the space dimension we are in, the
+   * second the dimensionality of the object that we integrate on, i.e. for
+   * usual @p hp::FEValues it is equal to the first one, while for face
+   * integration it is one less. The third template parameter indicates the
+   * type of underlying non-hp FE*Values base type, i.e. it could either be
+   * ::FEValues, ::FEFaceValues, or ::FESubfaceValues.
+   *
+   * @ingroup hp
+   *
+   * @author Wolfgang Bangerth, 2003
+   */
+  template <int dim, int q_dim, class FEValuesType>
+  class FEValuesBase
   {
+  public:
     /**
-     * Base class for the <tt>hp::FE*Values</tt> classes, storing the data
-     * that is common to them. The main task of this class is to provide a
-     * table where for every combination of finite element, mapping, and
-     * quadrature object from their corresponding collection objects there is
-     * a matching ::FEValues, ::FEFaceValues, or ::FESubfaceValues object. To
-     * make things more efficient, however, these FE*Values objects are only
-     * created once requested (lazy allocation).
-     *
-     * The first template parameter denotes the space dimension we are in, the
-     * second the dimensionality of the object that we integrate on, i.e. for
-     * usual @p hp::FEValues it is equal to the first one, while for face
-     * integration it is one less. The third template parameter indicates the
-     * type of underlying non-hp FE*Values base type, i.e. it could either be
-     * dealii::FEValues, dealii::FEFaceValues, or dealii::FESubfaceValues.
-     *
-     * @ingroup hp
-     *
-     * @author Wolfgang Bangerth, 2003
+     * Constructor. Set the fields of this class to the values indicated by
+     * the parameters to the constructor.
      */
-    template <int dim, int q_dim, class FEValuesType>
-    class FEValuesBase
-    {
-    public:
-      /**
-       * Constructor. Set the fields of this class to the values indicated by
-       * the parameters to the constructor.
-       */
-      FEValuesBase(
-        const dealii::hp::MappingCollection<dim, FEValuesType::space_dimension>
-          &mapping_collection,
-        const dealii::hp::FECollection<dim, FEValuesType::space_dimension>
-          &                                   fe_collection,
-        const dealii::hp::QCollection<q_dim> &q_collection,
-        const dealii::UpdateFlags             update_flags);
-      /**
-       * Constructor. This constructor is equivalent to the other one except
-       * that it makes the object use a $Q_1$ mapping (i.e., an object of type
-       * MappingQGeneric(1)) implicitly.
-       */
-      FEValuesBase(
-        const dealii::hp::FECollection<dim, FEValuesType::space_dimension>
-          &                                   fe_collection,
-        const dealii::hp::QCollection<q_dim> &q_collection,
-        const UpdateFlags                     update_flags);
+    FEValuesBase(
+      const MappingCollection<dim, FEValuesType::space_dimension>
+        &mapping_collection,
+      const FECollection<dim, FEValuesType::space_dimension> &fe_collection,
+      const QCollection<q_dim> &                              q_collection,
+      const UpdateFlags                                       update_flags);
+    /**
+     * Constructor. This constructor is equivalent to the other one except
+     * that it makes the object use a $Q_1$ mapping (i.e., an object of type
+     * MappingQGeneric(1)) implicitly.
+     */
+    FEValuesBase(
+      const FECollection<dim, FEValuesType::space_dimension> &fe_collection,
+      const QCollection<q_dim> &                              q_collection,
+      const UpdateFlags                                       update_flags);
 
-      /**
-       * Get a reference to the collection of finite element objects used
-       * here.
-       */
-      const dealii::hp::FECollection<dim, FEValuesType::space_dimension> &
-      get_fe_collection() const;
+    /**
+     * Get a reference to the collection of finite element objects used
+     * here.
+     */
+    const FECollection<dim, FEValuesType::space_dimension> &
+    get_fe_collection() const;
 
-      /**
-       * Get a reference to the collection of mapping objects used here.
-       */
-      const dealii::hp::MappingCollection<dim, FEValuesType::space_dimension> &
-      get_mapping_collection() const;
+    /**
+     * Get a reference to the collection of mapping objects used here.
+     */
+    const MappingCollection<dim, FEValuesType::space_dimension> &
+    get_mapping_collection() const;
 
-      /**
-       * Get a reference to the collection of quadrature objects used here.
-       */
-      const dealii::hp::QCollection<q_dim> &
-      get_quadrature_collection() const;
+    /**
+     * Get a reference to the collection of quadrature objects used here.
+     */
+    const QCollection<q_dim> &
+    get_quadrature_collection() const;
 
-      /**
-       * Get the underlying update flags.
-       */
-      UpdateFlags
-      get_update_flags() const;
+    /**
+     * Get the underlying update flags.
+     */
+    UpdateFlags
+    get_update_flags() const;
 
-      /**
-       * Return a reference to the @p FEValues object selected by the last
-       * call to select_fe_values(). select_fe_values() in turn is called when
-       * you called the @p reinit function of the <tt>hp::FE*Values</tt> class
-       * the last time.
-       */
-      const FEValuesType &
-      get_present_fe_values() const;
+    /**
+     * Return a reference to the @p FEValues object selected by the last
+     * call to select_fe_values(). select_fe_values() in turn is called when
+     * you called the @p reinit function of the <tt>hp::FE*Values</tt> class
+     * the last time.
+     */
+    const FEValuesType &
+    get_present_fe_values() const;
 
-    protected:
-      /**
-       * Select a FEValues object suitable for the given FE, quadrature, and
-       * mapping indices. If such an object doesn't yet exist, create one.
-       *
-       * The function returns a writable reference so that derived classes can
-       * also reinit() the selected FEValues object.
-       */
-      FEValuesType &
-      select_fe_values(const unsigned int fe_index,
-                       const unsigned int mapping_index,
-                       const unsigned int q_index);
+  protected:
+    /**
+     * Select a FEValues object suitable for the given FE, quadrature, and
+     * mapping indices. If such an object doesn't yet exist, create one.
+     *
+     * The function returns a writable reference so that derived classes can
+     * also reinit() the selected FEValues object.
+     */
+    FEValuesType &
+    select_fe_values(const unsigned int fe_index,
+                     const unsigned int mapping_index,
+                     const unsigned int q_index);
 
-    protected:
-      /**
-       * A pointer to the collection of finite elements to be used.
-       */
-      const SmartPointer<
-        const dealii::hp::FECollection<dim, FEValuesType::space_dimension>,
-        FEValuesBase<dim, q_dim, FEValuesType>>
-        fe_collection;
+  protected:
+    /**
+     * A pointer to the collection of finite elements to be used.
+     */
+    const SmartPointer<const FECollection<dim, FEValuesType::space_dimension>,
+                       FEValuesBase<dim, q_dim, FEValuesType>>
+      fe_collection;
 
-      /**
-       * A pointer to the collection of mappings to be used.
-       */
-      const SmartPointer<
-        const dealii::hp::MappingCollection<dim, FEValuesType::space_dimension>,
-        FEValuesBase<dim, q_dim, FEValuesType>>
-        mapping_collection;
+    /**
+     * A pointer to the collection of mappings to be used.
+     */
+    const SmartPointer<
+      const MappingCollection<dim, FEValuesType::space_dimension>,
+      FEValuesBase<dim, q_dim, FEValuesType>>
+      mapping_collection;
 
-      /**
-       * Copy of the quadrature collection object provided to the constructor.
-       */
-      const dealii::hp::QCollection<q_dim> q_collection;
+    /**
+     * Copy of the quadrature collection object provided to the constructor.
+     */
+    const QCollection<q_dim> q_collection;
 
-    private:
-      /**
-       * A table in which we store pointers to fe_values objects for different
-       * finite element, mapping, and quadrature objects from our collection.
-       * The first index indicates the index of the finite element within the
-       * fe_collection, the second the index of the mapping within the mapping
-       * collection, and the last one the index of the quadrature formula
-       * within the q_collection.
-       *
-       * Initially, all entries have zero pointers, and we will allocate them
-       * lazily as needed in select_fe_values().
-       */
-      dealii::Table<3, std::shared_ptr<FEValuesType>> fe_values_table;
+  private:
+    /**
+     * A table in which we store pointers to fe_values objects for different
+     * finite element, mapping, and quadrature objects from our collection.
+     * The first index indicates the index of the finite element within the
+     * fe_collection, the second the index of the mapping within the mapping
+     * collection, and the last one the index of the quadrature formula
+     * within the q_collection.
+     *
+     * Initially, all entries have zero pointers, and we will allocate them
+     * lazily as needed in select_fe_values().
+     */
+    Table<3, std::shared_ptr<FEValuesType>> fe_values_table;
 
-      /**
-       * Set of indices pointing at the fe_values object selected last time
-       * the select_fe_value() function was called.
-       */
-      TableIndices<3> present_fe_values_index;
+    /**
+     * Set of indices pointing at the fe_values object selected last time
+     * the select_fe_value() function was called.
+     */
+    TableIndices<3> present_fe_values_index;
 
-      /**
-       * Values of the update flags as given to the constructor.
-       */
-      const UpdateFlags update_flags;
-    };
+    /**
+     * Values of the update flags as given to the constructor.
+     */
+    const UpdateFlags update_flags;
+  };
 
-  } // namespace hp
-
-} // namespace internal
+} // namespace hp
 
 
 namespace hp
@@ -238,8 +231,8 @@ namespace hp
    * @author Wolfgang Bangerth, 2003
    */
   template <int dim, int spacedim = dim>
-  class FEValues : public dealii::internal::hp::
-                     FEValuesBase<dim, dim, dealii::FEValues<dim, spacedim>>
+  class FEValues
+    : public hp::FEValuesBase<dim, dim, dealii::FEValues<dim, spacedim>>
   {
   public:
     static const unsigned int dimension = dim;
@@ -379,8 +372,7 @@ namespace hp
    */
   template <int dim, int spacedim = dim>
   class FEFaceValues
-    : public dealii::internal::hp::
-        FEValuesBase<dim, dim - 1, dealii::FEFaceValues<dim, spacedim>>
+    : public hp::FEValuesBase<dim, dim - 1, dealii::FEFaceValues<dim, spacedim>>
   {
   public:
     /**
@@ -499,7 +491,7 @@ namespace hp
    */
   template <int dim, int spacedim = dim>
   class FESubfaceValues
-    : public dealii::internal::hp::
+    : public hp::
         FEValuesBase<dim, dim - 1, dealii::FESubfaceValues<dim, spacedim>>
   {
   public:
@@ -606,56 +598,51 @@ namespace hp
 
 // -------------- inline and template functions --------------
 
-namespace internal
+namespace hp
 {
-  namespace hp
+  template <int dim, int q_dim, class FEValuesType>
+  inline const FEValuesType &
+  FEValuesBase<dim, q_dim, FEValuesType>::get_present_fe_values() const
   {
-    template <int dim, int q_dim, class FEValuesType>
-    inline const FEValuesType &
-    FEValuesBase<dim, q_dim, FEValuesType>::get_present_fe_values() const
-    {
-      return *fe_values_table(present_fe_values_index);
-    }
+    return *fe_values_table(present_fe_values_index);
+  }
 
 
 
-    template <int dim, int q_dim, class FEValuesType>
-    inline const dealii::hp::FECollection<dim, FEValuesType::space_dimension> &
-    FEValuesBase<dim, q_dim, FEValuesType>::get_fe_collection() const
-    {
-      return *fe_collection;
-    }
+  template <int dim, int q_dim, class FEValuesType>
+  inline const FECollection<dim, FEValuesType::space_dimension> &
+  FEValuesBase<dim, q_dim, FEValuesType>::get_fe_collection() const
+  {
+    return *fe_collection;
+  }
 
 
 
-    template <int dim, int q_dim, class FEValuesType>
-    inline const dealii::hp::MappingCollection<dim,
-                                               FEValuesType::space_dimension> &
-    FEValuesBase<dim, q_dim, FEValuesType>::get_mapping_collection() const
-    {
-      return *mapping_collection;
-    }
+  template <int dim, int q_dim, class FEValuesType>
+  inline const MappingCollection<dim, FEValuesType::space_dimension> &
+  FEValuesBase<dim, q_dim, FEValuesType>::get_mapping_collection() const
+  {
+    return *mapping_collection;
+  }
 
 
 
-    template <int dim, int q_dim, class FEValuesType>
-    inline const dealii::hp::QCollection<q_dim> &
-    FEValuesBase<dim, q_dim, FEValuesType>::get_quadrature_collection() const
-    {
-      return q_collection;
-    }
+  template <int dim, int q_dim, class FEValuesType>
+  inline const QCollection<q_dim> &
+  FEValuesBase<dim, q_dim, FEValuesType>::get_quadrature_collection() const
+  {
+    return q_collection;
+  }
 
 
 
-    template <int dim, int q_dim, class FEValuesType>
-    inline dealii::UpdateFlags
-    FEValuesBase<dim, q_dim, FEValuesType>::get_update_flags() const
-    {
-      return update_flags;
-    }
-  } // namespace hp
-
-} // namespace internal
+  template <int dim, int q_dim, class FEValuesType>
+  inline UpdateFlags
+  FEValuesBase<dim, q_dim, FEValuesType>::get_update_flags() const
+  {
+    return update_flags;
+  }
+} // namespace hp
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/source/hp/fe_values.inst.in
+++ b/source/hp/fe_values.inst.in
@@ -16,20 +16,17 @@
 
 for (deal_II_dimension : DIMENSIONS)
   {
-    namespace internal
+    namespace hp
     \{
-      namespace hp
-      \{
-        template class FEValuesBase<deal_II_dimension,
-                                    deal_II_dimension,
-                                    dealii::FEValues<deal_II_dimension>>;
-        template class FEValuesBase<deal_II_dimension,
-                                    deal_II_dimension - 1,
-                                    dealii::FEFaceValues<deal_II_dimension>>;
-        template class FEValuesBase<deal_II_dimension,
-                                    deal_II_dimension - 1,
-                                    dealii::FESubfaceValues<deal_II_dimension>>;
-      \}
+      template class FEValuesBase<deal_II_dimension,
+                                  deal_II_dimension,
+                                  dealii::FEValues<deal_II_dimension>>;
+      template class FEValuesBase<deal_II_dimension,
+                                  deal_II_dimension - 1,
+                                  dealii::FEFaceValues<deal_II_dimension>>;
+      template class FEValuesBase<deal_II_dimension,
+                                  deal_II_dimension - 1,
+                                  dealii::FESubfaceValues<deal_II_dimension>>;
     \}
 
     namespace hp
@@ -43,23 +40,20 @@ for (deal_II_dimension : DIMENSIONS)
 
 #if deal_II_dimension != 3
 
-    namespace internal
+    namespace hp
     \{
-      namespace hp
-      \{
-        template class FEValuesBase<
-          deal_II_dimension,
-          deal_II_dimension,
-          dealii::FEValues<deal_II_dimension, deal_II_dimension + 1>>;
-        template class FEValuesBase<
-          deal_II_dimension,
-          deal_II_dimension - 1,
-          dealii::FEFaceValues<deal_II_dimension, deal_II_dimension + 1>>;
-        template class FEValuesBase<
-          deal_II_dimension,
-          deal_II_dimension - 1,
-          dealii::FESubfaceValues<deal_II_dimension, deal_II_dimension + 1>>;
-      \}
+      template class FEValuesBase<
+        deal_II_dimension,
+        deal_II_dimension,
+        dealii::FEValues<deal_II_dimension, deal_II_dimension + 1>>;
+      template class FEValuesBase<
+        deal_II_dimension,
+        deal_II_dimension - 1,
+        dealii::FEFaceValues<deal_II_dimension, deal_II_dimension + 1>>;
+      template class FEValuesBase<
+        deal_II_dimension,
+        deal_II_dimension - 1,
+        dealii::FESubfaceValues<deal_II_dimension, deal_II_dimension + 1>>;
     \}
 
     namespace hp
@@ -72,14 +66,11 @@ for (deal_II_dimension : DIMENSIONS)
 
 #if deal_II_dimension == 3
 
-    namespace internal
+    namespace hp
     \{
-      namespace hp
-      \{
-        template class FEValuesBase<1, 1, dealii::FEValues<1, 3>>;
-        template class FEValuesBase<1, 1 - 1, dealii::FEFaceValues<1, 3>>;
-        template class FEValuesBase<1, 1 - 1, dealii::FESubfaceValues<1, 3>>;
-      \}
+      template class FEValuesBase<1, 1, dealii::FEValues<1, 3>>;
+      template class FEValuesBase<1, 1 - 1, dealii::FEFaceValues<1, 3>>;
+      template class FEValuesBase<1, 1 - 1, dealii::FESubfaceValues<1, 3>>;
     \}
 
     namespace hp


### PR DESCRIPTION
Fixes #8691 by moving `hp::internal::FEValuesBase` to `hp::FEValuesBase`. We publicly inherit from this class so I think its better (regardless of the doxygen status) to not make it `internal`.