### PR TITLE
Comment MSVC 2019 DEAL_II_HAVE_CXX14_CONSTEXPR_CAN_CALL_NONCONSTEXPR failure

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -731,6 +731,10 @@ CHECK_CXX_SOURCE_COMPILES(
 # expression, C++14 allows to call non-constexpr functions from constexpr
 # functions. Unfortunately, not all compilers obey the standard in this regard.
 #
+# In some cases, MSVC 2019 crashes with an internal compiler error when we
+# declare the respective functions as 'constexpr' even though the test below
+# passes, see #9080.
+#
 IF(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   CHECK_CXX_SOURCE_COMPILES(
     "


### PR DESCRIPTION
See https://github.com/dealii/dealii/pull/9080#discussion_r349796266.