### PR TITLE
Move operator== from a test to the CellData class itself.

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -193,6 +193,12 @@ struct CellData
   CellData();
 
   /**
+   * Comparison operator.
+   */
+  bool
+  operator==(const CellData<structdim> &other) const;
+
+  /**
    * Boost serialization function
    */
   template <class Archive>
@@ -4117,18 +4123,6 @@ private:
 
 #ifndef DOXYGEN
 
-
-template <int structdim>
-inline CellData<structdim>::CellData()
-{
-  for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell; ++i)
-    vertices[i] = numbers::invalid_unsigned_int;
-
-  material_id = 0;
-
-  // And the manifold to be invalid
-  manifold_id = numbers::flat_manifold_id;
-}
 
 template <int structdim>
 template <class Archive>

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -43,6 +43,40 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+
+template <int structdim>
+CellData<structdim>::CellData()
+  : material_id(0)
+  , manifold_id(numbers::flat_manifold_id)
+{
+  for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell; ++i)
+    vertices[i] = numbers::invalid_unsigned_int;
+}
+
+
+
+template <int structdim>
+bool
+CellData<structdim>::operator==(const CellData<structdim> &other) const
+{
+  for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell; i++)
+    if (vertices[i] != other.vertices[i])
+      return false;
+
+  if (material_id != other.material_id)
+    return false;
+
+  if (boundary_id != other.boundary_id)
+    return false;
+
+  if (manifold_id != other.manifold_id)
+    return false;
+
+  return true;
+}
+
+
+
 bool
 SubCellData::check_consistency(const unsigned int dim) const
 {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -49,8 +49,9 @@ CellData<structdim>::CellData()
   : material_id(0)
   , manifold_id(numbers::flat_manifold_id)
 {
-  for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell; ++i)
-    vertices[i] = numbers::invalid_unsigned_int;
+  std::fill(std::begin(vertices),
+            std::end(vertices),
+            numbers::invalid_unsigned_int);
 }
 
 

--- a/tests/serialization/cell_data_1.cc
+++ b/tests/serialization/cell_data_1.cc
@@ -22,26 +22,6 @@
 
 #include "serialization.h"
 
-namespace dealii
-{
-  template <int structdim>
-  bool
-  operator==(const CellData<structdim> &t1, const CellData<structdim> &t2)
-  {
-    for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell;
-         i++)
-      if (t1.vertices[i] != t2.vertices[i])
-        return false;
-
-    if (t1.material_id != t2.material_id)
-      return false;
-    if (t1.boundary_id != t2.boundary_id)
-      return false;
-    if (t1.manifold_id != t2.manifold_id)
-      return false;
-    return true;
-  }
-} // namespace dealii
 
 template <int structdim>
 void


### PR DESCRIPTION
This has the advantage that if that class ever gains a new member variable,
it is much easier to update the code for operator== since it's obvious
that one has to update it. If the code remained in the test, we would almost
certainly forget to update it.

Follow-up to #8746. @peterrum -- FYI.