### PR TITLE
add functions to access svd u and vt variables

### DIFF
--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -873,14 +873,14 @@ public:
   singular_value(const size_type i) const;
 
   /**
-   * Retrieves #svd_u matrix after compute_svd() or compute_inverse_svd() was
+   * Retrieve the matrix #svd_u after compute_svd() or compute_inverse_svd() was
    * called.
    */
   inline const LAPACKFullMatrix<number> &
   get_svd_u() const;
 
   /**
-   * Retrieves #svd_vt matrix after compute_svd() or compute_inverse_svd() was
+   * Retrieve the matrix #svd_vt after compute_svd() or compute_inverse_svd() was
    * called.
    */
   inline const LAPACKFullMatrix<number>&

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -815,7 +815,17 @@ public:
    *
    * Requires that the #state is LAPACKSupport::matrix, fills the data members
    * #wr, #svd_u, and #svd_vt, and leaves the object in the #state
-   * LAPACKSupport::svd.
+   * LAPACKSupport::svd. 
+   * 
+   * The singular value decomposition factorizes the provided matrix (A) into 
+   * three parts U, sigma and the transpose of V (V^T), such that A = U sigma 
+   * V^T. Sigma is a MxN matrix which contains the singular values of A on 
+   * the diagonal while all the other elements are zero. U is a MxM orthogonal 
+   * matrix containing the left singular vectors corresponding to the singular
+   * values of A. V is a NxN orthonal matrix containing the right singular 
+   * vectors corresponding the the singular values of A.
+   *  
+   * Note that the variable #svd_vt contains the tranposed of V.  
    */
   void
   compute_svd();

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -818,14 +818,14 @@ public:
    * LAPACKSupport::svd. 
    * 
    * The singular value decomposition factorizes the provided matrix (A) into 
-   * three parts U, sigma and the transpose of V (V^T), such that A = U sigma 
+   * three parts: U, sigma, and the transpose of V (V^T), such that A = U sigma 
    * V^T. Sigma is a MxN matrix which contains the singular values of A on 
    * the diagonal while all the other elements are zero. U is a MxM orthogonal 
    * matrix containing the left singular vectors corresponding to the singular
    * values of A. V is a NxN orthonal matrix containing the right singular 
    * vectors corresponding the the singular values of A.
    *  
-   * Note that the variable #svd_vt contains the tranposed of V.  
+   * Note that the variable #svd_vt contains the tranpose of V and can be accessed by get_svd_vt(), while U is accessed with get_svd_u().
    */
   void
   compute_svd();

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -815,17 +815,18 @@ public:
    *
    * Requires that the #state is LAPACKSupport::matrix, fills the data members
    * #wr, #svd_u, and #svd_vt, and leaves the object in the #state
-   * LAPACKSupport::svd. 
-   * 
-   * The singular value decomposition factorizes the provided matrix (A) into 
-   * three parts: U, sigma, and the transpose of V (V^T), such that A = U sigma 
-   * V^T. Sigma is a MxN matrix which contains the singular values of A on 
-   * the diagonal while all the other elements are zero. U is a MxM orthogonal 
+   * LAPACKSupport::svd.
+   *
+   * The singular value decomposition factorizes the provided matrix (A) into
+   * three parts: U, sigma, and the transpose of V (V^T), such that A = U sigma
+   * V^T. Sigma is a MxN matrix which contains the singular values of A on
+   * the diagonal while all the other elements are zero. U is a MxM orthogonal
    * matrix containing the left singular vectors corresponding to the singular
-   * values of A. V is a NxN orthonal matrix containing the right singular 
+   * values of A. V is a NxN orthonal matrix containing the right singular
    * vectors corresponding the the singular values of A.
-   *  
-   * Note that the variable #svd_vt contains the tranpose of V and can be accessed by get_svd_vt(), while U is accessed with get_svd_u().
+   *
+   * Note that the variable #svd_vt contains the tranpose of V and can be
+   * accessed by get_svd_vt(), while U is accessed with get_svd_u().
    */
   void
   compute_svd();
@@ -880,10 +881,10 @@ public:
   get_svd_u() const;
 
   /**
-   * Retrieve the matrix #svd_vt after compute_svd() or compute_inverse_svd() was
-   * called.
+   * Retrieve the matrix #svd_vt after compute_svd() or compute_inverse_svd()
+   * was called.
    */
-  inline const LAPACKFullMatrix<number>&
+  inline const LAPACKFullMatrix<number> &
   get_svd_vt() const;
 
   /**

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -863,6 +863,20 @@ public:
   singular_value(const size_type i) const;
 
   /**
+   * Retrieves #svd_u matrix after compute_svd() or compute_inverse_svd() was
+   * called.
+   */
+  inline const LAPACKFullMatrix<number> &
+  get_svd_u() const;
+
+  /**
+   * Retrieves #svd_vt matrix after compute_svd() or compute_inverse_svd() was
+   * called.
+   */
+  inline const LAPACKFullMatrix<number>&
+  get_svd_vt() const;
+
+  /**
    * Print the matrix and allow formatting of entries.
    *
    * The parameters allow for a flexible setting of the output format:
@@ -1171,6 +1185,28 @@ LAPACKFullMatrix<number>::singular_value(const size_type i) const
   AssertIndexRange(i, wr.size());
 
   return wr[i];
+}
+
+
+template <typename number>
+inline const LAPACKFullMatrix<number> &
+LAPACKFullMatrix<number>::get_svd_u() const
+{
+  Assert(state == LAPACKSupport::svd || state == LAPACKSupport::inverse_svd,
+         LAPACKSupport::ExcState(state));
+
+  return *svd_u;
+}
+
+
+template <typename number>
+inline const LAPACKFullMatrix<number> &
+LAPACKFullMatrix<number>::get_svd_vt() const
+{
+  Assert(state == LAPACKSupport::svd || state == LAPACKSupport::inverse_svd,
+         LAPACKSupport::ExcState(state));
+
+  return *svd_vt;
 }
 
 


### PR DESCRIPTION
This pull request adds two functions to the LAPACKFullMatrix class to give read access to the private variables `svd_u` and `svd_vt` generated by the `compute_svd` function. 