### PR TITLE
Remove std::bind from examples

### DIFF
--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -203,7 +203,7 @@ namespace Step12
     // pointers to these functions to the MeshWorker framework. If, however,
     // these functions would want to access member variables (or needed
     // additional arguments beyond the ones specified below), we could use the
-    // facilities of boost::bind (or std::bind, respectively) to provide the
+    // facilities of lambda functions to provide the
     // MeshWorker framework with objects that act as if they had the required
     // number and types of arguments, but have in fact other arguments already
     // bound.
@@ -312,7 +312,7 @@ namespace Step12
     // integrator class are not actually function pointers. Rather, they are
     // objects that can be called like functions with a certain number of
     // arguments. Consequently, we could also pass objects with appropriate
-    // operator() implementations here, or the result of std::bind if the local
+    // operator() implementations here, or lambda functions if the local
     // integrators were, for example, non-static member functions.
     MeshWorker::loop<dim,
                      dim,

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -788,7 +788,7 @@ namespace Step13
       // function</a> that wraps the function call including the individual
       // arguments with fixed values. The fixed values are passed into the
       // lambda function using the capture list
-      // ([...]). All the other arguments the wrapped function requires and are
+      // (`[...]`). All the other arguments the wrapped function requires and are
       // part of the outer function signature are specified as regular function
       // parameters in the lambda function.
       //

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -795,7 +795,7 @@ namespace Step13
       // the lambda function. The fixed values are passed into the lambda
       // function using the capture list (`[...]`). It is possible to use a
       // capture default or to list all the variables that are to be bound to
-      // the lambda explicitly. For the sake of clarity we decided to to omit
+      // the lambda explicitly. For the sake of clarity we decided to omit
       // the capture default here, but that capture list could equally well be
       // `[&]` meaning that all used variables are copied into the lambda by
       // reference.

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -797,7 +797,7 @@ namespace Step13
       // capture default or to list all the variables that are to be bound to
       // the lambda explicitly. For the sake of clarity we decided to omit
       // the capture default here, but that capture list could equally well be
-      // `[&]` meaning that all used variables are copied into the lambda by
+      // `[&]`, meaning that all used variables are copied into the lambda by
       // reference.
       //
       // At this point, we have assembled the matrix and condensed

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -756,7 +756,7 @@ namespace Step13
                       AssemblyCopyData());
       linear_system.hanging_node_constraints.condense(linear_system.matrix);
 
-      // The syntax above using lambda functions requires
+      // The syntax above requires
       // some explanation. There are multiple version of
       // WorkStream::run that expect different arguments. In step-9,
       // we used one version that took a pair of iterators, a pair of
@@ -790,11 +790,15 @@ namespace Step13
       // typical way to generate such function objects is using a
       // <a href="http://en.wikipedia.org/wiki/Anonymous_function">lambda
       // function</a> that wraps the function call including the individual
-      // arguments with fixed values. The fixed values are passed into the
-      // lambda function using the capture list
-      // (`[...]`). All the other arguments the wrapped function requires and are
-      // part of the outer function signature are specified as regular function
-      // parameters in the lambda function.
+      // arguments with fixed values. All the arguments that are part of the
+      // outer function signature are specified as regular function arguments in
+      // the lambda function. The fixed values are passed into the lambda
+      // function using the capture list (`[...]`). It is possible to use a
+      // capture default or to list all the variables that are to be bound to
+      // the lambda explicitly. For the sake of clarity we decided to to omit
+      // the capture default here, but that capture list could equally well be
+      // `[&]` meaning that all used variables are copied into the lambda by
+      // reference.
       //
       // At this point, we have assembled the matrix and condensed
       // it. The right hand side may or may not have been completely

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -2201,7 +2201,8 @@ namespace Step14
           cell, scratch_data, copy_data, error_indicators, face_integrals);
       };
 
-      auto copier = std::function<void(const WeightedResidualCopyData &)>();
+      auto do_nothing_copier =
+        std::function<void(const WeightedResidualCopyData &)>();
 
       // Then hand it all off to WorkStream::run() to compute the
       // estimators for all cells in parallel:
