### PR TITLE
Add a check on whether LLD links shared object

### DIFF
--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -448,73 +448,56 @@ RESET_CMAKE_REQUIRED()
 # ICC also emits a warning but passes for unsupported linkers
 # unless we turn diagnostic warnings into errors.
 #
-# Wolfgang Bangerth, Matthias Maier, Daniel Arndt, 2015, 2018
+# We also test linker support with "-shared -fPIC". This catches an
+# incompatibility where LLD refuses to produce a shared object from an
+# object file compiled by the Intel Compiler:
 #
-IF(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-Wno-unused-command-line-argument")
-  ELSEIF(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-    ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-diag-error warn")
-  ENDIF()
-  ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-Werror")
-  ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
-  CHECK_CXX_SOURCE_COMPILES(
-    "
-    int main() { return 0; }
-    "
-    DEAL_II_COMPILER_LLD_LINKS_EXEC)
-  RESET_CMAKE_REQUIRED()
-
-# It is observed that LLD refuses to produce a shared object from an object
-# file compiled by Intel Compiler, throwing error message saying
 #   ld.lld: error: can't create dynamic relocation R_X86_64_64 against symbol:
 #   __gxx_personality_v0 in readonly segment; recompile object files with -fPIC
 #   or pass '-Wl,-z,notext' to allow text relocations in the output
+#
 # even if we actually had -fPIC option present. If we add -Wl,-z,notext, it
 # will link, but the produced libdeal_II.so is faulty and will crash randomly.
 #
-# Therefore here adds a check on whether LLD could produce a .so from the
-# object file compiled by the specified C++ compiler.
-# 
-# - Binrui Dong, 2019
+# Wolfgang Bangerth, Matthias Maier, Daniel Arndt, Binrui Dong, 2015, 2018-2020
+#
+
+IF(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+
   IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-Wno-unused-command-line-argument")
   ELSEIF(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-diag-error warn")
   ENDIF()
   ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-Werror")
-  ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
   ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-shared")
   ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-fPIC")
+
+  #
+  # Check for ld.lld and ld.gold support:
+  #
+  ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
   CHECK_CXX_SOURCE_COMPILES(
     "
     #include <iostream>
     void foo() { std::cout << \"Hello, world!\" << std::endl; }
     "
-    DEAL_II_COMPILER_LLD_LINKS_SO)
-  RESET_CMAKE_REQUIRED()
+    DEAL_II_COMPILER_HAS_FUSE_LD_LLD)
 
-  IF(DEAL_II_COMPILER_LLD_LINKS_EXEC AND DEAL_II_COMPILER_LLD_LINKS_SO)
-    set(DEAL_II_COMPILER_HAS_FUSE_LD_LLD 1)
-  ENDIF()
-
-  IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-Wno-unused-command-line-argument")
-  ELSEIF(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-    ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-diag-error warn")
-  ENDIF()
-  ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-Werror")
+  STRIP_FLAG(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
   ADD_FLAGS(CMAKE_REQUIRED_FLAGS "-fuse-ld=gold")
   CHECK_CXX_SOURCE_COMPILES(
     "
-    int main() { return 0; }
+    #include <iostream>
+    void foo() { std::cout << \"Hello, world!\" << std::endl; }
     "
     DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
-  RESET_CMAKE_REQUIRED()
 
   IF(DEAL_II_COMPILER_HAS_FUSE_LD_LLD)
     ADD_FLAGS(DEAL_II_LINKER_FLAGS "-fuse-ld=lld")
   ELSEIF(DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
     ADD_FLAGS(DEAL_II_LINKER_FLAGS "-fuse-ld=gold")
   ENDIF()
+
+  RESET_CMAKE_REQUIRED()
 ENDIF()


### PR DESCRIPTION
I found that  [LLD doesn't link a shared object library with object files compiled with Intel C++ Compiler](https://software.intel.com/en-us/comment/1947463). For example, the following code
```c++
#include <iostream>
void foo() { std::cout << "Hello, world!" << std::endl; }
```
compiled by `icpc` will fail to link by `ld.lld` to produce a shared object library:
```
~$ icpc -fuse-ld=lld -shared -o libmylib.so lib.o
ld.lld: error: can't create dynamic relocation R_X86_64_64 against symbol: __gxx_personality_v0 in readonly segment;
recompile object files with -fPIC or pass '-Wl,-z,notext' to allow text relocations in the output
>>> defined in /usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.so
>>> referenced by lib.cpp
>>>               lib.o:(.gnu.linkonce.d.DW.ref.__gxx_personality_v0+0x0)
```
I was misled by the instruction `ld.lld` outputs, added `-Wl,-z,notext` flag and then `libdeal_II.so` linked successfully, but the generated `libdeal_II.so` was actually faulty and my application crashed in deal.II randomly. All problems disappeared after I tried to use `ld.gold` instead of `ld.lld` when building deal.II.

In this pull request I added a check on whether LLD can link the object file produced by C++ compiler to generate a shared object library. If LLD fails, then it will fallback to GOLD.

I tested this on my local machine. When using GCC, both `DEAL_II_COMPILER_LLD_LINKS_EXEC` and `DEAL_II_COMPILER_LLD_LINKS_SO` checks pass and LLD is finally used. When using Intel Compiler, `DEAL_II_COMPILER_LLD_LINKS_SO` fails and GOLD is used.