### PR TITLE
Document usage of empty copiers in WorkStream

### DIFF
--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -927,6 +927,10 @@ namespace WorkStream
    * copies of the <tt>ScratchData</tt> object and
    * <tt>queue_length*chunk_size</tt> copies of the <tt>CopyData</tt> object
    * are generated.
+   *
+   * @note In case the copier does not do anything, pass
+   * <code>std::function<void(const CopyData&)>()</code> as @p copier to make sure
+   * a more efficient algorithm is used internally.
    */
   template <typename Worker,
             typename Copier,
@@ -976,6 +980,10 @@ namespace WorkStream
    * copies of the <tt>ScratchData</tt> object and
    * <tt>queue_length*chunk_size</tt> copies of the <tt>CopyData</tt> object
    * are generated.
+   *
+   * @note In case the copier does not do anything, pass
+   * <code>std::function<void(const CopyData&)>()</code> as @p copier to make sure
+   * a more efficient algorithm is used internally.
    */
   template <typename Worker,
             typename Copier,
@@ -1266,6 +1274,10 @@ namespace WorkStream
    * copies of the <tt>ScratchData</tt> object and
    * <tt>queue_length*chunk_size</tt> copies of the <tt>CopyData</tt> object
    * are generated.
+   *
+   * @note In case the copier does not do anything, pass
+   * <code>std::function<void(const CopyData&)>()</code> as @p copier to make sure
+   * a more efficient algorithm is used internally.
    */
   template <typename MainClass,
             typename Iterator,


### PR DESCRIPTION
Motivated by https://github.com/dealii/dealii/pull/8891#discussion_r332079352, document how to best select an empty copier object in `WorkStream::run()`.