### PR TITLE
Remove TimeStepControl::format altogether.

### DIFF
--- a/doc/news/changes/incompatibilities/20190918Bangerth
+++ b/doc/news/changes/incompatibilities/20190918Bangerth
@@ -1,7 +1,7 @@
-Changed: The type of the argument of the
-Algorithms::TimeStepControl::file_name_format() function that takes a
-string has been changed from `char *` to `std::string`. Similarly, the
-returned type of the function of same name that doesn't take an
-argument has undergone the same kind of change.
+Changed: The 
+Algorithms::TimeStepControl::file_name_format() functions have been
+removed. They were setters and getters for an internal field of that
+class that turned out to be unused anywhere -- in other words, the
+functions had no real functionality.
 <br>
 (Wolfgang Bangerth, 2019/09/18)

--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -161,18 +161,6 @@ namespace Algorithms
     bool
     print();
 
-    /**
-     * Set the output name template.
-     */
-    void
-    file_name_format(const std::string &format);
-
-    /**
-     * Return the output name template.
-     */
-    const std::string &
-    file_name_format();
-
   private:
     /**
      * The beginning of the time interval.
@@ -231,11 +219,6 @@ namespace Algorithms
      * If current time exceeds this value, it is time to generate the output.
      */
     double next_print_val;
-
-    /**
-     * Output file name template.
-     */
-    std::string format;
   };
 
 
@@ -321,19 +304,6 @@ namespace Algorithms
       next_print_val = now_val - 1.;
   }
 
-
-  inline void
-  TimestepControl::file_name_format(const std::string &fmt)
-  {
-    format = fmt;
-  }
-
-
-  inline const std::string &
-  TimestepControl::file_name_format()
-  {
-    return format;
-  }
 } // namespace Algorithms
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/algorithms/timestep_control.cc
+++ b/source/algorithms/timestep_control.cc
@@ -38,7 +38,6 @@ TimestepControl::TimestepControl(double start,
   , step_val(start_step)
   , print_step(print_step)
   , next_print_val(print_step > 0. ? start_val + print_step : start_val - 1.)
-  , format("T.%06.3f")
 {
   now_val = start_val;
 


### PR DESCRIPTION
I had second thoughts about #8795 where I changed a `char[30]` variable to a `std::string` -- because it occurred to me that all I did was change getters and setters for the variable. I started to wonder whether that variable is actually used anywhere at all. It turns out that it's not -- the variable is just dead and can be removed.

I guess that class is just a mystery. Maybe we should just remove the whole class...