### PR TITLE
Embed vector operations in MatrixFree cell loops

### DIFF
--- a/doc/news/changes/minor/20190910MartinKronbichler
+++ b/doc/news/changes/minor/20190910MartinKronbichler
@@ -1,0 +1,9 @@
+New: There is a new variant of MatrixFree::cell_loop() which takes two
+std::function objects with ranges on the locally owned degrees of freedom, one
+with work to be scheduled before the cell operation first touches some
+unknowns, and one after the cell operation last touches them. The goal of
+these functions is to bring vector operations close to the time when the
+vector entries are accessed by the cell operation which increases the cache
+hit rate of modern processors (temporal locality).
+<br>
+(Martin Kronbichler, 2019/09/10)

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -75,10 +75,12 @@ namespace internal
        * caches, saving one global vector access for the case where this is
        * applied rather than `vector = 0.;`.
        *
-       * Size of the chunk is set to 64 kByte which generally fits to current
-       * caches.
+       * We set the granularity to 64 - that is a number sufficiently large
+       * to minimize loop peel overhead within the work (and compatible with
+       * vectorization lengths of up to 16) and small enough to not waste on
+       * the size of the individual chunks.
        */
-      static const unsigned int chunk_size_zero_vector = 8192;
+      static const unsigned int chunk_size_zero_vector = 64;
 
       /**
        * Default empty constructor.
@@ -600,7 +602,33 @@ namespace internal
       /**
        * Stores the actual ranges in the vector to be cleared.
        */
-      std::vector<unsigned int> vector_zero_range_list;
+      std::vector<std::pair<unsigned int, unsigned int>> vector_zero_range_list;
+
+      /**
+       * Stores an integer to each partition in TaskInfo that indicates when
+       * to schedule operations that will be done before any access to vector
+       * entries.
+       */
+      std::vector<unsigned int> cell_loop_pre_list_index;
+
+      /**
+       * Stores the actual ranges of the operation before any access to vector
+       * entries.
+       */
+      std::vector<std::pair<unsigned int, unsigned int>> cell_loop_pre_list;
+
+      /**
+       * Stores an integer to each partition in TaskInfo that indicates when
+       * to schedule operations that will be done after all access to vector
+       * entries.
+       */
+      std::vector<unsigned int> cell_loop_post_list_index;
+
+      /**
+       * Stores the actual ranges of the operation after all access to vector
+       * entries.
+       */
+      std::vector<std::pair<unsigned int, unsigned int>> cell_loop_post_list;
     };
 
 

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -1214,7 +1214,10 @@ namespace internal
       const unsigned int n_components = start_components.back();
       const unsigned int n_dofs       = vector_partitioner->local_size() +
                                   vector_partitioner->n_ghost_indices();
-      std::vector<unsigned int> touched_by(
+      std::vector<unsigned int> touched_first_by(
+        (n_dofs + chunk_size_zero_vector - 1) / chunk_size_zero_vector,
+        numbers::invalid_unsigned_int);
+      std::vector<unsigned int> touched_last_by(
         (n_dofs + chunk_size_zero_vector - 1) / chunk_size_zero_vector,
         numbers::invalid_unsigned_int);
       for (unsigned int part = 0;
@@ -1238,8 +1241,10 @@ namespace internal
                   {
                     const unsigned int myindex =
                       dof_indices[it] / chunk_size_zero_vector;
-                    if (touched_by[myindex] == numbers::invalid_unsigned_int)
-                      touched_by[myindex] = chunk;
+                    if (touched_first_by[myindex] ==
+                        numbers::invalid_unsigned_int)
+                      touched_first_by[myindex] = chunk;
+                    touched_last_by[myindex] = chunk;
                   }
               }
             if (faces.size() > 0)
@@ -1259,42 +1264,123 @@ namespace internal
                       {
                         const unsigned int myindex =
                           dof_indices[it] / chunk_size_zero_vector;
-                        if (touched_by[myindex] ==
+                        if (touched_first_by[myindex] ==
                             numbers::invalid_unsigned_int)
-                          touched_by[myindex] = chunk;
+                          touched_first_by[myindex] = chunk;
+                        touched_last_by[myindex] = chunk;
                       }
                   }
           }
-      // ensure that all indices are touched at least during the last round
-      for (auto &index : touched_by)
-        if (index == numbers::invalid_unsigned_int)
-          index = task_info.cell_partition_data.back() - 1;
 
