### PR TITLE
Fix a bug introduced in #8783

### DIFF
--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -394,6 +394,9 @@ namespace parallel
       // loop over all periodic face pairs
       for (const auto &pair : this->get_periodic_face_map())
         {
+          if (pair.first.first->level() != pair.second.first.first->level())
+            continue;
+
           const auto face_a = pair.first.first->face(pair.first.second);
           const auto face_b =
             pair.second.first.first->face(pair.second.first.second);


### PR DESCRIPTION
I have introduce in #8783 a bug, which I did not notice in my tests since I did not install PETSc but only Trilinos (sorry for that). This PR fixes the bug as the local tests show:

```
      Start 3888: mpi/periodicity_01.mpirun=3.debug
 1/12 Test #3888: mpi/periodicity_01.mpirun=3.debug ....   Passed    1.04 sec
      Start 3889: mpi/periodicity_01.mpirun=5.debug
 2/12 Test #3889: mpi/periodicity_01.mpirun=5.debug ....   Passed    1.02 sec
      Start 3890: mpi/periodicity_01.mpirun=7.debug
 3/12 Test #3890: mpi/periodicity_01.mpirun=7.debug ....   Passed    0.63 sec
      Start 3891: mpi/periodicity_02.mpirun=3.debug
 4/12 Test #3891: mpi/periodicity_02.mpirun=3.debug ....   Passed    0.54 sec
      Start 3892: mpi/periodicity_02.mpirun=5.debug
 5/12 Test #3892: mpi/periodicity_02.mpirun=5.debug ....   Passed    0.54 sec
      Start 3893: mpi/periodicity_02.mpirun=7.debug
 6/12 Test #3893: mpi/periodicity_02.mpirun=7.debug ....   Passed    0.55 sec
      Start 3894: mpi/periodicity_04.mpirun=3.debug
 7/12 Test #3894: mpi/periodicity_04.mpirun=3.debug ....   Passed    0.55 sec
      Start 3895: mpi/periodicity_04.mpirun=5.debug
 8/12 Test #3895: mpi/periodicity_04.mpirun=5.debug ....   Passed    0.56 sec
      Start 3896: mpi/periodicity_04.mpirun=7.debug
 9/12 Test #3896: mpi/periodicity_04.mpirun=7.debug ....   Passed    1.01 sec
      Start 3897: mpi/periodicity_05.mpirun=9.debug
10/12 Test #3897: mpi/periodicity_05.mpirun=9.debug ....   Passed    0.72 sec
      Start 3898: mpi/periodicity_06.mpirun=2.debug
11/12 Test #3898: mpi/periodicity_06.mpirun=2.debug ....   Passed    0.55 sec
      Start 3899: mpi/periodicity_07.mpirun=13.debug
12/12 Test #3899: mpi/periodicity_07.mpirun=13.debug ...   Passed    0.54 sec

100% tests passed, 0 tests failed out of 12

Total Test time (real) =   9.83 sec
```

Thanks: @masterleinad !