### PR TITLE
Extend MatrixFree::get_dof_handler

### DIFF
--- a/doc/news/changes/minor/20200102BrunoTurcksin
+++ b/doc/news/changes/minor/20200102BrunoTurcksin
@@ -1,0 +1,4 @@
+New: The function MatrixFree::get_dof_handler() has been templated to enable
+to return either a DoFHandler<dim> or an hp::DoFHandler<dim>.
+<br>
+(Bruno Turcksin, 2020/01/02)

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1520,9 +1520,14 @@ public:
 
   /**
    * Return the DoFHandler with the index as given to the respective
-   * `std::vector` argument in the reinit() function.
+   * `std::vector` argument in the reinit() function. Note that if you want to
+   * call this function with a template parameter different than the default
+   * one, you will need to use the `template` before the function call, i.e.,
+   * you will have something like `matrix_free.template
+   * get_dof_handler<hp::DoFHandler<dim>>()`.
    */
-  const DoFHandler<dim> &
+  template <typename DoFHandlerType = DoFHandler<dim>>
+  const DoFHandlerType &
   get_dof_handler(const unsigned int dof_handler_index = 0) const;
 
   /**

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -72,6 +72,7 @@ namespace internal
     const unsigned int n_dof_handlers,
     const unsigned int dof_handler_index)
   {
+    (void)n_dof_handlers;
     AssertDimension(dof_handler.size(), n_dof_handlers);
     return *dof_handler[dof_handler_index];
   }
@@ -92,6 +93,7 @@ namespace internal
     const unsigned int n_dof_handlers,
     const unsigned int dof_handler_index)
   {
+    (void)n_dof_handlers;
     AssertDimension(hp_dof_handler.size(), n_dof_handlers);
     return *hp_dof_handler[dof_handler_index];
   }

--- a/source/matrix_free/matrix_free.inst.in
+++ b/source/matrix_free/matrix_free.inst.in
@@ -66,6 +66,19 @@ for (deal_II_dimension : DIMENSIONS;
         const std::vector<hp::QCollection<1>> &,
         const AdditionalData &);
 
+    template const DoFHandler<deal_II_dimension> &
+    MatrixFree<deal_II_dimension,
+               deal_II_scalar_vectorized::value_type,
+               deal_II_scalar_vectorized>::
+      get_dof_handler<DoFHandler<deal_II_dimension>>(const unsigned int) const;
+
+    template const hp::DoFHandler<deal_II_dimension>
+      &MatrixFree<deal_II_dimension,
+                  deal_II_scalar_vectorized::value_type,
+                  deal_II_scalar_vectorized>::
+        get_dof_handler<hp::DoFHandler<deal_II_dimension>>(const unsigned int)
+          const;
+
     template void internal::MatrixFreeFunctions::
       ShapeInfo<deal_II_scalar_vectorized>::reinit<deal_II_dimension>(
         const Quadrature<1> &,


### PR DESCRIPTION
This extends the current `MatrixFree::get_dof_handler()` function to `hp::DoFHandler`. I have made the function fit with the current interface but it's pretty ugly when you want the function to return an `hp::DoFHandler<dim>`. You get something like:
```c++
matrix_free.template get_dof_handler<hp::DoFHandler<dim>>();
```
Let me know now if you think that we should have a `get_hp_dof_handler()` function instead. I didn't do that because it would be the only function in the interface that would have a different name for the `hp` case.