### PR TITLE
Avoid deprecated FE argument in distribute_mg_dofs

### DIFF
--- a/tests/bits/step-16.cc
+++ b/tests/bits/step-16.cc
@@ -107,7 +107,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   deallog << "   Number of degrees of freedom: " << mg_dof_handler.n_dofs()
           << std::endl;

--- a/tests/dofs/block_info.cc
+++ b/tests/dofs/block_info.cc
@@ -32,7 +32,7 @@ test_grid(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 {
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
   BlockInfo bi;
   bi.initialize(mgdof);
   bi.initialize_local(mgdof);

--- a/tests/dofs/block_info_02.cc
+++ b/tests/dofs/block_info_02.cc
@@ -35,7 +35,7 @@ test_grid(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 {
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
   BlockInfo bi;
   bi.initialize(mgdof, false, false);
   bi.initialize_local(mgdof);

--- a/tests/dofs/block_list_01.cc
+++ b/tests/dofs/block_list_01.cc
@@ -24,7 +24,7 @@ test_block_list(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   DoFHandler<dim> dof;
   dof.initialize(tr, fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
 
   const unsigned int level = tr.n_levels() - 1;
 

--- a/tests/dofs/block_list_02.cc
+++ b/tests/dofs/block_list_02.cc
@@ -24,7 +24,7 @@ test_block_list(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   DoFHandler<dim> dof;
   dof.initialize(tr, fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
 
   const unsigned int level = tr.n_levels() - 1;
 

--- a/tests/dofs/block_list_03.cc
+++ b/tests/dofs/block_list_03.cc
@@ -24,7 +24,7 @@ test_block_list(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   DoFHandler<dim> dof;
   dof.initialize(tr, fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
 
   const unsigned int level = tr.n_levels() - 1;
 

--- a/tests/dofs/block_list_04.cc
+++ b/tests/dofs/block_list_04.cc
@@ -24,7 +24,7 @@ test_block_list(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   DoFHandler<dim> dof;
   dof.initialize(tr, fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
 
   const unsigned int level = tr.n_levels() - 1;
 

--- a/tests/dofs/block_list_05.cc
+++ b/tests/dofs/block_list_05.cc
@@ -59,7 +59,7 @@ test_block_list(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   DoFHandler<dim> dof;
   dof.initialize(tr, fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
 
   const unsigned int level = tr.n_levels() - 1;
 

--- a/tests/dofs/block_list_parallel_01.cc
+++ b/tests/dofs/block_list_parallel_01.cc
@@ -27,7 +27,7 @@ test_block_list(const parallel::distributed::Triangulation<dim> &tr,
 
   DoFHandler<dim> dof;
   dof.initialize(tr, fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
 
   for (unsigned int level = 0; level < tr.n_global_levels(); ++level)
     {

--- a/tests/dofs/dof_renumbering.cc
+++ b/tests/dofs/dof_renumbering.cc
@@ -172,13 +172,13 @@ check()
 
   FESystem<dim> e1(FE_Q<dim>(2), 2, FE_DGQ<dim>(1), 1);
   mgdof.distribute_dofs(e1);
-  mgdof.distribute_mg_dofs(e1);
+  mgdof.distribute_mg_dofs();
   check_renumbering(mgdof, false);
   mgdof.clear();
 
   FESystem<dim> e2(FE_DGP<dim>(2), 2, FE_DGQ<dim>(1), 1);
   mgdof.distribute_dofs(e2);
-  mgdof.distribute_mg_dofs(e2);
+  mgdof.distribute_mg_dofs();
   check_renumbering(mgdof, true);
   mgdof.clear();
 }

--- a/tests/dofs/dof_renumbering_07.cc
+++ b/tests/dofs/dof_renumbering_07.cc
@@ -105,7 +105,7 @@ check()
     DoFHandler<dim> dof(tr);
 
     dof.distribute_dofs(fe);
-    dof.distribute_mg_dofs(fe);
+    dof.distribute_mg_dofs();
     check_renumbering(dof);
   }
 
@@ -114,7 +114,7 @@ check()
     DoFHandler<dim> dof(tr);
 
     dof.distribute_dofs(fe);
-    dof.distribute_mg_dofs(fe);
+    dof.distribute_mg_dofs();
     check_renumbering(dof);
   }
 }

--- a/tests/dofs/dof_renumbering_08.cc
+++ b/tests/dofs/dof_renumbering_08.cc
@@ -102,7 +102,7 @@ check()
     DoFHandler<dim> dof(tr);
 
     dof.distribute_dofs(fe);
-    dof.distribute_mg_dofs(fe);
+    dof.distribute_mg_dofs();
     check_renumbering(dof);
   }
 
@@ -111,7 +111,7 @@ check()
     DoFHandler<dim> dof(tr);
 
     dof.distribute_dofs(fe);
-    dof.distribute_mg_dofs(fe);
+    dof.distribute_mg_dofs();
     check_renumbering(dof);
   }
 }

--- a/tests/dofs/dof_renumbering_09.cc
+++ b/tests/dofs/dof_renumbering_09.cc
@@ -70,7 +70,7 @@ test()
 
   FE_Q<dim> fe(1);
   dof_handler.distribute_dofs(fe);
-  dof_handler.distribute_mg_dofs(fe);
+  dof_handler.distribute_mg_dofs();
 
 
   // Print dofs before reordering

--- a/tests/dofs/extract_dofs_by_component_01_mg.cc
+++ b/tests/dofs/extract_dofs_by_component_01_mg.cc
@@ -53,7 +53,7 @@ check()
   FESystem<dim>   element(FE_Q<dim>(2), 1, FE_Nedelec<dim>(0), 1);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(element);
-  dof.distribute_mg_dofs(element);
+  dof.distribute_mg_dofs();
 
   // try all possible component
   // masks, which we encode as bit

--- a/tests/dofs/extract_dofs_by_component_02_mg.cc
+++ b/tests/dofs/extract_dofs_by_component_02_mg.cc
@@ -54,7 +54,7 @@ check()
   FESystem<dim>   element(FE_Q<dim>(2), 1, FE_Nedelec<dim>(0), 1);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(element);
-  dof.distribute_mg_dofs(element);
+  dof.distribute_mg_dofs();
 
   // try all possible block
   // masks, which we encode as bit

--- a/tests/examples/step-56.cc
+++ b/tests/examples/step-56.cc
@@ -493,7 +493,7 @@ namespace Step56
     pressure_mass_matrix.clear();
 
     // The main DoFHandler only needs active DoFs, so we are not calling
-    // distribute_mg_dofs() here
+    // distribute_mg_dofs();
     dof_handler.distribute_dofs(fe);
 
     // This block structure separates the dim velocity components from

--- a/tests/fe/transfer.cc
+++ b/tests/fe/transfer.cc
@@ -54,7 +54,7 @@ print_matrix(Triangulation<dim> &      tr,
 {
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(finel);
-  dof.distribute_mg_dofs(finel);
+  dof.distribute_mg_dofs();
 
   MGTransferPrebuilt<Vector<double>> transfer;
   transfer.build_matrices(dof);

--- a/tests/integrators/assembler_simple_mgmatrix_03.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_03.cc
@@ -75,7 +75,7 @@ test(FiniteElement<dim> &fe)
 
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
   dof.initialize_local_block_info();
   for (unsigned int level = 0; level < tr.n_levels(); ++level)
     DoFRenumbering::component_wise(dof, level);

--- a/tests/integrators/assembler_simple_mgmatrix_04.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_04.cc
@@ -194,7 +194,7 @@ test(FiniteElement<dim> &fe)
 
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
   dof.initialize_local_block_info();
   mg::SparseMatrixCollection<double> mg;
   mg.resize(0, tr.n_levels() - 1);

--- a/tests/integrators/cells_and_faces_01.cc
+++ b/tests/integrators/cells_and_faces_01.cc
@@ -194,21 +194,21 @@ test(const FiniteElement<dim> &fe)
   tr.refine_global(1);
   deallog.push("1");
   dofs.distribute_dofs(fe);
-  dofs.distribute_mg_dofs(fe);
+  dofs.distribute_mg_dofs();
   test_mesh(dofs);
   deallog.pop();
   tr.begin(1)->set_refine_flag();
   tr.execute_coarsening_and_refinement();
   deallog.push("2");
   dofs.distribute_dofs(fe);
-  dofs.distribute_mg_dofs(fe);
+  dofs.distribute_mg_dofs();
   test_mesh(dofs);
   deallog.pop();
   tr.begin(2)->set_refine_flag();
   tr.execute_coarsening_and_refinement();
   deallog.push("3");
   dofs.distribute_dofs(fe);
-  dofs.distribute_mg_dofs(fe);
+  dofs.distribute_mg_dofs();
   test_mesh(dofs);
   deallog.pop();
 }

--- a/tests/integrators/functional_01.cc
+++ b/tests/integrators/functional_01.cc
@@ -166,21 +166,21 @@ test(const FiniteElement<dim> &fe)
   tr.refine_global(1);
   deallog.push("1");
   dofs.distribute_dofs(fe);
-  dofs.distribute_mg_dofs(fe);
+  dofs.distribute_mg_dofs();
   test_mesh(dofs);
   deallog.pop();
   tr.begin(1)->set_refine_flag();
   tr.execute_coarsening_and_refinement();
   deallog.push("2");
   dofs.distribute_dofs(fe);
-  dofs.distribute_mg_dofs(fe);
+  dofs.distribute_mg_dofs();
   test_mesh(dofs);
   deallog.pop();
   tr.begin(2)->set_refine_flag();
   tr.execute_coarsening_and_refinement();
   deallog.push("3");
   dofs.distribute_dofs(fe);
-  dofs.distribute_mg_dofs(fe);
+  dofs.distribute_mg_dofs();
   test_mesh(dofs);
   deallog.pop();
 }

--- a/tests/integrators/mesh_worker_01.cc
+++ b/tests/integrators/mesh_worker_01.cc
@@ -215,7 +215,7 @@ test(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> dofs(tr);
   dofs.distribute_dofs(fe);
-  dofs.distribute_mg_dofs(fe);
+  dofs.distribute_mg_dofs();
   deallog << "DoFHandler " << dofs.n_dofs() << " levels";
   for (unsigned int l = 0; l < tr.n_levels(); ++l)
     deallog << ' ' << l << ':' << dofs.n_dofs(l);

--- a/tests/integrators/mesh_worker_02.cc
+++ b/tests/integrators/mesh_worker_02.cc
@@ -314,7 +314,7 @@ test(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> dofs(tr);
   dofs.distribute_dofs(fe);
-  dofs.distribute_mg_dofs(fe);
+  dofs.distribute_mg_dofs();
   deallog << "DoFHandler " << dofs.n_dofs() << " levels";
   for (unsigned int l = 0; l < tr.n_levels(); ++l)
     deallog << ' ' << l << ':' << dofs.n_dofs(l);

--- a/tests/integrators/mesh_worker_03.cc
+++ b/tests/integrators/mesh_worker_03.cc
@@ -313,7 +313,7 @@ test(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> dofs(tr);
   dofs.distribute_dofs(fe);
-  dofs.distribute_mg_dofs(fe);
+  dofs.distribute_mg_dofs();
   deallog << "DoFHandler " << dofs.n_dofs() << " levels";
   for (unsigned int l = 0; l < tr.n_levels(); ++l)
     deallog << ' ' << l << ':' << dofs.n_dofs(l);

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -337,7 +337,7 @@ test()
   FE_DGQ<dim>     fe(fe_degree);
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
   deallog << "Number of DoFs: " << dof.n_dofs() << std::endl;
 
   MappingQGeneric<dim>                                   mapping(fe_degree + 1);

--- a/tests/matrix_free/dg_pbc_02.cc
+++ b/tests/matrix_free/dg_pbc_02.cc
@@ -82,7 +82,7 @@ test()
   FE_DGQ<dim>     fe(1);
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
   AffineConstraints<double> constraints;
   constraints.close();
 

--- a/tests/matrix_free/matrix_vector_mg.cc
+++ b/tests/matrix_free/matrix_vector_mg.cc
@@ -55,7 +55,7 @@ test()
   // setup DoFs
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
   AffineConstraints<double> constraints;
   VectorTools::interpolate_boundary_values(dof,
                                            0,

--- a/tests/matrix_free/multigrid_dg_periodic.cc
+++ b/tests/matrix_free/multigrid_dg_periodic.cc
@@ -630,7 +630,7 @@ test()
       FE_DGQ<dim>     fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof);
     }

--- a/tests/matrix_free/multigrid_dg_sip_01.cc
+++ b/tests/matrix_free/multigrid_dg_sip_01.cc
@@ -634,7 +634,7 @@ test()
       FE_DGQ<dim>     fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof, true);
     }

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -546,7 +546,7 @@ test()
       FE_DGQ<dim>     fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof, true);
     }

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -446,7 +446,7 @@ test()
       FE_Q<dim>       fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof);
     }

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -264,7 +264,7 @@ test()
       FE_Q<dim>       fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof);
     }

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -642,7 +642,7 @@ test()
       FE_Q<dim>       fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof);
     }

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -337,7 +337,7 @@ test()
       FE_Q<dim>       fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof);
     }

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -335,7 +335,7 @@ test()
       FE_Q<dim>       fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof);
     }

