### PR TITLE
Simpler CellwiseInverseMassMatrix::apply() function

### DIFF
--- a/doc/news/changes/minor/20200105MartinKronbichler
+++ b/doc/news/changes/minor/20200105MartinKronbichler
@@ -1,0 +1,5 @@
+New: A variant of CellwiseInverseMassMatrix::apply() defining the inverse of
+the diagonal by FEEvaluationBase::JxW() from the provided FEEvaluationBase
+variable has been implemented.
+<br>
+(Martin Kronbichler, 2020/01/05)

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -642,7 +642,7 @@ namespace MatrixFreeOperators
     /**
      * Applies the inverse mass matrix operation on an input array. It is
      * assumed that the passed input and output arrays are of correct size,
-     * namely FEEval::dofs_per_cell * n_components long. The inverse of the
+     * namely FEEvaluation::dofs_per_cell long. The inverse of the
      * local coefficient (also containing the inverse JxW values) must be
      * passed as first argument. Passing more than one component in the
      * coefficient is allowed.
@@ -652,6 +652,21 @@ namespace MatrixFreeOperators
           const unsigned int                        n_actual_components,
           const VectorizedArrayType *               in_array,
           VectorizedArrayType *                     out_array) const;
+
+    /**
+     * Applies the inverse mass matrix operation on an input array, using the
+     * inverse of the JxW values provided by the `fe_eval` argument passed to
+     * the constructor of this class. Note that the user code must call
+     * FEEvaluation::reinit() on the underlying evaluator to make the
+     * FEEvaluationBase::JxW() method return the information of the correct
+     * cell. It is assumed that the pointers of the input and output arrays
+     * are valid over the length FEEvaluation::dofs_per_cell, which is the
+     * number of entries processed by this function. The `in_array` and
+     * `out_array` arguments may point to the same memory position.
+     */
+    void
+    apply(const VectorizedArrayType *in_array,
+          VectorizedArrayType *      out_array) const;
 
     /**
      * This operation performs a projection from the data given in quadrature
@@ -986,6 +1001,29 @@ namespace MatrixFreeOperators
     for (unsigned int q = dofs_per_component_on_cell; q < inverse_jxw.size();)
       for (unsigned int i = 0; i < dofs_per_component_on_cell; ++i, ++q)
         inverse_jxw[q] = inverse_jxw[i];
+  }
+
+
+
+  template <int dim,
+            int fe_degree,
+            int n_components,
+            typename Number,
+            typename VectorizedArrayType>
+  inline void
+  CellwiseInverseMassMatrix<
+    dim,
+    fe_degree,
+    n_components,
+    Number,
+    VectorizedArrayType>::apply(const VectorizedArrayType *in_array,
+                                VectorizedArrayType *      out_array) const
+  {
+    internal::CellwiseInverseMassMatrixImpl<
+      dim,
+      fe_degree,
+      n_components,
+      VectorizedArrayType>::apply(fe_eval, in_array, out_array);
   }
 
 

--- a/tests/matrix_free/inverse_mass_06.cc
+++ b/tests/matrix_free/inverse_mass_06.cc
@@ -1,0 +1,228 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Tests CellwiseInverseMassMatrix::apply() with implicit definition from
+// FEEvaluationBase::JxW(), otherwise the same as inverse_mass_01
+
+#include <deal.II/base/function.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+#include <deal.II/matrix_free/matrix_free.h>
+#include <deal.II/matrix_free/operators.h>
+
+#include "../tests.h"
+
+
+
+template <int dim,
+          int fe_degree,
+          typename Number,
+          typename VectorType = Vector<Number>>
+class MatrixFreeTest
+{
+public:
+  MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
+    : data(data_in){};
+
+  void
+  local_mass_operator(
+    const MatrixFree<dim, Number> &              data,
+    VectorType &                                 dst,
+    const VectorType &                           src,
+    const std::pair<unsigned int, unsigned int> &cell_range) const
+  {
+    FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number> fe_eval(data);
+    const unsigned int n_q_points = fe_eval.n_q_points;
+
+    for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
+      {
+        fe_eval.reinit(cell);
+        fe_eval.read_dof_values(src);
+        fe_eval.evaluate(true, false);
+        for (unsigned int q = 0; q < n_q_points; ++q)
+          fe_eval.submit_value(fe_eval.get_value(q), q);
+        fe_eval.integrate(true, false);
+        fe_eval.set_dof_values(dst);
+      }
+  }
+
+  void
+  local_inverse_mass_operator(
+    const MatrixFree<dim, Number> &              data,
+    VectorType &                                 dst,
+    const VectorType &                           src,
+    const std::pair<unsigned int, unsigned int> &cell_range) const
+  {
+    FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number> fe_eval(data);
+    MatrixFreeOperators::CellwiseInverseMassMatrix<dim, fe_degree, 1, Number>
+      mass_inv(fe_eval);
+
+    for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
+      {
+        fe_eval.reinit(cell);
+        fe_eval.read_dof_values(src);
+        mass_inv.apply(fe_eval.begin_dof_values(), fe_eval.begin_dof_values());
+        fe_eval.set_dof_values(dst);
+      }
+  }
+
+  void
+  vmult(VectorType &dst, const VectorType &src) const
+  {
+    data.cell_loop(
+      &MatrixFreeTest<dim, fe_degree, Number, VectorType>::local_mass_operator,
+      this,
+      dst,
+      src);
+  };
+
+  void
+  apply_inverse(VectorType &dst, const VectorType &src) const
+  {
+    data.cell_loop(&MatrixFreeTest<dim, fe_degree, Number, VectorType>::
+                     local_inverse_mass_operator,
+                   this,
+                   dst,
+                   src);
+  };
+
+private:
+  const MatrixFree<dim, Number> &data;
+};
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+do_test(const DoFHandler<dim> &dof)
+{
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+  MappingQ<dim> mapping(4);
+
+  MatrixFree<dim, number> mf_data;
+  {
+    const QGauss<1>                                  quad(fe_degree + 1);
+    typename MatrixFree<dim, number>::AdditionalData data;
+    data.tasks_parallel_scheme =
+      MatrixFree<dim, number>::AdditionalData::partition_color;
+    data.tasks_block_size = 3;
+    AffineConstraints<double> constraints;
+
+    mf_data.reinit(mapping, dof, constraints, quad, data);
+  }
+
+  MatrixFreeTest<dim, fe_degree, number> mf(mf_data);
+  Vector<number> in(dof.n_dofs()), inverse(dof.n_dofs()),
+    reference(dof.n_dofs());
+
+  for (unsigned int i = 0; i < dof.n_dofs(); ++i)
+    {
+      const double entry = random_value<double>();
+      in(i)              = entry;
+    }
+
+  mf.apply_inverse(inverse, in);
+
+  SolverControl            control(1000, 1e-12);
+  SolverCG<Vector<number>> solver(control);
+  solver.solve(mf, reference, in, PreconditionIdentity());
+
+  inverse -= reference;
+  const double diff_norm = inverse.linfty_norm() / reference.linfty_norm();
+
+  deallog << "Norm of difference: " << diff_norm << std::endl << std::endl;
+}
+
+
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  const SphericalManifold<dim> manifold;
+  Triangulation<dim>           tria;
+  GridGenerator::hyper_ball(tria);
+  typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
+                                                    endc = tria.end();
+  for (; cell != endc; ++cell)
+    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold(0, manifold);
+
+  if (dim < 3 || fe_degree < 2)
+    tria.refine_global(1);
+  tria.begin(tria.n_levels() - 1)->set_refine_flag();
+  tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  cell = tria.begin_active();
+  for (; cell != endc; ++cell)
+    if (cell->center().norm() < 1e-8)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+
+  FE_DGQ<dim>     fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+
+  do_test<dim, fe_degree, double>(dof);
+
+  if (dim == 2)
+    {
+      deallog.push("float");
+      do_test<dim, fe_degree, float>(dof);
+      deallog.pop();
+    }
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  deallog << std::setprecision(3);
+  // do not output CG iteration numbers to log file because these are too
+  // sensitive
+  deallog.depth_file(2);
+
+  {
+    deallog.push("2d");
+    test<2, 1>();
+    test<2, 2>();
+    test<2, 4>();
+    deallog.pop();
+    deallog.push("3d");
+    test<3, 1>();
+    test<3, 2>();
+    deallog.pop();
+  }
+}

--- a/tests/matrix_free/inverse_mass_06.output
+++ b/tests/matrix_free/inverse_mass_06.output
@@ -1,0 +1,16 @@
+
+DEAL:2d::Testing FE_DGQ<2>(1)
+DEAL:2d::Norm of difference: 2.21e-13
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(2)
+DEAL:2d::Norm of difference: 1.29e-13
+DEAL:2d::
+DEAL:2d::Testing FE_DGQ<2>(4)
+DEAL:2d::Norm of difference: 4.60e-14
+DEAL:2d::
+DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of difference: 3.27e-14
+DEAL:3d::
+DEAL:3d::Testing FE_DGQ<3>(2)
+DEAL:3d::Norm of difference: 1.03e-15
+DEAL:3d::

--- a/tests/matrix_free/inverse_mass_07.cc
+++ b/tests/matrix_free/inverse_mass_07.cc
@@ -1,0 +1,214 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Tests CellwiseInverseMassMatrix::apply() with implicit definition from
+// FEEvaluationBase::JxW() for vector DG elements, otherwise the same as
+// inverse_mass_02
+
+#include <deal.II/base/function.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_system.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+#include <deal.II/matrix_free/matrix_free.h>
+#include <deal.II/matrix_free/operators.h>
+
+#include "../tests.h"
+
+
+
+template <int dim,
+          int fe_degree,
+          typename Number,
+          typename VectorType = Vector<Number>>
+class MatrixFreeTest
+{
+public:
+  MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
+    : data(data_in){};
+
+  void
+  local_mass_operator(
+    const MatrixFree<dim, Number> &              data,
+    VectorType &                                 dst,
+    const VectorType &                           src,
+    const std::pair<unsigned int, unsigned int> &cell_range) const
+  {
+    FEEvaluation<dim, fe_degree, fe_degree + 1, dim, Number> fe_eval(data);
+    const unsigned int n_q_points = fe_eval.n_q_points;
+
+    for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
+      {
+        fe_eval.reinit(cell);
+        fe_eval.read_dof_values(src);
+        fe_eval.evaluate(true, false);
+        for (unsigned int q = 0; q < n_q_points; ++q)
+          fe_eval.submit_value(fe_eval.get_value(q), q);
+        fe_eval.integrate(true, false);
+        fe_eval.set_dof_values(dst);
+      }
+  }
+
+  void
+  local_inverse_mass_operator(
+    const MatrixFree<dim, Number> &              data,
+    VectorType &                                 dst,
+    const VectorType &                           src,
+    const std::pair<unsigned int, unsigned int> &cell_range) const
+  {
+    FEEvaluation<dim, fe_degree, fe_degree + 1, dim, Number> fe_eval(data);
+    MatrixFreeOperators::CellwiseInverseMassMatrix<dim, fe_degree, dim, Number>
+                       mass_inv(fe_eval);
+    const unsigned int n_q_points = fe_eval.n_q_points;
+
+    for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
+      {
+        fe_eval.reinit(cell);
+        fe_eval.read_dof_values(src);
+        mass_inv.apply(fe_eval.begin_dof_values(), fe_eval.begin_dof_values());
+        fe_eval.set_dof_values(dst);
+      }
+  }
+
+  void
+  vmult(VectorType &dst, const VectorType &src) const
+  {
+    data.cell_loop(
+      &MatrixFreeTest<dim, fe_degree, Number, VectorType>::local_mass_operator,
+      this,
+      dst,
+      src);
+  };
+
+  void
+  apply_inverse(VectorType &dst, const VectorType &src) const
+  {
+    data.cell_loop(&MatrixFreeTest<dim, fe_degree, Number, VectorType>::
+                     local_inverse_mass_operator,
+                   this,
+                   dst,
+                   src);
+  };
+
+private:
+  const MatrixFree<dim, Number> &data;
+};
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+do_test(const DoFHandler<dim> &dof)
+{
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+
+  MatrixFree<dim, number> mf_data;
+  {
+    const QGauss<1>                                  quad(fe_degree + 1);
+    typename MatrixFree<dim, number>::AdditionalData data;
+    data.tasks_parallel_scheme =
+      MatrixFree<dim, number>::AdditionalData::partition_color;
+    data.tasks_block_size = 3;
+    AffineConstraints<double> constraints;
+
+    mf_data.reinit(dof, constraints, quad, data);
+  }
+
+  MatrixFreeTest<dim, fe_degree, number> mf(mf_data);
+  Vector<number> in(dof.n_dofs()), inverse(dof.n_dofs()),
+    reference(dof.n_dofs());
+
+  for (unsigned int i = 0; i < dof.n_dofs(); ++i)
+    {
+      const double entry = random_value<double>();
+      in(i)              = entry;
+    }
+
+  mf.apply_inverse(inverse, in);
+
+  SolverControl            control(1000, 1e-12);
+  SolverCG<Vector<number>> solver(control);
+  solver.solve(mf, reference, in, PreconditionIdentity());
+
+  inverse -= reference;
+  const double diff_norm = inverse.linfty_norm() / reference.linfty_norm();
+
+  deallog << "Norm of difference: " << diff_norm << std::endl << std::endl;
+}
+
+
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, -1, 1);
+  tria.refine_global(1);
+  if (dim < 3 || fe_degree < 2)
+    tria.refine_global(1);
+  tria.begin(tria.n_levels() - 1)->set_refine_flag();
+  tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
+                                                    endc = tria.end();
+  for (; cell != endc; ++cell)
+    if (cell->center().norm() < 1e-8)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+
+  const unsigned int degree = fe_degree;
+  FESystem<dim>      fe(FE_DGQ<dim>(degree), dim);
+  DoFHandler<dim>    dof(tria);
+  dof.distribute_dofs(fe);
+
+  do_test<dim, fe_degree, double>(dof);
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  deallog << std::setprecision(3);
+  deallog.depth_file(2);
+
+  {
+    deallog.push("2d");
+    test<2, 1>();
+    test<2, 2>();
+    test<2, 4>();
+    deallog.pop();
+    deallog.push("3d");
+    test<3, 1>();
+    test<3, 2>();
+    deallog.pop();
+  }
+}

--- a/tests/matrix_free/inverse_mass_07.output
+++ b/tests/matrix_free/inverse_mass_07.output
@@ -1,0 +1,16 @@
+
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(1)^2]
+DEAL:2d::Norm of difference: 5.67e-16
+DEAL:2d::
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(2)^2]
+DEAL:2d::Norm of difference: 1.01e-14
+DEAL:2d::
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(4)^2]
+DEAL:2d::Norm of difference: 9.43e-16
+DEAL:2d::
+DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
+DEAL:3d::Norm of difference: 1.23e-15
+DEAL:3d::
+DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
+DEAL:3d::Norm of difference: 2.30e-15
+DEAL:3d::


### PR DESCRIPTION
The new function allows to use the cellwise inverse mass matrix without providing an explicit `inverse` field, using the implicit definition of `FEEvaluationBase::JxW()`. This leads to simpler code, even though it is less general than the old one that also allowed to add a coefficient from the user code.

This is the function I promised in https://github.com/dealii/dealii/pull/9157#issuecomment-568302128 and that I will add to the step-67 tutorial program in #8319. I will re-base #8319 once this is merged; the comments there are already adapted to this new function.