### PR TITLE
Test python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,12 +156,13 @@ ADD_SUBDIRECTORY(source) # has to be included after bundled
 ADD_SUBDIRECTORY(cmake/config) # has to be included after source
 ADD_SUBDIRECTORY(examples)
 
-ADD_SUBDIRECTORY(contrib/python-bindings)
 ADD_SUBDIRECTORY(contrib/utilities)
 
 IF(DEAL_II_HAVE_TESTS_DIRECTORY)
   ADD_SUBDIRECTORY(tests)
 ENDIF()
+
+ADD_SUBDIRECTORY(contrib/python-bindings) # has to be included after tests
 
 #
 # And finally, print the configuration:

--- a/contrib/python-bindings/CMakeLists.txt
+++ b/contrib/python-bindings/CMakeLists.txt
@@ -78,6 +78,8 @@ IF(DEAL_II_COMPONENT_PYTHON_BINDINGS)
 
   ADD_SUBDIRECTORY(source)
 
+  ADD_SUBDIRECTORY(tests)
+
   MESSAGE(STATUS "Setting up python bindings - Done")
   MESSAGE(STATUS "")
 

--- a/contrib/python-bindings/CMakeLists.txt
+++ b/contrib/python-bindings/CMakeLists.txt
@@ -18,6 +18,64 @@ IF(DEAL_II_COMPONENT_PYTHON_BINDINGS)
   MESSAGE(STATUS "")
   MESSAGE(STATUS "Setting up python bindings")
 
+  #
+  # Find Python:
+  #
+  INCLUDE(FindPythonInterp)
+  INCLUDE(FindPythonLibs)
+
+  IF(FEATURE_BOOST_BUNDLED_CONFIGURED)
+    MESSAGE(FATAL_ERROR
+      "DEAL_II_COMPONENT_PYTHON_BINDINGS has unmet configuration requirements: "
+      "Python bindings require an external boost library, but deal.II was "
+      "configured with bundled boost."
+      )
+  ENDIF()
+
+  #
+  # As of 1.67, boost requires specifying the suffix for the python
+  # component manually.
+  #
+  UNSET(Boost_FOUND)
+  IF(${BOOST_VERSION} VERSION_LESS 1.67)
+    _FIND_PACKAGE(Boost 1.59 COMPONENTS python REQUIRED)
+  ELSE()
+    _FIND_PACKAGE(Boost 1.67 COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} REQUIRED)
+  ENDIF()
+
+  IF(NOT Boost_FOUND)
+    MESSAGE(FATAL_ERROR
+      "DEAL_II_COMPONENT_PYTHON_BINDINGS has unmet configuration requirements: "
+      "The external boost library does not provide Boost.Python"
+      )
+  ENDIF()
+
+  #
+  # FIXME: Once finalized, reconsider moving this definitions into
+  # cmake/setup_dealii.cmake
+  #
+  # General information about deal.II:
+  #
+  #     PYTHON_BINDINGS_BASE_NAME       *)
+  #     PYTHON_BINDINGS_DEBUG_NAME      *)
+  #     PYTHON_BINDINGS_RELEASE_NAME    *)
+  #
+  # Information about paths, install locations and names:
+  #
+  #     DEAL_II_PYTHON_RELDIR           *) **)
+  #
+  # *)  Can be overwritten by the command line via -D<...>
+  # **) We do a best effort guess on site-packages location...
+  #
+
+  SET_IF_EMPTY(PYTHON_BINDINGS_BASE_NAME "PyDealII")
+  SET_IF_EMPTY(PYTHON_BINDINGS_DEBUG_NAME "Debug")
+  SET_IF_EMPTY(PYTHON_BINDINGS_RELEASE_NAME "Release")
+
+  SET_IF_EMPTY(DEAL_II_PYTHON_RELDIR
+    "${DEAL_II_LIBRARY_RELDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/${PYTHON_BINDINGS_BASE_NAME}"
+    )
+
   ADD_SUBDIRECTORY(source)
 
   MESSAGE(STATUS "Setting up python bindings - Done")

--- a/contrib/python-bindings/source/CMakeLists.txt
+++ b/contrib/python-bindings/source/CMakeLists.txt
@@ -13,65 +13,6 @@
 ##
 ## ---------------------------------------------------------------------
 
