### PR TITLE
Fixed cmake 3.16.0 incompatibility.

### DIFF
--- a/cmake/configure/configure_1_threads.cmake
+++ b/cmake/configure/configure_1_threads.cmake
@@ -38,6 +38,16 @@ MACRO(SETUP_THREADING)
 
     RESET_CMAKE_REQUIRED()
 
+    #
+    # The FindThreads macro returned a linker option instead of the actual
+    # library name in earlier versions. We still require the linker option,
+    # so we fix the corresponding variable.
+    #  - See: https://gitlab.kitware.com/cmake/cmake/issues/19747
+    #
+    IF(CMAKE_THREAD_LIBS_INIT AND NOT "${CMAKE_THREAD_LIBS_INIT}" MATCHES "^-l")
+      STRING(PREPEND CMAKE_THREAD_LIBS_INIT "-l")
+    ENDIF()
+
   ELSE()
 
     #


### PR DESCRIPTION
Fixes #9116.

I chose with the most pragmatic way of resolving this issue: By simply imitating what `CMake` did in previous versions.

There may be other ways of fixing this, e.g. by considering `pthreads` at the `TARGET_LINK_LIBRARIES` stage via
```
LIST(APPEND THREADS_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
```
However right now, we just add a linker flag, and I didn't want to overhaul the whole process without being able to assess the consequences.