### PR TITLE
improve check for CAN_CALL_NONCONSTEXPR

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -733,12 +733,14 @@ CHECK_CXX_SOURCE_COMPILES(
 #
 CHECK_CXX_SOURCE_COMPILES(
   "
+  #define Assert(x,y) if (!(x)) throw y;
   void bar()
   {}
 
   constexpr int
   foo(const int n)
   {
+    Assert(n>0, \"hello\");
     if(!(n >= 0))
       bar();
     return n;


### PR DESCRIPTION
On intel 19.0.5, the check
DEAL_II_HAVE_CXX14_CONSTEXPR_CAN_CALL_NONCONSTEXPR passes but
compilation of an assert (and as such a throw call) fails.
Improve the test to catch this.
I can confirm that clang6 still passes this check as before.
fixes  #8758