### PR TITLE
remove TimerOutput error spam

### DIFF
--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -389,18 +389,18 @@ TimerOutput::~TimerOutput()
   if (std::uncaught_exception() == true && mpi_communicator != MPI_COMM_SELF)
 #  endif
     {
-      std::cerr << "---------------------------------------------------------"
-                << std::endl
-                << "TimerOutput objects finalize timed values printed to the"
-                << std::endl
-                << "screen by communicating over MPI in their destructors."
-                << std::endl
-                << "Since an exception is currently uncaught, this" << std::endl
-                << "synchronization (and subsequent output) will be skipped to"
-                << std::endl
-                << "avoid a possible deadlock." << std::endl
-                << "---------------------------------------------------------"
-                << std::endl;
+      const unsigned int myid =
+        Utilities::MPI::this_mpi_process(mpi_communicator);
+      if (myid == 0)
+        std::cerr
+          << "---------------------------------------------------------\n"
+          << "TimerOutput objects finalize timed values printed to the\n"
+          << "screen by communicating over MPI in their destructors.\n"
+          << "Since an exception is currently uncaught, this\n"
+          << "synchronization (and subsequent output) will be skipped\n"
+          << "to avoid a possible deadlock.\n"
+          << "---------------------------------------------------------"
+          << std::endl;
     }
   else
     {


### PR DESCRIPTION
TimerOutput produces output on each MPI rank when an exception is
thrown. This makes looking at output with 100k MPI ranks somewhat
annoying. Fix this by only outputting on rank 0.
This assumes that also rank 0 triggers this exception, which might not
be true. In that case, we would likely deadlock anyways...