### PR TITLE
Add more choices to QuadratureSelector

### DIFF
--- a/doc/news/changes/minor/20191111DanielJodlbauer
+++ b/doc/news/changes/minor/20191111DanielJodlbauer
@@ -1,0 +1,3 @@
+New: add more quadrature choices to QuadratureSelector class.
+<br>
+(Daniel Jodlbauer, 2019/11/11)

--- a/source/base/quadrature_selector.cc
+++ b/source/base/quadrature_selector.cc
@@ -25,10 +25,15 @@ QuadratureSelector<dim>::create_quadrature(const std::string &s,
                                            const unsigned int order)
 {
   if (s == "gauss")
-    {
-      AssertThrow(order >= 1, ExcInvalidQGaussOrder(order));
-      return QGauss<dim>(order);
-    }
+    return QGauss<dim>(order);
+  else if (s == "gauss_lobatto")
+    return QGaussLobatto<dim>(order);
+  else if (s == "gauss_chebyshev")
+    return QGaussChebyshev<dim>(order);
+  else if (s == "gauss_radau_chebyshev")
+    return QGaussRadauChebyshev<dim>(order);
+  else if (s == "gauss_lobatto_chebyshev")
+    return QGaussLobattoChebyshev<dim>(order);
   else
     {
       AssertThrow(order == 0, ExcInvalidOrder(s, order));
@@ -68,7 +73,8 @@ template <int dim>
 std::string
 QuadratureSelector<dim>::get_quadrature_names()
 {
-  return std::string("gauss|midpoint|milne|simpson|trapez|weddle");
+  return std::string(
+    "gauss|gauss_lobatto|gauss_chebyshev|gauss_radau_chebyshev|gauss_lobatto_chebyshev|midpoint|milne|simpson|trapez|weddle");
 }
 
 

--- a/tests/base/quadrature_selector.cc
+++ b/tests/base/quadrature_selector.cc
@@ -53,4 +53,20 @@ main()
   check("gauss", 10, QGauss<3>(10));
 
   check("weddle", 0, QWeddle<2>());
+
+  check("gauss_lobatto", 2, QGaussLobatto<1>(2));
+  check("gauss_lobatto", 3, QGaussLobatto<2>(3));
+  check("gauss_lobatto", 4, QGaussLobatto<3>(4));
+
+  check("gauss_chebyshev", 2, QGaussChebyshev<1>(2));
+  check("gauss_chebyshev", 3, QGaussChebyshev<2>(3));
+  check("gauss_chebyshev", 4, QGaussChebyshev<3>(4));
+
+  check("gauss_radau_chebyshev", 2, QGaussRadauChebyshev<1>(2));
+  check("gauss_radau_chebyshev", 3, QGaussRadauChebyshev<2>(3));
+  check("gauss_radau_chebyshev", 4, QGaussRadauChebyshev<3>(4));
+
+  check("gauss_lobatto_chebyshev", 2, QGaussLobattoChebyshev<1>(2));
+  check("gauss_lobatto_chebyshev", 3, QGaussLobattoChebyshev<2>(3));
+  check("gauss_lobatto_chebyshev", 4, QGaussLobattoChebyshev<3>(4));
 }

--- a/tests/base/quadrature_selector.output
+++ b/tests/base/quadrature_selector.output
@@ -6,3 +6,15 @@ DEAL::gauss 2 ok
 DEAL::gauss 6 ok
 DEAL::gauss 10 ok
 DEAL::weddle 0 ok
+DEAL::gauss_lobatto 2 ok
+DEAL::gauss_lobatto 3 ok
+DEAL::gauss_lobatto 4 ok
+DEAL::gauss_chebyshev 2 ok
+DEAL::gauss_chebyshev 3 ok
+DEAL::gauss_chebyshev 4 ok
+DEAL::gauss_radau_chebyshev 2 ok
+DEAL::gauss_radau_chebyshev 3 ok
+DEAL::gauss_radau_chebyshev 4 ok
+DEAL::gauss_lobatto_chebyshev 2 ok
+DEAL::gauss_lobatto_chebyshev 3 ok
+DEAL::gauss_lobatto_chebyshev 4 ok


### PR DESCRIPTION
Extends the class QuadratureSelector by some more choices.

Some points to discuss (probably):

- So far, I added all quadratures that could be constructed using an unsigned int argument, i.e. including those with default-valued additional arguments. Not sure if those should be selectable or not.
- Removed checks for valid order, this is done anyway by the called quadrature
- Naming of flags


PS: I think I screwed up something before and accidentally closed the previous PR #9037, but couldn't reopen it again ... . So here it is again.