### PR TITLE
Add a series of new python wrappers

### DIFF
--- a/contrib/python-bindings/include/cell_accessor_wrapper.h
+++ b/contrib/python-bindings/include/cell_accessor_wrapper.h
@@ -90,7 +90,7 @@ namespace python
     get_barycenter() const;
 
     /**
-     * Get the barycenter of the cell.
+     * Get the center of the cell.
      */
     PointWrapper
     get_center(const bool respect_manifold             = false,

--- a/contrib/python-bindings/include/cell_accessor_wrapper.h
+++ b/contrib/python-bindings/include/cell_accessor_wrapper.h
@@ -90,6 +90,13 @@ namespace python
     get_barycenter() const;
 
     /**
+     * Get the barycenter of the cell.
+     */
+    PointWrapper
+    get_center(const bool respect_manifold             = false,
+               const bool interpolate_from_surrounding = false) const;
+
+    /**
      * Set the material id.
      */
     void

--- a/contrib/python-bindings/include/mapping_wrapper.h
+++ b/contrib/python-bindings/include/mapping_wrapper.h
@@ -61,6 +61,12 @@ namespace python
     PointWrapper
     transform_real_to_unit_cell(CellAccessorWrapper &cell, PointWrapper &point);
 
+    /**
+     * Get the underlying mapping
+     */
+    void *
+    get_mapping();
+
   private:
     /**
      * Dimension of the underlying Mapping object.

--- a/contrib/python-bindings/include/mapping_wrapper.h
+++ b/contrib/python-bindings/include/mapping_wrapper.h
@@ -38,6 +38,11 @@ namespace python
     MappingQGenericWrapper(const MappingQGenericWrapper &other);
 
     /**
+     * Default constructor.
+     */
+    MappingQGenericWrapper();
+
+    /**
      * Constructor.
      */
     MappingQGenericWrapper(const int dim, const int spacedim, const int degree);
@@ -62,7 +67,7 @@ namespace python
     transform_real_to_unit_cell(CellAccessorWrapper &cell, PointWrapper &point);
 
     /**
-     * Get the underlying mapping
+     * Get the underlying mapping.
      */
     void *
     get_mapping();

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -348,12 +348,13 @@ namespace python
 
     /**
      * Find and return an active cell that surrounds a given point p.
-     * The mapping used to determine whether the given point is inside a given
-     * cell.
+     * The mapping is used to determine whether the given point is inside a
+     * given cell.
      */
     CellAccessorWrapper
-    find_active_cell_around_point(PointWrapper &          p,
-                                  MappingQGenericWrapper &mapping);
+    find_active_cell_around_point(
+      PointWrapper &         p,
+      MappingQGenericWrapper mapping = MappingQGenericWrapper());
 
     /**
      * Assign a manifold object to a certain part of the triangulation.

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -21,6 +21,7 @@
 #include <boost/python.hpp>
 
 #include <manifold_wrapper.h>
+#include <mapping_wrapper.h>
 #include <point_wrapper.h>
 
 #include <string>
@@ -315,6 +316,44 @@ namespace python
      */
     void
     flatten_triangulation(TriangulationWrapper &tria_out);
+
+    /**
+     * Take a 2d Triangulation that is being extruded in z direction by
+     * the total height of height using n_slices slices (minimum is 2).
+     * The boundary indicators of the faces of input are going to be
+     * assigned to the corresponding side walls in z direction. The
+     * bottom and top get the next two free boundary indicators.
+     */
+    void
+    extrude_triangulation(const unsigned int    n_slices,
+                          const double          height,
+                          TriangulationWrapper &tria_out);
+
+    /**
+     * Distort the given triangulation by randomly moving around all the
+     * vertices of the grid. The direction of movement of each vertex is
+     * random, while the length of the shift vector has a value of factor
+     * times the minimal length of the active edges adjacent to this vertex.
+     * Note that factor should obviously be well below 0.5.
+     */
+    void
+    distort_random(const double factor, const bool keep_boundary = true);
+
+    /**
+     * Transform the vertices of the given triangulation by applying the
+     * function object provided as first argument to all its vertices.
+     */
+    void
+    transform(boost::python::object &transformation);
+
+    /**
+     * Find and return an active cell that surrounds a given point p.
+     * The mapping used to determine whether the given point is inside a given
+     * cell.
+     */
+    CellAccessorWrapper
+    find_active_cell_around_point(PointWrapper &          p,
+                                  MappingQGenericWrapper &mapping);
 
     /**
      * Assign a manifold object to a certain part of the triangulation.

--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -173,6 +173,22 @@ namespace python
       return PointWrapper(barycenter_list);
     }
 
+    template <int dim, int spacedim>
+    PointWrapper
+    get_center(const bool  respect_manifold,
+               const bool  interpolate_from_surrounding,
+               const void *cell_accessor)
+    {
+      const CellAccessor<dim, spacedim> *cell =
+        static_cast<const CellAccessor<dim, spacedim> *>(cell_accessor);
+      Point<spacedim> center =
+        cell->center(respect_manifold, interpolate_from_surrounding);
+      boost::python::list center_list;
+      for (int i = 0; i < spacedim; ++i)
+        center_list.append(center[i]);
+
+      return PointWrapper(center_list);
+    }
 
 
     template <int dim, int spacedim>
@@ -492,6 +508,26 @@ namespace python
       return internal::get_barycenter<2, 3>(cell_accessor);
     else
       return internal::get_barycenter<3, 3>(cell_accessor);
+  }
+
+
+
+  PointWrapper
+  CellAccessorWrapper::get_center(const bool respect_manifold,
+                                  const bool interpolate_from_surrounding) const
+  {
+    if ((dim == 2) && (spacedim == 2))
+      return internal::get_center<2, 2>(respect_manifold,
+                                        interpolate_from_surrounding,
+                                        cell_accessor);
+    else if ((dim == 2) && (spacedim == 3))
+      return internal::get_center<2, 3>(respect_manifold,
+                                        interpolate_from_surrounding,
+                                        cell_accessor);
+    else
+      return internal::get_center<3, 3>(respect_manifold,
+                                        interpolate_from_surrounding,
+                                        cell_accessor);
   }
 
 

--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -173,6 +173,8 @@ namespace python
       return PointWrapper(barycenter_list);
     }
 
+
+
     template <int dim, int spacedim>
     PointWrapper
     get_center(const bool  respect_manifold,

--- a/contrib/python-bindings/source/export_cell_accessor.cc
+++ b/contrib/python-bindings/source/export_cell_accessor.cc
@@ -22,6 +22,8 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace python
 {
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(get_center_overloads, get_center, 0, 2)
+
   const char refine_flag_docstring[] =
     "Get/Set the refine_flag of the cell. In 2D, the possibilities are: \n"
     "  - isotropic                                                      \n"
@@ -65,6 +67,12 @@ namespace python
 
   const char barycenter_docstring[] =
     "Return the barycenter of the current cell                          \n";
+
+
+
+  const char center_docstring[] =
+    "Center of the object. This method can take into account manifold   \n"
+    "attached to a cell.                                                \n";
 
 
 
@@ -138,6 +146,13 @@ namespace python
            &CellAccessorWrapper::get_barycenter,
            barycenter_docstring,
            boost::python::args("self"))
+      .def("center",
+           &CellAccessorWrapper::get_center,
+           get_center_overloads(
+             boost::python::args("self",
+                                 "respect_manifold",
+                                 "interpolate_from_surrounding"),
+             center_docstring))
       .def("set_vertex",
            &CellAccessorWrapper::set_vertex,
            set_vertex_docstring,

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -101,6 +101,11 @@ namespace python
                                          distort_random,
                                          1,
                                          2)
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(
+    find_active_cell_around_point_overloads,
+    find_active_cell_around_point,
+    1,
+    2)
 
   const char n_active_cells_docstring[] =
     "Return the number of active cells                                      \n";
@@ -536,8 +541,9 @@ namespace python
            boost::python::args("self", "transformation"))
       .def("find_active_cell_around_point",
            &TriangulationWrapper::find_active_cell_around_point,
-           find_active_cell_around_point_docstring,
-           boost::python::args("self", "point", "mapping"))
+           find_active_cell_around_point_overloads(
+             boost::python::args("self", "point", "mapping"),
+             find_active_cell_around_point_docstring))
       .def("refine_global",
            &TriangulationWrapper::refine_global,
            refine_global_docstring,

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -97,6 +97,10 @@ namespace python
                                          generate_hyper_shell,
                                          3,
                                          5)
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(distort_random_overloads,
+                                         distort_random,
+                                         1,
+                                         2)
 
   const char n_active_cells_docstring[] =
     "Return the number of active cells                                      \n";
@@ -283,6 +287,15 @@ namespace python
 
 
 
+  const char extrude_docstring[] =
+    "Take a 2d Triangulation that is being extruded in z direction by       \n"
+    "the total height of height using n_slices slices (minimum is 2).       \n"
+    "The boundary indicators of the faces of input are going to be          \n"
+    "assigned to the corresponding side walls in z direction. The           \n"
+    "bottom and top get the next two free boundary indicators.              \n";
+
+
+
   const char flatten_triangulation_docstring[] =
     "Create a new flat triangulation out_tria which contains a single       \n"
     "level with all active cells of the input triangulation. If the spacedim\n"
@@ -300,6 +313,15 @@ namespace python
     "specify manifold ids on interior faces, they have to be specified      \n"
     "manually after the triangulation is created. This function will fail   \n"
     "if the input Triangulation contains hanging nodes.                     \n";
+
+
+
+  const char distort_random_docstring[] =
+    "Distort the given triangulation by randomly moving around all the      \n"
+    "vertices of the grid. The direction of movement of each vertex is      \n"
+    "random, while the length of the shift vector has a value of factor     \n"
+    "times the minimal length of the active edges adjacent to this vertex.  \n"
+    "Note that factor should obviously be well below 0.5.                   \n";
 
 
 
@@ -362,6 +384,17 @@ namespace python
   const char reset_manifold_docstring[] =
     "Reset those parts of the triangulation with the given manifold_number  \n"
     "to use a FlatManifold object.                                          \n";
+
+
+
+  const char transform_docstring[] =
+    "Transform the vertices of the given triangulation by applying the      \n"
+    "function object provided as first argument to all its vertices.        \n";
+
+
+
+  const char find_active_cell_around_point_docstring[] =
+    "Find and return an active cell that surrounds a given point p.         \n";
 
 
 
@@ -484,10 +517,27 @@ namespace python
            &TriangulationWrapper::merge_triangulations,
            merge_docstring,
            boost::python::args("self", "triangulation_1", "triangulation_2"))
+      .def("extrude_triangulation",
+           &TriangulationWrapper::extrude_triangulation,
+           extrude_docstring,
+           boost::python::args("self", "n_slices", "depth", "tria_out"))
       .def("flatten_triangulation",
            &TriangulationWrapper::flatten_triangulation,
            flatten_triangulation_docstring,
            boost::python::args("self", "tria_out"))
+      .def("distort_random",
+           &TriangulationWrapper::distort_random,
+           distort_random_overloads(
+             boost::python::args("self", "factor", "keep_boundary"),
+             distort_random_docstring))
+      .def("transform",
+           &TriangulationWrapper::transform,
+           transform_docstring,
+           boost::python::args("self", "transformation"))
+      .def("find_active_cell_around_point",
+           &TriangulationWrapper::find_active_cell_around_point,
+           find_active_cell_around_point_docstring,
+           boost::python::args("self", "point", "mapping"))
       .def("refine_global",
            &TriangulationWrapper::refine_global,
            refine_global_docstring,

--- a/contrib/python-bindings/source/mapping_wrapper.cc
+++ b/contrib/python-bindings/source/mapping_wrapper.cc
@@ -222,6 +222,14 @@ namespace python
                                                          p.point);
   }
 
+
+
+  void *
+  MappingQGenericWrapper::get_mapping()
+  {
+    return mapping_ptr;
+  }
+
 } // namespace python
 
 DEAL_II_NAMESPACE_CLOSE

--- a/contrib/python-bindings/source/mapping_wrapper.cc
+++ b/contrib/python-bindings/source/mapping_wrapper.cc
@@ -87,6 +87,15 @@ namespace python
 
 
 
+  MappingQGenericWrapper::MappingQGenericWrapper()
+    : dim(-1)
+    , spacedim(-1)
+    , degree(-1)
+    , mapping_ptr(nullptr)
+  {}
+
+
+
   MappingQGenericWrapper::MappingQGenericWrapper(const int dim,
                                                  const int spacedim,
                                                  const int degree)

--- a/contrib/python-bindings/tests/triangulation_wrapper.py
+++ b/contrib/python-bindings/tests/triangulation_wrapper.py
@@ -16,7 +16,6 @@
 import unittest
 from PyDealII.Debug import *
 
-
 class TestTriangulationWrapper(unittest.TestCase):
 
     def setUp(self):
@@ -374,6 +373,35 @@ class TestTriangulationWrapper(unittest.TestCase):
                 self.assertEqual(n_cells, 16)
             else:
                 self.assertEqual(n_cells, 64)
+
+
+    def test_transform(self):
+        for dim in self.dim:
+            triangulation_1 = self.build_hyper_cube_triangulation(dim)
+            triangulation_1.refine_global(1)
+            triangulation_2 = self.build_hyper_cube_triangulation(dim)
+            triangulation_2.refine_global(1)
+
+            triangulation_1.transform(lambda p: [v + 1. for v in p])
+
+            if dim[1] == '3D':
+                offset = Point([1., 1., 1.])
+            else:
+                offset = Point([1., 1.])
+
+            for (cell_1, cell_2) in zip(triangulation_1.active_cells(), triangulation_2.active_cells()):
+                self.assertTrue(cell_1.center().distance(cell_2.center() + offset) < 1e-8)
+
+
+    def test_find_active_cell_around_point(self):
+        for dim in self.dim:
+            triangulation = self.build_hyper_cube_triangulation(dim)
+            triangulation.refine_global(2)
+
+            for cell in triangulation.active_cells():
+                cell_ret = triangulation.find_active_cell_around_point(cell.center())
+                self.assertTrue(cell.center().distance(cell_ret.center()) < 1e-8)
+
 
     def test_save_load(self):
         for dim in self.dim:

--- a/doc/news/changes/minor/20191206Grayver
+++ b/doc/news/changes/minor/20191206Grayver
@@ -1,0 +1,5 @@
+Added: Python wrappers for the CellAccessor::center, GridTools::transform,
+GridTools::distort_random, GridGenerator::extrude_triangulation, 
+GridTools::find_active_cell_around_point
+<br>
+(Alexander Grayver, 2019/12/06)


### PR DESCRIPTION
Add python wrappers for the 
- CellAccessor::center, 
- GridTools::transform, 
- GridTools::distort_random 
- GridGenerator::extrude_triangulation,
- GridTools::find_active_cell_around_point

Part of #9015 