### PR TITLE
Compute number of locally owned active cells per process on-demand

### DIFF
--- a/doc/news/changes/incompatibilities/20190920PeterMunch
+++ b/doc/news/changes/incompatibilities/20190920PeterMunch
@@ -1,0 +1,5 @@
+Changed: The parallel::TriangulationBase class does not store the number of active cells
+of all MPI processes any more. Instead, the information is computed on-demand when calling
+the function parallel::TriangulationBase::compute_n_locally_owned_active_cells_per_processor.
+<br>
+(Peter Munch, 2019/09/20)

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2018 by the deal.II authors
+// Copyright (C) 2008 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -79,10 +79,11 @@ namespace parallel
      * that contribute to this triangulation. The element of this vector
      * indexed by locally_owned_subdomain() equals the result of
      * n_locally_owned_active_cells().
+     *
+     * @note This function involves global communication!
      */
-    const std::vector<unsigned int> &
-    n_locally_owned_active_cells_per_processor() const;
-
+    std::vector<unsigned int>
+    compute_n_locally_owned_active_cells_per_processor() const;
 
     /**
      * Return the number of active cells in the triangulation that are locally
@@ -195,10 +196,9 @@ namespace parallel
     struct NumberCache
     {
       /**
-       * This vector stores the number of locally owned active cells per MPI
-       * rank.
+       * Number of locally owned active cells of this MPI rank.
        */
