### PR TITLE
Cleanup function parser

### DIFF
--- a/doc/news/changes/incompatibilities/20191205DavidWells
+++ b/doc/news/changes/incompatibilities/20191205DavidWells
@@ -1,0 +1,3 @@
+Removed: The type alias FunctionParser::ConstMapIterator has been removed.
+<br>
+(David Wells, 2019/12/05)

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -91,8 +91,8 @@ class Vector;
  * @code
  * // set up problem:
  * std::string variables = "x,y";
- * std::string expression = "cos(x)+sqrt(y)";
- * std::map<std::string,double> constants;
+ * std::string expression = "cos(x) + sqrt(y)";
+ * std::map<std::string, double> constants;
  *
  * // FunctionParser with 2 variables and 1 component:
  * FunctionParser<2> fp(1);
@@ -113,7 +113,7 @@ class Vector;
  * The second example is a bit more complex:
  * @code
  * // Define some constants that will be used by the function parser
- * std::map<std::string,double> constants;
+ * std::map<std::string, double> constants;
  * constants["pi"] = numbers::PI;
  *
  * // Define the variables that will be used inside the expressions
@@ -162,7 +162,7 @@ class Vector;
  * at http://muparser.beltoforion.de/ .
  *
  * For a wrapper of the FunctionParser class that supports ParameterHandler,
- * see ParsedFunction.
+ * see Functions::ParsedFunction.
  *
  * Vector-valued functions can either be declared using strings where the
  * function components are separated by semicolons, or using a vector of
@@ -186,10 +186,8 @@ class Vector;
  *    function.initialize(variables,
  *                        expression,
  *                        constants,
- *                        true);        // This tells the parser that
- *                                      // it is a time-dependent function
- *                                      // and there is another variable
- *                                      // to be taken into account (t).
+ * // Treat the last variable ("t") as time.
+ *                        true);
  * @endcode
  *
  * The following is another example of how to instantiate a vector valued
