### PR TITLE
use global list of MPI tags for collective communication

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
+#include <deal.II/base/mpi_tags.h>
 #include <deal.II/base/numbers.h>
 
 #include <map>
@@ -1114,10 +1115,6 @@ namespace Utilities
     class ConsensusAlgorithm_NBX : public ConsensusAlgorithm<T1, T2>
     {
     public:
-      // Unique tags to be used during Isend and Irecv
-      static const unsigned int tag_request  = 12;
-      static const unsigned int tag_delivery = 13;
-
       /**
        * Constructor.
        *
@@ -1256,10 +1253,6 @@ namespace Utilities
     class ConsensusAlgorithm_PEX : public ConsensusAlgorithm<T1, T2>
     {
     public:
-      // Unique tags to be used during Isend and Irecv
-      static const unsigned int tag_request  = 14;
-      static const unsigned int tag_delivery = 15;
-
       /**
        * Constructor.
        *
@@ -1508,6 +1501,9 @@ namespace Utilities
       static CollectiveMutex      mutex;
       CollectiveMutex::ScopedLock lock(mutex, comm);
 
+      const int mpi_tag =
+        internal::Tags::compute_point_to_point_communication_pattern;
+
       // Sending buffers
       std::vector<std::vector<char>> buffers_to_send(send_to.size());
       std::vector<MPI_Request>       buffer_send_requests(send_to.size());
@@ -1521,7 +1517,7 @@ namespace Utilities
                                        buffers_to_send[i].size(),
                                        MPI_CHAR,
                                        rank,
-                                       21,
+                                       mpi_tag,
                                        comm,
                                        &buffer_send_requests[i]);
             AssertThrowMPI(ierr);
@@ -1538,7 +1534,7 @@ namespace Utilities
           {
             // Probe what's going on. Take data from the first available sender
             MPI_Status status;
-            int        ierr = MPI_Probe(MPI_ANY_SOURCE, 21, comm, &status);
+            int        ierr = MPI_Probe(MPI_ANY_SOURCE, mpi_tag, comm, &status);
             AssertThrowMPI(ierr);
 
             // Length of the message
@@ -1551,8 +1547,13 @@ namespace Utilities
             const unsigned int rank = status.MPI_SOURCE;
 
             // Actually receive the message
-            ierr = MPI_Recv(
-              buffer.data(), len, MPI_CHAR, rank, 21, comm, MPI_STATUS_IGNORE);
+            ierr = MPI_Recv(buffer.data(),
+                            len,
+                            MPI_CHAR,
+                            status.MPI_SOURCE,
+                            status.MPI_TAG,
+                            comm,
+                            MPI_STATUS_IGNORE);
             AssertThrowMPI(ierr);
             Assert(received_objects.find(rank) == received_objects.end(),
                    ExcInternalError(

--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -229,8 +229,8 @@ namespace Utilities
                 ierr = MPI_Recv(buffer.data(),
                                 number_amount,
                                 DEAL_II_DOF_INDEX_MPI_TYPE,
-                                status.MPI_TAG,
                                 status.MPI_SOURCE,
+                                status.MPI_TAG,
                                 comm,
                                 &status);
                 AssertThrowMPI(ierr);

--- a/include/deal.II/base/mpi_tags.h
+++ b/include/deal.II/base/mpi_tags.h
@@ -28,14 +28,22 @@ namespace Utilities
     namespace internal
     {
       /**
-       * This enum holds all MPI tags used in collective MPI communications with
-       * using MPI_ANY_SOURCE inside the deal.II library.
+       * This enum holds all MPI tags used in point to point MPI communications
+       * inside the deal.II library.
        *
        * We keep these tags in a central location so that they are unique within
-       * the library. Otherwise, communication that receives packages with
-       * MPI_ANY_SOURCE might pick up packets from a different algorithm.
+       * the library. Otherwise, communication that receives packages might pick
+       * up packets from a different algorithm. This is especially true if
+       * MPI_ANY_SOURCE is used.
+       *
+       * The list of MPI functions that use an MPI tag is:
+       * - MPI_Send, MPI_Recv, MPI_Sendrecv
+       * - MPI_Isend, MPI_Irecv
+       * - MPI_Probe, MPI_Iprobe
+       * - MPI_Comm_create_group, MPI_Intercomm_create,
+       * Utilities::MPI::create_group
        */
-      struct Tags
+      namespace Tags
       {
         /**
          * The enum with the tags.
@@ -87,10 +95,37 @@ namespace Utilities
           /// ConsensusAlgorithm_PEX::process
           consensus_algorithm_pex_process_deliver,
 
+          /// ConstructionData<dim,
+          /// spacedim>::create_construction_data_from_triangulation_in_groups()
+          fully_distributed_create,
+
+          /// TriangulationBase<dim, spacedim>::fill_level_ghost_owners()
+          triangulation_base_fill_level_ghost_owners,
+
+          /// GridTools::compute_local_to_global_vertex_index_map
+          grid_tools_compute_local_to_global_vertex_index_map,
+          /// GridTools::compute_local_to_global_vertex_index_map second tag
+          grid_tools_compute_local_to_global_vertex_index_map2,
+
+          /// ParticleHandler<dim, spacedim>::send_recv_particles
+          particle_handler_send_recv_particles_setup,
+          /// ParticleHandler<dim, spacedim>::send_recv_particles
+          particle_handler_send_recv_particles_send,
+
+          /// ScaLAPACKMatrix<NumberType>::copy_to
+          scalapack_copy_to,
+          /// ScaLAPACKMatrix<NumberType>::copy_to
+          scalapack_copy_to2,
+          /// ScaLAPACKMatrix<NumberType>::copy_from
+          scalapack_copy_from,
+
+          /// ProcessGrid::ProcessGrid
+          process_grid_constructor,
+
         };
-      };
-    } // namespace internal
-  }   // namespace MPI
+      } // namespace Tags
+    }   // namespace internal
+  }     // namespace MPI
 } // namespace Utilities
 
 

--- a/include/deal.II/base/mpi_tags.h
+++ b/include/deal.II/base/mpi_tags.h
@@ -48,7 +48,7 @@ namespace Utilities
         /**
          * The enum with the tags.
          */
-        enum enumeration
+        enum enumeration : std::uint16_t
         {
           /// Utilities::MPI::some_to_some()
           mpi_some_to_some = 300,

--- a/include/deal.II/base/mpi_tags.h
+++ b/include/deal.II/base/mpi_tags.h
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_mpi_tags_h
+#define dealii_mpi_tags_h
+
+#include <deal.II/base/config.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+
+namespace Utilities
+{
+  namespace MPI
+  {
+    namespace internal
+    {
+      /**
+       * This enum holds all MPI tags used in collective MPI communications with
+       * using MPI_ANY_SOURCE inside the deal.II library.
+       *
+       * We keep these tags in a central location so that they are unique within
+       * the library. Otherwise, communication that receives packages with
+       * MPI_ANY_SOURCE might pick up packets from a different algorithm.
+       */
+      struct Tags
+      {
+        /**
+         * The enum with the tags.
+         */
+        enum enumeration
+        {
+          /// Utilities::MPI::some_to_some()
+          mpi_some_to_some = 300,
+
+          /// Utilities::MPI::compute_point_to_point_communication_pattern()
+          compute_point_to_point_communication_pattern,
+
+          /// GridTools::exchange_cell_data_to_ghosts():
+          exchange_cell_data_to_ghosts,
+
+          /// Triangulation<dim, spacedim>::communicate_locally_moved_vertices()
+          triangulation_communicate_locally_moved_vertices,
+
+          /// dof_handler_policy.cc: communicate_mg_ghost_cells()
+          dofhandler_communicate_mg_ghost_cells,
+
+          /// dof_handler_policy.cc: communicate_mg_ghost_cells()
+          dofhandler_communicate_mg_ghost_cells_reply,
+
+          /// mg_transfer_internal.cc: fill_copy_indices()
+          mg_transfer_fill_copy_indices,
+
+          /// SparsityTools::sparsity_tools_distribute_sparsity_pattern()
+          sparsity_tools_distribute_sparsity_pattern,
+
+          /// Dictionary::reinit()
+          dictionary_reinit,
+
+          /// ConsensusAlgorithmPayload::get_requesters()
+          consensus_algorithm_payload_get_requesters,
+
+          /// FETools::extrapolate()
+          fe_tools_extrapolate,
+          /// FETools::extrapolate(), allocate space for 10 rounds:
+          fe_tools_extrapolate_end = fe_tools_extrapolate + 10,
+
+          /// ConsensusAlgorithm_NBX::process
+          consensus_algorithm_nbx_process_request,
+          /// ConsensusAlgorithm_NBX::process
+          consensus_algorithm_nbx_process_deliver,
+
+          /// ConsensusAlgorithm_PEX::process
+          consensus_algorithm_pex_process_request,
+          /// ConsensusAlgorithm_PEX::process
+          consensus_algorithm_pex_process_deliver,
+
+        };
+      };
+    } // namespace internal
+  }   // namespace MPI
+} // namespace Utilities
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -19,6 +19,7 @@
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/mpi.templates.h>
 #include <deal.II/base/mpi_compute_index_owner_internal.h>
+#include <deal.II/base/mpi_tags.h>
 #include <deal.II/base/multithread_info.h>
 #include <deal.II/base/utilities.h>
 
@@ -241,6 +242,9 @@ namespace Utilities
       static CollectiveMutex      mutex;
       CollectiveMutex::ScopedLock lock(mutex, mpi_comm);
 
+      const int mpi_tag =
+        internal::Tags::compute_point_to_point_communication_pattern;
+
       // Calculate the number of messages to send to each process
       std::vector<unsigned int> dest_vector(n_procs);
       for (const auto &el : destinations)
@@ -264,7 +268,7 @@ namespace Utilities
                       1,
                       MPI_UNSIGNED,
                       el,
-                      32766,
+                      mpi_tag,
                       mpi_comm,
                       send_requests.data() + (&el - destinations.data()));
           AssertThrowMPI(ierr);
@@ -281,7 +285,7 @@ namespace Utilities
                                     1,
                                     MPI_UNSIGNED,
                                     MPI_ANY_SOURCE,
-                                    32766,
+                                    mpi_tag,
                                     mpi_comm,
                                     MPI_STATUS_IGNORE);
           AssertThrowMPI(ierr);
@@ -1040,6 +1044,12 @@ namespace Utilities
     ConsensusAlgorithm_NBX<T1, T2>::process_requests()
     {
 #ifdef DEAL_II_WITH_MPI
+
+      const int tag_request =
+        Utilities::MPI::internal::Tags::consensus_algorithm_nbx_process_request;
+      const int tag_deliver =
+        Utilities::MPI::internal::Tags::consensus_algorithm_nbx_process_deliver;
+
       // check if there is a request pending
       MPI_Status status;
       int        request_is_pending;
@@ -1093,7 +1103,7 @@ namespace Utilities
                            request_buffer.size() * sizeof(T2),
                            MPI_BYTE,
                            other_rank,
-                           tag_delivery,
+                           tag_deliver,
                            this->comm,
                            request_requests.back().get());
           AssertThrowMPI(ierr);
@@ -1111,6 +1121,11 @@ namespace Utilities
       // 1)
       targets              = this->process.compute_targets();
       const auto n_targets = targets.size();
+
+      const int tag_request =
+        Utilities::MPI::internal::Tags::consensus_algorithm_nbx_process_request;
+      const int tag_deliver =
+        Utilities::MPI::internal::Tags::consensus_algorithm_nbx_process_deliver;
 
       // 2) allocate memory
       recv_buffers.resize(n_targets);
@@ -1146,7 +1161,7 @@ namespace Utilities
                              recv_buffer.size() * sizeof(T2),
                              MPI_BYTE,
                              rank,
-                             tag_delivery,
+                             tag_deliver,
                              this->comm,
                              &recv_requests[index]);
             AssertThrowMPI(ierr);
