### PR TITLE
Fix MatrixFree::reinit() with FE_Q with face integration facilities

### DIFF
--- a/doc/news/changes/minor/20191126MartinKronbichler
+++ b/doc/news/changes/minor/20191126MartinKronbichler
@@ -1,0 +1,5 @@
+Fixed: MatrixFree::reinit() would sometimes perform invalid index accesses on
+continuous elements with hanging nodes when data structures for face integrals
+are requested. This is now fixed.
+<br>
+(Martin Kronbichler, Peter Munch, Laura Prieto Saavedra, 2019/11/26)

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1547,8 +1547,14 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                       ghost_indices.push_back(
                         part.local_to_global(di.dof_indices[i]));
 
+                  const unsigned int fe_index = di.dofs_per_cell.size() == 1 ?
+                                                  0 :
+                                                  di.cell_active_fe_index[cell];
+                  const unsigned int dofs_this_cell =
+                    di.dofs_per_cell[fe_index];
+
                   for (unsigned int i = di.row_starts_plain_indices[cell];
-                       i < di.row_starts_plain_indices[cell + 1];
+                       i < di.row_starts_plain_indices[cell] + dofs_this_cell;
                        ++i)
                     if (di.plain_dof_indices[i] >= part.local_size())
                       ghost_indices.push_back(

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1520,10 +1520,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
           }
 
       // compute tighter index sets for various sets of face integrals
-      for (unsigned int no = 0; no < n_fe; ++no)
+      for (internal::MatrixFreeFunctions::DoFInfo &di : dof_info)
         {
-          const Utilities::MPI::Partitioner &part =
-            *dof_info[no].vector_partitioner;
+          const Utilities::MPI::Partitioner &part = *di.vector_partitioner;
 
           // partitioner 0: no face integrals, simply use the indices present
           // on the cells
@@ -1539,25 +1538,21 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                   cell_level_index[cell] != cell_level_index[cell - 1])
                 {
                   for (unsigned int i =
-                         dof_info[no]
-                           .row_starts[cell *
-                                       dof_info[no].start_components.back()]
-                           .first;
-                       i < dof_info[no]
-                             .row_starts[(cell + 1) *
-                                         dof_info[no].start_components.back()]
-                             .first;
+                         di.row_starts[cell * di.start_components.back()].first;
+                       i <
+                       di.row_starts[(cell + 1) * di.start_components.back()]
+                         .first;
                        ++i)
-                    if (dof_info[no].dof_indices[i] >= part.local_size())
+                    if (di.dof_indices[i] >= part.local_size())
                       ghost_indices.push_back(
-                        part.local_to_global(dof_info[no].dof_indices[i]));
-                  for (unsigned int i =
-                         dof_info[no].row_starts_plain_indices[cell];
-                       i < dof_info[no].row_starts_plain_indices[cell + 1];
+                        part.local_to_global(di.dof_indices[i]));
+
+                  for (unsigned int i = di.row_starts_plain_indices[cell];
+                       i < di.row_starts_plain_indices[cell + 1];
                        ++i)
-                    if (dof_info[no].plain_dof_indices[i] >= part.local_size())
-                      ghost_indices.push_back(part.local_to_global(
-                        dof_info[no].plain_dof_indices[i]));
+                    if (di.plain_dof_indices[i] >= part.local_size())
+                      ghost_indices.push_back(
+                        part.local_to_global(di.plain_dof_indices[i]));
                 }
             std::sort(ghost_indices.begin(), ghost_indices.end());
             ghost_indices.erase(std::unique(ghost_indices.begin(),
@@ -1567,22 +1562,21 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
             compressed_set.add_indices(ghost_indices.begin(),
                                        ghost_indices.end());
             compressed_set.subtract_set(
-              dof_info[no].vector_partitioner->locally_owned_range());
+              di.vector_partitioner->locally_owned_range());
             const bool all_ghosts_equal =
               Utilities::MPI::min<int>(
                 compressed_set.n_elements() ==
-                  dof_info[no].vector_partitioner->ghost_indices().n_elements(),
-                dof_info[no].vector_partitioner->get_mpi_communicator()) != 0;
+                  di.vector_partitioner->ghost_indices().n_elements(),
+                di.vector_partitioner->get_mpi_communicator()) != 0;
             if (all_ghosts_equal)
