### PR TITLE
Change gzip compression level to best_speed

### DIFF
--- a/source/dofs/number_cache.cc
+++ b/source/dofs/number_cache.cc
@@ -153,7 +153,7 @@ namespace internal
                 boost::iostreams::filtering_ostream out;
                 out.push(boost::iostreams::gzip_compressor(
                   boost::iostreams::gzip_params(
-                    boost::iostreams::gzip::best_compression)));
+                    boost::iostreams::gzip::best_speed)));
                 out.push(boost::iostreams::back_inserter(my_data));
 
                 boost::archive::binary_oarchive archive(out);


### PR DESCRIPTION
This change addresses one of three places where we use gzip. The second one, discussed in #8740, will be tackled by an upcoming PR. The third one in [Utilities::pack()](https://github.com/dealii/dealii/blob/master/include/deal.II/base/utilities.h#L1214) was already changed in #8513 to disable compression altogether. To reduce impact on the test suite, I have not touched it, but I can if one insists. From my experiments in #8740 for the `dof_handler_policy.cc` case the difference between `default_compression` and `best_speed` is maybe 20-50%, and `best_speed` in that case was around 2x slower than no compression at all on 50k MPI ranks (including the time to actually send the data).