@@ -1302,6 +1317,11 @@ namespace Utilities
     ConsensusAlgorithm_PEX<T1, T2>::process_requests(int index)
     {
 #ifdef DEAL_II_WITH_MPI
+      const int tag_request =
+        Utilities::MPI::internal::Tags::consensus_algorithm_pex_process_request;
+      const int tag_deliver =
+        Utilities::MPI::internal::Tags::consensus_algorithm_pex_process_deliver;
+
       MPI_Status status;
       MPI_Probe(MPI_ANY_SOURCE, tag_request, this->comm, &status);
 
@@ -1336,7 +1356,7 @@ namespace Utilities
                        request_buffer.size() * sizeof(T2),
                        MPI_BYTE,
                        other_rank,
-                       tag_delivery,
+                       tag_deliver,
                        this->comm,
                        &requests_answers[index]);
       AssertThrowMPI(ierr);
@@ -1354,6 +1374,11 @@ namespace Utilities
 #ifdef DEAL_II_WITH_MPI
       // 1) determine with which processes this process wants to communicate
       targets = this->process.compute_targets();
+
+      const int tag_request =
+        Utilities::MPI::internal::Tags::consensus_algorithm_pex_process_request;
+      const int tag_deliver =
+        Utilities::MPI::internal::Tags::consensus_algorithm_pex_process_deliver;
 
       // 2) determine who wants to communicate with this process
       const bool use_nbx = false;
