### PR TITLE
Fix the bounds of an index computation.

### DIFF
--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -329,7 +329,7 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
 
                               for (unsigned int i = 0;
                                    i < scratch_data.patch_values_scalar
-                                         .solution_values.size();
+                                         .solution_hessians.size();
                                    ++i)
                                 {
                                   AssertDimension(
@@ -412,7 +412,7 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
 
                               for (unsigned int i = 0;
                                    i < scratch_data.patch_values_scalar
-                                         .solution_values.size();
+                                         .solution_hessians.size();
                                    ++i)
                                 {
                                   AssertDimension(


### PR DESCRIPTION
In #8648, I had used the wrong variable to query a loop bound. I can't think of a case where this would lead to wrong results, but conceptually we ought to terminate the loop based on the array we're reading/writing.

Part of #1894.