### PR TITLE
Fix some to some.

### DIFF
--- a/doc/news/changes/minor/20191202LucaHeltai
+++ b/doc/news/changes/minor/20191202LucaHeltai
@@ -1,0 +1,3 @@
+Fixed: Utilities::MPI::some_to_some() now allows sending to our own mpi process.
+<br>
+(Luca Heltai, 2019/12/02)

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1504,9 +1504,8 @@ namespace Utilities
       if (send_to.size() == 0)
         return received_objects;
 
-      const auto receive_from =
-        Utilities::MPI::compute_point_to_point_communication_pattern(comm,
-                                                                     send_to);
+      const auto n_point_point_communications =
+        Utilities::MPI::compute_n_point_to_point_communications(comm, send_to);
 
       // Protect the following communication:
       static CollectiveMutex      mutex;
@@ -1541,7 +1540,7 @@ namespace Utilities
       {
         std::vector<char> buffer;
         // We do this on a first come/first served basis
-        for (unsigned int i = 0; i < receive_from.size(); ++i)
+        for (unsigned int i = 0; i < n_point_point_communications; ++i)
           {
             // Probe what's going on. Take data from the first available sender
             MPI_Status status;

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1500,12 +1500,15 @@ namespace Utilities
         else
           send_to.emplace_back(m.first);
 
-      // Shortcut, when running in serial
-      if (send_to.size() == 0)
-        return received_objects;
-
       const auto n_point_point_communications =
         Utilities::MPI::compute_n_point_to_point_communications(comm, send_to);
+
+      // If we have something to send, or we expect something from other
+      // processors, we need to visit one of the two scopes below. Otherwise,
+      // no other action is required by this mpi process, and we can safely
+      // return.
+      if (send_to.size() == 0 && n_point_point_communications == 0)
+        return received_objects;
 
       // Protect the following communication:
       static CollectiveMutex      mutex;

--- a/tests/base/mpi_some_to_some_03.cc
+++ b/tests/base/mpi_some_to_some_03.cc
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Test Utilities::MPI::some_to_some when sending to myself as well.
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/patterns.h>
+#include <deal.II/base/point.h>
+
+#include <tuple>
+#include <vector>
+
+#include "../tests.h"
+
+
+void
+test()
+{
+  const auto n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const auto my_proc = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  std::map<unsigned int, std::vector<unsigned int>> to_send;
+
+  // send to myself and to my next one
+  to_send[my_proc].emplace_back(my_proc + 1);
+  to_send[(my_proc + 1) % n_procs].emplace_back((my_proc + 1) * 10);
+
+  const auto received = Utilities::MPI::some_to_some(MPI_COMM_WORLD, to_send);
+
+  const auto original = Utilities::MPI::some_to_some(MPI_COMM_WORLD, received);
+
+  deallog << "Sent                      : "
+          << Patterns::Tools::to_string(to_send) << std::endl;
+  deallog << "Received                  : "
+          << Patterns::Tools::to_string(received) << std::endl;
+  deallog << "Received(Received) == Sent: "
+          << Patterns::Tools::to_string(original) << std::endl;
+
+  // now check that to_send and original are the same
+  if (original == to_send)
+    deallog << "OK" << std::endl;
+  else
+    deallog << "Not OK" << std::endl;
+}
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  test();
+}

--- a/tests/base/mpi_some_to_some_03.mpirun=1.output
+++ b/tests/base/mpi_some_to_some_03.mpirun=1.output
@@ -1,0 +1,5 @@
+
+DEAL:0::Sent                      : 0:1, 10
+DEAL:0::Received                  : 0:1, 10
+DEAL:0::Received(Received) == Sent: 0:1, 10
+DEAL:0::OK

--- a/tests/base/mpi_some_to_some_03.mpirun=2.output
+++ b/tests/base/mpi_some_to_some_03.mpirun=2.output
@@ -1,0 +1,11 @@
+
+DEAL:0::Sent                      : 0:1; 1:10
+DEAL:0::Received                  : 0:1; 1:20
+DEAL:0::Received(Received) == Sent: 0:1; 1:10
+DEAL:0::OK
+
+DEAL:1::Sent                      : 0:20; 1:2
+DEAL:1::Received                  : 0:10; 1:2
+DEAL:1::Received(Received) == Sent: 0:20; 1:2
+DEAL:1::OK
+

--- a/tests/base/mpi_some_to_some_03.mpirun=3.output
+++ b/tests/base/mpi_some_to_some_03.mpirun=3.output
@@ -1,0 +1,17 @@
+
+DEAL:0::Sent                      : 0:1; 1:10
+DEAL:0::Received                  : 0:1; 2:30
+DEAL:0::Received(Received) == Sent: 0:1; 1:10
+DEAL:0::OK
+
+DEAL:1::Sent                      : 1:2; 2:20
+DEAL:1::Received                  : 0:10; 1:2
+DEAL:1::Received(Received) == Sent: 1:2; 2:20
+DEAL:1::OK
+
+
+DEAL:2::Sent                      : 0:30; 2:3
+DEAL:2::Received                  : 1:20; 2:3
+DEAL:2::Received(Received) == Sent: 0:30; 2:3
+DEAL:2::OK
+

--- a/tests/base/mpi_some_to_some_03.mpirun=4.output
+++ b/tests/base/mpi_some_to_some_03.mpirun=4.output
@@ -1,0 +1,23 @@
+
+DEAL:0::Sent                      : 0:1; 1:10
+DEAL:0::Received                  : 0:1; 3:40
+DEAL:0::Received(Received) == Sent: 0:1; 1:10
+DEAL:0::OK
+
+DEAL:1::Sent                      : 1:2; 2:20
+DEAL:1::Received                  : 0:10; 1:2
+DEAL:1::Received(Received) == Sent: 1:2; 2:20
+DEAL:1::OK
+
+
+DEAL:2::Sent                      : 2:3; 3:30
+DEAL:2::Received                  : 1:20; 2:3
+DEAL:2::Received(Received) == Sent: 2:3; 3:30
+DEAL:2::OK
+
+
+DEAL:3::Sent                      : 0:40; 3:4
+DEAL:3::Received                  : 2:30; 3:4
+DEAL:3::Received(Received) == Sent: 0:40; 3:4
+DEAL:3::OK
+


### PR DESCRIPTION
When calling `Utilities::MPI::some_to_some`, if the map contained our own mpi process, an assert would be thrown stating that we cannot communicate with our own process.

This PR modifies this behaviour, and makes sure that anything that we try to send to our selves is actually simply copied in the output map, simplifying the logic behind many algorithms.