@@ -1409,7 +1434,7 @@ namespace Utilities
                            recv_buffer.size() * sizeof(T2),
                            MPI_BYTE,
                            rank,
-                           tag_delivery,
+                           tag_deliver,
                            this->comm,
                            &send_and_recv_buffers[i]);
           AssertThrowMPI(ierr);

--- a/source/base/process_grid.cc
+++ b/source/base/process_grid.cc
@@ -181,9 +181,12 @@ namespace Utilities
       // Note that on all the active MPI processes (except for the one with
       // rank 0) the resulting MPI_Comm mpi_communicator_inactive_with_root
       // will be MPI_COMM_NULL.
+      const int mpi_tag =
+        Utilities::MPI::internal::Tags::process_grid_constructor;
+
       ierr = Utilities::MPI::create_group(mpi_communicator,
                                           inactive_with_root_group,
-                                          55,
+                                          mpi_tag,
                                           &mpi_communicator_inactive_with_root);
       AssertThrowMPI(ierr);
 

--- a/source/distributed/fully_distributed_tria_util.cc
+++ b/source/distributed/fully_distributed_tria_util.cc
@@ -578,7 +578,7 @@ namespace parallel
         const unsigned int group_root = (my_rank / group_size) * group_size;
 
         const int mpi_tag =
