### PR TITLE
avoid 64bit overflow in Partiioner::set_ghost_indices

### DIFF
--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -174,7 +174,7 @@ namespace Utilities
       n_ghost_indices_data = ghost_indices_data.n_elements();
 
       have_ghost_indices =
-        Utilities::MPI::sum(n_ghost_indices_data, communicator) > 0;
+        Utilities::MPI::max(n_ghost_indices_data, communicator) > 0;
 
       // In the rest of this function, we determine the point-to-point
       // communication pattern of the partitioner. We make up a list with both


### PR DESCRIPTION
We MPI::sum() a 32 bit value of the total number of ghost indices, which
might overflow. This is unlikely to be a problem unless you exactly have
2^32 ghost indices, but this is nevertheless a bug.

also part of #8929