### PR TITLE
Fix boost problems with MSVC

### DIFF
--- a/bundled/boost-1.70.0/include/boost/config/pragma_message.hpp
+++ b/bundled/boost-1.70.0/include/boost/config/pragma_message.hpp
@@ -1,0 +1,31 @@
+#ifndef BOOST_CONFIG_PRAGMA_MESSAGE_HPP_INCLUDED
+#define BOOST_CONFIG_PRAGMA_MESSAGE_HPP_INCLUDED
+
+//  Copyright 2017 Peter Dimov.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+//
+//  BOOST_PRAGMA_MESSAGE("message")
+//
+//  Expands to the equivalent of #pragma message("message")
+//
+//  Note that this header is C compatible.
+
+#include <boost/config/helper_macros.hpp>
+
+#if defined(BOOST_DISABLE_PRAGMA_MESSAGE)
+# define BOOST_PRAGMA_MESSAGE(x)
+#elif defined(__INTEL_COMPILER)
+# define BOOST_PRAGMA_MESSAGE(x) __pragma(message(__FILE__ "(" BOOST_STRINGIZE(__LINE__) "): note: " x))
+#elif defined(__GNUC__)
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+#elif defined(_MSC_VER)
+# define BOOST_PRAGMA_MESSAGE(x) __pragma(message(__FILE__ "(" BOOST_STRINGIZE(__LINE__) "): note: " x))
+#else
+# define BOOST_PRAGMA_MESSAGE(x)
+#endif
+
+#endif // BOOST_CONFIG_PRAGMA_MESSAGE_HPP_INCLUDED

--- a/bundled/boost-1.70.0/include/boost/preprocessor/seq/detail/to_list_msvc.hpp
+++ b/bundled/boost-1.70.0/include/boost/preprocessor/seq/detail/to_list_msvc.hpp
@@ -1,0 +1,55 @@
+# /* **************************************************************************
+#  *                                                                          *
+#  *     (C) Copyright Edward Diener 2016.                                    *
+#  *     Distributed under the Boost Software License, Version 1.0. (See      *
+#  *     accompanying file LICENSE_1_0.txt or copy at                         *
+#  *     http://www.boost.org/LICENSE_1_0.txt)                                *
+#  *                                                                          *
+#  ************************************************************************** */
+#
+# /* See http://www.boost.org for most recent version. */
+#
+# ifndef BOOST_PREPROCESSOR_SEQ_DETAIL_TO_LIST_MSVC_HPP
+# define BOOST_PREPROCESSOR_SEQ_DETAIL_TO_LIST_MSVC_HPP
+#
+# include <boost/preprocessor/config/config.hpp>
+#
+# if BOOST_PP_CONFIG_FLAGS() & BOOST_PP_CONFIG_MSVC()
+#
+# include <boost/preprocessor/cat.hpp>
+# include <boost/preprocessor/arithmetic/dec.hpp>
+# include <boost/preprocessor/control/while.hpp>
+# include <boost/preprocessor/tuple/elem.hpp>
+#
+# define BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC_STATE_RESULT(state) \
+    BOOST_PP_TUPLE_ELEM(2, 0, state) \
+/**/
+# define BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC_STATE_SIZE(state) \
+    BOOST_PP_TUPLE_ELEM(2, 1, state) \
+/**/
+# define BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC_PRED(d,state) \
+    BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC_STATE_SIZE(state) \
+/**/
+# define BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC_OP(d,state) \
+    ( \
+    BOOST_PP_CAT(BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC_STATE_RESULT(state),), \
+    BOOST_PP_DEC(BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC_STATE_SIZE(state)) \
+    ) \
+/**/
+#
+# /* BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC */
+#
+# define BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC(result,seqsize) \
+    BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC_STATE_RESULT \
+        ( \
+        BOOST_PP_WHILE \
+            ( \
+            BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC_PRED, \
+            BOOST_PP_SEQ_DETAIL_TO_LIST_MSVC_OP, \
+            (result,seqsize) \
+            ) \
+        ) \
+/**/
+# endif // BOOST_PP_CONFIG_FLAGS() & BOOST_PP_CONFIG_MSVC()
+#
+# endif // BOOST_PREPROCESSOR_SEQ_DETAIL_TO_LIST_MSVC_HPP

--- a/cmake/configure/configure_2_boost.cmake
+++ b/cmake/configure/configure_2_boost.cmake
@@ -63,8 +63,14 @@ MACRO(FEATURE_BOOST_CONFIGURE_COMMON)
   ELSE()
     ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-Werror")
   ENDIF()
+  # The configure function is called only once. In case an externally provided
+  # boost library is detected, BOOST_INCLUDE_DIRS contains the include paths to
+  # be used and BOOST_BUNDLED_INCLUDE_DIRS is empty. For the bundled library, it
+  # is the other way around.
   LIST(APPEND CMAKE_REQUIRED_INCLUDES ${BOOST_INCLUDE_DIRS} ${BOOST_BUNDLED_INCLUDE_DIRS})
 
+  # In case, the boost library already sets BOOST_NO_AUTO_PTR we report
+  # DEAL_II_HAS_AUTO_PTR to be true to avoid redefining the macro.
   CHECK_CXX_SOURCE_COMPILES(
     "
     #include <memory>
@@ -104,6 +110,8 @@ MACRO(FEATURE_BOOST_CONFIGURE_BUNDLED)
     ENDIF()
   ENDIF()
 
+  # We need to set this path before calling the configure function
+  # to be able to use the include paths in the checks.
   SET(BOOST_BUNDLED_INCLUDE_DIRS ${BOOST_FOLDER}/include)
 
   FEATURE_BOOST_CONFIGURE_COMMON()

--- a/cmake/configure/configure_2_boost.cmake
+++ b/cmake/configure/configure_2_boost.cmake
@@ -63,15 +63,19 @@ MACRO(FEATURE_BOOST_CONFIGURE_COMMON)
   ELSE()
     ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-Werror")
   ENDIF()
+  LIST(APPEND CMAKE_REQUIRED_INCLUDES ${BOOST_INCLUDE_DIRS} ${BOOST_BUNDLED_INCLUDE_DIRS})
 
   CHECK_CXX_SOURCE_COMPILES(
     "
     #include <memory>
+    #include <boost/config.hpp>
 
     int main()
     {
+    #ifndef BOOST_NO_AUTO_PTR
       int *i = new int;
       std::auto_ptr<int> x(i);
+    #endif
       return 0;
     }
     "
@@ -100,9 +104,9 @@ MACRO(FEATURE_BOOST_CONFIGURE_BUNDLED)
     ENDIF()
   ENDIF()
 
-  FEATURE_BOOST_CONFIGURE_COMMON()
-
   SET(BOOST_BUNDLED_INCLUDE_DIRS ${BOOST_FOLDER}/include)
+
+  FEATURE_BOOST_CONFIGURE_COMMON()
 
   IF(CMAKE_SYSTEM_NAME MATCHES "Windows")
     #


### PR DESCRIPTION
There were some boost files missing required for compiling with `MSVC`. 
Also, newer boost versions set `BOOST_NO_AUTO_PTR` themselves in `config.hpp`. Hence, we should not define the macro first in that case.