### PR TITLE
Make a char[30] variable into a std::string.

### DIFF
--- a/doc/news/changes/incompatibilities/20190918Bangerth
+++ b/doc/news/changes/incompatibilities/20190918Bangerth
@@ -1,0 +1,7 @@
+Changed: The type of the argument of the
+Algorithms::TimeStepControl::file_name_format() function that takes a
+string has been changed from `char *` to `std::string`. Similarly, the
+returned type of the function of same name that doesn't take an
+argument has undergone the same kind of change.
+<br>
+(Wolfgang Bangerth, 2019/09/18)

--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -190,12 +190,12 @@ namespace Algorithms
      * Set the output name template.
      */
     void
-    file_name_format(const char *);
+    file_name_format(const std::string &format);
 
     /**
      * Return the output name template.
      */
-    const char *
+    const std::string &
     file_name_format();
 
   private:
@@ -265,7 +265,7 @@ namespace Algorithms
     /**
      * Output file name template.
      */
-    char format[30];
+    std::string format;
   };
 
 
@@ -360,13 +360,13 @@ namespace Algorithms
 
 
   inline void
-  TimestepControl::file_name_format(const char *fmt)
+  TimestepControl::file_name_format(const std::string &fmt)
   {
-    strcpy(format, fmt);
+    format = fmt;
   }
 
 
-  inline const char *
+  inline const std::string &
   TimestepControl::file_name_format()
   {
     return format;

--- a/source/algorithms/timestep_control.cc
+++ b/source/algorithms/timestep_control.cc
@@ -39,9 +39,9 @@ TimestepControl::TimestepControl(double start,
   , step_val(start_step)
   , print_step(print_step)
   , next_print_val(print_step > 0. ? start_val + print_step : start_val - 1.)
+  , format("T.%06.3f")
 {
   now_val = start_val;
-  strcpy(format, "T.%06.3f");
 
   // avoid compiler warning
   (void)min_step_val;


### PR DESCRIPTION
This avoids the potential for buffer overflows.

Fixes #8764.