### PR TITLE
Change TensorProductPolynomials and AnisotropicPolynomials to derive from ScalarPolynomialsBase

### DIFF
--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -44,7 +44,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Daniel Arndt, 2015
  */
 template <int dim>
-class TensorProductPolynomialsBubbles
+class TensorProductPolynomialsBubbles : public ScalarPolynomialsBase<dim>
 {
 public:
   /**
@@ -105,7 +105,7 @@ public:
            std::vector<Tensor<1, dim>> &grads,
            std::vector<Tensor<2, dim>> &grad_grads,
            std::vector<Tensor<3, dim>> &third_derivatives,
-           std::vector<Tensor<4, dim>> &fourth_derivatives) const;
+           std::vector<Tensor<4, dim>> &fourth_derivatives) const override;
 
   /**
    * Compute the value of the <tt>i</tt>th tensor product polynomial at
@@ -177,6 +177,18 @@ public:
   unsigned int
   n() const;
 
+  /**
+   * Return the name of the space, which is <tt>AnisotropicPolynomials</tt>.
+   */
+  std::string
+  name() const override;
+
+  /**
+   * @copydoc ScalarPolynomialsBase<dim>::clone()
+   */
+  virtual std::unique_ptr<ScalarPolynomialsBase<dim>>
+  clone() const override;
+
 private:
   /**
    * The TensorProductPolynomials object
@@ -205,7 +217,9 @@ template <int dim>
 template <class Pol>
 inline TensorProductPolynomialsBubbles<dim>::TensorProductPolynomialsBubbles(
   const std::vector<Pol> &pols)
-  : tensor_polys(pols)
+  : ScalarPolynomialsBase<dim>(1,
+                               Utilities::fixed_power<dim>(pols.size()) + dim)
+  , tensor_polys(pols)
   , index_map(tensor_polys.n() +
               ((tensor_polys.polynomials.size() <= 2) ? 1 : dim))
   , index_map_inverse(tensor_polys.n() +
@@ -255,6 +269,14 @@ TensorProductPolynomialsBubbles<dim>::get_numbering_inverse() const
 
 
 template <int dim>
+inline std::string
+TensorProductPolynomialsBubbles<dim>::name() const
+{
+  return "TensorProductPolynomialsBubbles";
+}
+
+
+template <int dim>
 template <int order>
 Tensor<order, dim>
 TensorProductPolynomialsBubbles<dim>::compute_derivative(
@@ -264,7 +286,6 @@ TensorProductPolynomialsBubbles<dim>::compute_derivative(
   const unsigned int q_degree      = tensor_polys.polynomials.size() - 1;
   const unsigned int max_q_indices = tensor_polys.n();
   const unsigned int n_bubbles     = ((q_degree <= 1) ? 1 : dim);
-  (void)n_bubbles;
   Assert(i < max_q_indices + n_bubbles, ExcInternalError());
 
   // treat the regular basis functions

--- a/include/deal.II/base/tensor_product_polynomials_const.h
+++ b/include/deal.II/base/tensor_product_polynomials_const.h
@@ -80,7 +80,7 @@ public:
            std::vector<Tensor<1, dim>> &grads,
            std::vector<Tensor<2, dim>> &grad_grads,
            std::vector<Tensor<3, dim>> &third_derivatives,
-           std::vector<Tensor<4, dim>> &fourth_derivatives) const;
+           std::vector<Tensor<4, dim>> &fourth_derivatives) const override;
 
   /**
    * Compute the value of the <tt>i</tt>th tensor product polynomial at
@@ -167,8 +167,8 @@ inline TensorProductPolynomialsConst<dim>::TensorProductPolynomialsConst(
   : TensorProductPolynomials<dim>(pols)
 {
   // append index for renumbering
-  this->index_map.push_back(this->n_tensor_pols);
-  this->index_map_inverse.push_back(this->n_tensor_pols);
+  this->index_map.push_back(TensorProductPolynomials<dim>::n());
+  this->index_map_inverse.push_back(TensorProductPolynomials<dim>::n());
 }
 
 
@@ -177,7 +177,7 @@ template <int dim>
 inline unsigned int
 TensorProductPolynomialsConst<dim>::n() const
 {
-  return this->n_tensor_pols + 1;
+  return TensorProductPolynomials<dim>::n() + 1;
 }
 
 
@@ -196,7 +196,7 @@ TensorProductPolynomialsConst<dim>::compute_derivative(
   const unsigned int i,
   const Point<dim> & p) const
 {
-  const unsigned int max_indices = this->n_tensor_pols;
+  const unsigned int max_indices = TensorProductPolynomials<dim>::n();
   Assert(i <= max_indices, ExcInternalError());
 
   // treat the regular basis functions

--- a/source/base/polynomials_abf.cc
+++ b/source/base/polynomials_abf.cc
@@ -112,12 +112,12 @@ PolynomialsABF<dim>::evaluate(
       for (unsigned int c = 0; c < dim; ++c)
         p(c) = unit_point((c + d) % dim);
 
-      polynomial_space.compute(p,
-                               p_values,
-                               p_grads,
-                               p_grad_grads,
-                               p_third_derivatives,
-                               p_fourth_derivatives);
+      polynomial_space.evaluate(p,
+                                p_values,
+                                p_grads,
+                                p_grad_grads,
+                                p_third_derivatives,
+                                p_fourth_derivatives);
 
       for (unsigned int i = 0; i < p_values.size(); ++i)
         values[i + d * n_sub][d] = p_values[i];

--- a/source/base/polynomials_bernardi_raugel.cc
+++ b/source/base/polynomials_bernardi_raugel.cc
@@ -137,7 +137,7 @@ PolynomialsBernardiRaugel<dim>::evaluate(
     }
 
   // set indices for the anisotropic polynomials to find
-  // them after polynomial_space_bubble.compute is called
+  // them after polynomial_space_bubble.evaluate is called
   std::vector<int> aniso_indices;
   if (dim == 2)
     {
@@ -156,18 +156,18 @@ PolynomialsBernardiRaugel<dim>::evaluate(
       aniso_indices.push_back(17);
     }
 
-  polynomial_space_bubble.compute(unit_point,
-                                  bubble_values,
-                                  bubble_grads,
-                                  bubble_grad_grads,
-                                  bubble_third_derivatives,
-                                  bubble_fourth_derivatives);
-  polynomial_space_Q.compute(unit_point,
-                             Q_values,
-                             Q_grads,
-                             Q_grad_grads,
-                             Q_third_derivatives,
-                             Q_fourth_derivatives);
+  polynomial_space_bubble.evaluate(unit_point,
+                                   bubble_values,
+                                   bubble_grads,
+                                   bubble_grad_grads,
+                                   bubble_third_derivatives,
+                                   bubble_fourth_derivatives);
+  polynomial_space_Q.evaluate(unit_point,
+                              Q_values,
+                              Q_grads,
+                              Q_grad_grads,
+                              Q_third_derivatives,
+                              Q_fourth_derivatives);
 
   // first dim*vertices_per_cell functions are Q_1^2 functions
   for (unsigned int i = 0; i < dim * GeometryInfo<dim>::vertices_per_cell; ++i)

--- a/source/base/polynomials_nedelec.cc
+++ b/source/base/polynomials_nedelec.cc
@@ -95,12 +95,12 @@ PolynomialsNedelec<dim>::evaluate(
     {
       case 1:
         {
-          polynomial_space.compute(unit_point,
-                                   unit_point_values,
-                                   unit_point_grads,
-                                   unit_point_grad_grads,
-                                   empty_vector_of_3rd_order_tensors,
-                                   empty_vector_of_4th_order_tensors);
+          polynomial_space.evaluate(unit_point,
+                                    unit_point_values,
+                                    unit_point_grads,
+                                    unit_point_grad_grads,
+                                    empty_vector_of_3rd_order_tensors,
+                                    empty_vector_of_4th_order_tensors);
 
           // Assign the correct values to the
           // corresponding shape functions.
@@ -121,12 +121,12 @@ PolynomialsNedelec<dim>::evaluate(
 
       case 2:
         {
-          polynomial_space.compute(unit_point,
-                                   unit_point_values,
-                                   unit_point_grads,
-                                   unit_point_grad_grads,
-                                   empty_vector_of_3rd_order_tensors,
-                                   empty_vector_of_4th_order_tensors);
+          polynomial_space.evaluate(unit_point,
+                                    unit_point_values,
+                                    unit_point_grads,
+                                    unit_point_grad_grads,
+                                    empty_vector_of_3rd_order_tensors,
+                                    empty_vector_of_4th_order_tensors);
 
           // Declare the values, derivatives and
           // second derivatives vectors of
@@ -144,12 +144,12 @@ PolynomialsNedelec<dim>::evaluate(
           std::vector<Tensor<2, dim>> p_grad_grads(
             (grad_grads.size() == 0) ? 0 : n_basis);
 
-          polynomial_space.compute(p,
-                                   p_values,
-                                   p_grads,
-                                   p_grad_grads,
-                                   empty_vector_of_3rd_order_tensors,
-                                   empty_vector_of_4th_order_tensors);
+          polynomial_space.evaluate(p,
+                                    p_values,
+                                    p_grads,
+                                    p_grad_grads,
+                                    empty_vector_of_3rd_order_tensors,
+                                    empty_vector_of_4th_order_tensors);
 
           // Assign the correct values to the
           // corresponding shape functions.
@@ -307,12 +307,12 @@ PolynomialsNedelec<dim>::evaluate(
 
       case 3:
         {
-          polynomial_space.compute(unit_point,
-                                   unit_point_values,
-                                   unit_point_grads,
-                                   unit_point_grad_grads,
-                                   empty_vector_of_3rd_order_tensors,
-                                   empty_vector_of_4th_order_tensors);
+          polynomial_space.evaluate(unit_point,
+                                    unit_point_values,
+                                    unit_point_grads,
+                                    unit_point_grad_grads,
+                                    empty_vector_of_3rd_order_tensors,
+                                    empty_vector_of_4th_order_tensors);
 
           // Declare the values, derivatives
           // and second derivatives vectors of
@@ -335,21 +335,21 @@ PolynomialsNedelec<dim>::evaluate(
           p1(0) = unit_point(1);
           p1(1) = unit_point(2);
           p1(2) = unit_point(0);
-          polynomial_space.compute(p1,
-                                   p1_values,
-                                   p1_grads,
-                                   p1_grad_grads,
-                                   empty_vector_of_3rd_order_tensors,
-                                   empty_vector_of_4th_order_tensors);
+          polynomial_space.evaluate(p1,
+                                    p1_values,
+                                    p1_grads,
+                                    p1_grad_grads,
+                                    empty_vector_of_3rd_order_tensors,
+                                    empty_vector_of_4th_order_tensors);
           p2(0) = unit_point(2);
           p2(1) = unit_point(0);
           p2(2) = unit_point(1);
-          polynomial_space.compute(p2,
-                                   p2_values,
-                                   p2_grads,
-                                   p2_grad_grads,
-                                   empty_vector_of_3rd_order_tensors,
-                                   empty_vector_of_4th_order_tensors);
+          polynomial_space.evaluate(p2,
+                                    p2_values,
+                                    p2_grads,
+                                    p2_grad_grads,
+                                    empty_vector_of_3rd_order_tensors,
+                                    empty_vector_of_4th_order_tensors);
 
           // Assign the correct values to the
           // corresponding shape functions.

--- a/source/base/polynomials_raviart_thomas.cc
+++ b/source/base/polynomials_raviart_thomas.cc
@@ -127,12 +127,12 @@ PolynomialsRaviartThomas<dim>::evaluate(
       for (unsigned int c = 0; c < dim; ++c)
         p(c) = unit_point((c + d) % dim);
 
-      polynomial_space.compute(p,
-                               p_values,
-                               p_grads,
-                               p_grad_grads,
-                               p_third_derivatives,
-                               p_fourth_derivatives);
+      polynomial_space.evaluate(p,
+                                p_values,
+                                p_grads,
+                                p_grad_grads,
+                                p_third_derivatives,
+                                p_fourth_derivatives);
 
       for (unsigned int i = 0; i < p_values.size(); ++i)
         values[i + d * n_sub][d] = p_values[i];

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -15,6 +15,7 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/polynomials_piecewise.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
 #include <boost/container/small_vector.hpp>
@@ -98,7 +99,7 @@ TensorProductPolynomials<dim, PolynomialType>::output_indices(
   std::ostream &out) const
 {
   unsigned int ix[dim];
-  for (unsigned int i = 0; i < n_tensor_pols; ++i)
+  for (unsigned int i = 0; i < this->n(); ++i)
     {
       compute_index(i, ix);
       out << i << "\t";
@@ -250,26 +251,23 @@ TensorProductPolynomials<dim, PolynomialType>::evaluate(
   std::vector<Tensor<4, dim>> &fourth_derivatives) const
 {
   Assert(dim <= 3, ExcNotImplemented());
-  Assert(values.size() == n_tensor_pols || values.size() == 0,
-         ExcDimensionMismatch2(values.size(), n_tensor_pols, 0));
-  Assert(grads.size() == n_tensor_pols || grads.size() == 0,
-         ExcDimensionMismatch2(grads.size(), n_tensor_pols, 0));
-  Assert(grad_grads.size() == n_tensor_pols || grad_grads.size() == 0,
-         ExcDimensionMismatch2(grad_grads.size(), n_tensor_pols, 0));
-  Assert(third_derivatives.size() == n_tensor_pols ||
-           third_derivatives.size() == 0,
-         ExcDimensionMismatch2(third_derivatives.size(), n_tensor_pols, 0));
-  Assert(fourth_derivatives.size() == n_tensor_pols ||
+  Assert(values.size() == this->n() || values.size() == 0,
+         ExcDimensionMismatch2(values.size(), this->n(), 0));
+  Assert(grads.size() == this->n() || grads.size() == 0,
+         ExcDimensionMismatch2(grads.size(), this->n(), 0));
+  Assert(grad_grads.size() == this->n() || grad_grads.size() == 0,
+         ExcDimensionMismatch2(grad_grads.size(), this->n(), 0));
+  Assert(third_derivatives.size() == this->n() || third_derivatives.size() == 0,
+         ExcDimensionMismatch2(third_derivatives.size(), this->n(), 0));
+  Assert(fourth_derivatives.size() == this->n() ||
            fourth_derivatives.size() == 0,
-         ExcDimensionMismatch2(fourth_derivatives.size(), n_tensor_pols, 0));
+         ExcDimensionMismatch2(fourth_derivatives.size(), this->n(), 0));
 
-  const bool update_values     = (values.size() == n_tensor_pols),
-             update_grads      = (grads.size() == n_tensor_pols),
-             update_grad_grads = (grad_grads.size() == n_tensor_pols),
-             update_3rd_derivatives =
-               (third_derivatives.size() == n_tensor_pols),
-             update_4th_derivatives =
-               (fourth_derivatives.size() == n_tensor_pols);
+  const bool update_values          = (values.size() == this->n()),
+             update_grads           = (grads.size() == this->n()),
+             update_grad_grads      = (grad_grads.size() == this->n()),
+             update_3rd_derivatives = (third_derivatives.size() == this->n()),
+             update_4th_derivatives = (fourth_derivatives.size() == this->n());
 
   // check how many values/derivatives we have to compute
   unsigned int n_values_and_derivatives = 0;
@@ -405,14 +403,24 @@ TensorProductPolynomials<dim, PolynomialType>::evaluate(
 
 
 
+template <int dim, typename PolynomialType>
+std::unique_ptr<ScalarPolynomialsBase<dim>>
+TensorProductPolynomials<dim, PolynomialType>::clone() const
+{
+  return std_cxx14::make_unique<TensorProductPolynomials<dim, PolynomialType>>(
+    *this);
+}
+
+
+
 /* ------------------- AnisotropicPolynomials -------------- */
 
 
 template <int dim>
 AnisotropicPolynomials<dim>::AnisotropicPolynomials(
   const std::vector<std::vector<Polynomials::Polynomial<double>>> &pols)
-  : polynomials(pols)
-  , n_tensor_pols(get_n_tensor_pols(pols))
+  : ScalarPolynomialsBase<dim>(1, get_n_tensor_pols(pols))
+  , polynomials(pols)
 {
   Assert(pols.size() == dim, ExcDimensionMismatch(pols.size(), dim));
   for (unsigned int d = 0; d < dim; ++d)
@@ -531,7 +539,7 @@ AnisotropicPolynomials<dim>::compute_grad_grad(const unsigned int i,
 
 template <int dim>
 void
-AnisotropicPolynomials<dim>::compute(
+AnisotropicPolynomials<dim>::evaluate(
   const Point<dim> &           p,
   std::vector<double> &        values,
   std::vector<Tensor<1, dim>> &grads,
@@ -539,26 +547,23 @@ AnisotropicPolynomials<dim>::compute(
   std::vector<Tensor<3, dim>> &third_derivatives,
   std::vector<Tensor<4, dim>> &fourth_derivatives) const
 {
-  Assert(values.size() == n_tensor_pols || values.size() == 0,
-         ExcDimensionMismatch2(values.size(), n_tensor_pols, 0));
-  Assert(grads.size() == n_tensor_pols || grads.size() == 0,
-         ExcDimensionMismatch2(grads.size(), n_tensor_pols, 0));
-  Assert(grad_grads.size() == n_tensor_pols || grad_grads.size() == 0,
-         ExcDimensionMismatch2(grad_grads.size(), n_tensor_pols, 0));
-  Assert(third_derivatives.size() == n_tensor_pols ||
-           third_derivatives.size() == 0,
-         ExcDimensionMismatch2(third_derivatives.size(), n_tensor_pols, 0));
-  Assert(fourth_derivatives.size() == n_tensor_pols ||
+  Assert(values.size() == this->n() || values.size() == 0,
+         ExcDimensionMismatch2(values.size(), this->n(), 0));
+  Assert(grads.size() == this->n() || grads.size() == 0,
+         ExcDimensionMismatch2(grads.size(), this->n(), 0));
+  Assert(grad_grads.size() == this->n() || grad_grads.size() == 0,
+         ExcDimensionMismatch2(grad_grads.size(), this->n(), 0));
+  Assert(third_derivatives.size() == this->n() || third_derivatives.size() == 0,
+         ExcDimensionMismatch2(third_derivatives.size(), this->n(), 0));
+  Assert(fourth_derivatives.size() == this->n() ||
            fourth_derivatives.size() == 0,
-         ExcDimensionMismatch2(fourth_derivatives.size(), n_tensor_pols, 0));
+         ExcDimensionMismatch2(fourth_derivatives.size(), this->n(), 0));
 
-  const bool update_values     = (values.size() == n_tensor_pols),
-             update_grads      = (grads.size() == n_tensor_pols),
-             update_grad_grads = (grad_grads.size() == n_tensor_pols),
-             update_3rd_derivatives =
-               (third_derivatives.size() == n_tensor_pols),
-             update_4th_derivatives =
-               (fourth_derivatives.size() == n_tensor_pols);
+  const bool update_values          = (values.size() == this->n()),
+             update_grads           = (grads.size() == this->n()),
+             update_grad_grads      = (grad_grads.size() == this->n()),
+             update_3rd_derivatives = (third_derivatives.size() == this->n()),
+             update_4th_derivatives = (fourth_derivatives.size() == this->n());
 
   // check how many
   // values/derivatives we have to
@@ -590,7 +595,7 @@ AnisotropicPolynomials<dim>::compute(
         }
     }
 
-  for (unsigned int i = 0; i < n_tensor_pols; ++i)
+  for (unsigned int i = 0; i < this->n(); ++i)
     {
       // first get the
       // one-dimensional indices of
@@ -679,15 +684,6 @@ AnisotropicPolynomials<dim>::compute(
 }
 
 
-
-template <int dim>
-unsigned int
-AnisotropicPolynomials<dim>::n() const
-{
-  return n_tensor_pols;
-}
-
-
 template <int dim>
 unsigned int
 AnisotropicPolynomials<dim>::get_n_tensor_pols(
@@ -697,6 +693,14 @@ AnisotropicPolynomials<dim>::get_n_tensor_pols(
   for (unsigned int d = 0; d < dim; ++d)
     y *= pols[d].size();
   return y;
+}
+
+
+template <int dim>
+std::unique_ptr<ScalarPolynomialsBase<dim>>
+AnisotropicPolynomials<dim>::clone() const
+{
+  return std_cxx14::make_unique<AnisotropicPolynomials<dim>>(*this);
 }
 
 

--- a/source/base/tensor_product_polynomials_bubbles.cc
+++ b/source/base/tensor_product_polynomials_bubbles.cc
@@ -15,6 +15,7 @@
 
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/tensor_product_polynomials_bubbles.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -70,7 +71,6 @@ TensorProductPolynomialsBubbles<dim>::compute_value(const unsigned int i,
   const unsigned int q_degree      = tensor_polys.polynomials.size() - 1;
   const unsigned int max_q_indices = tensor_polys.n();
   const unsigned int n_bubbles     = ((q_degree <= 1) ? 1 : dim);
-  (void)n_bubbles;
   Assert(i < max_q_indices + n_bubbles, ExcInternalError());
 
   // treat the regular basis functions
@@ -110,7 +110,6 @@ TensorProductPolynomialsBubbles<dim>::compute_grad(const unsigned int i,
   const unsigned int q_degree      = tensor_polys.polynomials.size() - 1;
   const unsigned int max_q_indices = tensor_polys.n();
   const unsigned int n_bubbles     = ((q_degree <= 1) ? 1 : dim);
-  (void)n_bubbles;
   Assert(i < max_q_indices + n_bubbles, ExcInternalError());
 
   // treat the regular basis functions
@@ -158,7 +157,6 @@ TensorProductPolynomialsBubbles<dim>::compute_grad_grad(
   const unsigned int q_degree      = tensor_polys.polynomials.size() - 1;
   const unsigned int max_q_indices = tensor_polys.n();
   const unsigned int n_bubbles     = ((q_degree <= 1) ? 1 : dim);
-  (void)n_bubbles;
   Assert(i < max_q_indices + n_bubbles, ExcInternalError());
 
   // treat the regular basis functions
@@ -266,8 +264,7 @@ TensorProductPolynomialsBubbles<dim>::evaluate(
 {
   const unsigned int q_degree      = tensor_polys.polynomials.size() - 1;
   const unsigned int max_q_indices = tensor_polys.n();
-  (void)max_q_indices;
-  const unsigned int n_bubbles = ((q_degree <= 1) ? 1 : dim);
+  const unsigned int n_bubbles     = ((q_degree <= 1) ? 1 : dim);
   Assert(values.size() == max_q_indices + n_bubbles || values.size() == 0,
          ExcDimensionMismatch2(values.size(), max_q_indices + n_bubbles, 0));
   Assert(grads.size() == max_q_indices + n_bubbles || grads.size() == 0,
@@ -330,6 +327,15 @@ TensorProductPolynomialsBubbles<dim>::evaluate(
       if (do_4th_derivatives)
         fourth_derivatives.push_back(compute_derivative<4>(i, p));
     }
+}
+
+
+
+template <int dim>
+std::unique_ptr<ScalarPolynomialsBase<dim>>
+TensorProductPolynomialsBubbles<dim>::clone() const
+{
+  return std_cxx14::make_unique<TensorProductPolynomialsBubbles<dim>>(*this);
 }
 
 

--- a/source/base/tensor_product_polynomials_const.cc
+++ b/source/base/tensor_product_polynomials_const.cc
@@ -29,7 +29,7 @@ double
 TensorProductPolynomialsConst<dim>::compute_value(const unsigned int i,
                                                   const Point<dim> & p) const
 {
-  const unsigned int max_indices = this->n_tensor_pols;
+  const unsigned int max_indices = TensorProductPolynomials<dim>::n();
   Assert(i <= max_indices, ExcInternalError());
 
   // treat the regular basis functions
@@ -57,7 +57,7 @@ Tensor<1, dim>
 TensorProductPolynomialsConst<dim>::compute_grad(const unsigned int i,
                                                  const Point<dim> & p) const
 {
-  const unsigned int max_indices = this->n_tensor_pols;
+  const unsigned int max_indices = TensorProductPolynomials<dim>::n();
   Assert(i <= max_indices, ExcInternalError());
 
   // treat the regular basis functions
@@ -73,7 +73,7 @@ Tensor<2, dim>
 TensorProductPolynomialsConst<dim>::compute_grad_grad(const unsigned int i,
                                                       const Point<dim> &p) const
 {
-  const unsigned int max_indices = this->n_tensor_pols;
+  const unsigned int max_indices = TensorProductPolynomials<dim>::n();
   Assert(i <= max_indices, ExcInternalError());
 
   // treat the regular basis functions
@@ -94,21 +94,30 @@ TensorProductPolynomialsConst<dim>::evaluate(
   std::vector<Tensor<3, dim>> &third_derivatives,
   std::vector<Tensor<4, dim>> &fourth_derivatives) const
 {
-  Assert(values.size() == this->n_tensor_pols + 1 || values.size() == 0,
-         ExcDimensionMismatch2(values.size(), this->n_tensor_pols + 1, 0));
-  Assert(grads.size() == this->n_tensor_pols + 1 || grads.size() == 0,
-         ExcDimensionMismatch2(grads.size(), this->n_tensor_pols + 1, 0));
-  Assert(grad_grads.size() == this->n_tensor_pols + 1 || grad_grads.size() == 0,
-         ExcDimensionMismatch2(grad_grads.size(), this->n_tensor_pols + 1, 0));
-  Assert(third_derivatives.size() == this->n_tensor_pols + 1 ||
+  Assert(values.size() == TensorProductPolynomials<dim>::n() + 1 ||
+           values.size() == 0,
+         ExcDimensionMismatch2(values.size(),
+                               TensorProductPolynomials<dim>::n() + 1,
+                               0));
+  Assert(grads.size() == TensorProductPolynomials<dim>::n() + 1 ||
+           grads.size() == 0,
+         ExcDimensionMismatch2(grads.size(),
+                               TensorProductPolynomials<dim>::n() + 1,
+                               0));
+  Assert(grad_grads.size() == TensorProductPolynomials<dim>::n() + 1 ||
+           grad_grads.size() == 0,
+         ExcDimensionMismatch2(grad_grads.size(),
+                               TensorProductPolynomials<dim>::n() + 1,
+                               0));
+  Assert(third_derivatives.size() == TensorProductPolynomials<dim>::n() + 1 ||
            third_derivatives.size() == 0,
          ExcDimensionMismatch2(third_derivatives.size(),
-                               this->n_tensor_pols + 1,
+                               TensorProductPolynomials<dim>::n() + 1,
                                0));
-  Assert(fourth_derivatives.size() == this->n_tensor_pols + 1 ||
+  Assert(fourth_derivatives.size() == TensorProductPolynomials<dim>::n() + 1 ||
            fourth_derivatives.size() == 0,
          ExcDimensionMismatch2(fourth_derivatives.size(),
-                               this->n_tensor_pols + 1,
+                               TensorProductPolynomials<dim>::n() + 1,
                                0));
 
   // remove slot for const value, go into the base class compute method and
@@ -132,12 +141,12 @@ TensorProductPolynomialsConst<dim>::evaluate(
     }
   if (third_derivatives.empty() == false)
     {
-      third_derivatives.resize(this->n_tensor_pols);
+      third_derivatives.resize(TensorProductPolynomials<dim>::n());
       do_3rd_derivatives = true;
     }
   if (fourth_derivatives.empty() == false)
     {
-      fourth_derivatives.resize(this->n_tensor_pols);
+      fourth_derivatives.resize(TensorProductPolynomials<dim>::n());
       do_4th_derivatives = true;
     }
 

--- a/tests/base/anisotropic_1.cc
+++ b/tests/base/anisotropic_1.cc
@@ -43,7 +43,7 @@ check_poly(const Point<dim> &     x,
   std::vector<Tensor<4, dim>> fourth1(n), fourth2(n);
 
   p.evaluate(x, values1, gradients1, second1, third1, fourth1);
-  q.compute(x, values2, gradients2, second2, third2, fourth2);
+  q.evaluate(x, values2, gradients2, second2, third2, fourth2);
 
   for (unsigned int k = 0; k < n; ++k)
     {


### PR DESCRIPTION
While working on #8711, I realized that these two classes need to derive from `ScalarPolynomialsBase` as well since there are FE classes which are constructed using `TensorProductPolynomials` or `AnisotropicPolynomials`. I will have to rebase #8711 onto this once everything is polished. Think of this as a follow-up to #8678 for working on #1973 as well.

To do: Currently the base classes store duplicate information for the number of polynomials, but I was unsure what value should be assigned to the base class for `degree`, so I used a placeholder.

This passes the `base/` and `fe/` tests on my end at the moment.

This closes #8682 as well because I rename all instances of `compute()` to `evaluate()`.