### PR TITLE
Fix hp_cell_weights_03/04

### DIFF
--- a/tests/mpi/hp_cell_weights_03.cc
+++ b/tests/mpi/hp_cell_weights_03.cc
@@ -117,6 +117,8 @@ test()
     {
       deallog << "Triangulation changed" << std::endl;
     }
+#else
+  deallog << "Triangulation changed" << std::endl;
 #endif
 
   // make sure no processor is hanging

--- a/tests/mpi/hp_cell_weights_04.cc
+++ b/tests/mpi/hp_cell_weights_04.cc
@@ -119,6 +119,8 @@ test()
     {
       deallog << "Triangulation changed" << std::endl;
     }
+#else
+  deallog << "Triangulation changed" << std::endl;
 #endif
 
   // make sure no processor is hanging


### PR DESCRIPTION
This should fix https://cdash.43-1.org/testSummary.php?project=1&name=mpi%2Fhp_cell_weights_03.mpirun%3D2.release&date=2019-11-19 and https://cdash.43-1.org/testSummary.php?project=1&name=mpi%2Fhp_cell_weights_04.mpirun%3D2.release&date=2019-11-19 similar to #9013.