### PR TITLE
Avoid _n and _m as variable names.

### DIFF
--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -317,14 +317,15 @@ public:
 
 private:
   /**
-   * The dimension of the range space.
+   * The dimension of the range space, i.e., the number of rows of the matrix.
    */
-  size_type _m;
+  size_type n_rows;
 
   /**
-   * The dimension of the domain space.
+   * The dimension of the domain space, i.e., the number of columns of the
+   * matrix.
    */
-  size_type _n;
+  size_type n_cols;
 
   /**
    * The UMFPACK routines allocate objects in which they store information

--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -51,8 +51,8 @@ SparseDirectUMFPACK::initialize(const SparsityPattern &)
 #ifdef DEAL_II_WITH_UMFPACK
 
 SparseDirectUMFPACK::SparseDirectUMFPACK()
-  : _m(0)
-  , _n(0)
+  : n_rows(0)
+  , n_cols(0)
   , symbolic_decomposition(nullptr)
   , numeric_decomposition(nullptr)
   , control(UMFPACK_CONTROL)
@@ -198,8 +198,8 @@ SparseDirectUMFPACK::factorize(const Matrix &matrix)
 
     clear();
 
-  _m = matrix.m();
-  _n = matrix.n();
+  n_rows = matrix.m();
+  n_cols = matrix.n();
 
   const size_type N = matrix.m();
 
@@ -367,8 +367,8 @@ SparseDirectUMFPACK::solve(const Matrix &       matrix,
 
 
 SparseDirectUMFPACK::SparseDirectUMFPACK()
-  : _m(0)
-  , _n(0)
+  : n_rows(0)
+  , n_cols(0)
   , symbolic_decomposition(nullptr)
   , numeric_decomposition(nullptr)
   , control(0)
@@ -484,15 +484,15 @@ SparseDirectUMFPACK::Tvmult(BlockVector<double> &      dst,
 SparseDirectUMFPACK::size_type
 SparseDirectUMFPACK::m() const
 {
-  Assert(_m != 0, ExcNotInitialized());
-  return _m;
+  Assert(n_rows != 0, ExcNotInitialized());
+  return n_rows;
 }
 
 SparseDirectUMFPACK::size_type
 SparseDirectUMFPACK::n() const
 {
-  Assert(_n != 0, ExcNotInitialized());
-  return _n;
+  Assert(n_cols != 0, ExcNotInitialized());
+  return n_cols;
 }
 
 


### PR DESCRIPTION
In general, we don't use variable names that start with underscores, but here using
one-letter variables can also easily be avoided.