### PR TITLE
Fix typo in step 50

### DIFF
--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -18,7 +18,7 @@
  */
 
 
-// @note: This a work in progress example of parallel geometric
+// @note This is a work in progress example of parallel geometric
 // multigrid. Some parts are still in heavy development.
 
 // This program is a parallel version of step-16 with a slightly different


### PR DESCRIPTION
Fix small typo in step_50. I removed the colon, it looks good in the source file, but looks awkward in the generated documentation.