### PR TITLE
Suppress warning in python-bindings

### DIFF
--- a/contrib/python-bindings/source/export_point.cc
+++ b/contrib/python-bindings/source/export_point.cc
@@ -20,6 +20,8 @@
 
 #include <point_wrapper.h>
 
+// clang complains about explicitly assigning boost::python::self to itself
+// below. However, this is the correct way to define the python bindings.
 #ifdef __clang__
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wself-assign-overloaded"

--- a/contrib/python-bindings/source/export_point.cc
+++ b/contrib/python-bindings/source/export_point.cc
@@ -20,6 +20,11 @@
 
 #include <point_wrapper.h>
 
+#ifdef __clang__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace python
@@ -99,3 +104,7 @@ namespace python
 } // namespace python
 
 DEAL_II_NAMESPACE_CLOSE
+
+#ifdef __clang__
+#  pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Suppresses the warnings in https://cdash.43-1.org/viewBuildError.php?type=1&buildid=2990. Also, see https://github.com/pybind/pybind11/issues/1893.