-          Utilities::MPI::internal::Tags::fully_distributed_create;
+          dealii::Utilities::MPI::internal::Tags::fully_distributed_create;
 
         // check if process is root of the group
         if (my_rank == group_root)

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -253,6 +253,9 @@ namespace parallel
       int ierr = MPI_Barrier(this->mpi_communicator);
       AssertThrowMPI(ierr);
 
+      const int mpi_tag = Utilities::MPI::internal::Tags::
+        triangulation_base_fill_level_ghost_owners;
+
       // important: preallocate to avoid (re)allocation:
       std::vector<MPI_Request> requests(
         this->number_cache.level_ghost_owners.size());
@@ -268,7 +271,7 @@ namespace parallel
                            1,
                            MPI_UNSIGNED,
                            *it,
-                           9001,
+                           mpi_tag,
                            this->mpi_communicator,
                            &requests[req_counter]);
           AssertThrowMPI(ierr);
@@ -284,7 +287,7 @@ namespace parallel
                           1,
                           MPI_UNSIGNED,
                           *it,
-                          9001,
+                          mpi_tag,
                           this->mpi_communicator,
                           MPI_STATUS_IGNORE);
           AssertThrowMPI(ierr);

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2498,6 +2498,13 @@ namespace GridTools
     for (; global_index_it != global_index_end; ++global_index_it)
       global_index_it->second += shift;
 
