### PR TITLE
Generate particles on support or quadrature points on other grid

### DIFF
--- a/source/particles/generators.inst.in
+++ b/source/particles/generators.inst.in
@@ -51,6 +51,29 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
             &particle_handler,
           const Mapping<deal_II_dimension, deal_II_space_dimension> &mapping,
           const unsigned int random_number_seed);
+
+        template void
+        dof_support_points<deal_II_dimension, deal_II_space_dimension>(
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension>
+            &particle_dof_handler,
+          const std::vector<std::vector<BoundingBox<deal_II_space_dimension>>>
+            &global_bounding_boxes,
+          ParticleHandler<deal_II_dimension, deal_II_space_dimension>
+            &particle_handler,
+          const Mapping<deal_II_dimension, deal_II_space_dimension> &mapping,
+          const ComponentMask &components);
+
+        template void
+        quadrature_points<deal_II_dimension, deal_II_space_dimension>(
+          const Triangulation<deal_II_dimension, deal_II_space_dimension>
+            &                                  particle_tria,
+          const Quadrature<deal_II_dimension> &quadrature,
+          const std::vector<std::vector<BoundingBox<deal_II_space_dimension>>>
+            &global_bounding_boxes,
+          ParticleHandler<deal_II_dimension, deal_II_space_dimension>
+            &particle_handler,
+          const Mapping<deal_II_dimension, deal_II_space_dimension> &mapping);
+
       \}
     \}
 #endif

--- a/tests/particles/generators_07.cc
+++ b/tests/particles/generators_07.cc
@@ -1,0 +1,124 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Insert particles within an hyper_cube triangulation using the degrees of
+// freedom associated with a non-matching hyper_cube triangulation and then
+// check if the particles are correctly positioned
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/function_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/generators.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+  GridGenerator::hyper_cube(tr);
+  tr.refine_global(2);
+
+  DoFHandler<dim, spacedim>       dof_handler(tr);
+  const FE_Nothing<dim, spacedim> fe_nothing;
+  dof_handler.distribute_dofs(fe_nothing);
+
+  const MappingQ<dim, spacedim> mapping(1);
+
+  Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
+
+  parallel::distributed::Triangulation<dim, spacedim> particles_tr(
+    MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(particles_tr, 0.1, 0.9);
+
+  // Generate the necessary bounding boxes for the generator
+  const auto my_bounding_box = GridTools::compute_mesh_predicate_bounding_box(
+    tr, IteratorFilters::LocallyOwnedCell());
+  const auto global_bounding_boxes =
+    Utilities::MPI::all_gather(MPI_COMM_WORLD, my_bounding_box);
+
+  DoFHandler<dim, spacedim> particles_dof_handler(particles_tr);
+  const FE_Q<dim, spacedim> particles_fe(1);
+  particles_dof_handler.distribute_dofs(particles_fe);
+
+
+  Particles::Generators::dof_support_points(particles_dof_handler,
+                                            global_bounding_boxes,
+                                            particle_handler);
+
+
+  {
+    deallog << "Locally owned active cells: "
+            << tr.n_locally_owned_active_cells() << std::endl;
+
+    deallog << "Global particles: " << particle_handler.n_global_particles()
+            << std::endl;
+
+    for (const auto &cell : tr.active_cell_iterators())
+      {
+        if (cell->is_locally_owned())
+          {
+            deallog << "Cell " << cell << " has "
+                    << particle_handler.n_particles_in_cell(cell)
+                    << " particles." << std::endl;
+          }
+      }
+
+    for (const auto &particle : particle_handler)
+      {
+        deallog << "Particle index " << particle.get_id() << " is in cell "
+                << particle.get_surrounding_cell(tr) << std::endl;
+        deallog << "Particle location: " << particle.get_location()
+                << std::endl;
+      }
+  }
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll init;
+
+  deallog.push("2d/2d");
+  test<2, 2>();
+  deallog.pop();
+  deallog.push("2d/3d");
+  test<2, 3>();
+  deallog.pop();
+  deallog.push("3d/3d");
+  test<3, 3>();
+  deallog.pop();
+}

