### PR TITLE
Avoid dangling pointer in initializer_list

### DIFF
--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1439,7 +1439,7 @@ namespace Patterns
                   "are derived from PatternBase");
     static_assert(sizeof...(ps) > 0,
                   "The number of PatternTypes must be greater than zero!");
-    const auto &pattern_pointers = {(static_cast<const PatternBase *>(&ps))...};
+    const auto pattern_pointers = {(static_cast<const PatternBase *>(&ps))...};
     for (const auto p : pattern_pointers)
       patterns.push_back(p->clone());
   }

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1439,7 +1439,7 @@ namespace Patterns
                   "are derived from PatternBase");
     static_assert(sizeof...(ps) > 0,
                   "The number of PatternTypes must be greater than zero!");
-    auto pattern_pointers = {(static_cast<const PatternBase *>(&ps))...};
+    const auto &pattern_pointers = {(static_cast<const PatternBase *>(&ps))...};
     for (const auto p : pattern_pointers)
       patterns.push_back(p->clone());
   }

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -834,7 +834,8 @@ namespace hp
     // loop over all of the given arguments and add the finite elements to
     // this collection. Inlining the definition of fe_pointers causes internal
     // compiler errors on GCC 7.1.1 so we define it separately:
-    const auto fe_pointers = {&fes...};
+    const auto &fe_pointers =
+      std::initializer_list<const FiniteElement<dim, spacedim> *>{&fes...};
     for (const auto p : fe_pointers)
       push_back(*p);
   }

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -834,8 +834,8 @@ namespace hp
     // loop over all of the given arguments and add the finite elements to
     // this collection. Inlining the definition of fe_pointers causes internal
     // compiler errors on GCC 7.1.1 so we define it separately:
-    const auto &fe_pointers =
-      std::initializer_list<const FiniteElement<dim, spacedim> *>{&fes...};
+    const auto fe_pointers = {
+      (static_cast<const FiniteElement<dim, spacedim> *>(&fes))...};
     for (const auto p : fe_pointers)
       push_back(*p);
   }

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -156,8 +156,8 @@ namespace hp
     // loop over all of the given arguments and add the quadrature objects to
     // this collection. Inlining the definition of q_pointers causes internal
     // compiler errors on GCC 7.1.1 so we define it separately:
-    const auto &q_pointers =
-      std::initializer_list<const Quadrature<dim> *>{&quadrature_objects...};
+    const auto q_pointers = {
+      (static_cast<const Quadrature<dim> *>(&quadrature_objects))...};
     for (const auto p : q_pointers)
       push_back(*p);
   }

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -156,7 +156,8 @@ namespace hp
     // loop over all of the given arguments and add the quadrature objects to
     // this collection. Inlining the definition of q_pointers causes internal
     // compiler errors on GCC 7.1.1 so we define it separately:
-    const auto q_pointers = {&quadrature_objects...};
+    const auto &q_pointers =
+      std::initializer_list<const Quadrature<dim> *>{&quadrature_objects...};
     for (const auto p : q_pointers)
       push_back(*p);
   }

--- a/tests/mpi/hp_unify_dof_indices_07.cc
+++ b/tests/mpi/hp_unify_dof_indices_07.cc
@@ -70,9 +70,7 @@ test()
   Assert(triangulation.n_global_active_cells() == 2, ExcInternalError());
   Assert(triangulation.n_active_cells() == 2, ExcInternalError());
 
-  hp::FECollection<dim> fe;
-  fe.push_back(FE_Q<dim>(2));
-  fe.push_back(FE_Q<dim>(2));
+  hp::FECollection<dim> fe(FE_Q<dim>(2), FE_Q<dim>(2));
 
   hp::DoFHandler<dim> dof_handler(triangulation);
   if (dof_handler.begin_active()->is_locally_owned())

--- a/tests/vector_tools/integrate_difference_04_hp.cc
+++ b/tests/vector_tools/integrate_difference_04_hp.cc
@@ -101,8 +101,7 @@ test(VectorTools::NormType norm, double value, double exp = 2.0)
   solution = interpolated;
 
   Vector<double>       cellwise_errors(tria.n_active_cells());
-  hp::QCollection<dim> quadrature;
-  quadrature.push_back(QIterated<dim>(QTrapez<1>(), 5));
+  hp::QCollection<dim> quadrature(QIterated<dim>(QTrapez<1>(), 5));
 
   const dealii::Function<dim, double> *w = nullptr;
   VectorTools::integrate_difference(dofh,


### PR DESCRIPTION
See https://godbolt.org/z/_X7hQ-. We should avoid copying `std::initializer_list` objects.
The copy is shallow and the underlying data is destroyed when the original object goes out of scope.
We seem to be lucky if all the objects pointed to had the same type. In case of different types, we need to cast the pointers to a common base class pointer type and run into segmentation faults.