### PR TITLE
fix gcc 4.9 warning

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -547,7 +547,7 @@ namespace GridTools
       SubCellData
       get()
       {
-        return SubCellData{};
+        return SubCellData();
       }
     };
 


### PR DESCRIPTION
fixes:
source/grid/grid_tools.cc:550:28: warning: missing initializer for
member ‘dealii::SubCellData::boundary_lines’ [-Wmissing-field-
initializers]