--- a/tests/particles/generators_07.with_p4est=true.mpirun=1.output
+++ b/tests/particles/generators_07.with_p4est=true.mpirun=1.output
@@ -1,0 +1,138 @@
+
+DEAL:0:2d/2d::Locally owned active cells: 16
+DEAL:0:2d/2d::Global particles: 4
+DEAL:0:2d/2d::Cell 2.0 has 1 particles.
+DEAL:0:2d/2d::Cell 2.1 has 0 particles.
+DEAL:0:2d/2d::Cell 2.2 has 0 particles.
+DEAL:0:2d/2d::Cell 2.3 has 0 particles.
+DEAL:0:2d/2d::Cell 2.4 has 0 particles.
+DEAL:0:2d/2d::Cell 2.5 has 1 particles.
+DEAL:0:2d/2d::Cell 2.6 has 0 particles.
+DEAL:0:2d/2d::Cell 2.7 has 0 particles.
+DEAL:0:2d/2d::Cell 2.8 has 0 particles.
+DEAL:0:2d/2d::Cell 2.9 has 0 particles.
+DEAL:0:2d/2d::Cell 2.10 has 1 particles.
+DEAL:0:2d/2d::Cell 2.11 has 0 particles.
+DEAL:0:2d/2d::Cell 2.12 has 0 particles.
+DEAL:0:2d/2d::Cell 2.13 has 0 particles.
+DEAL:0:2d/2d::Cell 2.14 has 0 particles.
+DEAL:0:2d/2d::Cell 2.15 has 1 particles.
+DEAL:0:2d/2d::Particle index 0 is in cell 2.0
+DEAL:0:2d/2d::Particle location: 0.100000 0.100000
+DEAL:0:2d/2d::Particle index 1 is in cell 2.5
+DEAL:0:2d/2d::Particle location: 0.900000 0.100000
+DEAL:0:2d/2d::Particle index 2 is in cell 2.10
+DEAL:0:2d/2d::Particle location: 0.100000 0.900000
+DEAL:0:2d/2d::Particle index 3 is in cell 2.15
+DEAL:0:2d/2d::Particle location: 0.900000 0.900000
+DEAL:0:2d/2d::OK
+DEAL:0:2d/3d::Locally owned active cells: 16
+DEAL:0:2d/3d::Global particles: 4
+DEAL:0:2d/3d::Cell 2.0 has 1 particles.
+DEAL:0:2d/3d::Cell 2.1 has 0 particles.
+DEAL:0:2d/3d::Cell 2.2 has 0 particles.
+DEAL:0:2d/3d::Cell 2.3 has 0 particles.
+DEAL:0:2d/3d::Cell 2.4 has 0 particles.
+DEAL:0:2d/3d::Cell 2.5 has 1 particles.
+DEAL:0:2d/3d::Cell 2.6 has 0 particles.
+DEAL:0:2d/3d::Cell 2.7 has 0 particles.
+DEAL:0:2d/3d::Cell 2.8 has 0 particles.
+DEAL:0:2d/3d::Cell 2.9 has 0 particles.
+DEAL:0:2d/3d::Cell 2.10 has 1 particles.
+DEAL:0:2d/3d::Cell 2.11 has 0 particles.
+DEAL:0:2d/3d::Cell 2.12 has 0 particles.
+DEAL:0:2d/3d::Cell 2.13 has 0 particles.
+DEAL:0:2d/3d::Cell 2.14 has 0 particles.
+DEAL:0:2d/3d::Cell 2.15 has 1 particles.
+DEAL:0:2d/3d::Particle index 0 is in cell 2.0
+DEAL:0:2d/3d::Particle location: 0.100000 0.100000 0.00000
+DEAL:0:2d/3d::Particle index 1 is in cell 2.5
+DEAL:0:2d/3d::Particle location: 0.900000 0.100000 0.00000
+DEAL:0:2d/3d::Particle index 2 is in cell 2.10
+DEAL:0:2d/3d::Particle location: 0.100000 0.900000 0.00000
+DEAL:0:2d/3d::Particle index 3 is in cell 2.15
+DEAL:0:2d/3d::Particle location: 0.900000 0.900000 0.00000
+DEAL:0:2d/3d::OK
+DEAL:0:3d/3d::Locally owned active cells: 64
+DEAL:0:3d/3d::Global particles: 8
+DEAL:0:3d/3d::Cell 2.0 has 1 particles.
+DEAL:0:3d/3d::Cell 2.1 has 0 particles.
+DEAL:0:3d/3d::Cell 2.2 has 0 particles.
+DEAL:0:3d/3d::Cell 2.3 has 0 particles.
+DEAL:0:3d/3d::Cell 2.4 has 0 particles.
+DEAL:0:3d/3d::Cell 2.5 has 0 particles.
+DEAL:0:3d/3d::Cell 2.6 has 0 particles.
+DEAL:0:3d/3d::Cell 2.7 has 0 particles.
+DEAL:0:3d/3d::Cell 2.8 has 0 particles.
+DEAL:0:3d/3d::Cell 2.9 has 1 particles.
+DEAL:0:3d/3d::Cell 2.10 has 0 particles.
+DEAL:0:3d/3d::Cell 2.11 has 0 particles.
+DEAL:0:3d/3d::Cell 2.12 has 0 particles.
+DEAL:0:3d/3d::Cell 2.13 has 0 particles.
+DEAL:0:3d/3d::Cell 2.14 has 0 particles.
+DEAL:0:3d/3d::Cell 2.15 has 0 particles.
+DEAL:0:3d/3d::Cell 2.16 has 0 particles.
+DEAL:0:3d/3d::Cell 2.17 has 0 particles.
+DEAL:0:3d/3d::Cell 2.18 has 1 particles.
+DEAL:0:3d/3d::Cell 2.19 has 0 particles.
+DEAL:0:3d/3d::Cell 2.20 has 0 particles.
+DEAL:0:3d/3d::Cell 2.21 has 0 particles.
+DEAL:0:3d/3d::Cell 2.22 has 0 particles.
+DEAL:0:3d/3d::Cell 2.23 has 0 particles.
+DEAL:0:3d/3d::Cell 2.24 has 0 particles.
+DEAL:0:3d/3d::Cell 2.25 has 0 particles.
+DEAL:0:3d/3d::Cell 2.26 has 0 particles.
+DEAL:0:3d/3d::Cell 2.27 has 1 particles.
+DEAL:0:3d/3d::Cell 2.28 has 0 particles.
+DEAL:0:3d/3d::Cell 2.29 has 0 particles.
+DEAL:0:3d/3d::Cell 2.30 has 0 particles.
+DEAL:0:3d/3d::Cell 2.31 has 0 particles.
+DEAL:0:3d/3d::Cell 2.32 has 0 particles.
+DEAL:0:3d/3d::Cell 2.33 has 0 particles.
+DEAL:0:3d/3d::Cell 2.34 has 0 particles.
+DEAL:0:3d/3d::Cell 2.35 has 0 particles.
+DEAL:0:3d/3d::Cell 2.36 has 1 particles.
+DEAL:0:3d/3d::Cell 2.37 has 0 particles.
+DEAL:0:3d/3d::Cell 2.38 has 0 particles.
+DEAL:0:3d/3d::Cell 2.39 has 0 particles.
+DEAL:0:3d/3d::Cell 2.40 has 0 particles.
+DEAL:0:3d/3d::Cell 2.41 has 0 particles.
+DEAL:0:3d/3d::Cell 2.42 has 0 particles.
+DEAL:0:3d/3d::Cell 2.43 has 0 particles.
+DEAL:0:3d/3d::Cell 2.44 has 0 particles.
+DEAL:0:3d/3d::Cell 2.45 has 1 particles.
+DEAL:0:3d/3d::Cell 2.46 has 0 particles.
+DEAL:0:3d/3d::Cell 2.47 has 0 particles.
+DEAL:0:3d/3d::Cell 2.48 has 0 particles.
+DEAL:0:3d/3d::Cell 2.49 has 0 particles.
+DEAL:0:3d/3d::Cell 2.50 has 0 particles.
+DEAL:0:3d/3d::Cell 2.51 has 0 particles.
+DEAL:0:3d/3d::Cell 2.52 has 0 particles.
+DEAL:0:3d/3d::Cell 2.53 has 0 particles.
+DEAL:0:3d/3d::Cell 2.54 has 1 particles.
+DEAL:0:3d/3d::Cell 2.55 has 0 particles.
+DEAL:0:3d/3d::Cell 2.56 has 0 particles.
+DEAL:0:3d/3d::Cell 2.57 has 0 particles.
+DEAL:0:3d/3d::Cell 2.58 has 0 particles.
+DEAL:0:3d/3d::Cell 2.59 has 0 particles.
+DEAL:0:3d/3d::Cell 2.60 has 0 particles.
+DEAL:0:3d/3d::Cell 2.61 has 0 particles.
+DEAL:0:3d/3d::Cell 2.62 has 0 particles.
+DEAL:0:3d/3d::Cell 2.63 has 1 particles.
+DEAL:0:3d/3d::Particle index 0 is in cell 2.0
+DEAL:0:3d/3d::Particle location: 0.100000 0.100000 0.100000
+DEAL:0:3d/3d::Particle index 1 is in cell 2.9
+DEAL:0:3d/3d::Particle location: 0.900000 0.100000 0.100000
+DEAL:0:3d/3d::Particle index 2 is in cell 2.18
+DEAL:0:3d/3d::Particle location: 0.100000 0.900000 0.100000
+DEAL:0:3d/3d::Particle index 3 is in cell 2.27
+DEAL:0:3d/3d::Particle location: 0.900000 0.900000 0.100000
+DEAL:0:3d/3d::Particle index 4 is in cell 2.36
+DEAL:0:3d/3d::Particle location: 0.100000 0.100000 0.900000
+DEAL:0:3d/3d::Particle index 5 is in cell 2.45
+DEAL:0:3d/3d::Particle location: 0.900000 0.100000 0.900000
+DEAL:0:3d/3d::Particle index 6 is in cell 2.54
+DEAL:0:3d/3d::Particle location: 0.100000 0.900000 0.900000
+DEAL:0:3d/3d::Particle index 7 is in cell 2.63
+DEAL:0:3d/3d::Particle location: 0.900000 0.900000 0.900000
+DEAL:0:3d/3d::OK

