### PR TITLE
Export the built library as artifact in appveyor

### DIFF
--- a/contrib/ci/appveyor.yml
+++ b/contrib/ci/appveyor.yml
@@ -5,5 +5,16 @@ build_script:
 - cmd: >-
     mkdir build &&
     cd build &&
-    cmake c:\projects\source -DCMAKE_BUILD_TYPE=Debug -G "Visual Studio 16 2019" &&
-    cmake --build . -- -m
+    cmake c:\projects\source -DCMAKE_BUILD_TYPE=Debug -G "Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX="c:\projects\dealii" &&
+    cmake --build . --target install -- -m
+
+for:
+-
+  branches:
+    only:
+      - master
+  after_build:
+    - cmd: 7z a c:\projects\source\dealii.zip c:\projects\dealii
+  artifacts:
+    - path: dealii.zip
+      name: deal.II


### PR DESCRIPTION
Responding to https://github.com/dealii/dealii/issues/1681#issuecomment-560464729, this exports the built library as an artifact. Tested at https://ci.appveyor.com/project/masterleinad/dealii/builds/29287957/artifacts. The build time increased by about 5 minutes.

We only do this for the master branch.