### PR TITLE
deprecate members in TimerOutput

### DIFF
--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -790,12 +790,11 @@ public:
 
   /**
    * Same as @p enter_subsection.
+   *
+   * @deprecated Use enter_subsection() instead.
    */
-  void
+  DEAL_II_DEPRECATED void
   enter_section(const std::string &section_name);
-
-  // TODO: make some of these functions DEPRECATED (I would keep
-  // enter/exit_section)
 
   /**
    * Leave a section. If no name is given, the last section that was entered
@@ -806,8 +805,10 @@ public:
 
   /**
    * Same as @p leave_subsection.
+   *
+   * @deprecated Use leave_subsection() instead.
    */
-  void
+  DEAL_II_DEPRECATED void
   exit_section(const std::string &section_name = "");
 
   /**

--- a/tests/base/timer_03.cc
+++ b/tests/base/timer_03.cc
@@ -77,14 +77,14 @@ main()
   Timer       t1, t2;
   TimerOutput tO(std::cout, TimerOutput::summary, TimerOutput::cpu_times);
 
-  tO.enter_section("Section1");
-  tO.enter_section("Section2");
+  tO.enter_subsection("Section1");
+  tO.enter_subsection("Section2");
   burn(50);
-  tO.exit_section("Section2");
-  tO.enter_section("Section2");
+  tO.leave_subsection("Section2");
+  tO.enter_subsection("Section2");
   burn(50);
-  tO.exit_section("Section2");
-  tO.exit_section("Section1");
+  tO.leave_subsection("Section2");
+  tO.leave_subsection("Section1");
 
   std::map<std::string, double> cpu_times =
     tO.get_summary_data(TimerOutput::OutputData::total_cpu_time);

--- a/tests/base/timer_07.cc
+++ b/tests/base/timer_07.cc
@@ -39,7 +39,7 @@ main(int argc, char **argv)
                             std::cerr,
                             TimerOutput::summary,
                             TimerOutput::cpu_times);
-      timer_out.enter_section("Section1");
+      timer_out.enter_subsection("Section1");
 
       throw Timer07Exception();
     }


### PR DESCRIPTION
It looks like these identical functions have been around for a long
time. While I prefer enter/exit_section(), we use the others in most
places.