### PR TITLE
Let step-40 only depend on step-6, not step-17.

### DIFF
--- a/examples/step-40/doc/builds-on
+++ b/examples/step-40/doc/builds-on
@@ -1,1 +1,1 @@
-step-6 step-17
+step-6


### PR DESCRIPTION
Back in the day, we thought of 17 (which now uses the parallel::shared::Triangulation) as
a stepping stone to get to 40, but that's not really any longer how I think about step-40:
To me, that's a stand-alone basic technique, whereas step-17 is sort of a niche topic
for connoisseurs and those interested in a particular topic.

So remove the dependency 17->40 to make the tutorial graph simpler.