### PR TITLE
Avoid including thread_management.h

### DIFF
--- a/include/deal.II/base/polynomials_integrated_legendre_sz.h
+++ b/include/deal.II/base/polynomials_integrated_legendre_sz.h
@@ -21,7 +21,6 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
-#include <deal.II/base/thread_management.h>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -21,7 +21,6 @@
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/std_cxx14/memory.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_accessor.h>

--- a/include/deal.II/grid/composition_manifold.h
+++ b/include/deal.II/grid/composition_manifold.h
@@ -26,7 +26,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/subscriptor.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/grid/manifold.h>
 #include <deal.II/grid/tria.h>

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -26,7 +26,6 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/subscriptor.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/grid/tria.h>
 

--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -19,7 +19,6 @@
 
 #include <deal.II/base/parallel.h>
 #include <deal.II/base/template_constraints.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/lac/chunk_sparse_matrix.h>
 #include <deal.II/lac/full_matrix.h>

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -22,7 +22,6 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/template_constraints.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/types.h>
 #include <deal.II/base/utilities.h>
 

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -21,7 +21,6 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/subscriptor.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/lac/block_sparse_matrix.h>
 #include <deal.II/lac/sparse_matrix.h>

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -21,7 +21,6 @@
 
 #include <deal.II/base/parallel.h>
 #include <deal.II/base/template_constraints.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/dynamic_sparsity_pattern.h>

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -20,7 +20,6 @@
 #include <deal.II/base/memory_space.h>
 #include <deal.II/base/multithread_info.h>
 #include <deal.II/base/parallel.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/types.h>
 #include <deal.II/base/vectorization.h>
 

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -20,7 +20,6 @@
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/distributed/tria.h>

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -21,7 +21,6 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/dofs/deprecated_function_map.h>
 

--- a/source/base/multithread_info.cc
+++ b/source/base/multithread_info.cc
@@ -28,8 +28,6 @@
 #include <algorithm>
 
 #ifdef DEAL_II_WITH_THREADS
-#  include <deal.II/base/thread_management.h>
-
 #  include <tbb/task_scheduler_init.h>
 #endif
 

--- a/source/base/scalar_polynomials_base.cc
+++ b/source/base/scalar_polynomials_base.cc
@@ -16,7 +16,6 @@
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/scalar_polynomials_base.h>
-#include <deal.II/base/thread_management.h>
 
 #include <iomanip>
 #include <iostream>

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -15,7 +15,6 @@
 
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/subscriptor.h>
-#include <deal.II/base/thread_management.h>
 
 #include <algorithm>
 #include <iostream>

--- a/source/base/tensor_polynomials_base.cc
+++ b/source/base/tensor_polynomials_base.cc
@@ -16,7 +16,6 @@
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/tensor_polynomials_base.h>
-#include <deal.II/base/thread_management.h>
 
 #include <iomanip>
 #include <iostream>

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -16,7 +16,6 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/signaling_nan.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/timer.h>
 #include <deal.II/base/utilities.h>
 

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -15,7 +15,6 @@
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/template_constraints.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/types.h>
 #include <deal.II/base/utilities.h>
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -16,7 +16,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/template_constraints.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/shared_tria.h>

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -15,7 +15,6 @@
 
 #include <deal.II/base/table.h>
 #include <deal.II/base/template_constraints.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/work_stream.h>
 

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -16,7 +16,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/template_constraints.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/shared_tria.h>

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -21,7 +21,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/tensor_product_polynomials.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_accessor.h>

--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -14,7 +14,6 @@
 // ---------------------------------------------------------------------
 
 #include <deal.II/base/memory_consumption.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/lac/block_sparse_matrix.h>
 #include <deal.II/lac/sparse_direct.h>

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -16,7 +16,6 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/distributed/tria.h>

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -15,7 +15,6 @@
 
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/parallel.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/grid/grid_refinement.h>


### PR DESCRIPTION
It seems there are a number of places where including this header, in fact, is not necessary.