### PR TITLE
Fix coarse solver documentation in step-50

### DIFF
--- a/doc/news/changes/minor/20191022GarciaSanchez
+++ b/doc/news/changes/minor/20191022GarciaSanchez
@@ -1,0 +1,5 @@
+Changed: Fix coarse solver documentation in step-50 which uses for the coarse
+solver MGCoarseGridIterativeSolver, not MGCoarseGridHouseholder. Add discussion
+about when it would be appropriated to use MGCoarseGridHouseholder.
+<br>
+(Daniel Garcia-Sanchez, 2019/10/22)

--- a/examples/step-50/doc/intro.dox
+++ b/examples/step-50/doc/intro.dox
@@ -27,7 +27,7 @@ most of what needs to be done is provided by deal.II itself. These are
 <li>An the object handling transfer between grids; we use the
     MGTransferPrebuilt class for this that does almost all of the work
     inside the library.
-<li>The solver on the coarsest level; here, we use MGCoarseGridHouseholder.
+<li>The solver on the coarsest level; here, we use MGCoarseGridIterativeSolver.
 <li>The smoother on all other levels, which in our case will be the
     MGSmootherRelaxation class using SOR as the underlying method
 <li>And mg::Matrix, a class having a special level multiplication, i.e. we

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -681,13 +681,15 @@ namespace Step50
   // on the global level and an DoFHandler object computes the
   // matrices corresponding to these transfer operators.
   //
-  // The second part of the following lines deals with the coarse grid
-  // solver. Since our coarse grid is very coarse indeed, we decide
-  // for a direct solver (a Householder decomposition of the coarsest
-  // level matrix), even if its implementation is not particularly
-  // sophisticated. If our coarse mesh had many more cells than the
-  // five we have here, something better suited would obviously be
-  // necessary here.
+  // The second part of the following lines deals with the coarse grid solver.
+  // We use MGCoarseGridIterativeSolver which provides a wrapper for a deal.II
+  // iterative solver with a given matrix and preconditioner; in this particular
+  // case we use SolverCG. Since our coarse grid is very coarse indeed, we could
+  // have decided to use the direct solver MGCoarseGridHouseholder (a
+  // Householder decomposition of the coarsest level matrix), even if its
+  // implementation is not particularly sophisticated. If our coarse mesh had
+  // many more cells than the five we have here, something better than
+  // MGCoarseGridHouseholder would obviously be necessary here.
   template <int dim>
   void LaplaceProblem<dim>::solve()
   {


### PR DESCRIPTION
Step-50 uses for the coarse solver `MGCoarseGridIterativeSolver`, not `MGCoarseGridHouseholder`. Add discussion about when it would be appropriated to use `MGCoarseGridHouseholder`.

I guess that in the past step-50 used `MGCoarseGridHouseholder`. Although, I did a little bit of git archaeology and I couldn't find when step-50 used `MGCoarseGridHouseholder`.