### PR TITLE
ECL: make mapping of neighbor available

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7417,10 +7417,11 @@ FEFaceEvaluation<dim,
                             .normal_vectors[offsets];
   this->jacobian = &this->matrix_info->get_mapping_info()
                       .face_data_by_cells[this->quad_no]
-                      .jacobians[0][offsets];
-  this->normal_x_jacobian = &this->matrix_info->get_mapping_info()
-                               .face_data_by_cells[this->quad_no]
-                               .normals_times_jacobians[0][offsets];
+                      .jacobians[!this->is_minus_face][offsets];
+  this->normal_x_jacobian =
+    &this->matrix_info->get_mapping_info()
+       .face_data_by_cells[this->quad_no]
+       .normals_times_jacobians[!this->is_minus_face][offsets];
 
 #  ifdef DEBUG
   this->dof_values_initialized     = false;


### PR DESCRIPTION
Only the last commit is relevant.

@kronbichler:
- should we add a new parameter to `MatrixFree::AdditionalData` to request the setup of these data structures?
- how should we treat hanging nodes; we could ignore them for now; however, we should add an assert in that case!
- any suggestions for a suitable test?

Related to issue #9153.