### PR TITLE
Return error code from indent-all in check_indentation.sh

### DIFF
--- a/contrib/utilities/check_indentation.sh
+++ b/contrib/utilities/check_indentation.sh
@@ -34,6 +34,6 @@ else
 	echo "Running indentation test on Pull Request #${TRAVIS_PULL_REQUEST}"
 fi
 
-./contrib/utilities/indent-all
+./contrib/utilities/indent-all || exit $?
 git diff
 git diff-files --quiet 


### PR DESCRIPTION
Travis reports success in https://github.com/dealii/dealii/pull/9228 although the author information requirements are not met. We just need to forward the exit code in case of failure to fix this.