### PR TITLE
Redefine TimestepControl::tolerance()

### DIFF
--- a/doc/news/changes/incompatibilities/20190917RezaRastak
+++ b/doc/news/changes/incompatibilities/20190917RezaRastak
@@ -1,0 +1,5 @@
+Modified: The definition of tolerance in TimestepControl is changed to
+represent the amount that the time step size can be increased in the last
+step.
+<br>
+(Reza Rastak, 2019/09/17)

--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -45,7 +45,8 @@ namespace Algorithms
    * <li> If the resulting time exceeds the final time of the interval, the
    * step size is reduced in order to meet this time.
    * <li> If the resulting time is below the final time by just a fraction of
-   * the step size, the step size is increased in order to meet this time.
+   * the step size, the step size is increased in order to meet this time. The
+   * fraction of time must be smaller than tolerance().
    * <li> The resulting step size is used from the current time.
    * </ol>
    *
@@ -56,19 +57,17 @@ namespace Algorithms
   {
   public:
     /**
-     * The time stepping strategies. These are controlled by the value of
-     * tolerance() and start_step().
+     * The time stepping strategies.
      */
     enum Strategy
     {
       /**
-       * Choose a uniform time step size. The step size is determined by
-       * start_step(), tolerance() is ignored.
+       * Choose a uniform time step size.
        */
       uniform,
       /**
        * Start with the time step size given by start_step() and double it in
-       * every step. tolerance() is ignored.
+       * every step.
        *
        * This strategy is intended for pseudo-timestepping schemes computing a
        * stationary limit.
@@ -114,7 +113,8 @@ namespace Algorithms
     double
     final() const;
     /**
-     * Return the tolerance value controlling the time steps.
+     * Return the tolerance value controlling the time steps. In the final time
+     * step, the step size can be increased (at most) by this tolerance amount.
      */
     double
     tolerance() const;
@@ -210,7 +210,8 @@ namespace Algorithms
     double final_val;
 
     /**
-     * The tolerance value controlling the time steps.
+     * The tolerance value controlling how much the time step size can be
+     * increased in the last time step.
      */
     double tolerance_val;
 

--- a/source/algorithms/timestep_control.cc
+++ b/source/algorithms/timestep_control.cc
@@ -94,7 +94,7 @@ TimestepControl::advance()
   // first step.
   if (now_val != start())
     {
-      if (strategy_val == doubling && 2 * s <= tolerance_val)
+      if (strategy_val == doubling)
         s *= 2;
       if (s > max_step_val)
         s = max_step_val;
@@ -113,8 +113,7 @@ TimestepControl::advance()
   // shot over the final time, adjust
   // it so we hit the final time
   // exactly.
-  double s1 = .01 * s;
-  if (h > final_val - s1)
+  if (h > final_val - tolerance_val)
     {
       current_step_val = final_val - now_val;
       h                = final_val;

--- a/tests/algorithms/timestep_control_1.cc
+++ b/tests/algorithms/timestep_control_1.cc
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Basic tests for class TimestepControl
+
+#include <deal.II/algorithms/timestep_control.h>
+
+#include "../tests.h"
+
+using Algorithms::TimestepControl;
+
+void
+print_time(TimestepControl &time)
+{
+  deallog << "Current time = " << time.now() << ", step size = " << time.step()
+          << ", Generate output = " << (time.print() ? "yes" : "no")
+          << std::endl;
+}
+
+void
+test_uniform_strategy()
+{
+  LogStream::Prefix p("uniform");
+
+  TimestepControl time(/*start*/ 0.,
+                       /*final*/ 1.5,
+                       /*tolerance*/ 0.1,
+                       /*start_step*/ 0.123,
+                       /*print_step*/ 0.31);
+  time.strategy(TimestepControl::uniform);
+
+  print_time(time);
+  while (time.now() != time.final())
+    {
+      time.advance();
+      print_time(time);
+    }
+}
+
+void
+test_doubling_strategy()
+{
+  LogStream::Prefix p("doubling");
+
+  TimestepControl time;
+  // using the set methods to configure the object
+  time.start(0.);
+  time.final(2.53);
+  time.tolerance(0.1);
+  time.start_step(0.123);
+  time.strategy(TimestepControl::doubling);
+  time.restart();
+
+  print_time(time);
+  while (time.now() != time.final())
+    {
+      time.advance();
+      print_time(time);
+    }
+}
+
+int
+main()
+{
+  initlog();
+  test_uniform_strategy();
+  test_doubling_strategy();
+  deallog << "OK" << std::endl;
+  return 0;
+}

--- a/tests/algorithms/timestep_control_1.output
+++ b/tests/algorithms/timestep_control_1.output
@@ -1,0 +1,21 @@
+
+DEAL:uniform::Current time = 0.00000, step size = 0.123000, Generate output = no
+DEAL:uniform::Current time = 0.123000, step size = 0.123000, Generate output = no
+DEAL:uniform::Current time = 0.246000, step size = 0.123000, Generate output = no
+DEAL:uniform::Current time = 0.369000, step size = 0.123000, Generate output = yes
+DEAL:uniform::Current time = 0.492000, step size = 0.123000, Generate output = no
+DEAL:uniform::Current time = 0.615000, step size = 0.123000, Generate output = no
+DEAL:uniform::Current time = 0.738000, step size = 0.123000, Generate output = yes
+DEAL:uniform::Current time = 0.861000, step size = 0.123000, Generate output = no
+DEAL:uniform::Current time = 0.984000, step size = 0.123000, Generate output = yes
+DEAL:uniform::Current time = 1.10700, step size = 0.123000, Generate output = no
+DEAL:uniform::Current time = 1.23000, step size = 0.123000, Generate output = no
+DEAL:uniform::Current time = 1.35300, step size = 0.123000, Generate output = yes
+DEAL:uniform::Current time = 1.50000, step size = 0.147000, Generate output = yes
+DEAL:doubling::Current time = 0.00000, step size = 0.123000, Generate output = yes
+DEAL:doubling::Current time = 0.123000, step size = 0.123000, Generate output = yes
+DEAL:doubling::Current time = 0.369000, step size = 0.246000, Generate output = yes
+DEAL:doubling::Current time = 0.861000, step size = 0.492000, Generate output = yes
+DEAL:doubling::Current time = 1.84500, step size = 0.984000, Generate output = yes
+DEAL:doubling::Current time = 2.53000, step size = 0.685000, Generate output = yes
+DEAL::OK


### PR DESCRIPTION
fixes #8771 

The previous implementation used the variable `tolerance_val` in the following block in the method `advance()`
```c++
   if (now_val != start())
     {
       if (strategy_val == doubling && 2 * s <= tolerance_val)
         s *= 2;
       if (s > max_step_val)
         s = max_step_val;
     }
```
The implementation is confusing and implies `tolerance_val` and `max_step_val` provide the same functionality.

In my opinion, the best way we can define `tolerance` is the amount a time step can be increased at the final step. For example, is current time is 0.945, the step size is 0.5, and the tolerance is 0.1, the algorithm can increase the step size to 0.55 so that we reach the final time (t = 1) in a single step. Here we increase the step size by 0.05 which is smaller than the tolerance. I modified the documentation to explain this concept in a clear way.

This PR changes the behavior of the `advance()` in a tiny way and might break backward compatibility in rare cases. Since there were no tests for `TimestepControl`, I added one test to ensure its usability in the future.