### PR TITLE
GeometryInfo<dim>::unit_normal_vector 

### DIFF
--- a/doc/news/changes/minor/20190904RezaRastak
+++ b/doc/news/changes/minor/20190904RezaRastak
@@ -1,0 +1,4 @@
+Added: GeometryInfo<dim>::unit_normal_vector provides outward-facing unit
+vectors for each face of the reference cell in the form of Tensor<1, dim>.
+<br>
+(Reza Rastak, 2019/09/04)

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -48,6 +48,9 @@ namespace internal
 
       static constexpr std::array<int, 2> unit_normal_orientation{{-1, 1}};
 
+      static constexpr std::array<Tensor<1, 1>, 2> unit_normal_vector{
+        {Tensor<1, 1>{{-1}}, Tensor<1, 1>{{1}}}};
+
       static constexpr std::array<unsigned int, 2> opposite_face{{1, 0}};
 
       static constexpr std::array<unsigned int, 2> dx_to_deal{{0, 1}};
@@ -66,6 +69,12 @@ namespace internal
 
       static constexpr std::array<int, 4> unit_normal_orientation{
         {-1, 1, -1, 1}};
+
+      static constexpr std::array<Tensor<1, 2>, 4> unit_normal_vector{
+        {Tensor<1, 2>{{-1., 0.}},
+         Tensor<1, 2>{{1., 0.}},
+         Tensor<1, 2>{{0., -1.}},
+         Tensor<1, 2>{{0., 1.}}}};
 
       static constexpr std::array<unsigned int, 4> opposite_face{{1, 0, 3, 2}};
 
@@ -86,6 +95,14 @@ namespace internal
 
       static constexpr std::array<int, 6> unit_normal_orientation{
         {-1, 1, -1, 1, -1, 1}};
+
+      static constexpr std::array<Tensor<1, 3>, 6> unit_normal_vector{
+        {Tensor<1, 3>{{-1, 0, 0}},
+         Tensor<1, 3>{{1, 0, 0}},
+         Tensor<1, 3>{{0, -1, 0}},
+         Tensor<1, 3>{{0, 1, 0}},
+         Tensor<1, 3>{{0, 0, -1}},
+         Tensor<1, 3>{{0, 0, 1}}}};
 
       static constexpr std::array<unsigned int, 6> opposite_face{
         {1, 0, 3, 2, 5, 4}};
@@ -130,6 +147,16 @@ namespace internal
 
       static constexpr std::array<int, 8> unit_normal_orientation{
         {-1, 1, -1, 1, -1, 1, -1, 1}};
+
+      static constexpr std::array<Tensor<1, 4>, 8> unit_normal_vector{
+        {Tensor<1, 4>{{-1, 0, 0, 0}},
+         Tensor<1, 4>{{1, 0, 0, 0}},
+         Tensor<1, 4>{{0, -1, 0, 0}},
+         Tensor<1, 4>{{0, 1, 0, 0}},
+         Tensor<1, 4>{{0, 0, -1, 0}},
+         Tensor<1, 4>{{0, 0, 1, 0}},
+         Tensor<1, 4>{{0, 0, 0, -1}},
+         Tensor<1, 4>{{0, 0, 0, 1}}}};
 
       static constexpr std::array<unsigned int, 8> opposite_face{
         {1, 0, 3, 2, 5, 4, 7, 6}};
@@ -2261,6 +2288,20 @@ struct GeometryInfo
    */
   static constexpr std::array<int, faces_per_cell> unit_normal_orientation =
     internal::GeometryInfoHelper::Initializers<dim>::unit_normal_orientation;
