### PR TITLE
Make DoFHandlerPolicy independent of p4est 

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -4778,6 +4778,7 @@ namespace internal
 #endif // DEAL_II_WITH_P4EST
 
 
+
       template <class DoFHandlerType>
       ParallelDistributed<DoFHandlerType>::ParallelDistributed(
         DoFHandlerType &dof_handler)
@@ -5248,7 +5249,8 @@ namespace internal
 #  endif // DEBUG
 
         return number_caches;
-#endif   // DEAL_II_WITH_P4EST
+
+#endif // DEAL_II_WITH_P4EST
       }
 
 
@@ -5506,7 +5508,7 @@ namespace internal
               number_cache.locally_owned_dofs.n_elements();
             return number_cache;
           }
-#endif // DEAL_II_WITH_P4EST
+#endif
       }
 
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -4213,10 +4213,10 @@ namespace internal
           const parallel::DistributedTriangulationBase<dim, spacedim> &tria,
           const typename DoFHandler<dim, spacedim>::level_cell_iterator
             &                                           dealii_cell,
-          const CellId &                                quadrant,
+          const typename CellId::binary_type &          quadrant,
           std::vector<dealii::types::global_dof_index> &dof_numbers_and_indices)
         {
-          if (dealii_cell->id() == quadrant)
+          if (dealii_cell->id() == CellId(quadrant))
             {
               // why would somebody request a cell that is not ours?
               Assert(dealii_cell->level_subdomain_id() ==
@@ -4238,7 +4238,7 @@ namespace internal
           if (!dealii_cell->has_children())
             return;
 
-          if (!dealii_cell->id().is_ancestor_of(quadrant))
+          if (!dealii_cell->id().is_ancestor_of(CellId(quadrant)))
             return;
 
           for (unsigned int c = 0; c < GeometryInfo<dim>::max_children_per_cell;
@@ -4257,8 +4257,9 @@ namespace internal
           const unsigned int tree_index,
           const typename DoFHandler<dim, spacedim>::level_cell_iterator
             &dealii_cell,
-          std::map<dealii::types::subdomain_id,
-                   std::vector<std::pair<unsigned int, CellId>>>
+          std::map<
+            dealii::types::subdomain_id,
+            std::vector<std::pair<unsigned int, typename CellId::binary_type>>>
             &neighbor_cell_list)
         {
           // recurse...
@@ -4276,7 +4277,8 @@ namespace internal
                 tria.locally_owned_subdomain())
             {
               neighbor_cell_list[dealii_cell->level_subdomain_id()]
-                .emplace_back(tree_index, dealii_cell->id());
+                .emplace_back(tree_index,
+                              dealii_cell->id().template to_binary<spacedim>());
             }
         }
 
@@ -4287,11 +4289,11 @@ namespace internal
         set_mg_dofindices_recursively(
           const parallel::DistributedTriangulationBase<dim, spacedim> &tria,
           const typename DoFHandler<dim, spacedim>::level_cell_iterator
-            &                              dealii_cell,
-          const CellId &                   quadrant,
-          dealii::types::global_dof_index *dofs)
+            &                                 dealii_cell,
+          const typename CellId::binary_type &quadrant,
+          dealii::types::global_dof_index *   dofs)
         {
-          if (dealii_cell->id() == quadrant)
+          if (dealii_cell->id() == CellId(quadrant))
             {
               Assert(dealii_cell->level_subdomain_id() !=
                        dealii::numbers::artificial_subdomain_id,
@@ -4335,7 +4337,7 @@ namespace internal
           if (!dealii_cell->has_children())
             return;
 
-          if (!dealii_cell->id().is_ancestor_of(quadrant))
+          if (!dealii_cell->id().is_ancestor_of(CellId(quadrant)))
             return;
 
           for (unsigned int c = 0; c < GeometryInfo<dim>::max_children_per_cell;
@@ -4356,7 +4358,7 @@ namespace internal
           DoFHandlerType &dof_handler)
         {
           using QuadrantBufferType =
-            std::vector<std::pair<unsigned int, CellId>>;
+            std::vector<std::pair<unsigned int, typename CellId::binary_type>>;
           // build list of cells to request for each neighbor
           std::set<dealii::types::subdomain_id> level_ghost_owners =
             tria.level_ghost_owners();

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -4202,6 +4202,9 @@ namespace internal
 
 
       /* --------------------- class ParallelDistributed ---------------- */
+
+#ifdef DEAL_II_WITH_P4EST
+
       namespace
       {
         template <int dim, int spacedim>
@@ -4604,10 +4607,10 @@ namespace internal
           const DoFHandlerType &dof_handler,
           const std::map<unsigned int, std::set<dealii::types::subdomain_id>> &)
         {
-#ifndef DEAL_II_WITH_MPI
+#  ifndef DEAL_II_WITH_MPI
           (void)vertices_with_ghost_neighbors;
           Assert(false, ExcNotImplemented());
-#else
+#  else
           const unsigned int dim      = DoFHandlerType::dimension;
           const unsigned int spacedim = DoFHandlerType::space_dimension;
 
@@ -4655,7 +4658,7 @@ namespace internal
                 // nothing we need to send that hasn't been sent so far.
                 // so return an empty array, but also verify that indeed
                 // the cell is complete
-#  ifdef DEBUG
+#    ifdef DEBUG
                 std::vector<types::global_dof_index> local_dof_indices(
                   cell->get_fe().dofs_per_cell);
                 cell->get_dof_indices(local_dof_indices);
@@ -4666,7 +4669,7 @@ namespace internal
                              numbers::invalid_dof_index) ==
                    local_dof_indices.end());
                 Assert(is_complete, ExcInternalError());
-#  endif
+#    endif
                 return std_cxx17::optional<
                   std::vector<types::global_dof_index>>();
               }
@@ -4765,13 +4768,14 @@ namespace internal
                        "The function communicate_dof_indices_on_marked_cells() "
                        "only works with parallel distributed triangulations."));
             }
