### PR TITLE
fix doxygen documentation generation for tutorial steps

### DIFF
--- a/doc/doxygen/scripts/make_step.pl
+++ b/doc/doxygen/scripts/make_step.pl
@@ -26,7 +26,7 @@ $cmake_source_dir=$ARGV[1];
 
 print
 "/**
-  * \@page $step_underscore The $step tutorial program
+\@page $step_underscore The $step tutorial program
 ";
 
 open BF, "$cmake_source_dir/examples/$step/doc/builds-on"
@@ -98,5 +98,5 @@ print
 "<a name=\"PlainProg\"></a>
 <h1> The plain program</h1>
 \@include \"$step.$file_extension\"
- */
+*/
 ";


### PR DESCRIPTION
Newer versions seem to be a bit more picky in what they consider a valid
documentation comment.

Thus, make sure to
 - start with "/**" and close with "*/" on the same line
 - remove the lonely "*" from the first line
Everything else seems to confuse the lexer/reader