### PR TITLE
Fix VectorTools::interpolate() for p::d::Triangulation

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -615,24 +615,27 @@ namespace VectorTools
 
     for (; h != endh; ++h, ++l)
       {
-        h->get_dof_values(data_1, cell_data_1);
-        transfer.vmult(cell_data_2, cell_data_1);
-
-        l->get_dof_indices(local_dof_indices);
-
-        // distribute cell vector
-        for (unsigned int j = 0; j < dof_2.get_fe().dofs_per_cell; ++j)
+        if (h->is_locally_owned())
           {
-            ::dealii::internal::ElementAccess<OutVector>::add(
-              cell_data_2(j), local_dof_indices[j], data_2);
+            h->get_dof_values(data_1, cell_data_1);
+            transfer.vmult(cell_data_2, cell_data_1);
 
-            // count, how often we have
-            // added to this dof
-            Assert(
-              touch_count[local_dof_indices[j]] <
-                std::numeric_limits<decltype(touch_count)::value_type>::max(),
-              ExcInternalError());
-            ++touch_count[local_dof_indices[j]];
+            l->get_dof_indices(local_dof_indices);
+
+            // distribute cell vector
+            for (unsigned int j = 0; j < dof_2.get_fe().dofs_per_cell; ++j)
+              {
+                ::dealii::internal::ElementAccess<OutVector>::add(
+                  cell_data_2(j), local_dof_indices[j], data_2);
+
+                // count, how often we have
+                // added to this dof
+                Assert(touch_count[local_dof_indices[j]] <
+                         std::numeric_limits<decltype(
+                           touch_count)::value_type>::max(),
+                       ExcInternalError());
+                ++touch_count[local_dof_indices[j]];
+              }
           }
       }
 

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -625,32 +625,15 @@ namespace VectorTools
             // distribute cell vector
             for (unsigned int j = 0; j < dof_2.get_fe().dofs_per_cell; ++j)
               {
-                ::dealii::internal::ElementAccess<OutVector>::add(
-                  cell_data_2(j), local_dof_indices[j], data_2);
+                if (touch_count[local_dof_indices[j]] == 0)
+                  {
+                    ::dealii::internal::ElementAccess<OutVector>::set(
+                      cell_data_2(j), local_dof_indices[j], data_2);
 
-                // count, how often we have
-                // added to this dof
-                Assert(touch_count[local_dof_indices[j]] <
-                         std::numeric_limits<decltype(
-                           touch_count)::value_type>::max(),
-                       ExcInternalError());
-                ++touch_count[local_dof_indices[j]];
+                    ++touch_count[local_dof_indices[j]];
+                  }
               }
           }
-      }
-
-    // compute the mean value of the
-    // sum which we have placed in each
-    // entry of the output vector
-    for (unsigned int i = 0; i < dof_2.n_dofs(); ++i)
-      {
-        Assert(touch_count[i] != 0, ExcInternalError());
-        using value_type = typename OutVector::value_type;
-        const value_type val =
-          ::dealii::internal::ElementAccess<OutVector>::get(data_2, i);
-
-        ::dealii::internal::ElementAccess<OutVector>::set(
-          val / static_cast<value_type>(touch_count[i]), i, data_2);
       }
   }
 

