### PR TITLE
Improve performance of DoFHandler::distribute_mg_dofs

### DIFF
--- a/doc/news/changes/minor/20190913MartinKronbichler
+++ b/doc/news/changes/minor/20190913MartinKronbichler
@@ -1,0 +1,5 @@
+Fixed: DoFHandler::distribute_mg_dofs() for distributed triangulations has
+been made up to ten times faster by replacing an inefficient function for the
+exchange of ghosted level degrees of freedom.
+<br>
+(Martin Kronbichler, 2019/09/13)


### PR DESCRIPTION
Fixes #8740.

Even though I though in #8740 that I would simply change the compression level, I decided that it was worth to delete around 150 lines of code by sending the uncompressed data. So this is a double gain - simpler code and faster implementation.

While there, I also used a slightly cheaper MPI routine, `MPI_Bcast` rather than `MPI_Allreduce` for counting the global number of dofs since we have that information on one processor already.