### PR TITLE
Fix two bugs in matrix-free code

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7417,11 +7417,11 @@ FEFaceEvaluation<dim,
                             .normal_vectors[offsets];
   this->jacobian = &this->matrix_info->get_mapping_info()
                       .face_data_by_cells[this->quad_no]
-                      .jacobians[!this->is_minus_face][offsets];
+                      .jacobians[!this->is_interior_face][offsets];
   this->normal_x_jacobian =
     &this->matrix_info->get_mapping_info()
        .face_data_by_cells[this->quad_no]
-       .normals_times_jacobians[!this->is_minus_face][offsets];
+       .normals_times_jacobians[!this->is_interior_face][offsets];
 
 #  ifdef DEBUG
   this->dof_values_initialized     = false;

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2049,7 +2049,9 @@ namespace internal
                   fe_val.reinit(cell_it, face);
 
                   const bool is_local =
-                    cell_it->is_locally_owned() &&
+                    (cell_it->active() ?
+                       cell_it->is_locally_owned() :
+                       cell_it->is_locally_owned_on_level()) &&
                     (!cell_it->at_boundary(face) ||
                      (cell_it->at_boundary(face) &&
                       cell_it->has_periodic_neighbor(face)));


### PR DESCRIPTION
These were introduced by #9155 (code in `fe_evaluation.h`) and #9223 (code in `mapping_info.templates.h`).

This should fix the 8 matrix-free test failures seen here:
https://cdash.43-1.org/viewTest.php?onlyfailed&buildid=3534

@peterrum FYI