-#endif
+#  endif
         }
 
 
 
       } // namespace
 
+#endif // DEAL_II_WITH_P4EST
 
 
       template <class DoFHandlerType>
@@ -4786,6 +4790,10 @@ namespace internal
       NumberCache
       ParallelDistributed<DoFHandlerType>::distribute_dofs() const
       {
+#ifndef DEAL_II_WITH_P4EST
+        Assert(false, ExcNotImplemented());
+        return NumberCache();
+#else
         const unsigned int dim      = DoFHandlerType::dimension;
         const unsigned int spacedim = DoFHandlerType::space_dimension;
 
@@ -4965,15 +4973,15 @@ namespace internal
 
           // at this point, we must have taken care of the data transfer
           // on all cells we had previously marked. verify this
-#ifdef DEBUG
+#  ifdef DEBUG
           for (const auto &cell : dof_handler->active_cell_iterators())
             Assert(cell->user_flag_set() == false, ExcInternalError());
-#endif
+#  endif
 
           triangulation->load_user_flags(user_flags);
         }
 
-#ifdef DEBUG
+#  ifdef DEBUG
         // check that we are really done
         {
           std::vector<dealii::types::global_dof_index> local_dof_indices;
@@ -5008,8 +5016,9 @@ namespace internal
                   }
               }
         }
-#endif // DEBUG
+#  endif // DEBUG
         return number_cache;
+#endif   // DEAL_II_WITH_P4EST
       }
 
 
@@ -5018,6 +5027,10 @@ namespace internal
       std::vector<NumberCache>
       ParallelDistributed<DoFHandlerType>::distribute_mg_dofs() const
       {
+#ifndef DEAL_II_WITH_P4EST
+        Assert(false, ExcNotImplemented());
+        return std::vector<NumberCache>();
+#else
         const unsigned int dim      = DoFHandlerType::dimension;
         const unsigned int spacedim = DoFHandlerType::space_dimension;
 
@@ -5192,7 +5205,7 @@ namespace internal
           // in Phase 1.
           communicate_mg_ghost_cells(*triangulation, *dof_handler);
 
-#ifdef DEBUG
+#  ifdef DEBUG
           // make sure we have removed all flags:
           {
             typename DoFHandlerType::level_cell_iterator cell,
@@ -5203,14 +5216,14 @@ namespace internal
                   !cell->is_locally_owned_on_level())
                 Assert(cell->user_flag_set() == false, ExcInternalError());
           }
-#endif
+#  endif
 
           triangulation->load_user_flags(user_flags);
         }
 
 
 
-#ifdef DEBUG
+#  ifdef DEBUG
         // check that we are really done
         {
           std::vector<dealii::types::global_dof_index> local_dof_indices;
@@ -5232,9 +5245,10 @@ namespace internal
                   }
               }
         }
-#endif // DEBUG
+#  endif // DEBUG
 
         return number_caches;
+#endif   // DEAL_II_WITH_P4EST
       }
 
 
@@ -5248,6 +5262,10 @@ namespace internal
         Assert(new_numbers.size() == dof_handler->n_locally_owned_dofs(),
                ExcInternalError());
 
+#ifndef DEAL_II_WITH_P4EST
+        Assert(false, ExcNotImplemented());
+        return NumberCache();
+#else
         const unsigned int dim      = DoFHandlerType::dimension;
         const unsigned int spacedim = DoFHandlerType::space_dimension;
 
@@ -5488,6 +5506,7 @@ namespace internal
               number_cache.locally_owned_dofs.n_elements();
             return number_cache;
           }
+#endif // DEAL_II_WITH_P4EST
       }
 
 


### PR DESCRIPTION
This PR makes `internal::DoFHandlerImplementation::Policy::ParallelDistributed` independent from `p4est`. The only reason why the dofhandler-policy was depending on `p4est` was because it used the data structure `dealii::internal::p4est::types<dim>::quadrant` to identify globally uniquely the cells (and some utility functions to compare ids). This goal can be also reached by using `CellId`.

This PR depends on PR #9214 (which adds `CellId::is_ancestor_of`).

Once this is merged, `p:f:t` will be working completely without `p4est` (see also PR #9106).