### PR TITLE
p:d:step-27: Adjusted AdditionalData object for Trilinos.

### DIFF
--- a/tests/mpi/trilinos_step-27.cc
+++ b/tests/mpi/trilinos_step-27.cc
@@ -342,8 +342,11 @@ namespace Step27
     // Loss of precision with a factor of 1e-12 with Trilinos
     LA::SolverCG cg(solver_control);
 
-    LA::MPI::PreconditionAMG preconditioner;
-    preconditioner.initialize(system_matrix);
+    LA::MPI::PreconditionAMG                 preconditioner;
+    LA::MPI::PreconditionAMG::AdditionalData data;
+    data.elliptic              = true;
+    data.higher_order_elements = true;
+    preconditioner.initialize(system_matrix, data);
 
     check_solver_within_range(cg.solve(system_matrix,
                                        completely_distributed_solution,


### PR DESCRIPTION
Following #8729, I adjusted the `AdditionalData` object for the `Trilinos` AMG preconditioner to enable `higher_order_elements` in the parallel version of `step-27`.

However, that does not seem to have a big impact on the test results, since the number of iterations is preserved. The reason for this may be the small size of the test scenario. I'll check if this is of any benefit on a larger scenario on our supercomputer...

Merge or discard how you like. Or we may leave this PR open and adjust it depending on the discussion on #8729.