### PR TITLE
Avoid warnings in python-bindings

### DIFF
--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -505,8 +505,8 @@ namespace python
   void
   CellAccessorWrapper::set_vertex(const int i, PointWrapper &point_wrapper)
   {
-    AssertThrow(i < std::pow(2, dim),
-                ExcVertexDoesNotExist(i, std::pow(2, dim)));
+    AssertThrow(i < static_cast<int>(Utilities::pow(2, dim)),
+                ExcVertexDoesNotExist(i, Utilities::pow(2, dim)));
     if ((dim == 2) && (spacedim == 2))
       internal::set_vertex<2, 2>(i, point_wrapper, cell_accessor);
     else if ((dim == 2) && (spacedim == 3))
@@ -520,8 +520,8 @@ namespace python
   PointWrapper
   CellAccessorWrapper::get_vertex(const int i) const
   {
-    AssertThrow(i < std::pow(2, dim),
-                ExcVertexDoesNotExist(i, std::pow(2, dim)));
+    AssertThrow(i < static_cast<int>(Utilities::pow(2, dim)),
+                ExcVertexDoesNotExist(i, Utilities::pow(2, dim)));
     if ((dim == 2) && (spacedim == 2))
       return internal::get_vertex<2, 2>(i, cell_accessor);
     else if ((dim == 2) && (spacedim == 3))

--- a/contrib/python-bindings/source/tria_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/tria_accessor_wrapper.cc
@@ -272,8 +272,8 @@ namespace python
   void
   TriaAccessorWrapper::set_vertex(const int i, PointWrapper &point_wrapper)
   {
-    AssertThrow(i < std::pow(2, dim),
-                ExcVertexDoesNotExist(i, std::pow(2, dim)));
+    AssertThrow(i < static_cast<int>(Utilities::pow(2, dim)),
+                ExcVertexDoesNotExist(i, Utilities::pow(2, dim)));
     if ((dim == 2) && (spacedim == 2) && (structdim == 1))
       internal::set_vertex<1, 2, 2>(i, point_wrapper, tria_accessor);
     else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
@@ -287,8 +287,8 @@ namespace python
   PointWrapper
   TriaAccessorWrapper::get_vertex(const int i) const
   {
-    AssertThrow(i < std::pow(2, dim),
-                ExcVertexDoesNotExist(i, std::pow(2, dim)));
+    AssertThrow(i < static_cast<int>(Utilities::pow(2, dim)),
+                ExcVertexDoesNotExist(i, Utilities::pow(2, dim)));
     if ((dim == 2) && (spacedim == 2) && (structdim == 1))
       return internal::get_vertex<1, 2, 2>(i, tria_accessor);
     else if ((dim == 2) && (spacedim == 3) && (structdim == 1))

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -326,7 +326,7 @@ namespace python
     generate_enclosed_hyper_cube(const double left,
                                  const double right,
                                  const double thickness,
-                                 const double colorize,
+                                 const bool   colorize,
                                  void *       triangulation)
     {
       Triangulation<dim> *tria =


### PR DESCRIPTION
Fixes most of the warnings in https://cdash.43-1.org/viewBuildError.php?type=1&buildid=2952.