### PR TITLE
Use a better way to create graphical output in step-61.

### DIFF
--- a/doc/news/changes/minor/20191202WolfgangBangerth-2
+++ b/doc/news/changes/minor/20191202WolfgangBangerth-2
@@ -1,0 +1,5 @@
+Changed: step-61 no longer generates two output files for the interior
+pressures and the Darcy velocities, respectively. Instead, it puts all
+of this information into a single graphical output file.
+<br>
+(Wolfgang Bangerth, 2019/12/02)

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -773,14 +773,15 @@ public:
    * discussion of the arguments except the first one) and allows to set a
    * vector with its own DoFHandler object. This DoFHandler needs to be
    * compatible with the other DoFHandler objects assigned with calls to @p
-   * add_data_vector or @p attach_dof_handler, in the sense that the
+   * add_data_vector or @p attach_dof_handler, in the sense that all of the
    * DoFHandler objects need to be based on the same triangulation. This
-   * function allows you to export data from multiple DoFHandlers that
-   * describe different solution components.
+   * function allows you to export data from multiple DoFHandler objects that
+   * describe different solution components. An example of using this function
+   * is given in step-61.
    *
    * Since this function takes a DoFHandler object and hence naturally
    * represents dof data, the data vector type argument present in the other
-   * methods above is skipped.
+   * methods above is not necessary.
    */
   template <class VectorType>
   void


### PR DESCRIPTION
Specifically, rather than creating two output files for the cell pressures
and the Darcy velocities, put them all into a single file using a method
that @kronbichler introduced a while ago.