### PR TITLE
Mark 'Possibilities for extensions' as <h3>.

### DIFF
--- a/examples/step-3/doc/results.dox
+++ b/examples/step-3/doc/results.dox
@@ -52,7 +52,7 @@ of the solution. Several video lectures show how to use these programs.
 
 
 <a name="extensions"></a>
-<h2>Possibilities for extensions</h2>
+<h3>Possibilities for extensions</h3>
 
 If you want to play around a little bit with this program, here are a few
 suggestions:

--- a/examples/step-36/doc/results.dox
+++ b/examples/step-36/doc/results.dox
@@ -47,7 +47,7 @@ look like this:
 </tr>
 </table>
 
-<h2>Possibilities for extensions</h2>
+<h3>Possibilities for extensions</h3>
 
 It is always worth playing a few games in the playground! So here goes
 with a few suggestions:


### PR DESCRIPTION
Otherwise, our scripts don't pick these headings up and it won't show
in the table of contents.