--- a/tests/vector_tools/interpolate.cc
+++ b/tests/vector_tools/interpolate.cc
@@ -1,0 +1,223 @@
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/grid/tria.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include "../tests.h"
+
+template<int dim>
+void run_1d()
+{
+    using Vector = dealii::Vector<double>;
+
+    // Create grid
+    dealii::Triangulation<dim> triangulation(
+        typename dealii::Triangulation<dim>::MeshSmoothing(
+        dealii::Triangulation<dim>::smoothing_on_refinement |
+        dealii::Triangulation<dim>::smoothing_on_coarsening));
+    const unsigned int n_1d_cells = 2;
+    dealii::GridGenerator::subdivided_hyper_cube(triangulation, n_1d_cells);
+
+    // Create low order system
+    dealii::DoFHandler<dim> dof_handler_coarse(triangulation);
+
+    const unsigned int degree_coarse = 2;
+    const dealii::FE_Q<dim> fe_q_coarse(degree_coarse);
+    const dealii::FESystem<dim> fe_system_coarse(fe_q_coarse, dim);
+    dof_handler_coarse.initialize(triangulation, fe_system_coarse);
+    dof_handler_coarse.distribute_dofs(fe_system_coarse);
+
+    Vector solution_coarse;
+    solution_coarse.reinit(dof_handler_coarse.n_dofs());
+    // Initialize dummy coarse solution
+    //solution_coarse.add(1.0);
+    for (unsigned int idof = 0; idof < dof_handler_coarse.n_dofs(); ++idof) {
+        solution_coarse[idof] = idof;
+    }
+
+    const unsigned int degree_fine = 3;
+
+    dealii::DoFHandler<dim> dof_handler_fine(triangulation);
+
+    const dealii::FE_Q<dim> fe_q_fine(degree_fine);
+    const dealii::FESystem<dim> fe_system_fine(fe_q_fine, dim);
+    dof_handler_fine.initialize(triangulation, fe_system_fine);
+    dof_handler_fine.distribute_dofs(fe_system_fine);
+
+    Vector solution_fine;
+    solution_fine.reinit(dof_handler_fine.n_dofs());
+
+    // Interpolate the solution
+    dealii::FullMatrix<double> interpolation_matrix(fe_system_fine.dofs_per_cell, fe_system_coarse.dofs_per_cell);
+    fe_system_fine.get_interpolation_matrix(fe_system_coarse, interpolation_matrix);
+    dealii::VectorTools::interpolate(dof_handler_coarse, dof_handler_fine, interpolation_matrix, solution_coarse, solution_fine);
+
+
+    const unsigned int n_dofs_coarse = fe_system_coarse.dofs_per_cell;
+    const unsigned int n_dofs_fine = fe_system_fine.dofs_per_cell;
+    const std::vector< dealii::Point<dim> > &points = fe_system_fine.get_unit_support_points();
+
+    // Check that interpolated solution matches at the support points
+    std::vector< dealii::types::global_dof_index > dof_indices_coarse(n_dofs_coarse);
+    std::vector< dealii::types::global_dof_index > dof_indices_fine(n_dofs_fine);
+
+    auto cell_coarse = dof_handler_coarse.begin_active();
+    auto cell_fine = dof_handler_fine.begin_active();
+    auto endcell = dof_handler_fine.end();
+
+    bool matching = true;
+    for (; cell_fine != dof_handler_fine.end(); ++cell_fine, ++cell_coarse) {
+        if ( !cell_fine->is_locally_owned() ) continue;
+        cell_fine->get_dof_indices(dof_indices_fine);
+        cell_coarse->get_dof_indices(dof_indices_coarse);
+        for (unsigned int iquad=0; iquad<points.size(); ++iquad) {
+      
+            dealii::Tensor<1,dim,double> local_solution_coarse;
+            dealii::Tensor<1,dim,double> local_solution_fine;
+            for (unsigned int idof=0; idof<n_dofs_coarse; ++idof) {
+                const unsigned int axis = fe_system_coarse.system_to_component_index(idof).first;
+                local_solution_coarse[axis] += solution_coarse[dof_indices_coarse[idof]] * fe_system_coarse.shape_value (idof, points[iquad]);
+            }
+            for (unsigned int idof=0; idof<n_dofs_fine; ++idof) {
+                const unsigned int axis = fe_system_fine.system_to_component_index(idof).first;
+                local_solution_fine[axis] += solution_fine[dof_indices_fine[idof]] * fe_system_fine.shape_value (idof, points[iquad]);
+            }
+            dealii::Tensor<1,dim,double> diff = local_solution_fine;
+            diff -= local_solution_coarse;
+            const double diff_norm = diff.norm();
+
+            std::cout << "Fine solution " << local_solution_fine
+                      << " Coarse solution " << local_solution_coarse
+                      << " Difference " << diff_norm << std::endl;
+            if (diff_norm > 1e-12) matching = false;
+        }
+    }
+    if (matching) dealii::deallog << "OK" << std::endl;
+    if (!matching) dealii::deallog << "Non matching" << std::endl;
+}
+
+template<int dim>
+void run()
+{
+    using Vector = dealii::LinearAlgebra::distributed::Vector<double>;
+    // Create grid
+    dealii::parallel::distributed::Triangulation<dim> triangulation(
+        MPI_COMM_WORLD,
+        typename dealii::Triangulation<dim>::MeshSmoothing(
+        dealii::Triangulation<dim>::smoothing_on_refinement |
+        dealii::Triangulation<dim>::smoothing_on_coarsening));
+    const unsigned int n_1d_cells = 2;
+    dealii::GridGenerator::subdivided_hyper_cube(triangulation, n_1d_cells);
+
+    // Create low order system
+    dealii::DoFHandler<dim> dof_handler_coarse(triangulation);
+
+    const unsigned int degree_coarse = 2;
+    const dealii::FE_Q<dim> fe_q_coarse(degree_coarse);
+    const dealii::FESystem<dim> fe_system_coarse(fe_q_coarse, dim);
+    dof_handler_coarse.initialize(triangulation, fe_system_coarse);
+    dof_handler_coarse.distribute_dofs(fe_system_coarse);
+
+    Vector solution_coarse;
+    dealii::IndexSet locally_owned_dofs_coarse = dof_handler_coarse.locally_owned_dofs();
+    dealii::IndexSet ghost_dofs_coarse;
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_coarse, ghost_dofs_coarse);
+    dealii::IndexSet locally_relevant_dofs_coarse = ghost_dofs_coarse;
+    ghost_dofs_coarse.subtract_set(locally_owned_dofs_coarse);
+    solution_coarse.reinit(locally_owned_dofs_coarse, ghost_dofs_coarse, MPI_COMM_WORLD);
+    // Initialize dummy coarse solution
+    for (unsigned int idof = 0; idof < dof_handler_coarse.n_dofs(); ++idof) {
+        if (locally_owned_dofs_coarse.is_element(idof)) {
+            solution_coarse[idof] = idof;
+        }
+    }
+    solution_coarse.update_ghost_values();
+
+    const unsigned int degree_fine = 3;
+
+    dealii::DoFHandler<dim> dof_handler_fine(triangulation);
+
+    const dealii::FE_Q<dim> fe_q_fine(degree_fine);
+    const dealii::FESystem<dim> fe_system_fine(fe_q_fine, dim);
+    dof_handler_fine.initialize(triangulation, fe_system_fine);
+    dof_handler_fine.distribute_dofs(fe_system_fine);
+
+    Vector solution_fine;
+    dealii::IndexSet locally_owned_dofs_fine = dof_handler_fine.locally_owned_dofs();
+    dealii::IndexSet ghost_dofs_fine;
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_fine, ghost_dofs_fine);
+    dealii::IndexSet locally_relevant_dofs_fine = ghost_dofs_fine;
+    ghost_dofs_fine.subtract_set(locally_owned_dofs_fine);
+    solution_fine.reinit(locally_owned_dofs_fine, ghost_dofs_fine, MPI_COMM_WORLD);
+
+    // Interpolate the solution
+    dealii::FullMatrix<double> interpolation_matrix(fe_system_fine.dofs_per_cell, fe_system_coarse.dofs_per_cell);
+    fe_system_fine.get_interpolation_matrix(fe_system_coarse, interpolation_matrix);
+    dealii::VectorTools::interpolate(dof_handler_coarse, dof_handler_fine, interpolation_matrix, solution_coarse, solution_fine);
+
+
+    const unsigned int n_dofs_coarse = fe_system_coarse.dofs_per_cell;
+    const unsigned int n_dofs_fine = fe_system_fine.dofs_per_cell;
+    const std::vector< dealii::Point<dim> > &points = fe_system_fine.get_unit_support_points();
+
+    // Check that interpolated solution matches at the support points
+    std::vector< dealii::types::global_dof_index > dof_indices_coarse(n_dofs_coarse);
+    std::vector< dealii::types::global_dof_index > dof_indices_fine(n_dofs_fine);
+
+    auto cell_coarse = dof_handler_coarse.begin_active();
+    auto cell_fine = dof_handler_fine.begin_active();
+    auto endcell = dof_handler_fine.end();
+
+    bool matching = true;
+    for (; cell_fine != dof_handler_fine.end(); ++cell_fine, ++cell_coarse) {
+        if ( !cell_fine->is_locally_owned() ) continue;
+        cell_fine->get_dof_indices(dof_indices_fine);
+        cell_coarse->get_dof_indices(dof_indices_coarse);
+        for (unsigned int iquad=0; iquad<points.size(); ++iquad) {
+      
+            dealii::Tensor<1,dim,double> local_solution_coarse;
+            dealii::Tensor<1,dim,double> local_solution_fine;
+            for (unsigned int idof=0; idof<n_dofs_coarse; ++idof) {
+                const unsigned int axis = fe_system_coarse.system_to_component_index(idof).first;
+                local_solution_coarse[axis] += solution_coarse[dof_indices_coarse[idof]] * fe_system_coarse.shape_value (idof, points[iquad]);
+            }
+            for (unsigned int idof=0; idof<n_dofs_fine; ++idof) {
+                const unsigned int axis = fe_system_fine.system_to_component_index(idof).first;
+                local_solution_fine[axis] += solution_fine[dof_indices_fine[idof]] * fe_system_fine.shape_value (idof, points[iquad]);
+            }
+            dealii::Tensor<1,dim,double> diff = local_solution_fine;
+            diff -= local_solution_coarse;
+            const double diff_norm = diff.norm();
+
+            std::cout << "Fine solution " << local_solution_fine
+                      << " Coarse solution " << local_solution_coarse
+                      << " Difference " << diff_norm << std::endl;
+            if (diff_norm > 1e-12) matching = false;
+        }
+    }
+    if (matching) dealii::deallog << "OK" << std::endl;
+    if (!matching) dealii::deallog << "Non matching" << std::endl;
+}
+
+int main (int argc, char *argv[])
+{
+  dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  initlog();
+
+  // dealii::deallog.push("1d");
+  dealii::deallog << "1d" << std::endl;
+  run_1d<1>();
+  dealii::deallog << "2d" << std::endl;
+  run<2>();
+  dealii::deallog << "3d" << std::endl;
+  run<3>();
+}

