### PR TITLE
cleanup typedefs in DataOut

### DIFF
--- a/doc/news/changes/incompatibilities/20191125MatthiasMaier
+++ b/doc/news/changes/incompatibilities/20191125MatthiasMaier
@@ -1,0 +1,5 @@
+Removed: The typedefs DataOut::active_cell_iterator and
+DataOut_DoFData::active_cell_iterator have been removed. These typedefs are
+an implementational detail that should have never exposed in the interface.
+<br>
+(Matthias Maier, 2019/11/25)

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -170,10 +170,6 @@ public:
     typename DataOut_DoFData<DoFHandlerType,
                              DoFHandlerType::dimension,
                              DoFHandlerType::space_dimension>::cell_iterator;
-  using active_cell_iterator = typename DataOut_DoFData<
-    DoFHandlerType,
-    DoFHandlerType::dimension,
-    DoFHandlerType::space_dimension>::active_cell_iterator;
 
   /**
    * Enumeration describing the part of the domain in which cells

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -604,9 +604,6 @@ public:
   using cell_iterator =
     typename Triangulation<DoFHandlerType::dimension,
                            DoFHandlerType::space_dimension>::cell_iterator;
-  using active_cell_iterator = typename Triangulation<
-    DoFHandlerType::dimension,
-    DoFHandlerType::space_dimension>::active_cell_iterator;
 
 public:
   /**

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -228,7 +228,11 @@ namespace internal
           bool duplicate = false;
           for (unsigned int j = 0; j < dataset; ++j)
             if (finite_elements[dataset].get() == finite_elements[j].get())
-              duplicate = true;
+              {
+                duplicate = true;
+                break;
+              }
+
           if (duplicate == false)
             {
               typename DoFHandlerType::active_cell_iterator dh_cell(

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -95,7 +95,7 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
           cell_and_index->first,
           GeometryInfo<DoFHandlerType::dimension>::unit_cell_vertex(vertex));
 
-  // create DoFHandlerType::active_cell_iterator and initialize FEValues
+  // initialize FEValues
   scratch_data.reinit_all_fe_values(this->dof_data, cell_and_index->first);
 
   const FEValuesBase<DoFHandlerType::dimension, DoFHandlerType::space_dimension>
@@ -202,7 +202,7 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
                     scratch_data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  const typename DoFHandlerType::active_cell_iterator dh_cell(
+                  const typename DoFHandlerType::cell_iterator dh_cell(
                     &cell_and_index->first->get_triangulation(),
                     cell_and_index->first->level(),
                     cell_and_index->first->index(),
@@ -627,7 +627,7 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
                     scratch_data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  const typename DoFHandlerType::active_cell_iterator dh_cell(
+                  const typename DoFHandlerType::cell_iterator dh_cell(
                     &cell_and_index->first->get_triangulation(),
                     cell_and_index->first->level(),
                     cell_and_index->first->index(),

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -910,16 +910,16 @@ DataOut<dim, DoFHandlerType>::build_patches(
     // data from (cell data vectors do not have the length distance computed by
     // first_locally_owned_cell/next_locally_owned_cell because this might skip
     // some values (FilteredIterator).
-    active_cell_iterator active_cell  = this->triangulation->begin_active();
-    unsigned int         active_index = 0;
-    cell_iterator        cell         = first_locally_owned_cell();
+    auto          active_cell  = this->triangulation->begin_active();
+    unsigned int  active_index = 0;
+    cell_iterator cell         = first_locally_owned_cell();
     for (; cell != this->triangulation->end();
          cell = next_locally_owned_cell(cell))
       {
         // move forward until active_cell points at the cell (cell) we are
         // looking at to compute the current active_index
         while (active_cell != this->triangulation->end() && cell->active() &&
-               active_cell_iterator(cell) != active_cell)
+               decltype(active_cell)(cell) != active_cell)
           {
             ++active_cell;
             ++active_index;

--- a/tests/data_out/data_out_08.cc
+++ b/tests/data_out/data_out_08.cc
@@ -70,8 +70,7 @@ public:
   virtual typename DataOut<dim>::cell_iterator
   first_cell()
   {
-    typename DataOut<dim>::active_cell_iterator cell =
-      this->dofs->begin_active();
+    auto cell = this->dofs->begin_active();
     while ((cell != this->dofs->end()) &&
            (cell->subdomain_id() != subdomain_id))
       ++cell;
@@ -86,8 +85,9 @@ public:
       {
         const IteratorFilters::SubdomainEqualTo predicate(subdomain_id);
 
-        return ++(FilteredIterator<typename DataOut<dim>::active_cell_iterator>(
-          predicate, old_cell));
+        return ++(
+          FilteredIterator<typename DataOut<dim>::cell_iterator>(predicate,
+                                                                 old_cell));
       }
     else
       return old_cell;


### PR DESCRIPTION
The goal is to support (interpolated) coarser output of a solution with
distributed data structures. The subtle problem here lies in the fact that
we can not simply iterate on a (local) coarser level and output the
solution - we have to communicate the ghost layer to do the interpolation
first; secondly, we also have to create a partition on the desired coarser
level. But that pretty much sounds like multigrid!

So my idea is as follows: Suppose you have a distributed solution
`solution`. We can then create a (matrix free) multrigrid transfer as
follows:
```
unsigned int coarsening_steps = 2;
vector_type solution_vector;

MGConstrainedDoFs constrained_dofs;
MGTransferMatrixFree<dim, Number> transfer;

MGLevelObject<vector_type> output_vector;

const auto max_level = triangulation.n_global_levels() - 1;
const auto output_level = max_level - std::min(coarsening_steps, max_level);

constrained_dofs.initialize(dof_handler);
transfer.initialize_constraints(constrained_dofs);
transfer.build(dof_handler);
transfer.interpolate_to_mg(dof_handler, output_vector, solution_vector);
```
So, the only step left over is to actually output said level. For example
via
```
MyDataOut<dim> data_out;
data_out.attach_dof_handler(dof_handler);
data_out.add_data_vector(output_vector);
```
where `MyDataOut` is derived from `dealii::DataOut` and overrides the
`first_cell()` and `next_cell()` functions to iterate over a fixed level.

With the current functionality I think we can integrate this quite nicely.
The following might work:
 - [x] remove unnecessary `active_cell_iterator`s from `DataOut` and `DataOut_DoFData`
 - [ ] improve the `first_locally_owned_cell` and `next_locally_owned_cell`
       member functions to use
       `cell->level_subdomain_id() == triangulation.locally_owned_subdomain`
 - [ ] improve `ParallelDataBase<dim, spacedim>::reinit_all_fe_values` to
       initialize with a `DoFHandler::level_cell_iterator` if the current
       cell is not active.
 - [ ] change `get_function_values` (and similar) to work on level dofs
       instead of dofs if the cell is not active.

@kronbichler *ping*