### PR TITLE
PERL_PATH removed from options.dox

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -240,7 +240,6 @@ SKIP_FUNCTION_MACROS   = YES
 GENERATE_TAGFILE       = deal.tag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
-PERL_PATH              = /usr/bin/perl
 
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool


### PR DESCRIPTION
I generated the documentation and received this warning (Doxygen version 1.8.16)
```
warning: Tag 'PERL_PATH' at line 243 of file 'options.dox' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
```

I removed one line from `doxygen.dox.in`. It shouldn't break anything because it was specifying the default system path for perl.