### PR TITLE
Change TensorProductPolynomialsConst from "is-a" to "has-a" TensorProductPolynomials

### DIFF
--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -30,8 +30,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations for friends
+// TODO: We may be able to modify these classes so they aren't
+// required to be friends
 template <int dim>
 class TensorProductPolynomialsBubbles;
+template <int dim>
+class TensorProductPolynomialsConst;
 
 /**
  * @addtogroup Polynomials
@@ -236,6 +241,12 @@ protected:
    * so we declare it as a friend class.
    */
   friend class TensorProductPolynomialsBubbles<dim>;
+
+  /**
+   * TensorProductPolynomialsConst has a TensorProductPolynomials class
+   * so we declare it as a friend class.
+   */
+  friend class TensorProductPolynomialsConst<dim>;
 };
 
 

--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -178,7 +178,7 @@ public:
   n() const;
 
   /**
-   * Return the name of the space, which is <tt>AnisotropicPolynomials</tt>.
+   * Return the name of the space, which is <tt>TensorProductPolynomialsBubbles</tt>.
    */
   std::string
   name() const override;

--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -178,7 +178,8 @@ public:
   n() const;
 
   /**
-   * Return the name of the space, which is <tt>TensorProductPolynomialsBubbles</tt>.
+   * Return the name of the space, which is
+   * <tt>TensorProductPolynomialsBubbles</tt>.
    */
   std::string
   name() const override;

--- a/include/deal.II/base/tensor_product_polynomials_const.h
+++ b/include/deal.II/base/tensor_product_polynomials_const.h
@@ -45,7 +45,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Timo Heister, 2012
  */
 template <int dim>
-class TensorProductPolynomialsConst
+class TensorProductPolynomialsConst : public ScalarPolynomialsBase<dim>
 {
 public:
   /**
@@ -178,6 +178,19 @@ public:
   unsigned int
   n() const;
 
+  /**
+   * Return the name of the space, which is
+   * <tt>TensorProductPolynomialsConst</tt>.
+   */
+  std::string
+  name() const override;
+
+  /**
+   * @copydoc ScalarPolynomialsBase<dim>::clone()
+   */
+  virtual std::unique_ptr<ScalarPolynomialsBase<dim>>
+  clone() const override;
+
 private:
   /**
    * The TensorProductPolynomials object
@@ -206,7 +219,8 @@ template <int dim>
 template <class Pol>
 inline TensorProductPolynomialsConst<dim>::TensorProductPolynomialsConst(
   const std::vector<Pol> &pols)
-  : tensor_polys(pols)
+  : ScalarPolynomialsBase<dim>(1, Utilities::fixed_power<dim>(pols.size()) + 1)
+  , tensor_polys(pols)
   , index_map(tensor_polys.n() + 1)
   , index_map_inverse(tensor_polys.n() + 1)
 {}

--- a/include/deal.II/base/tensor_product_polynomials_const.h
+++ b/include/deal.II/base/tensor_product_polynomials_const.h
@@ -252,6 +252,13 @@ TensorProductPolynomialsConst<dim>::get_numbering_inverse() const
 }
 
 
+template <int dim>
+inline std::string
+TensorProductPolynomialsConst<dim>::name() const
+{
+  return "TensorProductPolynomialsConst";
+}
+
 
 template <>
 inline unsigned int
@@ -259,6 +266,7 @@ TensorProductPolynomialsConst<0>::n() const
 {
   return numbers::invalid_unsigned_int;
 }
+
 
 template <int dim>
 template <int order>

--- a/source/base/tensor_product_polynomials_const.cc
+++ b/source/base/tensor_product_polynomials_const.cc
@@ -15,6 +15,7 @@
 
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/tensor_product_polynomials_const.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -194,6 +195,15 @@ TensorProductPolynomialsConst<dim>::evaluate(
     third_derivatives.emplace_back();
   if (do_4th_derivatives)
     fourth_derivatives.emplace_back();
+}
+
+
+
+template <int dim>
+std::unique_ptr<ScalarPolynomialsBase<dim>>
+TensorProductPolynomialsConst<dim>::clone() const
+{
+  return std_cxx14::make_unique<TensorProductPolynomialsConst<dim>>(*this);
 }
 
 


### PR DESCRIPTION
This is almost exactly the same as #8742 except for `TensorProductPolynomialsConst` instead.

Future work would involve modifying the classes to remove the need for friendship with `TensorProductPolynomials`. I'd like to push this through before #8723 so I may base that PR off this work and derive all 4 classes from `ScalarPolynomialsBase` in one PR.

All tests for `fe` and `base` are successful on my end.