-      vector_zero_range_list_index.resize(
-        1 + task_info
-              .partition_row_index[task_info.partition_row_index.size() - 2],
-        numbers::invalid_unsigned_int);
-      std::map<unsigned int, std::vector<unsigned int>> chunk_must_zero_vector;
-      for (unsigned int i = 0; i < touched_by.size(); ++i)
-        chunk_must_zero_vector[touched_by[i]].push_back(i);
-      vector_zero_range_list.clear();
-      vector_zero_range_list_index[0] = 0;
-      for (unsigned int chunk = 0;
-           chunk < vector_zero_range_list_index.size() - 1;
-           ++chunk)
-        {
-          auto it = chunk_must_zero_vector.find(chunk);
-          if (it != chunk_must_zero_vector.end())
+      // ensure that all indices are touched at least during the last round
+      for (auto &index : touched_first_by)
+        if (index == numbers::invalid_unsigned_int)
+          index =
+            task_info
+              .partition_row_index[task_info.partition_row_index.size() - 2] -
+            1;
+
+      // lambda to convert from a map, with keys associated to the buckets by
+      // which we sliced the index space, length chunk_size_zero_vector, and
+      // values equal to the slice index which are touched by the respective
+      // partition, to a "vectors-of-vectors" like data structure. Rather than
+      // using the vectors, we set up a sparsity-pattern like structure where
+      // one index specifies the start index (range_list_index), and the other
+      // the actual ranges (range_list).
+      auto convert_map_to_range_list =
+        [=](const unsigned int n_partitions,
+            const std::map<unsigned int, std::vector<unsigned int>> &ranges_in,
+            std::vector<unsigned int> &range_list_index,
+            std::vector<std::pair<unsigned int, unsigned int>> &range_list,
+            const unsigned int                                  max_size) {
+          range_list_index.resize(n_partitions + 1);
+          range_list_index[0] = 0;
+          range_list.clear();
+          for (unsigned int partition = 0; partition < n_partitions;
+               ++partition)
             {
-              for (const auto i : it->second)
-                vector_zero_range_list.push_back(i);
-              vector_zero_range_list_index[chunk + 1] =
-                vector_zero_range_list.size();
+              auto it = ranges_in.find(partition);
+              if (it != ranges_in.end())
+                {
+                  for (unsigned int i = 0; i < it->second.size(); ++i)
+                    {
+                      const unsigned int first_i = i;
+                      while (i + 1 < it->second.size() &&
+                             it->second[i + 1] == it->second[i] + 1)
+                        ++i;
+                      range_list.emplace_back(
+                        std::min(it->second[first_i] * chunk_size_zero_vector,
+                                 max_size),
+                        std::min((it->second[i] + 1) * chunk_size_zero_vector,
+                                 max_size));
+                    }
+                  range_list_index[partition + 1] = range_list.size();
+                }
+              else
+                range_list_index[partition + 1] = range_list_index[partition];
             }
-          else
-            vector_zero_range_list_index[chunk + 1] =
-              vector_zero_range_list_index[chunk];
-        }
+        };
+
+      // first we determine the ranges to zero the vector
+      std::map<unsigned int, std::vector<unsigned int>> chunk_must_zero_vector;
+      for (unsigned int i = 0; i < touched_first_by.size(); ++i)
+        chunk_must_zero_vector[touched_first_by[i]].push_back(i);
+      const unsigned int n_partitions =
+        task_info.partition_row_index[task_info.partition_row_index.size() - 2];
+      convert_map_to_range_list(n_partitions,
+                                chunk_must_zero_vector,
+                                vector_zero_range_list_index,
+                                vector_zero_range_list,
+                                vector_partitioner->local_size());
+
+      // the other two operations only work on the local range (without
+      // ghosts), so we skip the latter parts of the vector now
+      touched_first_by.resize(
+        (vector_partitioner->local_size() + chunk_size_zero_vector - 1) /
+        chunk_size_zero_vector);
+
+      // set the import indices in the vector partitioner to one index higher
+      // to indicate that we want to process it first. This additional index
+      // is reflected in the argument 'n_partitions+1' in the
+      // convert_map_to_range_list function below.
+      for (auto it : vector_partitioner->import_indices())
+        for (unsigned int i = it.first; i < it.second; ++i)
+          touched_first_by[i / chunk_size_zero_vector] = n_partitions;
+      std::map<unsigned int, std::vector<unsigned int>> chunk_must_do_pre;
+      for (unsigned int i = 0; i < touched_first_by.size(); ++i)
+        chunk_must_do_pre[touched_first_by[i]].push_back(i);
+      convert_map_to_range_list(n_partitions + 1,
+                                chunk_must_do_pre,
+                                cell_loop_pre_list_index,
+                                cell_loop_pre_list,
+                                vector_partitioner->local_size());
+
+      touched_last_by.resize(
+        (vector_partitioner->local_size() + chunk_size_zero_vector - 1) /
+        chunk_size_zero_vector);
+
+      // set the indices which were not touched by the cell loop (i.e.,
+      // constrained indices) to the last valid partition index. Since
+      // partition_row_index contains one extra slot for ghosted faces (which
+      // are not part of the cell/face loops), we use the second to last entry
+      // in the partition list.
+      for (auto &index : touched_last_by)
+        if (index == numbers::invalid_unsigned_int)
+          index =
+            task_info
+              .partition_row_index[task_info.partition_row_index.size() - 2] -
+            1;
+      for (auto it : vector_partitioner->import_indices())
+        for (unsigned int i = it.first; i < it.second; ++i)
+          touched_last_by[i / chunk_size_zero_vector] = n_partitions;
+      std::map<unsigned int, std::vector<unsigned int>> chunk_must_do_post;
+      for (unsigned int i = 0; i < touched_last_by.size(); ++i)
+        chunk_must_do_post[touched_last_by[i]].push_back(i);
+      convert_map_to_range_list(n_partitions + 1,
+                                chunk_must_do_post,
+                                cell_loop_post_list_index,
+                                cell_loop_post_list,
+                                vector_partitioner->local_size());
     }
 
 

--- a/include/deal.II/matrix_free/task_info.h
+++ b/include/deal.II/matrix_free/task_info.h
@@ -67,6 +67,12 @@ namespace internal
     virtual void
     zero_dst_vector_range(const unsigned int range_index) = 0;
 
