### PR TITLE
Fix an error check with MathJax.

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -65,7 +65,7 @@ IF(DEAL_II_DOXYGEN_USE_MATHJAX)
       "/usr/share/yelp/mathjax"
       DOC "Root path of MathJax.js"
       )
-    IF(MATHJAX MATCHES "-NOTFOUND")
+    IF(MATHJAX_PATH MATCHES "MATHJAX_PATH-NOTFOUND")
       MESSAGE(FATAL_ERROR "MathJax was not found.")
     ENDIF()
   ENDIF()


### PR DESCRIPTION
Part of #8938: this patch makes our mathjax detection fail correctly.

The correct variable name is `MATHJAX_PATH` and its correct invalid value (i.e., if nothing is found) is `MATHJAX_PATH-NOTFOUND`.