### PR TITLE
Remove unnecessary trilinos options

### DIFF
--- a/doc/external-libs/trilinos.html
+++ b/doc/external-libs/trilinos.html
@@ -94,8 +94,8 @@
     -DTrilinos_ENABLE_ML=ON                          \
     -DTrilinos_ENABLE_ROL=ON                         \
     -DTrilinos_ENABLE_Tpetra=ON                      \
-    -DTpetra_INST_COMPLEX_DOUBLE=ON                  \
-    -DTpetra_INST_COMPLEX_FLOAT=ON                   \
+    -DTrilinos_ENABLE_COMPLEX_DOUBLE=ON              \
+    -DTrilinos_ENABLE_COMPLEX_FLOAT=ON               \
     -DTrilinos_ENABLE_Zoltan=ON                      \
     -DTrilinos_VERBOSE_CONFIGURE=OFF                 \
     -DTPL_ENABLE_MPI=ON                              \


### PR DESCRIPTION
The options `-DTpetra_INST_COMPLEX_DOUBLE=ON` and `-DTpetra_INST_COMPLEX_FLOAT=ON`
are no longer necessary. `-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION=ON` can be
used to enable explicit instantiations.

I built without `-DTpetra_INST_COMPLEX_DOUBLE=ON`, `-DTpetra_INST_COMPLEX_FLOAT=ON`,  `-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION=ON` and everything works perfect :)

When I tried to use `-DTpetra_INST_COMPLEX_DOUBLE=ON` and `-DTpetra_INST_COMPLEX_FLOAT=ON` I got the following errors:

```
CMake Warning at packages/tpetra/CMakeLists.txt:864 (MESSAGE):
  Tpetra_INST_COMPLEX_DOUBLE=ON, but Trilinos_ENABLE_COMPLEX_DOUBLE=OFF.
  This will work, but it will make builds more expensive, because it turns
  off explicit instantiation for complex<double> in KokkosKernels.  If you
  want to use Scalar=complex<double> in Tpetra, just set
  Trilinos_ENABLE_COMPLEX_DOUBLE=ON.  You do not need to set
  Tpetra_INST_COMPLEX_DOUBLE explicitly any more.


CMake Error at packages/tpetra/CMakeLists.txt:884 (MESSAGE):
  Tpetra: Tpetra_INST_COMPLEX_DOUBLE is ON (meaning that you want to want to
  instantiate and/or test Tpetra classes with Scalar = std::complex<double>),
  but Teuchos_ENABLE_COMPLEX is OFF.  Please set
  Teuchos_ENABLE_COMPLEX:BOOL=ON, reconfigure, and rebuild.
```

I use Trilinos 12.14