### PR TITLE
Keep the 'dealii::' in 'using namespace dealii::'.

### DIFF
--- a/doc/doxygen/scripts/filter
+++ b/doc/doxygen/scripts/filter
@@ -60,6 +60,11 @@ while (<>)
         s/::dealii::(.*)\\$/::\1        \\/g;
         s/dealii::(.*)\\$/\1        \\/g;
     }
+    elsif (m/using namespace dealii::/)
+    {
+        # namespace declarations (see, e.g., step-40) in source code don't work
+        # if we cut off the 'dealii::' part, so leave it in that case.
+    }
     else
     {
         s/(::)?dealii::/::/g;


### PR DESCRIPTION
Some of our example code on the website (e.g., step-40) doesn't work since we get rid of the preceding `dealii` and print

    using namespace ::LinearAlgebraPETSc;

when it should be

    using namespace dealii::LinearAlgebraPETSc;

instead. This change keeps the `dealii::` only in this case, which currently only occurs in step-40.cc, step-50.cc, step-55.cc, and local_integrators.h.

Fixes #9163.