### PR TITLE
Fix ADOL-C tests

### DIFF
--- a/include/deal.II/base/symmetric_tensor.templates.h
+++ b/include/deal.II/base/symmetric_tensor.templates.h
@@ -1001,6 +1001,44 @@ eigenvectors(const SymmetricTensor<2, dim, Number> &T,
 
 
 
+#ifdef DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING
+namespace internal
+{
+  namespace SymmetricTensorImplementation
+  {
+    template <>
+    struct Inverse<4, 3, adouble>;
+  } // namespace SymmetricTensorImplementation
+} // namespace internal
+
+template <>
+std::array<adouble, 1>
+eigenvalues(const SymmetricTensor<2, 1, adouble> & /*T*/);
+
+template <>
+std::array<adouble, 2>
+eigenvalues(const SymmetricTensor<2, 2, adouble> & /*T*/);
+
+template <>
+std::array<adouble, 3>
+eigenvalues(const SymmetricTensor<2, 3, adouble> & /*T*/);
+
+template <>
+std::array<std::pair<adouble, Tensor<1, 1, adouble>>, 1>
+eigenvectors(const SymmetricTensor<2, 1, adouble> & /*T*/,
+             const SymmetricTensorEigenvectorMethod /*method*/);
+
+template <>
+std::array<std::pair<adouble, Tensor<1, 2, adouble>>, 2>
+eigenvectors(const SymmetricTensor<2, 2, adouble> & /*T*/,
+             const SymmetricTensorEigenvectorMethod /*method*/);
+
+template <>
+std::array<std::pair<adouble, Tensor<1, 3, adouble>>, 3>
+eigenvectors(const SymmetricTensor<2, 3, adouble> & /*T*/,
+             const SymmetricTensorEigenvectorMethod /*method*/);
+#endif
+
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/source/differentiation/ad/adolc_number_types.cc
+++ b/source/differentiation/ad/adolc_number_types.cc
@@ -21,6 +21,7 @@
 #  include <deal.II/differentiation/ad/ad_number_traits.h>
 #  include <deal.II/differentiation/ad/adolc_number_types.h>
 
+#  include <functional>
 #  include <utility>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
Fixes the tests https://cdash.43-1.org/viewTest.php?onlydelta&buildid=2958. Since these tests implicitly include `symmetric_tensor.templates.h` it is necessary to forward declare the specializations
defined in `symmetric_tensor.templates.cc`. I also noticed that `adolc_number_types.cc` uses `std::function` without including the `functional` header.