--- a/tests/matrix_free/parallel_multigrid_adaptive_05.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_05.cc
@@ -646,7 +646,7 @@ test()
       FE_Q<dim>       fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       deallog.push("threaded");
       do_test<dim, fe_degree, fe_degree + 1, Number>(dof, true);

--- a/tests/matrix_free/parallel_multigrid_adaptive_06.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06.cc
@@ -415,7 +415,7 @@ test(const unsigned int nbands = 1)
       FE_Q<dim>       fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof, nbands);
     }

--- a/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
@@ -324,7 +324,7 @@ test()
       FE_Q<dim>       fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof);
     }

--- a/tests/matrix_free/parallel_multigrid_adaptive_08.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_08.cc
@@ -405,7 +405,7 @@ test()
       FE_Q<dim>       fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, double>(dof);
     }

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -452,7 +452,7 @@ test()
       FE_Q<dim>       fe(fe_degree);
       DoFHandler<dim> dof(tria);
       dof.distribute_dofs(fe);
-      dof.distribute_mg_dofs(fe);
+      dof.distribute_mg_dofs();
 
       do_test<dim, fe_degree, fe_degree + 1, number>(dof);
     }

--- a/tests/matrix_free/step-37.cc
+++ b/tests/matrix_free/step-37.cc
@@ -416,7 +416,7 @@ namespace Step37
     mg_constraints.clear_elements();
 
     dof_handler.distribute_dofs(fe);
