### PR TITLE
Fix MPI::Utilities::some_to_some

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1506,16 +1506,16 @@ namespace Utilities
       const unsigned int n_point_point_communications =
         Utilities::MPI::compute_n_point_to_point_communications(comm, send_to);
 
+      // Protect the following communication:
+      static CollectiveMutex      mutex;
+      CollectiveMutex::ScopedLock lock(mutex, comm);
+
       // If we have something to send, or we expect something from other
       // processors, we need to visit one of the two scopes below. Otherwise,
       // no other action is required by this mpi process, and we can safely
       // return.
       if (send_to.size() == 0 && n_point_point_communications == 0)
         return received_objects;
-
-      // Protect the following communication:
-      static CollectiveMutex      mutex;
-      CollectiveMutex::ScopedLock lock(mutex, comm);
 
       const int mpi_tag =
         internal::Tags::compute_point_to_point_communication_pattern;

--- a/tests/dofs/dof_tools_22a.cc
+++ b/tests/dofs/dof_tools_22a.cc
@@ -124,7 +124,7 @@ test()
   deallog.push(Utilities::int_to_string(myid));
 
   deallog << "**** proc " << myid << ": \n\n";
-  deallog << "Sparsity pattern:\n";
+  deallog << "Sparsity pattern:" << std::endl;
   sp.print_gnuplot(deallog.get_file_stream());
 
   MPI_Barrier(MPI_COMM_WORLD);

--- a/tests/dofs/dof_tools_22a.with_p4est=true.with_trilinos=true.mpirun=1.output
+++ b/tests/dofs/dof_tools_22a.with_p4est=true.with_trilinos=true.mpirun=1.output
@@ -1,4 +1,7 @@
 
+DEAL:0:0:0::**** proc 0: 
+
+Sparsity pattern:
 0 0
 1 0
 2 0

--- a/tests/dofs/dof_tools_22a.with_p4est=true.with_trilinos=true.mpirun=3.output
+++ b/tests/dofs/dof_tools_22a.with_p4est=true.with_trilinos=true.mpirun=3.output
@@ -1,4 +1,7 @@
 
+DEAL:0:0:0::**** proc 0: 
+
+Sparsity pattern:
 0 0
 1 0
 2 0
@@ -2508,6 +2511,9 @@
 118 -119
 119 -119
 
+DEAL:1:1:1::**** proc 1: 
+
+Sparsity pattern:
 2 -2
 3 -2
 7 -2
@@ -3421,6 +3427,9 @@
 133 -133
 
 
+DEAL:2:2:2::**** proc 2: 
+
+Sparsity pattern:
 3 -3
 50 -3
 53 -3

--- a/tests/dofs/dof_tools_22a.with_p4est=true.with_trilinos=true.mpirun=5.output
+++ b/tests/dofs/dof_tools_22a.with_p4est=true.with_trilinos=true.mpirun=5.output
@@ -1,4 +1,7 @@
 
+DEAL:0:0:0::**** proc 0: 
+
+Sparsity pattern:
 0 0
 1 0
 2 0
@@ -947,6 +950,9 @@
 90 -91
 91 -91
 
+DEAL:1:1:1::**** proc 1: 
+
+Sparsity pattern:
 1 -1
 3 -1
 5 -1
@@ -3116,6 +3122,9 @@
 119 -119
 
 
+DEAL:2:2:2::**** proc 2: 
+
+Sparsity pattern:
 2 -2
 3 -2
 7 -2
@@ -4029,6 +4038,9 @@
 133 -133
 
 
+DEAL:3:3:3::**** proc 3: 
+
+Sparsity pattern:
 3 -3
 50 -3
 53 -3
@@ -6170,4 +6182,7 @@
 146 -146
 
 
+DEAL:4:4:4::**** proc 4: 
+
+Sparsity pattern:
 


### PR DESCRIPTION
Fixes `dofs/dof_tools_22a`(https://cdash.43-1.org/testSummary.php?project=1&name=dofs%2Fdof_tools_22a.mpirun%3D5.debug&date=2019-12-09).

Evene if, we don't have anything to communicate, we still need to call
```
CollectiveMutex::ScopedLock lock(mutex, comm);
```
since that calls `MPI_Barrier` which is blocking and collective.

We also forgot to flush `deallog` in the test.