### PR TITLE
Add copy_triangulation to parallel::fullydistributed::Triangulation

### DIFF
--- a/source/distributed/fully_distributed_tria_util.inst.in
+++ b/source/distributed/fully_distributed_tria_util.inst.in
@@ -15,7 +15,7 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
   {
     namespace parallel
     \{
@@ -23,26 +23,28 @@ for (deal_II_dimension : DIMENSIONS)
       \{
         namespace Utilities
         \{
-          template ConstructionData<deal_II_dimension, deal_II_dimension>
+#if deal_II_dimension <= deal_II_space_dimension
+          template ConstructionData<deal_II_dimension, deal_II_space_dimension>
           create_construction_data_from_triangulation(
-            const dealii::Triangulation<deal_II_dimension, deal_II_dimension>
-              &                tria,
-            const MPI_Comm     comm,
+            const dealii::Triangulation<deal_II_dimension,
+                                        deal_II_space_dimension> &tria,
+            const MPI_Comm                                        comm,
             const bool         construct_multilevel_hierarchy,
             const unsigned int my_rank_in);
 
-          template ConstructionData<deal_II_dimension, deal_II_dimension>
+          template ConstructionData<deal_II_dimension, deal_II_space_dimension>
           create_construction_data_from_triangulation_in_groups(
             std::function<void(
-              dealii::Triangulation<deal_II_dimension, deal_II_dimension> &)>
-                                   serial_grid_generator,
-            std::function<void(
-              dealii::Triangulation<deal_II_dimension, deal_II_dimension> &,
-              const MPI_Comm,
-              const unsigned int)> serial_grid_partitioner,
-            const MPI_Comm         comm,
-            const int              group_size,
-            const bool             construct_multilevel_hierarchy);
+              dealii::Triangulation<deal_II_dimension, deal_II_space_dimension>
+                &)>                                 serial_grid_generator,
+            std::function<void(dealii::Triangulation<deal_II_dimension,
+                                                     deal_II_space_dimension> &,
+                               const MPI_Comm,
+                               const unsigned int)> serial_grid_partitioner,
+            const MPI_Comm                          comm,
+            const int                               group_size,
+            const bool construct_multilevel_hierarchy);
+#endif
         \}
       \}
     \}

--- a/tests/fullydistributed_grids/copy_serial_tria_07.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_07.cc
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Create a serial triangulation with multigrid levels and copy it with .
+// copy_triangulation.
+
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/fully_distributed_tria_util.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+
+#include "./tests.h"
+
+using namespace dealii;
+
+template <int dim>
+void
+test(int n_refinements, const int n_subdivisions, MPI_Comm comm)
+{
+  // create serial triangulation
+  Triangulation<dim> basetria(
+    Triangulation<dim>::limit_level_difference_at_vertices);
+  GridGenerator::subdivided_hyper_cube(basetria, n_subdivisions);
+  basetria.refine_global(n_refinements);
+
+  // create instance of pft
+  parallel::fullydistributed::Triangulation<dim> tria_pft(comm);
+
+  // register dynamic construction data
+  tria_pft.set_partitioner(
+    [](dealii::Triangulation<dim> &tria, const unsigned int n_partitions) {
+      GridTools::partition_triangulation_zorder(n_partitions, tria);
+    },
+    parallel::fullydistributed::Settings::construct_multigrid_hierarchy);
+
+  // actually create triangulation
+  tria_pft.copy_triangulation(basetria);
+
+  // test triangulation
+  FE_Q<dim>       fe(2);
+  DoFHandler<dim> dof_handler(tria_pft);
+  dof_handler.distribute_dofs(fe);
+  dof_handler.distribute_mg_dofs();
+
+  // print statistics
+  print_statistics(tria_pft, true);
+  print_statistics(dof_handler, true);
+}
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    all;
+
+  const MPI_Comm comm = MPI_COMM_WORLD;
+
+
+  {
+    deallog.push("1d");
+    const int n_refinements  = 6;
+    const int n_subdivisions = 8;
+    test<1>(n_refinements, n_subdivisions, comm);
+    deallog.pop();
+  }
+  {
+    deallog.push("2d");
+    const int n_refinements  = 3;
+    const int n_subdivisions = 8;
+    test<2>(n_refinements, n_subdivisions, comm);
+    deallog.pop();
+  }
+
+  {
+    deallog.push("3d");
+    const int n_refinements  = 3;
+    const int n_subdivisions = 4;
+    test<3>(n_refinements, n_subdivisions, comm);
+    deallog.pop();
+  }
+}

