### PR TITLE
Do not transfer the MPI communicator when copying the triangulation

### DIFF
--- a/doc/news/changes/minor/20193110Grayver
+++ b/doc/news/changes/minor/20193110Grayver
@@ -1,0 +1,4 @@
+Changed: parallel::TriangulationBase::copy_triangulation does not
+copy the MPI communicator from the given source triangulation.
+<br>
+(Alexander Grayver, 2019/10/31)

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -98,6 +98,11 @@ namespace parallel
 
     /**
      * Implementation of the same function as in the base class.
+     *
+     * @note This function copies the cells, but not the communicator,
+     * of the source triangulation. In other words, the resulting
+     * triangulation will operate on the communicator it was constructed
+     * with.
      */
     virtual void
     copy_triangulation(

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -77,8 +77,6 @@ namespace parallel
           dynamic_cast<const dealii::parallel::TriangulationBase<dim, spacedim>
                          *>(&other_tria))
       {
-        mpi_communicator = other_tria_x->get_communicator();
-
         // release unused vector memory because we will have very different
         // vectors now
         ::dealii::internal::GrowingVectorMemoryImplementation::


### PR DESCRIPTION
Follow-up of the discussion in #8969 

@bangerth @masterleinad FYI