### PR TITLE
Fix description of a test.

### DIFF
--- a/tests/particles/extract_index_set_01.cc
+++ b/tests/particles/extract_index_set_01.cc
@@ -13,7 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
-// Test extract_index_set.
+// Test ParticleHandler::locally_relevant_ids().
 
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>


### PR DESCRIPTION
This test came in as part of #9074. The test states the previous name of the function being tested, but that was changed during patch review.