### PR TITLE
Use 5 refinements in step-61 as default.

### DIFF
--- a/examples/step-61/doc/results.dox
+++ b/examples/step-61/doc/results.dox
@@ -21,7 +21,8 @@ $\mbox{WG}(Q_2,Q_2;RT_{[2]})$.
 
 The following figures show interior pressures and face pressures using the
 $\mbox{WG}(Q_0,Q_0;RT_{[0]})$ element. The mesh is refined 2 times (top)
-and 4 times (bottom), respectively. When the mesh is coarse, one can see
+and 4 times (bottom), respectively. (This number can be adjusted in the
+`make_grid()` function.) When the mesh is coarse, one can see
 the face pressures $p^\partial$ neatly between the values of the interior
 pressures $p^\circ$ on the two adjacent cells.
 
@@ -45,7 +46,8 @@ in the interior of the cell, as expected.
 
 <h4>Convergence table</h4>
 
-We run the code with finer meshes and get the following convergence rates of pressure, 
+We run the code with differently refined meshes (chosen in the `make_grid()` function)
+and get the following convergence rates of pressure, 
 velocity, and flux (as defined in the introduction).
 
 <table align="center" class="doxtable">

--- a/examples/step-61/step-61.cc
+++ b/examples/step-61/step-61.cc
@@ -275,7 +275,7 @@ namespace Step61
   void WGDarcyEquation<dim>::make_grid()
   {
     GridGenerator::hyper_cube(triangulation, 0, 1);
-    triangulation.refine_global(2);
+    triangulation.refine_global(5);
 
     std::cout << "   Number of active cells: " << triangulation.n_active_cells()
               << std::endl


### PR DESCRIPTION
The current default of 2 is just too uninteresting when visualizing data.