### PR TITLE
Fix mpi/collective_mean_std

### DIFF
--- a/tests/mpi/collective_mean_std.cc
+++ b/tests/mpi/collective_mean_std.cc
@@ -17,7 +17,7 @@
 
 // check Utilities::MPI::mean_and_standard_deviation()
 
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi.templates.h>
 
 #include "../tests.h"
 


### PR DESCRIPTION
If `deal.II` is configured with `DEAL_II_WITH_COMPLEX_VALUES=OFF`, Utilities::MPI::sum is not instantiated for `std::complex<double>`. One workaround for making this test work is to include `<deal.II/base/mpi.templates.h>` instead of `<deal.II/base/mpi.h>`.