### PR TITLE
Fix for fe-degree in VectorTools::project_boundary_values_curl_conforming_l2

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -5366,9 +5366,6 @@ namespace VectorTools
 
       // Initialize the required objects.
       const FEValues<dim> &fe_values = hp_fe_values.get_present_fe_values();
-      // Store degree as fe.degree-1
-      // For nedelec elements FE_Nedelec<dim> (0) returns fe.degree = 1.
-      const unsigned int degree = fe.degree - 1;
 
       const std::vector<Point<dim>> &quadrature_points =
         fe_values.get_quadrature_points();
@@ -5412,6 +5409,11 @@ namespace VectorTools
           base_indices.second = (first_vector_component - fe_index_old) /
                                 fe.base_element(i).n_components();
         }
+      // Store degree as fe.degree-1
+      // For nedelec elements FE_Nedelec<dim> (0) returns fe.degree = 1.
+      // For FESystem get the degree from the base_element
+      // indicated by the first_vector_component
+      const unsigned int degree = fe.base_element(base_indices.first).degree - 1;
 
       // Find DoFs we want to constrain:
       // There are fe.dofs_per_line DoFs associated with the

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -5413,7 +5413,8 @@ namespace VectorTools
       // For nedelec elements FE_Nedelec<dim> (0) returns fe.degree = 1.
       // For FESystem get the degree from the base_element
       // indicated by the first_vector_component
-      const unsigned int degree = fe.base_element(base_indices.first).degree - 1;
+      const unsigned int degree =
+        fe.base_element(base_indices.first).degree - 1;
 
       // Find DoFs we want to constrain:
       // There are fe.dofs_per_line DoFs associated with the
@@ -5668,7 +5669,8 @@ namespace VectorTools
           base_indices.second = (first_vector_component - fe_index_old) /
                                 fe.base_element(i).n_components();
         }
-      const unsigned int degree = fe.base_element(base_indices.first).degree - 1;
+      const unsigned int degree =
+        fe.base_element(base_indices.first).degree - 1;
 
       switch (dim)
         {
@@ -6017,11 +6019,11 @@ namespace VectorTools
                 }
 
               // Solve linear system:
-              if(associated_face_dofs > 0)
-	      {
-		face_matrix_inv.invert(face_matrix);
-		face_matrix_inv.vmult(face_solution, face_rhs);
-	      }
+              if (associated_face_dofs > 0)
+                {
+                  face_matrix_inv.invert(face_matrix);
+                  face_matrix_inv.vmult(face_solution, face_rhs);
+                }
 
               // Store computed DoFs:
               for (unsigned int associated_face_dof = 0;

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -5629,7 +5629,6 @@ namespace VectorTools
       const FiniteElement<dim> &     fe = cell->get_fe();
       const std::vector<Point<dim>> &quadrature_points =
         fe_face_values.get_quadrature_points();
-      const unsigned int degree = fe.degree - 1;
 
       std::vector<Vector<number>> values(fe_face_values.n_quadrature_points,
                                          Vector<number>(fe.n_components()));
@@ -5669,6 +5668,7 @@ namespace VectorTools
           base_indices.second = (first_vector_component - fe_index_old) /
                                 fe.base_element(i).n_components();
         }
+      const unsigned int degree = fe.base_element(base_indices.first).degree - 1;
 
       switch (dim)
         {
@@ -6016,10 +6016,12 @@ namespace VectorTools
                     }
                 }
 
