### PR TITLE
enum Strategy is removed from TimestepControl

### DIFF
--- a/doc/news/changes/incompatibilities/20190918RezaRastak
+++ b/doc/news/changes/incompatibilities/20190918RezaRastak
@@ -1,0 +1,3 @@
+Removed: The enum TimestepControl::Strategy is removed.
+<br>
+(Reza Rastak, 2019/09/18)

--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -56,27 +56,6 @@ namespace Algorithms
   {
   public:
     /**
-     * The time stepping strategies. These are controlled by the value of
-     * tolerance() and start_step().
-     */
-    enum Strategy
-    {
-      /**
-       * Choose a uniform time step size. The step size is determined by
-       * start_step(), tolerance() is ignored.
-       */
-      uniform,
-      /**
-       * Start with the time step size given by start_step() and double it in
-       * every step. tolerance() is ignored.
-       *
-       * This strategy is intended for pseudo-timestepping schemes computing a
-       * stationary limit.
-       */
-      doubling
-    };
-
-    /**
      * Constructor setting default values
      */
     TimestepControl(double start      = 0.,
@@ -152,10 +131,6 @@ namespace Algorithms
      */
     void
     tolerance(double);
-    /**
-     * Set strategy.
-     */
-    void strategy(Strategy);
 
     /**
      * Set size of the first step. This may be overwritten by the time
@@ -213,11 +188,6 @@ namespace Algorithms
      * The tolerance value controlling the time steps.
      */
     double tolerance_val;
-
-    /**
-     * Time-stepping strategy.
-     */
-    Strategy strategy_val;
 
     /**
      * The size of the first step.
@@ -322,13 +292,6 @@ namespace Algorithms
   TimestepControl::tolerance(double t)
   {
     tolerance_val = t;
-  }
-
-
-  inline void
-  TimestepControl::strategy(Strategy t)
-  {
-    strategy_val = t;
   }
 
 

--- a/source/algorithms/timestep_control.cc
+++ b/source/algorithms/timestep_control.cc
@@ -31,7 +31,6 @@ TimestepControl::TimestepControl(double start,
   : start_val(start)
   , final_val(final)
   , tolerance_val(tolerance)
-  , strategy_val(uniform)
   , start_step_val(start_step)
   , max_step_val(max_step)
   , min_step_val(0)
@@ -58,9 +57,6 @@ TimestepControl::declare_parameters(ParameterHandler &param)
   param.declare_entry("Max step", "1.", Patterns::Double(0.));
   param.declare_entry("Tolerance", "1.e-2", Patterns::Double(0.));
   param.declare_entry("Print step", "-1.", Patterns::Double());
-  param.declare_entry("Strategy",
-                      "uniform",
-                      Patterns::Selection("uniform|doubling"));
 }
 
 
@@ -73,13 +69,7 @@ TimestepControl::parse_parameters(ParameterHandler &param)
   max_step(param.get_double("Max step"));
   final(param.get_double("Final"));
   tolerance(param.get_double("Tolerance"));
-  print_step                 = param.get_double("Print step");
-  const std::string strategy = param.get("Strategy");
-  if (strategy == std::string("uniform"))
-    strategy_val = uniform;
-  else if (strategy == std::string("doubling"))
-    strategy_val = doubling;
-  restart();
+  print_step = param.get_double("Print step");
 }
 
 
@@ -87,41 +77,24 @@ TimestepControl::parse_parameters(ParameterHandler &param)
 bool
 TimestepControl::advance()
 {
-  bool   changed = false;
-  double s       = step_val;
-
-  // Do time step control, but not in
-  // first step.
-  if (now_val != start())
-    {
-      if (strategy_val == doubling && 2 * s <= tolerance_val)
-        s *= 2;
-      if (s > max_step_val)
-        s = max_step_val;
-    }
+  bool changed = false;
 
   // Try incrementing time by s
-  double h = now_val + s;
-  changed  = s != step_val;
+  double now_trial = now_val + step_val;
+  current_step_val = step_val;
 
-  step_val         = s;
-  current_step_val = s;
-  // If we just missed the final
-  // time, increase the step size a
-  // bit. This way, we avoid a very
-  // small final step. If the step
-  // shot over the final time, adjust
-  // it so we hit the final time
-  // exactly.
-  double s1 = .01 * s;
-  if (h > final_val - s1)
+  // If we just missed the final time, increase the step size a bit. This way,
+  // we avoid a very small final step. If the step shot over the final time,
+  // adjust it so we hit the final time exactly.
+  double s1 = .01 * step_val;
+  if (now_trial > final_val - s1)
     {
       current_step_val = final_val - now_val;
-      h                = final_val;
+      now_trial        = final_val;
       changed          = true;
     }
 
-  now_val = h;
+  now_val = now_trial;
   return changed;
 }
 


### PR DESCRIPTION
From our discussion in #8782 

Since people rarely use this enum and the implementation of the `doubling` strategy does not make much sense, I removed  `enum Streategy` from `TimestepControl`.