### PR TITLE
Delete FunctionParse copy constructor.

### DIFF
--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -259,6 +259,13 @@ public:
   ~FunctionParser() override;
 
   /**
+   * Copy operator. Objects of this type can not be copied, and
+   * consequently this operator is deleted.
+   */
+  FunctionParser &
+  operator=(const FunctionParser &) = delete;
+
+  /**
    * Type for the constant map. Used by the initialize() method.
    */
   using ConstMap = std::map<std::string, double>;

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -253,6 +253,12 @@ public:
   FunctionParser(const FunctionParser &) = delete;
 
   /**
+   * Move constructor. Objects of this type can not be moved, and
+   * consequently this constructor is deleted.
+   */
+  FunctionParser(FunctionParser &&) = delete;
+
+  /**
    * Destructor. Explicitly delete the FunctionParser objects (there is one
    * for each component of the function).
    */
@@ -264,6 +270,13 @@ public:
    */
   FunctionParser &
   operator=(const FunctionParser &) = delete;
+
+  /**
+   * Move operator. Objects of this type can not be moved, and
+   * consequently this operator is deleted.
+   */
+  FunctionParser &
+  operator=(FunctionParser &&) = delete;
 
   /**
    * Type for the constant map. Used by the initialize() method.

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -247,6 +247,12 @@ public:
                  const double h = 1e-8);
 
   /**
+   * Copy constructor. Objects of this type can not be copied, and
+   * consequently this constructor is deleted.
+   */
+  FunctionParser(const FunctionParser &) = delete;
+
+  /**
    * Destructor. Explicitly delete the FunctionParser objects (there is one
    * for each component of the function).
    */


### PR DESCRIPTION
In response to #8951. This just makes more obvious what is already the case.