### PR TITLE
Avoid workaround for zero-dimensional C-style arrays

### DIFF
--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -231,10 +231,9 @@ protected:
    * dimensional polynomials for each space direction, given the index
    * <i>i</i>.
    */
-  // fix to avoid compiler warnings about zero length arrays
   void
-  compute_index(const unsigned int i,
-                unsigned int (&indices)[(dim > 0 ? dim : 1)]) const;
+  compute_index(const unsigned int             i,
+                std::array<unsigned int, dim> &indices) const;
 
   /**
    * TensorProductPolynomialsBubbles has a TensorProductPolynomials class
@@ -410,8 +409,8 @@ private:
    * <tt>i</tt>.
    */
   void
-  compute_index(const unsigned int i,
-                unsigned int (&indices)[(dim > 0 ? dim : 1)]) const;
+  compute_index(const unsigned int             i,
+                std::array<unsigned int, dim> &indices) const;
 
   /**
    * Given the input to the constructor, compute <tt>n_pols</tt>.
@@ -479,10 +478,10 @@ TensorProductPolynomials<dim, PolynomialType>::compute_derivative(
   const unsigned int i,
   const Point<dim> & p) const
 {
-  unsigned int indices[dim];
+  std::array<unsigned int, dim> indices;
   compute_index(i, indices);
 
-  double v[dim][5];
+  std::array<std::array<double, 5>, dim> v;
   {
     std::vector<double> tmp(5);
     for (unsigned int d = 0; d < dim; ++d)
@@ -607,7 +606,7 @@ Tensor<order, dim>
 AnisotropicPolynomials<dim>::compute_derivative(const unsigned int i,
                                                 const Point<dim> & p) const
 {
-  unsigned int indices[dim];
+  std::array<unsigned int, dim> indices;
   compute_index(i, indices);
 
   std::vector<std::vector<double>> v(dim, std::vector<double>(order + 1));

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -38,35 +38,38 @@ namespace internal
     compute_tensor_index(const unsigned int,
                          const unsigned int,
                          const unsigned int,
-                         unsigned int (&)[dim])
+                         std::array<unsigned int, dim> &)
     {
       Assert(false, ExcNotImplemented());
     }
 
+    template <>
     inline void
-    compute_tensor_index(const unsigned int n,
-                         const unsigned int,
-                         const unsigned int,
-                         unsigned int (&indices)[1])
+    compute_tensor_index<1>(const unsigned int n,
+                            const unsigned int,
+                            const unsigned int,
+                            std::array<unsigned int, 1> &indices)
     {
       indices[0] = n;
     }
 
+    template <>
     inline void
-    compute_tensor_index(const unsigned int n,
-                         const unsigned int n_pols_0,
-                         const unsigned int,
-                         unsigned int (&indices)[2])
+    compute_tensor_index<2>(const unsigned int n,
+                            const unsigned int n_pols_0,
+                            const unsigned int,
+                            std::array<unsigned int, 2> &indices)
     {
       indices[0] = n % n_pols_0;
       indices[1] = n / n_pols_0;
     }
 
+    template <>
     inline void
-    compute_tensor_index(const unsigned int n,
-                         const unsigned int n_pols_0,
-                         const unsigned int n_pols_1,
-                         unsigned int (&indices)[3])
+    compute_tensor_index<3>(const unsigned int           n,
+                            const unsigned int           n_pols_0,
+                            const unsigned int           n_pols_1,
+                            std::array<unsigned int, 3> &indices)
     {
       indices[0] = n % n_pols_0;
       indices[1] = (n / n_pols_0) % n_pols_1;
@@ -80,15 +83,15 @@ namespace internal
 template <int dim, typename PolynomialType>
 inline void
 TensorProductPolynomials<dim, PolynomialType>::compute_index(
-  const unsigned int i,
-  unsigned int (&indices)[(dim > 0 ? dim : 1)]) const
+  const unsigned int             i,
+  std::array<unsigned int, dim> &indices) const
 {
   Assert(i < Utilities::fixed_power<dim>(polynomials.size()),
          ExcInternalError());
-  internal::compute_tensor_index(index_map[i],
-                                 polynomials.size(),
-                                 polynomials.size(),
-                                 indices);
+  internal::compute_tensor_index<dim>(index_map[i],
+                                      polynomials.size(),
+                                      polynomials.size(),
+                                      indices);
 }
 
 
@@ -98,7 +101,7 @@ void
 TensorProductPolynomials<dim, PolynomialType>::output_indices(
   std::ostream &out) const
 {
-  unsigned int ix[(dim > 0) ? dim : 1];
+  std::array<unsigned int, dim> ix;
   for (unsigned int i = 0; i < this->n(); ++i)
     {
       compute_index(i, ix);
@@ -146,7 +149,7 @@ TensorProductPolynomials<dim, PolynomialType>::compute_value(
 {
   Assert(dim > 0, ExcNotImplemented());
 
-  unsigned int indices[dim];
+  std::array<unsigned int, dim> indices;
   compute_index(i, indices);
 
   double value = 1.;
@@ -164,14 +167,14 @@ TensorProductPolynomials<dim, PolynomialType>::compute_grad(
   const unsigned int i,
   const Point<dim> & p) const
 {
-  unsigned int indices[dim];
+  std::array<unsigned int, dim> indices;
   compute_index(i, indices);
 
   // compute values and
   // uni-directional derivatives at
   // the given point in each
   // co-ordinate direction
-  double v[dim][2];
+  std::array<std::array<double, 2>, dim> v;
   {
     std::vector<double> tmp(2);
     for (unsigned int d = 0; d < dim; ++d)
@@ -212,10 +215,10 @@ TensorProductPolynomials<dim, PolynomialType>::compute_grad_grad(
   const unsigned int i,
   const Point<dim> & p) const
 {
-  unsigned int indices[(dim > 0) ? dim : 1];
+  std::array<unsigned int, dim> indices;
   compute_index(i, indices);
 
-  double v[dim][3];
+  std::array<std::array<double, 3>, dim> v;
   {
     std::vector<double> tmp(3);
     for (unsigned int d = 0; d < dim; ++d)
@@ -456,8 +459,8 @@ AnisotropicPolynomials<dim>::AnisotropicPolynomials(
 template <int dim>
 void
 AnisotropicPolynomials<dim>::compute_index(
-  const unsigned int i,
-  unsigned int (&indices)[(dim > 0 ? dim : 1)]) const
+  const unsigned int             i,
+  std::array<unsigned int, dim> &indices) const
 {
 #ifdef DEBUG
   unsigned int n_poly = 1;
@@ -470,15 +473,15 @@ AnisotropicPolynomials<dim>::compute_index(
     {
     }
   else if (dim == 1)
-    internal::compute_tensor_index(i,
-                                   polynomials[0].size(),
-                                   0 /*not used*/,
-                                   indices);
+    internal::compute_tensor_index<dim>(i,
+                                        polynomials[0].size(),
+                                        0 /*not used*/,
+                                        indices);
   else