+    virtual void
+    cell_loop_pre_range(const unsigned int range_index) = 0;
+
+    virtual void
+    cell_loop_post_range(const unsigned int range_index) = 0;
+
     /// Runs the cell work specified by MatrixFree::loop or
     /// MatrixFree::cell_loop
     virtual void

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -336,6 +336,10 @@ namespace internal
     void
     TaskInfo::loop(MFWorkerInterface &funct) const
     {
+      if (scheme == none)
+        funct.cell_loop_pre_range(
+          partition_row_index[partition_row_index.size() - 2]);
+
       funct.vector_update_ghosts_start();
 
 #ifdef DEAL_II_WITH_THREADS
@@ -584,10 +588,11 @@ namespace internal
                    i < partition_row_index[part + 1];
                    ++i)
                 {
+                  funct.cell_loop_pre_range(i);
+                  funct.zero_dst_vector_range(i);
                   AssertIndexRange(i + 1, cell_partition_data.size());
                   if (cell_partition_data[i + 1] > cell_partition_data[i])
                     {
-                      funct.zero_dst_vector_range(i);
                       funct.cell(std::make_pair(cell_partition_data[i],
                                                 cell_partition_data[i + 1]));
                     }
@@ -603,6 +608,7 @@ namespace internal
                           std::make_pair(boundary_partition_data[i],
                                          boundary_partition_data[i + 1]));
                     }
+                  funct.cell_loop_post_range(i);
                 }
 
               if (part == 1)
@@ -610,6 +616,9 @@ namespace internal
             }
         }
       funct.vector_compress_finish();
+      if (scheme == none)
+        funct.cell_loop_post_range(
+          partition_row_index[partition_row_index.size() - 2]);
     }
 
 

--- a/tests/matrix_free/pre_and_post_loops_01.cc
+++ b/tests/matrix_free/pre_and_post_loops_01.cc
@@ -1,0 +1,205 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test the correctness of the matrix-free cell loop with additional
+// operation_before_loop and operation_after_loop lambdas
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+#include "matrix_vector_mf.h"
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d = fe_degree + 1,
+          typename Number   = double>
+class Matrix
+{
+public:
+  Matrix(const MatrixFree<dim, Number> &data_in)
+    : data(data_in)
+  {}
+
+  void
+  vmult(LinearAlgebra::distributed::Vector<Number> &      dst,
+        const LinearAlgebra::distributed::Vector<Number> &src) const
+  {
+    const std::function<void(const MatrixFree<dim, Number> &,
+                             LinearAlgebra::distributed::Vector<Number> &,
+                             const LinearAlgebra::distributed::Vector<Number> &,
+                             const std::pair<unsigned int, unsigned int> &)>
+      wrap = helmholtz_operator<dim,
+                                fe_degree,
+                                LinearAlgebra::distributed::Vector<Number>,
+                                n_q_points_1d>;
+    dst    = 0;
+    data.cell_loop(wrap, dst, src);
+    for (auto i : data.get_constrained_dofs())
+      dst.local_element(i) = src.local_element(i);
+  }
+
+  void
+  vmult_with_update_basic(
+    LinearAlgebra::distributed::Vector<Number> &dst,
+    LinearAlgebra::distributed::Vector<Number> &src,
+    LinearAlgebra::distributed::Vector<Number> &other_vector) const
+  {
+    src.add(1.5, other_vector);
+    other_vector.add(0.7, dst);
+    dst = 0;
+    vmult(dst, src);
+    dst.sadd(0.63, -1.3, other_vector);
+  }
+
+  void
+  vmult_with_update_merged(
+    LinearAlgebra::distributed::Vector<Number> &dst,
+    LinearAlgebra::distributed::Vector<Number> &src,
+    LinearAlgebra::distributed::Vector<Number> &other_vector) const
+  {
+    const std::function<void(const MatrixFree<dim, Number> &,
+                             LinearAlgebra::distributed::Vector<Number> &,
+                             const LinearAlgebra::distributed::Vector<Number> &,
+                             const std::pair<unsigned int, unsigned int> &)>
+      wrap = helmholtz_operator<dim,
+                                fe_degree,
+                                LinearAlgebra::distributed::Vector<Number>,
+                                n_q_points_1d>;
+    data.cell_loop(
+      wrap,
+      dst,
+      src,
+      // operation before cell operation
+      [&](const unsigned int start_range, const unsigned int end_range) {
+        for (unsigned int i = start_range; i < end_range; ++i)
+          {
+            src.local_element(i) += 1.5 * other_vector.local_element(i);
+            other_vector.local_element(i) += 0.7 * dst.local_element(i);
+            dst.local_element(i) = 0;
+          }
+      },
+      // operation after cell operation
+      [&](const unsigned int start_range, const unsigned int end_range) {
+        for (unsigned int i = start_range; i < end_range; ++i)
+          {
+            dst.local_element(i) =
+              0.63 * dst.local_element(i) - 1.3 * other_vector.local_element(i);
+          }
+      });
+  }
+
+private:
+  const MatrixFree<dim, Number> &data;
+};
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(7 - dim);
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+
+  MatrixFree<dim, number> mf_data;
+  {
+    const QGauss<1>                                  quad(fe_degree + 1);
+    typename MatrixFree<dim, number>::AdditionalData data;
+    data.tasks_parallel_scheme = MatrixFree<dim, number>::AdditionalData::none;
+    mf_data.reinit(dof, constraints, quad, data);
+  }
+
+  Matrix<dim, fe_degree, fe_degree + 1, number> mf(mf_data);
+  LinearAlgebra::distributed::Vector<number>    vec1, vec2, vec3;
+  mf_data.initialize_dof_vector(vec1);
+  mf_data.initialize_dof_vector(vec2);
+  mf_data.initialize_dof_vector(vec3);
+
+  for (unsigned int i = 0; i < vec1.local_size(); ++i)
+    {
+      double entry          = random_value<double>();
+      vec1.local_element(i) = entry;
+      entry                 = random_value<double>();
+      vec2.local_element(i) = entry;
+      entry                 = random_value<double>();
+      vec3.local_element(i) = entry;
+    }
+
+  LinearAlgebra::distributed::Vector<number> ref1 = vec1;
+  LinearAlgebra::distributed::Vector<number> ref2 = vec2;
+  LinearAlgebra::distributed::Vector<number> ref3 = vec3;
+
+  mf.vmult_with_update_basic(ref3, ref2, ref1);
+  mf.vmult_with_update_basic(vec3, vec2, vec1);
+
+  vec3 -= ref3;
+  deallog << "Error in 1x merged operation: " << vec3.linfty_norm()
+          << std::endl;
+
+  ref3 = 0;
+
+  mf.vmult_with_update_basic(ref1, ref2, ref3);
+  mf.vmult_with_update_basic(vec1, vec2, vec3);
+
+  mf.vmult_with_update_basic(ref1, ref2, ref3);
+  mf.vmult_with_update_basic(vec1, vec2, vec3);
+
+  vec3 -= ref3;
+  deallog << "Error in 2x merged operation: " << vec3.linfty_norm()
+          << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
+
+  mpi_initlog();
+  deallog << std::setprecision(3);
+
+  test<2, 3, double>();
+  test<2, 3, float>();
+  test<3, 3, double>();
+}

