### PR TITLE
Fix ConsensusAlgorithm_NBX

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -941,12 +941,12 @@ namespace Utilities
       /**
        * Buffers for sending answers to requests.
        */
-      std::vector<std::vector<T2>> request_buffers;
+      std::vector<std::unique_ptr<std::vector<T2>>> request_buffers;
 
       /**
        * Requests for sending answers to requests.
        */
-      std::vector<std::shared_ptr<MPI_Request>> request_requests;
+      std::vector<std::unique_ptr<MPI_Request>> request_requests;
 
       // request for barrier
       MPI_Request barrier_request;

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -1011,11 +1011,12 @@ namespace Utilities
           AssertThrowMPI(ierr);
 
           // allocate memory for answer message
-          request_buffers.emplace_back();
-          request_requests.emplace_back(new MPI_Request);
+          request_buffers.emplace_back(
+            std_cxx14::make_unique<std::vector<T2>>());
+          request_requests.emplace_back(std_cxx14::make_unique<MPI_Request>());
 
           // process request
-          auto &request_buffer = request_buffers.back();
+          auto &request_buffer = *request_buffers.back();
           this->process.process_request(other_rank,
                                         buffer_recv,
                                         request_buffer);


### PR DESCRIPTION
part of #8929.

@tjhei could you try this patch out? I have my doubt that it will help. I would have imagined that `std::vector` on itself is something like a `std::shared_ptr`: the actual data is on the heap. When the size of the outer vector is resized the data of the inner vectors should not be moved...

FYI: @kronbichler @tcclevenger 

