### PR TITLE
Fix Open Cascade incompatibility

### DIFF
--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -328,9 +328,13 @@ namespace OpenCASCADE
       }
 
     StlAPI_Writer writer;
-    const auto    error = writer.Write(shape_to_be_written, filename.c_str());
+#  if (OCC_VERSION_MAJOR >= 7)
+    const auto error = writer.Write(shape_to_be_written, filename.c_str());
     AssertThrow(error == StlAPI_StatusOK,
                 ExcMessage("Error writing STL from shape."));
+#  else
+    writer.Write(shape_to_be_written, filename.c_str());
+#  endif
   }
 
   TopoDS_Shape


### PR DESCRIPTION
This is related to #8976 

There is an incompatibility with old cascade versions. I have opencascad 6.8. When I compile deal.II I get:
```
/opt/src/dealii/source/opencascade/utilities.cc:331:19: error: variable has incomplete type 'const void'
    const auto    error = writer.Write(shape_to_be_written, filename.c_str());  
                  ^                                                                     
/opt/src/dealii/source/opencascade/utilities.cc:332:26: error: use of undeclared identifier 'StlAPI_StatusOK'
    AssertThrow(error == StlAPI_StatusOK,
```
This PR fixes the incompatibility issues.

The problem is that `StlAPI_StatusOK` is defined in `StlAPI_ErrorStatus.hxx` which does not exit in opencascade 6.8