--- a/tests/matrix_free/pre_and_post_loops_01.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/matrix_free/pre_and_post_loops_01.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,0 +1,10 @@
+
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00
+DEAL::Testing FE_Q<3>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00

--- a/tests/matrix_free/pre_and_post_loops_01.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/matrix_free/pre_and_post_loops_01.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,10 @@
+
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00
+DEAL::Testing FE_Q<3>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00

--- a/tests/matrix_free/pre_and_post_loops_02.cc
+++ b/tests/matrix_free/pre_and_post_loops_02.cc
@@ -1,0 +1,218 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test the correctness of the matrix-free cell loop with additional
+// operation_before_loop and operation_after_loop lambdas. similar to
+// pre_and_post_loops_01 but using Dirichlet boundary conditions as
+// constraints
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+#include "matrix_vector_mf.h"
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d = fe_degree + 1,
+          typename Number   = double>
+class Matrix
+{
+public:
+  Matrix(const MatrixFree<dim, Number> &data_in)
+    : data(data_in)
+  {}
+
+  void
+  vmult(LinearAlgebra::distributed::Vector<Number> &      dst,
+        const LinearAlgebra::distributed::Vector<Number> &src) const
+  {
+    const std::function<void(const MatrixFree<dim, Number> &,
+                             LinearAlgebra::distributed::Vector<Number> &,
+                             const LinearAlgebra::distributed::Vector<Number> &,
+                             const std::pair<unsigned int, unsigned int> &)>
+      wrap = helmholtz_operator<dim,
+                                fe_degree,
+                                LinearAlgebra::distributed::Vector<Number>,
+                                n_q_points_1d>;
+    dst    = 0;
+    data.cell_loop(wrap, dst, src);
+    for (auto i : data.get_constrained_dofs())
+      dst.local_element(i) = src.local_element(i);
+  }
+
+  void
+  vmult_with_update_basic(
+    LinearAlgebra::distributed::Vector<Number> &dst,
+    LinearAlgebra::distributed::Vector<Number> &src,
+    LinearAlgebra::distributed::Vector<Number> &other_vector) const
+  {
+    src.add(1.5, other_vector);
+    other_vector.add(0.7, dst);
+    dst = 0;
+    vmult(dst, src);
+    dst.sadd(0.63, -1.3, other_vector);
+  }
+
+  void
+  vmult_with_update_merged(
+    LinearAlgebra::distributed::Vector<Number> &dst,
+    LinearAlgebra::distributed::Vector<Number> &src,
+    LinearAlgebra::distributed::Vector<Number> &other_vector) const
+  {
+    const std::function<void(const MatrixFree<dim, Number> &,
+                             LinearAlgebra::distributed::Vector<Number> &,
+                             const LinearAlgebra::distributed::Vector<Number> &,
+                             const std::pair<unsigned int, unsigned int> &)>
+      wrap = helmholtz_operator<dim,
+                                fe_degree,
+                                LinearAlgebra::distributed::Vector<Number>,
+                                n_q_points_1d>;
+    data.cell_loop(
+      wrap,
+      dst,
+      src,
+      // operation before cell operation
+      [&](const unsigned int start_range, const unsigned int end_range) {
+        for (unsigned int i = start_range; i < end_range; ++i)
+          {
+            src.local_element(i) += 1.5 * other_vector.local_element(i);
+            other_vector.local_element(i) += 0.7 * dst.local_element(i);
+            dst.local_element(i) = 0;
+          }
+      },
+      // operation after cell operation
+      [&](const unsigned int start_range, const unsigned int end_range) {
+        for (unsigned int i = start_range; i < end_range; ++i)
+          {
+            dst.local_element(i) =
+              0.63 * dst.local_element(i) - 1.3 * other_vector.local_element(i);
+          }
+      });
+  }
+
+private:
+  const MatrixFree<dim, Number> &data;
+};
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(7 - dim);
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  IndexSet                  relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dof, relevant_dofs);
+  constraints.reinit(relevant_dofs);
+  VectorTools::interpolate_boundary_values(dof,
+                                           0,
+                                           ZeroFunction<dim>(),
+                                           constraints);
+  constraints.close();
+
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+
+  MatrixFree<dim, number> mf_data;
+  {
+    const QGauss<1>                                  quad(fe_degree + 1);
+    typename MatrixFree<dim, number>::AdditionalData data;
+    data.tasks_parallel_scheme = MatrixFree<dim, number>::AdditionalData::none;
+    mf_data.reinit(dof, constraints, quad, data);
+  }
+
+  Matrix<dim, fe_degree, fe_degree + 1, number> mf(mf_data);
+  LinearAlgebra::distributed::Vector<number>    vec1, vec2, vec3;
+  mf_data.initialize_dof_vector(vec1);
+  mf_data.initialize_dof_vector(vec2);
+  mf_data.initialize_dof_vector(vec3);
+
+  for (unsigned int i = 0; i < vec1.local_size(); ++i)
+    {
+      if (constraints.is_constrained(
+            vec1.get_partitioner()->local_to_global(i)))
+        continue;
+
+      double entry          = random_value<double>();
+      vec1.local_element(i) = entry;
+      entry                 = random_value<double>();
+      vec2.local_element(i) = entry;
+      entry                 = random_value<double>();
+      vec3.local_element(i) = entry;
+    }
+
+  LinearAlgebra::distributed::Vector<number> ref1 = vec1;
+  LinearAlgebra::distributed::Vector<number> ref2 = vec2;
+  LinearAlgebra::distributed::Vector<number> ref3 = vec3;
+
+  mf.vmult_with_update_basic(ref3, ref2, ref1);
+  mf.vmult_with_update_basic(vec3, vec2, vec1);
+
+  vec3 -= ref3;
+  deallog << "Error in 1x merged operation: " << vec3.linfty_norm()
+          << std::endl;
+
+  ref3 = 0;
+
+  mf.vmult_with_update_basic(ref1, ref2, ref3);
+  mf.vmult_with_update_basic(vec1, vec2, vec3);
+
+  mf.vmult_with_update_basic(ref1, ref2, ref3);
+  mf.vmult_with_update_basic(vec1, vec2, vec3);
+
+  vec3 -= ref3;
+  deallog << "Error in 2x merged operation: " << vec3.linfty_norm()
+          << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
+
+  mpi_initlog();
+  deallog << std::setprecision(3);
+
+  test<2, 3, double>();
+  test<2, 3, float>();
+  test<3, 3, double>();
+}

