### PR TITLE
jenkins: increase OSX timeout

### DIFF
--- a/contrib/ci/Jenkinsfile.osx
+++ b/contrib/ci/Jenkinsfile.osx
@@ -84,7 +84,7 @@ pipeline
         {
           steps
           {
-            timeout(time: 1, unit: 'HOURS')
+            timeout(time: 2, unit: 'HOURS')
             {
               sh "echo \"building on node ${env.NODE_NAME}\""
               sh '''#!/bin/bash


### PR DESCRIPTION
It turns out that builds take longer after updating the machine to a
newer xcode and we regularly encounter a timeout.