### PR TITLE
Extend cell python wrappers and add face wrappers

### DIFF
--- a/contrib/python-bindings/include/tria_accessor_wrapper.h
+++ b/contrib/python-bindings/include/tria_accessor_wrapper.h
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_tria_accessor_wrapper_h
+#define dealii_tria_accessor_wrapper_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/grid/tria_accessor.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace python
+{
+  class PointWrapper;
+  class TriangulationWrapper;
+
+  class TriaAccessorWrapper
+  {
+  public:
+    /**
+     * Copy constructor.
+     */
+    TriaAccessorWrapper(const TriaAccessorWrapper &other);
+
+    /**
+     * Constructor.
+     */
+    TriaAccessorWrapper(void* tria_accessor, const int structdim, const int dim, const int spacedim);
+
+    /**
+     * Destructor.
+     */
+    ~TriaAccessorWrapper();
+
+    /**
+     * Get the barycenter of the cell.
+     */
+    PointWrapper get_barycenter() const;
+
+    /**
+     * Set the ith vertex of the cell to @p point_wrapper.
+     */
+    void set_vertex(const int i, PointWrapper &point_wrapper);
+
+    /**
+     * Return the ith vertex of the cell.
+     */
+    PointWrapper get_vertex(const int i) const;
+
+    /**
+     * Set the manifold id.
+     */
+    void set_manifold_id(const int manifold_id);
+
+    /**
+     * Get the manifold id.
+     */
+    int get_manifold_id() const;
+
+    /**
+     * Set the boundary id.
+     */
+    void set_boundary_id(const int boundary_id);
+
+    /**
+     * Get the boundary id.
+     */
+    int get_boundary_id() const;
+
+    /**
+     * Set the boundary id for all objects.
+     */
+    void set_all_boundary_ids(const int boundary_id);
+
+    /**
+     * Return whether the cell is at the boundary.
+     */
+    bool at_boundary() const;
+
+    /**
+     * Exception.
+     */
+    DeclException2(ExcVertexDoesNotExist,
+                   int, int,
+                   << "Requested vertex number " << arg1
+                   << " does not exist. The largest vertex number "
+                   << "acceptable is "<< arg2-1);
+
+  private:
+    /**
+     * Dimension of the underlying TriaAccessor object
+     */
+    int structdim;
+
+    /**
+     * Dimension of the triangulation which TriaAccessor object
+     * is linked to.
+     */
+    int dim;
+
+    /**
+     * Space dimension of the underlying TriaAccessor object.
+     */
+    int spacedim;
+
+    /**
+     * Pointer that can be casted to the underlying TriaAccessor object.
+     */
+    void *tria_accessor;
+  };
+}
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/contrib/python-bindings/source/CMakeLists.txt
+++ b/contrib/python-bindings/source/CMakeLists.txt
@@ -90,10 +90,12 @@ INCLUDE_DIRECTORIES(SYSTEM ${PYTHON_INCLUDE_DIRS})
 
 SET(_src
   wrappers.cc
+  export_tria_accessor.cc
   export_cell_accessor.cc
   export_point.cc
   export_triangulation.cc
   cell_accessor_wrapper.cc
+  tria_accessor_wrapper.cc
   point_wrapper.cc
   triangulation_wrapper.cc
   )

--- a/contrib/python-bindings/source/export_cell_accessor.cc
+++ b/contrib/python-bindings/source/export_cell_accessor.cc
@@ -78,6 +78,35 @@ namespace python
 
 
 
