### PR TITLE
Bypass vector copy in MatrixFree::cell_loop with MPI

### DIFF
--- a/doc/news/changes/minor/20190927MartinKronbichler
+++ b/doc/news/changes/minor/20190927MartinKronbichler
@@ -1,0 +1,6 @@
+Improved: CUDAWrappers::MatrixFree::cell_loop() can now detect whether the
+given vectors have the same parallel MPI partitioner as the matrix-free
+class, which circumvents vector copies and speeds up execution. This
+approach has also been applied to step-64.
+<br>
+(Martin Kronbichler, Peter Munch, 2019/09/27)

--- a/examples/step-64/step-64.cu
+++ b/examples/step-64/step-64.cu
@@ -236,6 +236,9 @@ namespace Step64
           const LinearAlgebra::distributed::Vector<double, MemorySpace::CUDA>
             &src) const;
 
+    void initialize_dof_vector(
+      LinearAlgebra::distributed::Vector<double, MemorySpace::CUDA> &vec) const;
+
   private:
     CUDAWrappers::MatrixFree<dim, double>       mf_data;
     LinearAlgebra::CUDAWrappers::Vector<double> coef;
@@ -301,6 +304,15 @@ namespace Step64
       coef.get_values());
     mf_data.cell_loop(helmholtz_operator, src, dst);
     mf_data.copy_constrained_values(src, dst);
+  }
+
+
+
+  template <int dim, int fe_degree>
+  void HelmholtzOperator<dim, fe_degree>::initialize_dof_vector(
+    LinearAlgebra::distributed::Vector<double, MemorySpace::CUDA> &vec) const
+  {
+    mf_data.initialize_dof_vector(vec);
   }
 
 
@@ -401,8 +413,8 @@ namespace Step64
     ghost_solution_host.reinit(locally_owned_dofs,
                                locally_relevant_dofs,
                                mpi_communicator);
-    solution_dev.reinit(locally_owned_dofs, mpi_communicator);
-    system_rhs_dev.reinit(locally_owned_dofs, mpi_communicator);
+    system_matrix_dev->initialize_dof_vector(solution_dev);
+    system_rhs_dev.reinit(solution_dev);
   }
 
 


### PR DESCRIPTION
The CUDA code with MPI would previously copy the vector in `CUDAWrappers::MatrixFree::cell_loop` for handling the ghost entries. However, if we have compatible partitioners, we can bypass that and simply let the vectors call `update_ghost_values()` and `compress()`.