--- a/tests/particles/generators_07.with_p4est=true.mpirun=3.output
+++ b/tests/particles/generators_07.with_p4est=true.mpirun=3.output
@@ -1,0 +1,160 @@
+
+DEAL:0:2d/2d::Locally owned active cells: 4
+DEAL:0:2d/2d::Global particles: 4
+DEAL:0:2d/2d::Cell 2.0 has 1 particles.
+DEAL:0:2d/2d::Cell 2.1 has 0 particles.
+DEAL:0:2d/2d::Cell 2.2 has 0 particles.
+DEAL:0:2d/2d::Cell 2.3 has 0 particles.
+DEAL:0:2d/2d::Particle index 0 is in cell 2.0
+DEAL:0:2d/2d::Particle location: 0.100000 0.100000
+DEAL:0:2d/2d::OK
+DEAL:0:2d/3d::Locally owned active cells: 4
+DEAL:0:2d/3d::Global particles: 4
+DEAL:0:2d/3d::Cell 2.0 has 1 particles.
+DEAL:0:2d/3d::Cell 2.1 has 0 particles.
+DEAL:0:2d/3d::Cell 2.2 has 0 particles.
+DEAL:0:2d/3d::Cell 2.3 has 0 particles.
+DEAL:0:2d/3d::Particle index 0 is in cell 2.0
+DEAL:0:2d/3d::Particle location: 0.100000 0.100000 0.00000
+DEAL:0:2d/3d::OK
+DEAL:0:3d/3d::Locally owned active cells: 24
+DEAL:0:3d/3d::Global particles: 8
+DEAL:0:3d/3d::Cell 2.0 has 1 particles.
+DEAL:0:3d/3d::Cell 2.1 has 0 particles.
+DEAL:0:3d/3d::Cell 2.2 has 0 particles.
+DEAL:0:3d/3d::Cell 2.3 has 0 particles.
+DEAL:0:3d/3d::Cell 2.4 has 0 particles.
+DEAL:0:3d/3d::Cell 2.5 has 0 particles.
+DEAL:0:3d/3d::Cell 2.6 has 0 particles.
+DEAL:0:3d/3d::Cell 2.7 has 0 particles.
+DEAL:0:3d/3d::Cell 2.8 has 0 particles.
+DEAL:0:3d/3d::Cell 2.9 has 1 particles.
+DEAL:0:3d/3d::Cell 2.10 has 0 particles.
+DEAL:0:3d/3d::Cell 2.11 has 0 particles.
+DEAL:0:3d/3d::Cell 2.12 has 0 particles.
+DEAL:0:3d/3d::Cell 2.13 has 0 particles.
+DEAL:0:3d/3d::Cell 2.14 has 0 particles.
+DEAL:0:3d/3d::Cell 2.15 has 0 particles.
+DEAL:0:3d/3d::Cell 2.16 has 0 particles.
+DEAL:0:3d/3d::Cell 2.17 has 0 particles.
+DEAL:0:3d/3d::Cell 2.18 has 1 particles.
+DEAL:0:3d/3d::Cell 2.19 has 0 particles.
+DEAL:0:3d/3d::Cell 2.20 has 0 particles.
+DEAL:0:3d/3d::Cell 2.21 has 0 particles.
+DEAL:0:3d/3d::Cell 2.22 has 0 particles.
+DEAL:0:3d/3d::Cell 2.23 has 0 particles.
+DEAL:0:3d/3d::Particle index 0 is in cell 2.0
+DEAL:0:3d/3d::Particle location: 0.100000 0.100000 0.100000
+DEAL:0:3d/3d::Particle index 1 is in cell 2.9
+DEAL:0:3d/3d::Particle location: 0.900000 0.100000 0.100000
+DEAL:0:3d/3d::Particle index 2 is in cell 2.18
+DEAL:0:3d/3d::Particle location: 0.100000 0.900000 0.100000
+DEAL:0:3d/3d::OK
+
+DEAL:1:2d/2d::Locally owned active cells: 8
+DEAL:1:2d/2d::Global particles: 4
+DEAL:1:2d/2d::Cell 2.4 has 0 particles.
+DEAL:1:2d/2d::Cell 2.5 has 1 particles.
+DEAL:1:2d/2d::Cell 2.6 has 0 particles.
+DEAL:1:2d/2d::Cell 2.7 has 0 particles.
+DEAL:1:2d/2d::Cell 2.8 has 0 particles.
+DEAL:1:2d/2d::Cell 2.9 has 0 particles.
+DEAL:1:2d/2d::Cell 2.10 has 1 particles.
+DEAL:1:2d/2d::Cell 2.11 has 0 particles.
+DEAL:1:2d/2d::Particle index 1 is in cell 2.5
+DEAL:1:2d/2d::Particle location: 0.900000 0.100000
+DEAL:1:2d/2d::Particle index 2 is in cell 2.10
+DEAL:1:2d/2d::Particle location: 0.100000 0.900000
+DEAL:1:2d/2d::OK
+DEAL:1:2d/3d::Locally owned active cells: 8
+DEAL:1:2d/3d::Global particles: 4
+DEAL:1:2d/3d::Cell 2.4 has 0 particles.
+DEAL:1:2d/3d::Cell 2.5 has 1 particles.
+DEAL:1:2d/3d::Cell 2.6 has 0 particles.
+DEAL:1:2d/3d::Cell 2.7 has 0 particles.
+DEAL:1:2d/3d::Cell 2.8 has 0 particles.
+DEAL:1:2d/3d::Cell 2.9 has 0 particles.
+DEAL:1:2d/3d::Cell 2.10 has 1 particles.
+DEAL:1:2d/3d::Cell 2.11 has 0 particles.
+DEAL:1:2d/3d::Particle index 1 is in cell 2.5
+DEAL:1:2d/3d::Particle location: 0.900000 0.100000 0.00000
+DEAL:1:2d/3d::Particle index 2 is in cell 2.10
+DEAL:1:2d/3d::Particle location: 0.100000 0.900000 0.00000
+DEAL:1:2d/3d::OK
+DEAL:1:3d/3d::Locally owned active cells: 16
+DEAL:1:3d/3d::Global particles: 8
+DEAL:1:3d/3d::Cell 2.24 has 0 particles.
+DEAL:1:3d/3d::Cell 2.25 has 0 particles.
+DEAL:1:3d/3d::Cell 2.26 has 0 particles.
+DEAL:1:3d/3d::Cell 2.27 has 1 particles.
+DEAL:1:3d/3d::Cell 2.28 has 0 particles.
+DEAL:1:3d/3d::Cell 2.29 has 0 particles.
+DEAL:1:3d/3d::Cell 2.30 has 0 particles.
+DEAL:1:3d/3d::Cell 2.31 has 0 particles.
+DEAL:1:3d/3d::Cell 2.32 has 0 particles.
+DEAL:1:3d/3d::Cell 2.33 has 0 particles.
+DEAL:1:3d/3d::Cell 2.34 has 0 particles.
+DEAL:1:3d/3d::Cell 2.35 has 0 particles.
+DEAL:1:3d/3d::Cell 2.36 has 1 particles.
+DEAL:1:3d/3d::Cell 2.37 has 0 particles.
+DEAL:1:3d/3d::Cell 2.38 has 0 particles.
+DEAL:1:3d/3d::Cell 2.39 has 0 particles.
+DEAL:1:3d/3d::Particle index 3 is in cell 2.27
+DEAL:1:3d/3d::Particle location: 0.900000 0.900000 0.100000
+DEAL:1:3d/3d::Particle index 4 is in cell 2.36
+DEAL:1:3d/3d::Particle location: 0.100000 0.100000 0.900000
+DEAL:1:3d/3d::OK
+
+
+DEAL:2:2d/2d::Locally owned active cells: 4
+DEAL:2:2d/2d::Global particles: 4
+DEAL:2:2d/2d::Cell 2.12 has 0 particles.
+DEAL:2:2d/2d::Cell 2.13 has 0 particles.
+DEAL:2:2d/2d::Cell 2.14 has 0 particles.
+DEAL:2:2d/2d::Cell 2.15 has 1 particles.
+DEAL:2:2d/2d::Particle index 3 is in cell 2.15
+DEAL:2:2d/2d::Particle location: 0.900000 0.900000
+DEAL:2:2d/2d::OK
+DEAL:2:2d/3d::Locally owned active cells: 4
+DEAL:2:2d/3d::Global particles: 4
+DEAL:2:2d/3d::Cell 2.12 has 0 particles.
+DEAL:2:2d/3d::Cell 2.13 has 0 particles.
+DEAL:2:2d/3d::Cell 2.14 has 0 particles.
+DEAL:2:2d/3d::Cell 2.15 has 1 particles.
+DEAL:2:2d/3d::Particle index 3 is in cell 2.15
+DEAL:2:2d/3d::Particle location: 0.900000 0.900000 0.00000
+DEAL:2:2d/3d::OK
+DEAL:2:3d/3d::Locally owned active cells: 24
+DEAL:2:3d/3d::Global particles: 8
+DEAL:2:3d/3d::Cell 2.40 has 0 particles.
+DEAL:2:3d/3d::Cell 2.41 has 0 particles.
+DEAL:2:3d/3d::Cell 2.42 has 0 particles.
+DEAL:2:3d/3d::Cell 2.43 has 0 particles.
+DEAL:2:3d/3d::Cell 2.44 has 0 particles.
+DEAL:2:3d/3d::Cell 2.45 has 1 particles.
+DEAL:2:3d/3d::Cell 2.46 has 0 particles.
+DEAL:2:3d/3d::Cell 2.47 has 0 particles.
+DEAL:2:3d/3d::Cell 2.48 has 0 particles.
+DEAL:2:3d/3d::Cell 2.49 has 0 particles.
+DEAL:2:3d/3d::Cell 2.50 has 0 particles.
+DEAL:2:3d/3d::Cell 2.51 has 0 particles.
+DEAL:2:3d/3d::Cell 2.52 has 0 particles.
+DEAL:2:3d/3d::Cell 2.53 has 0 particles.
+DEAL:2:3d/3d::Cell 2.54 has 1 particles.
+DEAL:2:3d/3d::Cell 2.55 has 0 particles.
+DEAL:2:3d/3d::Cell 2.56 has 0 particles.
+DEAL:2:3d/3d::Cell 2.57 has 0 particles.
+DEAL:2:3d/3d::Cell 2.58 has 0 particles.
+DEAL:2:3d/3d::Cell 2.59 has 0 particles.
+DEAL:2:3d/3d::Cell 2.60 has 0 particles.
+DEAL:2:3d/3d::Cell 2.61 has 0 particles.
+DEAL:2:3d/3d::Cell 2.62 has 0 particles.
+DEAL:2:3d/3d::Cell 2.63 has 1 particles.
+DEAL:2:3d/3d::Particle index 5 is in cell 2.45
+DEAL:2:3d/3d::Particle location: 0.900000 0.100000 0.900000
+DEAL:2:3d/3d::Particle index 6 is in cell 2.54
+DEAL:2:3d/3d::Particle location: 0.100000 0.900000 0.900000
+DEAL:2:3d/3d::Particle index 7 is in cell 2.63
+DEAL:2:3d/3d::Particle location: 0.900000 0.900000 0.900000
+DEAL:2:3d/3d::OK
+

