### PR TITLE
unify MPI tags for Partitioner/parallel Vector

### DIFF
--- a/include/deal.II/base/mpi_tags.h
+++ b/include/deal.II/base/mpi_tags.h
@@ -122,6 +122,15 @@ namespace Utilities
           /// ProcessGrid::ProcessGrid
           process_grid_constructor,
 
+          /// 200 tags for Partitioner::import_from_ghosted_array_start
+          partitioner_import_start,
+          partitioner_import_end = partitioner_import_start + 200,
+
+          /// 200 tags for Partitioner::export_to_ghosted_array_start
+          partitioner_export_start,
+          partitioner_export_end = partitioner_export_start + 200,
+
+
         };
       } // namespace Tags
     }   // namespace internal

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -393,7 +393,8 @@ namespace Utilities
        * @param communication_channel Sets an offset to the MPI_Isend and
        * MPI_Irecv calls that avoids interference with other ongoing
        * export_to_ghosted_array_start() calls on different entries. Typically
-       * handled within the blocks of a block vector.
+       * handled within the blocks of a block vector. Any value less than 200
+       * is a valid value.
        *
        * @param locally_owned_array The array of data from which the data is
        * extracted and sent to the ghost entries on a remote processor.
@@ -464,6 +465,7 @@ namespace Utilities
        * MPI_Irecv calls that avoids interference with other ongoing
        * import_from_ghosted_array_start() calls on different
        * entries. Typically handled within the blocks of a block vector.
+       * Any value less than 200 is a valid value.
        *
        * @param ghost_array The array of ghost data that is sent to a remote
        * owner of the respective index in a vector. Its size must either be

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -262,10 +262,11 @@ namespace LinearAlgebra
           // start all requests for all blocks before finishing the transfers as
           // this saves repeated synchronizations. In order to avoid conflict
           // with possible other ongoing communication requests (from
-          // LA::distributed::Vector that supports unfinished requests), add an
-          // arbitrary number 8273 to the communication tag
+          // LA::distributed::Vector that supports unfinished requests), add
+          // 100 to the communication tag (the first 100 can be used by normal
+          // vectors).
           for (unsigned int block = start; block < end; ++block)
-            this->block(block).compress_start(block + 8273 - start, operation);
+            this->block(block).compress_start(block - start + 100, operation);
           for (unsigned int block = start; block < end; ++block)
             this->block(block).compress_finish(operation);
         }

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -523,7 +523,8 @@ namespace LinearAlgebra
        * In case this function is called for more than one vector before @p
        * compress_finish() is invoked, it is mandatory to specify a unique
        * communication channel to each such call, in order to avoid several
-       * messages with the same ID that will corrupt this operation.
+       * messages with the same ID that will corrupt this operation. Any
+       * communication channel less than 100 is a valid value.
        */
       void
       compress_start(
@@ -561,6 +562,7 @@ namespace LinearAlgebra
        * update_ghost_values_finish() is invoked, it is mandatory to specify a
        * unique communication channel to each such call, in order to avoid
        * several messages with the same ID that will corrupt this operation.
+       * Any communication channel less than 100 is a valid value.
        */
       void
       update_ghost_values_start(

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -897,10 +897,10 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     void
     Vector<Number, MemorySpaceType>::compress_start(
-      const unsigned int                counter,
+      const unsigned int                communication_channel,
       ::dealii::VectorOperation::values operation)
     {
-      (void)counter;
+      (void)communication_channel;
       (void)operation;
       Assert(vector_is_ghosted == false,
              ExcMessage("Cannot call compress() on a ghosted vector"));
@@ -972,7 +972,7 @@ namespace LinearAlgebra
         {
           partitioner->import_from_ghosted_array_start(
             operation,
-            counter,
+            communication_channel,
             ArrayView<Number, MemorySpace::CUDA>(
               data.values_dev.get() + partitioner->local_size(),
               partitioner->n_ghost_indices()),
@@ -985,7 +985,7 @@ namespace LinearAlgebra
         {
           partitioner->import_from_ghosted_array_start(
             operation,
-            counter,
+            communication_channel,
             ArrayView<Number, MemorySpace::Host>(
               data.values.get() + partitioner->local_size(),
               partitioner->n_ghost_indices()),
@@ -1076,7 +1076,7 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     void
     Vector<Number, MemorySpaceType>::update_ghost_values_start(
-      const unsigned int counter) const
+      const unsigned int communication_channel) const
     {
 #ifdef DEAL_II_WITH_MPI
       // nothing to do when we neither have import nor ghost indices.
@@ -1141,7 +1141,7 @@ namespace LinearAlgebra
 #  if !(defined(DEAL_II_COMPILER_CUDA_AWARE) && \
         defined(DEAL_II_MPI_WITH_CUDA_SUPPORT))
       partitioner->export_to_ghosted_array_start<Number, MemorySpace::Host>(
-        counter,
+        communication_channel,
         ArrayView<const Number, MemorySpace::Host>(data.values.get(),
                                                    partitioner->local_size()),
         ArrayView<Number, MemorySpace::Host>(import_data.values.get(),
@@ -1152,7 +1152,7 @@ namespace LinearAlgebra
         update_ghost_values_requests);
 #  else
       partitioner->export_to_ghosted_array_start<Number, MemorySpace::CUDA>(
-        counter,
+        communication_channel,
         ArrayView<const Number, MemorySpace::CUDA>(data.values_dev.get(),
                                                    partitioner->local_size()),
         ArrayView<Number, MemorySpace::CUDA>(import_data.values_dev.get(),
@@ -1164,7 +1164,7 @@ namespace LinearAlgebra
 #  endif
 
 #else
-      (void)counter;
+      (void)communication_channel;
 #endif
     }
 


### PR DESCRIPTION
- use specified range of MPI tags by Partitioner (and not different tags
by rank)
- limit communication channel in partitioner to 0..200
- limit vector communication channel to 0..100 (using Partitioner)
- use 100..200 for block vectors
