### PR TITLE
Avoid dynamic_cast in ghost/artificial cell queries

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -26,6 +26,8 @@
 #include <deal.II/base/iterator_range.h>
 #include <deal.II/base/smartpointer.h>
 
+#include <deal.II/distributed/tria_base.h>
+
 #include <deal.II/dofs/block_info.h>
 #include <deal.II/dofs/deprecated_function_map.h>
 #include <deal.II/dofs/dof_faces.h>

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/array_view.h>
 #include <deal.II/base/derivative_form.h>
 
 #include <deal.II/fe/fe_update_flags.h>

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -22,8 +22,6 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/template_constraints.h>
 
-#include <deal.II/distributed/tria_base.h>
-
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_faces.h>
@@ -34,15 +32,6 @@
 #include <cmath>
 
 DEAL_II_NAMESPACE_OPEN
-
-// Forward declaration
-#ifndef DOXYGEN
-namespace parallel
-{
-  template <int, int>
-  class TriangulationBase;
-}
-#endif
 
 
 /*--------------------- Functions: TriaAccessorBase -------------------------*/

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -3566,17 +3566,10 @@ CellAccessor<dim, spacedim>::is_locally_owned() const
 #ifndef DEAL_II_WITH_MPI
   return true;
 #else
-  if (is_artificial())
-    return false;
 
-  const parallel::TriangulationBase<dim, spacedim> *pt =
-    dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
-      this->tria);
-
-  if (pt == nullptr)
-    return true;
-  else
-    return (this->subdomain_id() == pt->locally_owned_subdomain());
+  return (this->tria->locally_owned_subdomain() ==
+            numbers::invalid_subdomain_id ||
+          this->subdomain_id() == this->tria->locally_owned_subdomain());
 
 #endif
 }
@@ -3590,14 +3583,9 @@ CellAccessor<dim, spacedim>::is_locally_owned_on_level() const
   return true;
 #else
 
-  const parallel::TriangulationBase<dim, spacedim> *pt =
-    dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
-      this->tria);
-
-  if (pt == nullptr)
-    return true;
-  else
-    return (this->level_subdomain_id() == pt->locally_owned_subdomain());
+  return (this->tria->locally_owned_subdomain() ==
+            numbers::invalid_subdomain_id ||
+          this->level_subdomain_id() == this->tria->locally_owned_subdomain());
 
 #endif
 }
@@ -3609,21 +3597,17 @@ CellAccessor<dim, spacedim>::is_ghost() const
 {
   Assert(this->active(),
          ExcMessage("is_ghost() can only be called on active cells!"));
-  if (is_artificial() || this->has_children())
+  if (this->has_children())
     return false;
 
 #ifndef DEAL_II_WITH_MPI
   return false;
 #else
 
-  const parallel::TriangulationBase<dim, spacedim> *pt =
-    dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
-      this->tria);
-
-  if (pt == nullptr)
-    return false;
-  else
-    return (this->subdomain_id() != pt->locally_owned_subdomain());
+  return (this->tria->locally_owned_subdomain() !=
+            numbers::invalid_subdomain_id &&
+          this->subdomain_id() != this->tria->locally_owned_subdomain() &&
+          this->subdomain_id() != numbers::artificial_subdomain_id);
 
 #endif
 }
@@ -3640,14 +3624,9 @@ CellAccessor<dim, spacedim>::is_artificial() const
   return false;
 #else
 
-  const parallel::TriangulationBase<dim, spacedim> *pt =
-    dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
-      this->tria);
-
-  if (pt == nullptr)
-    return false;
-  else
-    return this->subdomain_id() == numbers::artificial_subdomain_id;
+  return (this->tria->locally_owned_subdomain() !=
+            numbers::invalid_subdomain_id &&
+          this->subdomain_id() == numbers::artificial_subdomain_id);
 
 #endif
 }

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -3567,6 +3567,10 @@ CellAccessor<dim, spacedim>::is_locally_owned() const
   return true;
 #else
 
+  // Serial triangulations report invalid_subdomain_id as their locally owned
+  // subdomain, so the first condition checks whether we have a serial
+  // triangulation, in which case all cells are locally owned. The second
+  // condition compares the subdomain id in the parallel case.
   return (this->tria->locally_owned_subdomain() ==
             numbers::invalid_subdomain_id ||
           this->subdomain_id() == this->tria->locally_owned_subdomain());
@@ -3583,6 +3587,10 @@ CellAccessor<dim, spacedim>::is_locally_owned_on_level() const
   return true;
 #else
 
+  // Serial triangulations report invalid_subdomain_id as their locally owned
+  // subdomain, so the first condition checks whether we have a serial
+  // triangulation, in which case all cells are locally owned. The second
+  // condition compares the subdomain id in the parallel case.
   return (this->tria->locally_owned_subdomain() ==
             numbers::invalid_subdomain_id ||
           this->level_subdomain_id() == this->tria->locally_owned_subdomain());
@@ -3604,6 +3612,11 @@ CellAccessor<dim, spacedim>::is_ghost() const
   return false;
 #else
 
+  // Serial triangulations report invalid_subdomain_id as their locally owned
+  // subdomain, so the first condition rules out that case as all cells to a
+  // serial triangulation are locally owned and none is ghosted. The second
+  // and third conditions check whether the cell's subdomain is not the
+  // locally owned one and not artificial.
   return (this->tria->locally_owned_subdomain() !=
             numbers::invalid_subdomain_id &&
           this->subdomain_id() != this->tria->locally_owned_subdomain() &&
@@ -3624,6 +3637,9 @@ CellAccessor<dim, spacedim>::is_artificial() const
   return false;
 #else
 
+  // Serial triangulations report invalid_subdomain_id as their locally owned
+  // subdomain, so the first condition rules out that case as all cells to a
+  // serial triangulation are locally owned and none is artificial.
   return (this->tria->locally_owned_subdomain() !=
             numbers::invalid_subdomain_id &&
           this->subdomain_id() == numbers::artificial_subdomain_id);

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -20,6 +20,8 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/utilities.h>
 
+#include <deal.II/distributed/tria_base.h>
+
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 
@@ -195,8 +197,8 @@ namespace internal
       // boundaries as evenly as possible between the processors
       std::map<types::subdomain_id, FaceIdentifier>
         inner_faces_at_proc_boundary;
-      if (dynamic_cast<const parallel::TriangulationBase<dim> *>(
-            &triangulation))
+      if (triangulation.locally_owned_subdomain() !=
+          numbers::invalid_subdomain_id)
         {
           const types::subdomain_id my_domain =
             triangulation.locally_owned_subdomain();


### PR DESCRIPTION
This replaces the `dynamic_cast` in the `CellAccessor::is_locally_owned` and friends functions by a query to the subdomain of the triangulation as discussed in #8801. While that is also a virtual function call, it is still much cheaper than finding out about the actual type of a class with virtual inheritance. As discussed in #8801, we do not intend to change the subdomain id of a serial triangulation at this point.

Closes #8801.