### PR TITLE
added default case for normal to mesh projection manifold

### DIFF
--- a/tests/opencascade/normal_to_mesh_projection_04.cc
+++ b/tests/opencascade/normal_to_mesh_projection_04.cc
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Create a BSpline surface, and test NormalToMeshProjectionManifold  projection
+// using 5 surrounding points.
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q_generic.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/opencascade/manifold_lib.h>
+#include <deal.II/opencascade/utilities.h>
+
+#include <BRepFill.hxx>
+#include <Standard_Stream.hxx>
+#include <TopTools.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+
+#include "../tests.h"
+
+using namespace OpenCASCADE;
+
+int
+main()
+{
+  initlog();
+
+  // Create a bspline passing through the points
+  std::vector<Point<3>> pts;
+  pts.push_back(Point<3>(0, 0, 0));
+  pts.push_back(Point<3>(1, 0, 0));
+  // pts.push_back(Point<3>(0.5, 2, -0.5));
+  pts.push_back(Point<3>(1, 0, -1));
+  pts.push_back(Point<3>(0, 0, -1));
+
+  TopoDS_Edge edge1 = interpolation_curve(pts);
+  for (unsigned int i = 0; i < pts.size(); ++i)
+    pts[i] += Point<3>(0, 1, 0);
+  TopoDS_Edge edge2 = interpolation_curve(pts);
+
+  TopoDS_Face face = BRepFill::Face(edge1, edge2);
+
+  NormalToMeshProjectionManifold<2, 3> manifold(face);
+  FlatManifold<2, 3>                   flat_manifold;
+  std::vector<Point<3>>                surrounding_points;
+  surrounding_points.push_back(Point<3>(0., 0., 0.));
+  surrounding_points.push_back(Point<3>(1., 0., 0.));
+  Vector<double> weights(surrounding_points.size());
+  weights = 1. / surrounding_points.size();
+  auto intermediate_point =
+    manifold.get_new_point(ArrayView<Point<3>>(&surrounding_points[0],
+                                               surrounding_points.size()),
+                           ArrayView<double>(&weights[0], weights.size()));
+  surrounding_points.push_back(intermediate_point);
+  surrounding_points.push_back(Point<3>(0., 1., 0.));
+  surrounding_points.push_back(Point<3>(1., 1., 0.));
+  weights.reinit(surrounding_points.size());
+  weights = 1. / surrounding_points.size();
+
+
+  auto new_point =
+    manifold.get_new_point(ArrayView<Point<3>>(&surrounding_points[0],
+                                               surrounding_points.size()),
+                           ArrayView<double>(&weights[0], weights.size()));
+  auto new_point_flat =
+    flat_manifold.get_new_point(ArrayView<Point<3>>(&surrounding_points[0],
+                                                    surrounding_points.size()),
+                                ArrayView<double>(&weights[0], weights.size()));
+
+  for (unsigned int i = 0; i < surrounding_points.size(); ++i)
+    {
+      deallog << "Surrunding point " << i << " " << surrounding_points[i]
+              << " weight " << weights[i] << std::endl;
+    }
+  deallog << "Mean point " << new_point_flat << std::endl;
+  deallog << "Projected point "
+          << " " << new_point << std::endl;
+}

--- a/tests/opencascade/normal_to_mesh_projection_04.output
+++ b/tests/opencascade/normal_to_mesh_projection_04.output
@@ -1,0 +1,8 @@
+
+DEAL::Surrunding point 0 0.00000 0.00000 0.00000 weight 0.200000
+DEAL::Surrunding point 1 1.00000 0.00000 0.00000 weight 0.200000
+DEAL::Surrunding point 2 0.500000 0.00000 0.245356 weight 0.200000
+DEAL::Surrunding point 3 0.00000 1.00000 0.00000 weight 0.200000
+DEAL::Surrunding point 4 1.00000 1.00000 0.00000 weight 0.200000
+DEAL::Mean point 0.500000 0.400000 0.0490712
+DEAL::Projected point  0.500000 0.447721 0.245356


### PR DESCRIPTION
I have noticed that NormalToMeshProjectionManifold lacks a default case, it only implements case 2, 4, 8. I have added a simple default scenario to take care of any strange projection case. I have also added a new test to check the implementation.