### PR TITLE
remove warning in fully_distributed_tria_util

### DIFF
--- a/source/distributed/fully_distributed_tria_util.inst.in
+++ b/source/distributed/fully_distributed_tria_util.inst.in
@@ -28,8 +28,8 @@ for (deal_II_dimension : DIMENSIONS)
             const dealii::Triangulation<deal_II_dimension, deal_II_dimension>
               &                tria,
             const MPI_Comm     comm,
-            const bool         construct_multilevel_hierarchy = false,
-            const unsigned int my_rank_in = numbers::invalid_unsigned_int);
+            const bool         construct_multilevel_hierarchy,
+            const unsigned int my_rank_in);
         \}
       \}
     \}


### PR DESCRIPTION
```
source/distributed/fully_distributed_tria_util.inst(17): warning #1077: specifying a default argument on this declaration is nonstandard
   create_construction_data_from_triangulation(
```