### PR TITLE
Remove reference to the IA64 architecture.

### DIFF
--- a/bundled/setup_bundled.cmake
+++ b/bundled/setup_bundled.cmake
@@ -36,8 +36,7 @@ SET(BOOST_FOLDER "${CMAKE_SOURCE_DIR}/bundled/boost-1.70.0")
 #
 
 IF( NOT CMAKE_SYSTEM_NAME MATCHES "CYGWIN"
-    AND NOT CMAKE_SYSTEM_NAME MATCHES "Windows"
-    AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "ia64" )
+    AND NOT CMAKE_SYSTEM_NAME MATCHES "Windows" )
   #
   # Cygwin is unsupported by tbb, Windows due to the way we compile tbb...
   #


### PR DESCRIPTION
IA64 was an interesting historical experiment that I enjoyed working on
and even more thinking about. But the architecture has not been updated
since 2012, and so there is no real danger in removing a piece of
code related to it from actually breaking anything for anyone.