+   const char at_boundary_docstring [] =
+    " Return whether the cell is at the boundary                        \n"
+    ; 
+
+
+
+   const char has_boundary_lines_docstring [] =
+    " This is a slight variation to the at_boundary function:           \n"
+    " for two dimensions, it is equivalent, for three                   \n"
+    " dimensions it returns whether at least one of the 12              \n" 
+    " lines of the hexahedron is at a boundary.                         \n"
+    ;
+
+
+
+   const char neighbor_docstring [] =
+    " Return the ith neighbor of a cell. If the neighbor does not exist,\n" 
+    " i.e., if the ith face of the current object is at the boundary,   \n" 
+    " then an exception is thrown.                                      \n"
+    ; 
+
+
+
+   const char faces_docstring [] =
+    " Return list of cell's faces.                                      \n"
+    ; 
+
+
+
   void export_cell_accessor()
   {
     boost::python::class_<CellAccessorWrapper>("CellAccessor",
@@ -102,7 +131,19 @@ namespace python
          boost::python::args("self", "i", "point_wrapper"))
     .def("get_vertex", &CellAccessorWrapper::get_vertex,
          get_vertex_docstring,
-         boost::python::args("self", "i"));
+         boost::python::args("self", "i"))
+    .def("at_boundary", &CellAccessorWrapper::at_boundary,
+         at_boundary_docstring,
+         boost::python::args("self"))
+    .def("has_boundary_lines", &CellAccessorWrapper::has_boundary_lines,
+         has_boundary_lines_docstring,
+         boost::python::args("self"))
+    .def("neighbor", &CellAccessorWrapper::neighbor,
+         neighbor_docstring,
+         boost::python::args("self", "i"))
+    .def("faces", &CellAccessorWrapper::faces,
+         faces_docstring,
+         boost::python::args("self"));
   }
 }
 

--- a/contrib/python-bindings/source/export_tria_accessor.cc
+++ b/contrib/python-bindings/source/export_tria_accessor.cc
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <tria_accessor_wrapper.h>
+#include <triangulation_wrapper.h>
+#include <boost/python.hpp>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace python
+{
+  const char manifold_id_docstring [] =
+    "Get/Set the manifold_id of the face                                \n"
+    ;
+
+  const char boundary_id_docstring [] =
+    "Get/Set the boundary_id of the face                                \n"
+    ;
+
+  const char set_all_boundary_ids_docstring [] =
+    "Do as set_boundary_id() but also set the boundary indicators       \n"
+    "of the objects that bound the current object.                      \n"  
+    ;
+
+  const char barycenter_docstring [] =
+    "Return the barycenter of the current face                          \n"
+    ;
+
+  const char set_vertex_docstring [] =
+    " Set the ith vertex of the face to point_wrapper                   \n"
+    ;
+
+  const char get_vertex_docstring [] =
+    " Get the ith vertex of the face                                    \n"
+    ;
+
+   const char at_boundary_docstring [] =
+    " Return whether the face is at the boundary                        \n"
+    ; 
+
+  void export_tria_accessor()
+  {
+    boost::python::class_<TriaAccessorWrapper>("TriaAccessor",
+                                               boost::python::init<void*, const int, const int, const int> ())
+    .add_property("boundary_id", &TriaAccessorWrapper::get_boundary_id,
+                  &TriaAccessorWrapper::set_boundary_id,
+                  boundary_id_docstring)
+    .add_property("manifold_id", &TriaAccessorWrapper::get_manifold_id,
+                  &TriaAccessorWrapper::set_manifold_id,
+                  manifold_id_docstring)
+    .def("barycenter", &TriaAccessorWrapper::get_barycenter,
+         barycenter_docstring,
+         boost::python::args("self"))
+    .def("set_vertex", &TriaAccessorWrapper::set_vertex,
+         set_vertex_docstring,
+         boost::python::args("self", "i", "point_wrapper"))
+    .def("get_vertex", &TriaAccessorWrapper::get_vertex,
+         get_vertex_docstring,
+         boost::python::args("self", "i"))
+    .def("at_boundary", &TriaAccessorWrapper::at_boundary,
+         at_boundary_docstring,
+         boost::python::args("self"))
+    .def("set_all_boundary_ids", &TriaAccessorWrapper::set_all_boundary_ids,
+         set_all_boundary_ids_docstring,
+         boost::python::args("self", "boundary_id"));
+  }
+}
+
+DEAL_II_NAMESPACE_CLOSE