+
+    const int mpi_tag = Utilities::MPI::internal::Tags::
+      grid_tools_compute_local_to_global_vertex_index_map;
+    const int mpi_tag2 = Utilities::MPI::internal::Tags::
+      grid_tools_compute_local_to_global_vertex_index_map2;
+
+
     // In a first message, send the global ID of the vertices and the local
     // positions in the cells. In a second messages, send the cell ID as a
     // resize string. This is done in two messages so that types are not mixed
@@ -2535,7 +2542,7 @@ namespace GridTools
                          buffer_size,
                          DEAL_II_VERTEX_INDEX_MPI_TYPE,
                          destination,
-                         0,
+                         mpi_tag,
                          triangulation.get_communicator(),
                          &first_requests[i]);
         AssertThrowMPI(ierr);
@@ -2560,7 +2567,7 @@ namespace GridTools
                         buffer_size,
                         DEAL_II_VERTEX_INDEX_MPI_TYPE,
                         source,
-                        0,
+                        mpi_tag,
                         triangulation.get_communicator(),
                         MPI_STATUS_IGNORE);
         AssertThrowMPI(ierr);
@@ -2601,7 +2608,7 @@ namespace GridTools
                          buffer_size,
                          MPI_CHAR,
                          destination,
-                         0,
+                         mpi_tag2,
                          triangulation.get_communicator(),
                          &second_requests[i]);
         AssertThrowMPI(ierr);
@@ -2624,7 +2631,7 @@ namespace GridTools
                         buffer_size,
                         MPI_CHAR,
                         source,
