### PR TITLE
Remove default constructor for classes derived from Function<dim> if empty.

### DIFF
--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -1250,20 +1250,10 @@ namespace Step13
   // the sine-factor with <code>y</code> replaced by <code>z</code> and so
   // on. Given this, the following two classes are probably straightforward
   // from the previous examples.
-  //
-  // As in previous examples, the C++ language forces us to declare and define
-  // a constructor to the following classes even though they are empty. This
-  // is due to the fact that the base class has no default constructor
-  // (i.e. one without arguments), even though it has a constructor which has
-  // default values for all arguments.
   template <int dim>
   class Solution : public Function<dim>
   {
   public:
-    Solution()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component) const override;
   };
@@ -1288,10 +1278,6 @@ namespace Step13
   class RightHandSide : public Function<dim>
   {
   public:
-    RightHandSide()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component) const override;
   };

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -1132,10 +1132,6 @@ namespace Step14
       class BoundaryValues : public Function<dim>
       {
       public:
-        BoundaryValues()
-          : Function<dim>()
-        {}
-
         virtual double value(const Point<dim> & p,
                              const unsigned int component) const;
       };
@@ -1144,10 +1140,6 @@ namespace Step14
       class RightHandSide : public Function<dim>
       {
       public:
-        RightHandSide()
-          : Function<dim>()
-        {}
-
         virtual double value(const Point<dim> & p,
                              const unsigned int component) const;
       };

--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -140,10 +140,6 @@ namespace Step15
   class BoundaryValues : public Function<dim>
   {
   public:
-    BoundaryValues()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
   };

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -136,10 +136,6 @@ namespace Step27
   class RightHandSide : public Function<dim>
   {
   public:
-    RightHandSide()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component) const override;
   };

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -86,10 +86,6 @@ namespace Step37
   class Coefficient : public Function<dim>
   {
   public:
-    Coefficient()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
 

--- a/examples/step-38/step-38.cc
+++ b/examples/step-38/step-38.cc
@@ -141,10 +141,6 @@ namespace Step38
   class Solution : public Function<dim>
   {
   public:
-    Solution()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
 
@@ -202,10 +198,6 @@ namespace Step38
   class RightHandSide : public Function<dim>
   {
   public:
-    RightHandSide()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
   };

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -121,10 +121,6 @@ namespace Step41
   class RightHandSide : public Function<dim>
   {
   public:
-    RightHandSide()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & /*p*/,
                          const unsigned int component = 0) const override
     {
@@ -141,10 +137,6 @@ namespace Step41
   class BoundaryValues : public Function<dim>
   {
   public:
-    BoundaryValues()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & /*p*/,
                          const unsigned int component = 0) const override
     {
@@ -163,10 +155,6 @@ namespace Step41
   class Obstacle : public Function<dim>
   {
   public:
-    Obstacle()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override
     {

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -157,10 +157,6 @@ namespace Step50
   class Coefficient : public Function<dim>
   {
   public:
-    Coefficient()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
 

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -83,7 +83,7 @@
 
 
 
-// We start by putting the class into its own namespace.
+// We start by putting all of our classes into their own namespace.
 namespace Step51
 {
   using namespace dealii;
@@ -130,10 +130,6 @@ namespace Step51
   class Solution : public Function<dim>, protected SolutionBase<dim>
   {
   public:
-    Solution()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> &p,
                          const unsigned int /*component*/ = 0) const override
     {
@@ -243,10 +239,6 @@ namespace Step51
   class RightHandSide : public Function<dim>, protected SolutionBase<dim>
   {
   public:
-    RightHandSide()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> &p,
                          const unsigned int /*component*/ = 0) const override
     {

--- a/examples/step-59/step-59.cc
+++ b/examples/step-59/step-59.cc
@@ -98,10 +98,6 @@ namespace Step59
   class Solution : public Function<dim>
   {
   public:
-    Solution()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> &p,
                          const unsigned int = 0) const override final
     {
@@ -135,10 +131,6 @@ namespace Step59
   class RightHandSide : public Function<dim>
   {
   public:
-    RightHandSide()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> &p,
                          const unsigned int = 0) const override final
     {

--- a/examples/step-61/step-61.cc
+++ b/examples/step-61/step-61.cc
@@ -168,10 +168,6 @@ namespace Step61
   class RightHandSide : public Function<dim>
   {
   public:
-    RightHandSide()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
   };

--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -364,10 +364,6 @@ namespace Step63
   class RightHandSide : public Function<dim>
   {
   public:
-    RightHandSide()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
 
@@ -410,10 +406,6 @@ namespace Step63
   class BoundaryValues : public Function<dim>
   {
   public:
-    BoundaryValues()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
 

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -178,10 +178,6 @@ namespace Step7
   class Solution : public Function<dim>, protected SolutionBase<dim>
   {
   public:
-    Solution()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
 
@@ -278,10 +274,6 @@ namespace Step7
   class RightHandSide : public Function<dim>, protected SolutionBase<dim>
   {
   public:
-    RightHandSide()
-      : Function<dim>()
-    {}
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
   };


### PR DESCRIPTION
These constructors were necessary in an earlier era when compilers would warn about this,
but they are no longer necessary now. We've removed them from a couple of tutorials
already, and this is the remainder.