### PR TITLE
Change the storage type of MG copy indices to table

### DIFF
--- a/doc/news/changes/minor/20190920MartinKronbichler
+++ b/doc/news/changes/minor/20190920MartinKronbichler
@@ -1,0 +1,7 @@
+Changed: The storage type of MGLevelGlobalTransfer::copy_indices,
+MGLevelGlobalTransfer::copy_indices_global_mine,
+MGLevelGlobalTransfer::copy_indices_level_mine has been changed to a
+std::vector of Table<2,unsigned int>, in order to simplify some copy
+operations.
+<br>
+(Martin Kronbichler, 2019/09/20)

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -1254,7 +1254,6 @@ public:
   typename AlignedVector<T>::const_reference
   operator()(const size_type i, const size_type j) const;
 
-
   /**
    * Direct access to one element of the table by specifying all indices at
    * the same time. Range checks are performed.

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -541,49 +541,44 @@ protected:
    * Mapping for the copy_to_mg() and copy_from_mg() functions. Here only
    * index pairs locally owned is stored.
    *
-   * The data is organized as follows: one vector per level. Each element of
-   * these vectors contains first the global index, then the level index.
+   * The data is organized as follows: one table per level. This table has two
+   * rows. The first row contains the global index, the second one the level
+   * index.
    */
-  std::vector<std::vector<std::pair<unsigned int, unsigned int>>> copy_indices;
-
+  std::vector<Table<2, unsigned int>> copy_indices;
 
   /**
    * Same as above, but used to transfer solution vectors.
    */
-  std::vector<std::vector<std::pair<unsigned int, unsigned int>>>
-    solution_copy_indices;
+  std::vector<Table<2, unsigned int>> solution_copy_indices;
 
   /**
    * Additional degrees of freedom for the copy_to_mg() function. These are
    * the ones where the global degree of freedom is locally owned and the
    * level degree of freedom is not.
    *
-   * Organization of the data is like for @p copy_indices_mine.
+   * Organization of the data is like for @p copy_indices.
    */
-  std::vector<std::vector<std::pair<unsigned int, unsigned int>>>
-    copy_indices_global_mine;
+  std::vector<Table<2, unsigned int>> copy_indices_global_mine;
 
   /**
    * Same as above, but used to transfer solution vectors.
    */
-  std::vector<std::vector<std::pair<unsigned int, unsigned int>>>
-    solution_copy_indices_global_mine;
+  std::vector<Table<2, unsigned int>> solution_copy_indices_global_mine;
 
   /**
    * Additional degrees of freedom for the copy_from_mg() function. These are
    * the ones where the level degree of freedom is locally owned and the
    * global degree of freedom is not.
    *
-   * Organization of the data is like for @p copy_indices_mine.
+   * Organization of the data is like for @p copy_indices.
    */
-  std::vector<std::vector<std::pair<unsigned int, unsigned int>>>
-    copy_indices_level_mine;
+  std::vector<Table<2, unsigned int>> copy_indices_level_mine;
 
   /**
    * Same as above, but used to transfer solution vectors.
    */
-  std::vector<std::vector<std::pair<unsigned int, unsigned int>>>
-    solution_copy_indices_level_mine;
+  std::vector<Table<2, unsigned int>> solution_copy_indices_level_mine;
 
   /**
    * This variable stores whether the copy operation from the global to the

--- a/include/deal.II/multigrid/mg_transfer_internal.h
+++ b/include/deal.II/multigrid/mg_transfer_internal.h
@@ -129,8 +129,7 @@ namespace internal
       std::vector<unsigned int> &n_owned_level_cells,
       std::vector<std::vector<std::vector<unsigned short>>> &dirichlet_indices,
       std::vector<std::vector<Number>> &                     weights_on_refined,
-      std::vector<std::vector<std::pair<unsigned int, unsigned int>>>
-        &copy_indices_global_mine,
+      std::vector<Table<2, unsigned int>> &copy_indices_global_mine,
       MGLevelObject<LinearAlgebra::distributed::Vector<Number>>
         &ghosted_level_vector);
 

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -377,8 +377,7 @@ namespace internal
       std::vector<types::global_dof_index> &      ghosted_level_dofs,
       const MPI_Comm &                            communicator,
       LinearAlgebra::distributed::Vector<Number> &ghosted_level_vector,
-      std::vector<std::pair<unsigned int, unsigned int>>
-        &copy_indices_global_mine)
+      Table<2, unsigned int> &                    copy_indices_global_mine)
     {
       std::sort(ghosted_level_dofs.begin(), ghosted_level_dofs.end());
       IndexSet ghosted_dofs(locally_owned.size());
@@ -394,10 +393,11 @@ namespace internal
           // partitioner that we are going to use for the vector
           const auto &part = ghosted_level_vector.get_partitioner();
           ghosted_dofs.add_indices(part->ghost_indices());
-          for (auto &indices : copy_indices_global_mine)
-            indices.second = locally_owned.n_elements() +
-                             ghosted_dofs.index_within_set(
-                               part->local_to_global(indices.second));
+          for (unsigned int i = 0; i < copy_indices_global_mine.n_cols(); ++i)
+            copy_indices_global_mine(1, i) =
+              locally_owned.n_elements() +
+              ghosted_dofs.index_within_set(
+                part->local_to_global(copy_indices_global_mine(1, i)));
         }
       ghosted_level_vector.reinit(locally_owned, ghosted_dofs, communicator);
     }
@@ -592,8 +592,7 @@ namespace internal
       std::vector<unsigned int> &n_owned_level_cells,
       std::vector<std::vector<std::vector<unsigned short>>> &dirichlet_indices,
       std::vector<std::vector<Number>> &                     weights_on_refined,
-      std::vector<std::vector<std::pair<unsigned int, unsigned int>>>
-        &copy_indices_global_mine,
+      std::vector<Table<2, unsigned int>> &copy_indices_global_mine,
       MGLevelObject<LinearAlgebra::distributed::Vector<Number>>
         &ghosted_level_vector)
     {

--- a/source/multigrid/mg_transfer_internal.inst.in
+++ b/source/multigrid/mg_transfer_internal.inst.in
@@ -85,7 +85,7 @@ for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS)
           std::vector<unsigned int> &,
           std::vector<std::vector<std::vector<unsigned short>>> &,
           std::vector<std::vector<S>> &,
-          std::vector<std::vector<std::pair<unsigned int, unsigned int>>> &,
+          std::vector<Table<2, unsigned int>> &,
           MGLevelObject<LinearAlgebra::distributed::Vector<S>> &);
       \}
     \}


### PR DESCRIPTION
For some of the renumbered copies, I want to avoid accessing both sides of a `std::pair`. Therefore, I switched the storage type from `std::vector<std::pair<unsigned int,unsigned int>>` to `Table<2,unsigned int>` with two rows and as many columns as there were entries in the vector. This also shortens quite a bit of code.

As a further cleanup, I have replaced some repeated calls with copy indices by lambdas.