### PR TITLE
Merge computation of values and gradients in the matrixfree CUDA code

### DIFF
--- a/doc/news/changes/minor/20190924PeterMunch-1
+++ b/doc/news/changes/minor/20190924PeterMunch-1
@@ -1,0 +1,4 @@
+Improved: Evaluate/integrate the gradients in CUDAWrappers::EvaluatorTensorProduct
+with collocation method if both values and gradients are requested.
+<br>
+(Peter Munch, 2019/09/24)

--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -314,13 +314,18 @@ namespace CUDAWrappers
       n_q_points_1d,
       Number>
       evaluator_tensor_product;
-    if (evaluate_grad == true)
+    if (evaluate_val == true && evaluate_grad == true)
+      {
+        evaluator_tensor_product.value_and_gradient_at_quad_pts(values,
+                                                                gradients);
+        __syncthreads();
+      }
+    else if (evaluate_grad == true)
       {
         evaluator_tensor_product.gradient_at_quad_pts(values, gradients);
         __syncthreads();
       }
-
-    if (evaluate_val == true)
+    else if (evaluate_val == true)
       {
         evaluator_tensor_product.value_at_quad_pts(values);
         __syncthreads();
@@ -346,16 +351,15 @@ namespace CUDAWrappers
       n_q_points_1d,
       Number>
       evaluator_tensor_product;
-    if (integrate_val == true)
+    if (integrate_val == true && integrate_grad == true)
+      {
+        evaluator_tensor_product.integrate_value_and_gradient(values,
+                                                              gradients);
+      }
+    else if (integrate_val == true)
       {
         evaluator_tensor_product.integrate_value(values);
         __syncthreads();
-        if (integrate_grad == true)
-          {
-            evaluator_tensor_product.integrate_gradient<true>(values,
-                                                              gradients);
-            __syncthreads();
-          }
       }
     else if (integrate_grad == true)
       {


### PR DESCRIPTION
Reduce the number of sum-factorization sweeps from `dim+dim^2` to `2*dim` in the case that values and gradients are needed in the quadrature points. An optimization known from `MatrixFree` (actual).

I still have to finish the code (and compile it on a GPU^^); but the main intention of this PR is clear.

@kronbichler @Rombur @masterleinad Any objections?