### PR TITLE
Only allocate some MappingQGeneric internal data if necessary

### DIFF
--- a/doc/news/changes/minor/20191126MartinKronbichler-b
+++ b/doc/news/changes/minor/20191126MartinKronbichler-b
@@ -1,0 +1,9 @@
+Improved: The setup of MappingQGeneric::InternalData within the constructor of
+FEValues would previously unconditionally allocate memory for all shape
+functions and all quadrature points, also for the case where we use the tensor
+product and the full interpolation is unnecessary. This has been fixed,
+improving the situation for very high orders and numbers of quadrature points
+(e.g., avoiding 400 MB of memory for mapping degrees of 15 with $16^3$
+quadrature points in 3D).
+<br>
+(Martin Kronbichler, 2019/11/26)


### PR DESCRIPTION
The setup of MappingQGeneric::InternalData within the constructor of FEValues would previously unconditionally allocate memory for all shape functions and all quadrature, also for the case where we use the tensor product and the full interpolation is unnecessary. This has been fixed, improving the situation for very high orders and numbers of quadrature points (e.g., avoiding 400 MB of memory for mapping degrees of 15 with $16^3$ quadrature points in 3D).

This is one of several steps I plan to improve setup times of `MatrixFree` for very high degrees and numbers of quadrature points in 3D, e.g. more than 8. The issue was that it shows up very prominently in profilers, even though we do this only once per traversal through the grid.

The `FEFaceValues` setup unfortunately does not profit from this because the given quadratures are not tensor products; I plan a different strategy there within `MatrixFreeFunctions::MappingInfo::initialize()`.

FYI @nfehn 