### PR TITLE
Avoid warning about unused variable

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -286,6 +286,8 @@ namespace Utilities
     {
       const unsigned int myid    = Utilities::MPI::this_mpi_process(mpi_comm);
       const unsigned int n_procs = Utilities::MPI::n_mpi_processes(mpi_comm);
+      (void)myid;
+      (void)n_procs;
 
       for (const unsigned int destination : destinations)
         {


### PR DESCRIPTION
In case we have MPI-3.0 and are in release mode, we do not use these variables, so silence warnings of the compiler. This is due to #9033.