-              // Solve lienar system:
-              face_matrix_inv.invert(face_matrix);
-              face_matrix_inv.vmult(face_solution, face_rhs);
-
+              // Solve linear system:
+              if(associated_face_dofs > 0)
+	      {
+		face_matrix_inv.invert(face_matrix);
+		face_matrix_inv.vmult(face_solution, face_rhs);
+	      }
 
               // Store computed DoFs:
               for (unsigned int associated_face_dof = 0;

--- a/source/numerics/vector_tools_integrate_difference.inst.in
+++ b/source/numerics/vector_tools_integrate_difference.inst.in
@@ -319,8 +319,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
                            Vector<float>,
                            deal_II_space_dimension>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const LinearAlgebra::TpetraWrappers::Vector<float>,
-          &,
+        const LinearAlgebra::TpetraWrappers::Vector<float> &,
         const Function<deal_II_space_dimension> &,
         Vector<float> &,
         const Quadrature<deal_II_dimension> &,

--- a/tests/numerics/project_bv_curl_conf_03.cc
+++ b/tests/numerics/project_bv_curl_conf_03.cc
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2014 - 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+// The test checks that project_boundary_values_curl_conforming
+// works for FESystems with FE_Nedelec of different order.
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_nedelec.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+using namespace dealii;
+
+int main(int argc, char **argv) {
+  initlog();
+  const unsigned int dim=3;
+
+  Triangulation<dim> triangulation;
+  GridGenerator::hyper_cube(triangulation, 0, 1, true);
+  MappingQ<dim> mapping(1);
+  ConstraintMatrix constraints;
+
+  //Testing cases with only Nedelec Elements in FE_System
+  {
+    deallog << "Equal order Nedelec degree 0 \t";
+    //Equal-order elements
+    FESystem<dim> fe_system(FE_Nedelec<dim>(0), 1, FE_Nedelec<dim>(0), 1);
+    DoFHandler<dim> dof_handler(triangulation);
+    dof_handler.distribute_dofs(fe_system);
+    
+    constraints.clear();
+    VectorTools::project_boundary_values_curl_conforming_l2(dof_handler, dim,
+							    Functions::ZeroFunction<dim>(dim + dim), 0, constraints, mapping);
+    constraints.close();
+    deallog << "OK" << std::endl;
+  }
+
+  {
+    deallog << "Mixed order Nedelec (degree 1,degree 0) \t";
+    //Elements of mixed order
+    FESystem<dim> fe_system(FE_Nedelec<dim>(1), 1, FE_Nedelec<dim>(0), 1);
+    DoFHandler<dim> dof_handler(triangulation);
+    dof_handler.distribute_dofs(fe_system);
+    
+    constraints.clear();
+    VectorTools::project_boundary_values_curl_conforming_l2(dof_handler, dim,
+							    Functions::ZeroFunction<dim>(dim + dim), 0, constraints, mapping);
+    constraints.close();
+    deallog << "OK" << std::endl;
+  }
+  
+  return 0;
+}

--- a/tests/numerics/project_bv_curl_conf_03.cc
+++ b/tests/numerics/project_bv_curl_conf_03.cc
@@ -15,56 +15,72 @@
 // The test checks that project_boundary_values_curl_conforming
 // works for FESystems with FE_Nedelec of different order.
 
-#include <deal.II/grid/grid_generator.h>
-#include <deal.II/fe/fe_system.h>
-#include <deal.II/fe/fe_q.h>
-#include <deal.II/fe/fe_nedelec.h>
-#include <deal.II/fe/mapping_q.h>
-#include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_nedelec.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/constraint_matrix.h>
+
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
 
 using namespace dealii;
 
-int main(int argc, char **argv) {
+int
+main(int argc, char **argv)
+{
   initlog();
-  const unsigned int dim=3;
+  const unsigned int dim = 3;
 
   Triangulation<dim> triangulation;
   GridGenerator::hyper_cube(triangulation, 0, 1, true);
-  MappingQ<dim> mapping(1);
+  MappingQ<dim>    mapping(1);
   ConstraintMatrix constraints;
 
-  //Testing cases with only Nedelec Elements in FE_System
+  // Testing cases with only Nedelec Elements in FE_System
   {
     deallog << "Equal order Nedelec degree 0 \t";
-    //Equal-order elements
-    FESystem<dim> fe_system(FE_Nedelec<dim>(0), 1, FE_Nedelec<dim>(0), 1);
+    // Equal-order elements
+    FESystem<dim>   fe_system(FE_Nedelec<dim>(0), 1, FE_Nedelec<dim>(0), 1);
     DoFHandler<dim> dof_handler(triangulation);
     dof_handler.distribute_dofs(fe_system);
-    
+
     constraints.clear();
-    VectorTools::project_boundary_values_curl_conforming_l2(dof_handler, dim,
-							    Functions::ZeroFunction<dim>(dim + dim), 0, constraints, mapping);
+    VectorTools::project_boundary_values_curl_conforming_l2(
+      dof_handler,
+      dim,
+      Functions::ZeroFunction<dim>(dim + dim),
+      0,
+      constraints,
+      mapping);
     constraints.close();
     deallog << "OK" << std::endl;
   }
 
   {
     deallog << "Mixed order Nedelec (degree 1,degree 0) \t";
-    //Elements of mixed order
-    FESystem<dim> fe_system(FE_Nedelec<dim>(1), 1, FE_Nedelec<dim>(0), 1);
+    // Elements of mixed order
+    FESystem<dim>   fe_system(FE_Nedelec<dim>(1), 1, FE_Nedelec<dim>(0), 1);
     DoFHandler<dim> dof_handler(triangulation);
     dof_handler.distribute_dofs(fe_system);
-    
+
     constraints.clear();
-    VectorTools::project_boundary_values_curl_conforming_l2(dof_handler, dim,
-							    Functions::ZeroFunction<dim>(dim + dim), 0, constraints, mapping);
+    VectorTools::project_boundary_values_curl_conforming_l2(
+      dof_handler,
+      dim,
+      Functions::ZeroFunction<dim>(dim + dim),
+      0,
+      constraints,
+      mapping);
     constraints.close();
     deallog << "OK" << std::endl;
   }
-  
+
   return 0;
 }

--- a/tests/numerics/project_bv_curl_conf_03.output
+++ b/tests/numerics/project_bv_curl_conf_03.output
@@ -1,0 +1,3 @@
+
+DEAL::Equal order Nedelec degree 0 	OK
+DEAL::Mixed order Nedelec (degree 1,degree 0) 	OK


### PR DESCRIPTION
This is the fix announced in https://groups.google.com/forum/#!topic/dealii/taFA8q2ugsg
for the application of VectorTools::project_boundary_values_curl_conforming_l2 to FE Systems 
containing multiple FE_Nedelec of different degree. 

It is tested in deal v 9.1.1 - I could not test in the current deal git version since dealii/dealii/master fails to compile in debug mode at the moment. 