### PR TITLE
Include dof_accessor.h

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -30,6 +30,7 @@
 
 #include <deal.II/dofs/block_info.h>
 #include <deal.II/dofs/deprecated_function_map.h>
+#include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_faces.h>
 #include <deal.II/dofs/dof_iterator_selector.h>
 #include <deal.II/dofs/dof_levels.h>


### PR DESCRIPTION
I want to compile the following program:
```cpp
#include <deal.II/dofs/dof_handler.h>

#include <deal.II/fe/fe_dgq.h>

#include <deal.II/grid/grid_generator.h>
#include <deal.II/grid/tria.h>

using namespace dealii;

int
main()
{
  FE_DGQ<2> fe(1);

  Triangulation<2> tria;
  GridGenerator::hyper_cube(tria);

  DoFHandler<2> dof_handler(tria);
  dof_handler.distribute_dofs(fe);

  for (const auto &cell : dof_handler.active_cell_iterators())
    if (cell->active())
      {
        // do something
      }
}
```

without `#include <deal.II/dofs/dof_accessor.h>`. Currently, the compiler complaints if I do not include that file and says `invalid use of incomplete type ‘class dealii::DoFCellAccessor<dealii::DoFHandler<2>, false>’`. This PR fixes this.