### PR TITLE
Defaulted copy constructor for Function

### DIFF
--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -178,6 +178,11 @@ public:
            const time_type    initial_time = 0.0);
 
   /**
+   * Copy constructor.
+   */
+  Function(const Function &f) = default;
+
+  /**
    * Virtual destructor; absolutely necessary in this case.
    *
    * This destructor is declared pure virtual, such that objects of this class


### PR DESCRIPTION
This should fix the warnings in https://cdash.43-1.org/viewBuildError.php?type=1&buildid=2901.