-      std::vector<unsigned int> n_locally_owned_active_cells;
+      unsigned int n_locally_owned_active_cells;
       /**
        * The total number of active cells (sum of @p
        * n_locally_owned_active_cells).

--- a/tests/mpi/cell_weights_01.cc
+++ b/tests/mpi/cell_weights_01.cc
@@ -53,10 +53,12 @@ test()
   // (roughly) equal between all processors
   tr.repartition();
 
+  const auto n_locally_owned_active_cells_per_processor =
+    tr.compute_n_locally_owned_active_cells_per_processor();
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
-              << tr.n_locally_owned_active_cells_per_processor()[p]
+              << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 }
 

--- a/tests/mpi/cell_weights_01_back_and_forth_01.cc
+++ b/tests/mpi/cell_weights_01_back_and_forth_01.cc
@@ -87,11 +87,12 @@ test()
                                            std::placeholders::_2));
   tr.repartition();
 
-
+  const auto n_locally_owned_active_cells_per_processor =
+    tr.compute_n_locally_owned_active_cells_per_processor();
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
-              << tr.n_locally_owned_active_cells_per_processor()[p]
+              << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 }
 

--- a/tests/mpi/cell_weights_01_back_and_forth_02.cc
+++ b/tests/mpi/cell_weights_01_back_and_forth_02.cc
@@ -72,11 +72,12 @@ test()
   tr.signals.cell_weight.disconnect_all_slots();
   tr.repartition();
 
-
+  const auto n_locally_owned_active_cells_per_processor =
+    tr.compute_n_locally_owned_active_cells_per_processor();
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
-              << tr.n_locally_owned_active_cells_per_processor()[p]
+              << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 }
 

--- a/tests/mpi/cell_weights_02.cc
+++ b/tests/mpi/cell_weights_02.cc
@@ -59,10 +59,12 @@ test()
     std::bind(&cell_weight<dim>, std::placeholders::_1, std::placeholders::_2));
   tr.refine_global(1);
 
+  const auto n_locally_owned_active_cells_per_processor =
+    tr.compute_n_locally_owned_active_cells_per_processor();
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
-              << tr.n_locally_owned_active_cells_per_processor()[p]
+              << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 }
 

--- a/tests/mpi/cell_weights_03.cc
+++ b/tests/mpi/cell_weights_03.cc
@@ -67,10 +67,12 @@ test()
 
   tr.repartition();
 
+  const auto n_locally_owned_active_cells_per_processor =
+    tr.compute_n_locally_owned_active_cells_per_processor();
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
-              << tr.n_locally_owned_active_cells_per_processor()[p]
+              << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 
   // let each processor sum up its weights

--- a/tests/mpi/cell_weights_04.cc
+++ b/tests/mpi/cell_weights_04.cc
@@ -61,10 +61,12 @@ test()
 
   tr.refine_global(1);
 
+  const auto n_locally_owned_active_cells_per_processor =
+    tr.compute_n_locally_owned_active_cells_per_processor();
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
-              << tr.n_locally_owned_active_cells_per_processor()[p]
+              << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 
   // let each processor sum up its weights

--- a/tests/mpi/cell_weights_05.cc
+++ b/tests/mpi/cell_weights_05.cc
@@ -80,10 +80,12 @@ test()
 
   tr.repartition();
 
+  const auto n_locally_owned_active_cells_per_processor =
+    tr.compute_n_locally_owned_active_cells_per_processor();
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
-              << tr.n_locally_owned_active_cells_per_processor()[p]
+              << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 
   // let each processor sum up its weights

--- a/tests/mpi/cell_weights_06.cc
+++ b/tests/mpi/cell_weights_06.cc
@@ -79,10 +79,12 @@ test()
     std::bind(&cell_weight<dim>, std::placeholders::_1, std::placeholders::_2));
   tr.repartition();
 
+  const auto n_locally_owned_active_cells_per_processor =
+    tr.compute_n_locally_owned_active_cells_per_processor();
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
-              << tr.n_locally_owned_active_cells_per_processor()[p]
+              << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 
   // let each processor sum up its weights

--- a/tests/mpi/hp_step-40.cc
+++ b/tests/mpi/hp_step-40.cc
@@ -329,11 +329,12 @@ namespace Step40
         pcout << "   Number of active cells:       "
               << triangulation.n_global_active_cells() << std::endl
               << "      ";
+        const auto n_locally_owned_active_cells_per_processor =
+          triangulation.compute_n_locally_owned_active_cells_per_processor();
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << triangulation.n_locally_owned_active_cells_per_processor()[i]
-                << '+';
+          pcout << n_locally_owned_active_cells_per_processor[i] << '+';
         pcout << std::endl;
 
         pcout << "   Number of degrees of freedom: " << dof_handler.n_dofs()

--- a/tests/mpi/hp_step-40_variable_01.cc
+++ b/tests/mpi/hp_step-40_variable_01.cc
@@ -332,11 +332,12 @@ namespace Step40
         pcout << "   Number of active cells:       "
               << triangulation.n_global_active_cells() << std::endl
               << "      ";
+        const auto n_locally_owned_active_cells_per_processor =
+          triangulation.compute_n_locally_owned_active_cells_per_processor();
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << triangulation.n_locally_owned_active_cells_per_processor()[i]
-                << '+';
+          pcout << n_locally_owned_active_cells_per_processor[i] << '+';
         pcout << std::endl;
 
         pcout << "   Number of degrees of freedom: " << dof_handler.n_dofs()

--- a/tests/mpi/step-40.cc
+++ b/tests/mpi/step-40.cc
@@ -314,11 +314,12 @@ namespace Step40
         pcout << "   Number of active cells:       "
               << triangulation.n_global_active_cells() << std::endl
               << "      ";
+        const auto n_locally_owned_active_cells_per_processor =
+          triangulation.compute_n_locally_owned_active_cells_per_processor();
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << triangulation.n_locally_owned_active_cells_per_processor()[i]
-                << '+';
+          pcout << n_locally_owned_active_cells_per_processor[i] << '+';
         pcout << std::endl;
 
         pcout << "   Number of degrees of freedom: " << dof_handler.n_dofs()

--- a/tests/mpi/step-40_cuthill_mckee.cc
+++ b/tests/mpi/step-40_cuthill_mckee.cc
@@ -378,11 +378,12 @@ namespace Step40
         pcout << "   Number of active cells:       "
               << triangulation.n_global_active_cells() << std::endl
               << "      ";
+        const auto n_locally_owned_active_cells_per_processor =
+          triangulation.compute_n_locally_owned_active_cells_per_processor();
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << triangulation.n_locally_owned_active_cells_per_processor()[i]
-                << '+';
+          pcout << n_locally_owned_active_cells_per_processor[i] << '+';
         pcout << std::endl;
 
         pcout << "   Number of degrees of freedom: " << dof_handler.n_dofs()

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
@@ -379,11 +379,12 @@ namespace Step40
         pcout << "   Number of active cells:       "
               << triangulation.n_global_active_cells() << std::endl
               << "      ";
+        const auto n_locally_owned_active_cells_per_processor =
+          triangulation.compute_n_locally_owned_active_cells_per_processor();
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << triangulation.n_locally_owned_active_cells_per_processor()[i]
-                << '+';
+          pcout << n_locally_owned_active_cells_per_processor[i] << '+';
         pcout << std::endl;
 
         pcout << "   Number of degrees of freedom: " << dof_handler.n_dofs()

--- a/tests/mpi/step-40_direct_solver.cc
+++ b/tests/mpi/step-40_direct_solver.cc
@@ -292,11 +292,12 @@ namespace Step40
         pcout << "   Number of active cells:       "
               << triangulation.n_global_active_cells() << std::endl
               << "      ";
+        const auto n_locally_owned_active_cells_per_processor =
+          triangulation.compute_n_locally_owned_active_cells_per_processor();
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
-          pcout << triangulation.n_locally_owned_active_cells_per_processor()[i]
-                << '+';
+          pcout << n_locally_owned_active_cells_per_processor[i] << '+';
         pcout << std::endl;
 
         pcout << "   Number of degrees of freedom: " << dof_handler.n_dofs()


### PR DESCRIPTION
Do not update `number_cache.n_locally_owned_active_cells` in `TriangulationBase::update_number_cache()`. This data structure stores for every process the number of active cells...

If the data structure should be actually requested by the user (by calling `n_locally_owned_active_cells_per_processor`), the user should call `update_n_locally_owned_active_cells_per_processor()` first. Normally the data structure is only needed during debugging.

Once we agree that this is a useful change (and we want it), I will add some additional comments.

Closes #8778.