### PR TITLE
Document unsupported MG refinement edges for matrix-free DG

### DIFF
--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -898,6 +898,10 @@ namespace internal
                                 if (face_is_owned[dcell->face(f)->index()] ==
                                     FaceCategory::locally_active_done_here)
                                   {
+                                    Assert(use_active_cells ||
+                                             dcell->level() ==
+                                               neighbor->level(),
+                                           ExcInternalError());
                                     ++inner_counter;
                                     inner_faces.push_back(create_face(
                                       f,
@@ -947,6 +951,9 @@ namespace internal
           task_info.boundary_partition_data[partition + 1] =
             task_info.boundary_partition_data[partition] + boundary_counter;
         }
+      Assert(refinement_edge_faces.empty(),
+             ExcNotImplemented("Setting up data structures on MG levels with "
+                               "hanging nodes is currently not supported."));
       task_info.ghost_face_partition_data.resize(2);
       task_info.ghost_face_partition_data[0] = 0;
       task_info.ghost_face_partition_data[1] = inner_ghost_faces.size();


### PR DESCRIPTION
I added an assertion (the second added) that bails out in case we detect refinement edges.

Related to #8905.