--- a/tests/fullydistributed_grids/copy_serial_tria_07.mpirun=1.output
+++ b/tests/fullydistributed_grids/copy_serial_tria_07.mpirun=1.output
@@ -1,0 +1,82 @@
+
+DEAL:0:1d::n_levels:                  7
+DEAL:0:1d::n_cells:                   1016
+DEAL:0:1d::n_active_cells:            512
+DEAL:0:1d::n_cells on level=0:        8
+DEAL:0:1d::n_cells on level=1:        16
+DEAL:0:1d::n_cells on level=2:        32
+DEAL:0:1d::n_cells on level=3:        64
+DEAL:0:1d::n_cells on level=4:        128
+DEAL:0:1d::n_cells on level=5:        256
+DEAL:0:1d::n_cells on level=6:        512
+DEAL:0:1d::n_active_cells on level=0: 0
+DEAL:0:1d::n_active_cells on level=1: 0
+DEAL:0:1d::n_active_cells on level=2: 0
+DEAL:0:1d::n_active_cells on level=3: 0
+DEAL:0:1d::n_active_cells on level=4: 0
+DEAL:0:1d::n_active_cells on level=5: 0
+DEAL:0:1d::n_active_cells on level=6: 512
+DEAL:0:1d::
+DEAL:0:1d::n_dofs:                             1025
+DEAL:0:1d::n_locally_owned_dofs:               1025
+DEAL:0:1d::n_dofs on level=0:                  17
+DEAL:0:1d::n_dofs on level=1:                  33
+DEAL:0:1d::n_dofs on level=2:                  65
+DEAL:0:1d::n_dofs on level=3:                  129
+DEAL:0:1d::n_dofs on level=4:                  257
+DEAL:0:1d::n_dofs on level=5:                  513
+DEAL:0:1d::n_dofs on level=6:                  1025
+DEAL:0:1d::n_locally_owned_mg_dofs on level=0: 17
+DEAL:0:1d::n_locally_owned_mg_dofs on level=1: 33
+DEAL:0:1d::n_locally_owned_mg_dofs on level=2: 65
+DEAL:0:1d::n_locally_owned_mg_dofs on level=3: 129
+DEAL:0:1d::n_locally_owned_mg_dofs on level=4: 257
+DEAL:0:1d::n_locally_owned_mg_dofs on level=5: 513
+DEAL:0:1d::n_locally_owned_mg_dofs on level=6: 1025
+DEAL:0:1d::
+DEAL:0:2d::n_levels:                  4
+DEAL:0:2d::n_cells:                   5440
+DEAL:0:2d::n_active_cells:            4096
+DEAL:0:2d::n_cells on level=0:        64
+DEAL:0:2d::n_cells on level=1:        256
+DEAL:0:2d::n_cells on level=2:        1024
+DEAL:0:2d::n_cells on level=3:        4096
+DEAL:0:2d::n_active_cells on level=0: 0
+DEAL:0:2d::n_active_cells on level=1: 0
+DEAL:0:2d::n_active_cells on level=2: 0
+DEAL:0:2d::n_active_cells on level=3: 4096
+DEAL:0:2d::
+DEAL:0:2d::n_dofs:                             16641
+DEAL:0:2d::n_locally_owned_dofs:               16641
+DEAL:0:2d::n_dofs on level=0:                  289
+DEAL:0:2d::n_dofs on level=1:                  1089
+DEAL:0:2d::n_dofs on level=2:                  4225
+DEAL:0:2d::n_dofs on level=3:                  16641
+DEAL:0:2d::n_locally_owned_mg_dofs on level=0: 289
+DEAL:0:2d::n_locally_owned_mg_dofs on level=1: 1089
+DEAL:0:2d::n_locally_owned_mg_dofs on level=2: 4225
+DEAL:0:2d::n_locally_owned_mg_dofs on level=3: 16641
+DEAL:0:2d::
+DEAL:0:3d::n_levels:                  4
+DEAL:0:3d::n_cells:                   37440
+DEAL:0:3d::n_active_cells:            32768
+DEAL:0:3d::n_cells on level=0:        64
+DEAL:0:3d::n_cells on level=1:        512
+DEAL:0:3d::n_cells on level=2:        4096
+DEAL:0:3d::n_cells on level=3:        32768
+DEAL:0:3d::n_active_cells on level=0: 0
+DEAL:0:3d::n_active_cells on level=1: 0
+DEAL:0:3d::n_active_cells on level=2: 0
+DEAL:0:3d::n_active_cells on level=3: 32768
+DEAL:0:3d::
+DEAL:0:3d::n_dofs:                             274625
+DEAL:0:3d::n_locally_owned_dofs:               274625
+DEAL:0:3d::n_dofs on level=0:                  729
+DEAL:0:3d::n_dofs on level=1:                  4913
+DEAL:0:3d::n_dofs on level=2:                  35937
+DEAL:0:3d::n_dofs on level=3:                  274625
+DEAL:0:3d::n_locally_owned_mg_dofs on level=0: 729
+DEAL:0:3d::n_locally_owned_mg_dofs on level=1: 4913
+DEAL:0:3d::n_locally_owned_mg_dofs on level=2: 35937
+DEAL:0:3d::n_locally_owned_mg_dofs on level=3: 274625
+DEAL:0:3d::