-              dof_info[no].vector_partitioner_face_variants[0] =
-                dof_info[no].vector_partitioner;
+              di.vector_partitioner_face_variants[0] = di.vector_partitioner;
             else
               {
-                dof_info[no].vector_partitioner_face_variants[0].reset(
+                di.vector_partitioner_face_variants[0].reset(
                   new Utilities::MPI::Partitioner(part.locally_owned_range(),
                                                   part.get_mpi_communicator()));
                 const_cast<Utilities::MPI::Partitioner *>(
-                  dof_info[no].vector_partitioner_face_variants[0].get())
+                  di.vector_partitioner_face_variants[0].get())
                   ->set_ghost_indices(compressed_set, part.ghost_indices());
               }
           }
@@ -1590,14 +1584,12 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
           // partitioner 1: values on faces
           {
             bool all_nodal = true;
-            for (unsigned int c = 0; c < dof_info[no].n_base_elements; ++c)
-              if (!shape_info(
-                     dof_info[no].global_base_element_offset + c, 0, 0, 0)
+            for (unsigned int c = 0; c < di.n_base_elements; ++c)
+              if (!shape_info(di.global_base_element_offset + c, 0, 0, 0)
                      .nodal_at_cell_boundaries)
                 all_nodal = false;
             if (all_nodal == false)
-              dof_info[no].vector_partitioner_face_variants[1] =
-                dof_info[no].vector_partitioner;
+              di.vector_partitioner_face_variants[1] = di.vector_partitioner;
             else
               {
                 bool has_noncontiguous_cell = false;
@@ -1611,12 +1603,12 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                       AssertIndexRange(face_info.faces[f].cells_interior[v],
                                        n_macro_cells_before *
                                          VectorizedArrayType::n_array_elements);
-                      if (dof_info[no].index_storage_variants
+                      if (di.index_storage_variants
                               [internal::MatrixFreeFunctions::DoFInfo::
                                  dof_access_face_exterior][f] >=
                             internal::MatrixFreeFunctions::DoFInfo::
                               IndexStorageVariants::contiguous &&
-                          dof_info[no].dof_indices_contiguous
+                          di.dof_indices_contiguous
                               [internal::MatrixFreeFunctions::DoFInfo::
                                  dof_access_cell]
                               [face_info.faces[f].cells_exterior[v]] >=
@@ -1625,27 +1617,23 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                           const unsigned int p =
                             face_info.faces[f].cells_exterior[v];
                           const unsigned int stride =
-                            dof_info[no].dof_indices_interleave_strides[2][p];
+                            di.dof_indices_interleave_strides[2][p];
                           unsigned int i = 0;
-                          for (unsigned int e = 0;
-                               e < dof_info[no].n_base_elements;
-                               ++e)
-                            for (unsigned int c = 0;
-                                 c < dof_info[no].n_components[e];
+                          for (unsigned int e = 0; e < di.n_base_elements; ++e)
+                            for (unsigned int c = 0; c < di.n_components[e];
                                  ++c)
                               {
                                 const internal::MatrixFreeFunctions::ShapeInfo<
                                   VectorizedArrayType> &shape =
-                                  shape_info(
-                                    dof_info[no].global_base_element_offset + e,
-                                    0,
-                                    0,
-                                    0);
+                                  shape_info(di.global_base_element_offset + e,
+                                             0,
+                                             0,
+                                             0);
                                 for (unsigned int j = 0;
                                      j < shape.dofs_per_component_on_face;
                                      ++j)
                                   ghost_indices.push_back(part.local_to_global(
-                                    dof_info[no].dof_indices_contiguous
+                                    di.dof_indices_contiguous
                                       [internal::MatrixFreeFunctions::DoFInfo::
                                          dof_access_cell][p] +
                                     i +
@@ -1654,11 +1642,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                                       stride));
                                 i += shape.dofs_per_component_on_cell * stride;
                               }
-                          AssertDimension(i,
-                                          dof_info[no].dofs_per_cell[0] *
-                                            stride);
+                          AssertDimension(i, di.dofs_per_cell[0] * stride);
                         }
-                      else if (dof_info[no].index_storage_variants
+                      else if (di.index_storage_variants
                                  [internal::MatrixFreeFunctions::DoFInfo::
                                     dof_access_face_exterior][f] <
                                internal::MatrixFreeFunctions::DoFInfo::
@@ -1677,26 +1663,23 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                 compressed_set.add_indices(ghost_indices.begin(),
                                            ghost_indices.end());
                 compressed_set.subtract_set(
-                  dof_info[no].vector_partitioner->locally_owned_range());
+                  di.vector_partitioner->locally_owned_range());
                 const bool all_ghosts_equal =
                   Utilities::MPI::min<int>(
                     compressed_set.n_elements() ==
-                      dof_info[no]
-                        .vector_partitioner->ghost_indices()
-                        .n_elements(),
-                    dof_info[no].vector_partitioner->get_mpi_communicator()) !=
-                  0;
+                      di.vector_partitioner->ghost_indices().n_elements(),
+                    di.vector_partitioner->get_mpi_communicator()) != 0;
                 if (all_ghosts_equal || has_noncontiguous_cell)
-                  dof_info[no].vector_partitioner_face_variants[1] =
-                    dof_info[no].vector_partitioner;
+                  di.vector_partitioner_face_variants[1] =
+                    di.vector_partitioner;
                 else
                   {
-                    dof_info[no].vector_partitioner_face_variants[1].reset(
+                    di.vector_partitioner_face_variants[1].reset(
                       new Utilities::MPI::Partitioner(
                         part.locally_owned_range(),
                         part.get_mpi_communicator()));
                     const_cast<Utilities::MPI::Partitioner *>(
-                      dof_info[no].vector_partitioner_face_variants[1].get())
+                      di.vector_partitioner_face_variants[1].get())
                       ->set_ghost_indices(compressed_set, part.ghost_indices());
                   }
               }
@@ -1705,17 +1688,15 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
           // partitioner 2: values and gradients on faces
           {
             bool all_hermite = true;
-            for (unsigned int c = 0; c < dof_info[no].n_base_elements; ++c)
-              if (shape_info(
-                    dof_info[no].global_base_element_offset + c, 0, 0, 0)
+            for (unsigned int c = 0; c < di.n_base_elements; ++c)
+              if (shape_info(di.global_base_element_offset + c, 0, 0, 0)
                     .element_type !=
                   internal::MatrixFreeFunctions::tensor_symmetric_hermite)
                 all_hermite = false;
             if (all_hermite == false ||
-                dof_info[no].vector_partitioner_face_variants[1].get() ==
-                  dof_info[no].vector_partitioner.get())
-              dof_info[no].vector_partitioner_face_variants[2] =
-                dof_info[no].vector_partitioner;
+                di.vector_partitioner_face_variants[1].get() ==
+                  di.vector_partitioner.get())
+              di.vector_partitioner_face_variants[2] = di.vector_partitioner;
             else
               {
                 for (unsigned int f = 0; f < n_inner_face_batches(); ++f)
@@ -1728,12 +1709,12 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                       AssertIndexRange(face_info.faces[f].cells_interior[v],
                                        n_macro_cells_before *
                                          VectorizedArrayType::n_array_elements);
-                      if (dof_info[no].index_storage_variants
+                      if (di.index_storage_variants
                               [internal::MatrixFreeFunctions::DoFInfo::
                                  dof_access_face_exterior][f] >=
                             internal::MatrixFreeFunctions::DoFInfo::
                               IndexStorageVariants::contiguous &&
-                          dof_info[no].dof_indices_contiguous
+                          di.dof_indices_contiguous
                               [internal::MatrixFreeFunctions::DoFInfo::
                                  dof_access_cell]
                               [face_info.faces[f].cells_exterior[v]] >=
@@ -1742,27 +1723,23 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                           const unsigned int p =
                             face_info.faces[f].cells_exterior[v];
                           const unsigned int stride =
-                            dof_info[no].dof_indices_interleave_strides[2][p];
+                            di.dof_indices_interleave_strides[2][p];
                           unsigned int i = 0;
-                          for (unsigned int e = 0;
-                               e < dof_info[no].n_base_elements;
-                               ++e)
-                            for (unsigned int c = 0;
-                                 c < dof_info[no].n_components[e];
+                          for (unsigned int e = 0; e < di.n_base_elements; ++e)
+                            for (unsigned int c = 0; c < di.n_components[e];
                                  ++c)
                               {
                                 const internal::MatrixFreeFunctions::ShapeInfo<
                                   VectorizedArrayType> &shape =
-                                  shape_info(
-                                    dof_info[no].global_base_element_offset + e,
-                                    0,
-                                    0,
-                                    0);
+                                  shape_info(di.global_base_element_offset + e,
+                                             0,
+                                             0,
+                                             0);
                                 for (unsigned int j = 0;
                                      j < 2 * shape.dofs_per_component_on_face;
                                      ++j)
                                   ghost_indices.push_back(part.local_to_global(
-                                    dof_info[no].dof_indices_contiguous
+                                    di.dof_indices_contiguous
                                       [internal::MatrixFreeFunctions::DoFInfo::
                                          dof_access_cell][p] +
                                     i +
@@ -1771,9 +1748,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                                       stride));
                                 i += shape.dofs_per_component_on_cell * stride;
                               }
-                          AssertDimension(i,
-                                          dof_info[no].dofs_per_cell[0] *
-                                            stride);
+                          AssertDimension(i, di.dofs_per_cell[0] * stride);
                         }
                     }
                 std::sort(ghost_indices.begin(), ghost_indices.end());
@@ -1784,26 +1759,23 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                 compressed_set.add_indices(ghost_indices.begin(),
                                            ghost_indices.end());
                 compressed_set.subtract_set(
-                  dof_info[no].vector_partitioner->locally_owned_range());
+                  di.vector_partitioner->locally_owned_range());
                 const bool all_ghosts_equal =
                   Utilities::MPI::min<int>(
                     compressed_set.n_elements() ==
-                      dof_info[no]
-                        .vector_partitioner->ghost_indices()
-                        .n_elements(),
-                    dof_info[no].vector_partitioner->get_mpi_communicator()) !=
-                  0;
+                      di.vector_partitioner->ghost_indices().n_elements(),
+                    di.vector_partitioner->get_mpi_communicator()) != 0;
                 if (all_ghosts_equal)
-                  dof_info[no].vector_partitioner_face_variants[2] =
-                    dof_info[no].vector_partitioner;
+                  di.vector_partitioner_face_variants[2] =
+                    di.vector_partitioner;
                 else
                   {
-                    dof_info[no].vector_partitioner_face_variants[2].reset(
+                    di.vector_partitioner_face_variants[2].reset(
                       new Utilities::MPI::Partitioner(
                         part.locally_owned_range(),
                         part.get_mpi_communicator()));
                     const_cast<Utilities::MPI::Partitioner *>(
-                      dof_info[no].vector_partitioner_face_variants[2].get())
+                      di.vector_partitioner_face_variants[2].get())
                       ->set_ghost_indices(compressed_set, part.ghost_indices());
                   }
               }

--- a/tests/matrix_free/face_setup_01.cc
+++ b/tests/matrix_free/face_setup_01.cc
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check the initialization of MatrixFree with face information on a
+// continuous element with hanging nodes
+
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/matrix_free/matrix_free.h>
+
+#include "../tests.h"
+
+int
+main(int argc, char **argv)
+{
+  using namespace dealii;
+
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  const int dim = 3;
+
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    {
+      tria.begin_active()->set_refine_flag();
+    }
+  tria.execute_coarsening_and_refinement();
+
+  DoFHandler<dim> dof_handler(tria);
+  dof_handler.distribute_dofs(FE_Q<dim>(3));
+
+  MatrixFree<dim>                          matrix_free;
+  typename MatrixFree<dim>::AdditionalData data;
+
+  data.mapping_update_flags                = update_values;
+  data.mapping_update_flags_inner_faces    = update_values; // problem
+  data.mapping_update_flags_boundary_faces = update_values; // problem
+
+  AffineConstraints<double> constraint;
+  constraint.clear();
+  DoFTools::make_hanging_node_constraints(dof_handler, constraint);
+  constraint.close();
+
+  matrix_free.reinit(dof_handler, constraint, QGauss<1>(4), data);
+
+  LinearAlgebra::distributed::Vector<double> src;
+  matrix_free.initialize_dof_vector(src);
+
+  deallog << "main partitioner: size="
+          << matrix_free.get_dof_info().vector_partitioner->size()
+          << " local_size="
+          << matrix_free.get_dof_info().vector_partitioner->local_size()
+          << " n_ghosts="
+          << matrix_free.get_dof_info().vector_partitioner->n_ghost_indices()
+          << std::endl;
+  for (auto &p : matrix_free.get_dof_info().vector_partitioner_face_variants)
+    deallog << "partitioner: size=" << p->size()
+            << " local_size=" << p->local_size()
+            << " n_ghosts=" << p->n_ghost_indices() << std::endl;
+}

--- a/tests/matrix_free/face_setup_01.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/matrix_free/face_setup_01.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,0 +1,5 @@
+
+DEAL:0::main partitioner: size=2506 local_size=2506 n_ghosts=0
+DEAL:0::partitioner: size=2506 local_size=2506 n_ghosts=0
+DEAL:0::partitioner: size=2506 local_size=2506 n_ghosts=0
+DEAL:0::partitioner: size=2506 local_size=2506 n_ghosts=0

--- a/tests/matrix_free/face_setup_01.with_mpi=true.with_p4est=true.mpirun=2.output
+++ b/tests/matrix_free/face_setup_01.with_mpi=true.with_p4est=true.mpirun=2.output
@@ -1,0 +1,11 @@
+
+DEAL:0::main partitioner: size=2506 local_size=1492 n_ghosts=273
+DEAL:0::partitioner: size=2506 local_size=1492 n_ghosts=0
+DEAL:0::partitioner: size=2506 local_size=1492 n_ghosts=273
+DEAL:0::partitioner: size=2506 local_size=1492 n_ghosts=273
+
+DEAL:1::main partitioner: size=2506 local_size=1014 n_ghosts=442
+DEAL:1::partitioner: size=2506 local_size=1014 n_ghosts=169
+DEAL:1::partitioner: size=2506 local_size=1014 n_ghosts=442
+DEAL:1::partitioner: size=2506 local_size=1014 n_ghosts=442
+


### PR DESCRIPTION
In MatrixFree::reinit() we would sometimes access invalid data for the case
- with hanging nodes with continuous elements, i.e., indirections in the index access due to hanging node constraints, and
- face information is required.

The bug happened in the part where we try to find smaller ghost sets to be exchanged in case not the full face integrals are requested. The relevant change to fix the bug is the second commit 4d98910. I added a first commit in this PR replacing a regular `for` loop by a range-based one. The shorter variable name `dof_info[no]` -> `di` makes the very ugly line breaks/indentation (long variable names together with the 80 character limit) a bit nicer.

Fixes #9084.

FYI @peterrum @lpsaavedra