### PR TITLE
Change TensorProductPolynomialsBubbles from "is-a" to "has-a" TensorProductPolynomials

### DIFF
--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -29,6 +29,9 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+template <int dim>
+class TensorProductPolynomialsBubbles;
+
 /**
  * @addtogroup Polynomials
  * @{
@@ -227,6 +230,12 @@ protected:
   void
   compute_index(const unsigned int i,
                 unsigned int (&indices)[(dim > 0 ? dim : 1)]) const;
+
+  /**
+   * TensorProductPolynomialsBubbles has a TensorProductPolynomials class
+   * so we declare it as a friend class.
+   */
+  friend class TensorProductPolynomialsBubbles<dim>;
 };
 
 


### PR DESCRIPTION
This is an interesting sub-problem that appeared while attempting to assign a base class of `ScalarPolynomialsBase` to `TensorProductPolynomials` that was discussed in the comments of #8723. This is required in order to eventually remove the `PolynomialType` template argument from `FE_Poly`.

I made `TensorProductPolynomialsBubbles` a friend of `TensorProductPolynomials` and then assigned the computations in `TensorProductPolynomialsBubbles` to the member variable `tensor_polys`, which is just an object of type `TensorProductPolynomials`. 

I will do a separate PR for `TensorProductPolynomialsConst` since that must also be done, but all tests of the form `base/.*debug` pass on my end, so I think this is ready for testing.