### PR TITLE
Fix formatting.

### DIFF
--- a/examples/step-60/doc/intro.dox
+++ b/examples/step-60/doc/intro.dox
@@ -329,3 +329,4 @@ $\Omega$.
 - Heltai, L., and F. Costanzo. 2012. “Variational Implementation of Immersed
   Finite Element Methods.” Computer Methods in Applied Mechanics and Engineering
   229–232.
+


### PR DESCRIPTION
When collating the introduction of step-60 to the commented program
section, the lack of an extra newline means that the heading
'The commented program' is treated like an entry in the enumerated
list that's at the end of the introduction. Fix this by providing
an additional newline.