### PR TITLE
 Speed up MGTools::make_boundary_list() 

### DIFF
--- a/doc/news/changes/minor/20190919MartinKronbichler-2
+++ b/doc/news/changes/minor/20190919MartinKronbichler-2
@@ -1,0 +1,3 @@
+Improved: MGTools::make_boundary_list() has been made faster.
+<br>
+(Martin Kronbichler, 2019/09/19)


### PR DESCRIPTION
While looking at #8772 (via `bin/step-37.release`), I observed that `MGTools::make_boundary_list` has quadratic cost in the number of ranges in the index set. Change this to a linear algorithm (the number of ranges is often not too large, so it was often not too bad).