### PR TITLE
Add python wrappers for manifolds and extend tria wrappers

### DIFF
--- a/contrib/python-bindings/include/cell_accessor_wrapper.h
+++ b/contrib/python-bindings/include/cell_accessor_wrapper.h
@@ -126,6 +126,13 @@ namespace python
     get_manifold_id() const;
 
     /**
+     * Do as set_manifold_id() but also set the manifold indicators of
+     * the objects that bound the current object.
+     */
+    void
+    set_all_manifold_ids(const int manifold_id);
+
+    /**
      * Return the ith neighbor of a cell. If the neighbor does not exist,
      * i.e., if the ith face of the current object is at the boundary,
      * then an exception is thrown.
@@ -153,6 +160,18 @@ namespace python
      */
     boost::python::list
     faces() const;
+
+    /**
+     * Compute the dim-dimensional measure of the object.
+     * For a dim-dimensional cell in dim-dimensional space,
+     * this equals its volume. On the other hand, for a 2d
+     * cell in 3d space, or if the current object pointed to
+     * is a 2d face of a 3d cell in 3d space, then the function
+     * computes the area the object occupies. For a
+     * one-dimensional object, return its length.
+     */
+    double
+    measure() const;
 
     /**
      * Exception.

--- a/contrib/python-bindings/include/manifold_wrapper.h
+++ b/contrib/python-bindings/include/manifold_wrapper.h
@@ -60,7 +60,7 @@ namespace python
      * Create CylindricalManifold
      */
     void
-    create_cylindrical(const int axis, const double tolerance);
+    create_cylindrical(const int axis = 0, const double tolerance = 1e-10);
 
     /**
      * Return pointer to an underlying manifold object

--- a/contrib/python-bindings/include/manifold_wrapper.h
+++ b/contrib/python-bindings/include/manifold_wrapper.h
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_manifold_wrapper_h
+#define dealii_manifold_wrapper_h
+
+#include <deal.II/base/config.h>
+
+#include <boost/python.hpp>
+
+#include <point_wrapper.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace python
+{
+  class ManifoldWrapper
+  {
+  public:
+    /**
+     * Copy constructor.
+     */
+    ManifoldWrapper(const ManifoldWrapper &other);
+
+    /**
+     * Constructor.
+     */
+    ManifoldWrapper(const int dim, const int spacedim);
+
+    /**
+     * Destructor.
+     */
+    ~ManifoldWrapper();
+
+    /**
+     * Create SphericalManifold
+     */
+    void
+    create_spherical(const PointWrapper center);
+
+    /**
+     * Create PolarManifold
+     */
+    void
+    create_polar(const PointWrapper center);
+
+    /**
+     * Create CylindricalManifold
+     */
+    void
+    create_cylindrical(const int axis, const double tolerance);
+
+    /**
+     * Return pointer to an underlying manifold object
+     */
+    void *
+    get_manifold() const;
+
+
+  private:
+    /**
+     * Dimension of the underlying Manifold object.
+     */
+    int dim;
+
+    /**
+     * Space dimension of the underlying Manifold object.
+     */
+    int spacedim;
+
+    /**
+     * Pointer that can be casted to the underlying Mapping object.
+     */
+    void *manifold_ptr;
+  };
+
+} // namespace python
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/contrib/python-bindings/include/manifold_wrapper.h
+++ b/contrib/python-bindings/include/manifold_wrapper.h
@@ -68,6 +68,17 @@ namespace python
     void *
     get_manifold() const;
 
