### PR TITLE
Let step-61 only build on step-51, not step-4.

### DIFF
--- a/examples/step-61/doc/builds-on
+++ b/examples/step-61/doc/builds-on
@@ -1,1 +1,1 @@
-step-51 step-4
+step-51


### PR DESCRIPTION
The tutorial graph is complicated enough as it is. We don't need to list dependencies
on some of the more basic tutorials.