--- a/tests/fullydistributed_grids/copy_serial_tria_07.mpirun=5.output
+++ b/tests/fullydistributed_grids/copy_serial_tria_07.mpirun=5.output
@@ -1,0 +1,414 @@
+
+DEAL:0:1d::n_levels:                  7
+DEAL:0:1d::n_cells:                   221
+DEAL:0:1d::n_active_cells:            112
+DEAL:0:1d::n_cells on level=0:        3
+DEAL:0:1d::n_cells on level=1:        6
+DEAL:0:1d::n_cells on level=2:        10
+DEAL:0:1d::n_cells on level=3:        16
+DEAL:0:1d::n_cells on level=4:        28
+DEAL:0:1d::n_cells on level=5:        54
+DEAL:0:1d::n_cells on level=6:        104
+DEAL:0:1d::n_active_cells on level=0: 0
+DEAL:0:1d::n_active_cells on level=1: 1
+DEAL:0:1d::n_active_cells on level=2: 2
+DEAL:0:1d::n_active_cells on level=3: 2
+DEAL:0:1d::n_active_cells on level=4: 1
+DEAL:0:1d::n_active_cells on level=5: 2
+DEAL:0:1d::n_active_cells on level=6: 104
+DEAL:0:1d::
+DEAL:0:1d::n_dofs:                             1025
+DEAL:0:1d::n_locally_owned_dofs:               205
+DEAL:0:1d::n_dofs on level=0:                  17
+DEAL:0:1d::n_dofs on level=1:                  33
+DEAL:0:1d::n_dofs on level=2:                  65
+DEAL:0:1d::n_dofs on level=3:                  129
+DEAL:0:1d::n_dofs on level=4:                  257
+DEAL:0:1d::n_dofs on level=5:                  513
+DEAL:0:1d::n_dofs on level=6:                  1025
+DEAL:0:1d::n_locally_owned_mg_dofs on level=0: 5
+DEAL:0:1d::n_locally_owned_mg_dofs on level=1: 9
+DEAL:0:1d::n_locally_owned_mg_dofs on level=2: 15
+DEAL:0:1d::n_locally_owned_mg_dofs on level=3: 27
+DEAL:0:1d::n_locally_owned_mg_dofs on level=4: 53
+DEAL:0:1d::n_locally_owned_mg_dofs on level=5: 103
+DEAL:0:1d::n_locally_owned_mg_dofs on level=6: 205
+DEAL:0:1d::
+DEAL:0:2d::n_levels:                  4
+DEAL:0:2d::n_cells:                   1338
+DEAL:0:2d::n_active_cells:            1009
+DEAL:0:2d::n_cells on level=0:        22
+DEAL:0:2d::n_cells on level=1:        88
+DEAL:0:2d::n_cells on level=2:        276
+DEAL:0:2d::n_cells on level=3:        952
+DEAL:0:2d::n_active_cells on level=0: 0
+DEAL:0:2d::n_active_cells on level=1: 19
+DEAL:0:2d::n_active_cells on level=2: 38
+DEAL:0:2d::n_active_cells on level=3: 952
+DEAL:0:2d::
+DEAL:0:2d::n_dofs:                             16641
+DEAL:0:2d::n_locally_owned_dofs:               3409
+DEAL:0:2d::n_dofs on level=0:                  289
+DEAL:0:2d::n_dofs on level=1:                  1089
+DEAL:0:2d::n_dofs on level=2:                  4225
+DEAL:0:2d::n_dofs on level=3:                  16641
+DEAL:0:2d::n_locally_owned_mg_dofs on level=0: 69
+DEAL:0:2d::n_locally_owned_mg_dofs on level=1: 241
+DEAL:0:2d::n_locally_owned_mg_dofs on level=2: 885
+DEAL:0:2d::n_locally_owned_mg_dofs on level=3: 3409
+DEAL:0:2d::
+DEAL:0:3d::n_levels:                  4
+DEAL:0:3d::n_cells:                   10651
+DEAL:0:3d::n_active_cells:            9324
+DEAL:0:3d::n_cells on level=0:        35
+DEAL:0:3d::n_cells on level=1:        280
+DEAL:0:3d::n_cells on level=2:        1448
+DEAL:0:3d::n_cells on level=3:        8888
+DEAL:0:3d::n_active_cells on level=0: 0
+DEAL:0:3d::n_active_cells on level=1: 99
+DEAL:0:3d::n_active_cells on level=2: 337
+DEAL:0:3d::n_active_cells on level=3: 8888
+DEAL:0:3d::
+DEAL:0:3d::n_dofs:                             274625
+DEAL:0:3d::n_locally_owned_dofs:               57409
+DEAL:0:3d::n_dofs on level=0:                  729
+DEAL:0:3d::n_dofs on level=1:                  4913
+DEAL:0:3d::n_dofs on level=2:                  35937
+DEAL:0:3d::n_dofs on level=3:                  274625
+DEAL:0:3d::n_locally_owned_mg_dofs on level=0: 197
+DEAL:0:3d::n_locally_owned_mg_dofs on level=1: 1161
+DEAL:0:3d::n_locally_owned_mg_dofs on level=2: 7833
+DEAL:0:3d::n_locally_owned_mg_dofs on level=3: 57409
+DEAL:0:3d::
+
+DEAL:1:1d::n_levels:                  7
+DEAL:1:1d::n_cells:                   236
+DEAL:1:1d::n_active_cells:            120
+DEAL:1:1d::n_cells on level=0:        4
+DEAL:1:1d::n_cells on level=1:        8
+DEAL:1:1d::n_cells on level=2:        12
+DEAL:1:1d::n_cells on level=3:        18
+DEAL:1:1d::n_cells on level=4:        32
+DEAL:1:1d::n_cells on level=5:        56
+DEAL:1:1d::n_cells on level=6:        106
+DEAL:1:1d::n_active_cells on level=0: 0
+DEAL:1:1d::n_active_cells on level=1: 2
+DEAL:1:1d::n_active_cells on level=2: 3
+DEAL:1:1d::n_active_cells on level=3: 2
+DEAL:1:1d::n_active_cells on level=4: 4
+DEAL:1:1d::n_active_cells on level=5: 3
+DEAL:1:1d::n_active_cells on level=6: 106
+DEAL:1:1d::
+DEAL:1:1d::n_dofs:                             1025
+DEAL:1:1d::n_locally_owned_dofs:               204
+DEAL:1:1d::n_dofs on level=0:                  17
+DEAL:1:1d::n_dofs on level=1:                  33
+DEAL:1:1d::n_dofs on level=2:                  65
+DEAL:1:1d::n_dofs on level=3:                  129
+DEAL:1:1d::n_dofs on level=4:                  257
+DEAL:1:1d::n_dofs on level=5:                  513
+DEAL:1:1d::n_dofs on level=6:                  1025
+DEAL:1:1d::n_locally_owned_mg_dofs on level=0: 4
+DEAL:1:1d::n_locally_owned_mg_dofs on level=1: 6
+DEAL:1:1d::n_locally_owned_mg_dofs on level=2: 12
+DEAL:1:1d::n_locally_owned_mg_dofs on level=3: 26
+DEAL:1:1d::n_locally_owned_mg_dofs on level=4: 50
+DEAL:1:1d::n_locally_owned_mg_dofs on level=5: 102
+DEAL:1:1d::n_locally_owned_mg_dofs on level=6: 204
+DEAL:1:1d::
+DEAL:1:2d::n_levels:                  4
+DEAL:1:2d::n_cells:                   1512
+DEAL:1:2d::n_active_cells:            1141
+DEAL:1:2d::n_cells on level=0:        28
+DEAL:1:2d::n_cells on level=1:        112
+DEAL:1:2d::n_cells on level=2:        324
+DEAL:1:2d::n_cells on level=3:        1048
+DEAL:1:2d::n_active_cells on level=0: 0
+DEAL:1:2d::n_active_cells on level=1: 31
+DEAL:1:2d::n_active_cells on level=2: 62
+DEAL:1:2d::n_active_cells on level=3: 1048
+DEAL:1:2d::
+DEAL:1:2d::n_dofs:                             16641
+DEAL:1:2d::n_locally_owned_dofs:               3344
+DEAL:1:2d::n_dofs on level=0:                  289
+DEAL:1:2d::n_dofs on level=1:                  1089
+DEAL:1:2d::n_dofs on level=2:                  4225
+DEAL:1:2d::n_dofs on level=3:                  16641
+DEAL:1:2d::n_locally_owned_mg_dofs on level=0: 60
+DEAL:1:2d::n_locally_owned_mg_dofs on level=1: 220
+DEAL:1:2d::n_locally_owned_mg_dofs on level=2: 852
+DEAL:1:2d::n_locally_owned_mg_dofs on level=3: 3344
+DEAL:1:2d::
+DEAL:1:3d::n_levels:                  4
+DEAL:1:3d::n_cells:                   12732
+DEAL:1:3d::n_active_cells:            11146
+DEAL:1:3d::n_cells on level=0:        44
+DEAL:1:3d::n_cells on level=1:        352
+DEAL:1:3d::n_cells on level=2:        1840
+DEAL:1:3d::n_cells on level=3:        10496
+DEAL:1:3d::n_active_cells on level=0: 0
+DEAL:1:3d::n_active_cells on level=1: 122
+DEAL:1:3d::n_active_cells on level=2: 528
+DEAL:1:3d::n_active_cells on level=3: 10496
+DEAL:1:3d::
+DEAL:1:3d::n_dofs:                             274625
+DEAL:1:3d::n_locally_owned_dofs:               55264
+DEAL:1:3d::n_dofs on level=0:                  729
+DEAL:1:3d::n_dofs on level=1:                  4913
+DEAL:1:3d::n_dofs on level=2:                  35937
+DEAL:1:3d::n_dofs on level=3:                  274625
+DEAL:1:3d::n_locally_owned_mg_dofs on level=0: 152
+DEAL:1:3d::n_locally_owned_mg_dofs on level=1: 1000
+DEAL:1:3d::n_locally_owned_mg_dofs on level=2: 7272
+DEAL:1:3d::n_locally_owned_mg_dofs on level=3: 55264
+DEAL:1:3d::
+
+
+DEAL:2:1d::n_levels:                  7
+DEAL:2:1d::n_cells:                   233
+DEAL:2:1d::n_active_cells:            118
+DEAL:2:1d::n_cells on level=0:        3
+DEAL:2:1d::n_cells on level=1:        6
+DEAL:2:1d::n_cells on level=2:        10
+DEAL:2:1d::n_cells on level=3:        18
+DEAL:2:1d::n_cells on level=4:        32
+DEAL:2:1d::n_cells on level=5:        56
+DEAL:2:1d::n_cells on level=6:        108
+DEAL:2:1d::n_active_cells on level=0: 0
+DEAL:2:1d::n_active_cells on level=1: 1
+DEAL:2:1d::n_active_cells on level=2: 1
+DEAL:2:1d::n_active_cells on level=3: 2
+DEAL:2:1d::n_active_cells on level=4: 4
+DEAL:2:1d::n_active_cells on level=5: 2
+DEAL:2:1d::n_active_cells on level=6: 108
+DEAL:2:1d::
+DEAL:2:1d::n_dofs:                             1025
+DEAL:2:1d::n_locally_owned_dofs:               208
+DEAL:2:1d::n_dofs on level=0:                  17
+DEAL:2:1d::n_dofs on level=1:                  33
+DEAL:2:1d::n_dofs on level=2:                  65
+DEAL:2:1d::n_dofs on level=3:                  129
+DEAL:2:1d::n_dofs on level=4:                  257
+DEAL:2:1d::n_dofs on level=5:                  513
+DEAL:2:1d::n_dofs on level=6:                  1025
+DEAL:2:1d::n_locally_owned_mg_dofs on level=0: 2
+DEAL:2:1d::n_locally_owned_mg_dofs on level=1: 6
+DEAL:2:1d::n_locally_owned_mg_dofs on level=2: 14
+DEAL:2:1d::n_locally_owned_mg_dofs on level=3: 26
+DEAL:2:1d::n_locally_owned_mg_dofs on level=4: 52
+DEAL:2:1d::n_locally_owned_mg_dofs on level=5: 104
+DEAL:2:1d::n_locally_owned_mg_dofs on level=6: 208
+DEAL:2:1d::
+DEAL:2:2d::n_levels:                  4
+DEAL:2:2d::n_cells:                   1669
+DEAL:2:2d::n_active_cells:            1260
+DEAL:2:2d::n_cells on level=0:        33
+DEAL:2:2d::n_cells on level=1:        132
+DEAL:2:2d::n_cells on level=2:        368
+DEAL:2:2d::n_cells on level=3:        1136
+DEAL:2:2d::n_active_cells on level=0: 0
+DEAL:2:2d::n_active_cells on level=1: 40
+DEAL:2:2d::n_active_cells on level=2: 84
+DEAL:2:2d::n_active_cells on level=3: 1136
+DEAL:2:2d::
+DEAL:2:2d::n_dofs:                             16641
+DEAL:2:2d::n_locally_owned_dofs:               3296
+DEAL:2:2d::n_dofs on level=0:                  289
+DEAL:2:2d::n_dofs on level=1:                  1089
+DEAL:2:2d::n_dofs on level=2:                  4225
+DEAL:2:2d::n_dofs on level=3:                  16641
+DEAL:2:2d::n_locally_owned_mg_dofs on level=0: 56
+DEAL:2:2d::n_locally_owned_mg_dofs on level=1: 212
+DEAL:2:2d::n_locally_owned_mg_dofs on level=2: 832
+DEAL:2:2d::n_locally_owned_mg_dofs on level=3: 3296
+DEAL:2:2d::
+DEAL:2:3d::n_levels:                  4
+DEAL:2:3d::n_cells:                   12702
+DEAL:2:3d::n_active_cells:            11120
+DEAL:2:3d::n_cells on level=0:        46
+DEAL:2:3d::n_cells on level=1:        368
+DEAL:2:3d::n_cells on level=2:        1872
+DEAL:2:3d::n_cells on level=3:        10416
+DEAL:2:3d::n_active_cells on level=0: 0
+DEAL:2:3d::n_active_cells on level=1: 134
+DEAL:2:3d::n_active_cells on level=2: 570
+DEAL:2:3d::n_active_cells on level=3: 10416
+DEAL:2:3d::
+DEAL:2:3d::n_dofs:                             274625
+DEAL:2:3d::n_locally_owned_dofs:               54944
+DEAL:2:3d::n_dofs on level=0:                  729
+DEAL:2:3d::n_dofs on level=1:                  4913
+DEAL:2:3d::n_dofs on level=2:                  35937
+DEAL:2:3d::n_dofs on level=3:                  274625
+DEAL:2:3d::n_locally_owned_mg_dofs on level=0: 148
+DEAL:2:3d::n_locally_owned_mg_dofs on level=1: 984
+DEAL:2:3d::n_locally_owned_mg_dofs on level=2: 7184
+DEAL:2:3d::n_locally_owned_mg_dofs on level=3: 54944
+DEAL:2:3d::
+
+
+DEAL:3:1d::n_levels:                  7
+DEAL:3:1d::n_cells:                   236
+DEAL:3:1d::n_active_cells:            120
+DEAL:3:1d::n_cells on level=0:        4
+DEAL:3:1d::n_cells on level=1:        8
+DEAL:3:1d::n_cells on level=2:        12
+DEAL:3:1d::n_cells on level=3:        18
+DEAL:3:1d::n_cells on level=4:        32
+DEAL:3:1d::n_cells on level=5:        56
+DEAL:3:1d::n_cells on level=6:        106
+DEAL:3:1d::n_active_cells on level=0: 0
+DEAL:3:1d::n_active_cells on level=1: 2
+DEAL:3:1d::n_active_cells on level=2: 3
+DEAL:3:1d::n_active_cells on level=3: 2
+DEAL:3:1d::n_active_cells on level=4: 4
+DEAL:3:1d::n_active_cells on level=5: 3
+DEAL:3:1d::n_active_cells on level=6: 106
+DEAL:3:1d::
+DEAL:3:1d::n_dofs:                             1025
+DEAL:3:1d::n_locally_owned_dofs:               204
+DEAL:3:1d::n_dofs on level=0:                  17
+DEAL:3:1d::n_dofs on level=1:                  33
+DEAL:3:1d::n_dofs on level=2:                  65
+DEAL:3:1d::n_dofs on level=3:                  129
+DEAL:3:1d::n_dofs on level=4:                  257
+DEAL:3:1d::n_dofs on level=5:                  513
+DEAL:3:1d::n_dofs on level=6:                  1025
+DEAL:3:1d::n_locally_owned_mg_dofs on level=0: 4
+DEAL:3:1d::n_locally_owned_mg_dofs on level=1: 6
+DEAL:3:1d::n_locally_owned_mg_dofs on level=2: 12
+DEAL:3:1d::n_locally_owned_mg_dofs on level=3: 26
+DEAL:3:1d::n_locally_owned_mg_dofs on level=4: 52
+DEAL:3:1d::n_locally_owned_mg_dofs on level=5: 102
+DEAL:3:1d::n_locally_owned_mg_dofs on level=6: 204
+DEAL:3:1d::
+DEAL:3:2d::n_levels:                  4
+DEAL:3:2d::n_cells:                   1512
+DEAL:3:2d::n_active_cells:            1141
+DEAL:3:2d::n_cells on level=0:        28
+DEAL:3:2d::n_cells on level=1:        112
+DEAL:3:2d::n_cells on level=2:        324
+DEAL:3:2d::n_cells on level=3:        1048
+DEAL:3:2d::n_active_cells on level=0: 0
+DEAL:3:2d::n_active_cells on level=1: 31
+DEAL:3:2d::n_active_cells on level=2: 62
+DEAL:3:2d::n_active_cells on level=3: 1048
+DEAL:3:2d::
+DEAL:3:2d::n_dofs:                             16641
+DEAL:3:2d::n_locally_owned_dofs:               3312
+DEAL:3:2d::n_dofs on level=0:                  289
+DEAL:3:2d::n_dofs on level=1:                  1089
+DEAL:3:2d::n_dofs on level=2:                  4225
+DEAL:3:2d::n_dofs on level=3:                  16641
+DEAL:3:2d::n_locally_owned_mg_dofs on level=0: 56
+DEAL:3:2d::n_locally_owned_mg_dofs on level=1: 212
+DEAL:3:2d::n_locally_owned_mg_dofs on level=2: 836
+DEAL:3:2d::n_locally_owned_mg_dofs on level=3: 3312
+DEAL:3:2d::
+DEAL:3:3d::n_levels:                  4
+DEAL:3:3d::n_cells:                   12732
+DEAL:3:3d::n_active_cells:            11146
+DEAL:3:3d::n_cells on level=0:        44
+DEAL:3:3d::n_cells on level=1:        352
+DEAL:3:3d::n_cells on level=2:        1840
+DEAL:3:3d::n_cells on level=3:        10496
+DEAL:3:3d::n_active_cells on level=0: 0
+DEAL:3:3d::n_active_cells on level=1: 122
+DEAL:3:3d::n_active_cells on level=2: 528
+DEAL:3:3d::n_active_cells on level=3: 10496
+DEAL:3:3d::
+DEAL:3:3d::n_dofs:                             274625
+DEAL:3:3d::n_locally_owned_dofs:               54080
+DEAL:3:3d::n_dofs on level=0:                  729
+DEAL:3:3d::n_dofs on level=1:                  4913
+DEAL:3:3d::n_dofs on level=2:                  35937
+DEAL:3:3d::n_dofs on level=3:                  274625
+DEAL:3:3d::n_locally_owned_mg_dofs on level=0: 128
+DEAL:3:3d::n_locally_owned_mg_dofs on level=1: 920
+DEAL:3:3d::n_locally_owned_mg_dofs on level=2: 6968
+DEAL:3:3d::n_locally_owned_mg_dofs on level=3: 54080
+DEAL:3:3d::
+
+
+DEAL:4:1d::n_levels:                  7
+DEAL:4:1d::n_cells:                   216
+DEAL:4:1d::n_active_cells:            109
+DEAL:4:1d::n_cells on level=0:        2
+DEAL:4:1d::n_cells on level=1:        4
+DEAL:4:1d::n_cells on level=2:        8
+DEAL:4:1d::n_cells on level=3:        16
+DEAL:4:1d::n_cells on level=4:        28
+DEAL:4:1d::n_cells on level=5:        54
+DEAL:4:1d::n_cells on level=6:        104
+DEAL:4:1d::n_active_cells on level=0: 0
+DEAL:4:1d::n_active_cells on level=1: 0
+DEAL:4:1d::n_active_cells on level=2: 0
+DEAL:4:1d::n_active_cells on level=3: 2
+DEAL:4:1d::n_active_cells on level=4: 1
+DEAL:4:1d::n_active_cells on level=5: 2
+DEAL:4:1d::n_active_cells on level=6: 104
+DEAL:4:1d::
+DEAL:4:1d::n_dofs:                             1025
+DEAL:4:1d::n_locally_owned_dofs:               204
+DEAL:4:1d::n_dofs on level=0:                  17
+DEAL:4:1d::n_dofs on level=1:                  33
+DEAL:4:1d::n_dofs on level=2:                  65
+DEAL:4:1d::n_dofs on level=3:                  129
+DEAL:4:1d::n_dofs on level=4:                  257
+DEAL:4:1d::n_dofs on level=5:                  513
+DEAL:4:1d::n_dofs on level=6:                  1025
+DEAL:4:1d::n_locally_owned_mg_dofs on level=0: 2
+DEAL:4:1d::n_locally_owned_mg_dofs on level=1: 6
+DEAL:4:1d::n_locally_owned_mg_dofs on level=2: 12
+DEAL:4:1d::n_locally_owned_mg_dofs on level=3: 24
+DEAL:4:1d::n_locally_owned_mg_dofs on level=4: 50
+DEAL:4:1d::n_locally_owned_mg_dofs on level=5: 102
+DEAL:4:1d::n_locally_owned_mg_dofs on level=6: 204
+DEAL:4:1d::
+DEAL:4:2d::n_levels:                  4
+DEAL:4:2d::n_cells:                   1329
+DEAL:4:2d::n_active_cells:            1002
+DEAL:4:2d::n_cells on level=0:        21
+DEAL:4:2d::n_cells on level=1:        84
+DEAL:4:2d::n_cells on level=2:        272
+DEAL:4:2d::n_cells on level=3:        952
+DEAL:4:2d::n_active_cells on level=0: 0
+DEAL:4:2d::n_active_cells on level=1: 16
+DEAL:4:2d::n_active_cells on level=2: 34
+DEAL:4:2d::n_active_cells on level=3: 952
+DEAL:4:2d::
+DEAL:4:2d::n_dofs:                             16641
+DEAL:4:2d::n_locally_owned_dofs:               3280
+DEAL:4:2d::n_dofs on level=0:                  289
+DEAL:4:2d::n_dofs on level=1:                  1089
+DEAL:4:2d::n_dofs on level=2:                  4225
+DEAL:4:2d::n_dofs on level=3:                  16641
+DEAL:4:2d::n_locally_owned_mg_dofs on level=0: 48
+DEAL:4:2d::n_locally_owned_mg_dofs on level=1: 204
+DEAL:4:2d::n_locally_owned_mg_dofs on level=2: 820
+DEAL:4:2d::n_locally_owned_mg_dofs on level=3: 3280
+DEAL:4:2d::
+DEAL:4:3d::n_levels:                  4
+DEAL:4:3d::n_cells:                   10642
+DEAL:4:3d::n_active_cells:            9316
+DEAL:4:3d::n_cells on level=0:        34
+DEAL:4:3d::n_cells on level=1:        272
+DEAL:4:3d::n_cells on level=2:        1448
+DEAL:4:3d::n_cells on level=3:        8888
+DEAL:4:3d::n_active_cells on level=0: 0
+DEAL:4:3d::n_active_cells on level=1: 91
+DEAL:4:3d::n_active_cells on level=2: 337
+DEAL:4:3d::n_active_cells on level=3: 8888
+DEAL:4:3d::
+DEAL:4:3d::n_dofs:                             274625
+DEAL:4:3d::n_locally_owned_dofs:               52928
+DEAL:4:3d::n_dofs on level=0:                  729
+DEAL:4:3d::n_dofs on level=1:                  4913
+DEAL:4:3d::n_dofs on level=2:                  35937
+DEAL:4:3d::n_dofs on level=3:                  274625
+DEAL:4:3d::n_locally_owned_mg_dofs on level=0: 104
+DEAL:4:3d::n_locally_owned_mg_dofs on level=1: 848
+DEAL:4:3d::n_locally_owned_mg_dofs on level=2: 6680
+DEAL:4:3d::n_locally_owned_mg_dofs on level=3: 52928
+DEAL:4:3d::
+


### PR DESCRIPTION
While integrating `p:f:t` in a user code, I noticed it is sometimes somewhat annoying to pass the information how to partition a serial triangulation and how to construct the `ConstructionData`. Instead, I propose in this PR *register* the information in `p:f:t`, which is used during a new `copy_triangulation`-method to construct the `ConstrucionData`.

An example (part of the new test `fullydistributed_grids/copy_serial_tria_07`, which is a variant of  `fullydistributed_grids/copy_serial_tria_02`):

```cpp
  // create instance of pft
  parallel::fullydistributed::Triangulation<dim> tria_pft(comm);

  // register dynamic construction data
  tria_pft.register_dynamic_construction_data(
    std::make_shared<
      const parallel::fullydistributed::DynamicConstructionData<dim>>(
      [](dealii::Triangulation<dim> &tria, const unsigned int n_partitions) {
        GridTools::partition_triangulation_zorder(n_partitions, tria);
      },
      true));

  // actually create triangulation
  tria_pft.copy_triangulation(basetria);
```
@bangerth @tjhei Your opinion would be valuable! I think in a similar way we might want to handle re-partitioning with arbitrary *oracles* in the future...

ping @eliasstudiert