### PR TITLE
return MPI_Comm by const ref

### DIFF
--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -93,7 +93,7 @@ namespace parallel
     /**
      * Return MPI communicator used by this triangulation.
      */
-    virtual MPI_Comm
+    virtual const MPI_Comm &
     get_communicator() const;
 
     /**

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -577,7 +577,7 @@ public:
   /**
    * Return the MPI communicator object in use with this preconditioner.
    */
-  MPI_Comm
+  const MPI_Comm &
   get_mpi_communicator() const;
 
   /**
@@ -929,14 +929,14 @@ PreconditionMG<dim, VectorType, TRANSFER>::locally_owned_domain_indices(
 
 
 template <int dim, typename VectorType, class TRANSFER>
-MPI_Comm
+const MPI_Comm &
 PreconditionMG<dim, VectorType, TRANSFER>::get_mpi_communicator() const
 {
-  // currently parallel GMG works with distributed Triangulation only,
+  // currently parallel GMG works with parallel triangulations only,
   // so it should be a safe bet to use it to query MPI communicator:
   const Triangulation<dim> &tria = dof_handler_vector[0]->get_triangulation();
-  const parallel::distributed::Triangulation<dim> *ptria =
-    dynamic_cast<const parallel::distributed::Triangulation<dim> *>(&tria);
+  const parallel::TriangulationBase<dim> *ptria =
+    dynamic_cast<const parallel::TriangulationBase<dim> *>(&tria);
   Assert(ptria != nullptr, ExcInternalError());
   return ptria->get_communicator();
 }

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -167,7 +167,7 @@ namespace parallel
   }
 
   template <int dim, int spacedim>
-  MPI_Comm
+  const MPI_Comm &
   TriangulationBase<dim, spacedim>::get_communicator() const
   {
     return mpi_communicator;


### PR DESCRIPTION
Fix a few places where we return the MPI_Comm by value. This is
problematic if we pass it to a function taking a reference and storing
it:
```
    CollectiveMutex::ScopedLock lock(mutex, tria.get_communicator());
```
discovered in #9001