### PR TITLE
duplicate MPI communicator in ConsensusAlgorithm

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -904,6 +904,9 @@ namespace Utilities
     class ConsensusAlgorithm
     {
     public:
+      /**
+       * Constructor.
+       */
       ConsensusAlgorithm(ConsensusAlgorithmProcess<T1, T2> &process,
                          const MPI_Comm &                   comm);
 
@@ -912,6 +915,9 @@ namespace Utilities
        */
       virtual ~ConsensusAlgorithm() = default;
 
+      /**
+       * Run the algorithm.
+       */
       virtual void
       run() = 0;
 
@@ -922,7 +928,13 @@ namespace Utilities
       ConsensusAlgorithmProcess<T1, T2> &process;
 
       /**
-       * MPI communicator.
+       * We duplicate the communicator to make this algorithm safe
+       * when executed twice in a row as we are using nonblocking operations.
+       */
+      const DuplicatedCommunicator comm_dup;
+
+      /**
+       * MPI communicator. Reference to comm_dup.
        */
       const MPI_Comm &comm;
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -892,9 +892,10 @@ namespace Utilities
     template <typename T1, typename T2>
     ConsensusAlgorithm<T1, T2>::ConsensusAlgorithm(
       ConsensusAlgorithmProcess<T1, T2> &process,
-      const MPI_Comm &                   comm)
+      const MPI_Comm &                   communicator)
       : process(process)
-      , comm(comm)
+      , comm_dup(communicator)
+      , comm(*comm_dup)
       , my_rank(this_mpi_process(comm))
       , n_procs(n_mpi_processes(comm))
     {}


### PR DESCRIPTION
avoid race condition in ConsensusAlgorithm as discussed in #8955