### PR TITLE
Fix behavior for CUDA-aware MPI

### DIFF
--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -513,18 +513,30 @@ namespace Utilities
                    "vector_operation argument was passed to "
                    "import_from_ghosted_array_start as is passed "
                    "to import_from_ghosted_array_finish."));
-#      ifdef DEAL_II_WITH_CXX17
-          if constexpr (std::is_trivial<Number>::value)
-#      else
-          if (std::is_trivial<Number>::value)
-#      endif
-            std::memset(ghost_array.data(),
-                        0,
-                        sizeof(Number) * ghost_array.size());
+
+#      if (defined(DEAL_II_COMPILER_CUDA_AWARE))
+          if (std::is_same<MemorySpaceType, MemorySpace::CUDA>::value)
+            {
+              cudaMemset(ghost_array.data(),
+                         0,
+                         sizeof(Number) * ghost_array.size());
+            }
           else
-            std::fill(ghost_array.data(),
-                      ghost_array.data() + ghost_array.size(),
-                      0);
+#      endif
+            {
+#      ifdef DEAL_II_WITH_CXX17
+              if constexpr (std::is_trivial<Number>::value)
+#      else
+            if (std::is_trivial<Number>::value)
+#      endif
+                std::memset(ghost_array.data(),
+                            0,
+                            sizeof(Number) * ghost_array.size());
+              else
+                std::fill(ghost_array.data(),
+                          ghost_array.data() + ghost_array.size(),
+                          0);
+            }
           return;
         }
 #    endif

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -687,17 +687,9 @@ namespace Utilities
             {
               for (auto const &import_indices_plain : import_indices_plain_dev)
                 {
+                  // We can't easily assert here, so we just move the pointer
+                  // matching the host code.
                   const auto chunk_size = import_indices_plain.second;
-                  const int n_blocks =
-                    1 + chunk_size / (::dealii::CUDAWrappers::chunk_size *
-                                      ::dealii::CUDAWrappers::block_size);
-                  dealii::LinearAlgebra::CUDAWrappers::kernel::
-                    set_permutated<<<n_blocks,
-                                     dealii::CUDAWrappers::block_size>>>(
-                      import_indices_plain.first.get(),
-                      locally_owned_array.data(),
-                      read_position,
-                      chunk_size);
                   read_position += chunk_size;
                 }
             }

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -514,7 +514,7 @@ namespace Utilities
                    "import_from_ghosted_array_start as is passed "
                    "to import_from_ghosted_array_finish."));
 
-#      if (defined(DEAL_II_COMPILER_CUDA_AWARE))
+#      if defined(DEAL_II_COMPILER_CUDA_AWARE)
           if (std::is_same<MemorySpaceType, MemorySpace::CUDA>::value)
             {
               cudaMemset(ghost_array.data(),


### PR DESCRIPTION
With this pull request, all the tests using CUDA-aware MPI are passing again.
- We must not use `std::memset` for device data. Instead use `.cudaMemset`.
- Ghost entries must not be actually inserted matching the behavior for the CPU code. There we assert that the values are the same, but this is difficult on the GPU so we omit it.