### PR TITLE
Assertion checks the wrong item size.

### DIFF
--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -838,7 +838,8 @@ namespace internal
 
         if (update_flags & update_volume_elements)
           {
-            AssertDimension(data.covariant.size(), data.volume_elements.size());
+            AssertDimension(data.contravariant.size(),
+                            data.volume_elements.size());
             if (cell_similarity != CellSimilarity::translation)
               for (unsigned int point = 0; point < data.contravariant.size();
                    ++point)

--- a/tests/mappings/mapping_fe_field_01.cc
+++ b/tests/mappings/mapping_fe_field_01.cc
@@ -77,7 +77,8 @@ test(const unsigned int degree)
   FEValues<dim, spacedim> fe_values(map_fe,
                                     fe_sys,
                                     quadrature_formula,
-                                    update_values | update_JxW_values);
+                                    update_values | update_JxW_values |
+                                      update_volume_elements);
 
   typename DoFHandler<dim, spacedim>::active_cell_iterator cell =
                                                              dof_sys


### PR DESCRIPTION
If the covariant is not required, its size will be zero and the assertion will fail.