### PR TITLE
Allow using float shape functions

### DIFF
--- a/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
@@ -256,25 +256,37 @@ namespace CUDAWrappers
         {
           case 1:
             {
-              values<0, true, false, true>(global_shape_values, u, u);
+              values<0, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
 
               break;
             }
           case 2:
             {
-              values<0, true, false, true>(global_shape_values, u, u);
+              values<0, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
               __syncthreads();
-              values<1, true, false, true>(global_shape_values, u, u);
+              values<1, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
 
               break;
             }
           case 3:
             {
-              values<0, true, false, true>(global_shape_values, u, u);
+              values<0, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
               __syncthreads();
-              values<1, true, false, true>(global_shape_values, u, u);
+              values<1, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
               __syncthreads();
-              values<2, true, false, true>(global_shape_values, u, u);
+              values<2, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
 
               break;
             }
@@ -300,25 +312,37 @@ namespace CUDAWrappers
         {
           case 1:
             {
-              values<0, false, false, true>(global_shape_values, u, u);
+              values<0, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
 
               break;
             }
           case 2:
             {
-              values<0, false, false, true>(global_shape_values, u, u);
+              values<0, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
               __syncthreads();
-              values<1, false, false, true>(global_shape_values, u, u);
+              values<1, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
 
               break;
             }
           case 3:
             {
-              values<0, false, false, true>(global_shape_values, u, u);
+              values<0, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
               __syncthreads();
-              values<1, false, false, true>(global_shape_values, u, u);
+              values<1, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
               __syncthreads();
-              values<2, false, false, true>(global_shape_values, u, u);
+              values<2, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
 
               break;
             }
@@ -345,61 +369,61 @@ namespace CUDAWrappers
         {
           case 1:
             {
-              gradients<0, true, false, false>(global_shape_gradients,
-                                               u,
-                                               grad_u[0]);
+              gradients<0, true, false, false>(
+                get_global_shape_gradients<Number>(), u, grad_u[0]);
 
               break;
             }
           case 2:
             {
-              gradients<0, true, false, false>(global_shape_gradients,
-                                               u,
-                                               grad_u[0]);
-              values<0, true, false, false>(global_shape_values, u, grad_u[1]);
+              gradients<0, true, false, false>(
+                get_global_shape_gradients<Number>(), u, grad_u[0]);
+              values<0, true, false, false>(get_global_shape_values<Number>(),
+                                            u,
+                                            grad_u[1]);
 
               __syncthreads();
 
-              values<1, true, false, true>(global_shape_values,
+              values<1, true, false, true>(get_global_shape_values<Number>(),
                                            grad_u[0],
                                            grad_u[0]);
-              gradients<1, true, false, true>(global_shape_gradients,
-                                              grad_u[1],
-                                              grad_u[1]);
+              gradients<1, true, false, true>(
+                get_global_shape_gradients<Number>(), grad_u[1], grad_u[1]);
 
               break;
             }
           case 3:
             {
-              gradients<0, true, false, false>(global_shape_gradients,
-                                               u,
-                                               grad_u[0]);
-              values<0, true, false, false>(global_shape_values, u, grad_u[1]);
-              values<0, true, false, false>(global_shape_values, u, grad_u[2]);
+              gradients<0, true, false, false>(
+                get_global_shape_gradients<Number>(), u, grad_u[0]);
+              values<0, true, false, false>(get_global_shape_values<Number>(),
+                                            u,
+                                            grad_u[1]);
+              values<0, true, false, false>(get_global_shape_values<Number>(),
+                                            u,
+                                            grad_u[2]);
 
               __syncthreads();
 
-              values<1, true, false, true>(global_shape_values,
+              values<1, true, false, true>(get_global_shape_values<Number>(),
                                            grad_u[0],
                                            grad_u[0]);
-              gradients<1, true, false, true>(global_shape_gradients,
-                                              grad_u[1],
-                                              grad_u[1]);
-              values<1, true, false, true>(global_shape_values,
+              gradients<1, true, false, true>(
+                get_global_shape_gradients<Number>(), grad_u[1], grad_u[1]);
+              values<1, true, false, true>(get_global_shape_values<Number>(),
                                            grad_u[2],
                                            grad_u[2]);
 
               __syncthreads();
 
-              values<2, true, false, true>(global_shape_values,
+              values<2, true, false, true>(get_global_shape_values<Number>(),
                                            grad_u[0],
                                            grad_u[0]);
-              values<2, true, false, true>(global_shape_values,
+              values<2, true, false, true>(get_global_shape_values<Number>(),
                                            grad_u[1],
                                            grad_u[1]);
-              gradients<2, true, false, true>(global_shape_gradients,
-                                              grad_u[2],
-                                              grad_u[2]);
+              gradients<2, true, false, true>(
+                get_global_shape_gradients<Number>(), grad_u[2], grad_u[2]);
 
               break;
             }
@@ -427,49 +451,55 @@ namespace CUDAWrappers
         {
           case 1:
             {
-              values<0, true, false, true>(global_shape_values, u, u);
+              values<0, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
               __syncthreads();
 
-              gradients<0, true, false, false>(global_co_shape_gradients,
-                                               u,
-                                               grad_u[0]);
+              gradients<0, true, false, false>(
+                get_global_co_shape_gradients<Number>(), u, grad_u[0]);
 
               break;
             }
           case 2:
             {
-              values<0, true, false, true>(global_shape_values, u, u);
+              values<0, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
               __syncthreads();
-              values<1, true, false, true>(global_shape_values, u, u);
+              values<1, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
               __syncthreads();
 
-              gradients<0, true, false, false>(global_co_shape_gradients,
-                                               u,
-                                               grad_u[0]);
-              gradients<1, true, false, false>(global_co_shape_gradients,
-                                               u,
-                                               grad_u[1]);
+              gradients<0, true, false, false>(
+                get_global_co_shape_gradients<Number>(), u, grad_u[0]);
+              gradients<1, true, false, false>(
+                get_global_co_shape_gradients<Number>(), u, grad_u[1]);
 
               break;
             }
           case 3:
             {
-              values<0, true, false, true>(global_shape_values, u, u);
+              values<0, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
               __syncthreads();
-              values<1, true, false, true>(global_shape_values, u, u);
+              values<1, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
               __syncthreads();
-              values<2, true, false, true>(global_shape_values, u, u);
+              values<2, true, false, true>(get_global_shape_values<Number>(),
+                                           u,
+                                           u);
               __syncthreads();
 
-              gradients<0, true, false, false>(global_co_shape_gradients,
-                                               u,
-                                               grad_u[0]);
-              gradients<1, true, false, false>(global_co_shape_gradients,
-                                               u,
-                                               grad_u[1]);
-              gradients<2, true, false, false>(global_co_shape_gradients,
-                                               u,
-                                               grad_u[2]);
+              gradients<0, true, false, false>(
+                get_global_co_shape_gradients<Number>(), u, grad_u[0]);
+              gradients<1, true, false, false>(
+                get_global_co_shape_gradients<Number>(), u, grad_u[1]);
+              gradients<2, true, false, false>(
+                get_global_co_shape_gradients<Number>(), u, grad_u[2]);
 
               break;
             }
@@ -497,64 +527,64 @@ namespace CUDAWrappers
         {
           case 1:
             {
-              gradients<0, false, add, false>(global_shape_gradients,
-                                              grad_u[dim],
-                                              u);
+              gradients<0, false, add, false>(
+                get_global_shape_gradients<Number>(), grad_u[dim], u);
 
               break;
             }
           case 2:
             {
-              gradients<0, false, false, true>(global_shape_gradients,
-                                               grad_u[0],
-                                               grad_u[0]);
-              values<0, false, false, true>(global_shape_values,
+              gradients<0, false, false, true>(
+                get_global_shape_gradients<Number>(), grad_u[0], grad_u[0]);
+              values<0, false, false, true>(get_global_shape_values<Number>(),
                                             grad_u[1],
                                             grad_u[1]);
 
               __syncthreads();
 
-              values<1, false, add, false>(global_shape_values, grad_u[0], u);
+              values<1, false, add, false>(get_global_shape_values<Number>(),
+                                           grad_u[0],
+                                           u);
               __syncthreads();
-              gradients<1, false, true, false>(global_shape_gradients,
-                                               grad_u[1],
-                                               u);
+              gradients<1, false, true, false>(
+                get_global_shape_gradients<Number>(), grad_u[1], u);
 
               break;
             }
           case 3:
             {
-              gradients<0, false, false, true>(global_shape_gradients,
-                                               grad_u[0],
-                                               grad_u[0]);
-              values<0, false, false, true>(global_shape_values,
+              gradients<0, false, false, true>(
+                get_global_shape_gradients<Number>(), grad_u[0], grad_u[0]);
+              values<0, false, false, true>(get_global_shape_values<Number>(),
                                             grad_u[1],
                                             grad_u[1]);
-              values<0, false, false, true>(global_shape_values,
+              values<0, false, false, true>(get_global_shape_values<Number>(),
                                             grad_u[2],
                                             grad_u[2]);
 
               __syncthreads();
 
-              values<1, false, false, true>(global_shape_values,
+              values<1, false, false, true>(get_global_shape_values<Number>(),
                                             grad_u[0],
                                             grad_u[0]);
-              gradients<1, false, false, true>(global_shape_gradients,
-                                               grad_u[1],
-                                               grad_u[1]);
-              values<1, false, false, true>(global_shape_values,
+              gradients<1, false, false, true>(
+                get_global_shape_gradients<Number>(), grad_u[1], grad_u[1]);
+              values<1, false, false, true>(get_global_shape_values<Number>(),
                                             grad_u[2],
                                             grad_u[2]);
 
               __syncthreads();
 
-              values<2, false, add, false>(global_shape_values, grad_u[0], u);
+              values<2, false, add, false>(get_global_shape_values<Number>(),
+                                           grad_u[0],
+                                           u);
               __syncthreads();
-              values<2, false, true, false>(global_shape_values, grad_u[1], u);
+              values<2, false, true, false>(get_global_shape_values<Number>(),
+                                            grad_u[1],
+                                            u);
               __syncthreads();
-              gradients<2, false, true, false>(global_shape_gradients,
-                                               grad_u[2],
-                                               u);
+              gradients<2, false, true, false>(
+                get_global_shape_gradients<Number>(), grad_u[2], u);
 
               break;
             }
@@ -582,53 +612,59 @@ namespace CUDAWrappers
         {
           case 1:
             {
-              gradients<0, false, true, false>(global_co_shape_gradients,
-                                               grad_u[0],
-                                               u);
+              gradients<0, false, true, false>(
+                get_global_co_shape_gradients<Number>(), grad_u[0], u);
               __syncthreads();
 
-              values<0, false, false, true>(global_shape_values, u, u);
+              values<0, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
 
               break;
             }
           case 2:
             {
-              gradients<1, false, true, false>(global_co_shape_gradients,
-                                               grad_u[1],
-                                               u);
+              gradients<1, false, true, false>(
+                get_global_co_shape_gradients<Number>(), grad_u[1], u);
               __syncthreads();
-              gradients<0, false, true, false>(global_co_shape_gradients,
-                                               grad_u[0],
-                                               u);
+              gradients<0, false, true, false>(
+                get_global_co_shape_gradients<Number>(), grad_u[0], u);
               __syncthreads();
 
-              values<1, false, false, true>(global_shape_values, u, u);
+              values<1, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
               __syncthreads();
-              values<0, false, false, true>(global_shape_values, u, u);
+              values<0, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
               __syncthreads();
 
               break;
             }
           case 3:
             {
-              gradients<2, false, true, false>(global_co_shape_gradients,
-                                               grad_u[2],
-                                               u);
+              gradients<2, false, true, false>(
+                get_global_co_shape_gradients<Number>(), grad_u[2], u);
               __syncthreads();
-              gradients<1, false, true, false>(global_co_shape_gradients,
-                                               grad_u[1],
-                                               u);
+              gradients<1, false, true, false>(
+                get_global_co_shape_gradients<Number>(), grad_u[1], u);
               __syncthreads();
-              gradients<0, false, true, false>(global_co_shape_gradients,
-                                               grad_u[0],
-                                               u);
+              gradients<0, false, true, false>(
+                get_global_co_shape_gradients<Number>(), grad_u[0], u);
               __syncthreads();
 
-              values<2, false, false, true>(global_shape_values, u, u);
+              values<2, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
               __syncthreads();
-              values<1, false, false, true>(global_shape_values, u, u);
+              values<1, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
               __syncthreads();
-              values<0, false, false, true>(global_shape_values, u, u);
+              values<0, false, false, true>(get_global_shape_values<Number>(),
+                                            u,
+                                            u);
               __syncthreads();
 
               break;

--- a/tests/cuda/cuda_evaluate_1d_shape.cu
+++ b/tests/cuda/cuda_evaluate_1d_shape.cu
@@ -46,10 +46,10 @@ evaluate_tensor_product(double *dst, double *src)
 
   if (type == 0)
     evaluator.template values<0, dof_to_quad, add, false>(
-      CUDAWrappers::internal::global_shape_values, src, dst);
+      CUDAWrappers::internal::get_global_shape_values<double>(), src, dst);
   if (type == 1)
     evaluator.template gradients<0, dof_to_quad, add, false>(
-      CUDAWrappers::internal::global_shape_values, src, dst);
+      CUDAWrappers::internal::get_global_shape_values<double>(), src, dst);
 }
 
 template <int M, int N, int type, bool add>
@@ -98,20 +98,20 @@ test()
 
   unsigned int size_shape_values = M * N * sizeof(double);
 
-  cudaError_t cuda_error =
-    cudaMemcpyToSymbol(CUDAWrappers::internal::global_shape_values,
-                       shape_host.begin(),
-                       size_shape_values,
-                       0,
-                       cudaMemcpyHostToDevice);
+  cudaError_t cuda_error = cudaMemcpyToSymbol(
+    CUDAWrappers::internal::get_global_shape_values<double>(),
+    shape_host.begin(),
+    size_shape_values,
+    0,
+    cudaMemcpyHostToDevice);
   AssertCuda(cuda_error);
 
-  cuda_error =
-    cudaMemcpyToSymbol(CUDAWrappers::internal::global_shape_gradients,
-                       shape_host.begin(),
-                       size_shape_values,
-                       0,
-                       cudaMemcpyHostToDevice);
+  cuda_error = cudaMemcpyToSymbol(
+    CUDAWrappers::internal::get_global_shape_gradients<double>(),
+    shape_host.begin(),
+    size_shape_values,
+    0,
+    cudaMemcpyHostToDevice);
   AssertCuda(cuda_error);
 
   // Launch the kernel

--- a/tests/cuda/cuda_evaluate_2d_shape.cu
+++ b/tests/cuda/cuda_evaluate_2d_shape.cu
@@ -47,18 +47,18 @@ evaluate_tensor_product(double *dst, double *src)
   if (type == 0)
     {
       evaluator.template values<0, dof_to_quad, false, false>(
-        CUDAWrappers::internal::global_shape_values, src, src);
+        CUDAWrappers::internal::get_global_shape_values<double>(), src, src);
       __syncthreads();
       evaluator.template values<1, dof_to_quad, add, false>(
-        CUDAWrappers::internal::global_shape_values, src, dst);
+        CUDAWrappers::internal::get_global_shape_values<double>(), src, dst);
     }
   if (type == 1)
     {
       evaluator.template gradients<0, dof_to_quad, false, false>(
-        CUDAWrappers::internal::global_shape_values, src, src);
+        CUDAWrappers::internal::get_global_shape_values<double>(), src, src);
       __syncthreads();
       evaluator.template gradients<1, dof_to_quad, add, false>(
-        CUDAWrappers::internal::global_shape_values, src, dst);
+        CUDAWrappers::internal::get_global_shape_values<double>(), src, dst);
     }
 }
 
@@ -123,20 +123,20 @@ test()
 
   unsigned int size_shape_values = M * N * sizeof(double);
 
-  cudaError_t cuda_error =
-    cudaMemcpyToSymbol(CUDAWrappers::internal::global_shape_values,
-                       shape_host.begin(),
-                       size_shape_values,
-                       0,
-                       cudaMemcpyHostToDevice);
+  cudaError_t cuda_error = cudaMemcpyToSymbol(
+    CUDAWrappers::internal::get_global_shape_values<double>(),
+    shape_host.begin(),
+    size_shape_values,
+    0,
+    cudaMemcpyHostToDevice);
   AssertCuda(cuda_error);
 
-  cuda_error =
-    cudaMemcpyToSymbol(CUDAWrappers::internal::global_shape_gradients,
-                       shape_host.begin(),
-                       size_shape_values,
-                       0,
-                       cudaMemcpyHostToDevice);
+  cuda_error = cudaMemcpyToSymbol(
+    CUDAWrappers::internal::get_global_shape_gradients<double>(),
+    shape_host.begin(),
+    size_shape_values,
+    0,
+    cudaMemcpyHostToDevice);
   AssertCuda(cuda_error);
 
   // Launch the kernel


### PR DESCRIPTION
Previously, we were not able to compile with `float` as number type since `global_co_shape_gradients`/`global_shape_gradients`/`global_shape_values` were `double` arrays.
This pull request fixes the issue by duplicating the storage for `float`.