--- a/contrib/python-bindings/source/tria_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/tria_accessor_wrapper.cc
@@ -1,0 +1,321 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <tria_accessor_wrapper.h>
+
+#include <boost/python.hpp>
+#include <point_wrapper.h>
+#include <triangulation_wrapper.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace python
+{
+  namespace internal
+  {
+    template <int structdim, int dim, int spacedim>
+    PointWrapper get_barycenter(const void *tria_accessor)
+    {
+      const TriaAccessor<structdim,dim,spacedim> *accessor =
+        static_cast<const TriaAccessor<structdim,dim,spacedim>*>(tria_accessor);
+      Point<spacedim> barycenter = accessor->barycenter();
+      boost::python::list barycenter_list;
+      for (int i=0; i<dim; ++i)
+        barycenter_list.append(barycenter[i]);
+
+      return PointWrapper(barycenter_list);
+    }
+
+
+
+    template <int structdim, int dim, int spacedim>
+    void set_boundary_id(const int boundary_id, void *tria_accessor)
+    {
+      TriaAccessor<structdim,dim,spacedim> *accessor =
+        static_cast<TriaAccessor<structdim, dim,spacedim>*>(tria_accessor);
+      accessor->set_boundary_id(boundary_id);
+    }
+
+
+
+    template <int structdim, int dim, int spacedim>
+    int get_boundary_id(const void *tria_accessor)
+    {
+      const TriaAccessor<structdim,dim,spacedim> *accessor =
+        static_cast<const TriaAccessor<structdim,dim,spacedim>*>(tria_accessor);
+
+      return accessor->boundary_id();
+    }
+
+
+
+    template <int structdim, int dim, int spacedim>
+    void set_all_boundary_ids(const int boundary_id, void *tria_accessor)
+    {
+      TriaAccessor<structdim,dim,spacedim> *accessor =
+        static_cast<TriaAccessor<structdim,dim,spacedim>*>(tria_accessor);
+      accessor->set_all_boundary_ids(boundary_id);
+    }
+
+
+    template <int structdim, int dim, int spacedim>
+    void set_vertex(const int     i,
+                    PointWrapper &point_wrapper,
+                    void         *tria_accessor)
+    {
+      TriaAccessor<structdim,dim,spacedim> *accessor =
+        static_cast<TriaAccessor<structdim,dim,spacedim>*>(tria_accessor);
+      Point<spacedim> *point =
+        static_cast<Point<spacedim>*>(point_wrapper.get_point());
+
+      accessor->vertex(i) = *point;
+    }
+
+
+
+    template <int structdim, int dim, int spacedim>
+    PointWrapper get_vertex(const int i, const void *tria_accessor)
+    {
+      const TriaAccessor<structdim,dim,spacedim> *accessor =
+        static_cast<const TriaAccessor<structdim,dim,spacedim>*>(tria_accessor);
+      Point<spacedim> vertex = accessor->vertex(i);
+
+      boost::python::list coordinates;
+      for (int i=0; i<spacedim; ++i)
+        coordinates.append(vertex[i]);
+
+      return PointWrapper(coordinates);
+    }
+
+
+
+    template <int structdim, int dim, int spacedim>
+    void set_manifold_id(const int manifold_id, void *tria_accessor)
+    {
+      TriaAccessor<structdim,dim,spacedim> *accessor =
+        static_cast<TriaAccessor<structdim,dim,spacedim>*>(tria_accessor);
+      accessor->set_manifold_id(manifold_id);
+    }
+
+
+
+    template <int structdim, int dim, int spacedim>
+    int get_manifold_id(const void *tria_accessor)
+    {
+      const TriaAccessor<structdim,dim,spacedim> *accessor =
+        static_cast<const TriaAccessor<structdim,dim,spacedim>*>(tria_accessor);
+      return accessor->manifold_id();
+    }
+
+
+
+    template <int structdim, int dim, int spacedim>
+    bool at_boundary(const void *tria_accessor)
+    {
+      const TriaAccessor<structdim,dim,spacedim> *accessor =
+        static_cast<const TriaAccessor<structdim,dim,spacedim>*>(tria_accessor);
+      return accessor->at_boundary();
+    }
+  }
+
+
+
+  TriaAccessorWrapper::TriaAccessorWrapper(const TriaAccessorWrapper &other)
+    :
+    structdim(other.structdim),
+    dim(other.dim),
+    spacedim(other.spacedim)
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      {
+        TriaAccessor<1,2,2> *other_accessor =
+          static_cast<TriaAccessor<1,2,2>*>(other.tria_accessor);
+        tria_accessor = new TriaAccessor<1,2,2>(*other_accessor);
+      }
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      {
+        TriaAccessor<1,2,3> *other_accessor =
+          static_cast<TriaAccessor<1,2,3>*>(other.tria_accessor);
+        tria_accessor = new TriaAccessor<1,2,3>(*other_accessor);
+      }
+    else if ((dim == 3) && (spacedim == 3) && (structdim == 2))
+      {
+        TriaAccessor<2,3,3> *other_accessor =
+          static_cast<TriaAccessor<2,3,3>*>(other.tria_accessor);
+        tria_accessor = new TriaAccessor<2,3,3>(*other_accessor);
+      }
+    else
+      AssertThrow(false, ExcMessage("Wrong structdim-dim-spacedim combination."));
+  }
+
+  TriaAccessorWrapper::TriaAccessorWrapper(void* tria_accessor, 
+                                           const int structdim, 
+                                           const int dim, 
+                                           const int spacedim):
+    structdim(structdim),
+    dim(dim),
+    spacedim(spacedim),
+    tria_accessor(tria_accessor)
+  {}
+
+
+  TriaAccessorWrapper::~TriaAccessorWrapper()
+  {
+    if (dim != -1)
+      {
+        if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+          {
+            // We cannot call delete on a void pointer so cast the void pointer back
+            // first.
+            TriaAccessor<1,2,2> *tmp =
+              static_cast<TriaAccessor<1,2,2>*>(tria_accessor);
+            delete tmp;
+          }
+        else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+          {
+            TriaAccessor<1,2,3> *tmp =
+              static_cast<TriaAccessor<1,2,3>*>(tria_accessor);
+            delete tmp;
+          }
+        else
+          {
+            TriaAccessor<2,3,3> *tmp =
+              static_cast<TriaAccessor<2,3,3>*>(tria_accessor);
+            delete tmp;
+          }
+
+        dim = -1;
+        spacedim = -1;
+        structdim = -1;
+        tria_accessor = nullptr;
+      }
+  }
+
+
+
+  PointWrapper TriaAccessorWrapper::get_barycenter() const
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      return internal::get_barycenter<1,2,2>(tria_accessor);
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      return internal::get_barycenter<1,2,3>(tria_accessor);
+    else
+      return internal::get_barycenter<2,3,3>(tria_accessor);
+  }
+
+
+
+  void TriaAccessorWrapper::set_boundary_id(const int boundary_id)
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      internal::set_boundary_id<1,2,2>(boundary_id, tria_accessor);
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      internal::set_boundary_id<1,2,3>(boundary_id, tria_accessor);
+    else
+      internal::set_boundary_id<2,3,3>(boundary_id, tria_accessor);
+  }
+
+
+
+  void TriaAccessorWrapper::set_all_boundary_ids(const int boundary_id)
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      internal::set_all_boundary_ids<1,2,2>(boundary_id, tria_accessor);
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      internal::set_all_boundary_ids<1,2,3>(boundary_id, tria_accessor);
+    else
+      internal::set_all_boundary_ids<2,3,3>(boundary_id, tria_accessor);
+  }
+
+
+
+  int TriaAccessorWrapper::get_boundary_id() const
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      return internal::get_boundary_id<1,2,2>(tria_accessor);
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      return internal::get_boundary_id<1,2,3>(tria_accessor);
+    else
+      return internal::get_boundary_id<2,3,3>(tria_accessor);
+  }
+
+
+
+  void TriaAccessorWrapper::set_vertex(const int     i,
+                                       PointWrapper &point_wrapper)
+  {
+    AssertThrow(i<std::pow(2,dim),
+                ExcVertexDoesNotExist(i, std::pow(2,dim)));
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      internal::set_vertex<1,2,2>(i, point_wrapper, tria_accessor);
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      internal::set_vertex<1,2,3>(i, point_wrapper, tria_accessor);
+    else
+      internal::set_vertex<2,3,3>(i, point_wrapper, tria_accessor);
+  }
+
+
+
+  PointWrapper TriaAccessorWrapper::get_vertex(const int i) const
+  {
+    AssertThrow(i<std::pow(2,dim),
+                ExcVertexDoesNotExist(i, std::pow(2,dim)));
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      return internal::get_vertex<1,2,2>(i, tria_accessor);
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      return internal::get_vertex<1,2,3>(i, tria_accessor);
+    else
+      return internal::get_vertex<2,3,3>(i, tria_accessor);
+  }
+
+
+
+  void TriaAccessorWrapper::set_manifold_id(const int manifold_id)
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      internal::set_manifold_id<1,2,2>(manifold_id, tria_accessor);
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      internal::set_manifold_id<1,2,3>(manifold_id, tria_accessor);
+    else
+      internal::set_manifold_id<2,3,3>(manifold_id, tria_accessor);
+  }
+
+
+
+  int TriaAccessorWrapper::get_manifold_id() const
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      return internal::get_manifold_id<1,2,2>(tria_accessor);
+    else if ((dim== 2) && (spacedim == 3) && (structdim == 1))
+      return internal::get_manifold_id<1,2,3>(tria_accessor);
+    else
+      return internal::get_manifold_id<2,3,3>(tria_accessor);
+  }
+
+
+
+  bool TriaAccessorWrapper::at_boundary() const
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      return internal::at_boundary<1,2,2>(tria_accessor);
+    else if ((dim== 2) && (spacedim == 3) && (structdim == 1))
+      return internal::at_boundary<1,2,3>(tria_accessor);
+    else
+      return internal::at_boundary<2,3,3>(tria_accessor);
+  }
+
+}
+
+DEAL_II_NAMESPACE_CLOSE

