### PR TITLE
Fix test output for fullydistributed_grids/copy_serial_tria

### DIFF
--- a/tests/fullydistributed_grids/copy_serial_tria_04.mpirun=4.output
+++ b/tests/fullydistributed_grids/copy_serial_tria_04.mpirun=4.output
@@ -14,8 +14,8 @@ DEAL:0:2d::n_dofs:                             16641
 DEAL:0:2d::n_locally_owned_dofs:               4225
 DEAL:0:2d::
 DEAL:0:3d::n_levels:                  1
-DEAL:0:3d::n_cells:                   9792
-DEAL:0:3d::n_active_cells:            9792
+DEAL:0:3d::n_cells:                   10368
+DEAL:0:3d::n_active_cells:            10368
 DEAL:0:3d::
 DEAL:0:3d::n_dofs:                             274625
 DEAL:0:3d::n_locally_owned_dofs:               70785
@@ -36,8 +36,8 @@ DEAL:1:2d::n_dofs:                             16641
 DEAL:1:2d::n_locally_owned_dofs:               4160
 DEAL:1:2d::
 DEAL:1:3d::n_levels:                  1
-DEAL:1:3d::n_cells:                   9792
-DEAL:1:3d::n_active_cells:            9792
+DEAL:1:3d::n_cells:                   10368
+DEAL:1:3d::n_active_cells:            10368
 DEAL:1:3d::
 DEAL:1:3d::n_dofs:                             274625
 DEAL:1:3d::n_locally_owned_dofs:               68640
@@ -59,8 +59,8 @@ DEAL:2:2d::n_dofs:                             16641
 DEAL:2:2d::n_locally_owned_dofs:               4160
 DEAL:2:2d::
 DEAL:2:3d::n_levels:                  1
-DEAL:2:3d::n_cells:                   9792
-DEAL:2:3d::n_active_cells:            9792
+DEAL:2:3d::n_cells:                   10368
+DEAL:2:3d::n_active_cells:            10368
 DEAL:2:3d::
 DEAL:2:3d::n_dofs:                             274625
 DEAL:2:3d::n_locally_owned_dofs:               68640
@@ -82,8 +82,8 @@ DEAL:3:2d::n_dofs:                             16641
 DEAL:3:2d::n_locally_owned_dofs:               4096
 DEAL:3:2d::
 DEAL:3:3d::n_levels:                  1
-DEAL:3:3d::n_cells:                   9792
-DEAL:3:3d::n_active_cells:            9792
+DEAL:3:3d::n_cells:                   10368
+DEAL:3:3d::n_active_cells:            10368
 DEAL:3:3d::
 DEAL:3:3d::n_dofs:                             274625
 DEAL:3:3d::n_locally_owned_dofs:               66560

--- a/tests/fullydistributed_grids/copy_serial_tria_04.mpirun=5.output
+++ b/tests/fullydistributed_grids/copy_serial_tria_04.mpirun=5.output
@@ -14,8 +14,8 @@ DEAL:0:2d::n_dofs:                             16641
 DEAL:0:2d::n_locally_owned_dofs:               3409
 DEAL:0:2d::
 DEAL:0:3d::n_levels:                  1
-DEAL:0:3d::n_cells:                   8312
-DEAL:0:3d::n_active_cells:            8312
+DEAL:0:3d::n_cells:                   8888
+DEAL:0:3d::n_active_cells:            8888
 DEAL:0:3d::
 DEAL:0:3d::n_dofs:                             274625
 DEAL:0:3d::n_locally_owned_dofs:               57409
@@ -36,8 +36,8 @@ DEAL:1:2d::n_dofs:                             16641
 DEAL:1:2d::n_locally_owned_dofs:               3344
 DEAL:1:2d::
 DEAL:1:3d::n_levels:                  1
-DEAL:1:3d::n_cells:                   9208
-DEAL:1:3d::n_active_cells:            9208
+DEAL:1:3d::n_cells:                   9672
+DEAL:1:3d::n_active_cells:            9672
 DEAL:1:3d::
 DEAL:1:3d::n_dofs:                             274625
 DEAL:1:3d::n_locally_owned_dofs:               55264
@@ -59,8 +59,8 @@ DEAL:2:2d::n_dofs:                             16641
 DEAL:2:2d::n_locally_owned_dofs:               3296
 DEAL:2:2d::
 DEAL:2:3d::n_levels:                  1
-DEAL:2:3d::n_cells:                   9512
-DEAL:2:3d::n_active_cells:            9512
+DEAL:2:3d::n_cells:                   9856
+DEAL:2:3d::n_active_cells:            9856
 DEAL:2:3d::
 DEAL:2:3d::n_dofs:                             274625
 DEAL:2:3d::n_locally_owned_dofs:               54944
@@ -82,8 +82,8 @@ DEAL:3:2d::n_dofs:                             16641
 DEAL:3:2d::n_locally_owned_dofs:               3312
 DEAL:3:2d::
 DEAL:3:3d::n_levels:                  1
-DEAL:3:3d::n_cells:                   9208
-DEAL:3:3d::n_active_cells:            9208
+DEAL:3:3d::n_cells:                   9672
+DEAL:3:3d::n_active_cells:            9672
 DEAL:3:3d::
 DEAL:3:3d::n_dofs:                             274625
 DEAL:3:3d::n_locally_owned_dofs:               54080
@@ -105,8 +105,8 @@ DEAL:4:2d::n_dofs:                             16641
 DEAL:4:2d::n_locally_owned_dofs:               3280
 DEAL:4:2d::
 DEAL:4:3d::n_levels:                  1
-DEAL:4:3d::n_cells:                   8312
-DEAL:4:3d::n_active_cells:            8312
+DEAL:4:3d::n_cells:                   8888
+DEAL:4:3d::n_active_cells:            8888
 DEAL:4:3d::
 DEAL:4:3d::n_dofs:                             274625
 DEAL:4:3d::n_locally_owned_dofs:               52928


### PR DESCRIPTION
Fixes the newly failing tests in https://cdash.43-1.org/viewTest.php?onlydelta&buildid=2605. The test output is consistent across all regression testers. Related to #8982.