### PR TITLE
Avoid ambiguous unrolled_to_component_indices call

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2401,9 +2401,10 @@ namespace internal
     // this function is for tensors of a rank not already handled
     // above
     template <int dim, int rank_>
-    DEAL_II_CONSTEXPR inline TableIndices<rank_>
-    unrolled_to_component_indices(const unsigned int i,
-                                  const std::integral_constant<int, rank_> &)
+    DEAL_II_CONSTEXPR inline
+      typename std::enable_if<rank_ != 2, TableIndices<rank_>>::type
+      unrolled_to_component_indices(const unsigned int i,
+                                    const std::integral_constant<int, rank_> &)
     {
       (void)i;
       Assert(


### PR DESCRIPTION
Part of #9060.