--- a/tests/particles/generators_08.cc
+++ b/tests/particles/generators_08.cc
@@ -1,0 +1,121 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Insert particles within an hyper_cube triangulation using a Q1 quadrature
+// defined on a non-matching hyper_cube triangulation and then check if the
+// particles are correctly positioned
+
+
+#include <deal.II/base/function_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/generators.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+  GridGenerator::hyper_cube(tr);
+  tr.refine_global(2);
+
+  DoFHandler<dim, spacedim>       dof_handler(tr);
+  const FE_Nothing<dim, spacedim> fe_nothing;
+  dof_handler.distribute_dofs(fe_nothing);
+
+  const MappingQ<dim, spacedim> mapping(1);
+
+  Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
+
+  parallel::distributed::Triangulation<dim, spacedim> particles_tr(
+    MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(particles_tr, 0.1, 0.9);
+
+  const QGauss<dim> quadrature(2);
+
+  // Generate the necessary bounding boxes for the generator
+  const auto my_bounding_box = GridTools::compute_mesh_predicate_bounding_box(
+    tr, IteratorFilters::LocallyOwnedCell());
+  const auto global_bounding_boxes =
+    Utilities::MPI::all_gather(MPI_COMM_WORLD, my_bounding_box);
+
+  Particles::Generators::quadrature_points(particles_tr,
+                                           quadrature,
+                                           global_bounding_boxes,
+                                           particle_handler);
+
+  {
+    deallog << "Locally owned active cells: "
+            << tr.n_locally_owned_active_cells() << std::endl;
+
+    deallog << "Global particles: " << particle_handler.n_global_particles()
+            << std::endl;
+
+    for (const auto &cell : tr.active_cell_iterators())
+      {
+        if (cell->is_locally_owned())
+          {
+            deallog << "Cell " << cell << " has "
+                    << particle_handler.n_particles_in_cell(cell)
+                    << " particles." << std::endl;
+          }
+      }
+
+    for (const auto &particle : particle_handler)
+      {
+        deallog << "Particle index " << particle.get_id() << " is in cell "
+                << particle.get_surrounding_cell(tr) << std::endl;
+        deallog << "Particle location: " << particle.get_location()
+                << std::endl;
+      }
+  }
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll init;
+
+  deallog.push("2d/2d");
+  test<2, 2>();
+  deallog.pop();
+  deallog.push("2d/3d");
+  test<2, 3>();
+  deallog.pop();
+  deallog.push("3d/3d");
+  test<3, 3>();
+  deallog.pop();
+}

