### PR TITLE
Avoid warnings as a result of an unused variable.

### DIFF
--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -285,8 +285,8 @@ TensorProductPolynomialsBubbles<dim>::compute_derivative(
 {
   const unsigned int q_degree      = tensor_polys.polynomials.size() - 1;
   const unsigned int max_q_indices = tensor_polys.n();
-  const unsigned int n_bubbles     = ((q_degree <= 1) ? 1 : dim);
-  Assert(i < max_q_indices + n_bubbles, ExcInternalError());
+  Assert(i < max_q_indices + /* n_bubbles= */ ((q_degree <= 1) ? 1 : dim),
+         ExcInternalError());
 
   // treat the regular basis functions
   if (i < max_q_indices)

--- a/source/base/tensor_product_polynomials_bubbles.cc
+++ b/source/base/tensor_product_polynomials_bubbles.cc
@@ -70,8 +70,8 @@ TensorProductPolynomialsBubbles<dim>::compute_value(const unsigned int i,
 {
   const unsigned int q_degree      = tensor_polys.polynomials.size() - 1;
   const unsigned int max_q_indices = tensor_polys.n();
-  const unsigned int n_bubbles     = ((q_degree <= 1) ? 1 : dim);
-  Assert(i < max_q_indices + n_bubbles, ExcInternalError());
+  Assert(i < max_q_indices + /* n_bubbles= */ ((q_degree <= 1) ? 1 : dim),
+         ExcInternalError());
 
   // treat the regular basis functions
   if (i < max_q_indices)
@@ -109,8 +109,8 @@ TensorProductPolynomialsBubbles<dim>::compute_grad(const unsigned int i,
 {
   const unsigned int q_degree      = tensor_polys.polynomials.size() - 1;
   const unsigned int max_q_indices = tensor_polys.n();
-  const unsigned int n_bubbles     = ((q_degree <= 1) ? 1 : dim);
-  Assert(i < max_q_indices + n_bubbles, ExcInternalError());
+  Assert(i < max_q_indices + /* n_bubbles= */ ((q_degree <= 1) ? 1 : dim),
+         ExcInternalError());
 
   // treat the regular basis functions
   if (i < max_q_indices)
@@ -156,8 +156,8 @@ TensorProductPolynomialsBubbles<dim>::compute_grad_grad(
 {
   const unsigned int q_degree      = tensor_polys.polynomials.size() - 1;
   const unsigned int max_q_indices = tensor_polys.n();
-  const unsigned int n_bubbles     = ((q_degree <= 1) ? 1 : dim);
-  Assert(i < max_q_indices + n_bubbles, ExcInternalError());
+  Assert(i < max_q_indices + /* n_bubbles= */ ((q_degree <= 1) ? 1 : dim),
+         ExcInternalError());
 
   // treat the regular basis functions
   if (i < max_q_indices)
@@ -264,7 +264,8 @@ TensorProductPolynomialsBubbles<dim>::evaluate(
 {
   const unsigned int q_degree      = tensor_polys.polynomials.size() - 1;
   const unsigned int max_q_indices = tensor_polys.n();
-  const unsigned int n_bubbles     = ((q_degree <= 1) ? 1 : dim);
+  (void)max_q_indices;
+  const unsigned int n_bubbles = ((q_degree <= 1) ? 1 : dim);
   Assert(values.size() == max_q_indices + n_bubbles || values.size() == 0,
          ExcDimensionMismatch2(values.size(), max_q_indices + n_bubbles, 0));
   Assert(grads.size() == max_q_indices + n_bubbles || grads.size() == 0,


### PR DESCRIPTION
These were introduced in some of the recent patches addressing #1973. The warning only happens in release mode when the `Assert` that uses the variable is not evaluated.

@GrahamBenHarper -- FYI.