@@ -2209,7 +2210,7 @@ namespace Step14
         DualSolver<dim>::dof_handler.begin_active(),
         DualSolver<dim>::dof_handler.end(),
         worker,
-        copier,
+        do_nothing_copier,
         WeightedResidualScratchData(*DualSolver<dim>::fe,
                                     *DualSolver<dim>::quadrature,
                                     *DualSolver<dim>::face_quadrature,

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -691,9 +691,9 @@ namespace Step27
         std::pair<std::vector<unsigned int>, std::vector<double>> res =
           FESeries::process_coefficients<dim>(
             fourier_coefficients,
-            std::bind(&LaplaceProblem<dim>::predicate,
-                      this,
-                      std::placeholders::_1),
+            [this](const TableIndices<dim> &indices) {
+              return this->predicate(indices);
+            },
             VectorTools::Linfty_norm);
 
         Assert(res.first.size() == res.second.size(), ExcInternalError());

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -2728,7 +2728,7 @@ namespace Step32
                                              data);
       };
 
-    auto copier = [=](const Assembly::CopyData::TemperatureRHS<dim> &data) {
+    auto copier = [this](const Assembly::CopyData::TemperatureRHS<dim> &data) {
       this->copy_local_to_global_temperature_rhs(data);
     };
 

--- a/examples/step-49/step-49.cc
+++ b/examples/step-49/step-49.cc
@@ -237,8 +237,7 @@ void grid_4()
 // the address of a function that takes a point and returns a point, an object
 // that has an <code>operator()</code> like the code below, or for example, a
 // <code>std::function@<Point@<2@>(const Point@<2@>)@></code> object one can
-// get via <code>std::bind</code> in more complex cases. Here we have a simple
-// transformation and use the simplest method: a lambda function.
+// get as a lambda function. Here we choose the latter option.
 void grid_5()
 {
   Triangulation<2>          triangulation;

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -1035,7 +1035,7 @@ namespace Step51
                unsigned int &                                        data) {
           this->postprocess_one_cell(cell, scratch, data);
         },
-        [](const unsigned int &) {},
+        std::function<void(const unsigned int &)>(),
         scratch,
         0U);
     }

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -1027,16 +1027,17 @@ namespace Step51
       PostProcessScratchData scratch(
         fe_u_post, fe_local, quadrature_formula, local_flags, flags);
 
-      WorkStream::run(dof_handler_u_post.begin_active(),
-                      dof_handler_u_post.end(),
-                      std::bind(&HDG<dim>::postprocess_one_cell,
-                                std::ref(*this),
-                                std::placeholders::_1,
-                                std::placeholders::_2,
-                                std::placeholders::_3),
-                      std::function<void(const unsigned int &)>(),
-                      scratch,
-                      0U);
+      WorkStream::run(
+        dof_handler_u_post.begin_active(),
+        dof_handler_u_post.end(),
+        [this](const typename DoFHandler<dim>::active_cell_iterator &cell,
+               PostProcessScratchData &                              scratch,
+               unsigned int &                                        data) {
+          this->postprocess_one_cell(cell, scratch, data);
+        },
+        [](const unsigned int &) {},
+        scratch,
+        0U);
     }
 
     Vector<float> difference_per_cell(triangulation.n_active_cells());

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -955,7 +955,7 @@ namespace Step9
     WorkStream::run(dof_handler.begin_active(),
                     dof_handler.end(),
                     &GradientEstimation::template estimate_cell<dim>,
-                    [](const EstimateCopyData &) {},
+                    std::function<void(const EstimateCopyData &)>(),
                     EstimateScratchData<dim>(dof_handler.get_fe(),
                                              solution,
                                              error_per_cell),


### PR DESCRIPTION
This pull request removes all the uses of `std::bind` from the examples. I am happy for suggestions for improving the documentation. Currently, I am removing all occurences of `std::bind` also in the documentation for the examples but would also be fine to mention it as long as we encourage using lambdas.