--- a/tests/particles/generators_08.with_p4est=true.mpirun=1.output
+++ b/tests/particles/generators_08.with_p4est=true.mpirun=1.output
@@ -1,0 +1,138 @@
+
+DEAL:0:2d/2d::Locally owned active cells: 16
+DEAL:0:2d/2d::Global particles: 4
+DEAL:0:2d/2d::Cell 2.0 has 0 particles.
+DEAL:0:2d/2d::Cell 2.1 has 0 particles.
+DEAL:0:2d/2d::Cell 2.2 has 0 particles.
+DEAL:0:2d/2d::Cell 2.3 has 1 particles.
+DEAL:0:2d/2d::Cell 2.4 has 0 particles.
+DEAL:0:2d/2d::Cell 2.5 has 0 particles.
+DEAL:0:2d/2d::Cell 2.6 has 1 particles.
+DEAL:0:2d/2d::Cell 2.7 has 0 particles.
+DEAL:0:2d/2d::Cell 2.8 has 0 particles.
+DEAL:0:2d/2d::Cell 2.9 has 1 particles.
+DEAL:0:2d/2d::Cell 2.10 has 0 particles.
+DEAL:0:2d/2d::Cell 2.11 has 0 particles.
+DEAL:0:2d/2d::Cell 2.12 has 1 particles.
+DEAL:0:2d/2d::Cell 2.13 has 0 particles.
+DEAL:0:2d/2d::Cell 2.14 has 0 particles.
+DEAL:0:2d/2d::Cell 2.15 has 0 particles.
+DEAL:0:2d/2d::Particle index 0 is in cell 2.3
+DEAL:0:2d/2d::Particle location: 0.269060 0.269060
+DEAL:0:2d/2d::Particle index 1 is in cell 2.6
+DEAL:0:2d/2d::Particle location: 0.730940 0.269060
+DEAL:0:2d/2d::Particle index 2 is in cell 2.9
+DEAL:0:2d/2d::Particle location: 0.269060 0.730940
+DEAL:0:2d/2d::Particle index 3 is in cell 2.12
+DEAL:0:2d/2d::Particle location: 0.730940 0.730940
+DEAL:0:2d/2d::OK
+DEAL:0:2d/3d::Locally owned active cells: 16
+DEAL:0:2d/3d::Global particles: 4
+DEAL:0:2d/3d::Cell 2.0 has 0 particles.
+DEAL:0:2d/3d::Cell 2.1 has 0 particles.
+DEAL:0:2d/3d::Cell 2.2 has 0 particles.
+DEAL:0:2d/3d::Cell 2.3 has 1 particles.
+DEAL:0:2d/3d::Cell 2.4 has 0 particles.
+DEAL:0:2d/3d::Cell 2.5 has 0 particles.
+DEAL:0:2d/3d::Cell 2.6 has 1 particles.
+DEAL:0:2d/3d::Cell 2.7 has 0 particles.
+DEAL:0:2d/3d::Cell 2.8 has 0 particles.
+DEAL:0:2d/3d::Cell 2.9 has 1 particles.
+DEAL:0:2d/3d::Cell 2.10 has 0 particles.
+DEAL:0:2d/3d::Cell 2.11 has 0 particles.
+DEAL:0:2d/3d::Cell 2.12 has 1 particles.
+DEAL:0:2d/3d::Cell 2.13 has 0 particles.
+DEAL:0:2d/3d::Cell 2.14 has 0 particles.
+DEAL:0:2d/3d::Cell 2.15 has 0 particles.
+DEAL:0:2d/3d::Particle index 0 is in cell 2.3
+DEAL:0:2d/3d::Particle location: 0.269060 0.269060 0.00000
+DEAL:0:2d/3d::Particle index 1 is in cell 2.6
+DEAL:0:2d/3d::Particle location: 0.730940 0.269060 0.00000
+DEAL:0:2d/3d::Particle index 2 is in cell 2.9
+DEAL:0:2d/3d::Particle location: 0.269060 0.730940 0.00000
+DEAL:0:2d/3d::Particle index 3 is in cell 2.12
+DEAL:0:2d/3d::Particle location: 0.730940 0.730940 0.00000
+DEAL:0:2d/3d::OK
+DEAL:0:3d/3d::Locally owned active cells: 64
+DEAL:0:3d/3d::Global particles: 8
+DEAL:0:3d/3d::Cell 2.0 has 0 particles.
+DEAL:0:3d/3d::Cell 2.1 has 0 particles.
+DEAL:0:3d/3d::Cell 2.2 has 0 particles.
+DEAL:0:3d/3d::Cell 2.3 has 0 particles.
+DEAL:0:3d/3d::Cell 2.4 has 0 particles.
+DEAL:0:3d/3d::Cell 2.5 has 0 particles.
+DEAL:0:3d/3d::Cell 2.6 has 0 particles.
+DEAL:0:3d/3d::Cell 2.7 has 1 particles.
+DEAL:0:3d/3d::Cell 2.8 has 0 particles.
+DEAL:0:3d/3d::Cell 2.9 has 0 particles.
+DEAL:0:3d/3d::Cell 2.10 has 0 particles.
+DEAL:0:3d/3d::Cell 2.11 has 0 particles.
+DEAL:0:3d/3d::Cell 2.12 has 0 particles.
+DEAL:0:3d/3d::Cell 2.13 has 0 particles.
+DEAL:0:3d/3d::Cell 2.14 has 1 particles.
+DEAL:0:3d/3d::Cell 2.15 has 0 particles.
+DEAL:0:3d/3d::Cell 2.16 has 0 particles.
+DEAL:0:3d/3d::Cell 2.17 has 0 particles.
+DEAL:0:3d/3d::Cell 2.18 has 0 particles.
+DEAL:0:3d/3d::Cell 2.19 has 0 particles.
+DEAL:0:3d/3d::Cell 2.20 has 0 particles.
+DEAL:0:3d/3d::Cell 2.21 has 1 particles.
+DEAL:0:3d/3d::Cell 2.22 has 0 particles.
+DEAL:0:3d/3d::Cell 2.23 has 0 particles.
+DEAL:0:3d/3d::Cell 2.24 has 0 particles.
+DEAL:0:3d/3d::Cell 2.25 has 0 particles.
+DEAL:0:3d/3d::Cell 2.26 has 0 particles.
+DEAL:0:3d/3d::Cell 2.27 has 0 particles.
+DEAL:0:3d/3d::Cell 2.28 has 1 particles.
+DEAL:0:3d/3d::Cell 2.29 has 0 particles.
+DEAL:0:3d/3d::Cell 2.30 has 0 particles.
+DEAL:0:3d/3d::Cell 2.31 has 0 particles.
+DEAL:0:3d/3d::Cell 2.32 has 0 particles.
+DEAL:0:3d/3d::Cell 2.33 has 0 particles.
+DEAL:0:3d/3d::Cell 2.34 has 0 particles.
+DEAL:0:3d/3d::Cell 2.35 has 1 particles.
+DEAL:0:3d/3d::Cell 2.36 has 0 particles.
+DEAL:0:3d/3d::Cell 2.37 has 0 particles.
+DEAL:0:3d/3d::Cell 2.38 has 0 particles.
+DEAL:0:3d/3d::Cell 2.39 has 0 particles.
+DEAL:0:3d/3d::Cell 2.40 has 0 particles.
+DEAL:0:3d/3d::Cell 2.41 has 0 particles.
+DEAL:0:3d/3d::Cell 2.42 has 1 particles.
+DEAL:0:3d/3d::Cell 2.43 has 0 particles.
+DEAL:0:3d/3d::Cell 2.44 has 0 particles.
+DEAL:0:3d/3d::Cell 2.45 has 0 particles.
+DEAL:0:3d/3d::Cell 2.46 has 0 particles.
+DEAL:0:3d/3d::Cell 2.47 has 0 particles.
+DEAL:0:3d/3d::Cell 2.48 has 0 particles.
+DEAL:0:3d/3d::Cell 2.49 has 1 particles.
+DEAL:0:3d/3d::Cell 2.50 has 0 particles.
+DEAL:0:3d/3d::Cell 2.51 has 0 particles.
+DEAL:0:3d/3d::Cell 2.52 has 0 particles.
+DEAL:0:3d/3d::Cell 2.53 has 0 particles.
+DEAL:0:3d/3d::Cell 2.54 has 0 particles.
+DEAL:0:3d/3d::Cell 2.55 has 0 particles.
+DEAL:0:3d/3d::Cell 2.56 has 1 particles.
+DEAL:0:3d/3d::Cell 2.57 has 0 particles.
+DEAL:0:3d/3d::Cell 2.58 has 0 particles.
+DEAL:0:3d/3d::Cell 2.59 has 0 particles.
+DEAL:0:3d/3d::Cell 2.60 has 0 particles.
+DEAL:0:3d/3d::Cell 2.61 has 0 particles.
+DEAL:0:3d/3d::Cell 2.62 has 0 particles.
+DEAL:0:3d/3d::Cell 2.63 has 0 particles.
+DEAL:0:3d/3d::Particle index 0 is in cell 2.7
+DEAL:0:3d/3d::Particle location: 0.269060 0.269060 0.269060
+DEAL:0:3d/3d::Particle index 1 is in cell 2.14
+DEAL:0:3d/3d::Particle location: 0.730940 0.269060 0.269060
+DEAL:0:3d/3d::Particle index 2 is in cell 2.21
+DEAL:0:3d/3d::Particle location: 0.269060 0.730940 0.269060
+DEAL:0:3d/3d::Particle index 3 is in cell 2.28
+DEAL:0:3d/3d::Particle location: 0.730940 0.730940 0.269060
+DEAL:0:3d/3d::Particle index 4 is in cell 2.35
+DEAL:0:3d/3d::Particle location: 0.269060 0.269060 0.730940
+DEAL:0:3d/3d::Particle index 5 is in cell 2.42
+DEAL:0:3d/3d::Particle location: 0.730940 0.269060 0.730940
+DEAL:0:3d/3d::Particle index 6 is in cell 2.49
+DEAL:0:3d/3d::Particle location: 0.269060 0.730940 0.730940
+DEAL:0:3d/3d::Particle index 7 is in cell 2.56
+DEAL:0:3d/3d::Particle location: 0.730940 0.730940 0.730940
+DEAL:0:3d/3d::OK

