### PR TITLE
Implement data_out for mg levels (WIP)

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -3907,25 +3907,39 @@ DoFCellAccessor<DoFHandlerType, level_dof_access>::get_dof_values(
   ForwardIterator    local_values_end) const
 {
   (void)local_values_end;
-  Assert(this->is_artificial() == false,
-         ExcMessage("Can't ask for DoF indices on artificial cells."));
-  Assert(!this->has_children(), ExcMessage("Cell must be active."));
-  Assert(this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
+  // Assert(this->is_artificial() == false,
+  //       ExcMessage("Can't ask for DoF indices on artificial cells."));
+  // Assert(!this->has_children(), ExcMessage("Cell must be active."));
+  // Assert(this->dof_handler != nullptr, typename
+  // BaseClass::ExcInvalidObject());
 
-  Assert(static_cast<unsigned int>(local_values_end - local_values_begin) ==
-           this->get_fe().dofs_per_cell,
-         typename DoFCellAccessor::ExcVectorDoesNotMatch());
-  Assert(values.size() == this->get_dof_handler().n_dofs(),
-         typename DoFCellAccessor::ExcVectorDoesNotMatch());
+  // Assert(static_cast<unsigned int>(local_values_end - local_values_begin) ==
+  //         this->get_fe().dofs_per_cell,
+  //       typename DoFCellAccessor::ExcVectorDoesNotMatch());
+  // Assert(values.size() == this->get_dof_handler().n_dofs(),
+  //       typename DoFCellAccessor::ExcVectorDoesNotMatch());
 
-  const types::global_dof_index *cache =
+  std::vector<types::global_dof_index> temp;
+  types::global_dof_index *            cache;
+  if (this->active())
     this->dof_handler->levels[this->present_level]->get_cell_cache_start(
       this->present_index, this->get_fe().dofs_per_cell);
+  else
+    {
+      temp.resize(this->get_fe().dofs_per_cell);
+      this->get_mg_dof_indices(temp);
+      cache = &temp[0];
+    }
+
   dealii::internal::DoFAccessorImplementation::Implementation::
     extract_subvector_to(values,
                          cache,
                          cache + this->get_fe().dofs_per_cell,
                          local_values_begin);
+
+  for (unsigned int i = 0; i < this->get_fe().dofs_per_cell; i++)
+    std::cout << local_values_begin[i] << std::endl;
+  std::cout << std::endl;
 }
 
 

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -739,8 +739,9 @@ public:
     const std::vector<std::string> &names,
     const DataVectorType            type = type_automatic,
     const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      &data_component_interpretation = std::vector<
-        DataComponentInterpretation::DataComponentInterpretation>());
+      &data_component_interpretation =
+        std::vector<DataComponentInterpretation::DataComponentInterpretation>(),
+    const unsigned int mg_level = numbers::invalid_unsigned_int);
 
   /**
    * This function is an abbreviation to the above one (see there for a
@@ -765,8 +766,9 @@ public:
     const std::string &  name,
     const DataVectorType type = type_automatic,
     const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      &data_component_interpretation = std::vector<
-        DataComponentInterpretation::DataComponentInterpretation>());
+      &data_component_interpretation =
+        std::vector<DataComponentInterpretation::DataComponentInterpretation>(),
+    const unsigned int mg_level = numbers::invalid_unsigned_int);
 
   /**
    * This function is an extension of the above one (see there for a
@@ -789,8 +791,9 @@ public:
     const VectorType &              data,
     const std::vector<std::string> &names,
     const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      &data_component_interpretation = std::vector<
-        DataComponentInterpretation::DataComponentInterpretation>());
+      &data_component_interpretation =
+        std::vector<DataComponentInterpretation::DataComponentInterpretation>(),
+    const unsigned int mg_level = numbers::invalid_unsigned_int);
 
 
   /**
@@ -804,8 +807,9 @@ public:
     const VectorType &    data,
     const std::string &   name,
     const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      &data_component_interpretation = std::vector<
-        DataComponentInterpretation::DataComponentInterpretation>());
+      &data_component_interpretation =
+        std::vector<DataComponentInterpretation::DataComponentInterpretation>(),
+    const unsigned int mg_level = numbers::invalid_unsigned_int);
 
   /**
    * This function is an alternative to the above ones, allowing the output of
@@ -837,7 +841,8 @@ public:
   void
   add_data_vector(const VectorType &data,
                   const DataPostprocessor<DoFHandlerType::space_dimension>
-                    &data_postprocessor);
+                    &                data_postprocessor,
+                  const unsigned int mg_level = numbers::invalid_unsigned_int);
 
   /**
    * Same function as above, but with a DoFHandler object that does not need
@@ -850,7 +855,8 @@ public:
   add_data_vector(const DoFHandlerType &dof_handler,
                   const VectorType &    data,
                   const DataPostprocessor<DoFHandlerType::space_dimension>
-                    &data_postprocessor);
+                    &                data_postprocessor,
+                  const unsigned int mg_level = numbers::invalid_unsigned_int);
 
   /**
    * Release the pointers to the data vectors. This allows output of a new set
@@ -1009,8 +1015,9 @@ private:
     const std::vector<std::string> &names,
     const DataVectorType            type,
     const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      &        data_component_interpretation,
-    const bool deduce_output_names);
+      &                data_component_interpretation,
+    const bool         deduce_output_names,
+    const unsigned int mg_level = numbers::invalid_unsigned_int);
 };
 
 
@@ -1024,13 +1031,14 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
   const std::string &  name,
   const DataVectorType type,
   const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    &data_component_interpretation)
+    &                data_component_interpretation,
+  const unsigned int mg_level)
 {
   Assert(triangulation != nullptr,
          Exceptions::DataOutImplementation::ExcNoTriangulationSelected());
   std::vector<std::string> names(1, name);
   add_data_vector_internal(
-    dofs, vec, names, type, data_component_interpretation, true);
+    dofs, vec, names, type, data_component_interpretation, true, mg_level);
 }
 
 
@@ -1043,12 +1051,13 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
   const std::vector<std::string> &names,
   const DataVectorType            type,
   const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    &data_component_interpretation)
+    &                data_component_interpretation,
+  const unsigned int mg_level)
 {
   Assert(triangulation != nullptr,
          Exceptions::DataOutImplementation::ExcNoTriangulationSelected());
   add_data_vector_internal(
-    dofs, vec, names, type, data_component_interpretation, false);
+    dofs, vec, names, type, data_component_interpretation, false, mg_level);
 }
 
 
@@ -1061,7 +1070,8 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
   const VectorType &    data,
   const std::string &   name,
   const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    &data_component_interpretation)
+    &                data_component_interpretation,
+  const unsigned int mg_level)
 {
   std::vector<std::string> names(1, name);
   add_data_vector_internal(&dof_handler,
@@ -1069,7 +1079,8 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
                            names,
                            type_dof_data,
                            data_component_interpretation,
-                           true);
+                           true,
+                           mg_level);
 }
 
 
@@ -1082,14 +1093,16 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
   const VectorType &              data,
   const std::vector<std::string> &names,
   const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    &data_component_interpretation)
+    &                data_component_interpretation,
+  const unsigned int mg_level)
 {
   add_data_vector_internal(&dof_handler,
                            data,
                            names,
                            type_dof_data,
                            data_component_interpretation,
-                           false);
+                           false,
+                           mg_level);
 }
 
 
@@ -1099,11 +1112,12 @@ template <typename VectorType>
 void
 DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
   const VectorType &                                        vec,
-  const DataPostprocessor<DoFHandlerType::space_dimension> &data_postprocessor)
+  const DataPostprocessor<DoFHandlerType::space_dimension> &data_postprocessor,
+  const unsigned int                                        mg_level)
 {
   Assert(dofs != nullptr,
          Exceptions::DataOutImplementation::ExcNoDoFHandlerSelected());
-  add_data_vector(*dofs, vec, data_postprocessor);
+  add_data_vector(*dofs, vec, data_postprocessor, mg_level);
 }
 
 

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -231,7 +231,7 @@ namespace internal
               duplicate = true;
           if (duplicate == false)
             {
-              typename DoFHandlerType::active_cell_iterator dh_cell(
+              typename DoFHandlerType::cell_iterator dh_cell(
                 &cell->get_triangulation(),
                 cell->level(),
                 cell->index(),
@@ -1042,8 +1042,10 @@ void
 DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::add_data_vector(
   const DoFHandlerType &                                    dof_handler,
   const VectorType &                                        vec,
-  const DataPostprocessor<DoFHandlerType::space_dimension> &data_postprocessor)
+  const DataPostprocessor<DoFHandlerType::space_dimension> &data_postprocessor,
+  const unsigned int                                        mg_level)
 {
+  (void)mg_level;
   // this is a specialized version of the other function where we have a
   // postprocessor. if we do, we know that we have type_dof_data, which makes
   // things a bit simpler, we also don't need to deal with some of the other
@@ -1087,8 +1089,9 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::
     const std::vector<std::string> &names,
     const DataVectorType            type,
     const std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      &        data_component_interpretation_,
-    const bool deduce_output_names)
+      &                data_component_interpretation_,
+    const bool         deduce_output_names,
+    const unsigned int mg_level)
 {
   // Check available mesh information:
   if (triangulation == nullptr)
@@ -1170,7 +1173,7 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::
       case type_dof_data:
         Assert(dof_handler != nullptr,
                Exceptions::DataOutImplementation::ExcNoDoFHandlerSelected());
-        Assert(data_vector.size() == dof_handler->n_dofs(),
+        Assert(data_vector.size() == dof_handler->n_dofs(mg_level),
                Exceptions::DataOutImplementation::ExcInvalidVectorSize(
                  data_vector.size(),
                  dof_handler->n_dofs(),

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -50,7 +50,7 @@ DoFCellAccessor<DoFHandlerType, lda>::get_interpolated_dof_values(
   Vector<number> &   interpolated_values,
   const unsigned int fe_index) const
 {
-  if (!this->has_children())
+  if (true || !this->has_children())
     // if this cell has no children: simply return the exact values on this
     // cell unless the finite element we need to interpolate to is different
     // than the one we have on the current cell

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2851,7 +2851,8 @@ FEValuesBase<dim, spacedim>::CellIterator<CI>::get_interpolated_dof_values(
 
   std::vector<types::global_dof_index> dof_indices(
     cell->get_fe().dofs_per_cell);
-  cell->get_dof_indices(dof_indices);
+
+  cell->get_active_or_mg_dof_indices(dof_indices);
 
   for (unsigned int i = 0; i < cell->get_fe().dofs_per_cell; ++i)
     out[i] = (in.is_element(dof_indices[i]) ? 1 : 0);
@@ -3586,7 +3587,8 @@ FEValuesBase<dim, spacedim>::get_function_values(
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
-  AssertDimension(fe_function.size(), present_cell->n_dofs_for_dof_handler());
+  // AssertDimension(fe_function.size(),
+  // present_cell->n_dofs_for_dof_handler());
 
   // get function values of dofs on this cell
   Vector<Number> dof_values(dofs_per_cell);

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -32,6 +32,7 @@
 #include <deal.II/numerics/data_out.h>
 
 #include <sstream>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -739,7 +740,8 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
       // first_cell/next_cell functions only return active cells
       if (this->cell_data.size() != 0)
         {
-          Assert(!cell_and_index->first->has_children(), ExcNotImplemented());
+          // Assert(!cell_and_index->first->has_children(),
+          // ExcNotImplemented());
 
           for (unsigned int dataset = 0; dataset < this->cell_data.size();
                ++dataset)
@@ -910,19 +912,18 @@ DataOut<dim, DoFHandlerType>::build_patches(
     // data from (cell data vectors do not have the length distance computed by
     // first_locally_owned_cell/next_locally_owned_cell because this might skip
     // some values (FilteredIterator).
-    active_cell_iterator active_cell  = this->triangulation->begin_active();
-    unsigned int         active_index = 0;
-    cell_iterator        cell         = first_locally_owned_cell();
+    cell_iterator active_cell  = this->triangulation->begin();
+    unsigned int  active_index = 0;
+    cell_iterator cell         = first_locally_owned_cell();
     for (; cell != this->triangulation->end();
          cell = next_locally_owned_cell(cell))
       {
         // move forward until active_cell points at the cell (cell) we are
         // looking at to compute the current active_index
-        while (active_cell != this->triangulation->end() && cell->active() &&
-               active_cell_iterator(cell) != active_cell)
+        while (active_cell != this->triangulation->end())
           {
             ++active_cell;
-            ++active_index;
+            //++active_index;
           }
 
         Assert(static_cast<unsigned int>(cell->level()) <
@@ -931,12 +932,12 @@ DataOut<dim, DoFHandlerType>::build_patches(
         Assert(static_cast<unsigned int>(cell->index()) <
                  cell_to_patch_index_map[cell->level()].size(),
                ExcInternalError());
-        Assert(active_index < this->triangulation->n_active_cells(),
-               ExcInternalError());
+        // Assert(active_index < this->triangulation->n_active_cells(),
+        //       ExcInternalError());
         cell_to_patch_index_map[cell->level()][cell->index()] =
           all_cells.size();
 
-        all_cells.emplace_back(cell, active_index);
+        all_cells.emplace_back(cell, active_index++);
       }
   }
 

--- a/source/numerics/data_out_dof_data.inst.in
+++ b/source/numerics/data_out_dof_data.inst.in
@@ -27,7 +27,8 @@ for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DataVectorType,
         const std::vector<
           DataComponentInterpretation::DataComponentInterpretation> &,
-        const bool);
+        const bool,
+        const unsigned int);
 
     template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
                                   deal_II_dimension,
@@ -36,7 +37,8 @@ for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DH<deal_II_dimension, deal_II_dimension> &,
         const VEC &,
         const DataPostprocessor<
-          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &,
+        const unsigned int);
 
 
 
@@ -52,7 +54,8 @@ for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DataVectorType,
         const std::vector<
           DataComponentInterpretation::DataComponentInterpretation> &,
-        const bool);
+        const bool,
+        const unsigned int);
 
     template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
                                   deal_II_dimension - 1,
@@ -61,7 +64,8 @@ for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DH<deal_II_dimension, deal_II_dimension> &,
         const VEC &,
         const DataPostprocessor<
-          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &,
+        const unsigned int);
 
 
 
@@ -78,7 +82,8 @@ for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DataVectorType,
         const std::vector<
           DataComponentInterpretation::DataComponentInterpretation> &,
-        const bool);
+        const bool,
+        const unsigned int);
 
     template void DataOut_DoFData<DH<deal_II_dimension, deal_II_dimension>,
                                   deal_II_dimension + 1,
@@ -87,7 +92,8 @@ for (VEC : VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DH<deal_II_dimension, deal_II_dimension> &,
         const VEC &,
         const DataPostprocessor<
-          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &);
+          DH<deal_II_dimension, deal_II_dimension>::space_dimension> &,
+        const unsigned int);
 #endif
   }
 

--- a/source/numerics/data_out_dof_data_codim.inst.in
+++ b/source/numerics/data_out_dof_data_codim.inst.in
@@ -30,7 +30,8 @@ for (VEC : REAL_VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DataVectorType,
         const std::vector<
           DataComponentInterpretation::DataComponentInterpretation> &,
-        const bool);
+        const bool,
+        const unsigned int);
 
     template void
     DataOut_DoFData<DH<deal_II_dimension, deal_II_space_dimension>,
@@ -39,7 +40,8 @@ for (VEC : REAL_VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
       add_data_vector<VEC>(
         const VEC &,
         const DataPostprocessor<
-          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension> &);
+          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension> &,
+        const unsigned int);
 
     template void
     DataOut_DoFData<DH<deal_II_dimension, deal_II_space_dimension>,
@@ -49,7 +51,8 @@ for (VEC : REAL_VECTOR_TYPES; DH : DOFHANDLER_TEMPLATES;
         const DH<deal_II_dimension, deal_II_space_dimension> &,
         const VEC &,
         const DataPostprocessor<
-          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension> &);
+          DH<deal_II_dimension, deal_II_space_dimension>::space_dimension> &,
+        const unsigned int);
 #endif
   }
 


### PR DESCRIPTION
Same as #9096 but implemented independently in parallel. 

My test program:
```cpp
#include <deal.II/distributed/tria.h>

#include <deal.II/dofs/dof_handler.h>

#include <deal.II/fe/fe_dgq.h>

#include <deal.II/grid/grid_generator.h>

#include <deal.II/numerics/data_out.h>

const int dim                = 2;
const int global_refinements = 2;
const int level              = 2;
const int degree             = 1;

using namespace dealii;

template <int dim, typename DoFHandlerType = DoFHandler<dim>>
class MGDataOut : public DataOut<dim, DoFHandlerType>
{
public:
  MGDataOut(unsigned int level)
    : level(level)
  {}

private:
  typename DataOut<dim, DoFHandlerType>::cell_iterator
  first_cell()
  {
    return this->triangulation->begin(level);
  }

  typename DataOut<dim, DoFHandlerType>::cell_iterator
  next_cell(const typename DataOut<dim, DoFHandlerType>::cell_iterator &cell)
  {
    typename Triangulation<DoFHandlerType::dimension,
                           DoFHandlerType::space_dimension>::cell_iterator
      active_cell = cell;

    ++active_cell;

    if (active_cell == this->triangulation->end(level))
      return this->dofs->end();

    return active_cell;
  }

  unsigned int level;
};



int
main(int argc, char **argv)
{
  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

  parallel::distributed::Triangulation<dim> tria(
    MPI_COMM_WORLD,
    dealii::Triangulation<dim>::none,
    parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
  GridGenerator::hyper_cube(tria);
  tria.refine_global(global_refinements);

  DoFHandler<dim> dof_handler(tria);
  FE_DGQ<dim>     fe(degree);
  dof_handler.distribute_dofs(fe);
  dof_handler.distribute_mg_dofs();


  for (unsigned int level = 0; level < global_refinements; level++)
    {
      MGDataOut<dim> data_out(level);
      data_out.attach_dof_handler(dof_handler);

      Vector<double> solution;
      solution.reinit(dof_handler.n_dofs(level));

      unsigned int i = 0;
      for (auto &v : solution)
        v = i++;
      // solution[3] = 1.0;

      solution.print(std::cout);

      data_out.add_data_vector(
        solution,
        "solution",
        MGDataOut<dim>::type_dof_data,
        std::vector<DataComponentInterpretation::DataComponentInterpretation>(),
        level);
      data_out.build_patches(1 /*degree*/);

      const std::string filename =
        "output/solution." + std::to_string(level) + ".vtu";
      data_out.write_vtu_in_parallel(filename.c_str(), MPI_COMM_WORLD);
    }
}
```

@tamiko Let's collaborate on this issue! @bangerth I had make changes (and remove some asserts) to make it work as it is. I would be thankful for some help regarding `FEValues`, ....

ping @lpsaavedra