+    /**
+     * Return the dimension of the underlying object
+     */
+    int
+    get_dim() const;
+
+    /**
+     * Return the space dimension of the underlying object
+     */
+    int
+    get_spacedim() const;
 
   private:
     /**

--- a/contrib/python-bindings/include/tria_accessor_wrapper.h
+++ b/contrib/python-bindings/include/tria_accessor_wrapper.h
@@ -103,6 +103,18 @@ namespace python
     at_boundary() const;
 
     /**
+     * Compute the dim-dimensional measure of the object.
+     * For a dim-dimensional cell in dim-dimensional space,
+     * this equals its volume. On the other hand, for a 2d
+     * cell in 3d space, or if the current object pointed to
+     * is a 2d face of a 3d cell in 3d space, then the function
+     * computes the area the object occupies. For a
+     * one-dimensional object, return its length.
+     */
+    double
+    measure() const;
+
+    /**
      * Exception.
      */
     DeclException2(ExcVertexDoesNotExist,

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -268,6 +268,19 @@ namespace python
     generate_half_hyper_ball(PointWrapper &center, const double radius = 1.);
 
     /**
+     * Produce a hyper-shell, the region between two spheres around center,
+     * with given inner_radius and outer_radius. The number n_cells indicates
+     * the number of cells of the resulting triangulation, i.e., how many
+     * cells form the ring (in 2d) or the shell (in 3d).
+     * The appropriate manifold class is SphericalManifold.
+     */
+    void
+    generate_hyper_shell(PointWrapper & center,
+                         const double   inner_radius,
+                         const double   outer_radius,
+                         const unsigned n_cells = 0);
+
+    /**
      * Shift each vertex of the Triangulation by the given @p shift_list.
      */
     void
@@ -333,6 +346,13 @@ namespace python
      */
     void
     write(const std::string &filename, const std::string format) const;
+
+    /**
+     * Read mesh from the file @filename using the given data
+     * format.
+     */
+    void
+    read(const std::string &filename, const std::string format) const;
 
     /**
      * Write the Triangulation in file.

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -20,6 +20,7 @@
 
 #include <boost/python.hpp>
 
+#include <manifold_wrapper.h>
 #include <point_wrapper.h>
 
 #include <string>
@@ -300,6 +301,12 @@ namespace python
      */
     void
     flatten_triangulation(TriangulationWrapper &tria_out);
+
+    /**
+     *
+     */
+    void
+    set_manifold(const int number, ManifoldWrapper &manifold);
 
     /**
      * Refine all the cells @p n times.

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -278,7 +278,8 @@ namespace python
     generate_hyper_shell(PointWrapper & center,
                          const double   inner_radius,
                          const double   outer_radius,
-                         const unsigned n_cells = 0);
+                         const unsigned n_cells  = 0,
+                         bool           colorize = false);
 
     /**
      * Shift each vertex of the Triangulation by the given @p shift_list.
@@ -316,10 +317,25 @@ namespace python
     flatten_triangulation(TriangulationWrapper &tria_out);
 
     /**
-     *
+     * Assign a manifold object to a certain part of the triangulation.
+     * If an object with manifold number is refined, this object
+     * is used to find the location of new vertices (see the results
+     * section of step-49 for a more in-depth discussion of this, with
+     * examples). It is also used for non-linear (i.e.: non-Q1)
+     * transformations of cells to the unit cell in shape function
+     * calculations.
      */
     void
     set_manifold(const int number, ManifoldWrapper &manifold);
+
+    /**
+     * Reset those parts of the triangulation with the given manifold_number to
+     * use a FlatManifold object. This is the default state of a non-curved
+     * triangulation, and undoes assignment of a different Manifold object by
+     * the function Triangulation::set_manifold().
+     */
+    void
+    reset_manifold(const int number);
 
     /**
      * Refine all the cells @p n times.

--- a/contrib/python-bindings/source/CMakeLists.txt
+++ b/contrib/python-bindings/source/CMakeLists.txt
@@ -95,11 +95,13 @@ SET(_src
   export_point.cc
   export_triangulation.cc
   export_mapping.cc
+  export_manifold.cc
   cell_accessor_wrapper.cc
   tria_accessor_wrapper.cc
   point_wrapper.cc
   triangulation_wrapper.cc
   mapping_wrapper.cc
+  manifold_wrapper.cc
   )
 
 FOREACH(_build ${DEAL_II_BUILD_TYPES})

--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -252,6 +252,17 @@ namespace python
 
 
     template <int dim, int spacedim>
+    void
+    set_all_manifold_ids(const int manifold_id, void *cell_accessor)
+    {
+      const CellAccessor<dim, spacedim> *cell =
+        static_cast<const CellAccessor<dim, spacedim> *>(cell_accessor);
+      return cell->set_all_manifold_ids(manifold_id);
+    }
+
+
+
+    template <int dim, int spacedim>
     bool
     at_boundary(const void *cell_accessor)
     {
@@ -303,6 +314,18 @@ namespace python
         }
 
       return faces_list;
+    }
+
+
+
+    template <int dim, int spacedim>
+    double
+    measure(const void *cell_accessor)
+    {
+      const CellAccessor<dim, spacedim> *cell =
+        static_cast<const CellAccessor<dim, spacedim> *>(cell_accessor);
+
+      return cell->measure();
     }
   } // namespace internal
 
@@ -558,6 +581,19 @@ namespace python
 
 
 
+  void
+  CellAccessorWrapper::set_all_manifold_ids(const int manifold_id)
+  {
+    if ((dim == 2) && (spacedim == 2))
+      internal::set_all_manifold_ids<2, 2>(manifold_id, cell_accessor);
+    else if ((dim == 2) && (spacedim == 3))
+      internal::set_all_manifold_ids<2, 3>(manifold_id, cell_accessor);
+    else
+      internal::set_all_manifold_ids<3, 3>(manifold_id, cell_accessor);
+  }
+
+
+
   bool
   CellAccessorWrapper::at_boundary() const
   {
@@ -608,6 +644,19 @@ namespace python
       return internal::faces<2, 3>(cell_accessor);
     else
       return internal::faces<3, 3>(cell_accessor);
+  }
+
+
+
+  double
+  CellAccessorWrapper::measure() const
+  {
+    if ((dim == 2) && (spacedim == 2))
+      return internal::measure<2, 2>(cell_accessor);
+    else if ((dim == 2) && (spacedim == 3))
+      return internal::measure<2, 3>(cell_accessor);
+    else
+      return internal::measure<3, 3>(cell_accessor);
   }
 
 } // namespace python

--- a/contrib/python-bindings/source/export_cell_accessor.cc
+++ b/contrib/python-bindings/source/export_cell_accessor.cc
@@ -57,6 +57,12 @@ namespace python
 
 
 
+  const char set_all_manifold_ids_docstring[] =
+    "Do as set_manifold_id() but also set the manifold indicators of    \n"
+    "the objects that bound the current object.                         \n";
+
+
+
   const char barycenter_docstring[] =
     "Return the barycenter of the current cell                          \n";
 
@@ -97,6 +103,11 @@ namespace python
 
 
 
+  const char measure_docstring[] =
+    " Compute the dim-dimensional measure of the object.                 \n";
+
+
+
   void
   export_cell_accessor()
   {
@@ -119,6 +130,10 @@ namespace python
                     &CellAccessorWrapper::get_manifold_id,
                     &CellAccessorWrapper::set_manifold_id,
                     manifold_id_docstring)
+      .def("set_all_manifold_ids",
+           &CellAccessorWrapper::set_all_manifold_ids,
+           set_all_manifold_ids_docstring,
+           boost::python::args("self", "number"))
       .def("barycenter",
            &CellAccessorWrapper::get_barycenter,
            barycenter_docstring,
@@ -146,6 +161,10 @@ namespace python
       .def("faces",
            &CellAccessorWrapper::faces,
            faces_docstring,
+           boost::python::args("self"))
+      .def("measure",
+           &CellAccessorWrapper::measure,
+           measure_docstring,
            boost::python::args("self"));
   }
 } // namespace python

--- a/contrib/python-bindings/source/export_manifold.cc
+++ b/contrib/python-bindings/source/export_manifold.cc
@@ -21,6 +21,12 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace python
 {
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(create_cylindrical_overloads,
+                                         create_cylindrical,
+                                         0,
+                                         2)
+
+
   const char create_spherical_docstring[] =
     " Create spherical manifold with a given center point       \n";
 
@@ -39,7 +45,7 @@ namespace python
   export_manifold()
   {
     boost::python::class_<ManifoldWrapper>(
-      "ManifoldWrapper",
+      "Manifold",
       boost::python::init<const int, const int>(
         boost::python::args("dim", "spacedim")))
       .def("create_spherical",
@@ -52,8 +58,9 @@ namespace python
            boost::python::args("self", "center"))
       .def("create_cylindrical",
            &ManifoldWrapper::create_cylindrical,
-           create_cylindrical_docstring,
-           boost::python::args("self", "axis", "tolerance"));
+           create_cylindrical_overloads(
+             boost::python::args("self", "axis", "tolerance"),
+             create_cylindrical_docstring));
   }
 } // namespace python
 

--- a/contrib/python-bindings/source/export_manifold.cc
+++ b/contrib/python-bindings/source/export_manifold.cc
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <boost/python.hpp>
+
+#include <manifold_wrapper.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace python
+{
+  const char create_spherical_docstring[] =
+    " Create spherical manifold with a given center point       \n";
+
+
+  const char create_polar_docstring[] =
+    " Create polar manifold with a given center point           \n";
+
+
+  const char create_cylindrical_docstring[] =
+    " Create cylindrical manifold along a given axis            \n"
+    " (0 - x, 1 - y, 2 - z)                                     \n";
+
+
+
+  void
+  export_manifold()
+  {
+    boost::python::class_<ManifoldWrapper>(
+      "ManifoldWrapper",
+      boost::python::init<const int, const int>(
+        boost::python::args("dim", "spacedim")))
+      .def("create_spherical",
+           &ManifoldWrapper::create_spherical,
+           create_spherical_docstring,
+           boost::python::args("self", "center"))
+      .def("create_polar",
+           &ManifoldWrapper::create_polar,
+           create_polar_docstring,
+           boost::python::args("self", "center"))
+      .def("create_cylindrical",
+           &ManifoldWrapper::create_cylindrical,
+           create_cylindrical_docstring,
+           boost::python::args("self", "axis", "tolerance"));
+  }
+} // namespace python
+
+DEAL_II_NAMESPACE_CLOSE

--- a/contrib/python-bindings/source/export_tria_accessor.cc
+++ b/contrib/python-bindings/source/export_tria_accessor.cc
@@ -44,6 +44,9 @@ namespace python
   const char at_boundary_docstring[] =
     " Return whether the face is at the boundary                        \n";
 
+  const char measure_docstring[] =
+    " Compute the dim-dimensional measure of the object.                 \n";
+
   void
   export_tria_accessor()
   {
@@ -77,7 +80,11 @@ namespace python
       .def("set_all_boundary_ids",
            &TriaAccessorWrapper::set_all_boundary_ids,
            set_all_boundary_ids_docstring,
-           boost::python::args("self", "boundary_id"));
+           boost::python::args("self", "boundary_id"))
+      .def("measure",
+           &TriaAccessorWrapper::measure,
+           measure_docstring,
+           boost::python::args("self"));
   }
 } // namespace python
 

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -93,11 +93,10 @@ namespace python
                                          generate_half_hyper_ball,
                                          1,
                                          2)
-
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(generate_hyper_shell_overloads,
                                          generate_hyper_shell,
                                          3,
-                                         4)
+                                         5)
 
   const char n_active_cells_docstring[] =
     "Return the number of active cells                                      \n";
@@ -360,6 +359,12 @@ namespace python
 
 
 
+  const char reset_manifold_docstring[] =
+    "Reset those parts of the triangulation with the given manifold_number  \n"
+    "to use a FlatManifold object.                                          \n";
+
+
+
   void
   export_triangulation()
   {
@@ -468,7 +473,8 @@ namespace python
                                                               "center",
                                                               "inner_radius",
                                                               "outer_radius",
-                                                              "n_cells"),
+                                                              "n_cells",
+                                                              "colorize"),
                                           generate_hyper_shell_docstring))
       .def("shift",
            &TriangulationWrapper::shift,
@@ -513,7 +519,11 @@ namespace python
       .def("set_manifold",
            &TriangulationWrapper::set_manifold,
            set_manifold_docstring,
-           boost::python::args("self", "number", "manifold"));
+           boost::python::args("self", "number", "manifold"))
+      .def("reset_manifold",
+           &TriangulationWrapper::reset_manifold,
+           reset_manifold_docstring,
+           boost::python::args("self", "number"));
   }
 } // namespace python
 

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -333,6 +333,13 @@ namespace python
 
 
 
+  const char set_manifold_docstring[] =
+    "Assign a manifold object to a certain part of the triangulation.       \n"
+    "The manifold_object is not copied and MUST persist until the           \n"
+    "triangulation is destroyed.                                            \n";
+
+
+
   void
   export_triangulation()
   {
@@ -470,7 +477,11 @@ namespace python
       .def("load",
            &TriangulationWrapper::load,
            load_docstring,
-           boost::python::args("self", "filename"));
+           boost::python::args("self", "filename"))
+      .def("set_manifold",
+           &TriangulationWrapper::set_manifold,
+           set_manifold_docstring,
+           boost::python::args("self", "number", "manifold"));
   }
 } // namespace python
 

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -94,7 +94,10 @@ namespace python
                                          1,
                                          2)
 
-
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(generate_hyper_shell_overloads,
+                                         generate_hyper_shell,
+                                         3,
+                                         4)
 
   const char n_active_cells_docstring[] =
     "Return the number of active cells                                      \n";
@@ -252,6 +255,15 @@ namespace python
 
 
 
+  const char generate_hyper_shell_docstring[] =
+    "Produce a hyper-shell, the region between two spheres around center,   \n"
+    "with given inner_radius and outer_radius. The number n_cells indicates \n"
+    "the number of cells of the resulting triangulation, i.e., how many     \n"
+    "cells form the ring (in 2d) or the shell (in 3d).                      \n"
+    "The appropriate manifold class is SphericalManifold.                   \n";
+
+
+
   const char generate_half_hyper_ball_docstring[] =
     "Generate a half hyper-ball around center, which contains four          \n"
     "elements in 2d and 6 in 3d. The cut plane is perpendicular to the      \n"
@@ -320,6 +332,14 @@ namespace python
     "  - mathgl                                                             \n"
     "  - vtk                                                                \n"
     "  - vtu                                                                \n";
+
+
+
+  const char read_docstring[] =
+    "Read a mesh from the file according to the given data format.          \n"
+    "The possible formats are:                                              \n"
+    "  - msh                                                                \n"
+    "  - vtk                                                                \n";
 
 
 
@@ -442,6 +462,14 @@ namespace python
            generate_half_hyper_ball_overloads(
              boost::python::args("self", "center", "radius"),
              generate_half_hyper_ball_docstring))
+      .def("generate_hyper_shell",
+           &TriangulationWrapper::generate_hyper_shell,
+           generate_hyper_shell_overloads(boost::python::args("self",
+                                                              "center",
+                                                              "inner_radius",
+                                                              "outer_radius",
+                                                              "n_cells"),
+                                          generate_hyper_shell_docstring))
       .def("shift",
            &TriangulationWrapper::shift,
            shift_docstring,
@@ -469,6 +497,10 @@ namespace python
       .def("write",
            &TriangulationWrapper::write,
            write_docstring,
+           boost::python::args("self", "filename", "format"))
+      .def("read",
+           &TriangulationWrapper::read,
+           read_docstring,
            boost::python::args("self", "filename", "format"))
       .def("save",
            &TriangulationWrapper::save,

--- a/contrib/python-bindings/source/manifold_wrapper.cc
+++ b/contrib/python-bindings/source/manifold_wrapper.cc
@@ -215,11 +215,29 @@ namespace python
   }
 
 
+
   void *
   ManifoldWrapper::get_manifold() const
   {
     return manifold_ptr;
   }
+
+
+
+  int
+  ManifoldWrapper::get_dim() const
+  {
+    return dim;
+  }
+
+
+
+  int
+  ManifoldWrapper::get_spacedim() const
+  {
+    return spacedim;
+  }
+
 
 } // namespace python
 

--- a/contrib/python-bindings/source/manifold_wrapper.cc
+++ b/contrib/python-bindings/source/manifold_wrapper.cc
@@ -1,0 +1,220 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/grid/manifold_lib.h>
+
+#include <manifold_wrapper.h>
+#include <point_wrapper.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace python
+{
+  namespace internal
+  {
+    template <int dim, int spacedim>
+    Manifold<dim, spacedim> *
+    create_spherical_manifold(PointWrapper center)
+    {
+      const Point<spacedim> *point =
+        static_cast<const Point<spacedim> *>(center.get_point());
+      return new SphericalManifold<dim, spacedim>(*point);
+    }
+
+
+
+    template <int dim, int spacedim>
+    Manifold<dim, spacedim> *
+    create_polar_manifold(PointWrapper center)
+    {
+      const Point<spacedim> *point =
+        static_cast<const Point<spacedim> *>(center.get_point());
+      return new PolarManifold<dim, spacedim>(*point);
+    }
+
+
+
+    template <int dim, int spacedim>
+    Manifold<dim, spacedim> *
+    create_cylindrical_manifold(const int axis, const double tolerance)
+    {
+      return new CylindricalManifold<dim, spacedim>(axis, tolerance);
+    }
+
+
+
+    template <int dim, int spacedim>
+    Manifold<dim, spacedim> *
+    clone(void *manifold_ptr)
+    {
+      const Manifold<dim, spacedim> *manifold =
+        static_cast<const Manifold<dim, spacedim> *>(manifold_ptr);
+
+      if (const SphericalManifold<dim, spacedim> *d =
+            dynamic_cast<const SphericalManifold<dim, spacedim> *>(manifold))
+        {
+          return new SphericalManifold<dim, spacedim>(*d);
+        }
+      else if (const PolarManifold<dim, spacedim> *d =
+                 dynamic_cast<const PolarManifold<dim, spacedim> *>(manifold))
+        {
+          return new PolarManifold<dim, spacedim>(*d);
+        }
+      else
+        ExcMessage("Unsupported manifold type in clone.");
+
+      return nullptr;
+    }
+  } // namespace internal
+
+
+
+  ManifoldWrapper::ManifoldWrapper(const int dim, const int spacedim)
+    : dim(dim)
+    , spacedim(spacedim)
+  {
+    AssertThrow(((dim == 2) && (spacedim == 2)) ||
+                  ((dim == 2) && (spacedim == 3)) ||
+                  ((dim == 3) && (spacedim == 3)),
+                ExcMessage("Wrong dim-spacedim combination."));
+  }
+
+
+
+  ManifoldWrapper::ManifoldWrapper(const ManifoldWrapper &other)
+  {
+    dim      = other.dim;
+    spacedim = other.spacedim;
+
+    AssertThrow(other.manifold_ptr != nullptr,
+                ExcMessage("Underlying manifold does not exist."));
+
+    if ((dim == 2) && (spacedim == 2))
+      {
+        manifold_ptr = internal::clone<2, 2>(other.manifold_ptr);
+      }
+    else if ((dim == 2) && (spacedim == 3))
+      {
+        manifold_ptr = internal::clone<2, 3>(other.manifold_ptr);
+      }
+    else if ((dim == 3) && (spacedim == 3))
+      {
+        manifold_ptr = internal::clone<3, 3>(other.manifold_ptr);
+      }
+    else
+      AssertThrow(false, ExcMessage("Wrong dim-spacedim combination."));
+  }
+
+
+
+  ManifoldWrapper::~ManifoldWrapper()
+  {
+    if (dim != -1)
+      {
+        if ((dim == 2) && (spacedim == 2))
+          {
+            // We cannot call delete on a void pointer so cast the void pointer
+            // back first.
+            Manifold<2, 2> *tmp = static_cast<Manifold<2, 2> *>(manifold_ptr);
+            delete tmp;
+          }
+        else if ((dim == 2) && (spacedim == 3))
+          {
+            Manifold<2, 3> *tmp = static_cast<Manifold<2, 3> *>(manifold_ptr);
+            delete tmp;
+          }
+        else
+          {
+            Manifold<3, 3> *tmp = static_cast<Manifold<3, 3> *>(manifold_ptr);
+            delete tmp;
+          }
+
+        dim          = -1;
+        spacedim     = -1;
+        manifold_ptr = nullptr;
+      }
+  }
+
+
+
+  void
+  ManifoldWrapper::create_spherical(const PointWrapper center)
+  {
+    if ((dim == 2) && (spacedim == 2))
+      {
+        manifold_ptr = internal::create_spherical_manifold<2, 2>(center);
+      }
+    else if ((dim == 2) && (spacedim == 3))
+      {
+        manifold_ptr = internal::create_spherical_manifold<2, 3>(center);
+      }
+    else if ((dim == 3) && (spacedim == 3))
+      {
+        manifold_ptr = internal::create_spherical_manifold<3, 3>(center);
+      }
+    else
+      AssertThrow(false, ExcMessage("Wrong dim-spacedim combination."));
+  }
+
+
+
+  void
+  ManifoldWrapper::create_polar(const PointWrapper center)
+  {
+    if ((dim == 2) && (spacedim == 2))
+      {
+        manifold_ptr = internal::create_polar_manifold<2, 2>(center);
+      }
+    else if ((dim == 2) && (spacedim == 3))
+      {
+        manifold_ptr = internal::create_polar_manifold<2, 3>(center);
+      }
+    else if ((dim == 3) && (spacedim == 3))
+      {
+        manifold_ptr = internal::create_polar_manifold<3, 3>(center);
+      }
+    else
+      AssertThrow(false, ExcMessage("Wrong dim-spacedim combination."));
+  }
+
+
+
+  void
+  ManifoldWrapper::create_cylindrical(const int axis, const double tolerance)
+  {
+    if ((dim == 2) && (spacedim == 3))
+      {
+        manifold_ptr =
+          internal::create_cylindrical_manifold<2, 3>(axis, tolerance);
+      }
+    else if ((dim == 3) && (spacedim == 3))
+      {
+        manifold_ptr =
+          internal::create_cylindrical_manifold<3, 3>(axis, tolerance);
+      }
+    else
+      AssertThrow(false, ExcMessage("Wrong dim-spacedim combination."));
+  }
+
+
+  void *
+  ManifoldWrapper::get_manifold() const
+  {
+    return manifold_ptr;
+  }
+
+} // namespace python
+
+DEAL_II_NAMESPACE_CLOSE

--- a/contrib/python-bindings/source/manifold_wrapper.cc
+++ b/contrib/python-bindings/source/manifold_wrapper.cc
@@ -26,7 +26,7 @@ namespace python
   {
     template <int dim, int spacedim>
     Manifold<dim, spacedim> *
-    create_spherical_manifold(PointWrapper center)
+    create_spherical_manifold(const PointWrapper &center)
     {
       const Point<spacedim> *point =
         static_cast<const Point<spacedim> *>(center.get_point());
@@ -37,7 +37,7 @@ namespace python
 
     template <int dim, int spacedim>
     Manifold<dim, spacedim> *
-    create_polar_manifold(PointWrapper center)
+    create_polar_manifold(const PointWrapper &center)
     {
       const Point<spacedim> *point =
         static_cast<const Point<spacedim> *>(center.get_point());
@@ -71,6 +71,12 @@ namespace python
                  dynamic_cast<const PolarManifold<dim, spacedim> *>(manifold))
         {
           return new PolarManifold<dim, spacedim>(*d);
+        }
+      else if (const CylindricalManifold<dim, spacedim> *d =
+                 dynamic_cast<const CylindricalManifold<dim, spacedim> *>(
+                   manifold))
+        {
+          return new CylindricalManifold<dim, spacedim>(*d);
         }
       else
         ExcMessage("Unsupported manifold type in clone.");

--- a/contrib/python-bindings/source/tria_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/tria_accessor_wrapper.cc
@@ -140,6 +140,17 @@ namespace python
           tria_accessor);
       return accessor->at_boundary();
     }
+
+
+    template <int structdim, int dim, int spacedim>
+    double
+    measure(const void *tria_accessor)
+    {
+      const TriaAccessor<structdim, dim, spacedim> *accessor =
+        static_cast<const TriaAccessor<structdim, dim, spacedim> *>(
+          tria_accessor);
+      return accessor->measure();
+    }
   } // namespace internal
 
 
@@ -334,6 +345,19 @@ namespace python
       return internal::at_boundary<1, 2, 3>(tria_accessor);
     else
       return internal::at_boundary<2, 3, 3>(tria_accessor);
+  }
+
+
+
+  double
+  TriaAccessorWrapper::measure() const
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      return internal::measure<1, 2, 2>(tria_accessor);
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      return internal::measure<1, 2, 3>(tria_accessor);
+    else
+      return internal::measure<2, 3, 3>(tria_accessor);
   }
 
 } // namespace python

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -380,6 +380,7 @@ namespace python
                          const double   inner_radius,
                          const double   outer_radius,
                          const unsigned n_cells,
+                         bool           colorize,
                          void *         triangulation)
     {
       // Cast the PointWrapper object to Point<dim>
@@ -390,7 +391,7 @@ namespace python
         static_cast<Triangulation<dim> *>(triangulation);
       tria->clear();
       GridGenerator::hyper_shell(
-        *tria, center_point, inner_radius, outer_radius, n_cells);
+        *tria, center_point, inner_radius, outer_radius, n_cells, colorize);
     }
 
 
@@ -1057,7 +1058,8 @@ namespace python
   TriangulationWrapper::generate_hyper_shell(PointWrapper & center,
                                              const double   inner_radius,
                                              const double   outer_radius,
-                                             const unsigned n_cells)
+                                             const unsigned n_cells,
+                                             bool           colorize)
   {
     AssertThrow(
       dim == spacedim,
@@ -1065,10 +1067,10 @@ namespace python
         "This function is only implemented for dim equal to spacedim."));
     if (dim == 2)
       internal::generate_hyper_shell<2>(
-        center, inner_radius, outer_radius, n_cells, triangulation);
+        center, inner_radius, outer_radius, n_cells, colorize, triangulation);
     else
       internal::generate_hyper_shell<3>(
-        center, inner_radius, outer_radius, n_cells, triangulation);
+        center, inner_radius, outer_radius, n_cells, colorize, triangulation);
   }
 
 
@@ -1354,6 +1356,15 @@ namespace python
   TriangulationWrapper::set_manifold(const int        number,
                                      ManifoldWrapper &manifold)
   {
+    AssertThrow(
+      dim == manifold.get_dim(),
+      ExcMessage(
+        "The Triangulation and Manifold should have the same dimension."));
+    AssertThrow(
+      spacedim == manifold.get_spacedim(),
+      ExcMessage(
+        "The Triangulation and Manifold should have the same space dimension."));
+
     if ((dim == 2) && (spacedim == 2))
       {
         Triangulation<2, 2> *tria =
@@ -1377,6 +1388,31 @@ namespace python
         Manifold<3, 3> *m =
           static_cast<Manifold<3, 3> *>(manifold.get_manifold());
         tria->set_manifold(number, *m);
+      }
+  }
+
+
+
+  void
+  TriangulationWrapper::reset_manifold(const int number)
+  {
+    if ((dim == 2) && (spacedim == 2))
+      {
+        Triangulation<2, 2> *tria =
+          static_cast<Triangulation<2, 2> *>(triangulation);
+        tria->reset_manifold(number);
+      }
+    else if ((dim == 2) && (spacedim == 3))
+      {
+        Triangulation<2, 3> *tria =
+          static_cast<Triangulation<2, 3> *>(triangulation);
+        tria->reset_manifold(number);
+      }
+    else
+      {
+        Triangulation<3, 3> *tria =
+          static_cast<Triangulation<3, 3> *>(triangulation);
+        tria->reset_manifold(number);
       }
   }
 

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -1266,6 +1266,39 @@ namespace python
   }
 
 
+
+  void
+  TriangulationWrapper::set_manifold(const int        number,
+                                     ManifoldWrapper &manifold)
+  {
+    if ((dim == 2) && (spacedim == 2))
+      {
+        Triangulation<2, 2> *tria =
+          static_cast<Triangulation<2, 2> *>(triangulation);
+        Manifold<2, 2> *m =
+          static_cast<Manifold<2, 2> *>(manifold.get_manifold());
+        tria->set_manifold(number, *m);
+      }
+    else if ((dim == 2) && (spacedim == 3))
+      {
+        Triangulation<2, 3> *tria =
+          static_cast<Triangulation<2, 3> *>(triangulation);
+        Manifold<2, 3> *m =
+          static_cast<Manifold<2, 3> *>(manifold.get_manifold());
+        tria->set_manifold(number, *m);
+      }
+    else
+      {
+        Triangulation<3, 3> *tria =
+          static_cast<Triangulation<3, 3> *>(triangulation);
+        Manifold<3, 3> *m =
+          static_cast<Manifold<3, 3> *>(manifold.get_manifold());
+        tria->set_manifold(number, *m);
+      }
+  }
+
+
+
   void
   TriangulationWrapper::setup(const std::string &dimension,
                               const std::string &spacedimension)

--- a/contrib/python-bindings/source/wrappers.cc
+++ b/contrib/python-bindings/source/wrappers.cc
@@ -33,6 +33,8 @@ namespace python
   export_triangulation();
   void
   export_mapping();
+  void
+  export_manifold();
 } // namespace python
 
 DEAL_II_NAMESPACE_CLOSE
@@ -66,6 +68,7 @@ BOOST_PYTHON_MODULE(Debug)
   dealii::python::export_point();
   dealii::python::export_triangulation();
   dealii::python::export_mapping();
+  dealii::python::export_manifold();
 }
 
 #else
@@ -84,6 +87,7 @@ BOOST_PYTHON_MODULE(Release)
   dealii::python::export_point();
   dealii::python::export_triangulation();
   dealii::python::export_mapping();
+  dealii::python::export_manifold();
 }
 
 #endif

--- a/contrib/python-bindings/tests/manifold_wrapper.py
+++ b/contrib/python-bindings/tests/manifold_wrapper.py
@@ -1,0 +1,71 @@
+# ---------------------------------------------------------------------
+#
+# Copyright (C) 2016 by the deal.II authors
+#
+# This file is part of the deal.II library.
+#
+# The deal.II library is free software; you can use it, redistribute
+# it, and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# The full text of the license can be found in the file LICENSE.md at
+# the top level directory of deal.II.
+#
+# ---------------------------------------------------------------------
+
+import math
+import unittest
+from PyDealII.Debug import *
+
+class TestManifoldWrapperShell(unittest.TestCase):
+
+    def setUp(self):
+        self.triangulation = Triangulation('2D')
+        p_center = Point([0, 0])
+        self.triangulation.generate_hyper_shell(center = p_center, inner_radius = 0.5, outer_radius = 1., n_cells = 0, colorize = True)
+
+        self.manifold = Manifold(dim = 2, spacedim = 2)
+        self.manifold.create_polar(p_center)
+
+    def test_manifold(self):
+        self.triangulation.set_manifold(0, self.manifold)
+        for cell in self.triangulation.active_cells():
+            cell.manifold_id = 0
+
+        self.triangulation.refine_global(3)
+
+        circumference = 0
+        for cell in self.triangulation.active_cells():
+            for face in cell.faces():
+                if face.at_boundary() and face.boundary_id == 1:
+                        circumference += face.measure()
+
+        self.assertTrue(abs(circumference - 2*math.pi)/(2*math.pi) < 1e-2)
+
+class TestManifoldWrapperBall(unittest.TestCase):
+
+    def setUp(self):
+        self.triangulation = Triangulation('3D')
+        p_center = Point([0., 0., 0.])
+        self.triangulation.generate_hyper_ball(center = p_center, radius = 1.)
+
+        self.manifold = Manifold(dim = 3, spacedim = 3)
+        self.manifold.create_spherical(p_center)
+
+    def test_manifold(self):
+        self.triangulation.reset_manifold(number = 0)
+        self.triangulation.set_manifold(number = 0, manifold = self.manifold)
+        for cell in self.triangulation.active_cells():
+            if cell.at_boundary():
+                cell.manifold_id = 0
+
+        self.triangulation.refine_global(3)
+
+        volume = 0
+        for cell in self.triangulation.active_cells():
+            volume += cell.measure()
+
+        self.assertTrue(abs(volume - 4./3. * math.pi) / (4./3.*math.pi) < 2e-2)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/contrib/python-bindings/tests/mapping_wrapper.py
+++ b/contrib/python-bindings/tests/mapping_wrapper.py
@@ -13,12 +13,6 @@
 #
 # ---------------------------------------------------------------------
 
-import os
-import sys
-module_path = os.path.abspath('/home/agrayver/lib/dealii/build_gofem/lib/python3.7/site-packages')
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
 import unittest
 from PyDealII.Debug import *
 

--- a/doc/news/changes/minor/20191128Grayver
+++ b/doc/news/changes/minor/20191128Grayver
@@ -1,0 +1,5 @@
+Added: New python wrappers for the Manifold class
+with a possibility to assign manifold object to a
+python triangulation object.
+<br>
+(Alexander Grayver, 2019/11/28)


### PR DESCRIPTION
This PR
- Adds possibility to work with manifolds from python. Currently SphericalManifold, PolarManifold and CylindricalManifold are supported. 
- In addition to the existing interface for the GridOut::write, adds GridIn::read support.
- Adds hyper_shell generator.

Here is an example:
![image](https://user-images.githubusercontent.com/8438035/69867480-31a5a880-12a7-11ea-8a3b-5b227f3dcb02.png)

Part of #9015 