--- a/tests/particles/generators_08.with_p4est=true.mpirun=3.output
+++ b/tests/particles/generators_08.with_p4est=true.mpirun=3.output
@@ -1,0 +1,160 @@
+
+DEAL:0:2d/2d::Locally owned active cells: 4
+DEAL:0:2d/2d::Global particles: 4
+DEAL:0:2d/2d::Cell 2.0 has 0 particles.
+DEAL:0:2d/2d::Cell 2.1 has 0 particles.
+DEAL:0:2d/2d::Cell 2.2 has 0 particles.
+DEAL:0:2d/2d::Cell 2.3 has 1 particles.
+DEAL:0:2d/2d::Particle index 0 is in cell 2.3
+DEAL:0:2d/2d::Particle location: 0.269060 0.269060
+DEAL:0:2d/2d::OK
+DEAL:0:2d/3d::Locally owned active cells: 4
+DEAL:0:2d/3d::Global particles: 4
+DEAL:0:2d/3d::Cell 2.0 has 0 particles.
+DEAL:0:2d/3d::Cell 2.1 has 0 particles.
+DEAL:0:2d/3d::Cell 2.2 has 0 particles.
+DEAL:0:2d/3d::Cell 2.3 has 1 particles.
+DEAL:0:2d/3d::Particle index 0 is in cell 2.3
+DEAL:0:2d/3d::Particle location: 0.269060 0.269060 0.00000
+DEAL:0:2d/3d::OK
+DEAL:0:3d/3d::Locally owned active cells: 24
+DEAL:0:3d/3d::Global particles: 8
+DEAL:0:3d/3d::Cell 2.0 has 0 particles.
+DEAL:0:3d/3d::Cell 2.1 has 0 particles.
+DEAL:0:3d/3d::Cell 2.2 has 0 particles.
+DEAL:0:3d/3d::Cell 2.3 has 0 particles.
+DEAL:0:3d/3d::Cell 2.4 has 0 particles.
+DEAL:0:3d/3d::Cell 2.5 has 0 particles.
+DEAL:0:3d/3d::Cell 2.6 has 0 particles.
+DEAL:0:3d/3d::Cell 2.7 has 1 particles.
+DEAL:0:3d/3d::Cell 2.8 has 0 particles.
+DEAL:0:3d/3d::Cell 2.9 has 0 particles.
+DEAL:0:3d/3d::Cell 2.10 has 0 particles.
+DEAL:0:3d/3d::Cell 2.11 has 0 particles.
+DEAL:0:3d/3d::Cell 2.12 has 0 particles.
+DEAL:0:3d/3d::Cell 2.13 has 0 particles.
+DEAL:0:3d/3d::Cell 2.14 has 1 particles.
+DEAL:0:3d/3d::Cell 2.15 has 0 particles.
+DEAL:0:3d/3d::Cell 2.16 has 0 particles.
+DEAL:0:3d/3d::Cell 2.17 has 0 particles.
+DEAL:0:3d/3d::Cell 2.18 has 0 particles.
+DEAL:0:3d/3d::Cell 2.19 has 0 particles.
+DEAL:0:3d/3d::Cell 2.20 has 0 particles.
+DEAL:0:3d/3d::Cell 2.21 has 1 particles.
+DEAL:0:3d/3d::Cell 2.22 has 0 particles.
+DEAL:0:3d/3d::Cell 2.23 has 0 particles.
+DEAL:0:3d/3d::Particle index 0 is in cell 2.7
+DEAL:0:3d/3d::Particle location: 0.269060 0.269060 0.269060
+DEAL:0:3d/3d::Particle index 1 is in cell 2.14
+DEAL:0:3d/3d::Particle location: 0.730940 0.269060 0.269060
+DEAL:0:3d/3d::Particle index 2 is in cell 2.21
+DEAL:0:3d/3d::Particle location: 0.269060 0.730940 0.269060
+DEAL:0:3d/3d::OK
+
+DEAL:1:2d/2d::Locally owned active cells: 8
+DEAL:1:2d/2d::Global particles: 4
+DEAL:1:2d/2d::Cell 2.4 has 0 particles.
+DEAL:1:2d/2d::Cell 2.5 has 0 particles.
+DEAL:1:2d/2d::Cell 2.6 has 1 particles.
+DEAL:1:2d/2d::Cell 2.7 has 0 particles.
+DEAL:1:2d/2d::Cell 2.8 has 0 particles.
+DEAL:1:2d/2d::Cell 2.9 has 1 particles.
+DEAL:1:2d/2d::Cell 2.10 has 0 particles.
+DEAL:1:2d/2d::Cell 2.11 has 0 particles.
+DEAL:1:2d/2d::Particle index 1 is in cell 2.6
+DEAL:1:2d/2d::Particle location: 0.730940 0.269060
+DEAL:1:2d/2d::Particle index 2 is in cell 2.9
+DEAL:1:2d/2d::Particle location: 0.269060 0.730940
+DEAL:1:2d/2d::OK
+DEAL:1:2d/3d::Locally owned active cells: 8
+DEAL:1:2d/3d::Global particles: 4
+DEAL:1:2d/3d::Cell 2.4 has 0 particles.
+DEAL:1:2d/3d::Cell 2.5 has 0 particles.
+DEAL:1:2d/3d::Cell 2.6 has 1 particles.
+DEAL:1:2d/3d::Cell 2.7 has 0 particles.
+DEAL:1:2d/3d::Cell 2.8 has 0 particles.
+DEAL:1:2d/3d::Cell 2.9 has 1 particles.
+DEAL:1:2d/3d::Cell 2.10 has 0 particles.
+DEAL:1:2d/3d::Cell 2.11 has 0 particles.
+DEAL:1:2d/3d::Particle index 1 is in cell 2.6
+DEAL:1:2d/3d::Particle location: 0.730940 0.269060 0.00000
+DEAL:1:2d/3d::Particle index 2 is in cell 2.9
+DEAL:1:2d/3d::Particle location: 0.269060 0.730940 0.00000
+DEAL:1:2d/3d::OK
+DEAL:1:3d/3d::Locally owned active cells: 16
+DEAL:1:3d/3d::Global particles: 8
+DEAL:1:3d/3d::Cell 2.24 has 0 particles.
+DEAL:1:3d/3d::Cell 2.25 has 0 particles.
+DEAL:1:3d/3d::Cell 2.26 has 0 particles.
+DEAL:1:3d/3d::Cell 2.27 has 0 particles.
+DEAL:1:3d/3d::Cell 2.28 has 1 particles.
+DEAL:1:3d/3d::Cell 2.29 has 0 particles.
+DEAL:1:3d/3d::Cell 2.30 has 0 particles.
+DEAL:1:3d/3d::Cell 2.31 has 0 particles.
+DEAL:1:3d/3d::Cell 2.32 has 0 particles.
+DEAL:1:3d/3d::Cell 2.33 has 0 particles.
+DEAL:1:3d/3d::Cell 2.34 has 0 particles.
+DEAL:1:3d/3d::Cell 2.35 has 1 particles.
+DEAL:1:3d/3d::Cell 2.36 has 0 particles.
+DEAL:1:3d/3d::Cell 2.37 has 0 particles.
+DEAL:1:3d/3d::Cell 2.38 has 0 particles.
+DEAL:1:3d/3d::Cell 2.39 has 0 particles.
+DEAL:1:3d/3d::Particle index 3 is in cell 2.28
+DEAL:1:3d/3d::Particle location: 0.730940 0.730940 0.269060
+DEAL:1:3d/3d::Particle index 4 is in cell 2.35
+DEAL:1:3d/3d::Particle location: 0.269060 0.269060 0.730940
+DEAL:1:3d/3d::OK
+
+
+DEAL:2:2d/2d::Locally owned active cells: 4
+DEAL:2:2d/2d::Global particles: 4
+DEAL:2:2d/2d::Cell 2.12 has 1 particles.
+DEAL:2:2d/2d::Cell 2.13 has 0 particles.
+DEAL:2:2d/2d::Cell 2.14 has 0 particles.
+DEAL:2:2d/2d::Cell 2.15 has 0 particles.
+DEAL:2:2d/2d::Particle index 3 is in cell 2.12
+DEAL:2:2d/2d::Particle location: 0.730940 0.730940
+DEAL:2:2d/2d::OK
+DEAL:2:2d/3d::Locally owned active cells: 4
+DEAL:2:2d/3d::Global particles: 4
+DEAL:2:2d/3d::Cell 2.12 has 1 particles.
+DEAL:2:2d/3d::Cell 2.13 has 0 particles.
+DEAL:2:2d/3d::Cell 2.14 has 0 particles.
+DEAL:2:2d/3d::Cell 2.15 has 0 particles.
+DEAL:2:2d/3d::Particle index 3 is in cell 2.12
+DEAL:2:2d/3d::Particle location: 0.730940 0.730940 0.00000
+DEAL:2:2d/3d::OK
+DEAL:2:3d/3d::Locally owned active cells: 24
+DEAL:2:3d/3d::Global particles: 8
+DEAL:2:3d/3d::Cell 2.40 has 0 particles.
+DEAL:2:3d/3d::Cell 2.41 has 0 particles.
+DEAL:2:3d/3d::Cell 2.42 has 1 particles.
+DEAL:2:3d/3d::Cell 2.43 has 0 particles.
+DEAL:2:3d/3d::Cell 2.44 has 0 particles.
+DEAL:2:3d/3d::Cell 2.45 has 0 particles.
+DEAL:2:3d/3d::Cell 2.46 has 0 particles.
+DEAL:2:3d/3d::Cell 2.47 has 0 particles.
+DEAL:2:3d/3d::Cell 2.48 has 0 particles.
+DEAL:2:3d/3d::Cell 2.49 has 1 particles.
+DEAL:2:3d/3d::Cell 2.50 has 0 particles.
+DEAL:2:3d/3d::Cell 2.51 has 0 particles.
+DEAL:2:3d/3d::Cell 2.52 has 0 particles.
+DEAL:2:3d/3d::Cell 2.53 has 0 particles.
+DEAL:2:3d/3d::Cell 2.54 has 0 particles.
+DEAL:2:3d/3d::Cell 2.55 has 0 particles.
+DEAL:2:3d/3d::Cell 2.56 has 1 particles.
+DEAL:2:3d/3d::Cell 2.57 has 0 particles.
+DEAL:2:3d/3d::Cell 2.58 has 0 particles.
+DEAL:2:3d/3d::Cell 2.59 has 0 particles.
+DEAL:2:3d/3d::Cell 2.60 has 0 particles.
+DEAL:2:3d/3d::Cell 2.61 has 0 particles.
+DEAL:2:3d/3d::Cell 2.62 has 0 particles.
+DEAL:2:3d/3d::Cell 2.63 has 0 particles.
+DEAL:2:3d/3d::Particle index 5 is in cell 2.42
+DEAL:2:3d/3d::Particle location: 0.730940 0.269060 0.730940
+DEAL:2:3d/3d::Particle index 6 is in cell 2.49
+DEAL:2:3d/3d::Particle location: 0.269060 0.730940 0.730940
+DEAL:2:3d/3d::Particle index 7 is in cell 2.56
+DEAL:2:3d/3d::Particle location: 0.730940 0.730940 0.730940
+DEAL:2:3d/3d::OK
+


### PR DESCRIPTION
Functions that generates particles at the location of the support points
or of the of the quadrature points of a DoFHandler.

The total number of particles that is added to the particle_handler
object is the number of dofs of the DoFHandler that is passed that are
within the triangulation and whose components are within the
ComponentMask.

Depends on #9071 , #9071 , #9069 