### PR TITLE
Fix two places where we used too large numbers in communication channel

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -289,10 +289,10 @@ namespace LinearAlgebra
 
           // In order to avoid conflict with possible other ongoing
           // communication requests (from LA::distributed::Vector that supports
-          // unfinished requests), add an arbitrary number 9923 to the
-          // communication tag
+          // unfinished requests), add 100 to the communication tag (the first
+          // 100 can be used by normal vectors)
           for (unsigned int block = start; block < end; ++block)
-            this->block(block).update_ghost_values_start(block - start + 9923);
+            this->block(block).update_ghost_values_start(block - start + 100);
           for (unsigned int block = start; block < end; ++block)
             this->block(block).update_ghost_values_finish();
         }

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -2923,10 +2923,12 @@ namespace internal
   template <int dim, typename Number, typename VectorizedArrayType>
   struct VectorDataExchange
   {
-    // An arbitrary shift for communication to reduce the risk for accidental
+    // A shift for the MPI messages to reduce the risk for accidental
     // interaction with other open communications that a user program might
-    // set up
-    static constexpr unsigned int channel_shift = 103;
+    // set up (parallel vectors support unfinished communication). We let
+    // the other vectors use the first 20 assigned numbers and start the
+    // matrix-free communication.
+    static constexpr unsigned int channel_shift = 20;
 
 
 


### PR DESCRIPTION
Follow-up to #9034: One place in the block vector was forgotten; furthermore, for the matrix-free code I think we can select yet another channel, placing it `20` within the range of `200` possible channels.

Previously, I had two failing asserts, `matrix_free/stokes_computation.mpirun=4.debug` and `matrix_free/matrix_vector_blocks.mpirun=5.debug`. I'm currently running all MPI tests to see if this is all. `matrix_free` is already through and correct.