### PR TITLE
Inline functions because of bugs in hipcc

### DIFF
--- a/include/deal.II/hp/dof_faces.h
+++ b/include/deal.II/hp/dof_faces.h
@@ -343,6 +343,15 @@ namespace internal
     {}
 
 
+
+    inline std::size_t
+    DoFIndicesOnFaces<1>::memory_consumption() const
+    {
+      return 0;
+    }
+
+
+
     template <class Archive>
     void
     DoFIndicesOnFaces<2>::serialize(Archive &ar, const unsigned int)
@@ -351,11 +360,29 @@ namespace internal
     }
 
 
+
+    inline std::size_t
+    DoFIndicesOnFaces<2>::memory_consumption() const
+    {
+      return MemoryConsumption::memory_consumption(lines);
+    }
+
+
+
     template <class Archive>
     void
     DoFIndicesOnFaces<3>::serialize(Archive &ar, const unsigned int)
     {
       ar &lines &quads;
+    }
+
+
+
+    inline std::size_t
+    DoFIndicesOnFaces<3>::memory_consumption() const
+    {
+      return (MemoryConsumption::memory_consumption(lines) +
+              MemoryConsumption::memory_consumption(quads));
     }
 
     template <int structdim>

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -1405,6 +1405,38 @@ namespace hp
     // then just hand everything over to the other function that does the work
     return n_boundary_dofs(boundary_ids_only);
   }
+
+
+
+  template <>
+  inline types::global_dof_index
+  DoFHandler<2, 3>::n_boundary_dofs() const
+  {
+    Assert(false, ExcNotImplemented());
+    return 0;
+  }
+
+
+
+  template <>
+  template <typename number>
+  inline types::global_dof_index
+  DoFHandler<2, 3>::n_boundary_dofs(
+    const std::map<types::boundary_id, const Function<3, number> *> &) const
+  {
+    Assert(false, ExcNotImplemented());
+    return 0;
+  }
+
+
+
+  template <>
+  inline types::global_dof_index
+  DoFHandler<2, 3>::n_boundary_dofs(const std::set<types::boundary_id> &) const
+  {
+    Assert(false, ExcNotImplemented());
+    return 0;
+  }
 }
 
 

--- a/source/hp/dof_faces.cc
+++ b/source/hp/dof_faces.cc
@@ -43,33 +43,6 @@ namespace internal
 
     template std::size_t
     DoFIndicesOnFacesOrEdges<3>::memory_consumption() const;
-
-
-    // ---------------------- DoFFaces ----------------------------
-
-    std::size_t
-    DoFIndicesOnFaces<1>::memory_consumption() const
-    {
-      return 0;
-    }
-
-
-
-    std::size_t
-    DoFIndicesOnFaces<2>::memory_consumption() const
-    {
-      return MemoryConsumption::memory_consumption(lines);
-    }
-
-
-
-    std::size_t
-    DoFIndicesOnFaces<3>::memory_consumption() const
-    {
-      return (MemoryConsumption::memory_consumption(lines) +
-              MemoryConsumption::memory_consumption(quads));
-    }
-
   } // namespace hp
 } // namespace internal
 

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -1498,38 +1498,6 @@ namespace hp
 
 
 
-  template <>
-  types::global_dof_index
-  DoFHandler<2, 3>::n_boundary_dofs() const
-  {
-    Assert(false, ExcNotImplemented());
-    return 0;
-  }
-
-
-
-  template <>
-  template <typename number>
-  types::global_dof_index
-  DoFHandler<2, 3>::n_boundary_dofs(
-    const std::map<types::boundary_id, const Function<3, number> *> &) const
-  {
-    Assert(false, ExcNotImplemented());
-    return 0;
-  }
-
-
-
-  template <>
-  types::global_dof_index
-  DoFHandler<2, 3>::n_boundary_dofs(const std::set<types::boundary_id> &) const
-  {
-    Assert(false, ExcNotImplemented());
-    return 0;
-  }
-
-
-
   template <int dim, int spacedim>
   std::size_t
   DoFHandler<dim, spacedim>::memory_consumption() const


### PR DESCRIPTION
With this PR, #8621, and renaming `lac/exceptions` to `lac/petsc_exceptions`, I can compile deal.II with hipcc. There is still quite a bit of work before we can run on AMD hardware but at least, it compiles.