### PR TITLE
Remove MF::get_size_info()

### DIFF
--- a/doc/news/changes/incompatibilities/20191201PeterMunch
+++ b/doc/news/changes/incompatibilities/20191201PeterMunch
@@ -1,0 +1,4 @@
+Removed: The deprecated method MatrixFree::get_size_info() has been removed.
+Please use the method MatrixFree::get_task_info() to access the same information.
+<br>
+(Peter Munch, 2019/12/01)

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3050,7 +3050,7 @@ inline FEEvaluationBase<dim,
 {
   set_data_pointers();
   Assert(matrix_info->mapping_initialized() == true, ExcNotInitialized());
-  AssertDimension(matrix_info->get_size_info().vectorization_length,
+  AssertDimension(matrix_info->get_task_info().vectorization_length,
                   VectorizedArrayType::n_array_elements);
   AssertDimension((is_face ? data->n_q_points_face : data->n_q_points),
                   n_quadrature_points);

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1725,13 +1725,6 @@ public:
   const internal::MatrixFreeFunctions::TaskInfo &
   get_task_info() const;
 
-  /**
-   * Return information on system size.
-   */
-  DEAL_II_DEPRECATED
-  const internal::MatrixFreeFunctions::TaskInfo &
-  get_size_info() const;
-
   /*
    * Return geometry-dependent information on the cells.
    */
@@ -2104,15 +2097,6 @@ MatrixFree<dim, Number, VectorizedArrayType>::n_base_elements(
 template <int dim, typename Number, typename VectorizedArrayType>
 inline const internal::MatrixFreeFunctions::TaskInfo &
 MatrixFree<dim, Number, VectorizedArrayType>::get_task_info() const
-{
-  return task_info;
-}
-
-
-
-template <int dim, typename Number, typename VectorizedArrayType>
-inline const internal::MatrixFreeFunctions::TaskInfo &
-MatrixFree<dim, Number, VectorizedArrayType>::get_size_info() const
 {
   return task_info;
 }


### PR DESCRIPTION
By having only a look at the Doxygen documentation, I was confused why there are two methods returning `TaskInfo` and which one I should use.

ping @kronbichler 