--- a/tests/vector_tools/interpolate.cc
+++ b/tests/vector_tools/interpolate.cc
@@ -1,214 +1,273 @@
 #include <deal.II/base/utilities.h>
 
-#include <deal.II/grid/grid_generator.h>
-
-#include <deal.II/grid/tria.h>
 #include <deal.II/distributed/tria.h>
 
-#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/dofs/dof_tools.h>
 
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 
-#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
 
-template<int dim>
-void run_1d()
+template <int dim>
+void
+run_1d()
 {
-    using Vector = dealii::Vector<double>;
+  using Vector = dealii::Vector<double>;
 
-    // Create grid
-    dealii::Triangulation<dim> triangulation(
-        typename dealii::Triangulation<dim>::MeshSmoothing(
-        dealii::Triangulation<dim>::smoothing_on_refinement |
-        dealii::Triangulation<dim>::smoothing_on_coarsening));
-    const unsigned int n_1d_cells = 2;
-    dealii::GridGenerator::subdivided_hyper_cube(triangulation, n_1d_cells);
+  // Create grid
+  dealii::Triangulation<dim> triangulation(
+    typename dealii::Triangulation<dim>::MeshSmoothing(
+      dealii::Triangulation<dim>::smoothing_on_refinement |
+      dealii::Triangulation<dim>::smoothing_on_coarsening));
+  const unsigned int n_1d_cells = 2;
+  dealii::GridGenerator::subdivided_hyper_cube(triangulation, n_1d_cells);
 
-    // Create low order system
-    dealii::DoFHandler<dim> dof_handler_coarse(triangulation);
+  // Create low order system
+  dealii::DoFHandler<dim> dof_handler_coarse(triangulation);
 
-    const unsigned int degree_coarse = 2;
-    const dealii::FE_Q<dim> fe_q_coarse(degree_coarse);
-    const dealii::FESystem<dim> fe_system_coarse(fe_q_coarse, dim);
-    dof_handler_coarse.initialize(triangulation, fe_system_coarse);
-    dof_handler_coarse.distribute_dofs(fe_system_coarse);
+  const unsigned int          degree_coarse = 2;
+  const dealii::FE_Q<dim>     fe_q_coarse(degree_coarse);
+  const dealii::FESystem<dim> fe_system_coarse(fe_q_coarse, dim);
+  dof_handler_coarse.initialize(triangulation, fe_system_coarse);
+  dof_handler_coarse.distribute_dofs(fe_system_coarse);
 
-    Vector solution_coarse;
-    solution_coarse.reinit(dof_handler_coarse.n_dofs());
-    // Initialize dummy coarse solution
-    //solution_coarse.add(1.0);
-    for (unsigned int idof = 0; idof < dof_handler_coarse.n_dofs(); ++idof) {
-        solution_coarse[idof] = idof;
+  Vector solution_coarse;
+  solution_coarse.reinit(dof_handler_coarse.n_dofs());
+  // Initialize dummy coarse solution
+  // solution_coarse.add(1.0);
+  for (unsigned int idof = 0; idof < dof_handler_coarse.n_dofs(); ++idof)
+    {
+      solution_coarse[idof] = idof;
     }
 
-    const unsigned int degree_fine = 3;
+  const unsigned int degree_fine = 3;
 
-    dealii::DoFHandler<dim> dof_handler_fine(triangulation);
+  dealii::DoFHandler<dim> dof_handler_fine(triangulation);
 
-    const dealii::FE_Q<dim> fe_q_fine(degree_fine);
-    const dealii::FESystem<dim> fe_system_fine(fe_q_fine, dim);
-    dof_handler_fine.initialize(triangulation, fe_system_fine);
-    dof_handler_fine.distribute_dofs(fe_system_fine);
+  const dealii::FE_Q<dim>     fe_q_fine(degree_fine);
+  const dealii::FESystem<dim> fe_system_fine(fe_q_fine, dim);
+  dof_handler_fine.initialize(triangulation, fe_system_fine);
+  dof_handler_fine.distribute_dofs(fe_system_fine);
 
-    Vector solution_fine;
-    solution_fine.reinit(dof_handler_fine.n_dofs());
+  Vector solution_fine;
+  solution_fine.reinit(dof_handler_fine.n_dofs());
+  solution_fine.add(1.0); // Initialize to non-zero
 
-    // Interpolate the solution
-    dealii::FullMatrix<double> interpolation_matrix(fe_system_fine.dofs_per_cell, fe_system_coarse.dofs_per_cell);
-    fe_system_fine.get_interpolation_matrix(fe_system_coarse, interpolation_matrix);
-    dealii::VectorTools::interpolate(dof_handler_coarse, dof_handler_fine, interpolation_matrix, solution_coarse, solution_fine);
+  // Interpolate the solution
+  dealii::FullMatrix<double> interpolation_matrix(
+    fe_system_fine.dofs_per_cell, fe_system_coarse.dofs_per_cell);
+  fe_system_fine.get_interpolation_matrix(fe_system_coarse,
+                                          interpolation_matrix);
+  dealii::VectorTools::interpolate(dof_handler_coarse,
+                                   dof_handler_fine,
+                                   interpolation_matrix,
+                                   solution_coarse,
+                                   solution_fine);
 
 
-    const unsigned int n_dofs_coarse = fe_system_coarse.dofs_per_cell;
-    const unsigned int n_dofs_fine = fe_system_fine.dofs_per_cell;
-    const std::vector< dealii::Point<dim> > &points = fe_system_fine.get_unit_support_points();
+  const unsigned int n_dofs_coarse = fe_system_coarse.dofs_per_cell;
+  const unsigned int n_dofs_fine   = fe_system_fine.dofs_per_cell;
+  const std::vector<dealii::Point<dim>> &points =
+    fe_system_fine.get_unit_support_points();
 
-    // Check that interpolated solution matches at the support points
-    std::vector< dealii::types::global_dof_index > dof_indices_coarse(n_dofs_coarse);
-    std::vector< dealii::types::global_dof_index > dof_indices_fine(n_dofs_fine);
+  // Check that interpolated solution matches at the support points
+  std::vector<dealii::types::global_dof_index> dof_indices_coarse(
+    n_dofs_coarse);
+  std::vector<dealii::types::global_dof_index> dof_indices_fine(n_dofs_fine);
 
-    auto cell_coarse = dof_handler_coarse.begin_active();
-    auto cell_fine = dof_handler_fine.begin_active();
-    auto endcell = dof_handler_fine.end();
+  auto cell_coarse = dof_handler_coarse.begin_active();
+  auto cell_fine   = dof_handler_fine.begin_active();
+  auto endcell     = dof_handler_fine.end();
 
-    bool matching = true;
-    for (; cell_fine != dof_handler_fine.end(); ++cell_fine, ++cell_coarse) {
-        if ( !cell_fine->is_locally_owned() ) continue;
-        cell_fine->get_dof_indices(dof_indices_fine);
-        cell_coarse->get_dof_indices(dof_indices_coarse);
-        for (unsigned int iquad=0; iquad<points.size(); ++iquad) {
-      
-            dealii::Tensor<1,dim,double> local_solution_coarse;
-            dealii::Tensor<1,dim,double> local_solution_fine;
-            for (unsigned int idof=0; idof<n_dofs_coarse; ++idof) {
-                const unsigned int axis = fe_system_coarse.system_to_component_index(idof).first;
-                local_solution_coarse[axis] += solution_coarse[dof_indices_coarse[idof]] * fe_system_coarse.shape_value (idof, points[iquad]);
+  bool matching = true;
+  for (; cell_fine != dof_handler_fine.end(); ++cell_fine, ++cell_coarse)
+    {
+      if (!cell_fine->is_locally_owned())
+        continue;
+      cell_fine->get_dof_indices(dof_indices_fine);
+      cell_coarse->get_dof_indices(dof_indices_coarse);
+      for (unsigned int iquad = 0; iquad < points.size(); ++iquad)
+        {
+          dealii::Tensor<1, dim, double> local_solution_coarse;
+          dealii::Tensor<1, dim, double> local_solution_fine;
+          for (unsigned int idof = 0; idof < n_dofs_coarse; ++idof)
+            {
+              const unsigned int axis =
+                fe_system_coarse.system_to_component_index(idof).first;
+              local_solution_coarse[axis] +=
+                solution_coarse[dof_indices_coarse[idof]] *
+                fe_system_coarse.shape_value(idof, points[iquad]);
             }
-            for (unsigned int idof=0; idof<n_dofs_fine; ++idof) {
-                const unsigned int axis = fe_system_fine.system_to_component_index(idof).first;
-                local_solution_fine[axis] += solution_fine[dof_indices_fine[idof]] * fe_system_fine.shape_value (idof, points[iquad]);
+          for (unsigned int idof = 0; idof < n_dofs_fine; ++idof)
+            {
+              const unsigned int axis =
+                fe_system_fine.system_to_component_index(idof).first;
+              local_solution_fine[axis] +=
+                solution_fine[dof_indices_fine[idof]] *
+                fe_system_fine.shape_value(idof, points[iquad]);
             }
-            dealii::Tensor<1,dim,double> diff = local_solution_fine;
-            diff -= local_solution_coarse;
-            const double diff_norm = diff.norm();
+          dealii::Tensor<1, dim, double> diff = local_solution_fine;
+          diff -= local_solution_coarse;
+          const double diff_norm = diff.norm();
 
-            std::cout << "Fine solution " << local_solution_fine
-                      << " Coarse solution " << local_solution_coarse
-                      << " Difference " << diff_norm << std::endl;
-            if (diff_norm > 1e-12) matching = false;
+          std::cout << "Fine solution " << local_solution_fine
+                    << " Coarse solution " << local_solution_coarse
+                    << " Difference " << diff_norm << std::endl;
+          if (diff_norm > 1e-12)
+            matching = false;
         }
     }
-    if (matching) dealii::deallog << "OK" << std::endl;
-    if (!matching) dealii::deallog << "Non matching" << std::endl;
+  if (matching)
+    dealii::deallog << "OK" << std::endl;
+  if (!matching)
+    dealii::deallog << "Non matching" << std::endl;
 }
 
-template<int dim>
-void run()
+template <int dim>
+void
+run()
 {
-    using Vector = dealii::LinearAlgebra::distributed::Vector<double>;
-    // Create grid
-    dealii::parallel::distributed::Triangulation<dim> triangulation(
-        MPI_COMM_WORLD,
-        typename dealii::Triangulation<dim>::MeshSmoothing(
-        dealii::Triangulation<dim>::smoothing_on_refinement |
-        dealii::Triangulation<dim>::smoothing_on_coarsening));
-    const unsigned int n_1d_cells = 2;
-    dealii::GridGenerator::subdivided_hyper_cube(triangulation, n_1d_cells);
+  using Vector = dealii::LinearAlgebra::distributed::Vector<double>;
+  // Create grid
+  dealii::parallel::distributed::Triangulation<dim> triangulation(
+    MPI_COMM_WORLD,
+    typename dealii::Triangulation<dim>::MeshSmoothing(
+      dealii::Triangulation<dim>::smoothing_on_refinement |
+      dealii::Triangulation<dim>::smoothing_on_coarsening));
+  const unsigned int n_1d_cells = 2;
+  dealii::GridGenerator::subdivided_hyper_cube(triangulation, n_1d_cells);
 
-    // Create low order system
-    dealii::DoFHandler<dim> dof_handler_coarse(triangulation);
+  // Create low order system
+  dealii::DoFHandler<dim> dof_handler_coarse(triangulation);
 
-    const unsigned int degree_coarse = 2;
-    const dealii::FE_Q<dim> fe_q_coarse(degree_coarse);
-    const dealii::FESystem<dim> fe_system_coarse(fe_q_coarse, dim);
-    dof_handler_coarse.initialize(triangulation, fe_system_coarse);
-    dof_handler_coarse.distribute_dofs(fe_system_coarse);
+  const unsigned int          degree_coarse = 2;
+  const dealii::FE_Q<dim>     fe_q_coarse(degree_coarse);
+  const dealii::FESystem<dim> fe_system_coarse(fe_q_coarse, dim);
+  dof_handler_coarse.initialize(triangulation, fe_system_coarse);
+  dof_handler_coarse.distribute_dofs(fe_system_coarse);
 
-    Vector solution_coarse;
-    dealii::IndexSet locally_owned_dofs_coarse = dof_handler_coarse.locally_owned_dofs();
-    dealii::IndexSet ghost_dofs_coarse;
-    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_coarse, ghost_dofs_coarse);
-    dealii::IndexSet locally_relevant_dofs_coarse = ghost_dofs_coarse;
-    ghost_dofs_coarse.subtract_set(locally_owned_dofs_coarse);
-    solution_coarse.reinit(locally_owned_dofs_coarse, ghost_dofs_coarse, MPI_COMM_WORLD);
-    // Initialize dummy coarse solution
-    for (unsigned int idof = 0; idof < dof_handler_coarse.n_dofs(); ++idof) {
-        if (locally_owned_dofs_coarse.is_element(idof)) {
-            solution_coarse[idof] = idof;
+  Vector           solution_coarse;
+  dealii::IndexSet locally_owned_dofs_coarse =
+    dof_handler_coarse.locally_owned_dofs();
+  dealii::IndexSet ghost_dofs_coarse;
+  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_coarse,
+                                                  ghost_dofs_coarse);
+  dealii::IndexSet locally_relevant_dofs_coarse = ghost_dofs_coarse;
+  ghost_dofs_coarse.subtract_set(locally_owned_dofs_coarse);
+  solution_coarse.reinit(locally_owned_dofs_coarse,
+                         ghost_dofs_coarse,
+                         MPI_COMM_WORLD);
+  // Initialize dummy coarse solution
+  for (unsigned int idof = 0; idof < dof_handler_coarse.n_dofs(); ++idof)
+    {
+      if (locally_owned_dofs_coarse.is_element(idof))
+        {
+          solution_coarse[idof] = idof;
         }
     }
-    solution_coarse.update_ghost_values();
+  solution_coarse.update_ghost_values();
 
-    const unsigned int degree_fine = 3;
+  const unsigned int degree_fine = 3;
 
-    dealii::DoFHandler<dim> dof_handler_fine(triangulation);
+  dealii::DoFHandler<dim> dof_handler_fine(triangulation);
 
-    const dealii::FE_Q<dim> fe_q_fine(degree_fine);
-    const dealii::FESystem<dim> fe_system_fine(fe_q_fine, dim);
-    dof_handler_fine.initialize(triangulation, fe_system_fine);
-    dof_handler_fine.distribute_dofs(fe_system_fine);
+  const dealii::FE_Q<dim>     fe_q_fine(degree_fine);
+  const dealii::FESystem<dim> fe_system_fine(fe_q_fine, dim);
+  dof_handler_fine.initialize(triangulation, fe_system_fine);
+  dof_handler_fine.distribute_dofs(fe_system_fine);
 
-    Vector solution_fine;
-    dealii::IndexSet locally_owned_dofs_fine = dof_handler_fine.locally_owned_dofs();
-    dealii::IndexSet ghost_dofs_fine;
-    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_fine, ghost_dofs_fine);
-    dealii::IndexSet locally_relevant_dofs_fine = ghost_dofs_fine;
-    ghost_dofs_fine.subtract_set(locally_owned_dofs_fine);
-    solution_fine.reinit(locally_owned_dofs_fine, ghost_dofs_fine, MPI_COMM_WORLD);
+  Vector           solution_fine;
+  dealii::IndexSet locally_owned_dofs_fine =
+    dof_handler_fine.locally_owned_dofs();
+  dealii::IndexSet ghost_dofs_fine;
+  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_fine,
+                                                  ghost_dofs_fine);
+  dealii::IndexSet locally_relevant_dofs_fine = ghost_dofs_fine;
+  ghost_dofs_fine.subtract_set(locally_owned_dofs_fine);
+  solution_fine.reinit(locally_owned_dofs_fine,
+                       ghost_dofs_fine,
+                       MPI_COMM_WORLD);
+  solution_fine.add(1.0); // Initialize to non-zero
+  solution_fine.update_ghost_values();
 
-    // Interpolate the solution
-    dealii::FullMatrix<double> interpolation_matrix(fe_system_fine.dofs_per_cell, fe_system_coarse.dofs_per_cell);
-    fe_system_fine.get_interpolation_matrix(fe_system_coarse, interpolation_matrix);
-    dealii::VectorTools::interpolate(dof_handler_coarse, dof_handler_fine, interpolation_matrix, solution_coarse, solution_fine);
+  // Interpolate the solution
+  dealii::FullMatrix<double> interpolation_matrix(
+    fe_system_fine.dofs_per_cell, fe_system_coarse.dofs_per_cell);
+  fe_system_fine.get_interpolation_matrix(fe_system_coarse,
+                                          interpolation_matrix);
+  dealii::VectorTools::interpolate(dof_handler_coarse,
+                                   dof_handler_fine,
+                                   interpolation_matrix,
+                                   solution_coarse,
+                                   solution_fine);
 
 
-    const unsigned int n_dofs_coarse = fe_system_coarse.dofs_per_cell;
-    const unsigned int n_dofs_fine = fe_system_fine.dofs_per_cell;
-    const std::vector< dealii::Point<dim> > &points = fe_system_fine.get_unit_support_points();
+  const unsigned int n_dofs_coarse = fe_system_coarse.dofs_per_cell;
+  const unsigned int n_dofs_fine   = fe_system_fine.dofs_per_cell;
+  const std::vector<dealii::Point<dim>> &points =
+    fe_system_fine.get_unit_support_points();
 
-    // Check that interpolated solution matches at the support points
-    std::vector< dealii::types::global_dof_index > dof_indices_coarse(n_dofs_coarse);
-    std::vector< dealii::types::global_dof_index > dof_indices_fine(n_dofs_fine);
+  // Check that interpolated solution matches at the support points
+  std::vector<dealii::types::global_dof_index> dof_indices_coarse(
+    n_dofs_coarse);
+  std::vector<dealii::types::global_dof_index> dof_indices_fine(n_dofs_fine);
 
-    auto cell_coarse = dof_handler_coarse.begin_active();
-    auto cell_fine = dof_handler_fine.begin_active();
-    auto endcell = dof_handler_fine.end();
+  auto cell_coarse = dof_handler_coarse.begin_active();
+  auto cell_fine   = dof_handler_fine.begin_active();
+  auto endcell     = dof_handler_fine.end();
 
-    bool matching = true;
-    for (; cell_fine != dof_handler_fine.end(); ++cell_fine, ++cell_coarse) {
-        if ( !cell_fine->is_locally_owned() ) continue;
-        cell_fine->get_dof_indices(dof_indices_fine);
-        cell_coarse->get_dof_indices(dof_indices_coarse);
-        for (unsigned int iquad=0; iquad<points.size(); ++iquad) {
-      
-            dealii::Tensor<1,dim,double> local_solution_coarse;
-            dealii::Tensor<1,dim,double> local_solution_fine;
-            for (unsigned int idof=0; idof<n_dofs_coarse; ++idof) {
-                const unsigned int axis = fe_system_coarse.system_to_component_index(idof).first;
-                local_solution_coarse[axis] += solution_coarse[dof_indices_coarse[idof]] * fe_system_coarse.shape_value (idof, points[iquad]);
+  bool matching = true;
+  for (; cell_fine != dof_handler_fine.end(); ++cell_fine, ++cell_coarse)
+    {
+      if (!cell_fine->is_locally_owned())
+        continue;
+      cell_fine->get_dof_indices(dof_indices_fine);
+      cell_coarse->get_dof_indices(dof_indices_coarse);
+      for (unsigned int iquad = 0; iquad < points.size(); ++iquad)
+        {
+          dealii::Tensor<1, dim, double> local_solution_coarse;
+          dealii::Tensor<1, dim, double> local_solution_fine;
+          for (unsigned int idof = 0; idof < n_dofs_coarse; ++idof)
+            {
+              const unsigned int axis =
+                fe_system_coarse.system_to_component_index(idof).first;
+              local_solution_coarse[axis] +=
+                solution_coarse[dof_indices_coarse[idof]] *
+                fe_system_coarse.shape_value(idof, points[iquad]);
             }
-            for (unsigned int idof=0; idof<n_dofs_fine; ++idof) {
-                const unsigned int axis = fe_system_fine.system_to_component_index(idof).first;
-                local_solution_fine[axis] += solution_fine[dof_indices_fine[idof]] * fe_system_fine.shape_value (idof, points[iquad]);
+          for (unsigned int idof = 0; idof < n_dofs_fine; ++idof)
+            {
+              const unsigned int axis =
+                fe_system_fine.system_to_component_index(idof).first;
+              local_solution_fine[axis] +=
+                solution_fine[dof_indices_fine[idof]] *
+                fe_system_fine.shape_value(idof, points[iquad]);
             }
-            dealii::Tensor<1,dim,double> diff = local_solution_fine;
-            diff -= local_solution_coarse;
-            const double diff_norm = diff.norm();
+          dealii::Tensor<1, dim, double> diff = local_solution_fine;
+          diff -= local_solution_coarse;
+          const double diff_norm = diff.norm();
 
-            std::cout << "Fine solution " << local_solution_fine
-                      << " Coarse solution " << local_solution_coarse
-                      << " Difference " << diff_norm << std::endl;
-            if (diff_norm > 1e-12) matching = false;
+          std::cout << "Fine solution " << local_solution_fine
+                    << " Coarse solution " << local_solution_coarse
+                    << " Difference " << diff_norm << std::endl;
+          if (diff_norm > 1e-12)
+            matching = false;
         }
     }
-    if (matching) dealii::deallog << "OK" << std::endl;
-    if (!matching) dealii::deallog << "Non matching" << std::endl;
+  if (matching)
+    dealii::deallog << "OK" << std::endl;
+  if (!matching)
+    dealii::deallog << "Non matching" << std::endl;
 }
 
-int main (int argc, char *argv[])
+int
+main(int argc, char *argv[])
 {
   dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   initlog();

--- a/tests/vector_tools/interpolate.output
+++ b/tests/vector_tools/interpolate.output
@@ -1,0 +1,7 @@
+
+DEAL::1d
+DEAL::OK
+DEAL::2d
+DEAL::OK
+DEAL::3d
+DEAL::OK

--- a/tests/vector_tools/interpolate.with_p4est=true.mpirun=2.output
+++ b/tests/vector_tools/interpolate.with_p4est=true.mpirun=2.output
@@ -1,0 +1,7 @@
+
+DEAL::1d
+DEAL::OK
+DEAL::2d
+DEAL::OK
+DEAL::3d
+DEAL::OK


### PR DESCRIPTION
More specifically this following overloaded version.
void VectorTools::interpolate(
    const DoFHandler< dim, spacedim > & dof_1,
    const DoFHandler< dim, spacedim > & dof_2,
    const FullMatrix< double > & transfer,
    const InVector & data_1,
    OutVector & data_2)

The older version would traverse every cell, including ones that are not locally owned. Basically just added an if-statement.

Checked that it didn't break any existing test using `ctest -R interpolate` and obtained `100% tests passed, 0 tests failed out of 134`