--- a/tests/matrix_free/pre_and_post_loops_02.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/matrix_free/pre_and_post_loops_02.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,10 @@
+
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00
+DEAL::Testing FE_Q<3>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00

--- a/tests/matrix_free/pre_and_post_loops_03.cc
+++ b/tests/matrix_free/pre_and_post_loops_03.cc
@@ -1,0 +1,207 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test the correctness of the matrix-free cell loop with additional
+// operation_before_loop and operation_after_loop lambdas. Similar to
+// pre_and_post_loops_01 but working on a hyper cube where we have some
+// different orientations, stressing different indices
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+#include "matrix_vector_mf.h"
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d = fe_degree + 1,
+          typename Number   = double>
+class Matrix
+{
+public:
+  Matrix(const MatrixFree<dim, Number> &data_in)
+    : data(data_in)
+  {}
+
+  void
+  vmult(LinearAlgebra::distributed::Vector<Number> &      dst,
+        const LinearAlgebra::distributed::Vector<Number> &src) const
+  {
+    const std::function<void(const MatrixFree<dim, Number> &,
+                             LinearAlgebra::distributed::Vector<Number> &,
+                             const LinearAlgebra::distributed::Vector<Number> &,
+                             const std::pair<unsigned int, unsigned int> &)>
+      wrap = helmholtz_operator<dim,
+                                fe_degree,
+                                LinearAlgebra::distributed::Vector<Number>,
+                                n_q_points_1d>;
+    dst    = 0;
+    data.cell_loop(wrap, dst, src);
+    for (auto i : data.get_constrained_dofs())
+      dst.local_element(i) = src.local_element(i);
+  }
+
+  void
+  vmult_with_update_basic(
+    LinearAlgebra::distributed::Vector<Number> &dst,
+    LinearAlgebra::distributed::Vector<Number> &src,
+    LinearAlgebra::distributed::Vector<Number> &other_vector) const
+  {
+    src.add(1.5, other_vector);
+    other_vector.add(0.7, dst);
+    dst = 0;
+    vmult(dst, src);
+    dst.sadd(0.63, -1.3, other_vector);
+  }
+
+  void
+  vmult_with_update_merged(
+    LinearAlgebra::distributed::Vector<Number> &dst,
+    LinearAlgebra::distributed::Vector<Number> &src,
+    LinearAlgebra::distributed::Vector<Number> &other_vector) const
+  {
+    const std::function<void(const MatrixFree<dim, Number> &,
+                             LinearAlgebra::distributed::Vector<Number> &,
+                             const LinearAlgebra::distributed::Vector<Number> &,
+                             const std::pair<unsigned int, unsigned int> &)>
+      wrap = helmholtz_operator<dim,
+                                fe_degree,
+                                LinearAlgebra::distributed::Vector<Number>,
+                                n_q_points_1d>;
+    data.cell_loop(
+      wrap,
+      dst,
+      src,
+      // operation before cell operation
+      [&](const unsigned int start_range, const unsigned int end_range) {
+        for (unsigned int i = start_range; i < end_range; ++i)
+          {
+            src.local_element(i) += 1.5 * other_vector.local_element(i);
+            other_vector.local_element(i) += 0.7 * dst.local_element(i);
+            dst.local_element(i) = 0;
+          }
+      },
+      // operation after cell operation
+      [&](const unsigned int start_range, const unsigned int end_range) {
+        for (unsigned int i = start_range; i < end_range; ++i)
+          {
+            dst.local_element(i) =
+              0.63 * dst.local_element(i) - 1.3 * other_vector.local_element(i);
+          }
+      });
+  }
+
+private:
+  const MatrixFree<dim, Number> &data;
+};
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_ball(tria);
+  tria.refine_global(6 - dim);
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+
+  MatrixFree<dim, number> mf_data;
+  {
+    const QGauss<1>                                  quad(fe_degree + 1);
+    typename MatrixFree<dim, number>::AdditionalData data;
+    data.tasks_parallel_scheme = MatrixFree<dim, number>::AdditionalData::none;
+    mf_data.reinit(dof, constraints, quad, data);
+  }
+
+  Matrix<dim, fe_degree, fe_degree + 1, number> mf(mf_data);
+  LinearAlgebra::distributed::Vector<number>    vec1, vec2, vec3;
+  mf_data.initialize_dof_vector(vec1);
+  mf_data.initialize_dof_vector(vec2);
+  mf_data.initialize_dof_vector(vec3);
+
+  for (unsigned int i = 0; i < vec1.local_size(); ++i)
+    {
+      double entry          = random_value<double>();
+      vec1.local_element(i) = entry;
+      entry                 = random_value<double>();
+      vec2.local_element(i) = entry;
+      entry                 = random_value<double>();
+      vec3.local_element(i) = entry;
+    }
+
+  LinearAlgebra::distributed::Vector<number> ref1 = vec1;
+  LinearAlgebra::distributed::Vector<number> ref2 = vec2;
+  LinearAlgebra::distributed::Vector<number> ref3 = vec3;
+
+  mf.vmult_with_update_basic(ref3, ref2, ref1);
+  mf.vmult_with_update_basic(vec3, vec2, vec1);
+
+  vec3 -= ref3;
+  deallog << "Error in 1x merged operation: " << vec3.linfty_norm()
+          << std::endl;
+
+  ref3 = 0;
+
+  mf.vmult_with_update_basic(ref1, ref2, ref3);
+  mf.vmult_with_update_basic(vec1, vec2, vec3);
+
+  mf.vmult_with_update_basic(ref1, ref2, ref3);
+  mf.vmult_with_update_basic(vec1, vec2, vec3);
+
+  vec3 -= ref3;
+  deallog << "Error in 2x merged operation: " << vec3.linfty_norm()
+          << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
+
+  mpi_initlog();
+  deallog << std::setprecision(3);
+
+  test<2, 3, double>();
+  test<2, 3, float>();
+  test<3, 3, double>();
+}

