### PR TITLE
Extend GridGenerator::torus<3,3>() so that one can generate a torus segment

### DIFF
--- a/doc/news/changes/minor/20191016NiklasFehn
+++ b/doc/news/changes/minor/20191016NiklasFehn
@@ -1,0 +1,4 @@
+New: Extend function GridGenerator::torus<3,3>() so that one can generate
+an open torus with an angle of 0 < phi <= 2*pi.
+<br>
+(Niklas Fehn, 2019/10/16)

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1188,6 +1188,13 @@ namespace GridGenerator
    * @param n_cells_toroidal Optional argument to set the number of cell
    * layers in toroidal direction. The default is 6 cell layers.
    *
+   * @param phi Optional argument to generate an open torus with angle
+   * $0 < \varphi <= 2 \pi$. The default value is $2 \pi$,
+   * in which case a closed torus is generated. If the torus is open,
+   * the torus is cut at two planes perpendicular to the torus centerline.
+   * The center of these two planes are located at $(x_1, y_1, z_1) = (R, 0, 0)$
+   * and $(x_2, y_2, z_2) = (R \cos(\varphi), 0, R \sin(\varphi))$.
+   *
    * @note Implemented for Triangulation<2,3> and Triangulation<3,3>.
    */
   template <int dim, int spacedim>
@@ -1195,7 +1202,8 @@ namespace GridGenerator
   torus(Triangulation<dim, spacedim> &tria,
         const double                  R,
         const double                  r,
-        const unsigned int            n_cells_toroidal = 6);
+        const unsigned int            n_cells_toroidal = 6,
+        const double                  phi              = 2.0 * numbers::PI);
 
   /**
    * This function produces a square in the <i>xy</i>-plane with a cylindrical

--- a/source/grid/grid_generator_from_name.cc
+++ b/source/grid/grid_generator_from_name.cc
@@ -275,9 +275,9 @@ namespace GridGenerator
         parse_and_create<3, 3, unsigned int, unsigned int, double, double>(
           moebius, arguments, tria);
       else if (name == "torus")
-        parse_and_create<3, 3, double, double, unsigned int>(torus,
-                                                             arguments,
-                                                             tria);
+        parse_and_create<3, 3, double, double, unsigned int, double>(torus,
+                                                                     arguments,
+                                                                     tria);
       else
         {
           return false;
@@ -296,9 +296,9 @@ namespace GridGenerator
                      Triangulation<2, 3> &tria)
     {
       if (name == "torus")
-        parse_and_create<2, 3, double, double, unsigned int>(torus,
-                                                             arguments,
-                                                             tria);
+        parse_and_create<2, 3, double, double, unsigned int, double>(torus,
+                                                                     arguments,
+                                                                     tria);
       else
         {
           return false;

--- a/tests/grid/grid_generator_open_torus.cc
+++ b/tests/grid/grid_generator_open_torus.cc
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Short test to validate GridGenerator::torus<3,3>() with angle < 2*pi
+// To test that the grid and the manifolds are generated correctly for
+// open torus, we compare the aspect ratio of a full torus and an open
+// torus for meshes with the same number of elements per arc length.
+
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/partitioner.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/mapping_q_generic.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include "../tests.h"
+
+using namespace dealii;
+
+void
+test()
+{
+  Triangulation<3>   tria;
+  unsigned int const n_cells_toroidal = 9;
+  double const       angle            = 2.0 * numbers::PI;
+  double const       R = 3., r = 1.;
+  GridGenerator::torus(tria, R, r, n_cells_toroidal, angle);
+
+  Triangulation<3>   tria_open;
+  unsigned int const factor = 3;
+  GridGenerator::torus(
+    tria_open, R, r, n_cells_toroidal / factor, angle / (double)factor);
+
+  MappingQGeneric<3> const mapping(3);
+  QGauss<3> const          gauss(4);
+
+  double const ar_full_torus =
+    GridTools::compute_maximum_aspect_ratio(tria, mapping, gauss);
+  double const ar_open_torus =
+    GridTools::compute_maximum_aspect_ratio(tria_open, mapping, gauss);
+
+  deallog << "N_active_cells_full = " << tria.n_global_active_cells()
+          << std::endl;
+  deallog << "N_active_cells_open = " << tria_open.n_global_active_cells()
+          << std::endl;
+  deallog << "| AR_full - AR_open | = "
+          << std::abs(ar_full_torus - ar_open_torus) << std::endl;
+}
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  deallog << std::scientific << std::setprecision(6);
+
+  try
+    {
+      Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+
+      test();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/grid/grid_generator_open_torus.output
+++ b/tests/grid/grid_generator_open_torus.output
@@ -1,0 +1,4 @@
+
+DEAL::N_active_cells_full = 45
+DEAL::N_active_cells_open = 15
+DEAL::| AR_full - AR_open | = 0.000000e+00


### PR DESCRIPTION
In the current implementation, the torus is closed (angle phi = 2 * pi). It can be useful to be able to generate an open torus with an angle of 0 < phi <= 2 * pi, which is addressed in this Pull Request. One application of this new functionality would be to simulate only on a part of the torus to reduce computational costs (since symmetries can be exploited). Another use case would be to glue together several torus segments to form more complex pipe systems (although this has currently some other limitations discussed elsewhere).

To implement this new functionality, the existing ``GridGenerator::torus<3,3>()`` function is extended by an additional parameter with default argument, and some tricky modifications need to be done in the code to obtain the correct cell connectivity and manifolds for a full and an open torus, respectively.

A new test case has been added to verify correctness of the new implementation. This is done by comparing the maximum aspect ratio (implemented recently in https://github.com/dealii/dealii/pull/8894) of a full torus to an open torus (which should be the same if the number of elements per arc length is the same). The idea behind is that if the manifolds are messed up in the open torus case, this will show up in the aspect ratio, while at the same time tests based on the aspect ratio are attractive as the result is reduced to one double value and one does not produce lengthy output files.