### PR TITLE
jenkins: allow testing master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,10 @@ pipeline
       {
         stage("permission")
         {
+          // skip permission check on master:
+          when {
+              not {branch 'master'}
+          }
           steps
           {
             githubNotify context: 'CI', description: 'need ready to test label and /rebuild',  status: 'PENDING'


### PR DESCRIPTION
The check to see if we are allowed to build fails on master (as it is not a pull request). We can trust master, so skip it.