### PR TITLE
Fix compilation of gmsh support

### DIFF
--- a/source/gmsh/utilities.cc
+++ b/source/gmsh/utilities.cc
@@ -76,7 +76,7 @@ namespace Gmsh
 
     dealii::OpenCASCADE::write_IGES(boundary, iges_file_name);
 
-    ofstream geofile;
+    std::ofstream geofile;
     geofile.open(geo_file_name);
     geofile << "Merge \"" << iges_file_name << "\";" << std::endl
             << "Line Loop (2) = {1};" << std::endl


### PR DESCRIPTION
Use std::ofstream rather than just ofstream.

It's unclear to me how this ever compiled, unless one the of the includes does `using namespace std` or `using std::ofstream`?