### PR TITLE
Instantiate ConsensusAlgorithmSelector

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -1436,6 +1436,10 @@ namespace Utilities
       return owning_ranks;
     }
 
+    template class ConsensusAlgorithmSelector<
+      std::pair<types::global_dof_index, types::global_dof_index>,
+      unsigned int>;
+
 #include "mpi.inst"
   } // end of namespace MPI
 } // end of namespace Utilities


### PR DESCRIPTION
This ought to fix the failing builds. The only place `ConsenusAlgorithmSelector` is currently used is in https://github.com/dealii/dealii/blob/efcb25b610a2cfde0db554858049ce0fae842d1f/source/base/partitioner.cc#L233-L236 for the template parameters below.