--- a/contrib/python-bindings/source/wrappers.cc
+++ b/contrib/python-bindings/source/wrappers.cc
@@ -22,6 +22,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace python
 {
+  void export_tria_accessor();
   void export_cell_accessor();
   void export_point();
   void export_triangulation();
@@ -54,6 +55,7 @@ BOOST_PYTHON_MODULE(Debug)
   // message is printed.
   dealii::deal_II_exceptions::disable_abort_on_exception();
 
+  dealii::python::export_tria_accessor();
   dealii::python::export_cell_accessor();
   dealii::python::export_point();
   dealii::python::export_triangulation();
@@ -70,6 +72,7 @@ BOOST_PYTHON_MODULE(Release)
   doc_options.enable_py_signatures();
   doc_options.disable_cpp_signatures();
 
+  dealii::python::export_tria_accessor();
   dealii::python::export_cell_accessor();
   dealii::python::export_point();
   dealii::python::export_triangulation();

--- a/contrib/python-bindings/tests/cell_accessor_wrapper.py
+++ b/contrib/python-bindings/tests/cell_accessor_wrapper.py
@@ -16,13 +16,31 @@
 import unittest
 from PyDealII.Debug import *
 
-
 class TestCellAccessorWrapper(unittest.TestCase):
 
     def setUp(self):
         self.triangulation = Triangulation('2D')
         self.triangulation.generate_hyper_cube()
         self.triangulation.refine_global(1)
+
+    def test_faces(self):
+        for cell in self.triangulation.active_cells():
+            faces = cell.faces()
+            self.assertEqual(len(faces), 4)
+
+    def test_at_boundary(self):
+        for cell in self.triangulation.active_cells():
+            self.assertEqual(cell.at_boundary(), cell.has_boundary_lines()) 
+
+    def test_faces(self):
+        n_neighbors = 0
+        for cell in self.triangulation.active_cells():
+            faces = cell.faces()
+            for i in range(len(faces)):
+                if not faces[i].at_boundary():
+                    neighbor = cell.neighbor(i)
+                    n_neighbors += 1
+        self.assertEqual(n_neighbors, 8)
 
     def test_material_id(self):
         material_id = 0

--- a/doc/news/changes/minor/20191114Grayver
+++ b/doc/news/changes/minor/20191114Grayver
@@ -1,0 +1,4 @@
+Added: extend python bindings to allow for working with cell's
+neighbors, iterate over faces and modify boundary ids. 
+<br>
+(Alexander Grayver, 2019/11/14)


### PR DESCRIPTION
As it says, this extends existing cell wrappers and adds support for face iterators. 

It enables working with boundary ids, e.g.:

```
triangulation = dealii.Triangulation('2D')
triangulation.generate_hyper_cube()
triangulation.refine_global(1)

for cell in triangulation.active_cells():
    for face in cell.faces():
        if face.at_boundary():
            face.boundary_id = 1
            
triangulation.write('mesh.vtk', 'vtk') 
```