--- a/tests/matrix_free/pre_and_post_loops_03.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/matrix_free/pre_and_post_loops_03.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,10 @@
+
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00
+DEAL::Testing FE_Q<3>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00

--- a/tests/matrix_free/pre_and_post_loops_04.cc
+++ b/tests/matrix_free/pre_and_post_loops_04.cc
@@ -1,0 +1,202 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test the correctness of the matrix-free cell loop with additional
+// operation_before_loop and operation_after_loop lambdas. Similar to
+// pre_and_post_loops_01 but using a pointer to a member function in
+// MatrixFree::cell_loop rather than a separate function
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+#include "matrix_vector_mf.h"
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d = fe_degree + 1,
+          typename Number   = double>
+class Matrix
+{
+public:
+  Matrix(const MatrixFree<dim, Number> &data_in)
+    : data(data_in)
+  {}
+
+  void
+  vmult(LinearAlgebra::distributed::Vector<Number> &      dst,
+        const LinearAlgebra::distributed::Vector<Number> &src) const
+  {
+    dst = 0;
+    data.cell_loop(&Matrix::local_apply, this, dst, src);
+    for (auto i : data.get_constrained_dofs())
+      dst.local_element(i) = src.local_element(i);
+  }
+
+  void
+  vmult_with_update_basic(
+    LinearAlgebra::distributed::Vector<Number> &dst,
+    LinearAlgebra::distributed::Vector<Number> &src,
+    LinearAlgebra::distributed::Vector<Number> &other_vector) const
+  {
+    src.add(1.5, other_vector);
+    other_vector.add(0.7, dst);
+    dst = 0;
+    vmult(dst, src);
+    dst.sadd(0.63, -1.3, other_vector);
+  }
+
+  void
+  vmult_with_update_merged(
+    LinearAlgebra::distributed::Vector<Number> &dst,
+    LinearAlgebra::distributed::Vector<Number> &src,
+    LinearAlgebra::distributed::Vector<Number> &other_vector) const
+  {
+    data.cell_loop(
+      &Matrix::local_apply,
+      this,
+      dst,
+      src,
+      // operation before cell operation
+      [&](const unsigned int start_range, const unsigned int end_range) {
+        for (unsigned int i = start_range; i < end_range; ++i)
+          {
+            src.local_element(i) += 1.5 * other_vector.local_element(i);
+            other_vector.local_element(i) += 0.7 * dst.local_element(i);
+            dst.local_element(i) = 0;
+          }
+      },
+      // operation after cell operation
+      [&](const unsigned int start_range, const unsigned int end_range) {
+        for (unsigned int i = start_range; i < end_range; ++i)
+          {
+            dst.local_element(i) =
+              0.63 * dst.local_element(i) - 1.3 * other_vector.local_element(i);
+          }
+      });
+  }
+
+private:
+  const MatrixFree<dim, Number> &data;
+
+  void
+  local_apply(const MatrixFree<dim, Number> &,
+              LinearAlgebra::distributed::Vector<Number> &      dst,
+              const LinearAlgebra::distributed::Vector<Number> &src,
+              const std::pair<unsigned int, unsigned int> &     range) const
+  {
+    helmholtz_operator<dim,
+                       fe_degree,
+                       LinearAlgebra::distributed::Vector<Number>,
+                       n_q_points_1d>(data, dst, src, range);
+  }
+};
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(7 - dim);
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+
+  MatrixFree<dim, number> mf_data;
+  {
+    const QGauss<1>                                  quad(fe_degree + 1);
+    typename MatrixFree<dim, number>::AdditionalData data;
+    data.tasks_parallel_scheme = MatrixFree<dim, number>::AdditionalData::none;
+    mf_data.reinit(dof, constraints, quad, data);
+  }
+
+  Matrix<dim, fe_degree, fe_degree + 1, number> mf(mf_data);
+  LinearAlgebra::distributed::Vector<number>    vec1, vec2, vec3;
+  mf_data.initialize_dof_vector(vec1);
+  mf_data.initialize_dof_vector(vec2);
+  mf_data.initialize_dof_vector(vec3);
+
+  for (unsigned int i = 0; i < vec1.local_size(); ++i)
+    {
+      double entry          = random_value<double>();
+      vec1.local_element(i) = entry;
+      entry                 = random_value<double>();
+      vec2.local_element(i) = entry;
+      entry                 = random_value<double>();
+      vec3.local_element(i) = entry;
+    }
+
+  LinearAlgebra::distributed::Vector<number> ref1 = vec1;
+  LinearAlgebra::distributed::Vector<number> ref2 = vec2;
+  LinearAlgebra::distributed::Vector<number> ref3 = vec3;
+
+  mf.vmult_with_update_basic(ref3, ref2, ref1);
+  mf.vmult_with_update_basic(vec3, vec2, vec1);
+
+  vec3 -= ref3;
+  deallog << "Error in 1x merged operation: " << vec3.linfty_norm()
+          << std::endl;
+
+  ref3 = 0;
+
+  mf.vmult_with_update_basic(ref1, ref2, ref3);
+  mf.vmult_with_update_basic(vec1, vec2, vec3);
+
+  mf.vmult_with_update_basic(ref1, ref2, ref3);
+  mf.vmult_with_update_basic(vec1, vec2, vec3);
+
+  vec3 -= ref3;
+  deallog << "Error in 2x merged operation: " << vec3.linfty_norm()
+          << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
+
+  mpi_initlog();
+  deallog << std::setprecision(3);
+
+  test<2, 3, double>();
+}