-    internal::compute_tensor_index(i,
-                                   polynomials[0].size(),
-                                   polynomials[1].size(),
-                                   indices);
+    internal::compute_tensor_index<dim>(i,
+                                        polynomials[0].size(),
+                                        polynomials[1].size(),
+                                        indices);
 }
 
 
@@ -488,7 +491,7 @@ double
 AnisotropicPolynomials<dim>::compute_value(const unsigned int i,
                                            const Point<dim> & p) const
 {
-  unsigned int indices[(dim > 0) ? dim : 1];
+  std::array<unsigned int, dim> indices;
   compute_index(i, indices);
 
   double value = 1.;
@@ -504,7 +507,7 @@ Tensor<1, dim>
 AnisotropicPolynomials<dim>::compute_grad(const unsigned int i,
                                           const Point<dim> & p) const
 {
-  unsigned int indices[(dim > 0) ? dim : 1];
+  std::array<unsigned int, dim> indices;
   compute_index(i, indices);
 
   // compute values and
@@ -532,7 +535,7 @@ Tensor<2, dim>
 AnisotropicPolynomials<dim>::compute_grad_grad(const unsigned int i,
                                                const Point<dim> & p) const
 {
-  unsigned int indices[(dim > 0) ? dim : 1];
+  std::array<unsigned int, dim> indices;
   compute_index(i, indices);
 
   std::vector<std::vector<double>> v(dim, std::vector<double>(3));
@@ -627,7 +630,7 @@ AnisotropicPolynomials<dim>::evaluate(
       // one-dimensional indices of
       // this particular tensor
       // product polynomial
-      unsigned int indices[(dim > 0) ? dim : 1];
+      std::array<unsigned int, dim> indices;
       compute_index(i, indices);
 
       if (update_values)

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -33,7 +33,7 @@ namespace internal
 {
   namespace
   {
-    template <int dim>
+    template <std::size_t dim>
     inline void
     compute_tensor_index(const unsigned int,
                          const unsigned int,
@@ -43,33 +43,30 @@ namespace internal
       Assert(false, ExcNotImplemented());
     }
 
-    template <>
     inline void
-    compute_tensor_index<1>(const unsigned int n,
-                            const unsigned int,
-                            const unsigned int,
-                            std::array<unsigned int, 1> &indices)
+    compute_tensor_index(const unsigned int n,
+                         const unsigned int,
+                         const unsigned int,
+                         std::array<unsigned int, 1> &indices)
     {
       indices[0] = n;
     }
 
-    template <>
     inline void
-    compute_tensor_index<2>(const unsigned int n,
-                            const unsigned int n_pols_0,
-                            const unsigned int,
-                            std::array<unsigned int, 2> &indices)
+    compute_tensor_index(const unsigned int n,
+                         const unsigned int n_pols_0,
+                         const unsigned int,
+                         std::array<unsigned int, 2> &indices)
     {
       indices[0] = n % n_pols_0;
       indices[1] = n / n_pols_0;
     }
 
-    template <>
     inline void
-    compute_tensor_index<3>(const unsigned int           n,
-                            const unsigned int           n_pols_0,
-                            const unsigned int           n_pols_1,
-                            std::array<unsigned int, 3> &indices)
+    compute_tensor_index(const unsigned int           n,
+                         const unsigned int           n_pols_0,
+                         const unsigned int           n_pols_1,
+                         std::array<unsigned int, 3> &indices)
     {
       indices[0] = n % n_pols_0;
       indices[1] = (n / n_pols_0) % n_pols_1;
@@ -88,10 +85,10 @@ TensorProductPolynomials<dim, PolynomialType>::compute_index(
 {
   Assert(i < Utilities::fixed_power<dim>(polynomials.size()),
          ExcInternalError());
-  internal::compute_tensor_index<dim>(index_map[i],
-                                      polynomials.size(),
-                                      polynomials.size(),
-                                      indices);
+  internal::compute_tensor_index(index_map[i],
+                                 polynomials.size(),
+                                 polynomials.size(),
+                                 indices);
 }
 
 
@@ -473,15 +470,15 @@ AnisotropicPolynomials<dim>::compute_index(
     {
     }
   else if (dim == 1)
-    internal::compute_tensor_index<dim>(i,
-                                        polynomials[0].size(),
-                                        0 /*not used*/,
-                                        indices);
+    internal::compute_tensor_index(i,
+                                   polynomials[0].size(),
+                                   0 /*not used*/,
+                                   indices);
   else
-    internal::compute_tensor_index<dim>(i,
-                                        polynomials[0].size(),
-                                        polynomials[1].size(),
-                                        indices);
+    internal::compute_tensor_index(i,
+                                   polynomials[0].size(),
+                                   polynomials[1].size(),
+                                   indices);
 }
 
 

--- a/source/base/tensor_product_polynomials_bubbles.cc
+++ b/source/base/tensor_product_polynomials_bubbles.cc
@@ -30,7 +30,7 @@ template <int dim>
 void
 TensorProductPolynomialsBubbles<dim>::output_indices(std::ostream &out) const
 {
-  unsigned int ix[dim];
+  std::array<unsigned int, dim> ix;
   for (unsigned int i = 0; i < tensor_polys.n(); ++i)
     {
       tensor_polys.compute_index(i, ix);

--- a/source/base/tensor_product_polynomials_const.cc
+++ b/source/base/tensor_product_polynomials_const.cc
@@ -30,7 +30,7 @@ template <int dim>
 void
 TensorProductPolynomialsConst<dim>::output_indices(std::ostream &out) const
 {
-  unsigned int ix[dim];
+  std::array<unsigned int, dim> ix;
   for (unsigned int i = 0; i < tensor_polys.n(); ++i)
     {
       tensor_polys.compute_index(i, ix);


### PR DESCRIPTION
Part of #9060.
This pull request replaces some C-style arrays we used a workaround for zero size for by `std::array` that allows zero size without problems.