### PR TITLE
instantiate uninitialized tensor struct

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1138,6 +1138,9 @@ namespace internal
       static ArrayElementType value;
     };
 
+    template <typename Type>
+    Type Uninitialized<Type>::value;
+
     template <typename ArrayElementType>
     DEAL_II_CONSTEXPR inline ArrayElementType &
     subscript(ArrayElementType *,


### PR DESCRIPTION
We already do this for the same construct for SymmetricTensor.

Fixes
```
lib/libdeal_II.g.so.9.2.0-pre: error: undefined reference to 'dealii::internal::TensorSubscriptor::Uninitialized<dealii::Tensor<0, 0, double> >::value'
```
see #8791 