--- a/tests/matrix_free/pre_and_post_loops_04.with_mpi=true.with_p4est=true.mpirun=2.output
+++ b/tests/matrix_free/pre_and_post_loops_04.with_mpi=true.with_p4est=true.mpirun=2.output
@@ -1,0 +1,4 @@
+
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00

--- a/tests/matrix_free/pre_and_post_loops_05.cc
+++ b/tests/matrix_free/pre_and_post_loops_05.cc
@@ -1,0 +1,221 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test the correctness of the matrix-free cell loop with additional
+// operation_before_loop and operation_after_loop lambdas. Similar to
+// pre_and_post_loops_01 but using a system of two DoFHandler objects,
+// operating on the second one
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+#include "matrix_vector_mf.h"
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d = fe_degree + 1,
+          typename Number   = double>
+class Matrix
+{
+public:
+  Matrix(const MatrixFree<dim, Number> &data_in)
+    : data(data_in)
+  {}
+
+  void
+  vmult(LinearAlgebra::distributed::Vector<Number> &      dst,
+        const LinearAlgebra::distributed::Vector<Number> &src) const
+  {
+    dst = 0;
+    data.cell_loop(&Matrix::local_apply, this, dst, src);
+    for (auto i : data.get_constrained_dofs())
+      dst.local_element(i) = src.local_element(i);
+  }
+
+  void
+  vmult_with_update_basic(
+    LinearAlgebra::distributed::Vector<Number> &dst,
+    LinearAlgebra::distributed::Vector<Number> &src,
+    LinearAlgebra::distributed::Vector<Number> &other_vector) const
+  {
+    src.add(1.5, other_vector);
+    other_vector.add(0.7, dst);
+    dst = 0;
+    vmult(dst, src);
+    dst.sadd(0.63, -1.3, other_vector);
+  }
+
+  void
+  vmult_with_update_merged(
+    LinearAlgebra::distributed::Vector<Number> &dst,
+    LinearAlgebra::distributed::Vector<Number> &src,
+    LinearAlgebra::distributed::Vector<Number> &other_vector) const
+  {
+    data.cell_loop(
+      &Matrix::local_apply,
+      this,
+      dst,
+      src,
+      // operation before cell operation
+      [&](const unsigned int start_range, const unsigned int end_range) {
+        for (unsigned int i = start_range; i < end_range; ++i)
+          {
+            src.local_element(i) += 1.5 * other_vector.local_element(i);
+            other_vector.local_element(i) += 0.7 * dst.local_element(i);
+            dst.local_element(i) = 0;
+          }
+      },
+      // operation after cell operation
+      [&](const unsigned int start_range, const unsigned int end_range) {
+        for (unsigned int i = start_range; i < end_range; ++i)
+          {
+            dst.local_element(i) =
+              0.63 * dst.local_element(i) - 1.3 * other_vector.local_element(i);
+          }
+      },
+      // dof handler component for the two lambdas
+      1);
+  }
+
+private:
+  const MatrixFree<dim, Number> &data;
+
+  void
+  local_apply(const MatrixFree<dim, Number> &,
+              LinearAlgebra::distributed::Vector<Number> &      dst,
+              const LinearAlgebra::distributed::Vector<Number> &src,
+              const std::pair<unsigned int, unsigned int> &     range) const
+  {
+    FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number> fe_eval(data, 1);
+
+    for (unsigned int cell = range.first; cell < range.second; ++cell)
+      {
+        fe_eval.reinit(cell);
+        fe_eval.read_dof_values(src);
+        fe_eval.evaluate(false, true);
+        for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
+          fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
+        fe_eval.integrate(false, true);
+        fe_eval.distribute_local_to_global(dst);
+      }
+  }
+};
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(7 - dim);
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  FE_Q<dim>       fe2(1);
+  DoFHandler<dim> dof2(tria);
+  dof2.distribute_dofs(fe2);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+
+  MatrixFree<dim, number> mf_data;
+  {
+    const QGauss<1>                                  quad(fe_degree + 1);
+    typename MatrixFree<dim, number>::AdditionalData data;
+    data.tasks_parallel_scheme = MatrixFree<dim, number>::AdditionalData::none;
+    mf_data.reinit(std::vector<const DoFHandler<dim> *>({&dof2, &dof}),
+                   std::vector<const AffineConstraints<double> *>(
+                     {&constraints, &constraints}),
+                   std::vector<Quadrature<1>>({quad}),
+                   data);
+  }
+
+  Matrix<dim, fe_degree, fe_degree + 1, number> mf(mf_data);
+  LinearAlgebra::distributed::Vector<number>    vec1, vec2, vec3;
+  mf_data.initialize_dof_vector(vec1, 1);
+  mf_data.initialize_dof_vector(vec2, 1);
+  mf_data.initialize_dof_vector(vec3, 1);
+
+  for (unsigned int i = 0; i < vec1.local_size(); ++i)
+    {
+      double entry          = random_value<double>();
+      vec1.local_element(i) = entry;
+      entry                 = random_value<double>();
+      vec2.local_element(i) = entry;
+      entry                 = random_value<double>();
+      vec3.local_element(i) = entry;
+    }
+
+  LinearAlgebra::distributed::Vector<number> ref1 = vec1;
+  LinearAlgebra::distributed::Vector<number> ref2 = vec2;
+  LinearAlgebra::distributed::Vector<number> ref3 = vec3;
+
+  mf.vmult_with_update_basic(ref3, ref2, ref1);
+  mf.vmult_with_update_basic(vec3, vec2, vec1);
+
+  vec3 -= ref3;
+  deallog << "Error in 1x merged operation: " << vec3.linfty_norm()
+          << std::endl;
+
+  ref3 = 0;
+
+  mf.vmult_with_update_basic(ref1, ref2, ref3);
+  mf.vmult_with_update_basic(vec1, vec2, vec3);
+
+  mf.vmult_with_update_basic(ref1, ref2, ref3);
+  mf.vmult_with_update_basic(vec1, vec2, vec3);
+
+  vec3 -= ref3;
+  deallog << "Error in 2x merged operation: " << vec3.linfty_norm()
+          << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
+
+  mpi_initlog();
+  deallog << std::setprecision(3);
+
+  test<2, 3, double>();
+  test<2, 3, float>();
+  test<3, 2, double>();
+}

