### PR TITLE
Disable compression in ghost exchange of DoFHandler

### DIFF
--- a/doc/news/changes/minor/20190916MartinKronbichler
+++ b/doc/news/changes/minor/20190916MartinKronbichler
@@ -1,0 +1,6 @@
+Improved: The gzip compression previously applied by
+GridTools::exchange_cell_data_to_ghosts() has been disabled because network
+throughput is typically higher than the rate by which gzip is able to
+compress. This speeds up DoFHandler::distribute_dofs(), among others.
+<br>
+(Martin Kronbichler, 2019/09/16)

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3892,7 +3892,7 @@ namespace GridTools
         // pack all the data into the buffer for this recipient and send it.
         // keep data around till we can make sure that the packet has been
         // received
-        sendbuffers[idx] = Utilities::pack(data);
+        sendbuffers[idx] = Utilities::pack(data, /*enable_compression*/ false);
         const int ierr   = MPI_Isend(sendbuffers[idx].data(),
                                    sendbuffers[idx].size(),
                                    MPI_BYTE,
@@ -3928,7 +3928,8 @@ namespace GridTools
         AssertThrowMPI(ierr);
 
         auto cellinfo =
-          Utilities::unpack<CellDataTransferBuffer<dim, DataType>>(receive);
+          Utilities::unpack<CellDataTransferBuffer<dim, DataType>>(
+            receive, /*enable_compression*/ false);
 
         DataType *data = cellinfo.data.data();
         for (unsigned int c = 0; c < cellinfo.cell_ids.size(); ++c, ++data)


### PR DESCRIPTION
Similarly to #8749, it is also better to not compress the ghost indices for DoFHandler. As observed in #8747, we already used the faster `default_compression` in `Utilities::pack`, but it is still slower than no compression at all. As also shown in #8513, the packing in terms of boost serialization still induces some overhead, but due to the generality of that function I refrain from further changes which would make the code more complicated to read.

To fix the case, I added a parameter to `GridTools::exchange_cell_data_to_ghosts` to enable/disable compression. Since I believe no compression is usually faster, I disabled it, but this is up to discussion with @bangerth, @marcfehling, @peterrum and @gassmoeller.