### PR TITLE
Avoid calling the constructor for emplace_back

### DIFF
--- a/include/deal.II/lac/vector_memory.templates.h
+++ b/include/deal.II/lac/vector_memory.templates.h
@@ -132,8 +132,7 @@ GrowingVectorMemory<VectorType>::alloc()
     }
 
   // no free vector found, so let's just allocate a new one
-  get_pool().data->emplace_back(
-    entry_type(true, std_cxx14::make_unique<VectorType>()));
+  get_pool().data->emplace_back(true, std_cxx14::make_unique<VectorType>());
 
   return get_pool().data->back().second.get();
 }

--- a/source/base/parsed_convergence_table.cc
+++ b/source/base/parsed_convergence_table.cc
@@ -48,10 +48,10 @@ namespace
     for (unsigned int i = 0; i < component_names.size(); ++i)
       {
         if (unique_component_names[j] != component_names[i])
-          masks.emplace_back(ComponentMask(bools[j++]));
+          masks.emplace_back(bools[j++]);
         bools[j][i] = true;
       }
-    masks.emplace_back(ComponentMask(bools[j++]));
+    masks.emplace_back(bools[j++]);
     AssertDimension(j, unique_component_names.size());
     return masks;
   }

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3476,7 +3476,7 @@ namespace internal
                 numbers::invalid_subdomain_id, *dof_handler, level);
 
             // then add a complete, sequential index set
-            number_caches.emplace_back(NumberCache(n_level_dofs));
+            number_caches.emplace_back(n_level_dofs);
           }
 
         const_cast<dealii::Triangulation<DoFHandlerType::dimension,


### PR DESCRIPTION
Motivated by the comments in #8800. There really is no reason to call `emplace_back` constructing the variable of the type that shall be constructed in-place.