### PR TITLE
VectorizedArrary: add a test for std::pow

### DIFF
--- a/tests/base/vectorization_13.cc
+++ b/tests/base/vectorization_13.cc
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// test std::pow for vectorized array
+
+#include <deal.II/base/vectorization.h>
+
+#include "../tests.h"
+
+
+template <typename VectorizedArrayType>
+void
+do_test(const VectorizedArrayType                      array,
+        const typename VectorizedArrayType::value_type number)
+{
+  deallog << "  test " << VectorizedArrayType::n_array_elements
+          << " array elements" << std::endl;
+
+  auto exponentiated_array = std::pow(array, number);
+
+  for (unsigned int i = 0; i < VectorizedArrayType::n_array_elements; i++)
+    deallog << exponentiated_array[i] << " ";
+  deallog << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
+  do_test(VectorizedArray<double, 8>(2.0), 3.0);
+  do_test(VectorizedArray<float, 16>(2.0), 3.0);
+#endif
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
+  do_test(VectorizedArray<double, 4>(2.0), 3.0);
+  do_test(VectorizedArray<float, 8>(2.0), 3.0);
+#endif
+
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
+  do_test(VectorizedArray<double, 2>(2.0), 3.0);
+  do_test(VectorizedArray<float, 4>(2.0), 3.0);
+#endif
+
+  do_test(VectorizedArray<double, 1>(2.0), 3.0);
+  do_test(VectorizedArray<float, 1>(2.0), 3.0);
+}

--- a/tests/base/vectorization_13.output
+++ b/tests/base/vectorization_13.output
@@ -1,0 +1,5 @@
+
+DEAL::  test 1 array elements
+DEAL::8.00000 
+DEAL::  test 1 array elements
+DEAL::8.00000 

--- a/tests/base/vectorization_13.output.avx
+++ b/tests/base/vectorization_13.output.avx
@@ -1,0 +1,13 @@
+
+DEAL::  test 4 array elements
+DEAL::8.00000 8.00000 8.00000 8.00000 
+DEAL::  test 8 array elements
+DEAL::8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 
+DEAL::  test 2 array elements
+DEAL::8.00000 8.00000 
+DEAL::  test 4 array elements
+DEAL::8.00000 8.00000 8.00000 8.00000 
+DEAL::  test 1 array elements
+DEAL::8.00000 
+DEAL::  test 1 array elements
+DEAL::8.00000 

--- a/tests/base/vectorization_13.output.avx512
+++ b/tests/base/vectorization_13.output.avx512
@@ -1,0 +1,17 @@
+
+DEAL::  test 8 array elements
+DEAL::8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 
+DEAL::  test 16 array elements
+DEAL::8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 
+DEAL::  test 4 array elements
+DEAL::8.00000 8.00000 8.00000 8.00000 
+DEAL::  test 8 array elements
+DEAL::8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 8.00000 
+DEAL::  test 2 array elements
+DEAL::8.00000 8.00000 
+DEAL::  test 4 array elements
+DEAL::8.00000 8.00000 8.00000 8.00000 
+DEAL::  test 1 array elements
+DEAL::8.00000 
+DEAL::  test 1 array elements
+DEAL::8.00000 

--- a/tests/base/vectorization_13.output.sse2
+++ b/tests/base/vectorization_13.output.sse2
@@ -1,0 +1,9 @@
+
+DEAL::  test 2 array elements
+DEAL::8.00000 8.00000 
+DEAL::  test 4 array elements
+DEAL::8.00000 8.00000 8.00000 8.00000 
+DEAL::  test 1 array elements
+DEAL::8.00000 
+DEAL::  test 1 array elements
+DEAL::8.00000 


### PR DESCRIPTION
let's add the one test from #8698 nevertheless - I think the codepath is
otherwise untested.

In reference to #8698