### PR TITLE
fixed inconsistent state in TimestepControl

### DIFF
--- a/source/algorithms/timestep_control.cc
+++ b/source/algorithms/timestep_control.cc
@@ -79,6 +79,7 @@ TimestepControl::parse_parameters(ParameterHandler &param)
     strategy_val = uniform;
   else if (strategy == std::string("doubling"))
     strategy_val = doubling;
+  restart();
 }
 
 


### PR DESCRIPTION
Calling `TimestepControl::parse_parameters()` is supposed to initialize the object. However, it does not update the internal variables such as `now_val`, `step_val`  etc, creating an inconsistent state. Calling the `restart()` method fixes this problem.