@@ -222,13 +220,12 @@ class FunctionParser : public AutoDerivativeFunction<dim>
 {
 public:
   /**
-   * Constructor for parsed functions. Its arguments are the same of
-   * the base class Function, with the additional parameter @p h, used
-   * for the computation of gradients using finite differences. This
-   * object needs to be initialized with the initialize() method
-   * before you can use it. If an attempt to use this function is made
-   * before the initialize() method has been called, then an exception
-   * is thrown.
+   * Constructor. Its arguments are the same of the base class Function, with
+   * the additional parameter @p h, used for the computation of gradients
+   * using finite differences. This object needs to be initialized with the
+   * initialize() method before you can use it. If an attempt to use this
+   * function is made before the initialize() method has been called, then an
+   * exception is thrown.
    */
   FunctionParser(const unsigned int n_components = 1,
                  const double       initial_time = 0.0,
@@ -238,7 +235,7 @@ public:
    * Constructor for parsed functions. Takes directly a semi-colon separated
    * list of expressions (one for each component of the function), an optional
    * comma-separated list of constants, variable names and step size for the
-   * computation of first order derivatives by finite difference.
+   * computation of first order derivatives by finite differences.
    */
   FunctionParser(const std::string &expression,
                  const std::string &constants      = "",
@@ -289,9 +286,9 @@ public:
   using ConstMapIterator = ConstMap::iterator;
 
   /**
-   * Initialize the function.  This methods accepts the following parameters:
+   * Initialize the object by setting the actual parsed functions.
    *
-   * <b>vars</b>: a string with the variables that will be used by the
+   * @param[in] vars a string with the variables that will be used by the
    * expressions to be evaluated. Note that the variables can have any name
    * (of course different from the function names defined above!), but the
    * order IS important. The first variable will correspond to the first
@@ -300,27 +297,27 @@ public:
    * time dependent, then it is necessary to specify it by setting the
    * <code>time_dependent</code> parameter to true.  An exception is thrown if
    * the number of variables specified here is different from dim (if this
-   * function is not time-dependent) or from dim+1 (if it is time- dependent).
+   * function is not time-dependent) or from dim+1 (if it is time-dependent).
    *
-   * <b>expressions</b>: a list of strings containing the expressions that
-   * will be byte compiled by the internal parser (FunctionParser). Note that
+   * @param[in] expressions a list of strings containing the expressions that
+   * will be byte compiled by the internal parser (muParser). Note that
    * the size of this vector must match exactly the number of components of
    * the FunctionParser, as declared in the constructor. If this is not the
    * case, an exception is thrown.
    *
-   * <b>constants</b>: a map of constants used to pass any necessary constant
+   * @param[in] constants a map of constants used to pass any necessary constant
    * that we want to specify in our expressions (in the example above the
    * number pi). An expression is valid if and only if it contains only
    * defined variables and defined constants (other than the functions
    * specified above). If a constant is given whose name is not valid (eg:
    * <code>constants["sin"] = 1.5;</code>) an exception is thrown.
    *
-   * <b>time_dependent</b>. If this is a time dependent function, then the
-   * last variable declared in <b>vars</b> is assumed to be the time variable,
-   * and this->get_time() is used to initialize it when evaluating the
-   * function. Naturally the number of variables parsed by the initialize()
-   * method in this case is dim+1. The value of this parameter defaults to
-   * false, i.e. do not consider time.
+   * @param[in] time_dependent If this is a time dependent function, then the
+   * last variable declared in @p vars is assumed to be the time variable, and
+   * FunctionTime::get_time() is used to initialize it when evaluating the
+   * function. Naturally the number of variables parsed by initialize() in
+   * this case is dim+1. The value of this parameter defaults to false, i.e.,
+   * do not consider time.
    */
   void
   initialize(const std::string &             vars,
@@ -351,8 +348,8 @@ public:
 
   /**
    * Return the value of the function at the given point. Unless there is only
-   * one component (i.e. the function is scalar), you should state the
-   * component you want to have evaluated; it defaults to zero, i.e. the first
+   * one component (i.e., the function is scalar), you should state the
+   * component you want to have evaluated; it defaults to zero, i.e., the first
    * component.
    */
   virtual double

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -281,11 +281,6 @@ public:
   using ConstMap = std::map<std::string, double>;
 
   /**
-   * Iterator for the constants map. Used by the initialize() method.
-   */
-  using ConstMapIterator = ConstMap::iterator;
-
-  /**
    * Initialize the object by setting the actual parsed functions.
    *
    * @param[in] vars a string with the variables that will be used by the

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -256,10 +256,9 @@ public:
   FunctionParser(FunctionParser &&) = delete;
 
   /**
-   * Destructor. Explicitly delete the FunctionParser objects (there is one
-   * for each component of the function).
+   * Destructor.
    */
-  ~FunctionParser() override;
+  virtual ~FunctionParser() override;
 
   /**
    * Copy operator. Objects of this type can not be copied, and

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -112,37 +112,26 @@ FunctionParser<dim>::initialize(const std::string &             variables,
   AssertThrow(((time_dependent) ? dim + 1 : dim) == var_names.size(),
               ExcMessage("Wrong number of variables"));
 
-  // We check that the number of
-  // components of this function
-  // matches the number of components
-  // passed in as a vector of
-  // strings.
+  // We check that the number of components of this function matches the
+  // number of components passed in as a vector of strings.
   AssertThrow(this->n_components == expressions.size(),
               ExcInvalidExpressionSize(this->n_components, expressions.size()));
 
-  // Now we define how many variables
-  // we expect to read in.  We
-  // distinguish between two cases:
-  // Time dependent problems, and not
-  // time dependent problems. In the
-  // first case the number of
-  // variables is given by the
-  // dimension plus one. In the other
-  // case, the number of variables is
-  // equal to the dimension. Once we
-  // parsed the variables string, if
-  // none of this is the case, then
-  // an exception is thrown.
+  // Now we define how many variables we expect to read in.  We distinguish
+  // between two cases: Time dependent problems, and not time dependent
+  // problems. In the first case the number of variables is given by the
+  // dimension plus one. In the other case, the number of variables is equal
+  // to the dimension. Once we parsed the variables string, if none of this is
+  // the case, then an exception is thrown.
   if (time_dependent)
     n_vars = dim + 1;
   else
     n_vars = dim;
 
-  // create a parser object for the current thread we can then query
-  // in value() and vector_value(). this is not strictly necessary
-  // because a user may never call these functions on the current
-  // thread, but it gets us error messages about wrong formulas right
-  // away
+  // create a parser object for the current thread we can then query in
+  // value() and vector_value(). this is not strictly necessary because a user
+  // may never call these functions on the current thread, but it gets us
+  // error messages about wrong formulas right away
   init_muparser();
 
   // finally set the initialization bit

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -281,12 +281,9 @@ FunctionParser<dim>::init_muparser() const
     {
       fp.get().emplace_back(new mu::Parser());
 
-      for (std::map<std::string, double>::const_iterator constant =
-             constants.begin();
-           constant != constants.end();
-           ++constant)
+      for (const auto &constant : constants)
         {
-          fp.get()[component]->DefineConst(constant->first, constant->second);
+          fp.get()[component]->DefineConst(constant.first, constant.second);
         }
 
       for (unsigned int iv = 0; iv < var_names.size(); ++iv)

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -28,15 +28,6 @@
 
 #ifdef DEAL_II_WITH_MUPARSER
 #  include <muParser.h>
-#else
-
-
-
-namespace fparser
-{
-  class FunctionParser
-  {};
-} // namespace fparser
 #endif
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -79,9 +79,11 @@ FunctionParser<dim>::FunctionParser(const std::string &expression,
 }
 
 
-// We deliberately delay the definition of the default destructor
-// so that we don't need to include the definition of mu::Parser
-// in the header file.
+
+// Note: we explicitly define the destructor here (instead of silently using
+// the default destructor by declaring nothing in the header) since we do not
+// expect muParser.h to be available in user projects: i.e., the destructor
+// must be defined in the source file.
 template <int dim>
 FunctionParser<dim>::~FunctionParser() = default;
 


### PR DESCRIPTION
Related to #9125: there were a few places in the documentation that needed to be converted to doxygen style comments, some dead code, and a few other small things.