### PR TITLE
Store Mapping in MatrixFree's MappingInfo

### DIFF
--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -386,6 +386,11 @@ namespace internal
         face_data_by_cells;
 
       /**
+       * The pointer to the underlying Mapping object.
+       */
+      SmartPointer<const Mapping<dim>> mapping;
+
+      /**
        * Computes the information in the given cells, called within
        * initialize.
        */

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -283,6 +283,7 @@ namespace internal
       const UpdateFlags update_flags_faces_by_cells)
     {
       clear();
+      this->mapping = &mapping;
 
       // Could call these functions in parallel, but not useful because the
       // work inside is nicely split up already


### PR DESCRIPTION
Store a pointer to the Mapping object used to initialize the MappingInfo of the MatrixFree infrastructure.