+
+  /**
+   * Unit normal vector (Point<dim>) of a face of the reference cell.
+   *
+   * Note that this is only the <em>standard orientation</em> of faces. At
+   * least in 3d, actual faces of cells in a triangulation can also have the
+   * opposite orientation, depending on a flag that one can query from the
+   * cell it belongs to. For more information, see the
+   * @ref GlossFaceOrientation "glossary"
+   * entry on face orientation.
+   */
+  static constexpr std::array<Tensor<1, dim>, faces_per_cell>
+    unit_normal_vector =
+      internal::GeometryInfoHelper::Initializers<dim>::unit_normal_vector;
 
   /**
    * List of numbers which denotes which face is opposite to a given face. Its

--- a/source/base/geometry_info.cc
+++ b/source/base/geometry_info.cc
@@ -54,6 +54,10 @@ constexpr std::array<unsigned int, GeometryInfo<dim>::faces_per_cell>
   GeometryInfo<dim>::unit_normal_direction;
 
 template <int dim>
+constexpr std::array<Tensor<1, dim>, GeometryInfo<dim>::faces_per_cell>
+  GeometryInfo<dim>::unit_normal_vector;
+
+template <int dim>
 constexpr std::array<unsigned int, GeometryInfo<dim>::vertices_per_cell>
   GeometryInfo<dim>::dx_to_deal;
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -279,19 +279,13 @@ MappingCartesian<dim, spacedim>::compute_fill(
     }
 
 
-  // compute normal vectors. since
-  // cells are aligned to coordinate
-  // axes, they are simply vectors
-  // with exactly one entry equal to
-  // 1 or -1. Furthermore, all
-  // normals on a face have the same
-  // value
+  // compute normal vectors. All normals on a face have the same value.
   if (update_flags & update_normal_vectors)
     {
       Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
       std::fill(normal_vectors.begin(),
                 normal_vectors.end(),
-                Point<dim>{GeometryInfo<dim>::unit_normal_vector[face_no]});
+                GeometryInfo<dim>::unit_normal_vector[face_no]);
     }
 }
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -289,50 +289,9 @@ MappingCartesian<dim, spacedim>::compute_fill(
   if (update_flags & update_normal_vectors)
     {
       Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
-
-      switch (dim)
-        {
-          case 1:
-            {
-              static const Point<dim> normals[GeometryInfo<1>::faces_per_cell] =
-                {Point<dim>(-1.), Point<dim>(1.)};
-              std::fill(normal_vectors.begin(),
-                        normal_vectors.end(),
-                        normals[face_no]);
-              break;
-            }
-
-          case 2:
-            {
-              static const Point<dim> normals[GeometryInfo<2>::faces_per_cell] =
-                {Point<dim>(-1, 0),
-                 Point<dim>(1, 0),
-                 Point<dim>(0, -1),
-                 Point<dim>(0, 1)};
-              std::fill(normal_vectors.begin(),
-                        normal_vectors.end(),
-                        normals[face_no]);
-              break;
-            }
-
-          case 3:
-            {
-              static const Point<dim> normals[GeometryInfo<3>::faces_per_cell] =
-                {Point<dim>(-1, 0, 0),
-                 Point<dim>(1, 0, 0),
-                 Point<dim>(0, -1, 0),
-                 Point<dim>(0, 1, 0),
-                 Point<dim>(0, 0, -1),
-                 Point<dim>(0, 0, 1)};
-              std::fill(normal_vectors.begin(),
-                        normal_vectors.end(),
-                        normals[face_no]);
-              break;
-            }
-
-          default:
-            Assert(false, ExcNotImplemented());
-        }
+      std::fill(normal_vectors.begin(),
+                normal_vectors.end(),
+                Point<dim>{GeometryInfo<dim>::unit_normal_vector[face_no]});
     }
 }
 

--- a/tests/base/geometry_info_9.cc
+++ b/tests/base/geometry_info_9.cc
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Test GeometryInfo<dim>::unit_normal_vector
+
+#include <deal.II/base/geometry_info.h>
+
+#include "../tests.h"
+
+const double eps = 1e-10;
+DeclException3(ExcWrongValue,
+               double,
+               double,
+               double,
+               << arg1 << " != " << arg2 << " with delta = " << arg3);
+
+template <int dim>
+void
+test()
+{
+  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+    {
+      const Tensor<1, dim> unit_normal_vector =
+        GeometryInfo<dim>::unit_normal_vector[i];
+      deallog << "Direction " << i << " = " << unit_normal_vector << std::endl;
+      // check consistency with other arrays within GeometryInfo
+      for (unsigned int j = 0; j < dim; j++)
+        {
+          const double obtained = unit_normal_vector[j];
+          const double expected =
+            (j == GeometryInfo<dim>::unit_normal_direction[i]) ?
+              static_cast<double>(
+                GeometryInfo<dim>::unit_normal_orientation[i]) :
+              0;
+          AssertThrow(obtained == expected,
+                      ExcWrongValue(obtained, expected, obtained - expected));
+        }
+    }
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("1d");
+  test<1>();
+  deallog.pop();
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+  return 0;
+}

--- a/tests/base/geometry_info_9.output
+++ b/tests/base/geometry_info_9.output
@@ -1,0 +1,16 @@
+
+DEAL:1d::Direction 0 = -1.00000
+DEAL:1d::Direction 1 = 1.00000
+DEAL:1d::OK
+DEAL:2d::Direction 0 = -1.00000 0.00000
+DEAL:2d::Direction 1 = 1.00000 0.00000
+DEAL:2d::Direction 2 = 0.00000 -1.00000
+DEAL:2d::Direction 3 = 0.00000 1.00000
+DEAL:2d::OK
+DEAL:3d::Direction 0 = -1.00000 0.00000 0.00000
+DEAL:3d::Direction 1 = 1.00000 0.00000 0.00000
+DEAL:3d::Direction 2 = 0.00000 -1.00000 0.00000
+DEAL:3d::Direction 3 = 0.00000 1.00000 0.00000
+DEAL:3d::Direction 4 = 0.00000 0.00000 -1.00000
+DEAL:3d::Direction 5 = 0.00000 0.00000 1.00000
+DEAL:3d::OK


### PR DESCRIPTION
Added a useful constant to `GeometryInfo` and used it to simplify a function in `mapping_cartesian.cc`. It also showcases the usefulness of `consexpr Tensor`.