### PR TITLE
Avoid empty MPI_Waitall in consensus algorithm

### DIFF
--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -192,13 +192,13 @@ namespace Utilities
             for (const auto &rank_pair : buffers)
               {
                 request.push_back(MPI_Request());
-                const auto ierr = MPI_Isend(rank_pair.second.data(),
-                                            rank_pair.second.size() * 2,
-                                            DEAL_II_DOF_INDEX_MPI_TYPE,
-                                            rank_pair.first,
-                                            tag_setup,
-                                            comm,
-                                            &request.back());
+                const int ierr = MPI_Isend(rank_pair.second.data(),
+                                           rank_pair.second.size() * 2,
+                                           DEAL_II_DOF_INDEX_MPI_TYPE,
+                                           rank_pair.first,
+                                           tag_setup,
+                                           comm,
+                                           &request.back());
                 AssertThrowMPI(ierr);
               }
 
@@ -270,9 +270,14 @@ namespace Utilities
                      ExcInternalError());
 
             // 5) make sure that all messages have been sent
-            const auto ierr =
-              MPI_Waitall(request.size(), request.data(), MPI_STATUSES_IGNORE);
-            AssertThrowMPI(ierr);
+            if (request.size() > 0)
+              {
+                const int ierr = MPI_Waitall(request.size(),
+                                             request.data(),
+                                             MPI_STATUSES_IGNORE);
+                AssertThrowMPI(ierr);
+              }
+
 #else
             (void)owned_indices;
             (void)comm;
@@ -743,9 +748,13 @@ namespace Utilities
               }
 
             if (send_requests.size() > 0)
-              MPI_Waitall(send_requests.size(),
-                          send_requests.data(),
-                          MPI_STATUSES_IGNORE);
+              {
+                const auto ierr = MPI_Waitall(send_requests.size(),
+                                              send_requests.data(),
+                                              MPI_STATUSES_IGNORE);
+                AssertThrowMPI(ierr);
+              }
+
 
 #  ifdef DEBUG
             for (const auto &it : requested_indices)

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -273,13 +273,13 @@ namespace Utilities
           AssertThrowMPI(ierr);
         }
 
-
-      {
-        const int ierr = MPI_Waitall(destinations.size(),
-                                     send_requests.data(),
-                                     MPI_STATUSES_IGNORE);
-        AssertThrowMPI(ierr);
-      }
+      if (destinations.size() > 0)
+        {
+          const int ierr = MPI_Waitall(destinations.size(),
+                                       send_requests.data(),
+                                       MPI_STATUSES_IGNORE);
+          AssertThrowMPI(ierr);
+        }
 
       return origins;
 #  else
@@ -1106,17 +1106,24 @@ namespace Utilities
 #ifdef DEAL_II_WITH_MPI
       // clean up
       {
-        auto ierr = MPI_Waitall(send_requests.size(),
-                                send_requests.data(),
-                                MPI_STATUSES_IGNORE);
-        AssertThrowMPI(ierr);
+        if (send_requests.size() > 0)
+          {
+            const int ierr = MPI_Waitall(send_requests.size(),
+                                         send_requests.data(),
+                                         MPI_STATUSES_IGNORE);
+            AssertThrowMPI(ierr);
+          }
 
-        ierr = MPI_Waitall(recv_requests.size(),
-                           recv_requests.data(),
-                           MPI_STATUSES_IGNORE);
-        AssertThrowMPI(ierr);
+        if (recv_requests.size() > 0)
+          {
+            const int ierr = MPI_Waitall(recv_requests.size(),
+                                         recv_requests.data(),
+                                         MPI_STATUSES_IGNORE);
+            AssertThrowMPI(ierr);
+          }
 
-        ierr = MPI_Wait(&barrier_request, MPI_STATUS_IGNORE);
+
+        const int ierr = MPI_Wait(&barrier_request, MPI_STATUS_IGNORE);
         AssertThrowMPI(ierr);
 
         for (auto &i : request_requests)
@@ -1361,12 +1368,21 @@ namespace Utilities
     {
 #ifdef DEAL_II_WITH_MPI
       // finalize all MPI_Requests
-      MPI_Waitall(send_and_recv_buffers.size(),
-                  send_and_recv_buffers.data(),
-                  MPI_STATUSES_IGNORE);
-      MPI_Waitall(requests_answers.size(),
-                  requests_answers.data(),
-                  MPI_STATUSES_IGNORE);
+      if (send_and_recv_buffers.size() > 0)
+        {
+          auto ierr = MPI_Waitall(send_and_recv_buffers.size(),
+                                  send_and_recv_buffers.data(),
+                                  MPI_STATUSES_IGNORE);
+          AssertThrowMPI(ierr);
+        }
+
+      if (requests_answers.size() > 0)
+        {
+          auto ierr = MPI_Waitall(requests_answers.size(),
+                                  requests_answers.data(),
+                                  MPI_STATUSES_IGNORE);
+          AssertThrowMPI(ierr);
+        }
 
       // unpack received data
       for (unsigned int i = 0; i < targets.size(); i++)


### PR DESCRIPTION
- check return values of MPI_ calls
- avoid call to MPI_Waitall with potentially 0 requests

Note: I am not sure if the MPI standard requires a call to Waitall to work for a count of 0, but we do this in many other places.

This is part of trying to make sense of the bug described in #8929, but it does not fix the crash by itself. 