-#
-# Find Python:
-#
-
-INCLUDE(FindPythonInterp)
-INCLUDE(FindPythonLibs)
-
-IF(FEATURE_BOOST_BUNDLED_CONFIGURED)
-  MESSAGE(FATAL_ERROR
-    "DEAL_II_COMPONENT_PYTHON_BINDINGS has unmet configuration requirements: "
-    "Python bindings require an external boost library, but deal.II was "
-    "configured with bundled boost."
-    )
-ENDIF()
-
-#
-# As of 1.67, boost requires specifying the suffix for the python
-# component manually.
-#
-UNSET(Boost_FOUND)
-IF(${BOOST_VERSION} VERSION_LESS 1.67)
-  _FIND_PACKAGE(Boost 1.59 COMPONENTS python REQUIRED)
-ELSE()
-  _FIND_PACKAGE(Boost 1.67 COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} REQUIRED)
-ENDIF()
-
-IF(NOT Boost_FOUND)
-  MESSAGE(FATAL_ERROR
-    "DEAL_II_COMPONENT_PYTHON_BINDINGS has unmet configuration requirements: "
-    "The external boost library does not provide Boost.Python"
-    )
-ENDIF()
-
-#
-# FIXME: Once finalized, reconsider moving this definitions into
-# cmake/setup_dealii.cmake
-#
-# General information about deal.II:
-#
-#     PYTHON_BINDINGS_BASE_NAME       *)
-#     PYTHON_BINDINGS_DEBUG_NAME      *)
-#     PYTHON_BINDINGS_RELEASE_NAME    *)
-#
-# Information about paths, install locations and names:
-#
-#     DEAL_II_PYTHON_RELDIR           *) **)
-#
-# *)  Can be overwritten by the command line via -D<...>
-# **) We do a best effort guess on site-packages location...
-#
-
-SET_IF_EMPTY(PYTHON_BINDINGS_BASE_NAME "PyDealII")
-SET_IF_EMPTY(PYTHON_BINDINGS_DEBUG_NAME "Debug")
-SET_IF_EMPTY(PYTHON_BINDINGS_RELEASE_NAME "Release")
-
-SET_IF_EMPTY(DEAL_II_PYTHON_RELDIR
-  "${DEAL_II_LIBRARY_RELDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/${PYTHON_BINDINGS_BASE_NAME}"
-  )
-
 INCLUDE_DIRECTORIES(
   ${CMAKE_BINARY_DIR}/include/
   ${CMAKE_SOURCE_DIR}/include/

--- a/contrib/python-bindings/tests/CMakeLists.txt
+++ b/contrib/python-bindings/tests/CMakeLists.txt
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2020 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE.md at
+## the top level directory of deal.II.
+##
+## ---------------------------------------------------------------------
+
+#
+# Make sure that the tests are picked up by a global CTest call
+#
+FILE(APPEND ${CMAKE_BINARY_DIR}/CTestTestfile.cmake "SUBDIRS(contrib/python-bindings/tests)\n")
+ENABLE_TESTING()
+
+FILE(GLOB _tests "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
+FOREACH(_test_path ${_tests})
+ GET_FILENAME_COMPONENT(_test ${_test_path} NAME_WE)
+ ADD_TEST(NAME python-bindings/${_test} COMMAND ${PYTHON_EXECUTABLE} ${_test_path})
+ SET_TESTS_PROPERTIES(python-bindings/${_test} PROPERTIES ENVIRONMENT
+   PYTHONPATH=${CMAKE_BINARY_DIR}/${DEAL_II_PYTHON_RELDIR}/../:$ENV{PYTHONPATH}
+   )
+ENDFOREACH()
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,7 +75,7 @@ IF(DEFINED DEAL_II_HAVE_TESTS_DIRECTORY)
   # Write minimalistic CTestTestfile.cmake files to CMAKE_BINARY_DIR and
   # CMAKE_BINARY_DIR/tests:
   #
-  FILE(WRITE ${CMAKE_BINARY_DIR}/CTestTestfile.cmake "SUBDIRS(tests)")
+  FILE(WRITE ${CMAKE_BINARY_DIR}/CTestTestfile.cmake "SUBDIRS(tests)\n")
 
   SET(_options "-DDEAL_II_DIR=${CMAKE_BINARY_DIR}")
 


### PR DESCRIPTION
This pull request makes sure that the tests for the python bindings are run when calling `ctest` in the build directory.
This required moving some code from `python-bindings/source/CMakeLists.txt` to `python-bindings/CMakeLists.txt` which is in line with how we split `CMake` code between `CMakeLists.txt` and `source/CMakeLists.txt`.