-                        0,
+                        mpi_tag2,
                         triangulation.get_communicator(),
                         MPI_STATUS_IGNORE);
         AssertThrowMPI(ierr);

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -392,9 +392,11 @@ ScaLAPACKMatrix<NumberType>::copy_from(const LAPACKFullMatrix<NumberType> &B,
   MPI_Group              group_B;
   MPI_Group_incl(group_A, n, DEAL_II_MPI_CONST_CAST(ranks.data()), &group_B);
   MPI_Comm communicator_B;
+
+  const int mpi_tag = Utilities::MPI::internal::Tags::scalapack_copy_from;
   Utilities::MPI::create_group(this->grid->mpi_communicator,
                                group_B,
-                               0,
+                               mpi_tag,
                                &communicator_B);
   int n_proc_rows_B = 1, n_proc_cols_B = 1;
   int this_process_row_B = -1, this_process_column_B = -1;
@@ -560,9 +562,11 @@ ScaLAPACKMatrix<NumberType>::copy_to(LAPACKFullMatrix<NumberType> &B,
   MPI_Group              group_B;
   MPI_Group_incl(group_A, n, DEAL_II_MPI_CONST_CAST(ranks.data()), &group_B);
   MPI_Comm communicator_B;
+
+  const int mpi_tag = Utilities::MPI::internal::Tags::scalapack_copy_to;
   Utilities::MPI::create_group(this->grid->mpi_communicator,
                                group_B,
-                               0,
+                               mpi_tag,
                                &communicator_B);
   int n_proc_rows_B = 1, n_proc_cols_B = 1;
   int this_process_row_B = -1, this_process_column_B = -1;
@@ -893,9 +897,11 @@ ScaLAPACKMatrix<NumberType>::copy_to(ScaLAPACKMatrix<NumberType> &dest) const
       // first argument, even if the program we are currently running
       // and that is calling this function only works on a subset of
       // processes. the same holds for the wrapper/fallback we are using here.
-      ierr = Utilities::MPI::create_group(MPI_COMM_WORLD,
+
+      const int mpi_tag = Utilities::MPI::internal::Tags::scalapack_copy_to2;
+      ierr              = Utilities::MPI::create_group(MPI_COMM_WORLD,
                                           group_union,
-                                          5,
+                                          mpi_tag,
                                           &mpi_communicator_union);
       AssertThrowMPI(ierr);
 

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -296,6 +296,9 @@ namespace internal
           Utilities::MPI::CollectiveMutex::ScopedLock lock(
             mutex, tria->get_communicator());
 
+          const int mpi_tag =
+            Utilities::MPI::internal::Tags::mg_transfer_fill_copy_indices;
+
           // * send
           std::vector<MPI_Request> requests;
           {
@@ -312,7 +315,7 @@ namespace internal
                                                data.size() * sizeof(data[0]),
                                                MPI_BYTE,
                                                dest,
-                                               71,
+                                               mpi_tag,
                                                tria->get_communicator(),
                                                &*requests.rbegin());
                     AssertThrowMPI(ierr);
@@ -323,7 +326,7 @@ namespace internal
                                                0,
                                                MPI_BYTE,
                                                dest,
-                                               71,
+                                               mpi_tag,
                                                tria->get_communicator(),
                                                &*requests.rbegin());
                     AssertThrowMPI(ierr);
@@ -339,12 +342,12 @@ namespace internal
                  ++counter)
               {
                 MPI_Status status;
-                int        len;
                 int        ierr = MPI_Probe(MPI_ANY_SOURCE,
-                                     71,
+                                     mpi_tag,
                                      tria->get_communicator(),
                                      &status);
                 AssertThrowMPI(ierr);
+                int len;
                 ierr = MPI_Get_count(&status, MPI_BYTE, &len);
                 AssertThrowMPI(ierr);
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -937,6 +937,9 @@ namespace Particles
 
     // Notify other processors how many particles we will send
     {
+      const int mpi_tag = Utilities::MPI::internal::Tags::
+        particle_handler_send_recv_particles_setup;
+
       std::vector<MPI_Request> n_requests(2 * n_neighbors);
       for (unsigned int i = 0; i < n_neighbors; ++i)
         {
@@ -944,7 +947,7 @@ namespace Particles
                                      1,
                                      MPI_UNSIGNED,
                                      neighbors[i],
-                                     0,
+                                     mpi_tag,
                                      triangulation->get_communicator(),
                                      &(n_requests[2 * i]));
           AssertThrowMPI(ierr);
@@ -955,7 +958,7 @@ namespace Particles
                                      1,
                                      MPI_UNSIGNED,
                                      neighbors[i],
-                                     0,
+                                     mpi_tag,
                                      triangulation->get_communicator(),
                                      &(n_requests[2 * i + 1]));
           AssertThrowMPI(ierr);
@@ -982,6 +985,9 @@ namespace Particles
       unsigned int             send_ops = 0;
       unsigned int             recv_ops = 0;
 
+      const int mpi_tag = Utilities::MPI::internal::Tags::
+        particle_handler_send_recv_particles_send;
+
       for (unsigned int i = 0; i < n_neighbors; ++i)
         if (n_recv_data[i] > 0)
           {
@@ -989,7 +995,7 @@ namespace Particles
                                        n_recv_data[i],
                                        MPI_CHAR,
                                        neighbors[i],
-                                       1,
+                                       mpi_tag,
                                        triangulation->get_communicator(),
                                        &(requests[send_ops]));
             AssertThrowMPI(ierr);
@@ -1003,7 +1009,7 @@ namespace Particles
                                        n_send_data[i],
                                        MPI_CHAR,
                                        neighbors[i],
-                                       1,
+                                       mpi_tag,
                                        triangulation->get_communicator(),
                                        &(requests[send_ops + recv_ops]));
             AssertThrowMPI(ierr);


### PR DESCRIPTION
introduce Utilities::MPI::internal::Tags with a list of unique MPI tags.

part of #8958