### PR TITLE
Clarify the degree of the elements NedelecSZ and Nedelec

### DIFF
--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -114,10 +114,16 @@ class FE_Nedelec : public FE_PolyTensor<dim>
 {
 public:
   /**
-   * Constructor for the N&eacute;d&eacute;lec element of given @p order.
-   * The maximal polynomial degree of the shape functions is
-   * <code>order+1</code> (in each variable; the total polynomial degree
-   * may be higher).
+   * Constructor for the Nedelec element of given @p order. The maximal
+   * polynomial degree of the shape functions is `order+1` (in each variable;
+   * the total polynomial degree may be higher). If `order = 0`, the element is
+   * linear and has degrees of freedom only on the edges. If `order >=1` the
+   * element has degrees of freedom on the edges, faces and volume. For example
+   * the 3D version of FE_Nedelec has 12 degrees of freedom for `order = 0`
+   * and 54 for `degree = 1`. It is important to have enough quadrature points
+   * in order to perform the quadrature with sufficient accuracy.
+   * For example [QGauss<dim>(order + 2)](@ref QGauss) can be used for the
+   * quadrature formula, where `order` is the order of FE_Nedelec.
    */
   FE_Nedelec(const unsigned int order);
 

--- a/include/deal.II/fe/fe_nedelec_sz.h
+++ b/include/deal.II/fe/fe_nedelec_sz.h
@@ -77,9 +77,18 @@ public:
                 "FE_NedelecSZ is only implemented for dim==spacedim!");
 
   /**
-   * Constructor for an element of given @p degree.
+   * Constructor for the NedelecSZ element of given @p order. The maximal
+   * polynomial degree of the shape functions is `order+1` (in each variable;
+   * the total polynomial degree may be higher). If `order = 0`, the element is
+   * linear and has degrees of freedom only on the edges. If `order >=1` the
+   * element has degrees of freedom on the edges, faces and volume. For example
+   * the 3D version of FE_NedelecSZ has 12 degrees of freedom for `order = 0`
+   * and 54 for `degree = 1`. It is important to have enough quadrature points
+   * in order to perform the quadrature with sufficient accuracy.
+   * For example [QGauss<dim>(order + 2)](@ref QGauss) can be used for the
+   * quadrature formula, where `order` is the order of FE_NedelecSZ.
    */
-  FE_NedelecSZ(const unsigned int degree);
+  FE_NedelecSZ(const unsigned int order);
 
   virtual UpdateFlags
   requires_update_flags(const UpdateFlags update_flags) const override;

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -21,14 +21,14 @@ DEAL_II_NAMESPACE_OPEN
 
 // Constructor:
 template <int dim, int spacedim>
-FE_NedelecSZ<dim, spacedim>::FE_NedelecSZ(const unsigned int degree)
+FE_NedelecSZ<dim, spacedim>::FE_NedelecSZ(const unsigned int order)
   : FiniteElement<dim, dim>(
-      FiniteElementData<dim>(get_dpo_vector(degree),
+      FiniteElementData<dim>(get_dpo_vector(order),
                              dim,
-                             degree + 1,
+                             order + 1,
                              FiniteElementData<dim>::Hcurl),
-      std::vector<bool>(compute_num_dofs(degree), true),
-      std::vector<ComponentMask>(compute_num_dofs(degree),
+      std::vector<bool>(compute_num_dofs(order), true),
+      std::vector<ComponentMask>(compute_num_dofs(order),
                                  std::vector<bool>(dim, true)))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
@@ -43,7 +43,7 @@ FE_NedelecSZ<dim, spacedim>::FE_NedelecSZ(const unsigned int degree)
     }
 
   // Generate the 1-D polynomial basis.
-  create_polynomials(degree);
+  create_polynomials(order);
 }
 
 


### PR DESCRIPTION
Here I summarize the outcome of the discussion in #8710

The NedelecSZ class used `degree` for the constructor, but it was really the 'order' of the element. The polynomial degree as used in the base class is 'order+1'.

See commit 121ecf772dccea4527ee6ef4247b10ca7d079dfd and #3459

I put the same text in the constructor of Nedelec and NedelecSZ in order to be consistent. Both elements have the same number of elements for `order=0` and `oder=1`.