--- a/tests/matrix_free/pre_and_post_loops_05.with_mpi=true.with_p4est=true.mpirun=2.output
+++ b/tests/matrix_free/pre_and_post_loops_05.with_mpi=true.with_p4est=true.mpirun=2.output
@@ -1,0 +1,10 @@
+
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00
+DEAL::Testing FE_Q<2>(3)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00
+DEAL::Testing FE_Q<3>(2)
+DEAL::Error in 1x merged operation: 0.00
+DEAL::Error in 2x merged operation: 0.00


### PR DESCRIPTION
This PR enables `MatrixFree::cell_loop` to schedule an operation before the cell operation first touches an unknown, and another operation after it last touches an unknown. The goal is to do operations on vectors close to the access to the vectors in matrix-free loops to improve caching. This can be used e.g. for conjugate gradient solvers with simple preconditioners, or with PreconditionChebyshev.

For conjugate gradients with a diagonal preconditioners, one can get very nice performance from this setup (using some special variant that I still need to commit in a later PR in the coming weeks):
![locality_loops](https://user-images.githubusercontent.com/8276200/64602128-7a437900-d3be-11e9-8354-0a7cdc0415d4.png)

For large sizes (many dofs) at the right of the plot, I can improve performance of a conjugate gradient solver with matrix-free implementation (and special geometry approximations) by more than a factor of 2, compare the "fully merged" line with the "plain CG" line in the plot, where the former uses the proposed loop facilities. Now this is of course application-dependent, i.e., the cost of the matrix-vector products compared to access to vectors. The motivation of this contribution is that I have several cases where the matrix-vector product no longer dominates, so we need an algorithm-level optimization.

I will later also add one or two tests doing some generic stuff like update a vector before/after to show how this works, but the code is ready. I have some code [in a private branch](https://github.com/kronbichler/ceed_benchmarks_dealii/blob/experimental_merge_vector/common_code/poisson_operator.h#L361-L397) somewhere that generated the above graph, and work towards that in several PRs.