-    dof_handler.distribute_mg_dofs(fe);
+    dof_handler.distribute_mg_dofs();
 
     deallog << "Number of degrees of freedom: " << dof_handler.n_dofs()
             << std::endl;

--- a/tests/meshworker/mesh_loop_gmg_01.cc
+++ b/tests/meshworker/mesh_loop_gmg_01.cc
@@ -68,7 +68,7 @@ test()
   FE_Q<dim>       fe(1);
   DoFHandler<dim> dofh(tria);
   dofh.distribute_dofs(fe);
-  dofh.distribute_mg_dofs(fe);
+  dofh.distribute_mg_dofs();
 
 
   ScratchData scratch;

--- a/tests/mpi/flux_edge_01.cc
+++ b/tests/mpi/flux_edge_01.cc
@@ -115,7 +115,7 @@ namespace Step39
   InteriorPenaltyProblem<dim>::setup_system()
   {
     dof_handler.distribute_dofs(fe);
-    dof_handler.distribute_mg_dofs(fe);
+    dof_handler.distribute_mg_dofs();
 
     DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_set);
 

--- a/tests/mpi/mg_02.cc
+++ b/tests/mpi/mg_02.cc
@@ -86,7 +86,7 @@ test()
   Assert(dofh.has_active_dofs() == true, ExcInternalError());
   Assert(dofh.has_level_dofs() == false, ExcInternalError());
 
-  dofh.distribute_mg_dofs(fe);
+  dofh.distribute_mg_dofs();
 
   Assert(dofh.has_active_dofs() == true, ExcInternalError());
   Assert(dofh.has_level_dofs() == true, ExcInternalError());

--- a/tests/mpi/mg_03.cc
+++ b/tests/mpi/mg_03.cc
@@ -99,7 +99,7 @@ test()
 
   static const FE_DGP<dim> fe(0);
   dofh.distribute_dofs(fe);
