### PR TITLE
Store 1D quadrature in ShapeInfo

### DIFF
--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -233,6 +233,12 @@ namespace internal
       AlignedVector<Number> hessians_within_subface[2];
 
       /**
+       * We store a copy of the one-dimensional quadrature formula
+       * used for initialization.
+       */
+      Quadrature<1> quadrature;
+
+      /**
        * Renumbering from deal.II's numbering of cell degrees of freedom to
        * lexicographic numbering used inside the FEEvaluation schemes of the
        * underlying element in the DoFHandler. For vector-valued elements, the

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -75,6 +75,7 @@ namespace internal
                               const FiniteElement<dim> &fe_in,
                               const unsigned int        base_element_number)
     {
+      this->quadrature             = quad;
       const FiniteElement<dim> *fe = &fe_in.base_element(base_element_number);
 
       Assert(fe->n_components() == 1,


### PR DESCRIPTION
Store a copy of the one-dimensional quadrature formula used to initialize the ShapeInfo.