### PR TITLE
Make TensorProductQuadrature a separate class.

### DIFF
--- a/include/deal.II/base/quadrature_lib.h
+++ b/include/deal.II/base/quadrature_lib.h
@@ -37,7 +37,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Guido Kanschat, 2001
  */
 template <int dim>
-class QGauss : public Quadrature<dim>
+class QGauss : public TensorProductQuadrature<dim>
 {
 public:
   /**
@@ -73,7 +73,7 @@ public:
  * @author Guido Kanschat, 2005, 2006; F. Prill, 2006
  */
 template <int dim>
-class QGaussLobatto : public Quadrature<dim>
+class QGaussLobatto : public TensorProductQuadrature<dim>
 {
 public:
   /**
@@ -90,7 +90,7 @@ public:
  * for linear polynomials.
  */
 template <int dim>
-class QMidpoint : public Quadrature<dim>
+class QMidpoint : public TensorProductQuadrature<dim>
 {
 public:
   QMidpoint();
@@ -102,7 +102,7 @@ public:
  * points is exact for polynomials of degree 3.
  */
 template <int dim>
-class QSimpson : public Quadrature<dim>
+class QSimpson : public TensorProductQuadrature<dim>
 {
 public:
   QSimpson();
@@ -123,7 +123,7 @@ public:
  * @author Wolfgang Bangerth, 1998
  */
 template <int dim>
-class QTrapez : public Quadrature<dim>
+class QTrapez : public TensorProductQuadrature<dim>
 {
 public:
   QTrapez();
@@ -138,7 +138,7 @@ public:
  * @sa Stoer: Einführung in die Numerische Mathematik I, p. 102
  */
 template <int dim>
-class QMilne : public Quadrature<dim>
+class QMilne : public TensorProductQuadrature<dim>
 {
 public:
   QMilne();
@@ -152,7 +152,7 @@ public:
  * @sa Stoer: Einführung in die Numerische Mathematik I, p. 102
  */
 template <int dim>
-class QWeddle : public Quadrature<dim>
+class QWeddle : public TensorProductQuadrature<dim>
 {
 public:
   QWeddle();
@@ -174,7 +174,7 @@ public:
  * The weights and functions have been tabulated up to order 12.
  */
 template <int dim>
-class QGaussLog : public Quadrature<dim>
+class QGaussLog : public TensorProductQuadrature<dim>
 {
 public:
   /**
@@ -235,7 +235,7 @@ private:
  * The weights and functions have been tabulated up to order 12.
  */
 template <int dim>
-class QGaussLogR : public Quadrature<dim>
+class QGaussLogR : public TensorProductQuadrature<dim>
 {
 public:
   /**
@@ -464,7 +464,7 @@ private:
  * @author Nicola Giuliani, Luca Heltai 2015
  */
 template <int dim>
-class QTelles : public Quadrature<dim>
+class QTelles : public TensorProductQuadrature<dim>
 {
 public:
   /**
@@ -496,7 +496,7 @@ public:
  * @author Giuseppe Pitton, Luca Heltai 2015
  */
 template <int dim>
-class QGaussChebyshev : public Quadrature<dim>
+class QGaussChebyshev : public TensorProductQuadrature<dim>
 {
 public:
   /// Generate a formula with <tt>n</tt> quadrature points
@@ -521,7 +521,7 @@ public:
  * @author Giuseppe Pitton, Luca Heltai 2015
  */
 template <int dim>
-class QGaussRadauChebyshev : public Quadrature<dim>
+class QGaussRadauChebyshev : public TensorProductQuadrature<dim>
 {
 public:
   /* EndPoint is used to specify which of the two endpoints of the unit interval
@@ -568,7 +568,7 @@ private:
  * @author Giuseppe Pitton, Luca Heltai 2015
  */
 template <int dim>
-class QGaussLobattoChebyshev : public Quadrature<dim>
+class QGaussLobattoChebyshev : public TensorProductQuadrature<dim>
 {
 public:
   /// Generate a formula with <tt>n</tt> quadrature points

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -36,7 +36,7 @@ template <>
 QGauss<0>::QGauss(const unsigned int)
   : // there are n_q^dim == 1
     // points
-  Quadrature<0>(1)
+  TensorProductQuadrature<0>(1)
 {
   // the single quadrature point gets unit
   // weight
@@ -49,7 +49,7 @@ template <>
 QGaussLobatto<0>::QGaussLobatto(const unsigned int)
   : // there are n_q^dim == 1
     // points
-  Quadrature<0>(1)
+  TensorProductQuadrature<0>(1)
 {
   // the single quadrature point gets unit
   // weight
@@ -60,7 +60,7 @@ QGaussLobatto<0>::QGaussLobatto(const unsigned int)
 
 template <>
 QGauss<1>::QGauss(const unsigned int n)
-  : Quadrature<1>(n)
+  : TensorProductQuadrature<1>(n)
 {
   if (n == 0)
     return;
@@ -139,7 +139,7 @@ namespace internal
 
 template <>
 QGaussLobatto<1>::QGaussLobatto(const unsigned int n)
-  : Quadrature<1>(n)
+  : TensorProductQuadrature<1>(n)
 {
   Assert(n >= 2, ExcNotImplemented());
 
@@ -162,7 +162,7 @@ QGaussLobatto<1>::QGaussLobatto(const unsigned int n)
 
 template <>
 QMidpoint<1>::QMidpoint()
-  : Quadrature<1>(1)
+  : TensorProductQuadrature<1>(1)
 {
   this->quadrature_points[0] = Point<1>(0.5);
   this->weights[0]           = 1.0;
@@ -172,7 +172,7 @@ QMidpoint<1>::QMidpoint()
 
 template <>
 QTrapez<1>::QTrapez()
-  : Quadrature<1>(2)
+  : TensorProductQuadrature<1>(2)
 {
   static const double xpts[] = {0.0, 1.0};
   static const double wts[]  = {0.5, 0.5};
@@ -188,7 +188,7 @@ QTrapez<1>::QTrapez()
 
 template <>
 QSimpson<1>::QSimpson()
-  : Quadrature<1>(3)
+  : TensorProductQuadrature<1>(3)
 {
   static const double xpts[] = {0.0, 0.5, 1.0};
   static const double wts[]  = {1. / 6., 2. / 3., 1. / 6.};
@@ -204,7 +204,7 @@ QSimpson<1>::QSimpson()
 
 template <>
 QMilne<1>::QMilne()
-  : Quadrature<1>(5)
+  : TensorProductQuadrature<1>(5)
 {
   static const double xpts[] = {0.0, .25, .5, .75, 1.0};
   static const double wts[]  = {
@@ -221,7 +221,7 @@ QMilne<1>::QMilne()
 
 template <>
 QWeddle<1>::QWeddle()
-  : Quadrature<1>(7)
+  : TensorProductQuadrature<1>(7)
 {
   static const double xpts[] = {
     0.0, 1. / 6., 1. / 3., .5, 2. / 3., 5. / 6., 1.0};
@@ -243,7 +243,7 @@ QWeddle<1>::QWeddle()
 
 template <>
 QGaussLog<1>::QGaussLog(const unsigned int n, const bool revert)
-  : Quadrature<1>(n)
+  : TensorProductQuadrature<1>(n)
 {
   std::vector<double> p = get_quadrature_points(n);
   std::vector<double> w = get_quadrature_weights(n);
@@ -529,7 +529,7 @@ QGaussLogR<1>::QGaussLogR(const unsigned int n,
                           const Point<1>     origin,
                           const double       alpha,
                           const bool         factor_out_singularity)
-  : Quadrature<1>(
+  : TensorProductQuadrature<1>(
       ((origin[0] == 0) || (origin[0] == 1)) ? (alpha == 1 ? n : 2 * n) : 4 * n)
   , fraction(((origin[0] == 0) || (origin[0] == 1.)) ? 1. : origin[0])
 {
@@ -790,8 +790,6 @@ QSorted<dim>::QSorted(const Quadrature<dim> &quad)
     {
       this->weights[i]           = quad.weight(permutation[i]);
       this->quadrature_points[i] = quad.point(permutation[i]);
-      if (permutation[i] != i)
-        this->is_tensor_product_flag = false;
     }
 }
 
@@ -809,48 +807,48 @@ QSorted<dim>::compare_weights(const unsigned int a, const unsigned int b) const
 
 template <int dim>
 QGauss<dim>::QGauss(const unsigned int n)
-  : Quadrature<dim>(QGauss<dim - 1>(n), QGauss<1>(n))
+  : TensorProductQuadrature<dim>(QGauss<dim - 1>(n), QGauss<1>(n))
 {}
 
 
 
 template <int dim>
 QGaussLobatto<dim>::QGaussLobatto(const unsigned int n)
-  : Quadrature<dim>(QGaussLobatto<dim - 1>(n), QGaussLobatto<1>(n))
+  : TensorProductQuadrature<dim>(QGaussLobatto<dim - 1>(n), QGaussLobatto<1>(n))
 {}
 
 
 
 template <int dim>
 QMidpoint<dim>::QMidpoint()
-  : Quadrature<dim>(QMidpoint<dim - 1>(), QMidpoint<1>())
+  : TensorProductQuadrature<dim>(QMidpoint<dim - 1>(), QMidpoint<1>())
 {}
 
 
 
 template <int dim>
 QTrapez<dim>::QTrapez()
-  : Quadrature<dim>(QTrapez<dim - 1>(), QTrapez<1>())
+  : TensorProductQuadrature<dim>(QTrapez<dim - 1>(), QTrapez<1>())
 {}
 
 
 
 template <int dim>
 QSimpson<dim>::QSimpson()
-  : Quadrature<dim>(QSimpson<dim - 1>(), QSimpson<1>())
+  : TensorProductQuadrature<dim>(QSimpson<dim - 1>(), QSimpson<1>())
 {}
 
 
 
 template <int dim>
 QMilne<dim>::QMilne()
-  : Quadrature<dim>(QMilne<dim - 1>(), QMilne<1>())
+  : TensorProductQuadrature<dim>(QMilne<dim - 1>(), QMilne<1>())
 {}
 
 
 template <int dim>
 QWeddle<dim>::QWeddle()
-  : Quadrature<dim>(QWeddle<dim - 1>(), QWeddle<1>())
+  : TensorProductQuadrature<dim>(QWeddle<dim - 1>(), QWeddle<1>())
 {}
 
 template <int dim>
@@ -859,7 +857,7 @@ QTelles<dim>::QTelles(const Quadrature<1> &base_quad,
   : // We need the explicit implementation if dim == 1. If dim > 1 we use the
     // former implementation and apply a tensorial product to obtain the higher
     // dimensions.
-  Quadrature<dim>(
+  TensorProductQuadrature<dim>(
     dim == 2 ?
       QAnisotropic<dim>(QTelles<1>(base_quad, Point<1>(singularity[0])),
                         QTelles<1>(base_quad, Point<1>(singularity[1]))) :
@@ -867,14 +865,14 @@ QTelles<dim>::QTelles(const Quadrature<1> &base_quad,
       QAnisotropic<dim>(QTelles<1>(base_quad, Point<1>(singularity[0])),
                         QTelles<1>(base_quad, Point<1>(singularity[1])),
                         QTelles<1>(base_quad, Point<1>(singularity[2]))) :
-      Quadrature<dim>())
+      TensorProductQuadrature<dim>())
 {}
 
 template <int dim>
 QTelles<dim>::QTelles(const unsigned int n, const Point<dim> &singularity)
   : // In this case we map the standard Gauss Legendre formula using the given
     // singularity point coordinates.
-  Quadrature<dim>(QTelles<dim>(QGauss<1>(n), singularity))
+  TensorProductQuadrature<dim>(QTelles<dim>(QGauss<1>(n), singularity))
 {}
 
 
@@ -882,7 +880,7 @@ QTelles<dim>::QTelles(const unsigned int n, const Point<dim> &singularity)
 template <>
 QTelles<1>::QTelles(const Quadrature<1> &base_quad, const Point<1> &singularity)
   : // We explicitly implement the Telles' variable change if dim == 1.
-  Quadrature<1>(base_quad)
+  TensorProductQuadrature<1>(base_quad)
 {
   // We define all the constants to be used in the implementation of
   // Telles' rule
@@ -1001,7 +999,7 @@ namespace internal
 
 template <>
 QGaussChebyshev<1>::QGaussChebyshev(const unsigned int n)
-  : Quadrature<1>(n)
+  : TensorProductQuadrature<1>(n)
 {
   Assert(n > 0, ExcMessage("Need at least one point for the quadrature rule"));
   std::vector<double> p = internal::QGaussChebyshev::get_quadrature_points(n);
@@ -1017,7 +1015,7 @@ QGaussChebyshev<1>::QGaussChebyshev(const unsigned int n)
 
 template <int dim>
 QGaussChebyshev<dim>::QGaussChebyshev(const unsigned int n)
-  : Quadrature<dim>(QGaussChebyshev<1>(n))
+  : TensorProductQuadrature<dim>(QGaussChebyshev<1>(n))
 {}
 
 
@@ -1097,7 +1095,7 @@ namespace internal
 
 template <>
 QGaussRadauChebyshev<1>::QGaussRadauChebyshev(const unsigned int n, EndPoint ep)
-  : Quadrature<1>(n)
+  : TensorProductQuadrature<1>(n)
   , ep(ep)
 {
   Assert(n > 0, ExcMessage("Need at least one point for quadrature rules"));
@@ -1117,7 +1115,7 @@ QGaussRadauChebyshev<1>::QGaussRadauChebyshev(const unsigned int n, EndPoint ep)
 template <int dim>
 QGaussRadauChebyshev<dim>::QGaussRadauChebyshev(const unsigned int n,
                                                 EndPoint           ep)
-  : Quadrature<dim>(QGaussRadauChebyshev<1>(
+  : TensorProductQuadrature<dim>(QGaussRadauChebyshev<1>(
       n,
       static_cast<QGaussRadauChebyshev<1>::EndPoint>(ep)))
   , ep(ep)
@@ -1169,7 +1167,7 @@ namespace internal
 
 template <>
 QGaussLobattoChebyshev<1>::QGaussLobattoChebyshev(const unsigned int n)
-  : Quadrature<1>(n)
+  : TensorProductQuadrature<1>(n)
 {
   Assert(n > 1,
          ExcMessage(
@@ -1189,7 +1187,7 @@ QGaussLobattoChebyshev<1>::QGaussLobattoChebyshev(const unsigned int n)
 
 template <int dim>
 QGaussLobattoChebyshev<dim>::QGaussLobattoChebyshev(const unsigned int n)
-  : Quadrature<dim>(QGaussLobattoChebyshev<1>(n))
+  : TensorProductQuadrature<dim>(QGaussLobattoChebyshev<1>(n))
 {}
 
 

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -728,7 +728,7 @@ MappingQGeneric<dim, spacedim>::InternalData::initialize(
   // now also fill the various fields with their correct values
   compute_shape_function_values(ref_q_points);
 
-  tensor_product_quadrature = q.is_tensor_product();
+  tensor_product_quadrature = is_tensor_product(q);
 
   // use of MatrixFree only for higher order elements
   if (polynomial_degree < 2)
@@ -740,8 +740,10 @@ MappingQGeneric<dim, spacedim>::InternalData::initialize(
       // in all directions
       if (tensor_product_quadrature)
         {
+          const TensorProductQuadrature<dim> &tensor_quadrature =
+            dynamic_cast<const TensorProductQuadrature<dim> &>(q);
           const std::array<Quadrature<1>, dim> quad_array =
-            q.get_tensor_basis();
+            tensor_quadrature.get_tensor_basis();
           for (unsigned int i = 1; i < dim && tensor_product_quadrature; ++i)
             {
               if (quad_array[i - 1].size() != quad_array[i].size())
@@ -773,8 +775,11 @@ MappingQGeneric<dim, spacedim>::InternalData::initialize(
 
           if (tensor_product_quadrature)
             {
+              const TensorProductQuadrature<dim> &tensor_quadrature =
+                dynamic_cast<const TensorProductQuadrature<dim> &>(q);
+
               const FE_Q<dim> fe(polynomial_degree);
-              shape_info.reinit(q.get_tensor_basis()[0], fe);
+              shape_info.reinit(tensor_quadrature.get_tensor_basis()[0], fe);
 
               const unsigned int n_shape_values = fe.n_dofs_per_cell();
               const unsigned int max_size =
@@ -805,7 +810,10 @@ MappingQGeneric<dim, spacedim>::InternalData::initialize_face(
     {
       const unsigned int  facedim = dim > 1 ? dim - 1 : 1;
       const FE_Q<facedim> fe(polynomial_degree);
-      shape_info.reinit(q.get_tensor_basis()[0], fe);
+
+      const TensorProductQuadrature<dim> &tensor_quadrature =
+        dynamic_cast<const TensorProductQuadrature<dim> &>(q);
+      shape_info.reinit(tensor_quadrature.get_tensor_basis()[0], fe);
 
       const unsigned int n_shape_values = fe.n_dofs_per_cell();
       const unsigned int n_q_points     = q.size();

--- a/tests/base/quadrature_check_tensor_product.cc
+++ b/tests/base/quadrature_check_tensor_product.cc
@@ -39,10 +39,13 @@ check_tensor_product(const std::vector<Quadrature<1>> &quadratures,
   for (unsigned int i = 0; i < quadratures.size(); ++i)
     {
       const Quadrature<1> &quadrature = quadratures[i];
-      if (quadrature.is_tensor_product())
+      if (is_tensor_product(quadrature))
         {
           deallog << "1D " << quadrature_names[i];
-          const auto &q_basis = quadrature.get_tensor_basis();
+          const TensorProductQuadrature<1> &tensor_product_quadrature =
+            dynamic_cast<const TensorProductQuadrature<1> &>(quadrature);
+
+          const auto &q_basis = tensor_product_quadrature.get_tensor_basis();
           AssertThrow(q_basis.size() == 1, ExcInternalError());
           const auto &q_points  = quadrature.get_points();
           const auto &q_weights = quadrature.get_weights();
@@ -72,10 +75,13 @@ check_tensor_product(const std::vector<Quadrature<2>> &quadratures,
   for (unsigned int i = 0; i < quadratures.size(); ++i)
     {
       const Quadrature<2> &quadrature = quadratures[i];
-      if (quadrature.is_tensor_product())
+      if (is_tensor_product(quadrature))
         {
           deallog << "2D " << quadrature_names[i];
-          const auto &q_basis = quadrature.get_tensor_basis();
+          const TensorProductQuadrature<2> &tensor_product_quadrature =
+            dynamic_cast<const TensorProductQuadrature<2> &>(quadrature);
+
+          const auto &q_basis = tensor_product_quadrature.get_tensor_basis();
           AssertThrow(q_basis.size() == 2, ExcInternalError());
           const auto &q_points  = quadrature.get_points();
           const auto &q_weights = quadrature.get_weights();
@@ -110,10 +116,13 @@ check_tensor_product(const std::vector<Quadrature<3>> &quadratures,
   for (unsigned int i = 0; i < quadratures.size(); ++i)
     {
       const Quadrature<3> &quadrature = quadratures[i];
-      if (quadrature.is_tensor_product())
+      if (is_tensor_product(quadrature))
         {
           deallog << "3D " << quadrature_names[i];
-          const auto &q_basis = quadrature.get_tensor_basis();
+          const TensorProductQuadrature<3> &tensor_product_quadrature =
+            dynamic_cast<const TensorProductQuadrature<3> &>(quadrature);
+
+          const auto &q_basis = tensor_product_quadrature.get_tensor_basis();
           AssertThrow(q_basis.size() == 3, ExcInternalError());
           const auto &q_points  = quadrature.get_points();
           const auto &q_weights = quadrature.get_weights();

--- a/tests/base/quadrature_is_tensor_product.cc
+++ b/tests/base/quadrature_is_tensor_product.cc
@@ -28,56 +28,53 @@ void
 print_is_tensor_product()
 {
   Quadrature<dim> q_0(1);
-  deallog << "Quadrature<" << dim << ">: " << q_0.is_tensor_product()
+  deallog << "Quadrature<" << dim << ">: " << is_tensor_product(q_0)
           << std::endl;
 
   QIterated<dim> q_1(QGauss<1>(1), 1);
-  deallog << "QIterated<" << dim << ">: " << q_1.is_tensor_product()
+  deallog << "QIterated<" << dim << ">: " << is_tensor_product(q_1)
           << std::endl;
 
   QGauss<dim> q_2(1);
-  deallog << "QGauss<" << dim << ">: " << q_2.is_tensor_product() << std::endl;
+  deallog << "QGauss<" << dim << ">: " << is_tensor_product(q_2) << std::endl;
 
   QGaussLobatto<dim> q_3(2);
-  deallog << "QGaussLobatto<" << dim << ">: " << q_3.is_tensor_product()
+  deallog << "QGaussLobatto<" << dim << ">: " << is_tensor_product(q_3)
           << std::endl;
 
   QMidpoint<dim> q_4;
-  deallog << "QMidpoint<" << dim << ">: " << q_4.is_tensor_product()
+  deallog << "QMidpoint<" << dim << ">: " << is_tensor_product(q_4)
           << std::endl;
 
   QSimpson<dim> q_5;
-  deallog << "QSimpson<" << dim << ">: " << q_5.is_tensor_product()
-          << std::endl;
+  deallog << "QSimpson<" << dim << ">: " << is_tensor_product(q_5) << std::endl;
 
   QTrapez<dim> q_6;
-  deallog << "QTrapez<" << dim << ">: " << q_6.is_tensor_product() << std::endl;
+  deallog << "QTrapez<" << dim << ">: " << is_tensor_product(q_6) << std::endl;
 
   QMilne<dim> q_7;
-  deallog << "QMilne<" << dim << ">: " << q_7.is_tensor_product() << std::endl;
+  deallog << "QMilne<" << dim << ">: " << is_tensor_product(q_7) << std::endl;
 
   QWeddle<dim> q_8;
-  deallog << "QWeddle<" << dim << ">: " << q_8.is_tensor_product() << std::endl;
+  deallog << "QWeddle<" << dim << ">: " << is_tensor_product(q_8) << std::endl;
 
   QGaussChebyshev<dim> q_9(3);
-  deallog << "QGaussChebyshev<" << dim << ">: " << q_9.is_tensor_product()
+  deallog << "QGaussChebyshev<" << dim << ">: " << is_tensor_product(q_9)
           << std::endl;
 
   QGaussRadauChebyshev<dim> q_10(1);
-  deallog << "QGaussRadauChebyshev<" << dim << ">: " << q_10.is_tensor_product()
+  deallog << "QGaussRadauChebyshev<" << dim << ">: " << is_tensor_product(q_10)
           << std::endl;
 
   QGaussLobattoChebyshev<dim> q_11(2);
   deallog << "QGaussLobattoChebyshev<" << dim
-          << ">: " << q_11.is_tensor_product() << std::endl;
+          << ">: " << is_tensor_product(q_11) << std::endl;
 
   QSorted<dim> q_16(QGauss<dim>(3));
-  deallog << "QSorted<" << dim << ">: " << q_16.is_tensor_product()
-          << std::endl;
+  deallog << "QSorted<" << dim << ">: " << is_tensor_product(q_16) << std::endl;
 
   QTelles<dim> q_17(1, Point<dim>());
-  deallog << "QTelles<" << dim << ">: " << q_17.is_tensor_product()
-          << std::endl;
+  deallog << "QTelles<" << dim << ">: " << is_tensor_product(q_17) << std::endl;
 }
 
 int
@@ -90,19 +87,19 @@ main()
 
   print_is_tensor_product<1>();
   QAnisotropic<1> q_1(q);
-  deallog << "QAnisotropic<1>: " << q_1.is_tensor_product() << std::endl;
+  deallog << "QAnisotropic<1>: " << is_tensor_product(q_1) << std::endl;
   QGaussLog<1> q_13(1);
-  deallog << "QGaussLog<1>: " << q_13.is_tensor_product() << std::endl;
+  deallog << "QGaussLog<1>: " << is_tensor_product(q_13) << std::endl;
   QGaussLogR<1> q_14(1);
-  deallog << "QGaussLogR<1>: " << q_14.is_tensor_product() << std::endl;
+  deallog << "QGaussLogR<1>: " << is_tensor_product(q_14) << std::endl;
 
   print_is_tensor_product<2>();
   QAnisotropic<2> q_2(q, q);
-  deallog << "QAnisotropic<2>: " << q_2.is_tensor_product() << std::endl;
+  deallog << "QAnisotropic<2>: " << is_tensor_product(q_2) << std::endl;
   QGaussOneOverR<2> q_15(2, Point<2>());
-  deallog << "QGaussOneOverR<2>: " << q_15.is_tensor_product() << std::endl;
+  deallog << "QGaussOneOverR<2>: " << is_tensor_product(q_15) << std::endl;
 
   print_is_tensor_product<3>();
   QAnisotropic<3> q_3(q, q, q);
-  deallog << "QAnisotropic<3>: " << q_3.is_tensor_product() << std::endl;
+  deallog << "QAnisotropic<3>: " << is_tensor_product(q_3) << std::endl;
 }

--- a/tests/base/tensor_product_quadrature.cc
+++ b/tests/base/tensor_product_quadrature.cc
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/quadrature.h>
+
+#include "../tests.h"
+
+// Write points and weights of the incoming quadrature to deallog.
+template <int dim>
+void
+print_quadrature(const Quadrature<dim> &quadrature)
+{
+  deallog << "points" << std::endl;
+  for (unsigned int i = 0; i < quadrature.size(); ++i)
+    deallog << quadrature.point(i) << ", ";
+  deallog << std::endl;
+
+  deallog << "weights" << std::endl;
+  for (unsigned int i = 0; i < quadrature.size(); ++i)
+    deallog << quadrature.weight(i) << ", ";
+  deallog << std::endl;
+}
+
+
+
+// Write points weights and 1D base quadratures to deallog
+template <int dim>
+void
+print_tensor_product_quadrature(const TensorProductQuadrature<dim> &quadrature)
+{
+  print_quadrature(quadrature);
+
+  const std::array<Quadrature<1>, dim> &tensor_basis =
+    quadrature.get_tensor_basis();
+  for (unsigned int i = 0; i < dim; ++i)
+    {
+      deallog << "base quadrature " << i << std::endl;
+      print_quadrature(tensor_basis[i]);
+    }
+}
+
+
+
+template <int dim>
+void
+test_constructor_taking_1D_quadratures()
+{
+  deallog << "Constructor taking 1D Quadratures" << std::endl;
+
+  const std::vector<Point<1>> points  = {Point<1>(.2), Point<1>(.8)};
+  const std::vector<double>   weights = {.1, .9};
+  const Quadrature<1>         quadrature_1D(points, weights);
+
+  const TensorProductQuadrature<dim> tensor_product_quadrature(quadrature_1D);
+  print_tensor_product_quadrature(tensor_product_quadrature);
+}
+
+
+
+template <int dim>
+void
+test_constructor_taking_1D_and_subquadrature()
+{
+  deallog << "Constructor taking 1D and SubQuadrature" << std::endl;
+
+  const std::vector<Point<1>> points1D  = {Point<1>(.2), Point<1>(.8)};
+  const std::vector<double>   weights1D = {.1, .9};
+  const Quadrature<1>         quadrature_1D(points1D, weights1D);
+
+  // Need to create a SubTensorProductQuadrautre to give the constructor. Create
+  // a different 1-dimensional quadrature to create the
+  // SubTensorProductQuadrautre from.
+  const std::vector<Point<1>> points1D_for_sub  = {Point<1>(.4), Point<1>(.6)};
+  const std::vector<double>   weights1D_for_sub = {.3, .7};
+  const Quadrature<1>         quadrature_1D_for_sub(points1D_for_sub,
+                                            weights1D_for_sub);
+
+  const TensorProductQuadrature<dim - 1> subquadrature(quadrature_1D_for_sub);
+
+  const TensorProductQuadrature<dim> tensor_product_quadrature(subquadrature,
+                                                               quadrature_1D);
+  print_tensor_product_quadrature(tensor_product_quadrature);
+}
+
+
+
+template <int dim>
+void
+test_constructor_taking_n_points()
+{
+  deallog << "Constructor taking n_points" << std::endl;
+
+  const unsigned int                 n_points = 1;
+  const TensorProductQuadrature<dim> tensor_product_quadrature(n_points);
+  AssertThrow(n_points == tensor_product_quadrature.size(), ExcInternalError());
+  deallog << "OK" << std::endl;
+}
+
+
+
+template <int dim>
+void
+test()
+{
+  deallog << "dim = " << dim << std::endl;
+
+  test_constructor_taking_1D_quadratures<dim>();
+  deallog << std::endl;
+
+  test_constructor_taking_1D_and_subquadrature<dim>();
+  deallog << std::endl;
+
+  test_constructor_taking_n_points<dim>();
+}
+
+
+
+int
+main()
+{
+  initlog();
+  test<2>();
+}

--- a/tests/base/tensor_product_quadrature.output
+++ b/tests/base/tensor_product_quadrature.output
@@ -1,0 +1,36 @@
+
+DEAL::dim = 2
+DEAL::Constructor taking 1D Quadratures
+DEAL::points
+DEAL::0.200000 0.200000, 0.800000 0.200000, 0.200000 0.800000, 0.800000 0.800000, 
+DEAL::weights
+DEAL::0.0100000, 0.0900000, 0.0900000, 0.810000, 
+DEAL::base quadrature 0
+DEAL::points
+DEAL::0.200000, 0.800000, 
+DEAL::weights
+DEAL::0.100000, 0.900000, 
+DEAL::base quadrature 1
+DEAL::points
+DEAL::0.200000, 0.800000, 
+DEAL::weights
+DEAL::0.100000, 0.900000, 
+DEAL::
+DEAL::Constructor taking 1D and SubQuadrature
+DEAL::points
+DEAL::0.400000 0.200000, 0.600000 0.200000, 0.400000 0.800000, 0.600000 0.800000, 
+DEAL::weights
+DEAL::0.0300000, 0.0700000, 0.270000, 0.630000, 
+DEAL::base quadrature 0
+DEAL::points
+DEAL::0.400000, 0.600000, 
+DEAL::weights
+DEAL::0.300000, 0.700000, 
+DEAL::base quadrature 1
+DEAL::points
+DEAL::0.200000, 0.800000, 
+DEAL::weights
+DEAL::0.100000, 0.900000, 
+DEAL::
+DEAL::Constructor taking n_points
+DEAL::OK


### PR DESCRIPTION
Presently a boolean is used internally to keep track of whether Quadrature<dim> is a tensor product or not. This makes Quadrature<dim> have two different states which suggests that the tensor product
functionality would be better off as a separate class. Add a new class TensorProductQuadrature and move the 1-dimensional base quadratures from Quadrture<dim> to this new class. Derive the different quadrature rules (QGauss, etc.) which are tensor products from TensorProductQuadrature.