-  dofh.distribute_mg_dofs(fe);
+  dofh.distribute_mg_dofs();
 
   {
     for (unsigned int lvl = 0; lvl < tr.n_levels(); ++lvl)

--- a/tests/mpi/mg_04.cc
+++ b/tests/mpi/mg_04.cc
@@ -89,7 +89,7 @@ test()
 
   static const FE_Q<dim> fe(1);
   dofh.distribute_dofs(fe);
-  dofh.distribute_mg_dofs(fe);
+  dofh.distribute_mg_dofs();
 
   {
     for (unsigned int lvl = 0; lvl < tr.n_levels(); ++lvl)

--- a/tests/mpi/mg_05.cc
+++ b/tests/mpi/mg_05.cc
@@ -113,7 +113,7 @@ test()
 
       static const FE_Q<dim> fe(1);
       dofh.distribute_dofs(fe);
-      dofh.distribute_mg_dofs(fe);
+      dofh.distribute_mg_dofs();
 
       {
         for (unsigned int lvl = 0; lvl < tr.n_levels(); ++lvl)

--- a/tests/mpi/mg_06.cc
+++ b/tests/mpi/mg_06.cc
@@ -119,7 +119,7 @@ test()
 
       static const FE_Q<dim> fe(1);
       dofh.distribute_dofs(fe);
-      dofh.distribute_mg_dofs(fe);
+      dofh.distribute_mg_dofs();
 
       {
         for (unsigned int lvl = 0; lvl < tr.n_levels(); ++lvl)

--- a/tests/mpi/mg_ghost_dofs_periodic_01.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_01.cc
@@ -78,7 +78,7 @@ test()
   FE_Q<dim>       fe(1);
   DoFHandler<dim> dof_handler(tria);
   dof_handler.distribute_dofs(fe);
-  dof_handler.distribute_mg_dofs(fe);
+  dof_handler.distribute_mg_dofs();
 
   std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
   for (unsigned int level = 0; level < tria.n_global_levels(); ++level)

--- a/tests/mpi/mg_ghost_dofs_periodic_02.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_02.cc
@@ -58,7 +58,7 @@ test()
   FE_Q<dim>       fe(1);
   DoFHandler<dim> dof_handler(tria);
   dof_handler.distribute_dofs(fe);
-  dof_handler.distribute_mg_dofs(fe);
+  dof_handler.distribute_mg_dofs();
 
   std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
   for (unsigned int level = 0; level < tria.n_global_levels(); ++level)

--- a/tests/mpi/mg_ghost_dofs_periodic_03.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_03.cc
@@ -71,7 +71,7 @@ test()
       FE_Q<dim>       fe(1);
       DoFHandler<dim> dof_handler(tria);
       dof_handler.distribute_dofs(fe);
-      dof_handler.distribute_mg_dofs(fe);
+      dof_handler.distribute_mg_dofs();
 
       std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
       for (unsigned int level = 0; level < tria.n_global_levels(); ++level)

--- a/tests/mpi/mg_ghost_dofs_periodic_04.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_04.cc
@@ -86,7 +86,7 @@ test()
   FE_Q<dim>       fe(1);
   DoFHandler<dim> dof_handler(tria);
   dof_handler.distribute_dofs(fe);
-  dof_handler.distribute_mg_dofs(fe);
+  dof_handler.distribute_mg_dofs();
 
   std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
   for (unsigned int level = 0; level < tria.n_global_levels(); ++level)

--- a/tests/mpi/mg_ghost_dofs_periodic_05.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_05.cc
@@ -72,7 +72,7 @@ test()
   deallog << "Number of cells: " << tria.n_global_active_cells() << std::endl
           << "Number of DoFs: " << dof_handler.n_dofs() << std::endl;
 
-  dof_handler.distribute_mg_dofs(fe);
+  dof_handler.distribute_mg_dofs();
   deallog << "Number of DoFs per level: ";
   for (unsigned int level = 0; level < tria.n_global_levels(); ++level)
     deallog << dof_handler.n_dofs(level) << " ";

--- a/tests/mpi/mg_ghost_dofs_periodic_07.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_07.cc
@@ -77,9 +77,9 @@ test()
   FE_Q<dim>       fe2(1);
   DoFHandler<dim> dof_handler(tria);
   dof_handler.distribute_dofs(fe1);
-  dof_handler.distribute_mg_dofs(fe1);
+  dof_handler.distribute_mg_dofs();
   dof_handler.distribute_dofs(fe2);
-  dof_handler.distribute_mg_dofs(fe2);
+  dof_handler.distribute_mg_dofs();
   deallog << "OK" << std::endl;
 }
 

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -176,7 +176,7 @@ namespace Step50
   LaplaceProblem<dim>::setup_system()
   {
     mg_dof_handler.distribute_dofs(fe);
-    mg_dof_handler.distribute_mg_dofs(fe);
+    mg_dof_handler.distribute_mg_dofs();
 
     deallog << "Number of degrees of freedom: " << mg_dof_handler.n_dofs();
 

--- a/tests/mpi/multigrid_uniform.cc
+++ b/tests/mpi/multigrid_uniform.cc
@@ -176,7 +176,7 @@ namespace Step50
   LaplaceProblem<dim>::setup_system()
   {
     mg_dof_handler.distribute_dofs(fe);
-    mg_dof_handler.distribute_mg_dofs(fe);
+    mg_dof_handler.distribute_mg_dofs();
 
     deallog << "Number of degrees of freedom: " << mg_dof_handler.n_dofs();
 

--- a/tests/mpi/step-39-block.cc
+++ b/tests/mpi/step-39-block.cc
@@ -462,7 +462,7 @@ namespace Step39
   InteriorPenaltyProblem<dim>::setup_system()
   {
     dof_handler.distribute_dofs(fe);
-    dof_handler.distribute_mg_dofs(fe);
+    dof_handler.distribute_mg_dofs();
 
     DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_set);
     solution.reinit(dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);

--- a/tests/mpi/step-39.cc
+++ b/tests/mpi/step-39.cc
@@ -463,7 +463,7 @@ namespace Step39
   InteriorPenaltyProblem<dim>::setup_system()
   {
     dof_handler.distribute_dofs(fe);
-    dof_handler.distribute_mg_dofs(fe);
+    dof_handler.distribute_mg_dofs();
 
     DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_set);
     solution.reinit(dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);

--- a/tests/multigrid/boundary_01.cc
+++ b/tests/multigrid/boundary_01.cc
@@ -72,7 +72,7 @@ check_fe(FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   std::vector<std::set<types::global_dof_index>> boundary_indices(
     tr.n_levels());

--- a/tests/multigrid/constrained_dofs_01.cc
+++ b/tests/multigrid/constrained_dofs_01.cc
@@ -80,7 +80,7 @@ check_fe(FiniteElement<dim> &fe)
 
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
-  dofh.distribute_mg_dofs(fe);
+  dofh.distribute_mg_dofs();
 
   MGConstrainedDoFs mg_constrained_dofs_ref;
   {
@@ -93,7 +93,7 @@ check_fe(FiniteElement<dim> &fe)
 
     DoFHandler<dim> dofhref(tr);
     dofhref.distribute_dofs(fe);
-    dofhref.distribute_mg_dofs(fe);
+    dofhref.distribute_mg_dofs();
 
     // std::map<std::string,std::vector<types::global_dof_index> > dofmap;
     std::map<std::string, std::vector<types::global_dof_index>> mgdofmap;

--- a/tests/multigrid/constrained_dofs_02.cc
+++ b/tests/multigrid/constrained_dofs_02.cc
@@ -141,7 +141,7 @@ check_fe(FiniteElement<dim> &fe)
 
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
-  dofh.distribute_mg_dofs(fe);
+  dofh.distribute_mg_dofs();
 
   MGConstrainedDoFs mg_constrained_dofs_ref;
   {
@@ -154,7 +154,7 @@ check_fe(FiniteElement<dim> &fe)
 
     DoFHandler<dim> dofhref(tr);
     dofhref.distribute_dofs(fe);
-    dofhref.distribute_mg_dofs(fe);
+    dofhref.distribute_mg_dofs();
 
     // std::map<std::string,std::vector<types::global_dof_index> > dofmap;
     std::map<std::string, std::vector<types::global_dof_index>> mgdofmap;

--- a/tests/multigrid/constrained_dofs_03.cc
+++ b/tests/multigrid/constrained_dofs_03.cc
@@ -56,7 +56,7 @@ check_fe(FiniteElement<dim> &fe, ComponentMask &component_mask)
 
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
-  dofh.distribute_mg_dofs(fe);
+  dofh.distribute_mg_dofs();
 
   MGConstrainedDoFs            mg_constrained_dofs;
   std::set<types::boundary_id> boundary_indicators;

--- a/tests/multigrid/count_01.cc
+++ b/tests/multigrid/count_01.cc
@@ -64,7 +64,7 @@ check_fe(FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   std::vector<std::vector<types::global_dof_index>> count(tr.n_levels());
   MGTools::count_dofs_per_component(mgdof, count, false);

--- a/tests/multigrid/distribute_bug_01.cc
+++ b/tests/multigrid/distribute_bug_01.cc
@@ -98,7 +98,7 @@ do_test()
 
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(fe);
-  dof_handler.distribute_mg_dofs(fe);
+  dof_handler.distribute_mg_dofs();
 }
 
 

--- a/tests/multigrid/dof_01.cc
+++ b/tests/multigrid/dof_01.cc
@@ -82,7 +82,7 @@ check_fe(FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
   dofs(mgdof);
 }
 

--- a/tests/multigrid/dof_02.cc
+++ b/tests/multigrid/dof_02.cc
@@ -88,7 +88,7 @@ check_fe(FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
   dofs(mgdof);
 }
 

--- a/tests/multigrid/dof_03.cc
+++ b/tests/multigrid/dof_03.cc
@@ -54,7 +54,7 @@ check()
 
 
     dof.distribute_dofs(fe);
-    dof.distribute_mg_dofs(fe);
+    dof.distribute_mg_dofs();
     deallog << "check " << dim << " level  distribute " << dof.has_active_dofs()
             << ' ' << dof.has_level_dofs() << std::endl;
 

--- a/tests/multigrid/dof_04.cc
+++ b/tests/multigrid/dof_04.cc
@@ -43,7 +43,7 @@ check()
 
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
 
   std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
   std::vector<types::global_dof_index> mg_dof_indices(fe.dofs_per_cell);

--- a/tests/multigrid/dof_05.cc
+++ b/tests/multigrid/dof_05.cc
@@ -46,7 +46,7 @@ check()
 
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
   deallog << dim << "D OK" << std::endl;
 }
 

--- a/tests/multigrid/events_01.cc
+++ b/tests/multigrid/events_01.cc
@@ -144,7 +144,7 @@ namespace Step50
   LaplaceProblem<dim>::setup_system()
   {
     mg_dof_handler.distribute_dofs(fe);
-    mg_dof_handler.distribute_mg_dofs(fe);
+    mg_dof_handler.distribute_mg_dofs();
 
     DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
                                             locally_relevant_set);

--- a/tests/multigrid/mg_coarse_01.cc
+++ b/tests/multigrid/mg_coarse_01.cc
@@ -201,7 +201,7 @@ namespace Step50
   LaplaceProblem<dim>::setup_system()
   {
     mg_dof_handler.distribute_dofs(fe);
-    mg_dof_handler.distribute_mg_dofs(fe);
+    mg_dof_handler.distribute_mg_dofs();
 
     DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
                                             locally_relevant_set);

--- a/tests/multigrid/mg_output_dirichlet.cc
+++ b/tests/multigrid/mg_output_dirichlet.cc
@@ -221,11 +221,11 @@ check_simple(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   DoFHandler<dim> mgdof_renumbered(tr);
   mgdof_renumbered.distribute_dofs(fe);
-  mgdof_renumbered.distribute_mg_dofs(fe);
+  mgdof_renumbered.distribute_mg_dofs();
 
   std::vector<unsigned int> block_component(4, 0);
   block_component[2] = 1;

--- a/tests/multigrid/mg_output_neumann.cc
+++ b/tests/multigrid/mg_output_neumann.cc
@@ -219,11 +219,11 @@ check_simple(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   DoFHandler<dim> mgdof_renumbered(tr);
   mgdof_renumbered.distribute_dofs(fe);
-  mgdof_renumbered.distribute_mg_dofs(fe);
+  mgdof_renumbered.distribute_mg_dofs();
 
   std::vector<unsigned int> block_component(4, 0);
   block_component[2] = 1;

--- a/tests/multigrid/mg_renumbered_01.cc
+++ b/tests/multigrid/mg_renumbered_01.cc
@@ -209,9 +209,9 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
   mg_dof_handler_renumbered.distribute_dofs(fe);
-  mg_dof_handler_renumbered.distribute_mg_dofs(fe);
+  mg_dof_handler_renumbered.distribute_mg_dofs();
 
   std::vector<unsigned int> block_component(2 * dim, 0);
   for (unsigned int c = dim; c < 2 * dim; ++c)

--- a/tests/multigrid/mg_renumbered_02.cc
+++ b/tests/multigrid/mg_renumbered_02.cc
@@ -221,7 +221,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler_renumbered.distribute_dofs(fe);
-  mg_dof_handler_renumbered.distribute_mg_dofs(fe);
+  mg_dof_handler_renumbered.distribute_mg_dofs();
 
   const unsigned int nlevels = triangulation.n_levels();
 

--- a/tests/multigrid/mg_renumbered_03.cc
+++ b/tests/multigrid/mg_renumbered_03.cc
@@ -271,9 +271,9 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
   mg_dof_handler_renumbered.distribute_dofs(fe);
-  mg_dof_handler_renumbered.distribute_mg_dofs(fe);
+  mg_dof_handler_renumbered.distribute_mg_dofs();
 
   const unsigned int nlevels = triangulation.n_levels();
 

--- a/tests/multigrid/renumbering_01.cc
+++ b/tests/multigrid/renumbering_01.cc
@@ -52,7 +52,7 @@ check()
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
   DoFRenumbering::component_wise(mgdof);
   for (unsigned int l = 0; l < tr.n_levels(); ++l)
     DoFRenumbering::component_wise(mgdof, l);

--- a/tests/multigrid/renumbering_02.cc
+++ b/tests/multigrid/renumbering_02.cc
@@ -57,7 +57,7 @@ check()
 
   DoFHandler<dim> mg_dof_handler(tria);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
   Point<dim> a;
   a(0) = 1;
   for (unsigned int level = 0; level < tria.n_levels(); ++level)

--- a/tests/multigrid/renumbering_03.cc
+++ b/tests/multigrid/renumbering_03.cc
@@ -59,7 +59,7 @@ check()
 
   DoFHandler<dim> mg_dof_handler(tria);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
   for (unsigned int level = 0; level < tria.n_levels(); ++level)
     {
       const types::global_dof_index   n_dofs = mg_dof_handler.n_dofs(level);

--- a/tests/multigrid/renumbering_04.cc
+++ b/tests/multigrid/renumbering_04.cc
@@ -52,7 +52,7 @@ check(FiniteElement<dim> &fe)
 
   DoFHandler<dim> dh(tria);
   dh.distribute_dofs(fe);
-  dh.distribute_mg_dofs(fe);
+  dh.distribute_mg_dofs();
 
   deallog << "** before:" << std::endl;
   {

--- a/tests/multigrid/step-16-02.cc
+++ b/tests/multigrid/step-16-02.cc
@@ -237,7 +237,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
   deallog << "Number of degrees of freedom: " << mg_dof_handler.n_dofs();
 
   for (unsigned int l = 0; l < triangulation.n_levels(); ++l)

--- a/tests/multigrid/step-16-03.cc
+++ b/tests/multigrid/step-16-03.cc
@@ -162,7 +162,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   sparsity_pattern.reinit(mg_dof_handler.n_dofs(),
                           mg_dof_handler.n_dofs(),

--- a/tests/multigrid/step-16-04.cc
+++ b/tests/multigrid/step-16-04.cc
@@ -166,7 +166,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   sparsity_pattern.reinit(mg_dof_handler.n_dofs(),
                           mg_dof_handler.n_dofs(),

--- a/tests/multigrid/step-16-05.cc
+++ b/tests/multigrid/step-16-05.cc
@@ -163,7 +163,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   sparsity_pattern.reinit(mg_dof_handler.n_dofs(),
                           mg_dof_handler.n_dofs(),

--- a/tests/multigrid/step-16-06.cc
+++ b/tests/multigrid/step-16-06.cc
@@ -163,7 +163,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   sparsity_pattern.reinit(mg_dof_handler.n_dofs(),
                           mg_dof_handler.n_dofs(),

--- a/tests/multigrid/step-16-07.cc
+++ b/tests/multigrid/step-16-07.cc
@@ -162,7 +162,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
   deallog << "Number of degrees of freedom: " << mg_dof_handler.n_dofs();
 
   for (unsigned int l = 0; l < triangulation.n_levels(); ++l)

--- a/tests/multigrid/step-16-50-mpi-linear-operator.cc
+++ b/tests/multigrid/step-16-50-mpi-linear-operator.cc
@@ -196,7 +196,7 @@ namespace Step50
   LaplaceProblem<dim>::setup_system()
   {
     mg_dof_handler.distribute_dofs(fe);
-    mg_dof_handler.distribute_mg_dofs(fe);
+    mg_dof_handler.distribute_mg_dofs();
 
     DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
                                             locally_relevant_set);

--- a/tests/multigrid/step-16-50-mpi-smoother.cc
+++ b/tests/multigrid/step-16-50-mpi-smoother.cc
@@ -196,7 +196,7 @@ namespace Step50
   LaplaceProblem<dim>::setup_system()
   {
     mg_dof_handler.distribute_dofs(fe);
-    mg_dof_handler.distribute_mg_dofs(fe);
+    mg_dof_handler.distribute_mg_dofs();
 
     DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
                                             locally_relevant_set);

--- a/tests/multigrid/step-16-50-mpi.cc
+++ b/tests/multigrid/step-16-50-mpi.cc
@@ -196,7 +196,7 @@ namespace Step50
   LaplaceProblem<dim>::setup_system()
   {
     mg_dof_handler.distribute_dofs(fe);
-    mg_dof_handler.distribute_mg_dofs(fe);
+    mg_dof_handler.distribute_mg_dofs();
 
     DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
                                             locally_relevant_set);

--- a/tests/multigrid/step-16-50-serial.cc
+++ b/tests/multigrid/step-16-50-serial.cc
@@ -165,7 +165,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   sparsity_pattern.reinit(mg_dof_handler.n_dofs(),
                           mg_dof_handler.n_dofs(),

--- a/tests/multigrid/step-16-bdry1.cc
+++ b/tests/multigrid/step-16-bdry1.cc
@@ -238,7 +238,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
   deallog << "Number of degrees of freedom: " << mg_dof_handler.n_dofs();
 
   for (unsigned int l = 0; l < triangulation.n_levels(); ++l)

--- a/tests/multigrid/step-16.cc
+++ b/tests/multigrid/step-16.cc
@@ -162,7 +162,7 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
   deallog << "Number of degrees of freedom: " << mg_dof_handler.n_dofs();
 
   for (unsigned int l = 0; l < triangulation.n_levels(); ++l)

--- a/tests/multigrid/step-39-02.cc
+++ b/tests/multigrid/step-39-02.cc
@@ -452,7 +452,7 @@ namespace Step39
   InteriorPenaltyProblem<dim>::setup_system()
   {
     dof_handler.distribute_dofs(fe);
-    dof_handler.distribute_mg_dofs(fe);
+    dof_handler.distribute_mg_dofs();
     types::global_dof_index n_dofs = dof_handler.n_dofs();
     solution.reinit(n_dofs);
     right_hand_side.reinit(n_dofs);

--- a/tests/multigrid/step-39-02a.cc
+++ b/tests/multigrid/step-39-02a.cc
@@ -455,7 +455,7 @@ namespace Step39
   InteriorPenaltyProblem<dim>::setup_system()
   {
     dof_handler.distribute_dofs(fe);
-    dof_handler.distribute_mg_dofs(fe);
+    dof_handler.distribute_mg_dofs();
     types::global_dof_index n_dofs = dof_handler.n_dofs();
     solution.reinit(n_dofs);
     right_hand_side.reinit(n_dofs);

--- a/tests/multigrid/step-39-03.cc
+++ b/tests/multigrid/step-39-03.cc
@@ -458,7 +458,7 @@ namespace Step39
   InteriorPenaltyProblem<dim>::setup_system()
   {
     dof_handler.distribute_dofs(fe);
-    dof_handler.distribute_mg_dofs(fe);
+    dof_handler.distribute_mg_dofs();
     types::global_dof_index n_dofs = dof_handler.n_dofs();
     solution.reinit(n_dofs);
     right_hand_side.reinit(n_dofs);

--- a/tests/multigrid/step-39.cc
+++ b/tests/multigrid/step-39.cc
@@ -452,7 +452,7 @@ namespace Step39
   InteriorPenaltyProblem<dim>::setup_system()
   {
     dof_handler.distribute_dofs(fe);
-    dof_handler.distribute_mg_dofs(fe);
+    dof_handler.distribute_mg_dofs();
     types::global_dof_index n_dofs = dof_handler.n_dofs();
     solution.reinit(n_dofs);
     right_hand_side.reinit(n_dofs);

--- a/tests/multigrid/step-50_01.cc
+++ b/tests/multigrid/step-50_01.cc
@@ -198,7 +198,7 @@ namespace Step50
   LaplaceProblem<dim>::setup_system()
   {
     mg_dof_handler.distribute_dofs(fe);
-    mg_dof_handler.distribute_mg_dofs(fe);
+    mg_dof_handler.distribute_mg_dofs();
 
     DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
                                             locally_relevant_set);

--- a/tests/multigrid/transfer_01.cc
+++ b/tests/multigrid/transfer_01.cc
@@ -67,7 +67,7 @@ check_simple(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   MGTransferPrebuilt<Vector<double>> transfer;
   transfer.build_matrices(mgdof);

--- a/tests/multigrid/transfer_02.cc
+++ b/tests/multigrid/transfer_02.cc
@@ -100,7 +100,7 @@ check_simple(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   MGTransferPrebuilt<Vector<double>> transfer;
   transfer.build_matrices(mgdof);

--- a/tests/multigrid/transfer_03.cc
+++ b/tests/multigrid/transfer_03.cc
@@ -193,11 +193,11 @@ check_simple(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   DoFHandler<dim> mgdof_renumbered(tr);
   mgdof_renumbered.distribute_dofs(fe);
-  mgdof_renumbered.distribute_mg_dofs(fe);
+  mgdof_renumbered.distribute_mg_dofs();
 
   std::vector<unsigned int> block_component(4, 0);
   block_component[2] = 1;

--- a/tests/multigrid/transfer_04.cc
+++ b/tests/multigrid/transfer_04.cc
@@ -122,7 +122,7 @@ check_fe(FiniteElement<dim> &fe)
 
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
-  dofh.distribute_mg_dofs(fe);
+  dofh.distribute_mg_dofs();
   typedef TrilinosWrappers::MPI::Vector vector_t;
 
   MGConstrainedDoFs mg_constrained_dofs;

--- a/tests/multigrid/transfer_04a.cc
+++ b/tests/multigrid/transfer_04a.cc
@@ -126,7 +126,7 @@ check_fe(FiniteElement<dim> &fe)
 
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
-  dofh.distribute_mg_dofs(fe);
+  dofh.distribute_mg_dofs();
   typedef TrilinosWrappers::MPI::Vector vector_t;
   {}
   MGTransferPrebuilt<vector_t> transfer;

--- a/tests/multigrid/transfer_04b.cc
+++ b/tests/multigrid/transfer_04b.cc
@@ -126,7 +126,7 @@ check_fe(FiniteElement<dim> &fe)
 
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
-  dofh.distribute_mg_dofs(fe);
+  dofh.distribute_mg_dofs();
   typedef PETScWrappers::MPI::Vector vector_t;
   {}
   MGTransferPrebuilt<vector_t> transfer;

--- a/tests/multigrid/transfer_05.cc
+++ b/tests/multigrid/transfer_05.cc
@@ -103,7 +103,7 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       MGConstrainedDoFs                                   mg_constrained_dofs;
       ZeroFunction<dim>                                   zero_function;

--- a/tests/multigrid/transfer_06.cc
+++ b/tests/multigrid/transfer_06.cc
@@ -109,11 +109,11 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof_1(tr);
       mgdof_1.distribute_dofs(fe_1);
-      mgdof_1.distribute_mg_dofs(fe_1);
+      mgdof_1.distribute_mg_dofs();
 
       DoFHandler<dim> mgdof_2(tr);
       mgdof_2.distribute_dofs(fe_2);
-      mgdof_2.distribute_mg_dofs(fe_2);
+      mgdof_2.distribute_mg_dofs();
 
       const std::vector<const DoFHandler<dim> *> mgdof_ptr{&mgdof_1, &mgdof_2};
 

--- a/tests/multigrid/transfer_block.cc
+++ b/tests/multigrid/transfer_block.cc
@@ -99,7 +99,7 @@ check_block(const FiniteElement<dim> &fe,
   DoFHandler<dim>  mgdof(tr);
   DoFHandler<dim> &dof = mgdof;
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
   DoFRenumbering::component_wise(mgdof);
   vector<types::global_dof_index> ndofs(fe.n_blocks());
   DoFTools::count_dofs_per_block(mgdof, ndofs);

--- a/tests/multigrid/transfer_block_select.cc
+++ b/tests/multigrid/transfer_block_select.cc
@@ -85,7 +85,7 @@ check_select(const FiniteElement<dim> &fe, unsigned int selected)
   DoFHandler<dim>  mgdof(tr);
   DoFHandler<dim> &dof = mgdof;
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
   DoFRenumbering::component_wise(mgdof);
   vector<types::global_dof_index> ndofs(fe.n_blocks());
   DoFTools::count_dofs_per_block(mgdof, ndofs);

--- a/tests/multigrid/transfer_compare_01.cc
+++ b/tests/multigrid/transfer_compare_01.cc
@@ -129,7 +129,7 @@ check_block(const FiniteElement<dim> &fe)
   DoFHandler<dim>  mgdof(tr);
   DoFHandler<dim> &dof = mgdof;
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   // Make sure all orderings are the
   // same

--- a/tests/multigrid/transfer_matrix_free_01.cc
+++ b/tests/multigrid/transfer_matrix_free_01.cc
@@ -65,7 +65,7 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       MGConstrainedDoFs                                   mg_constrained_dofs;
       Functions::ZeroFunction<dim>                        zero_function;

--- a/tests/multigrid/transfer_matrix_free_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02.cc
@@ -94,7 +94,7 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       MGConstrainedDoFs                                   mg_constrained_dofs;
       Functions::ZeroFunction<dim>                        zero_function;

--- a/tests/multigrid/transfer_matrix_free_02_block.cc
+++ b/tests/multigrid/transfer_matrix_free_02_block.cc
@@ -98,7 +98,7 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       MGConstrainedDoFs                                   mg_constrained_dofs;
       ZeroFunction<dim>                                   zero_function;

--- a/tests/multigrid/transfer_matrix_free_02_block_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02_block_02.cc
@@ -103,11 +103,11 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof_1(tr);
       mgdof_1.distribute_dofs(fe_1);
-      mgdof_1.distribute_mg_dofs(fe_1);
+      mgdof_1.distribute_mg_dofs();
 
       DoFHandler<dim> mgdof_2(tr);
       mgdof_2.distribute_dofs(fe_2);
-      mgdof_2.distribute_mg_dofs(fe_2);
+      mgdof_2.distribute_mg_dofs();
 
       const std::vector<const DoFHandler<dim> *> mgdof_ptr{&mgdof_1, &mgdof_2};
 

--- a/tests/multigrid/transfer_matrix_free_03.cc
+++ b/tests/multigrid/transfer_matrix_free_03.cc
@@ -63,7 +63,7 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       MGConstrainedDoFs                                   mg_constrained_dofs;
       Functions::ZeroFunction<dim>                        zero_function;

--- a/tests/multigrid/transfer_matrix_free_04.cc
+++ b/tests/multigrid/transfer_matrix_free_04.cc
@@ -66,7 +66,7 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>

--- a/tests/multigrid/transfer_matrix_free_05.cc
+++ b/tests/multigrid/transfer_matrix_free_05.cc
@@ -93,7 +93,7 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>

--- a/tests/multigrid/transfer_matrix_free_06.cc
+++ b/tests/multigrid/transfer_matrix_free_06.cc
@@ -96,7 +96,7 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       MGConstrainedDoFs                                   mg_constrained_dofs;
       Functions::ZeroFunction<dim>                        zero_function;

--- a/tests/multigrid/transfer_matrix_free_07.cc
+++ b/tests/multigrid/transfer_matrix_free_07.cc
@@ -93,7 +93,7 @@ check(const unsigned int fe_degree)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>

--- a/tests/multigrid/transfer_matrix_free_08.cc
+++ b/tests/multigrid/transfer_matrix_free_08.cc
@@ -67,7 +67,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   // build matrix-free transfer
   MGTransferMatrixFree<dim, Number> transfer;

--- a/tests/multigrid/transfer_matrix_free_09.cc
+++ b/tests/multigrid/transfer_matrix_free_09.cc
@@ -61,7 +61,7 @@ check(const FiniteElement<dim> &fe)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       Tensor<1, dim> exponents_monomial;
       for (unsigned int d = 0; d < dim; ++d)

--- a/tests/multigrid/transfer_matrix_free_10.cc
+++ b/tests/multigrid/transfer_matrix_free_10.cc
@@ -61,7 +61,7 @@ check(const FiniteElement<dim> &fe)
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       Tensor<1, dim> exponents_monomial;
       for (unsigned int d = 0; d < dim; ++d)

--- a/tests/multigrid/transfer_matrix_free_11.cc
+++ b/tests/multigrid/transfer_matrix_free_11.cc
@@ -55,7 +55,7 @@ check(const unsigned int fe_degree)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   MGConstrainedDoFs mg_constrained_dofs;
   mg_constrained_dofs.initialize(mgdof);

--- a/tests/multigrid/transfer_matrix_free_12.cc
+++ b/tests/multigrid/transfer_matrix_free_12.cc
@@ -70,7 +70,7 @@ check(const FiniteElement<dim> &fe_scalar)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   // build matrix-free transfer
   MGTransferMatrixFree<dim, Number> transfer;

--- a/tests/multigrid/transfer_prebuilt_01.cc
+++ b/tests/multigrid/transfer_prebuilt_01.cc
@@ -58,7 +58,7 @@ check_simple(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   MGTransferPrebuilt<Vector<double>> transfer;
   transfer.build_matrices(mgdof);

--- a/tests/multigrid/transfer_prebuilt_02.cc
+++ b/tests/multigrid/transfer_prebuilt_02.cc
@@ -60,7 +60,7 @@ check_simple(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   MGConstrainedDoFs mg_constrained_dofs;
   mg_constrained_dofs.initialize(mgdof);

--- a/tests/multigrid/transfer_prebuilt_03.cc
+++ b/tests/multigrid/transfer_prebuilt_03.cc
@@ -61,7 +61,7 @@ check_simple(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);

--- a/tests/multigrid/transfer_prebuilt_04.cc
+++ b/tests/multigrid/transfer_prebuilt_04.cc
@@ -63,7 +63,7 @@ check()
 
       DoFHandler<dim> mgdof(tr);
       mgdof.distribute_dofs(fe);
-      mgdof.distribute_mg_dofs(fe);
+      mgdof.distribute_mg_dofs();
 
       MGConstrainedDoFs                                   mg_constrained_dofs;
       Functions::ZeroFunction<dim>                        zero_function;

--- a/tests/multigrid/transfer_select.cc
+++ b/tests/multigrid/transfer_select.cc
@@ -58,7 +58,7 @@ check_select(const FiniteElement<dim> &fe,
   DoFHandler<dim>  mgdof(tr);
   DoFHandler<dim> &dof = mgdof;
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
   DoFRenumbering::component_wise(mgdof, target_component);
   vector<types::global_dof_index> ndofs(
     *std::max_element(target_component.begin(), target_component.end()) + 1);

--- a/tests/multigrid/transfer_system_01.cc
+++ b/tests/multigrid/transfer_system_01.cc
@@ -97,7 +97,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   DoFRenumbering::component_wise(mg_dof_handler);
   for (unsigned int level = 0; level < tr.n_levels(); ++level)

--- a/tests/multigrid/transfer_system_02.cc
+++ b/tests/multigrid/transfer_system_02.cc
@@ -98,7 +98,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   DoFRenumbering::component_wise(mg_dof_handler);
   for (unsigned int level = 0; level < tr.n_levels(); ++level)

--- a/tests/multigrid/transfer_system_03.cc
+++ b/tests/multigrid/transfer_system_03.cc
@@ -99,7 +99,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   DoFRenumbering::component_wise(mg_dof_handler);
   for (unsigned int level = 0; level < tr.n_levels(); ++level)

--- a/tests/multigrid/transfer_system_04.cc
+++ b/tests/multigrid/transfer_system_04.cc
@@ -99,7 +99,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   std::vector<unsigned int> block_component(3, 0);
   block_component[2] = 1;

--- a/tests/multigrid/transfer_system_05.cc
+++ b/tests/multigrid/transfer_system_05.cc
@@ -53,7 +53,7 @@ check(const FiniteElement<dim> &fe, const unsigned int selected_block)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   std::vector<unsigned int> block_component(5, 0);
   block_component[2] = 1;

--- a/tests/multigrid/transfer_system_adaptive_01.cc
+++ b/tests/multigrid/transfer_system_adaptive_01.cc
@@ -137,7 +137,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   deallog << "Global  dofs: " << mg_dof_handler.n_dofs() << std::endl;
   for (unsigned int l = 0; l < tr.n_levels(); ++l)

--- a/tests/multigrid/transfer_system_adaptive_02.cc
+++ b/tests/multigrid/transfer_system_adaptive_02.cc
@@ -137,7 +137,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   deallog << "Global  dofs: " << mg_dof_handler.n_dofs() << std::endl;
   for (unsigned int l = 0; l < tr.n_levels(); ++l)

--- a/tests/multigrid/transfer_system_adaptive_03.cc
+++ b/tests/multigrid/transfer_system_adaptive_03.cc
@@ -138,7 +138,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   deallog << "Global  dofs: " << mg_dof_handler.n_dofs() << std::endl;
   for (unsigned int l = 0; l < tr.n_levels(); ++l)

--- a/tests/multigrid/transfer_system_adaptive_04.cc
+++ b/tests/multigrid/transfer_system_adaptive_04.cc
@@ -137,7 +137,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   deallog << "Global  dofs: " << mg_dof_handler.n_dofs() << std::endl;
   for (unsigned int l = 0; l < tr.n_levels(); ++l)

--- a/tests/multigrid/transfer_system_adaptive_05.cc
+++ b/tests/multigrid/transfer_system_adaptive_05.cc
@@ -139,7 +139,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   deallog << "Global  dofs: " << mg_dof_handler.n_dofs() << std::endl;
   for (unsigned int l = 0; l < tr.n_levels(); ++l)

--- a/tests/multigrid/transfer_system_adaptive_06.cc
+++ b/tests/multigrid/transfer_system_adaptive_06.cc
@@ -137,7 +137,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   deallog << "Global  dofs: " << mg_dof_handler.n_dofs() << std::endl;
   for (unsigned int l = 0; l < tr.n_levels(); ++l)

--- a/tests/multigrid/transfer_system_adaptive_07.cc
+++ b/tests/multigrid/transfer_system_adaptive_07.cc
@@ -139,7 +139,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   std::vector<unsigned int> block_selected(3, 0);
   block_selected[2] = 1;

--- a/tests/multigrid/transfer_system_adaptive_08.cc
+++ b/tests/multigrid/transfer_system_adaptive_08.cc
@@ -138,7 +138,7 @@ check(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   std::vector<unsigned int> block_selected(3, 0);
   block_selected[2] = 1;

--- a/tests/multigrid/transfer_system_adaptive_09.cc
+++ b/tests/multigrid/transfer_system_adaptive_09.cc
@@ -99,7 +99,7 @@ check(const FiniteElement<dim> &fe, const unsigned int selected_block)
 
   DoFHandler<dim> mg_dof_handler(tr);
   mg_dof_handler.distribute_dofs(fe);
-  mg_dof_handler.distribute_mg_dofs(fe);
+  mg_dof_handler.distribute_mg_dofs();
 
   std::vector<unsigned int> block_component(5, 0);
   block_component[2] = 1;

--- a/tests/trilinos/mg_transfer_prebuilt_01.cc
+++ b/tests/trilinos/mg_transfer_prebuilt_01.cc
@@ -78,7 +78,7 @@ check_simple(const FiniteElement<dim> &fe)
 
   DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
-  mgdof.distribute_mg_dofs(fe);
+  mgdof.distribute_mg_dofs();
 
   MGTransferPrebuilt<TrilinosWrappers::MPI::Vector> transfer;
   transfer.build_matrices(mgdof);


### PR DESCRIPTION
There was a large number of tests still using the deprecated interface.

Noticed while working on #8726.