### PR TITLE
fix 64bit IndexSet::add_indices

### DIFF
--- a/doc/news/changes/minor/20191105TimoHeister
+++ b/doc/news/changes/minor/20191105TimoHeister
@@ -1,0 +1,5 @@
+Fixed: Computations with block vectors with more than 4 billion degrees of
+freedom reported incorrect values for locally_owned_elements(). This is now
+fixed by implementing IndexSet::add_indices() for large offsets.
+<br>
+(Timo Heister, 2019/11/05)

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -215,7 +215,7 @@ public:
    * <code>[0,size())</code> represented by the current object.
    */
   void
-  add_indices(const IndexSet &other, const unsigned int offset = 0);
+  add_indices(const IndexSet &other, const size_type offset = 0);
 
   /**
    * Return whether the specified index is an element of the index set.

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -347,7 +347,7 @@ IndexSet::pop_front()
 
 
 void
-IndexSet::add_indices(const IndexSet &other, const unsigned int offset)
+IndexSet::add_indices(const IndexSet &other, const size_type offset)
 {
   if ((this == &other) && (offset == 0))
     return;


### PR DESCRIPTION
The offset parameter needs to be 64 bit to allow shifting an IndexSet in
a large computation.

part of and hopefully a fix for #8937