### PR TITLE
add a barrier to avoid MPI race in ConsensusAlgorithm

### DIFF
--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -759,6 +759,11 @@ namespace Utilities
               }
 #  endif
 
+            // This barrier is important to make sure that two successive calls
+            // to this functions do not overlap and we confuse messages. See the
+            // discussion in https://github.com/dealii/dealii/issues/8929
+            MPI_Barrier(comm);
+
 #endif // DEAL_II_WITH_MPI
 
             return requested_indices;


### PR DESCRIPTION
As discussed in #8929, messages exchanged in this function can be mixed
up if called twice in succesion. Add a Barrier to make sure this won't
happen.