### PR TITLE
Mark some input arguments as 'const'.

### DIFF
--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -2262,7 +2262,7 @@ namespace DoFTools
     const DoFHandlerType &                dof_handler,
     std::vector<types::global_dof_index> &dofs_per_component,
     const bool                            vector_valued_once = false,
-    std::vector<unsigned int>             target_component   = {});
+    const std::vector<unsigned int> &     target_component   = {});
 
   /**
    * Count the degrees of freedom in each block. This function is similar to

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1900,13 +1900,15 @@ namespace DoFTools
     } // namespace
   }   // namespace internal
 
+
+
   template <typename DoFHandlerType>
   void
   count_dofs_per_component(
     const DoFHandlerType &                dof_handler,
     std::vector<types::global_dof_index> &dofs_per_component,
-    bool                                  only_once,
-    std::vector<unsigned int>             target_component)
+    const bool                            only_once,
+    const std::vector<unsigned int> &     target_component_)
   {
     const unsigned int n_components = dof_handler.get_fe(0).n_components();
 
@@ -1916,6 +1918,7 @@ namespace DoFTools
 
     // If the empty vector was given as default argument, set up this
     // vector as identity.
+    std::vector<unsigned int> target_component = target_component_;
     if (target_component.size() == 0)
       {
         target_component.resize(n_components);

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -398,15 +398,15 @@ for (deal_II_dimension : DIMENSIONS)
     template void DoFTools::count_dofs_per_component<
       DoFHandler<deal_II_dimension>>(const DoFHandler<deal_II_dimension> &,
                                      std::vector<types::global_dof_index> &,
-                                     bool,
-                                     std::vector<unsigned int>);
+                                     const bool,
+                                     const std::vector<unsigned int> &);
 
     template void
     DoFTools::count_dofs_per_component<hp::DoFHandler<deal_II_dimension>>(
       const hp::DoFHandler<deal_II_dimension> &,
       std::vector<types::global_dof_index> &,
-      bool,
-      std::vector<unsigned int>);
+      const bool,
+      const std::vector<unsigned int> &);
 
 
 #if deal_II_dimension < 3
@@ -414,15 +414,15 @@ for (deal_II_dimension : DIMENSIONS)
       DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
       const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
       std::vector<types::global_dof_index> &,
-      bool,
-      std::vector<unsigned int>);
+      const bool,
+      const std::vector<unsigned int> &);
 
     template void DoFTools::count_dofs_per_component<
       hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
       const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
       std::vector<types::global_dof_index> &,
-      bool,
-      std::vector<unsigned int>);
+      const bool,
+      const std::vector<unsigned int> &);
 
     template void DoFTools::extract_level_dofs<
       DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
@@ -438,14 +438,14 @@ for (deal_II_dimension : DIMENSIONS)
     template void DoFTools::count_dofs_per_component<DoFHandler<1, 3>>(
       const DoFHandler<1, 3> &,
       std::vector<types::global_dof_index> &,
-      bool,
-      std::vector<unsigned int>);
+      const bool,
+      const std::vector<unsigned int> &);
 
     template void DoFTools::count_dofs_per_component<hp::DoFHandler<1, 3>>(
       const hp::DoFHandler<1, 3> &,
       std::vector<types::global_dof_index> &,
-      bool,
-      std::vector<unsigned int>);
+      const bool,
+      const std::vector<unsigned int> &);
 
     template void DoFTools::extract_level_dofs<DoFHandler<1, 3>>(
       const unsigned int level,


### PR DESCRIPTION
This requires to also make a 'std::vector' argument a reference. Incidentally,
this also matches our usual style.