### PR TITLE
Add VectorizedArray::size() member function

### DIFF
--- a/doc/news/changes/minor/20191008MartinKronbichler
+++ b/doc/news/changes/minor/20191008MartinKronbichler
@@ -1,0 +1,5 @@
+New: The class VectorizedArray now provides a member function
+VectorizedArray::size() to return the number of array elements, in analogy to
+the STL containers.
+<br>
+(Martin Kronbichler, 2019/10/08)

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -217,6 +217,16 @@ public:
   }
 
   /**
+   * Return the number of elements in the array stored in the variable
+   * n_array_elements.
+   */
+  static constexpr unsigned int
+  size()
+  {
+    return n_array_elements;
+  }
+
+  /**
    * Access operator (only valid with component 0 in the base class without
    * specialization).
    */
@@ -685,6 +695,16 @@ public:
   }
 
   /**
+   * Return the number of elements in the array stored in the variable
+   * n_array_elements.
+   */
+  static constexpr unsigned int
+  size()
+  {
+    return n_array_elements;
+  }
+
+  /**
    * Access operator.
    */
   DEAL_II_ALWAYS_INLINE
@@ -1115,6 +1135,16 @@ public:
   {
     data = _mm512_set1_ps(x);
     return *this;
+  }
+
+  /**
+   * Return the number of elements in the array stored in the variable
+   * n_array_elements.
+   */
+  static constexpr unsigned int
+  size()
+  {
+    return n_array_elements;
   }
 
   /**
@@ -1602,6 +1632,16 @@ public:
   }
 
   /**
+   * Return the number of elements in the array stored in the variable
+   * n_array_elements.
+   */
+  static constexpr unsigned int
+  size()
+  {
+    return n_array_elements;
+  }
+
+  /**
    * Access operator.
    */
   DEAL_II_ALWAYS_INLINE
@@ -2001,6 +2041,16 @@ public:
   {
     data = _mm256_set1_ps(x);
     return *this;
+  }
+
+  /**
+   * Return the number of elements in the array stored in the variable
+   * n_array_elements.
+   */
+  static constexpr unsigned int
+  size()
+  {
+    return n_array_elements;
   }
 
   /**
@@ -2416,6 +2466,16 @@ public:
   }
 
   /**
+   * Return the number of elements in the array stored in the variable
+   * n_array_elements.
+   */
+  static constexpr unsigned int
+  size()
+  {
+    return n_array_elements;
+  }
+
+  /**
    * This function can be used to set all data fields to a given scalar.
    */
   DEAL_II_ALWAYS_INLINE
@@ -2786,6 +2846,16 @@ public:
   {
     data = _mm_set1_ps(x);
     return *this;
+  }
+
+  /**
+   * Return the number of elements in the array stored in the variable
+   * n_array_elements.
+   */
+  static constexpr unsigned int
+  size()
+  {
+    return n_array_elements;
   }
 
   /**
@@ -3170,6 +3240,16 @@ public:
   }
 
   /**
+   * Return the number of elements in the array stored in the variable
+   * n_array_elements.
+   */
+  static constexpr unsigned int
+  size()
+  {
+    return n_array_elements;
+  }
+
+  /**
    * Access operator. The component must be either 0 or 1.
    */
   DEAL_II_ALWAYS_INLINE
@@ -3399,6 +3479,16 @@ public:
   {
     data = vec_splats(x);
     return *this;
+  }
+
+  /**
+   * Return the number of elements in the array stored in the variable
+   * n_array_elements.
+   */
+  static constexpr unsigned int
+  size()
+  {
+    return n_array_elements;
   }
 
   /**

--- a/tests/base/vectorization_01.cc
+++ b/tests/base/vectorization_01.cc
@@ -36,6 +36,10 @@ test()
   for (unsigned int i = 0; i < n_vectors; ++i)
     c[i] = Number(i);
 
+  AssertDimension(n_vectors, a.size());
+  AssertDimension(a.size(), sizeof(a) / sizeof(Number));
+  AssertDimension(VectorizedArray<Number>::size(), sizeof(a) / sizeof(Number));
+
   deallog << "Addition: ";
   VectorizedArray<Number> d = a + b;
   for (unsigned int i = 0; i < n_vectors; ++i)


### PR DESCRIPTION
This adds a `size()` function to `VectorizedArray`. I find this more convenient than using the `VectorizedArray::n_array_elements` member variable when writing loops with STL in mind.

One thing to discuss is whether we want to add more interfaces familiar from `std::array`, such as `begin()/end()` that would also allow to use range-based for loops for example.