### PR TITLE
Use AssertIndexRange some more

### DIFF
--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -515,7 +515,7 @@ template <typename ElementType, typename MemorySpaceType>
 inline typename ArrayView<ElementType, MemorySpaceType>::value_type &
   ArrayView<ElementType, MemorySpaceType>::operator[](const std::size_t i) const
 {
-  Assert(i < n_elements, ExcIndexRange(i, 0, n_elements));
+  AssertIndexRange(i, n_elements);
   Assert(
     (std::is_same<MemorySpaceType, MemorySpace::Host>::value),
     ExcMessage(

--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -220,7 +220,7 @@ template <int order, int dim, int spacedim, typename Number>
 inline Tensor<order, dim, Number> &
   DerivativeForm<order, dim, spacedim, Number>::operator[](const unsigned int i)
 {
-  Assert(i < spacedim, ExcIndexRange(i, 0, spacedim));
+  AssertIndexRange(i, spacedim);
 
   return tensor[i];
 }
@@ -232,7 +232,7 @@ inline const Tensor<order, dim, Number> &
   DerivativeForm<order, dim, spacedim, Number>::
   operator[](const unsigned int i) const
 {
-  Assert(i < spacedim, ExcIndexRange(i, 0, spacedim));
+  AssertIndexRange(i, spacedim);
 
   return tensor[i];
 }

--- a/include/deal.II/base/function.templates.h
+++ b/include/deal.II/base/function.templates.h
@@ -382,8 +382,7 @@ namespace Functions
     const Point<dim> &,
     const unsigned int component) const
   {
-    Assert(component < this->n_components,
-           ExcIndexRange(component, 0, this->n_components));
+    AssertIndexRange(component, this->n_components);
     return function_value_vector[component];
   }
 
@@ -414,8 +413,7 @@ namespace Functions
   {
     // To avoid warning of unused parameter
     (void)points;
-    Assert(component < this->n_components,
-           ExcIndexRange(component, 0, this->n_components));
+    AssertIndexRange(component, this->n_components);
     Assert(return_values.size() == points.size(),
            ExcDimensionMismatch(return_values.size(), points.size()))
 
@@ -536,7 +534,7 @@ ComponentSelectFunction<dim, RangeNumberType>::ComponentSelectFunction(
   : ConstantFunction<dim, RangeNumberType>(1., n_components)
   , selected_components(std::make_pair(selected, selected + 1))
 {
-  Assert(selected < n_components, ExcIndexRange(selected, 0, n_components));
+  AssertIndexRange(selected, n_components);
 }
 
 
@@ -650,8 +648,7 @@ VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::
   , function_object(function_object)
   , selected_component(selected_component)
 {
-  Assert(selected_component < this->n_components,
-         ExcIndexRange(selected_component, 0, this->n_components));
+  AssertIndexRange(selected_component, this->n_components);
 }
 
 
@@ -662,8 +659,7 @@ VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::value(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  Assert(component < this->n_components,
-         ExcIndexRange(component, 0, this->n_components));
+  AssertIndexRange(component, this->n_components);
 
   if (component == selected_component)
     return function_object(p);
@@ -705,8 +701,7 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::
 {
   // Verify that the Tensor<1,dim,RangeNumberType> will fit in the given length
   // selected_components and not hang over the end of the vector.
-  Assert(selected_component + dim - 1 < this->n_components,
-         ExcIndexRange(selected_component, 0, this->n_components));
+  AssertIndexRange(selected_component + dim - 1, this->n_components);
 }
 
 
@@ -717,8 +712,7 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::value(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  Assert(component < this->n_components,
-         ExcIndexRange(component, 0, this->n_components));
+  AssertIndexRange(component, this->n_components);
 
   // if the requested component is out of the range selected, then we can
   // return early

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -2498,7 +2498,7 @@ template <>
 inline RefinementCase<1>
 RefinementCase<1>::cut_axis(const unsigned int i)
 {
-  Assert(i < 1, ExcIndexRange(i, 0, 1));
+  AssertIndexRange(i, 1);
 
   const RefinementCase options[1] = {RefinementPossibilities<1>::cut_x};
   return options[i];
@@ -2510,7 +2510,7 @@ template <>
 inline RefinementCase<2>
 RefinementCase<2>::cut_axis(const unsigned int i)
 {
-  Assert(i < 2, ExcIndexRange(i, 0, 2));
+  AssertIndexRange(i, 2);
 
   const RefinementCase options[2] = {RefinementPossibilities<2>::cut_x,
                                      RefinementPossibilities<2>::cut_y};
@@ -2523,7 +2523,7 @@ template <>
 inline RefinementCase<3>
 RefinementCase<3>::cut_axis(const unsigned int i)
 {
-  Assert(i < 3, ExcIndexRange(i, 0, 3));
+  AssertIndexRange(i, 3);
 
   const RefinementCase options[3] = {RefinementPossibilities<3>::cut_x,
                                      RefinementPossibilities<3>::cut_y,
@@ -2636,8 +2636,7 @@ template <>
 inline Point<1>
 GeometryInfo<1>::unit_cell_vertex(const unsigned int vertex)
 {
-  Assert(vertex < vertices_per_cell,
-         ExcIndexRange(vertex, 0, vertices_per_cell));
+  AssertIndexRange(vertex, vertices_per_cell);
 
   return Point<1>(static_cast<double>(vertex));
 }
@@ -2648,8 +2647,7 @@ template <>
 inline Point<2>
 GeometryInfo<2>::unit_cell_vertex(const unsigned int vertex)
 {
-  Assert(vertex < vertices_per_cell,
-         ExcIndexRange(vertex, 0, vertices_per_cell));
+  AssertIndexRange(vertex, vertices_per_cell);
 
   return {static_cast<double>(vertex % 2), static_cast<double>(vertex / 2)};
 }
@@ -2660,8 +2658,7 @@ template <>
 inline Point<3>
 GeometryInfo<3>::unit_cell_vertex(const unsigned int vertex)
 {
-  Assert(vertex < vertices_per_cell,
-         ExcIndexRange(vertex, 0, vertices_per_cell));
+  AssertIndexRange(vertex, vertices_per_cell);
 
   return {static_cast<double>(vertex % 2),
           static_cast<double>(vertex / 2 % 2),
@@ -2736,7 +2733,7 @@ GeometryInfo<1>::cell_to_child_coordinates(const Point<1> &        p,
                                            const RefinementCase<1> refine_case)
 
 {
-  Assert(child_index < 2, ExcIndexRange(child_index, 0, 2));
+  AssertIndexRange(child_index, 2);
   Assert(refine_case == RefinementCase<1>::cut_x, ExcInternalError());
   (void)refine_case; // removes -Wunused-parameter warning in optimized mode
 
@@ -2752,10 +2749,7 @@ GeometryInfo<2>::cell_to_child_coordinates(const Point<2> &        p,
                                            const RefinementCase<2> refine_case)
 
 {
-  Assert(child_index < GeometryInfo<2>::n_children(refine_case),
-         ExcIndexRange(child_index,
-                       0,
-                       GeometryInfo<2>::n_children(refine_case)));
+  AssertIndexRange(child_index, GeometryInfo<2>::n_children(refine_case));
 
   Point<2> point = p;
   switch (refine_case)
@@ -2790,10 +2784,7 @@ GeometryInfo<3>::cell_to_child_coordinates(const Point<3> &        p,
                                            const RefinementCase<3> refine_case)
 
 {
-  Assert(child_index < GeometryInfo<3>::n_children(refine_case),
-         ExcIndexRange(child_index,
-                       0,
-                       GeometryInfo<3>::n_children(refine_case)));
+  AssertIndexRange(child_index, GeometryInfo<3>::n_children(refine_case));
 
   Point<3> point = p;
   // there might be a cleverer way to do
@@ -2880,7 +2871,7 @@ GeometryInfo<1>::child_to_cell_coordinates(const Point<1> &        p,
                                            const RefinementCase<1> refine_case)
 
 {
-  Assert(child_index < 2, ExcIndexRange(child_index, 0, 2));
+  AssertIndexRange(child_index, 2);
   Assert(refine_case == RefinementCase<1>::cut_x, ExcInternalError());
   (void)refine_case; // removes -Wunused-parameter warning in optimized mode
 
@@ -2896,10 +2887,7 @@ GeometryInfo<3>::child_to_cell_coordinates(const Point<3> &        p,
                                            const RefinementCase<3> refine_case)
 
 {
-  Assert(child_index < GeometryInfo<3>::n_children(refine_case),
-         ExcIndexRange(child_index,
-                       0,
-                       GeometryInfo<3>::n_children(refine_case)));
+  AssertIndexRange(child_index, GeometryInfo<3>::n_children(refine_case));
 
   Point<3> point = p;
   // there might be a cleverer way to do
@@ -2971,10 +2959,7 @@ GeometryInfo<2>::child_to_cell_coordinates(const Point<2> &        p,
                                            const unsigned int      child_index,
                                            const RefinementCase<2> refine_case)
 {
-  Assert(child_index < GeometryInfo<2>::n_children(refine_case),
-         ExcIndexRange(child_index,
-                       0,
-                       GeometryInfo<2>::n_children(refine_case)));
+  AssertIndexRange(child_index, GeometryInfo<2>::n_children(refine_case));
 
   Point<2> point = p;
   switch (refine_case)
@@ -3095,8 +3080,8 @@ GeometryInfo<1>::line_to_cell_vertices(const unsigned int line,
                                        const unsigned int vertex)
 {
   (void)line;
-  Assert(line < lines_per_cell, ExcIndexRange(line, 0, lines_per_cell));
-  Assert(vertex < 2, ExcIndexRange(vertex, 0, 2));
+  AssertIndexRange(line, lines_per_cell);
+  AssertIndexRange(vertex, 2);
 
   return vertex;
 }
@@ -3118,8 +3103,8 @@ inline unsigned int
 GeometryInfo<3>::line_to_cell_vertices(const unsigned int line,
                                        const unsigned int vertex)
 {
-  Assert(line < lines_per_cell, ExcIndexRange(line, 0, lines_per_cell));
-  Assert(vertex < 2, ExcIndexRange(vertex, 0, 2));
+  AssertIndexRange(line, lines_per_cell);
+  AssertIndexRange(vertex, 2);
 
   constexpr unsigned vertices[lines_per_cell][2] = {{0, 2}, // bottom face
                                                     {1, 3},
@@ -3153,8 +3138,7 @@ GeometryInfo<3>::standard_to_real_face_vertex(const unsigned int vertex,
                                               const bool face_flip,
                                               const bool face_rotation)
 {
-  Assert(vertex < GeometryInfo<3>::vertices_per_face,
-         ExcIndexRange(vertex, 0, GeometryInfo<3>::vertices_per_face));
+  AssertIndexRange(vertex, GeometryInfo<3>::vertices_per_face);
 
   // set up a table to make sure that
   // we handle non-standard faces correctly
@@ -3209,8 +3193,7 @@ GeometryInfo<dim>::standard_to_real_face_vertex(const unsigned int vertex,
                                                 const bool)
 {
   Assert(dim > 1, ExcImpossibleInDim(dim));
-  Assert(vertex < GeometryInfo<dim>::vertices_per_face,
-         ExcIndexRange(vertex, 0, GeometryInfo<dim>::vertices_per_face));
+  AssertIndexRange(vertex, GeometryInfo<dim>::vertices_per_face);
   return vertex;
 }
 
@@ -3414,12 +3397,9 @@ GeometryInfo<2>::face_refinement_case(
   const bool)
 {
   const unsigned int dim = 2;
-  Assert(cell_refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(cell_refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
-  Assert(face_no < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(cell_refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
+  AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
   const RefinementCase<dim - 1>
     ref_cases[RefinementCase<dim>::isotropic_refinement +
@@ -3448,12 +3428,9 @@ GeometryInfo<3>::face_refinement_case(
   const bool face_rotation)
 {
   const unsigned int dim = 3;
-  Assert(cell_refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(cell_refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
-  Assert(face_no < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(cell_refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
+  AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
   const RefinementCase<dim - 1>
     ref_cases[RefinementCase<dim>::isotropic_refinement + 1]
@@ -3535,12 +3512,9 @@ GeometryInfo<1>::line_refinement_case(
   (void)line_no;
   const unsigned int dim = 1;
   (void)dim;
-  Assert(cell_refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(cell_refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
-  Assert(line_no < GeometryInfo<dim>::lines_per_cell,
-         ExcIndexRange(line_no, 0, GeometryInfo<dim>::lines_per_cell));
+  AssertIndexRange(cell_refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
+  AssertIndexRange(line_no, GeometryInfo<dim>::lines_per_cell);
 
   return cell_refinement_case;
 }
@@ -3564,12 +3538,9 @@ GeometryInfo<3>::line_refinement_case(
   const unsigned int       line_no)
 {
   const unsigned int dim = 3;
-  Assert(cell_refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(cell_refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
-  Assert(line_no < GeometryInfo<dim>::lines_per_cell,
-         ExcIndexRange(line_no, 0, GeometryInfo<dim>::lines_per_cell));
+  AssertIndexRange(cell_refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
+  AssertIndexRange(line_no, GeometryInfo<dim>::lines_per_cell);
 
   // array indicating, which simple refine
   // case cuts a line in direction x, y or
@@ -3633,13 +3604,9 @@ GeometryInfo<2>::min_cell_refinement_case_for_face_refinement(
   const bool)
 {
   const unsigned int dim = 2;
-  Assert(face_refinement_case <
-           RefinementCase<dim - 1>::isotropic_refinement + 1,
-         ExcIndexRange(face_refinement_case,
-                       0,
-                       RefinementCase<dim - 1>::isotropic_refinement + 1));
-  Assert(face_no < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(face_refinement_case,
+                   RefinementCase<dim - 1>::isotropic_refinement + 1);
+  AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
   if (face_refinement_case == RefinementCase<dim>::cut_x)
     return (face_no / 2) ? RefinementCase<dim>::cut_x :
@@ -3659,13 +3626,9 @@ GeometryInfo<3>::min_cell_refinement_case_for_face_refinement(
   const bool face_rotation)
 {
   const unsigned int dim = 3;
-  Assert(face_refinement_case <
-           RefinementCase<dim - 1>::isotropic_refinement + 1,
-         ExcIndexRange(face_refinement_case,
-                       0,
-                       RefinementCase<dim - 1>::isotropic_refinement + 1));
-  Assert(face_no < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(face_refinement_case,
+                   RefinementCase<dim - 1>::isotropic_refinement + 1);
+  AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
   const RefinementCase<2> flip[4] = {RefinementCase<2>::no_refinement,
                                      RefinementCase<2>::cut_y,
@@ -3727,7 +3690,7 @@ GeometryInfo<1>::min_cell_refinement_case_for_line_refinement(
   const unsigned int line_no)
 {
   (void)line_no;
-  Assert(line_no == 0, ExcIndexRange(line_no, 0, 1));
+  AssertIndexRange(line_no, 1);
 
   return RefinementCase<1>::cut_x;
 }
@@ -3740,8 +3703,7 @@ GeometryInfo<2>::min_cell_refinement_case_for_line_refinement(
 {
   const unsigned int dim = 2;
   (void)dim;
-  Assert(line_no < GeometryInfo<dim>::lines_per_cell,
-         ExcIndexRange(line_no, 0, GeometryInfo<dim>::lines_per_cell));
+  AssertIndexRange(line_no, GeometryInfo<dim>::lines_per_cell);
 
   return (line_no / 2) ? RefinementCase<2>::cut_x : RefinementCase<2>::cut_y;
 }
@@ -3753,8 +3715,7 @@ GeometryInfo<3>::min_cell_refinement_case_for_line_refinement(
   const unsigned int line_no)
 {
   const unsigned int dim = 3;
-  Assert(line_no < GeometryInfo<dim>::lines_per_cell,
-         ExcIndexRange(line_no, 0, GeometryInfo<dim>::lines_per_cell));
+  AssertIndexRange(line_no, GeometryInfo<dim>::lines_per_cell);
 
   const RefinementCase<dim> ref_cases[6] = {
     RefinementCase<dim>::cut_y,  // lines  0 and  1
@@ -3776,8 +3737,7 @@ GeometryInfo<3>::real_to_standard_face_vertex(const unsigned int vertex,
                                               const bool face_flip,
                                               const bool face_rotation)
 {
-  Assert(vertex < GeometryInfo<3>::vertices_per_face,
-         ExcIndexRange(vertex, 0, GeometryInfo<3>::vertices_per_face));
+  AssertIndexRange(vertex, GeometryInfo<3>::vertices_per_face);
 
   // set up a table to make sure that
   // we handle non-standard faces correctly
@@ -3832,8 +3792,7 @@ GeometryInfo<dim>::real_to_standard_face_vertex(const unsigned int vertex,
                                                 const bool)
 {
   Assert(dim > 1, ExcImpossibleInDim(dim));
-  Assert(vertex < GeometryInfo<dim>::vertices_per_face,
-         ExcIndexRange(vertex, 0, GeometryInfo<dim>::vertices_per_face));
+  AssertIndexRange(vertex, GeometryInfo<dim>::vertices_per_face);
   return vertex;
 }
 
@@ -3846,8 +3805,7 @@ GeometryInfo<3>::standard_to_real_face_line(const unsigned int line,
                                             const bool         face_flip,
                                             const bool         face_rotation)
 {
-  Assert(line < GeometryInfo<3>::lines_per_face,
-         ExcIndexRange(line, 0, GeometryInfo<3>::lines_per_face));
+  AssertIndexRange(line, GeometryInfo<3>::lines_per_face);
 
 
   // make sure we handle
@@ -3914,8 +3872,7 @@ GeometryInfo<3>::real_to_standard_face_line(const unsigned int line,
                                             const bool         face_flip,
                                             const bool         face_rotation)
 {
-  Assert(line < GeometryInfo<3>::lines_per_face,
-         ExcIndexRange(line, 0, GeometryInfo<3>::lines_per_face));
+  AssertIndexRange(line, GeometryInfo<3>::lines_per_face);
 
 
   // make sure we handle
@@ -3986,9 +3943,8 @@ GeometryInfo<1>::child_cell_on_face(const RefinementCase<1> &,
                                     const RefinementCase<0> &)
 {
   (void)subface;
-  Assert(face < faces_per_cell, ExcIndexRange(face, 0, faces_per_cell));
-  Assert(subface < max_children_per_face,
-         ExcIndexRange(subface, 0, max_children_per_face));
+  AssertIndexRange(face, faces_per_cell);
+  AssertIndexRange(subface, max_children_per_face);
 
   return face;
 }
@@ -4005,9 +3961,8 @@ GeometryInfo<2>::child_cell_on_face(const RefinementCase<2> &ref_case,
                                     const bool /*face_rotation*/,
                                     const RefinementCase<1> &)
 {
-  Assert(face < faces_per_cell, ExcIndexRange(face, 0, faces_per_cell));
-  Assert(subface < max_children_per_face,
-         ExcIndexRange(subface, 0, max_children_per_face));
+  AssertIndexRange(face, faces_per_cell);
+  AssertIndexRange(subface, max_children_per_face);
 
   // always return the child adjacent to the specified
   // subface. if the face of a cell is not refined, don't
@@ -4051,11 +4006,13 @@ GeometryInfo<3>::child_cell_on_face(const RefinementCase<3> &ref_case,
 
   Assert(ref_case > RefinementCase<dim - 1>::no_refinement,
          ExcMessage("Cell has no children."));
-  Assert(face < faces_per_cell, ExcIndexRange(face, 0, faces_per_cell));
-  Assert(subface < GeometryInfo<dim - 1>::n_children(face_ref_case) ||
-           (subface == 0 &&
-            face_ref_case == RefinementCase<dim - 1>::no_refinement),
-         ExcIndexRange(subface, 0, GeometryInfo<2>::n_children(face_ref_case)));
+  AssertIndexRange(face, faces_per_cell);
+  if (!(subface == 0 &&
+        face_ref_case == RefinementCase<dim - 1>::no_refinement))
+    {
+      AssertIndexRange(subface,
+                       GeometryInfo<dim - 1>::n_children(face_ref_case));
+    }
 
   // invalid number used for invalid cases,
   // e.g. when the children are more refined at
@@ -4281,8 +4238,8 @@ GeometryInfo<2>::face_to_cell_lines(const unsigned int face,
                                     const bool)
 {
   (void)line;
-  Assert(face < faces_per_cell, ExcIndexRange(face, 0, faces_per_cell));
-  Assert(line < lines_per_face, ExcIndexRange(line, 0, lines_per_face));
+  AssertIndexRange(face, faces_per_cell);
+  AssertIndexRange(line, lines_per_face);
 
   // The face is a line itself.
   return face;
@@ -4298,8 +4255,8 @@ GeometryInfo<3>::face_to_cell_lines(const unsigned int face,
                                     const bool         face_flip,
                                     const bool         face_rotation)
 {
-  Assert(face < faces_per_cell, ExcIndexRange(face, 0, faces_per_cell));
-  Assert(line < lines_per_face, ExcIndexRange(line, 0, lines_per_face));
+  AssertIndexRange(face, faces_per_cell);
+  AssertIndexRange(line, lines_per_face);
 
   const unsigned lines[faces_per_cell][lines_per_face] = {
     {8, 10, 0, 4},  // left face
@@ -4384,8 +4341,7 @@ inline double
 GeometryInfo<dim>::d_linear_shape_function(const Point<dim> & xi,
                                            const unsigned int i)
 {
-  Assert(i < GeometryInfo<dim>::vertices_per_cell,
-         ExcIndexRange(i, 0, GeometryInfo<dim>::vertices_per_cell));
+  AssertIndexRange(i, GeometryInfo<dim>::vertices_per_cell);
 
   switch (dim)
     {
@@ -4460,8 +4416,7 @@ Tensor<1, 1> inline GeometryInfo<1>::d_linear_shape_function_gradient(
   const Point<1> &,
   const unsigned int i)
 {
-  Assert(i < GeometryInfo<1>::vertices_per_cell,
-         ExcIndexRange(i, 0, GeometryInfo<1>::vertices_per_cell));
+  AssertIndexRange(i, GeometryInfo<1>::vertices_per_cell);
 
   switch (i)
     {
@@ -4481,8 +4436,7 @@ Tensor<1, 2> inline GeometryInfo<2>::d_linear_shape_function_gradient(
   const Point<2> &   xi,
   const unsigned int i)
 {
-  Assert(i < GeometryInfo<2>::vertices_per_cell,
-         ExcIndexRange(i, 0, GeometryInfo<2>::vertices_per_cell));
+  AssertIndexRange(i, GeometryInfo<2>::vertices_per_cell);
 
   const double x = xi[0];
   const double y = xi[1];
@@ -4507,8 +4461,7 @@ Tensor<1, 3> inline GeometryInfo<3>::d_linear_shape_function_gradient(
   const Point<3> &   xi,
   const unsigned int i)
 {
-  Assert(i < GeometryInfo<3>::vertices_per_cell,
-         ExcIndexRange(i, 0, GeometryInfo<3>::vertices_per_cell));
+  AssertIndexRange(i, GeometryInfo<3>::vertices_per_cell);
 
   const double x = xi[0];
   const double y = xi[1];

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -4274,26 +4274,6 @@ GeometryInfo<4>::child_cell_on_face(const RefinementCase<4> &,
 
 template <>
 inline unsigned int
-GeometryInfo<1>::face_to_cell_lines(const unsigned int face,
-                                    const unsigned int line,
-                                    const bool,
-                                    const bool,
-                                    const bool)
-{
-  (void)face;
-  (void)line;
-  Assert(face + 1 < faces_per_cell + 1, ExcIndexRange(face, 0, faces_per_cell));
-  Assert(line + 1 < lines_per_face + 1, ExcIndexRange(line, 0, lines_per_face));
-
-  // There is only a single line, so
-  // it must be this.
-  return 0;
-}
-
-
-
-template <>
-inline unsigned int
 GeometryInfo<2>::face_to_cell_lines(const unsigned int face,
                                     const unsigned int line,
                                     const bool,

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -1521,8 +1521,7 @@ inline IndexSet::ElementIterator
 IndexSet::at(const size_type global_index) const
 {
   compress();
-  Assert(global_index < size(),
-         ExcIndexRangeType<size_type>(global_index, 0, size()));
+  AssertIndexRange(global_index, size());
 
   if (ranges.empty())
     return end();
@@ -1644,8 +1643,7 @@ IndexSet::compress() const
 inline void
 IndexSet::add_index(const size_type index)
 {
-  Assert(index < index_space_size,
-         ExcIndexRangeType<size_type>(index, 0, index_space_size));
+  AssertIndexRange(index, index_space_size);
 
   const Range new_range(index, index + 1);
   if (ranges.size() == 0 || index > ranges.back().end)
@@ -1670,7 +1668,7 @@ IndexSet::add_range(const size_type begin, const size_type end)
          ExcIndexRangeType<size_type>(begin, 0, index_space_size));
   Assert(end <= index_space_size,
          ExcIndexRangeType<size_type>(end, 0, index_space_size + 1));
-  Assert(begin <= end, ExcIndexRangeType<size_type>(begin, 0, end));
+  AssertIndexRange(begin, end + 1);
 
   if (begin != end)
     {
@@ -1872,7 +1870,7 @@ IndexSet::largest_range_starting_index() const
 inline IndexSet::size_type
 IndexSet::nth_index_in_set(const size_type n) const
 {
-  Assert(n < n_elements(), ExcIndexRangeType<size_type>(n, 0, n_elements()));
+  AssertIndexRange(n, n_elements());
 
   compress();
 
@@ -1916,7 +1914,7 @@ IndexSet::index_within_set(const size_type n) const
   // to make this call thread-safe, compress() must not be called through this
   // function
   Assert(is_compressed == true, ExcMessage("IndexSet must be compressed."));
-  Assert(n < size(), ExcIndexRangeType<size_type>(n, 0, size()));
+  AssertIndexRange(n, size());
 
   // return immediately if the index set is empty
   if (is_empty())

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1667,7 +1667,7 @@ namespace Utilities
       const auto n_procs = dealii::Utilities::MPI::n_mpi_processes(comm);
       const auto my_rank = dealii::Utilities::MPI::this_mpi_process(comm);
 
-      Assert(root_process < n_procs, ExcIndexRange(root_process, 0, n_procs));
+      AssertIndexRange(root_process, n_procs);
 
       std::vector<char> buffer       = Utilities::pack(object_to_send);
       int               n_local_data = buffer.size();

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -103,7 +103,7 @@ namespace internal
                                                          const unsigned int     new_index,
                                                          const unsigned int     position)
     {
-      Assert(position < 2, ExcIndexRange(position, 0, 2));
+      AssertIndexRange(position, 2);
 
       if (position == 0)
         return {new_index, numbers::invalid_unsigned_int};
@@ -124,7 +124,7 @@ namespace internal
                                                          const unsigned int     new_index,
                                                          const unsigned int     position)
     {
-      Assert(position < 4, ExcIndexRange(position, 0, 4));
+      AssertIndexRange(position, 4);
 
       switch (position)
         {
@@ -1957,7 +1957,7 @@ DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE Number &
                                                operator()(const TableIndices<rank_> &indices)
 {
   for (unsigned int r = 0; r < rank; ++r)
-    Assert(indices[r] < dimension, ExcIndexRange(indices[r], 0, dimension));
+    AssertIndexRange(indices[r], dimension);
   return internal::symmetric_tensor_access<dim, Number>(indices, data);
 }
 
@@ -1969,7 +1969,7 @@ DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE const Number &
                                                      operator()(const TableIndices<rank_> &indices) const
 {
   for (unsigned int r = 0; r < rank; ++r)
-    Assert(indices[r] < dimension, ExcIndexRange(indices[r], 0, dimension));
+    AssertIndexRange(indices[r], dimension);
   return internal::symmetric_tensor_access<dim, Number>(indices, data);
 }
 
@@ -2248,8 +2248,8 @@ namespace internal
     DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE unsigned int
     component_to_unrolled_index(const TableIndices<2> &indices)
     {
-      Assert(indices[0] < dim, ExcIndexRange(indices[0], 0, dim));
-      Assert(indices[1] < dim, ExcIndexRange(indices[1], 0, dim));
+      AssertIndexRange(indices[0], dim);
+      AssertIndexRange(indices[1], dim);
 
       switch (dim)
         {

--- a/include/deal.II/base/symmetric_tensor.templates.h
+++ b/include/deal.II/base/symmetric_tensor.templates.h
@@ -752,7 +752,7 @@ namespace internal
                          const double       rotation_angle,
                          const unsigned int axis = 0)
     {
-      Assert(axis < 3, ExcIndexRange(axis, 0, 3));
+      AssertIndexRange(axis, 3);
 
       Tensor<2, 3> R;
       switch (axis)

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -2189,7 +2189,7 @@ namespace internal
     inline Accessor<N, T, C, P - 1> Accessor<N, T, C, P>::
                                     operator[](const size_type i) const
     {
-      Assert(i < table.size()[N - P], ExcIndexRange(i, 0, table.size()[N - P]));
+      AssertIndexRange(i, table.size()[N - P]);
 
       // access i-th
       // subobject. optimize on the
@@ -2397,7 +2397,7 @@ template <int N, typename T>
 inline typename TableBase<N, T>::size_type
 TableBase<N, T>::size(const unsigned int i) const
 {
-  Assert(i < N, ExcIndexRange(i, 0, N));
+  AssertIndexRange(i, N);
   return table_size[i];
 }
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1131,7 +1131,7 @@ namespace internal
     {
       // We cannot use Assert in a CUDA kernel
 #ifndef __CUDA_ARCH__
-      Assert(i < dim, ExcIndexRange(i, 0, dim));
+      AssertIndexRange(i, dim);
 #endif
       return values[i];
     }
@@ -1527,8 +1527,7 @@ template <int rank_, int dim, typename Number>
 DEAL_II_CONSTEXPR inline TableIndices<rank_>
 Tensor<rank_, dim, Number>::unrolled_to_component_indices(const unsigned int i)
 {
-  Assert(i < n_independent_components,
-         ExcIndexRange(i, 0, n_independent_components));
+  AssertIndexRange(i, n_independent_components);
 
   TableIndices<rank_> indices;
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1065,6 +1065,9 @@ Tensor<0, dim, Number>::serialize(Archive &ar, const unsigned int)
 }
 
 
+template <int dim, typename Number>
+constexpr unsigned int Tensor<0, dim, Number>::n_independent_components;
+
 
 /*-------------------- Inline functions: Tensor<rank,dim> --------------------*/
 
@@ -1565,6 +1568,10 @@ Tensor<rank_, dim, Number>::serialize(Archive &ar, const unsigned int)
 {
   ar &values;
 }
+
+
+template <int rank, int dim, typename Number>
+constexpr unsigned int Tensor<rank, dim, Number>::n_independent_components;
 
 
 /* ----------------- Non-member functions operating on tensors. ------------ */

--- a/include/deal.II/base/vector_slice.h
+++ b/include/deal.II/base/vector_slice.h
@@ -129,8 +129,7 @@ inline VectorSlice<VectorType>::VectorSlice(VectorType & v,
   : ArrayViewType(
       make_array_view(std::begin(v) + start, std::begin(v) + start + length))
 {
-  Assert((start + length <= v.size()),
-         ExcIndexRange(length, 0, v.size() - start + 1));
+  AssertIndexRange(length, v.size() - start + 1);
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -2443,8 +2443,7 @@ namespace Differentiation
                        const NumberType &  value)
       {
         // Where possible, set values using TableIndices
-        Assert(unrolled_index < t.n_independent_components,
-               ExcIndexRange(unrolled_index, 0, t.n_independent_components));
+        AssertIndexRange(unrolled_index, t.n_independent_components);
         t[TensorType::unrolled_to_component_indices(unrolled_index)] = value;
       }
 
@@ -2458,7 +2457,7 @@ namespace Differentiation
                                    const unsigned int &        unrolled_index,
                                    const NumberType &          value)
       {
-        Assert(unrolled_index == 0, ExcIndexRange(unrolled_index, 0, 1));
+        AssertIndexRange(unrolled_index, 1);
         (void)unrolled_index;
         t = value;
       }
@@ -2475,7 +2474,7 @@ namespace Differentiation
                        const unsigned int &unrolled_index,
                        const NumberType &  value)
       {
-        Assert(unrolled_index == 0, ExcIndexRange(unrolled_index, 0, 1));
+        AssertIndexRange(unrolled_index, 1);
         (void)unrolled_index;
         t = value;
       }
@@ -2495,14 +2494,10 @@ namespace Differentiation
         // Fourth order symmetric tensors require a specialized interface
         // to extract values.
         using SubTensorType = SymmetricTensor<2, dim, NumberType>;
-        Assert(unrolled_index_row < SubTensorType::n_independent_components,
-               ExcIndexRange(unrolled_index_row,
-                             0,
-                             SubTensorType::n_independent_components));
-        Assert(unrolled_index_col < SubTensorType::n_independent_components,
-               ExcIndexRange(unrolled_index_col,
-                             0,
-                             SubTensorType::n_independent_components));
+        AssertIndexRange(unrolled_index_row,
+                         SubTensorType::n_independent_components);
+        AssertIndexRange(unrolled_index_col,
+                         SubTensorType::n_independent_components);
         const TableIndices<2> indices_row =
           SubTensorType::unrolled_to_component_indices(unrolled_index_row);
         const TableIndices<2> indices_col =
@@ -2525,8 +2520,7 @@ namespace Differentiation
                        const unsigned int &                     unrolled_index)
       {
         // Where possible, get values using TableIndices
-        Assert(unrolled_index < t.n_independent_components,
-               ExcIndexRange(unrolled_index, 0, t.n_independent_components));
+        AssertIndexRange(unrolled_index, t.n_independent_components);
         return t[TensorType<rank, dim, NumberType>::
                    unrolled_to_component_indices(unrolled_index)];
       }
@@ -2543,7 +2537,7 @@ namespace Differentiation
       get_tensor_entry(const TensorType<0, dim, NumberType> &t,
                        const unsigned int &                  unrolled_index)
       {
-        Assert(unrolled_index == 0, ExcIndexRange(unrolled_index, 0, 1));
+        AssertIndexRange(unrolled_index, 1);
         (void)unrolled_index;
         return t;
       }
@@ -2558,7 +2552,7 @@ namespace Differentiation
       inline const NumberType &
       get_tensor_entry(const NumberType &t, const unsigned int &unrolled_index)
       {
-        Assert(unrolled_index == 0, ExcIndexRange(unrolled_index, 0, 1));
+        AssertIndexRange(unrolled_index, 1);
         (void)unrolled_index;
         return t;
       }
@@ -2577,8 +2571,7 @@ namespace Differentiation
                        const unsigned int &               unrolled_index)
       {
         // Where possible, get values using TableIndices
-        Assert(unrolled_index < t.n_independent_components,
-               ExcIndexRange(unrolled_index, 0, t.n_independent_components));
+        AssertIndexRange(unrolled_index, t.n_independent_components);
         return t[TensorType<rank, dim, NumberType>::
                    unrolled_to_component_indices(unrolled_index)];
       }
@@ -2594,7 +2587,7 @@ namespace Differentiation
       NumberType &get_tensor_entry(TensorType<0, dim, NumberType> &t,
                                    const unsigned int &            index)
       {
-        Assert(index == 0, ExcIndexRange(index, 0, 1));
+        AssertIndexRange(index, 1);
         (void)index;
         return t;
       }
@@ -2609,7 +2602,7 @@ namespace Differentiation
       inline NumberType &
       get_tensor_entry(NumberType &t, const unsigned int &index)
       {
-        Assert(index == 0, ExcIndexRange(index, 0, 1));
+        AssertIndexRange(index, 1);
         (void)index;
         return t;
       }

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -762,7 +762,7 @@ namespace internal
                      true)) == true,
                ExcMessage("This cell is not active and therefore can't be "
                           "queried for its active FE indices"));
-        Assert(n == 0, ExcIndexRange(n, 0, 1));
+        AssertIndexRange(n, 1);
 
         return dealii::DoFHandler<dim, spacedim>::default_fe_index;
       }
@@ -1048,10 +1048,7 @@ namespace internal
           (fe_index == dealii::DoFHandler<dim, spacedim>::default_fe_index),
           ExcMessage(
             "Only the default FE index is allowed for non-hp DoFHandler objects"));
-        Assert(local_index < dof_handler.get_fe().dofs_per_vertex,
-               ExcIndexRange(local_index,
-                             0,
-                             dof_handler.get_fe().dofs_per_vertex));
+        AssertIndexRange(local_index, dof_handler.get_fe().dofs_per_vertex);
 
         dof_handler
           .vertex_dofs[vertex_index * dof_handler.get_fe().dofs_per_vertex +
@@ -1074,10 +1071,8 @@ namespace internal
         Assert(dof_handler.fe_collection.size() > 0,
                ExcMessage("No finite element collection is associated with "
                           "this DoFHandler"));
-        Assert(local_index < dof_handler.get_fe(fe_index).dofs_per_vertex,
-               ExcIndexRange(local_index,
-                             0,
-                             dof_handler.get_fe(fe_index).dofs_per_vertex));
+        AssertIndexRange(local_index,
+                         dof_handler.get_fe(fe_index).dofs_per_vertex);
         Assert(fe_index < dof_handler.fe_collection.size(), ExcInternalError());
         Assert(dof_handler.vertex_dof_offsets[vertex_index] !=
                  numbers::invalid_unsigned_int,
@@ -1140,10 +1135,7 @@ namespace internal
           (fe_index == dealii::DoFHandler<dim, spacedim>::default_fe_index),
           ExcMessage(
             "Only the default FE index is allowed for non-hp DoFHandler objects"));
-        Assert(local_index < dof_handler.get_fe().dofs_per_vertex,
-               ExcIndexRange(local_index,
-                             0,
-                             dof_handler.get_fe().dofs_per_vertex));
+        AssertIndexRange(local_index, dof_handler.get_fe().dofs_per_vertex);
 
         return dof_handler
           .vertex_dofs[vertex_index * dof_handler.get_fe().dofs_per_vertex +
@@ -1166,14 +1158,9 @@ namespace internal
         Assert(dof_handler.fe_collection.size() > 0,
                ExcMessage("No finite element collection is associated with "
                           "this DoFHandler"));
-        Assert(local_index < dof_handler.get_fe(fe_index).dofs_per_vertex,
-               ExcIndexRange(local_index,
-                             0,
-                             dof_handler.get_fe(fe_index).dofs_per_vertex));
-        Assert(vertex_index < dof_handler.vertex_dof_offsets.size(),
-               ExcIndexRange(vertex_index,
-                             0,
-                             dof_handler.vertex_dof_offsets.size()));
+        AssertIndexRange(local_index,
+                         dof_handler.get_fe(fe_index).dofs_per_vertex);
+        AssertIndexRange(vertex_index, dof_handler.vertex_dof_offsets.size());
         Assert(dof_handler.vertex_dof_offsets[vertex_index] !=
                  numbers::invalid_unsigned_int,
                ExcMessage(
@@ -1745,12 +1732,8 @@ DoFAccessor<structdim, DoFHandlerType, level_dof_access>::mg_vertex_dof_index(
 {
   (void)fe_index;
   Assert(this->dof_handler != nullptr, ExcInvalidObject());
-  Assert(vertex < GeometryInfo<structdim>::vertices_per_cell,
-         ExcIndexRange(vertex, 0, GeometryInfo<structdim>::vertices_per_cell));
-  Assert(i < this->dof_handler->get_fe(fe_index).dofs_per_vertex,
-         ExcIndexRange(i,
-                       0,
-                       this->dof_handler->get_fe(fe_index).dofs_per_vertex));
+  AssertIndexRange(vertex, GeometryInfo<structdim>::vertices_per_cell);
+  AssertIndexRange(i, this->dof_handler->get_fe(fe_index).dofs_per_vertex);
 
   return dealii::internal::DoFAccessorImplementation::Implementation::
     mg_vertex_dof_index(*this->dof_handler,
@@ -1785,12 +1768,8 @@ DoFAccessor<structdim, DoFHandlerType, level_dof_access>::
 {
   (void)fe_index;
   Assert(this->dof_handler != nullptr, ExcInvalidObject());
-  Assert(vertex < GeometryInfo<structdim>::vertices_per_cell,
-         ExcIndexRange(vertex, 0, GeometryInfo<structdim>::vertices_per_cell));
-  Assert(i < this->dof_handler->get_fe(fe_index).dofs_per_vertex,
-         ExcIndexRange(i,
-                       0,
-                       this->dof_handler->get_fe(fe_index).dofs_per_vertex));
+  AssertIndexRange(vertex, GeometryInfo<structdim>::vertices_per_cell);
+  AssertIndexRange(i, this->dof_handler->get_fe(fe_index).dofs_per_vertex);
 
   return dealii::internal::DoFAccessorImplementation::Implementation::
     set_mg_vertex_dof_index(
@@ -2550,7 +2529,7 @@ DoFAccessor<0, DoFHandlerType<1, spacedim>, level_dof_access>::vertex_dof_index(
   const unsigned int fe_index) const
 {
   (void)vertex;
-  Assert(vertex == 0, ExcIndexRange(vertex, 0, 1));
+  AssertIndexRange(vertex, 1);
   return dealii::internal::DoFAccessorImplementation::Implementation::
     get_vertex_dof_index(*dof_handler, this->global_vertex_index, fe_index, i);
 }
@@ -3795,8 +3774,7 @@ inline typename DoFCellAccessor<DoFHandlerType, level_dof_access>::face_iterator
 DoFCellAccessor<DoFHandlerType, level_dof_access>::face(
   const unsigned int i) const
 {
-  Assert(i < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(i, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(i, GeometryInfo<dim>::faces_per_cell);
 
   const unsigned int dim = DoFHandlerType::dimension;
   return dealii::internal::DoFCellAccessorImplementation::get_face(

--- a/include/deal.II/fe/block_mask.h
+++ b/include/deal.II/fe/block_mask.h
@@ -264,8 +264,7 @@ inline bool BlockMask::operator[](const unsigned int block_index) const
     {
       // otherwise check the validity of the index and
       // return whatever is appropriate
-      Assert(block_index < block_mask.size(),
-             ExcIndexRange(block_index, 0, block_mask.size()));
+      AssertIndexRange(block_index, block_mask.size());
       return block_mask[block_index];
     }
 }

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -3110,8 +3110,7 @@ inline std::pair<unsigned int, unsigned int>
 FiniteElement<dim, spacedim>::system_to_component_index(
   const unsigned int index) const
 {
-  Assert(index < system_to_component_table.size(),
-         ExcIndexRange(index, 0, system_to_component_table.size()));
+  AssertIndexRange(index, system_to_component_table.size());
   Assert(is_primitive(index),
          (typename FiniteElement<dim, spacedim>::ExcShapeFunctionNotPrimitive(
            index)));
@@ -3171,8 +3170,7 @@ inline std::pair<unsigned int, unsigned int>
 FiniteElement<dim, spacedim>::face_system_to_component_index(
   const unsigned int index) const
 {
-  Assert(index < face_system_to_component_table.size(),
-         ExcIndexRange(index, 0, face_system_to_component_table.size()));
+  AssertIndexRange(index, face_system_to_component_table.size());
 
   // in debug mode, check whether the
   // function is primitive, since
@@ -3201,8 +3199,7 @@ inline std::pair<std::pair<unsigned int, unsigned int>, unsigned int>
 FiniteElement<dim, spacedim>::system_to_base_index(
   const unsigned int index) const
 {
-  Assert(index < system_to_base_table.size(),
-         ExcIndexRange(index, 0, system_to_base_table.size()));
+  AssertIndexRange(index, system_to_base_table.size());
   return system_to_base_table[index];
 }
 
@@ -3213,8 +3210,7 @@ inline std::pair<std::pair<unsigned int, unsigned int>, unsigned int>
 FiniteElement<dim, spacedim>::face_system_to_base_index(
   const unsigned int index) const
 {
-  Assert(index < face_system_to_base_table.size(),
-         ExcIndexRange(index, 0, face_system_to_base_table.size()));
+  AssertIndexRange(index, face_system_to_base_table.size());
   return face_system_to_base_table[index];
 }
 
@@ -3235,8 +3231,7 @@ inline std::pair<unsigned int, unsigned int>
 FiniteElement<dim, spacedim>::component_to_base_index(
   const unsigned int index) const
 {
-  Assert(index < component_to_base_table.size(),
-         ExcIndexRange(index, 0, component_to_base_table.size()));
+  AssertIndexRange(index, component_to_base_table.size());
 
   return component_to_base_table[index].first;
 }
@@ -3258,8 +3253,7 @@ inline std::pair<unsigned int, types::global_dof_index>
 FiniteElement<dim, spacedim>::system_to_block_index(
   const unsigned int index) const
 {
-  Assert(index < this->dofs_per_cell,
-         ExcIndexRange(index, 0, this->dofs_per_cell));
+  AssertIndexRange(index, this->dofs_per_cell);
   // The block is computed simply as
   // first block of this base plus
   // the index within the base blocks
@@ -3276,8 +3270,7 @@ inline bool
 FiniteElement<dim, spacedim>::restriction_is_additive(
   const unsigned int index) const
 {
-  Assert(index < this->dofs_per_cell,
-         ExcIndexRange(index, 0, this->dofs_per_cell));
+  AssertIndexRange(index, this->dofs_per_cell);
   return restriction_is_additive_flags[index];
 }
 
@@ -3287,7 +3280,7 @@ template <int dim, int spacedim>
 inline const ComponentMask &
 FiniteElement<dim, spacedim>::get_nonzero_components(const unsigned int i) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   return nonzero_components[i];
 }
 
@@ -3297,7 +3290,7 @@ template <int dim, int spacedim>
 inline unsigned int
 FiniteElement<dim, spacedim>::n_nonzero_components(const unsigned int i) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   return n_nonzero_components_table[i];
 }
 
@@ -3316,7 +3309,7 @@ template <int dim, int spacedim>
 inline bool
 FiniteElement<dim, spacedim>::is_primitive(const unsigned int i) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
 
   // return primitivity of a shape
   // function by checking whether it
@@ -3340,8 +3333,7 @@ inline GeometryPrimitive
 FiniteElement<dim, spacedim>::get_associated_geometry_primitive(
   const unsigned int cell_dof_index) const
 {
-  Assert(cell_dof_index < this->dofs_per_cell,
-         ExcIndexRange(cell_dof_index, 0, this->dofs_per_cell));
+  AssertIndexRange(cell_dof_index, this->dofs_per_cell);
 
   // just go through the usual cases, taking into account how DoFs
   // are enumerated on the reference cell

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -59,7 +59,7 @@ double
 FE_Poly<PolynomialType, dim, spacedim>::shape_value(const unsigned int i,
                                                     const Point<dim> & p) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   return poly_space.compute_value(i, p);
 }
 
@@ -72,8 +72,8 @@ FE_Poly<PolynomialType, dim, spacedim>::shape_value_component(
   const unsigned int component) const
 {
   (void)component;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component == 0, ExcIndexRange(component, 0, 1));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, 1);
   return poly_space.compute_value(i, p);
 }
 
@@ -84,7 +84,7 @@ Tensor<1, dim>
 FE_Poly<PolynomialType, dim, spacedim>::shape_grad(const unsigned int i,
                                                    const Point<dim> & p) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   return poly_space.template compute_derivative<1>(i, p);
 }
 
@@ -98,8 +98,8 @@ FE_Poly<PolynomialType, dim, spacedim>::shape_grad_component(
   const unsigned int component) const
 {
   (void)component;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component == 0, ExcIndexRange(component, 0, 1));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, 1);
   return poly_space.template compute_derivative<1>(i, p);
 }
 
@@ -111,7 +111,7 @@ FE_Poly<PolynomialType, dim, spacedim>::shape_grad_grad(
   const unsigned int i,
   const Point<dim> & p) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   return poly_space.template compute_derivative<2>(i, p);
 }
 
@@ -125,8 +125,8 @@ FE_Poly<PolynomialType, dim, spacedim>::shape_grad_grad_component(
   const unsigned int component) const
 {
   (void)component;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component == 0, ExcIndexRange(component, 0, 1));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, 1);
   return poly_space.template compute_derivative<2>(i, p);
 }
 
@@ -138,7 +138,7 @@ FE_Poly<PolynomialType, dim, spacedim>::shape_3rd_derivative(
   const unsigned int i,
   const Point<dim> & p) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   return poly_space.template compute_derivative<3>(i, p);
 }
 
@@ -152,8 +152,8 @@ FE_Poly<PolynomialType, dim, spacedim>::shape_3rd_derivative_component(
   const unsigned int component) const
 {
   (void)component;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component == 0, ExcIndexRange(component, 0, 1));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, 1);
   return poly_space.template compute_derivative<3>(i, p);
 }
 
@@ -165,7 +165,7 @@ FE_Poly<PolynomialType, dim, spacedim>::shape_4th_derivative(
   const unsigned int i,
   const Point<dim> & p) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   return poly_space.template compute_derivative<4>(i, p);
 }
 
@@ -179,8 +179,8 @@ FE_Poly<PolynomialType, dim, spacedim>::shape_4th_derivative_component(
   const unsigned int component) const
 {
   (void)component;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component == 0, ExcIndexRange(component, 0, 1));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, 1);
   return poly_space.template compute_derivative<4>(i, p);
 }
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -4026,8 +4026,7 @@ namespace FEValuesViews
   Scalar<dim, spacedim>::value(const unsigned int shape_function,
                                const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(
       fe_values->update_flags & update_values,
       ((typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -4050,8 +4049,7 @@ namespace FEValuesViews
   Scalar<dim, spacedim>::gradient(const unsigned int shape_function,
                                   const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4074,8 +4072,7 @@ namespace FEValuesViews
   Scalar<dim, spacedim>::hessian(const unsigned int shape_function,
                                  const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_hessians,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
@@ -4097,8 +4094,7 @@ namespace FEValuesViews
   Scalar<dim, spacedim>::third_derivative(const unsigned int shape_function,
                                           const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_3rd_derivatives,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
@@ -4121,8 +4117,7 @@ namespace FEValuesViews
   Vector<dim, spacedim>::value(const unsigned int shape_function,
                                const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
@@ -4160,8 +4155,7 @@ namespace FEValuesViews
   Vector<dim, spacedim>::gradient(const unsigned int shape_function,
                                   const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4201,8 +4195,7 @@ namespace FEValuesViews
                                     const unsigned int q_point) const
   {
     // this function works like in the case above
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4239,8 +4232,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
 
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4412,8 +4404,7 @@ namespace FEValuesViews
                                  const unsigned int q_point) const
   {
     // this function works like in the case above
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_hessians,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
@@ -4453,8 +4444,7 @@ namespace FEValuesViews
                                           const unsigned int q_point) const
   {
     // this function works like in the case above
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_3rd_derivatives,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
@@ -4497,7 +4487,7 @@ namespace FEValuesViews
     inline dealii::SymmetricTensor<2, 1>
     symmetrize_single_row(const unsigned int n, const dealii::Tensor<1, 1> &t)
     {
-      Assert(n < 1, ExcIndexRange(n, 0, 1));
+      AssertIndexRange(n, 1);
       (void)n;
 
       return {{t[0]}};
@@ -4520,7 +4510,7 @@ namespace FEValuesViews
             }
           default:
             {
-              Assert(false, ExcIndexRange(n, 0, 2));
+              AssertIndexRange(n, 2);
               return {};
             }
         }
@@ -4547,7 +4537,7 @@ namespace FEValuesViews
             }
           default:
             {
-              Assert(false, ExcIndexRange(n, 0, 3));
+              AssertIndexRange(n, 3);
               return {};
             }
         }
@@ -4561,8 +4551,7 @@ namespace FEValuesViews
   Vector<dim, spacedim>::symmetric_gradient(const unsigned int shape_function,
                                             const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4597,8 +4586,7 @@ namespace FEValuesViews
   SymmetricTensor<2, dim, spacedim>::value(const unsigned int shape_function,
                                            const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
@@ -4643,8 +4631,7 @@ namespace FEValuesViews
     const unsigned int shape_function,
     const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4722,8 +4709,7 @@ namespace FEValuesViews
   Tensor<2, dim, spacedim>::value(const unsigned int shape_function,
                                   const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
@@ -4773,8 +4759,7 @@ namespace FEValuesViews
   Tensor<2, dim, spacedim>::divergence(const unsigned int shape_function,
                                        const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4830,8 +4815,7 @@ namespace FEValuesViews
   Tensor<2, dim, spacedim>::gradient(const unsigned int shape_function,
                                      const unsigned int q_point) const
   {
-    Assert(shape_function < fe_values->fe->dofs_per_cell,
-           ExcIndexRange(shape_function, 0, fe_values->fe->dofs_per_cell));
+    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4891,10 +4875,7 @@ template <int dim, int spacedim>
 inline const FEValuesViews::Scalar<dim, spacedim> &FEValuesBase<dim, spacedim>::
                                                    operator[](const FEValuesExtractors::Scalar &scalar) const
 {
-  Assert(scalar.component < fe_values_views_cache.scalars.size(),
-         ExcIndexRange(scalar.component,
-                       0,
-                       fe_values_views_cache.scalars.size()));
+  AssertIndexRange(scalar.component, fe_values_views_cache.scalars.size());
 
   return fe_values_views_cache.scalars[scalar.component];
 }
@@ -4905,10 +4886,8 @@ template <int dim, int spacedim>
 inline const FEValuesViews::Vector<dim, spacedim> &FEValuesBase<dim, spacedim>::
                                                    operator[](const FEValuesExtractors::Vector &vector) const
 {
-  Assert(vector.first_vector_component < fe_values_views_cache.vectors.size(),
-         ExcIndexRange(vector.first_vector_component,
-                       0,
-                       fe_values_views_cache.vectors.size()));
+  AssertIndexRange(vector.first_vector_component,
+                   fe_values_views_cache.vectors.size());
 
   return fe_values_views_cache.vectors[vector.first_vector_component];
 }
@@ -4938,11 +4917,8 @@ inline const FEValuesViews::Tensor<2, dim, spacedim> &
   FEValuesBase<dim, spacedim>::
   operator[](const FEValuesExtractors::Tensor<2> &tensor) const
 {
-  Assert(tensor.first_tensor_component <
-           fe_values_views_cache.second_order_tensors.size(),
-         ExcIndexRange(tensor.first_tensor_component,
-                       0,
-                       fe_values_views_cache.second_order_tensors.size()));
+  AssertIndexRange(tensor.first_tensor_component,
+                   fe_values_views_cache.second_order_tensors.size());
 
   return fe_values_views_cache
     .second_order_tensors[tensor.first_tensor_component];
@@ -4955,7 +4931,7 @@ inline const double &
 FEValuesBase<dim, spacedim>::shape_value(const unsigned int i,
                                          const unsigned int j) const
 {
-  Assert(i < fe->dofs_per_cell, ExcIndexRange(i, 0, fe->dofs_per_cell));
+  AssertIndexRange(i, fe->dofs_per_cell);
   Assert(this->update_flags & update_values,
          ExcAccessToUninitializedField("update_values"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
@@ -4992,11 +4968,10 @@ FEValuesBase<dim, spacedim>::shape_value_component(
   const unsigned int j,
   const unsigned int component) const
 {
-  Assert(i < fe->dofs_per_cell, ExcIndexRange(i, 0, fe->dofs_per_cell));
+  AssertIndexRange(i, fe->dofs_per_cell);
   Assert(this->update_flags & update_values,
          ExcAccessToUninitializedField("update_values"));
-  Assert(component < fe->n_components(),
-         ExcIndexRange(component, 0, fe->n_components()));
+  AssertIndexRange(component, fe->n_components());
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
 
@@ -5022,7 +4997,7 @@ inline const Tensor<1, spacedim> &
 FEValuesBase<dim, spacedim>::shape_grad(const unsigned int i,
                                         const unsigned int j) const
 {
-  Assert(i < fe->dofs_per_cell, ExcIndexRange(i, 0, fe->dofs_per_cell));
+  AssertIndexRange(i, fe->dofs_per_cell);
   Assert(this->update_flags & update_gradients,
          ExcAccessToUninitializedField("update_gradients"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
@@ -5059,11 +5034,10 @@ FEValuesBase<dim, spacedim>::shape_grad_component(
   const unsigned int j,
   const unsigned int component) const
 {
-  Assert(i < fe->dofs_per_cell, ExcIndexRange(i, 0, fe->dofs_per_cell));
+  AssertIndexRange(i, fe->dofs_per_cell);
   Assert(this->update_flags & update_gradients,
          ExcAccessToUninitializedField("update_gradients"));
-  Assert(component < fe->n_components(),
-         ExcIndexRange(component, 0, fe->n_components()));
+  AssertIndexRange(component, fe->n_components());
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
   // check whether the shape function
@@ -5088,7 +5062,7 @@ inline const Tensor<2, spacedim> &
 FEValuesBase<dim, spacedim>::shape_hessian(const unsigned int i,
                                            const unsigned int j) const
 {
-  Assert(i < fe->dofs_per_cell, ExcIndexRange(i, 0, fe->dofs_per_cell));
+  AssertIndexRange(i, fe->dofs_per_cell);
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
@@ -5125,11 +5099,10 @@ FEValuesBase<dim, spacedim>::shape_hessian_component(
   const unsigned int j,
   const unsigned int component) const
 {
-  Assert(i < fe->dofs_per_cell, ExcIndexRange(i, 0, fe->dofs_per_cell));
+  AssertIndexRange(i, fe->dofs_per_cell);
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
-  Assert(component < fe->n_components(),
-         ExcIndexRange(component, 0, fe->n_components()));
+  AssertIndexRange(component, fe->n_components());
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
   // check whether the shape function
@@ -5154,7 +5127,7 @@ inline const Tensor<3, spacedim> &
 FEValuesBase<dim, spacedim>::shape_3rd_derivative(const unsigned int i,
                                                   const unsigned int j) const
 {
-  Assert(i < fe->dofs_per_cell, ExcIndexRange(i, 0, fe->dofs_per_cell));
+  AssertIndexRange(i, fe->dofs_per_cell);
   Assert(this->update_flags & update_3rd_derivatives,
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
@@ -5191,11 +5164,10 @@ FEValuesBase<dim, spacedim>::shape_3rd_derivative_component(
   const unsigned int j,
   const unsigned int component) const
 {
-  Assert(i < fe->dofs_per_cell, ExcIndexRange(i, 0, fe->dofs_per_cell));
+  AssertIndexRange(i, fe->dofs_per_cell);
   Assert(this->update_flags & update_3rd_derivatives,
          ExcAccessToUninitializedField("update_3rd_derivatives"));
-  Assert(component < fe->n_components(),
-         ExcIndexRange(component, 0, fe->n_components()));
+  AssertIndexRange(component, fe->n_components());
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
   // check whether the shape function
@@ -5450,8 +5422,7 @@ FEValuesBase<dim, spacedim>::quadrature_point(const unsigned int i) const
 {
   Assert(this->update_flags & update_quadrature_points,
          ExcAccessToUninitializedField("update_quadrature_points"));
-  Assert(i < this->mapping_output.quadrature_points.size(),
-         ExcIndexRange(i, 0, this->mapping_output.quadrature_points.size()));
+  AssertIndexRange(i, this->mapping_output.quadrature_points.size());
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
 
@@ -5466,8 +5437,7 @@ FEValuesBase<dim, spacedim>::JxW(const unsigned int i) const
 {
   Assert(this->update_flags & update_JxW_values,
          ExcAccessToUninitializedField("update_JxW_values"));
-  Assert(i < this->mapping_output.JxW_values.size(),
-         ExcIndexRange(i, 0, this->mapping_output.JxW_values.size()));
+  AssertIndexRange(i, this->mapping_output.JxW_values.size());
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
 
@@ -5482,8 +5452,7 @@ FEValuesBase<dim, spacedim>::jacobian(const unsigned int i) const
 {
   Assert(this->update_flags & update_jacobians,
          ExcAccessToUninitializedField("update_jacobians"));
-  Assert(i < this->mapping_output.jacobians.size(),
-         ExcIndexRange(i, 0, this->mapping_output.jacobians.size()));
+  AssertIndexRange(i, this->mapping_output.jacobians.size());
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
 
@@ -5498,8 +5467,7 @@ FEValuesBase<dim, spacedim>::jacobian_grad(const unsigned int i) const
 {
   Assert(this->update_flags & update_jacobian_grads,
          ExcAccessToUninitializedField("update_jacobians_grads"));
-  Assert(i < this->mapping_output.jacobian_grads.size(),
-         ExcIndexRange(i, 0, this->mapping_output.jacobian_grads.size()));
+  AssertIndexRange(i, this->mapping_output.jacobian_grads.size());
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
 
@@ -5514,8 +5482,7 @@ FEValuesBase<dim, spacedim>::inverse_jacobian(const unsigned int i) const
 {
   Assert(this->update_flags & update_inverse_jacobians,
          ExcAccessToUninitializedField("update_inverse_jacobians"));
-  Assert(i < this->mapping_output.inverse_jacobians.size(),
-         ExcIndexRange(i, 0, this->mapping_output.inverse_jacobians.size()));
+  AssertIndexRange(i, this->mapping_output.inverse_jacobians.size());
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
 
@@ -5531,8 +5498,7 @@ FEValuesBase<dim, spacedim>::normal_vector(const unsigned int i) const
   Assert(this->update_flags & update_normal_vectors,
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_normal_vectors")));
-  Assert(i < this->mapping_output.normal_vectors.size(),
-         ExcIndexRange(i, 0, this->mapping_output.normal_vectors.size()));
+  AssertIndexRange(i, this->mapping_output.normal_vectors.size());
   Assert(present_cell.get() != nullptr,
          ExcMessage("FEValues object is not reinit'ed to any cell"));
 
@@ -5605,8 +5571,7 @@ template <int dim, int spacedim>
 inline const Tensor<1, spacedim> &
 FEFaceValuesBase<dim, spacedim>::boundary_form(const unsigned int i) const
 {
-  Assert(i < this->mapping_output.boundary_forms.size(),
-         ExcIndexRange(i, 0, this->mapping_output.boundary_forms.size()));
+  AssertIndexRange(i, this->mapping_output.boundary_forms.size());
   Assert(this->update_flags & update_boundary_forms,
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_boundary_forms")));

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -757,10 +757,7 @@ MappingQGeneric<dim, spacedim>::InternalData::shape(
   const unsigned int qpoint,
   const unsigned int shape_nr) const
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_values.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_values.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr, shape_values.size());
   return shape_values[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -771,10 +768,7 @@ inline double &
 MappingQGeneric<dim, spacedim>::InternalData::shape(const unsigned int qpoint,
                                                     const unsigned int shape_nr)
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_values.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_values.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr, shape_values.size());
   return shape_values[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -785,10 +779,8 @@ MappingQGeneric<dim, spacedim>::InternalData::derivative(
   const unsigned int qpoint,
   const unsigned int shape_nr) const
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_derivatives.size());
   return shape_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -800,10 +792,8 @@ MappingQGeneric<dim, spacedim>::InternalData::derivative(
   const unsigned int qpoint,
   const unsigned int shape_nr)
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_derivatives.size());
   return shape_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -814,11 +804,8 @@ MappingQGeneric<dim, spacedim>::InternalData::second_derivative(
   const unsigned int qpoint,
   const unsigned int shape_nr) const
 {
-  Assert(qpoint * n_shape_functions + shape_nr <
-           shape_second_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_second_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_second_derivatives.size());
   return shape_second_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -829,11 +816,8 @@ MappingQGeneric<dim, spacedim>::InternalData::second_derivative(
   const unsigned int qpoint,
   const unsigned int shape_nr)
 {
-  Assert(qpoint * n_shape_functions + shape_nr <
-           shape_second_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_second_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_second_derivatives.size());
   return shape_second_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -843,10 +827,8 @@ MappingQGeneric<dim, spacedim>::InternalData::third_derivative(
   const unsigned int qpoint,
   const unsigned int shape_nr) const
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_third_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_third_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_third_derivatives.size());
   return shape_third_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -857,10 +839,8 @@ MappingQGeneric<dim, spacedim>::InternalData::third_derivative(
   const unsigned int qpoint,
   const unsigned int shape_nr)
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_third_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_third_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_third_derivatives.size());
   return shape_third_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -871,11 +851,8 @@ MappingQGeneric<dim, spacedim>::InternalData::fourth_derivative(
   const unsigned int qpoint,
   const unsigned int shape_nr) const
 {
-  Assert(qpoint * n_shape_functions + shape_nr <
-           shape_fourth_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_fourth_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_fourth_derivatives.size());
   return shape_fourth_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -886,11 +863,8 @@ MappingQGeneric<dim, spacedim>::InternalData::fourth_derivative(
   const unsigned int qpoint,
   const unsigned int shape_nr)
 {
-  Assert(qpoint * n_shape_functions + shape_nr <
-           shape_fourth_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_fourth_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_fourth_derivatives.size());
   return shape_fourth_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -4185,8 +4185,7 @@ template <int dim, int spacedim>
 inline bool
 Triangulation<dim, spacedim>::vertex_used(const unsigned int index) const
 {
-  Assert(index < vertices_used.size(),
-         ExcIndexRange(index, 0, vertices_used.size()));
+  AssertIndexRange(index, vertices_used.size());
   return vertices_used[index];
 }
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -695,8 +695,7 @@ namespace internal
       quad_index(const TriaAccessor<3, dim, spacedim> &accessor,
                  const unsigned int                    i)
       {
-        Assert(i < GeometryInfo<3>::quads_per_cell,
-               ExcIndexRange(i, 0, GeometryInfo<3>::quads_per_cell));
+        AssertIndexRange(i, GeometryInfo<3>::quads_per_cell);
         return accessor.tria->levels[accessor.present_level]
           ->cells.cells[accessor.present_index]
           .face(i);
@@ -761,8 +760,7 @@ namespace internal
       face_flip(const TriaAccessor<3, dim, spacedim> &accessor,
                 const unsigned int                    face)
       {
-        Assert(face < GeometryInfo<3>::faces_per_cell,
-               ExcIndexRange(face, 0, GeometryInfo<3>::faces_per_cell));
+        AssertIndexRange(face, GeometryInfo<3>::faces_per_cell);
         Assert(accessor.present_index * GeometryInfo<3>::faces_per_cell + face <
                  accessor.tria->levels[accessor.present_level]
                    ->cells.face_flips.size(),
@@ -798,8 +796,7 @@ namespace internal
       face_rotation(const TriaAccessor<3, dim, spacedim> &accessor,
                     const unsigned int                    face)
       {
-        Assert(face < GeometryInfo<3>::faces_per_cell,
-               ExcIndexRange(face, 0, GeometryInfo<3>::faces_per_cell));
+        AssertIndexRange(face, GeometryInfo<3>::faces_per_cell);
         Assert(accessor.present_index * GeometryInfo<3>::faces_per_cell + face <
                  accessor.tria->levels[accessor.present_level]
                    ->cells.face_rotations.size(),
@@ -851,8 +848,7 @@ namespace internal
                        const unsigned int                    line)
       {
         Assert(accessor.used(), TriaAccessorExceptions::ExcCellNotUsed());
-        Assert(line < GeometryInfo<3>::lines_per_cell,
-               ExcIndexRange(line, 0, GeometryInfo<3>::lines_per_cell));
+        AssertIndexRange(line, GeometryInfo<3>::lines_per_cell);
 
         // get the line index by asking the
         // quads. first assume standard orientation
@@ -954,8 +950,7 @@ namespace internal
                            const bool                            value)
       {
         Assert(accessor.used(), TriaAccessorExceptions::ExcCellNotUsed());
-        Assert(face < GeometryInfo<3>::faces_per_cell,
-               ExcIndexRange(face, 0, GeometryInfo<3>::faces_per_cell));
+        AssertIndexRange(face, GeometryInfo<3>::faces_per_cell);
         Assert(accessor.present_index * GeometryInfo<3>::faces_per_cell + face <
                  accessor.tria->levels[accessor.present_level]
                    ->cells.face_orientations.size(),
@@ -986,8 +981,7 @@ namespace internal
                     const unsigned int                    face,
                     const bool                            value)
       {
-        Assert(face < GeometryInfo<3>::faces_per_cell,
-               ExcIndexRange(face, 0, GeometryInfo<3>::faces_per_cell));
+        AssertIndexRange(face, GeometryInfo<3>::faces_per_cell);
         Assert(accessor.present_index * GeometryInfo<3>::faces_per_cell + face <
                  accessor.tria->levels[accessor.present_level]
                    ->cells.face_flips.size(),
@@ -1019,8 +1013,7 @@ namespace internal
                         const unsigned int                    face,
                         const bool                            value)
       {
-        Assert(face < GeometryInfo<3>::faces_per_cell,
-               ExcIndexRange(face, 0, GeometryInfo<3>::faces_per_cell));
+        AssertIndexRange(face, GeometryInfo<3>::faces_per_cell);
         Assert(accessor.present_index * GeometryInfo<3>::faces_per_cell + face <
                  accessor.tria->levels[accessor.present_level]
                    ->cells.face_rotations.size(),
@@ -1063,8 +1056,7 @@ namespace internal
                            const bool                          value)
       {
         Assert(accessor.used(), TriaAccessorExceptions::ExcCellNotUsed());
-        Assert(line < GeometryInfo<3>::lines_per_face,
-               ExcIndexRange(line, 0, GeometryInfo<3>::lines_per_face));
+        AssertIndexRange(line, GeometryInfo<3>::lines_per_face);
         Assert(accessor.present_index * GeometryInfo<3>::lines_per_face + line <
                  accessor.tria->faces->quads.line_orientations.size(),
                ExcInternalError());
@@ -1192,8 +1184,7 @@ inline unsigned int
 TriaAccessor<structdim, dim, spacedim>::vertex_index(
   const unsigned int corner) const
 {
-  Assert(corner < GeometryInfo<structdim>::vertices_per_cell,
-         ExcIndexRange(corner, 0, GeometryInfo<structdim>::vertices_per_cell));
+  AssertIndexRange(corner, GeometryInfo<structdim>::vertices_per_cell);
 
   return dealii::internal::TriaAccessorImplementation::Implementation::
     vertex_index(*this, corner);
@@ -1226,8 +1217,7 @@ template <int structdim, int dim, int spacedim>
 inline unsigned int
 TriaAccessor<structdim, dim, spacedim>::line_index(const unsigned int i) const
 {
-  Assert(i < GeometryInfo<structdim>::lines_per_cell,
-         ExcIndexRange(i, 0, GeometryInfo<structdim>::lines_per_cell));
+  AssertIndexRange(i, GeometryInfo<structdim>::lines_per_cell);
 
   return dealii::internal::TriaAccessorImplementation::Implementation::
     line_index(*this, i);
@@ -1300,8 +1290,7 @@ TriaAccessor<structdim, dim, spacedim>::line_orientation(
   const unsigned int line) const
 {
   Assert(used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(line < GeometryInfo<structdim>::lines_per_cell,
-         ExcIndexRange(line, 0, GeometryInfo<structdim>::lines_per_cell));
+  AssertIndexRange(line, GeometryInfo<structdim>::lines_per_cell);
 
   return dealii::internal::TriaAccessorImplementation::Implementation::
     line_orientation(*this, line);
@@ -1356,8 +1345,7 @@ TriaAccessor<structdim, dim, spacedim>::set_line_orientation(
   const bool         value) const
 {
   Assert(used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(line < GeometryInfo<structdim>::lines_per_cell,
-         ExcIndexRange(line, 0, GeometryInfo<structdim>::lines_per_cell));
+  AssertIndexRange(line, GeometryInfo<structdim>::lines_per_cell);
 
   dealii::internal::TriaAccessorImplementation::Implementation::
     set_line_orientation(*this, line, value);
@@ -1393,7 +1381,7 @@ int
 TriaAccessor<structdim, dim, spacedim>::child_index(const unsigned int i) const
 {
   Assert(has_children(), TriaAccessorExceptions::ExcCellHasNoChildren());
-  Assert(i < n_children(), ExcIndexRange(i, 0, n_children()));
+  AssertIndexRange(i, n_children());
 
   // each set of two children are stored
   // consecutively, so we only have to find
@@ -1411,8 +1399,7 @@ int
 TriaAccessor<structdim, dim, spacedim>::isotropic_child_index(
   const unsigned int i) const
 {
-  Assert(i < GeometryInfo<structdim>::max_children_per_cell,
-         ExcIndexRange(i, 0, GeometryInfo<structdim>::max_children_per_cell));
+  AssertIndexRange(i, GeometryInfo<structdim>::max_children_per_cell);
 
   switch (structdim)
     {
@@ -2840,7 +2827,7 @@ template <int spacedim>
 inline unsigned int
 TriaAccessor<0, 1, spacedim>::vertex_index(const unsigned int i) const
 {
-  Assert(i == 0, ExcIndexRange(i, 0, 1));
+  AssertIndexRange(i, 1);
   (void)i;
   return global_vertex_index;
 }
@@ -2851,7 +2838,7 @@ template <int spacedim>
 inline Point<spacedim> &
 TriaAccessor<0, 1, spacedim>::vertex(const unsigned int i) const
 {
-  Assert(i == 0, ExcIndexRange(i, 0, 1));
+  AssertIndexRange(i, 1);
   (void)i;
   return const_cast<Point<spacedim> &>(
     this->tria->vertices[global_vertex_index]);
@@ -3353,12 +3340,9 @@ CellAccessor<dim, spacedim>::flag_for_face_refinement(
   const RefinementCase<dim - 1> &face_refinement_case) const
 {
   Assert(dim > 1, ExcImpossibleInDim(dim));
-  Assert(face_no < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<dim>::faces_per_cell));
-  Assert(face_refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(face_refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
+  AssertIndexRange(face_refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
 
   // the new refinement case is a combination
   // of the minimum required one for the given
@@ -3387,8 +3371,7 @@ CellAccessor<dim, spacedim>::flag_for_line_refinement(
   const unsigned int line_no) const
 {
   Assert(dim > 1, ExcImpossibleInDim(dim));
-  Assert(line_no < GeometryInfo<dim>::lines_per_cell,
-         ExcIndexRange(line_no, 0, GeometryInfo<dim>::lines_per_cell));
+  AssertIndexRange(line_no, GeometryInfo<dim>::lines_per_cell);
 
   // the new refinement case is a combination
   // of the minimum required one for the given
@@ -3435,8 +3418,7 @@ inline dealii::internal::SubfaceCase<2>
 CellAccessor<2>::subface_case(const unsigned int face_no) const
 {
   Assert(active(), TriaAccessorExceptions::ExcCellNotActive());
-  Assert(face_no < GeometryInfo<2>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<2>::faces_per_cell));
+  AssertIndexRange(face_no, GeometryInfo<2>::faces_per_cell);
   return ((face(face_no)->has_children()) ?
             dealii::internal::SubfaceCase<2>::case_x :
             dealii::internal::SubfaceCase<2>::case_none);
@@ -3447,8 +3429,7 @@ inline dealii::internal::SubfaceCase<2>
 CellAccessor<2, 3>::subface_case(const unsigned int face_no) const
 {
   Assert(active(), TriaAccessorExceptions::ExcCellNotActive());
-  Assert(face_no < GeometryInfo<2>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<2>::faces_per_cell));
+  AssertIndexRange(face_no, GeometryInfo<2>::faces_per_cell);
   return ((face(face_no)->has_children()) ?
             dealii::internal::SubfaceCase<2>::case_x :
             dealii::internal::SubfaceCase<2>::case_none);
@@ -3460,8 +3441,7 @@ inline dealii::internal::SubfaceCase<3>
 CellAccessor<3>::subface_case(const unsigned int face_no) const
 {
   Assert(active(), TriaAccessorExceptions::ExcCellNotActive());
-  Assert(face_no < GeometryInfo<3>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<3>::faces_per_cell));
+  AssertIndexRange(face_no, GeometryInfo<3>::faces_per_cell);
   switch (static_cast<std::uint8_t>(face(face_no)->refinement_case()))
     {
       case RefinementCase<3>::no_refinement:

--- a/include/deal.II/grid/tria_object.h
+++ b/include/deal.II/grid/tria_object.h
@@ -167,8 +167,7 @@ namespace internal
     inline int
     TriaObject<structdim>::face(const unsigned int i) const
     {
-      Assert(i < GeometryInfo<structdim>::faces_per_cell,
-             ExcIndexRange(i, 0, GeometryInfo<structdim>::faces_per_cell));
+      AssertIndexRange(i, GeometryInfo<structdim>::faces_per_cell);
       return faces[i];
     }
 
@@ -178,8 +177,7 @@ namespace internal
     inline void
     TriaObject<structdim>::set_face(const unsigned int i, const int index)
     {
-      Assert(i < GeometryInfo<structdim>::faces_per_cell,
-             ExcIndexRange(i, 0, GeometryInfo<structdim>::faces_per_cell));
+      AssertIndexRange(i, GeometryInfo<structdim>::faces_per_cell);
       faces[i] = index;
     }
 

--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -635,7 +635,7 @@ namespace internal
              ExcPointerIndexClash());
       user_data_type = data_pointer;
 
-      Assert(i < user_data.size(), ExcIndexRange(i, 0, user_data.size()));
+      AssertIndexRange(i, user_data.size());
       return user_data[i].p;
     }
 
@@ -648,7 +648,7 @@ namespace internal
              ExcPointerIndexClash());
       user_data_type = data_pointer;
 
-      Assert(i < user_data.size(), ExcIndexRange(i, 0, user_data.size()));
+      AssertIndexRange(i, user_data.size());
       return user_data[i].p;
     }
 
@@ -661,7 +661,7 @@ namespace internal
              ExcPointerIndexClash());
       user_data_type = data_index;
 
-      Assert(i < user_data.size(), ExcIndexRange(i, 0, user_data.size()));
+      AssertIndexRange(i, user_data.size());
       return user_data[i].i;
     }
 
@@ -670,7 +670,7 @@ namespace internal
     inline void
     TriaObjects<G>::clear_user_data(const unsigned int i)
     {
-      Assert(i < user_data.size(), ExcIndexRange(i, 0, user_data.size()));
+      AssertIndexRange(i, user_data.size());
       user_data[i].i = 0;
     }
 
@@ -692,7 +692,7 @@ namespace internal
              ExcPointerIndexClash());
       user_data_type = data_index;
 
-      Assert(i < user_data.size(), ExcIndexRange(i, 0, user_data.size()));
+      AssertIndexRange(i, user_data.size());
       return user_data[i].i;
     }
 
@@ -768,13 +768,10 @@ namespace internal
     TriaObjectsHex::face_orientation(const unsigned int cell,
                                      const unsigned int face) const
     {
-      Assert(cell < face_orientations.size() / GeometryInfo<3>::faces_per_cell,
-             ExcIndexRange(0,
-                           cell,
-                           face_orientations.size() /
-                             GeometryInfo<3>::faces_per_cell));
-      Assert(face < GeometryInfo<3>::faces_per_cell,
-             ExcIndexRange(0, face, GeometryInfo<3>::faces_per_cell));
+      AssertIndexRange(cell,
+                       face_orientations.size() /
+                         GeometryInfo<3>::faces_per_cell);
+      AssertIndexRange(face, GeometryInfo<3>::faces_per_cell);
 
       return face_orientations[cell * GeometryInfo<3>::faces_per_cell + face];
     }

--- a/include/deal.II/hp/dof_faces.h
+++ b/include/deal.II/hp/dof_faces.h
@@ -399,18 +399,11 @@ namespace internal
               dealii::hp::DoFHandler<dim, spacedim>::default_fe_index),
              ExcMessage("You need to specify a FE index when working "
                         "with hp DoFHandlers"));
-      Assert(fe_index < dof_handler.get_fe_collection().size(),
-             ExcIndexRange(fe_index,
-                           0,
-                           dof_handler.get_fe_collection().size()));
-      Assert(local_index < dof_handler.get_fe(fe_index)
-                             .template n_dofs_per_object<structdim>(),
-             ExcIndexRange(local_index,
-                           0,
-                           dof_handler.get_fe(fe_index)
-                             .template n_dofs_per_object<structdim>()));
-      Assert(obj_index < dof_offsets.size(),
-             ExcIndexRange(obj_index, 0, dof_offsets.size()));
+      AssertIndexRange(fe_index, dof_handler.get_fe_collection().size());
+      AssertIndexRange(
+        local_index,
+        dof_handler.get_fe(fe_index).template n_dofs_per_object<structdim>());
+      AssertIndexRange(obj_index, dof_offsets.size());
 
       // make sure we are on an
       // object for which DoFs have
@@ -460,18 +453,11 @@ namespace internal
               dealii::hp::DoFHandler<dim, spacedim>::default_fe_index),
              ExcMessage("You need to specify a FE index when working "
                         "with hp DoFHandlers"));
-      Assert(fe_index < dof_handler.get_fe_collection().size(),
-             ExcIndexRange(fe_index,
-                           0,
-                           dof_handler.get_fe_collection().size()));
-      Assert(local_index < dof_handler.get_fe(fe_index)
-                             .template n_dofs_per_object<structdim>(),
-             ExcIndexRange(local_index,
-                           0,
-                           dof_handler.get_fe(fe_index)
-                             .template n_dofs_per_object<structdim>()));
-      Assert(obj_index < dof_offsets.size(),
-             ExcIndexRange(obj_index, 0, dof_offsets.size()));
+      AssertIndexRange(fe_index, dof_handler.get_fe_collection().size());
+      AssertIndexRange(
+        local_index,
+        dof_handler.get_fe(fe_index).template n_dofs_per_object<structdim>());
+      AssertIndexRange(obj_index, dof_offsets.size());
 
       // make sure we are on an
       // object for which DoFs have
@@ -515,8 +501,7 @@ namespace internal
       const dealii::hp::DoFHandler<dim, spacedim> &dof_handler,
       const unsigned int                           obj_index) const
     {
-      Assert(obj_index < dof_offsets.size(),
-             ExcIndexRange(obj_index, 0, dof_offsets.size()));
+      AssertIndexRange(obj_index, dof_offsets.size());
 
       // make sure we are on an
       // object for which DoFs have
@@ -561,8 +546,7 @@ namespace internal
       const unsigned int obj_index,
       const unsigned int n) const
     {
-      Assert(obj_index < dof_offsets.size(),
-             ExcIndexRange(obj_index, 0, dof_offsets.size()));
+      AssertIndexRange(obj_index, dof_offsets.size());
 
       // make sure we are on an
       // object for which DoFs have
@@ -575,8 +559,7 @@ namespace internal
       Assert(structdim < dim,
              ExcMessage("This object can not be used for cells."));
 
-      Assert(n < n_active_fe_indices(dof_handler, obj_index),
-             ExcIndexRange(n, 0, n_active_fe_indices(dof_handler, obj_index)));
+      AssertIndexRange(n, n_active_fe_indices(dof_handler, obj_index));
 
       // there may be multiple finite elements associated with
       // this object. hop along the list of index sets until we
@@ -616,18 +599,12 @@ namespace internal
       const unsigned int                           fe_index,
       const unsigned int /*obj_level*/) const
     {
-      Assert(obj_index < dof_offsets.size(),
-             ExcIndexRange(obj_index,
-                           0,
-                           static_cast<unsigned int>(dof_offsets.size())));
+      AssertIndexRange(obj_index, dof_offsets.size());
       Assert((fe_index !=
               dealii::hp::DoFHandler<dim, spacedim>::default_fe_index),
              ExcMessage("You need to specify a FE index when working "
                         "with hp DoFHandlers"));
-      Assert(fe_index < dof_handler.get_fe_collection().size(),
-             ExcIndexRange(fe_index,
-                           0,
-                           dof_handler.get_fe_collection().size()));
+      AssertIndexRange(fe_index, dof_handler.get_fe_collection().size());
 
       // make sure we are on an
       // object for which DoFs have

--- a/include/deal.II/hp/dof_level.h
+++ b/include/deal.II/hp/dof_level.h
@@ -408,8 +408,7 @@ namespace internal
                             const unsigned int local_index) const
     {
       (void)fe_index;
-      Assert(obj_index < dof_offsets.size(),
-             ExcIndexRange(obj_index, 0, dof_offsets.size()));
+      AssertIndexRange(obj_index, dof_offsets.size());
 
       // make sure we are on an object for which DoFs have been
       // allocated at all
@@ -441,8 +440,7 @@ namespace internal
                             const types::global_dof_index global_index)
     {
       (void)fe_index;
-      Assert(obj_index < dof_offsets.size(),
-             ExcIndexRange(obj_index, 0, dof_offsets.size()));
+      AssertIndexRange(obj_index, dof_offsets.size());
 
       // make sure we are on an
       // object for which DoFs have
@@ -465,8 +463,7 @@ namespace internal
     inline unsigned int
     DoFLevel::active_fe_index(const unsigned int obj_index) const
     {
-      Assert(obj_index < active_fe_indices.size(),
-             ExcIndexRange(obj_index, 0, active_fe_indices.size()));
+      AssertIndexRange(obj_index, active_fe_indices.size());
 
       if (is_compressed_entry(active_fe_indices[obj_index]) == false)
         return active_fe_indices[obj_index];
@@ -489,8 +486,7 @@ namespace internal
     DoFLevel::set_active_fe_index(const unsigned int obj_index,
                                   const unsigned int fe_index)
     {
-      Assert(obj_index < active_fe_indices.size(),
-             ExcIndexRange(obj_index, 0, active_fe_indices.size()));
+      AssertIndexRange(obj_index, active_fe_indices.size());
 
       // check whether the given fe_index is within the range of
       // values that we interpret as "not compressed". if not, then
@@ -516,8 +512,7 @@ namespace internal
     inline unsigned int
     DoFLevel::future_fe_index(const unsigned int obj_index) const
     {
-      Assert(obj_index < future_fe_indices.size(),
-             ExcIndexRange(obj_index, 0, future_fe_indices.size()));
+      AssertIndexRange(obj_index, future_fe_indices.size());
 
       if (future_fe_index_set(obj_index))
         return future_fe_indices[obj_index];
@@ -531,8 +526,7 @@ namespace internal
     DoFLevel::set_future_fe_index(const unsigned int obj_index,
                                   const unsigned int fe_index)
     {
-      Assert(obj_index < future_fe_indices.size(),
-             ExcIndexRange(obj_index, 0, future_fe_indices.size()));
+      AssertIndexRange(obj_index, future_fe_indices.size());
 
       // check whether the given fe_index is within the range of
       // values that we interpret as "not compressed". if not, then
@@ -558,8 +552,7 @@ namespace internal
     inline bool
     DoFLevel::future_fe_index_set(const unsigned int obj_index) const
     {
-      Assert(obj_index < future_fe_indices.size(),
-             ExcIndexRange(obj_index, 0, future_fe_indices.size()));
+      AssertIndexRange(obj_index, future_fe_indices.size());
 
       return (future_fe_indices[obj_index] != invalid_active_fe_index);
     }
@@ -569,8 +562,7 @@ namespace internal
     inline void
     DoFLevel::clear_future_fe_index(const unsigned int obj_index)
     {
-      Assert(obj_index < future_fe_indices.size(),
-             ExcIndexRange(obj_index, 0, future_fe_indices.size()));
+      AssertIndexRange(obj_index, future_fe_indices.size());
 
       future_fe_indices[obj_index] = invalid_active_fe_index;
     }

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -900,8 +900,7 @@ namespace hp
   inline const FiniteElement<dim, spacedim> &FECollection<dim, spacedim>::
                                              operator[](const unsigned int index) const
   {
-    Assert(index < finite_elements.size(),
-           ExcIndexRange(index, 0, finite_elements.size()));
+    AssertIndexRange(index, finite_elements.size());
     return *finite_elements[index];
   }
 

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -164,7 +164,7 @@ namespace hp
   inline const Mapping<dim, spacedim> &MappingCollection<dim, spacedim>::
                                        operator[](const unsigned int index) const
   {
-    Assert(index < mappings.size(), ExcIndexRange(index, 0, mappings.size()));
+    AssertIndexRange(index, mappings.size());
     return *mappings[index];
   }
 

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -194,8 +194,7 @@ namespace hp
   inline const Quadrature<dim> &QCollection<dim>::
                                 operator[](const unsigned int index) const
   {
-    Assert(index < quadratures.size(),
-           ExcIndexRange(index, 0, quadratures.size()));
+    AssertIndexRange(index, quadratures.size());
     return *quadratures[index];
   }
 

--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -330,7 +330,7 @@ BlockIndices::push_back(const size_type sz)
 inline std::pair<unsigned int, BlockIndices::size_type>
 BlockIndices::global_to_local(const size_type i) const
 {
-  Assert(i < total_size(), ExcIndexRangeType<size_type>(i, 0, total_size()));
+  AssertIndexRange(i, total_size());
   Assert(n_blocks > 0, ExcLowerRangeType<size_type>(i, size_type(1)));
 
   // start_indices[0] == 0 so we might as well start from the next one
@@ -345,10 +345,8 @@ inline BlockIndices::size_type
 BlockIndices::local_to_global(const unsigned int block,
                               const size_type    index) const
 {
-  Assert(block < n_blocks, ExcIndexRange(block, 0, n_blocks));
-  Assert(index < start_indices[block + 1] - start_indices[block],
-         ExcIndexRangeType<size_type>(
-           index, 0, start_indices[block + 1] - start_indices[block]));
+  AssertIndexRange(block, n_blocks);
+  AssertIndexRange(index, start_indices[block + 1] - start_indices[block]);
 
   return start_indices[block] + index;
 }
@@ -375,7 +373,7 @@ BlockIndices::total_size() const
 inline BlockIndices::size_type
 BlockIndices::block_size(const unsigned int block) const
 {
-  Assert(block < n_blocks, ExcIndexRange(block, 0, n_blocks));
+  AssertIndexRange(block, n_blocks);
   return start_indices[block + 1] - start_indices[block];
 }
 
@@ -400,7 +398,7 @@ BlockIndices::to_string() const
 inline BlockIndices::size_type
 BlockIndices::block_start(const unsigned int block) const
 {
-  Assert(block < n_blocks, ExcIndexRange(block, 0, n_blocks));
+  AssertIndexRange(block, n_blocks);
   return start_indices[block];
 }
 

--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -640,8 +640,8 @@ block_operator(const BlockMatrixType &block_matrix)
 #ifdef DEBUG
     const unsigned int m = block_matrix.n_block_rows();
     const unsigned int n = block_matrix.n_block_cols();
-    Assert(i < m, ExcIndexRange(i, 0, m));
-    Assert(j < n, ExcIndexRange(j, 0, n));
+    AssertIndexRange(i, m);
+    AssertIndexRange(j, n);
 #endif
 
     return BlockType(block_matrix.block(i, j));
@@ -707,8 +707,8 @@ block_operator(
   return_op.n_block_cols = []() -> unsigned int { return n; };
 
   return_op.block = [ops](unsigned int i, unsigned int j) -> BlockType {
-    Assert(i < m, ExcIndexRange(i, 0, m));
-    Assert(j < n, ExcIndexRange(j, 0, n));
+    AssertIndexRange(i, m);
+    AssertIndexRange(j, n);
 
     return ops[i][j];
   };
@@ -761,8 +761,8 @@ block_diagonal_operator(const BlockMatrixType &block_matrix)
     const unsigned int m = block_matrix.n_block_rows();
     const unsigned int n = block_matrix.n_block_cols();
     Assert(m == n, ExcDimensionMismatch(m, n));
-    Assert(i < m, ExcIndexRange(i, 0, m));
-    Assert(j < n, ExcIndexRange(j, 0, n));
+    AssertIndexRange(i, m);
+    AssertIndexRange(j, n);
 #endif
     if (i == j)
       return BlockType(block_matrix.block(i, j));

--- a/include/deal.II/lac/block_matrix_array.h
+++ b/include/deal.II/lac/block_matrix_array.h
@@ -568,8 +568,8 @@ BlockMatrixArray<number, BlockVectorType>::enter(const MatrixType &matrix,
                                                  number            prefix,
                                                  bool              transpose)
 {
-  Assert(row < n_block_rows(), ExcIndexRange(row, 0, n_block_rows()));
-  Assert(col < n_block_cols(), ExcIndexRange(col, 0, n_block_cols()));
+  AssertIndexRange(row, n_block_rows());
+  AssertIndexRange(col, n_block_cols());
   entries.push_back(Entry(matrix, row, col, prefix, transpose));
 }
 

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -1570,8 +1570,8 @@ inline typename BlockMatrixBase<MatrixType>::BlockType &
 BlockMatrixBase<MatrixType>::block(const unsigned int row,
                                    const unsigned int column)
 {
-  Assert(row < n_block_rows(), ExcIndexRange(row, 0, n_block_rows()));
-  Assert(column < n_block_cols(), ExcIndexRange(column, 0, n_block_cols()));
+  AssertIndexRange(row, n_block_rows());
+  AssertIndexRange(column, n_block_cols());
 
   return *sub_objects[row][column];
 }
@@ -1583,8 +1583,8 @@ inline const typename BlockMatrixBase<MatrixType>::BlockType &
 BlockMatrixBase<MatrixType>::block(const unsigned int row,
                                    const unsigned int column) const
 {
-  Assert(row < n_block_rows(), ExcIndexRange(row, 0, n_block_rows()));
-  Assert(column < n_block_cols(), ExcIndexRange(column, 0, n_block_cols()));
+  AssertIndexRange(row, n_block_rows());
+  AssertIndexRange(column, n_block_cols());
 
   return *sub_objects[row][column];
 }
@@ -2543,7 +2543,7 @@ template <class MatrixType>
 inline typename BlockMatrixBase<MatrixType>::const_iterator
 BlockMatrixBase<MatrixType>::begin(const size_type r) const
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
   return const_iterator(this, r);
 }
 
@@ -2553,7 +2553,7 @@ template <class MatrixType>
 inline typename BlockMatrixBase<MatrixType>::const_iterator
 BlockMatrixBase<MatrixType>::end(const size_type r) const
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
   return const_iterator(this, r + 1);
 }
 
@@ -2581,7 +2581,7 @@ template <class MatrixType>
 inline typename BlockMatrixBase<MatrixType>::iterator
 BlockMatrixBase<MatrixType>::begin(const size_type r)
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
   return iterator(this, r);
 }
 
@@ -2591,7 +2591,7 @@ template <class MatrixType>
 inline typename BlockMatrixBase<MatrixType>::iterator
 BlockMatrixBase<MatrixType>::end(const size_type r)
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
   return iterator(this, r + 1);
 }
 

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -291,8 +291,8 @@ inline SparseMatrixEZ<Number> &
 BlockSparseMatrixEZ<Number>::block(const unsigned int row,
                                    const unsigned int column)
 {
-  Assert(row < n_block_rows(), ExcIndexRange(row, 0, n_block_rows()));
-  Assert(column < n_block_cols(), ExcIndexRange(column, 0, n_block_cols()));
+  AssertIndexRange(row, n_block_rows());
+  AssertIndexRange(column, n_block_cols());
 
   return blocks[row][column];
 }
@@ -304,8 +304,8 @@ inline const SparseMatrixEZ<Number> &
 BlockSparseMatrixEZ<Number>::block(const unsigned int row,
                                    const unsigned int column) const
 {
-  Assert(row < n_block_rows(), ExcIndexRange(row, 0, n_block_rows()));
-  Assert(column < n_block_cols(), ExcIndexRange(column, 0, n_block_cols()));
+  AssertIndexRange(row, n_block_rows());
+  AssertIndexRange(column, n_block_cols());
 
   return blocks[row][column];
 }

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -767,8 +767,8 @@ inline SparsityPatternType &
 BlockSparsityPatternBase<SparsityPatternType>::block(const size_type row,
                                                      const size_type column)
 {
-  Assert(row < rows, ExcIndexRange(row, 0, rows));
-  Assert(column < columns, ExcIndexRange(column, 0, columns));
+  AssertIndexRange(row, rows);
+  AssertIndexRange(column, columns);
   return *sub_objects[row][column];
 }
 
@@ -780,8 +780,8 @@ BlockSparsityPatternBase<SparsityPatternType>::block(
   const size_type row,
   const size_type column) const
 {
-  Assert(row < rows, ExcIndexRange(row, 0, rows));
-  Assert(column < columns, ExcIndexRange(column, 0, columns));
+  AssertIndexRange(row, rows);
+  AssertIndexRange(column, columns);
   return *sub_objects[row][column];
 }
 
@@ -973,7 +973,7 @@ BlockDynamicSparsityPattern::column_number(const size_type    row,
   const std::pair<size_type, size_type> row_index =
     row_indices.global_to_local(row);
 
-  Assert(index < row_length(row), ExcIndexRange(index, 0, row_length(row)));
+  AssertIndexRange(index, row_length(row));
 
   size_type c             = 0;
   size_type block_columns = 0; // sum of n_cols for all blocks to the left

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -1478,7 +1478,7 @@ template <class VectorType>
 inline typename BlockVectorBase<VectorType>::BlockType &
 BlockVectorBase<VectorType>::block(const unsigned int i)
 {
-  Assert(i < n_blocks(), ExcIndexRange(i, 0, n_blocks()));
+  AssertIndexRange(i, n_blocks());
 
   return components[i];
 }
@@ -1489,7 +1489,7 @@ template <class VectorType>
 inline const typename BlockVectorBase<VectorType>::BlockType &
 BlockVectorBase<VectorType>::block(const unsigned int i) const
 {
-  Assert(i < n_blocks(), ExcIndexRange(i, 0, n_blocks()));
+  AssertIndexRange(i, n_blocks());
 
   return components[i];
 }

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -2009,7 +2009,7 @@ template <typename number>
 inline typename ChunkSparseMatrix<number>::const_iterator
 ChunkSparseMatrix<number>::begin(const unsigned int r) const
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
   return const_iterator(this, r);
 }
 
@@ -2019,7 +2019,7 @@ template <typename number>
 inline typename ChunkSparseMatrix<number>::const_iterator
 ChunkSparseMatrix<number>::end(const unsigned int r) const
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
   return const_iterator(this, r + 1);
 }
 
@@ -2029,7 +2029,7 @@ template <typename number>
 inline typename ChunkSparseMatrix<number>::iterator
 ChunkSparseMatrix<number>::begin(const unsigned int r)
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
   return iterator(this, r);
 }
 
@@ -2039,7 +2039,7 @@ template <typename number>
 inline typename ChunkSparseMatrix<number>::iterator
 ChunkSparseMatrix<number>::end(const unsigned int r)
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
   return iterator(this, r + 1);
 }
 

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -1123,7 +1123,7 @@ ChunkSparsityPattern::end() const
 inline ChunkSparsityPattern::iterator
 ChunkSparsityPattern::begin(const size_type r) const
 {
-  Assert(r < n_rows(), ExcIndexRange(r, 0, n_rows()));
+  AssertIndexRange(r, n_rows());
   return {this, r};
 }
 
@@ -1132,7 +1132,7 @@ ChunkSparsityPattern::begin(const size_type r) const
 inline ChunkSparsityPattern::iterator
 ChunkSparsityPattern::end(const size_type r) const
 {
-  Assert(r < n_rows(), ExcIndexRange(r, 0, n_rows()));
+  AssertIndexRange(r, n_rows());
   return {this, r + 1};
 }
 

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -1031,8 +1031,8 @@ DynamicSparsityPattern::n_cols() const
 inline void
 DynamicSparsityPattern::add(const size_type i, const size_type j)
 {
-  Assert(i < rows, ExcIndexRangeType<size_type>(i, 0, rows));
-  Assert(j < cols, ExcIndexRangeType<size_type>(j, 0, cols));
+  AssertIndexRange(i, rows);
+  AssertIndexRange(j, cols);
 
   if (rowset.size() > 0 && !rowset.is_element(i))
     return;
@@ -1053,7 +1053,7 @@ DynamicSparsityPattern::add_entries(const size_type row,
                                     ForwardIterator end,
                                     const bool      indices_are_sorted)
 {
-  Assert(row < rows, ExcIndexRangeType<size_type>(row, 0, rows));
+  AssertIndexRange(row, rows);
 
   if (rowset.size() > 0 && !rowset.is_element(row))
     return;
@@ -1071,7 +1071,7 @@ DynamicSparsityPattern::add_entries(const size_type row,
 inline types::global_dof_index
 DynamicSparsityPattern::row_length(const size_type row) const
 {
-  Assert(row < n_rows(), ExcIndexRangeType<size_type>(row, 0, n_rows()));
+  AssertIndexRange(row, n_rows());
 
   if (!have_entries)
     return 0;
@@ -1090,15 +1090,12 @@ inline types::global_dof_index
 DynamicSparsityPattern::column_number(const size_type row,
                                       const size_type index) const
 {
-  Assert(row < n_rows(), ExcIndexRangeType<size_type>(row, 0, n_rows()));
+  AssertIndexRange(row, n_rows());
   Assert(rowset.size() == 0 || rowset.is_element(row), ExcInternalError());
 
   const size_type local_row =
     rowset.size() ? rowset.index_within_set(row) : row;
-  Assert(index < lines[local_row].entries.size(),
-         ExcIndexRangeType<size_type>(index,
-                                      0,
-                                      lines[local_row].entries.size()));
+  AssertIndexRange(index, lines[local_row].entries.size());
   return lines[local_row].entries[index];
 }
 
@@ -1125,7 +1122,7 @@ DynamicSparsityPattern::end() const
 inline DynamicSparsityPattern::iterator
 DynamicSparsityPattern::begin(const size_type r) const
 {
-  Assert(r < n_rows(), ExcIndexRangeType<size_type>(r, 0, n_rows()));
+  AssertIndexRange(r, n_rows());
 
   if (!have_entries)
     return {this};
@@ -1183,7 +1180,7 @@ DynamicSparsityPattern::begin(const size_type r) const
 inline DynamicSparsityPattern::iterator
 DynamicSparsityPattern::end(const size_type r) const
 {
-  Assert(r < n_rows(), ExcIndexRangeType<size_type>(r, 0, n_rows()));
+  AssertIndexRange(r, n_rows());
 
   unsigned int row = r + 1;
   if (row == n_rows())

--- a/include/deal.II/lac/filtered_matrix.h
+++ b/include/deal.II/lac/filtered_matrix.h
@@ -581,8 +581,7 @@ inline FilteredMatrix<VectorType>::Accessor::Accessor(
   : matrix(matrix)
   , index(index)
 {
-  Assert(index <= matrix->constraints.size(),
-         ExcIndexRange(index, 0, matrix->constraints.size()));
+  AssertIndexRange(index, matrix->constraints.size() + 1);
 }
 
 

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -955,7 +955,7 @@ inline PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
   b_iterator = matrix->inverse(a_block).begin(r);
   b_end      = matrix->inverse(a_block).end();
 
-  Assert(a_block < matrix->size(), ExcIndexRange(a_block, 0, matrix->size()));
+  AssertIndexRange(a_block, matrix->size());
 }
 
 
@@ -1106,7 +1106,7 @@ inline
   PreconditionBlockJacobi<MatrixType, inverse_type>::begin(
     const size_type r) const
 {
-  Assert(r < this->A->m(), ExcIndexRange(r, 0, this->A->m()));
+  AssertIndexRange(r, this->A->m());
   return const_iterator(this, r);
 }
 
@@ -1118,7 +1118,7 @@ inline
   PreconditionBlockJacobi<MatrixType, inverse_type>::end(
     const size_type r) const
 {
-  Assert(r < this->A->m(), ExcIndexRange(r, 0, this->A->m()));
+  AssertIndexRange(r, this->A->m());
   return const_iterator(this, r + 1);
 }
 

--- a/include/deal.II/lac/precondition_block_base.h
+++ b/include/deal.II/lac/precondition_block_base.h
@@ -481,8 +481,7 @@ PreconditionBlockBase<number>::inverse(size_type i) const
   if (same_diagonal())
     return var_inverse_full[0];
 
-  Assert(i < var_inverse_full.size(),
-         ExcIndexRange(i, 0, var_inverse_full.size()));
+  AssertIndexRange(i, var_inverse_full.size());
   return var_inverse_full[i];
 }
 
@@ -520,7 +519,7 @@ PreconditionBlockBase<number>::diagonal(size_type i) const
   if (same_diagonal())
     return var_diagonal[0];
 
-  Assert(i < var_diagonal.size(), ExcIndexRange(i, 0, var_diagonal.size()));
+  AssertIndexRange(i, var_diagonal.size());
   return var_diagonal[i];
 }
 
@@ -534,8 +533,7 @@ PreconditionBlockBase<number>::inverse(size_type i)
   if (same_diagonal())
     return var_inverse_full[0];
 
-  Assert(i < var_inverse_full.size(),
-         ExcIndexRange(i, 0, var_inverse_full.size()));
+  AssertIndexRange(i, var_inverse_full.size());
   return var_inverse_full[i];
 }
 
@@ -577,7 +575,7 @@ PreconditionBlockBase<number>::diagonal(size_type i)
   if (same_diagonal())
     return var_diagonal[0];
 
-  Assert(i < var_diagonal.size(), ExcIndexRange(i, 0, var_diagonal.size()));
+  AssertIndexRange(i, var_diagonal.size());
   return var_diagonal[i];
 }
 

--- a/include/deal.II/lac/qr.h
+++ b/include/deal.II/lac/qr.h
@@ -615,8 +615,8 @@ void
 ImplicitQR<VectorType>::apply_givens_rotation(const unsigned int i,
                                               const unsigned int k)
 {
-  Assert(i < k, ExcIndexRange(i, 0, k));
-  Assert(k < this->current_size, ExcIndexRange(k, 0, this->current_size));
+  AssertIndexRange(i, k);
+  AssertIndexRange(k, this->current_size);
   const std::array<Number, 3> csr =
     dealii::Utilities::LinearAlgebra::givens_rotation<Number>(this->R(i, k),
                                                               this->R(k, k));
@@ -751,8 +751,8 @@ void
 QR<VectorType>::apply_givens_rotation(const unsigned int i,
                                       const unsigned int k)
 {
-  Assert(i < k, ExcIndexRange(i, 0, k));
-  Assert(k < this->current_size, ExcIndexRange(k, 0, this->current_size));
+  AssertIndexRange(i, k);
+  AssertIndexRange(k, this->current_size);
   const std::array<Number, 3> csr =
     dealii::Utilities::LinearAlgebra::givens_rotation<Number>(this->R(i, k),
                                                               this->R(k, k));
@@ -788,7 +788,7 @@ template <typename VectorType>
 void
 QR<VectorType>::remove_column(const unsigned int k)
 {
-  Assert(k < this->current_size, ExcIndexRange(k, 0, this->current_size));
+  AssertIndexRange(k, this->current_size);
   Assert(this->current_size > 0,
          ExcMessage("Can not remove a column if QR is empty"));
   // apply a sequence of Givens rotations

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -553,7 +553,7 @@ namespace internal
     inline VectorType &TmpVectors<VectorType>::
                        operator[](const unsigned int i) const
     {
-      Assert(i < data.size(), ExcIndexRange(i, 0, data.size()));
+      AssertIndexRange(i, data.size());
 
       Assert(data[i] != nullptr, ExcNotInitialized());
       return *data[i];
@@ -566,7 +566,7 @@ namespace internal
     TmpVectors<VectorType>::operator()(const unsigned int i,
                                        const VectorType & temp)
     {
-      Assert(i < data.size(), ExcIndexRange(i, 0, data.size()));
+      AssertIndexRange(i, data.size());
       if (data[i] == nullptr)
         {
           data[i] = std::move(typename VectorMemory<VectorType>::Pointer(mem));

--- a/include/deal.II/lac/solver_idr.h
+++ b/include/deal.II/lac/solver_idr.h
@@ -204,7 +204,7 @@ namespace internal
     inline VectorType &TmpVectors<VectorType>::
                        operator[](const unsigned int i) const
     {
-      Assert(i < data.size(), ExcIndexRange(i, 0, data.size()));
+      AssertIndexRange(i, data.size());
 
       Assert(data[i] != nullptr, ExcNotInitialized());
       return *data[i];

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -2417,7 +2417,7 @@ template <typename number>
 inline typename SparseMatrix<number>::const_iterator
 SparseMatrix<number>::begin(const size_type r) const
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
 
   return const_iterator(this, cols->rowstart[r]);
 }
@@ -2428,7 +2428,7 @@ template <typename number>
 inline typename SparseMatrix<number>::const_iterator
 SparseMatrix<number>::end(const size_type r) const
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
 
   return const_iterator(this, cols->rowstart[r + 1]);
 }
@@ -2439,7 +2439,7 @@ template <typename number>
 inline typename SparseMatrix<number>::iterator
 SparseMatrix<number>::begin(const size_type r)
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
 
   return iterator(this, cols->rowstart[r]);
 }
@@ -2450,7 +2450,7 @@ template <typename number>
 inline typename SparseMatrix<number>::iterator
 SparseMatrix<number>::end(const size_type r)
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
 
   return iterator(this, cols->rowstart[r + 1]);
 }

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -1104,8 +1104,8 @@ template <typename number>
 inline typename SparseMatrixEZ<number>::Entry *
 SparseMatrixEZ<number>::locate(const size_type row, const size_type col)
 {
-  Assert(row < m(), ExcIndexRange(row, 0, m()));
-  Assert(col < n(), ExcIndexRange(col, 0, n()));
+  AssertIndexRange(row, m());
+  AssertIndexRange(col, n());
 
   const RowInfo & r   = row_info[row];
   const size_type end = r.start + r.length;
@@ -1135,8 +1135,8 @@ template <typename number>
 inline typename SparseMatrixEZ<number>::Entry *
 SparseMatrixEZ<number>::allocate(const size_type row, const size_type col)
 {
-  Assert(row < m(), ExcIndexRange(row, 0, m()));
-  Assert(col < n(), ExcIndexRange(col, 0, n()));
+  AssertIndexRange(row, m());
+  AssertIndexRange(col, n());
 
   RowInfo &       r   = row_info[row];
   const size_type end = r.start + r.length;
@@ -1238,8 +1238,8 @@ SparseMatrixEZ<number>::set(const size_type i,
 {
   AssertIsFinite(value);
 
-  Assert(i < m(), ExcIndexRange(i, 0, m()));
-  Assert(j < n(), ExcIndexRange(j, 0, n()));
+  AssertIndexRange(i, m());
+  AssertIndexRange(j, n());
 
   if (elide_zero_values && value == 0.)
     {
@@ -1264,8 +1264,8 @@ SparseMatrixEZ<number>::add(const size_type i,
 {
   AssertIsFinite(value);
 
-  Assert(i < m(), ExcIndexRange(i, 0, m()));
-  Assert(j < n(), ExcIndexRange(j, 0, n()));
+  AssertIndexRange(i, m());
+  AssertIndexRange(j, n());
 
   // ignore zero additions
   if (std::abs(value) == 0.)
@@ -1386,7 +1386,7 @@ template <typename number>
 inline typename SparseMatrixEZ<number>::const_iterator
 SparseMatrixEZ<number>::begin(const size_type r) const
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
   const_iterator result(this, r, 0);
   return result;
 }
@@ -1395,7 +1395,7 @@ template <typename number>
 inline typename SparseMatrixEZ<number>::const_iterator
 SparseMatrixEZ<number>::end(const size_type r) const
 {
-  Assert(r < m(), ExcIndexRange(r, 0, m()));
+  AssertIndexRange(r, m());
   const_iterator result(this, r + 1, 0);
   return result;
 }

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -1463,7 +1463,7 @@ SparsityPatternBase::end() const
 inline SparsityPatternBase::iterator
 SparsityPatternBase::begin(const size_type r) const
 {
-  Assert(r < n_rows(), ExcIndexRangeType<size_type>(r, 0, n_rows()));
+  AssertIndexRange(r, n_rows());
 
   return {this, rowstart[r]};
 }
@@ -1473,7 +1473,7 @@ SparsityPatternBase::begin(const size_type r) const
 inline SparsityPatternBase::iterator
 SparsityPatternBase::end(const size_type r) const
 {
-  Assert(r < n_rows(), ExcIndexRangeType<size_type>(r, 0, n_rows()));
+  AssertIndexRange(r, n_rows());
 
   return {this, rowstart[r + 1]};
 }
@@ -1515,7 +1515,7 @@ SparsityPattern::stores_only_added_elements() const
 inline unsigned int
 SparsityPatternBase::row_length(const size_type row) const
 {
-  Assert(row < rows, ExcIndexRangeType<size_type>(row, 0, rows));
+  AssertIndexRange(row, rows);
   return rowstart[row + 1] - rowstart[row];
 }
 
@@ -1525,8 +1525,8 @@ inline SparsityPattern::size_type
 SparsityPatternBase::column_number(const size_type    row,
                                    const unsigned int index) const
 {
-  Assert(row < rows, ExcIndexRangeType<size_type>(row, 0, rows));
-  Assert(index < row_length(row), ExcIndexRange(index, 0, row_length(row)));
+  AssertIndexRange(row, rows);
+  AssertIndexRange(index, row_length(row));
 
   return colnums[rowstart[row] + index];
 }
@@ -1709,7 +1709,7 @@ SparsityPattern::copy_from(const size_type       n_rows,
         {
           const size_type col =
             internal::SparsityPatternTools::get_column_index_from_iterator(*j);
-          Assert(col < n_cols, ExcIndexRange(col, 0, n_cols));
+          AssertIndexRange(col, n_cols);
 
           if ((col != row) || !is_square)
             *cols++ = col;

--- a/include/deal.II/lac/tridiagonal_matrix.h
+++ b/include/deal.II/lac/tridiagonal_matrix.h
@@ -292,8 +292,8 @@ template <typename number>
 inline number
 TridiagonalMatrix<number>::operator()(size_type i, size_type j) const
 {
-  Assert(i < n(), ExcIndexRange(i, 0, n()));
-  Assert(j < n(), ExcIndexRange(j, 0, n()));
+  AssertIndexRange(i, n());
+  AssertIndexRange(j, n());
   Assert(i <= j + 1, ExcIndexRange(i, j - 1, j + 2));
   Assert(j <= i + 1, ExcIndexRange(j, i - 1, i + 2));
 
@@ -319,8 +319,8 @@ template <typename number>
 inline number &
 TridiagonalMatrix<number>::operator()(size_type i, size_type j)
 {
-  Assert(i < n(), ExcIndexRange(i, 0, n()));
-  Assert(j < n(), ExcIndexRange(j, 0, n()));
+  AssertIndexRange(i, n());
+  AssertIndexRange(j, n());
   Assert(i <= j + 1, ExcIndexRange(i, j - 1, j + 2));
   Assert(j <= i + 1, ExcIndexRange(j, i - 1, i + 2));
 

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2912,7 +2912,7 @@ namespace TrilinosWrappers
   inline SparseMatrix::const_iterator
   SparseMatrix::begin(const size_type r) const
   {
-    Assert(r < m(), ExcIndexRange(r, 0, m()));
+    AssertIndexRange(r, m());
     if (in_local_range(r) && (row_length(r) > 0))
       return const_iterator(this, r, 0);
     else
@@ -2924,7 +2924,7 @@ namespace TrilinosWrappers
   inline SparseMatrix::const_iterator
   SparseMatrix::end(const size_type r) const
   {
-    Assert(r < m(), ExcIndexRange(r, 0, m()));
+    AssertIndexRange(r, m());
 
     // place the iterator on the first entry
     // past this line, or at the end of the
@@ -2959,7 +2959,7 @@ namespace TrilinosWrappers
   inline SparseMatrix::iterator
   SparseMatrix::begin(const size_type r)
   {
-    Assert(r < m(), ExcIndexRange(r, 0, m()));
+    AssertIndexRange(r, m());
     if (in_local_range(r) && (row_length(r) > 0))
       return iterator(this, r, 0);
     else
@@ -2971,7 +2971,7 @@ namespace TrilinosWrappers
   inline SparseMatrix::iterator
   SparseMatrix::end(const size_type r)
   {
-    Assert(r < m(), ExcIndexRange(r, 0, m()));
+    AssertIndexRange(r, m());
 
     // place the iterator on the first entry
     // past this line, or at the end of the

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -1416,7 +1416,7 @@ namespace TrilinosWrappers
   inline SparsityPattern::const_iterator
   SparsityPattern::begin(const size_type r) const
   {
-    Assert(r < n_rows(), ExcIndexRangeType<size_type>(r, 0, n_rows()));
+    AssertIndexRange(r, n_rows());
     if (row_length(r) > 0)
       return const_iterator(this, r, 0);
     else
@@ -1428,7 +1428,7 @@ namespace TrilinosWrappers
   inline SparsityPattern::const_iterator
   SparsityPattern::end(const size_type r) const
   {
-    Assert(r < n_rows(), ExcIndexRangeType<size_type>(r, 0, n_rows()));
+    AssertIndexRange(r, n_rows());
 
     // place the iterator on the first entry
     // past this line, or at the end of the

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1175,7 +1175,7 @@ template <typename Number>
 inline Number
 Vector<Number>::operator()(const size_type i) const
 {
-  Assert(i < size(), ExcIndexRange(i, 0, size()));
+  AssertIndexRange(i, size());
   return values[i];
 }
 
@@ -1185,7 +1185,7 @@ template <typename Number>
 inline Number &
 Vector<Number>::operator()(const size_type i)
 {
-  Assert(i < size(), ExcIndexRangeType<size_type>(i, 0, size()));
+  AssertIndexRange(i, size());
   return values[i];
 }
 
@@ -1284,7 +1284,7 @@ Vector<Number>::add(const size_type    n_indices,
 {
   for (size_type i = 0; i < n_indices; ++i)
     {
-      Assert(indices[i] < size(), ExcIndexRange(indices[i], 0, size()));
+      AssertIndexRange(indices[i], size());
       Assert(
         numbers::is_finite(values[i]),
         ExcMessage(

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -686,7 +686,7 @@ namespace MeshWorker
   inline const FEValuesBase<dim, spacedim> &
   IntegrationInfo<dim, spacedim>::fe_values(unsigned int i) const
   {
-    Assert(i < fevalv.size(), ExcIndexRange(i, 0, fevalv.size()));
+    AssertIndexRange(i, fevalv.size());
     return *fevalv[i];
   }
 

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -389,8 +389,7 @@ MGConstrainedDoFs::make_no_normal_flux_constraints(
   // For a given boundary id, find which vector component is on the boundary
   // and set a zero boundary constraint for those degrees of freedom.
   const unsigned int n_components = DoFTools::n_components(dof);
-  Assert(first_vector_component + dim <= n_components,
-         ExcIndexRange(first_vector_component, 0, n_components - dim + 1));
+  AssertIndexRange(first_vector_component + dim - 1, n_components);
 
   ComponentMask comp_mask(n_components, false);
 

--- a/include/deal.II/numerics/history.h
+++ b/include/deal.II/numerics/history.h
@@ -148,7 +148,7 @@ template <typename T>
 void
 FiniteSizeHistory<T>::remove(const std::size_t ind)
 {
-  Assert(ind < data.size(), ExcIndexRange(ind, 0, data.size()));
+  AssertIndexRange(ind, data.size());
   auto el = std::move(data[ind]);
   data.erase(data.begin() + ind);
 
@@ -207,7 +207,7 @@ FiniteSizeHistory<T>::add(const T &element)
 template <typename T>
 T &FiniteSizeHistory<T>::operator[](const std::size_t ind)
 {
-  Assert(ind < data.size(), ExcIndexRange(ind, 0, data.size()));
+  AssertIndexRange(ind, data.size());
   return *data[ind];
 }
 
@@ -216,7 +216,7 @@ T &FiniteSizeHistory<T>::operator[](const std::size_t ind)
 template <typename T>
 const T &FiniteSizeHistory<T>::operator[](const std::size_t ind) const
 {
-  Assert(ind < data.size(), ExcIndexRange(ind, 0, data.size()));
+  AssertIndexRange(ind, data.size());
   return *data[ind];
 }
 

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -9662,8 +9662,7 @@ namespace VectorTools
     using Number = typename VectorType::value_type;
     Assert(v.size() == dof.n_dofs(),
            ExcDimensionMismatch(v.size(), dof.n_dofs()));
-    Assert(component < dof.get_fe(0).n_components(),
-           ExcIndexRange(component, 0, dof.get_fe(0).n_components()));
+    AssertIndexRange(component, dof.get_fe(0).n_components());
 
     FEValues<dim, spacedim> fe(mapping,
                                dof.get_fe(),

--- a/include/deal.II/physics/notation.h
+++ b/include/deal.II/physics/notation.h
@@ -690,7 +690,7 @@ namespace Physics
         inline std::pair<unsigned int, unsigned int>
         indices_from_component<1>(const unsigned int component_n, const bool)
         {
-          Assert(component_n < 1, ExcIndexRange(component_n, 0, 1));
+          AssertIndexRange(component_n, 1);
 
           return std::make_pair(0u, 0u);
         }

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -723,18 +723,15 @@ namespace
         switch (dim)
           {
             case 3:
-              Assert(zstep < n_subdivisions + 1,
-                     ExcIndexRange(zstep, 0, n_subdivisions + 1));
+              AssertIndexRange(zstep, n_subdivisions + 1);
               point_no += (n_subdivisions + 1) * (n_subdivisions + 1) * zstep;
               DEAL_II_FALLTHROUGH;
             case 2:
-              Assert(ystep < n_subdivisions + 1,
-                     ExcIndexRange(ystep, 0, n_subdivisions + 1));
+              AssertIndexRange(ystep, n_subdivisions + 1);
               point_no += (n_subdivisions + 1) * ystep;
               DEAL_II_FALLTHROUGH;
             case 1:
-              Assert(xstep < n_subdivisions + 1,
-                     ExcIndexRange(xstep, 0, n_subdivisions + 1));
+              AssertIndexRange(xstep, n_subdivisions + 1);
               point_no += xstep;
               DEAL_II_FALLTHROUGH;
             case 0:
@@ -1763,7 +1760,7 @@ namespace DataOutBase
     for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
       neighbors[i] = no_neighbor;
 
-    Assert(dim <= spacedim, ExcIndexRange(dim, 0, spacedim));
+    AssertIndexRange(dim, spacedim + 1);
     Assert(spacedim <= 3, ExcNotImplemented());
   }
 
@@ -6279,9 +6276,10 @@ namespace DataOutBase
 
     projected_point = compute_node(first_patch, 0, 0, 0, n_subdivisions);
 
-    Assert((flags.height_vector < first_patch.data.n_rows()) ||
-             first_patch.data.n_rows() == 0,
-           ExcIndexRange(flags.height_vector, 0, first_patch.data.n_rows()));
+    if (first_patch.data.n_rows() != 0)
+      {
+        AssertIndexRange(flags.height_vector, first_patch.data.n_rows());
+      }
 
     double x_min = projected_point[0];
     double x_max = x_min;
@@ -6486,9 +6484,10 @@ namespace DataOutBase
 
     projected_point = compute_node(first_patch, 0, 0, 0, n_subdivisions);
 
-    Assert((flags.height_vector < first_patch.data.n_rows()) ||
-             first_patch.data.n_rows() == 0,
-           ExcIndexRange(flags.height_vector, 0, first_patch.data.n_rows()));
+    if (first_patch.data.n_rows() != 0)
+      {
+        AssertIndexRange(flags.height_vector, first_patch.data.n_rows());
+      }
 
     point[0] = projected_point[0];
     point[1] = projected_point[1];

--- a/source/base/flow_function.cc
+++ b/source/base/flow_function.cc
@@ -103,7 +103,7 @@ namespace Functions
   FlowFunction<dim>::value(const Point<dim> & point,
                            const unsigned int comp) const
   {
-    Assert(comp < dim + 1, ExcIndexRange(comp, 0, dim + 1));
+    AssertIndexRange(comp, dim + 1);
     const unsigned int      n_points = 1;
     std::vector<Point<dim>> points(1);
     points[0] = point;

--- a/source/base/function_lib.cc
+++ b/source/base/function_lib.cc
@@ -1933,7 +1933,7 @@ namespace Functions
                                     const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
     return std::cos(fourier_coefficients * p);
   }
 
@@ -1945,7 +1945,7 @@ namespace Functions
                                        const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
     return -fourier_coefficients * std::sin(fourier_coefficients * p);
   }
 
@@ -1957,7 +1957,7 @@ namespace Functions
                                         const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
     return (fourier_coefficients * fourier_coefficients) *
            (-std::cos(fourier_coefficients * p));
   }
@@ -1983,7 +1983,7 @@ namespace Functions
                                   const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
     return std::sin(fourier_coefficients * p);
   }
 
@@ -1995,7 +1995,7 @@ namespace Functions
                                      const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
     return fourier_coefficients * std::cos(fourier_coefficients * p);
   }
 
@@ -2007,7 +2007,7 @@ namespace Functions
                                       const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
     return (fourier_coefficients * fourier_coefficients) *
            (-std::sin(fourier_coefficients * p));
   }
@@ -2039,7 +2039,7 @@ namespace Functions
                              const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
 
     const unsigned int n   = weights.size();
     double             sum = 0;
@@ -2057,7 +2057,7 @@ namespace Functions
                                 const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
 
     const unsigned int n = weights.size();
     Tensor<1, dim>     sum;
@@ -2075,7 +2075,7 @@ namespace Functions
                                  const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
 
     const unsigned int n   = weights.size();
     double             sum = 0;
@@ -2113,7 +2113,7 @@ namespace Functions
                                const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
 
     const unsigned int n   = weights.size();
     double             sum = 0;
@@ -2131,7 +2131,7 @@ namespace Functions
                                   const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
 
     const unsigned int n = weights.size();
     Tensor<1, dim>     sum;
@@ -2149,7 +2149,7 @@ namespace Functions
                                    const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
 
     const unsigned int n   = weights.size();
     double             sum = 0;
@@ -2180,8 +2180,7 @@ namespace Functions
   Monomial<dim>::value(const Point<dim> &p, const unsigned int component) const
   {
     (void)component;
-    Assert(component < this->n_components,
-           ExcIndexRange(component, 0, this->n_components));
+    AssertIndexRange(component, this->n_components);
 
     double prod = 1;
     for (unsigned int s = 0; s < dim; ++s)
@@ -2216,7 +2215,7 @@ namespace Functions
                           const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
 
     Tensor<1, dim> r;
     for (unsigned int d = 0; d < dim; ++d)
@@ -2748,7 +2747,7 @@ namespace Functions
                          const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
 
     double sum = 0;
     for (unsigned int monom = 0; monom < exponents.n_rows(); ++monom)
@@ -2790,7 +2789,7 @@ namespace Functions
                             const unsigned int component) const
   {
     (void)component;
-    Assert(component == 0, ExcIndexRange(component, 0, 1));
+    AssertIndexRange(component, 1);
 
     Tensor<1, dim> r;
 

--- a/source/base/function_lib_cutoff.cc
+++ b/source/base/function_lib_cutoff.cc
@@ -251,8 +251,7 @@ namespace Functions
   {
     Assert(values.size() == points.size(),
            ExcDimensionMismatch(values.size(), points.size()));
-    Assert(component < this->n_components,
-           ExcIndexRange(component, 0, this->n_components));
+    AssertIndexRange(component, this->n_components);
 
 
     if (this->selected == CutOffFunctionBase<dim>::no_component ||

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -277,8 +277,7 @@ FunctionParser<dim>::value(const Point<dim> & p,
                            const unsigned int component) const
 {
   Assert(initialized == true, ExcNotInitialized());
-  Assert(component < this->n_components,
-         ExcIndexRange(component, 0, this->n_components));
+  AssertIndexRange(component, this->n_components);
 
   // initialize the parser if that hasn't happened yet on the current thread
   if (fp.get().size() == 0)

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -364,11 +364,10 @@ IndexSet::add_indices(const IndexSet &other, const size_type offset)
   if ((this == &other) && (offset == 0))
     return;
 
-  Assert(other.ranges.size() == 0 ||
-           other.ranges.back().end - 1 < index_space_size,
-         ExcIndexRangeType<size_type>(other.ranges.back().end - 1,
-                                      0,
-                                      index_space_size));
+  if (other.ranges.size() != 0)
+    {
+      AssertIndexRange(other.ranges.back().end - 1, index_space_size);
+    }
 
   compress();
   other.compress();

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -293,7 +293,7 @@ namespace Utilities
       for (const unsigned int destination : destinations)
         {
           (void)destination;
-          Assert(destination < n_procs, ExcIndexRange(destination, 0, n_procs));
+          AssertIndexRange(destination, n_procs);
           Assert(destination != myid,
                  ExcMessage(
                    "There is no point in communicating with ourselves."));
@@ -431,7 +431,7 @@ namespace Utilities
       for (const unsigned int destination : destinations)
         {
           (void)destination;
-          Assert(destination < n_procs, ExcIndexRange(destination, 0, n_procs));
+          AssertIndexRange(destination, n_procs);
           Assert(destination != Utilities::MPI::this_mpi_process(mpi_comm),
                  ExcMessage(
                    "There is no point in communicating with ourselves."));

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -754,11 +754,10 @@ namespace Polynomials
                                             const unsigned int   support_point,
                                             std::vector<double> &a)
   {
-    Assert(support_point < n + 1, ExcIndexRange(support_point, 0, n + 1));
+    AssertIndexRange(support_point, n + 1);
 
     unsigned int n_functions = n + 1;
-    Assert(support_point < n_functions,
-           ExcIndexRange(support_point, 0, n_functions));
+    AssertIndexRange(support_point, n_functions);
     double const *x = nullptr;
 
     switch (n)

--- a/source/base/polynomial_space.cc
+++ b/source/base/polynomial_space.cc
@@ -47,7 +47,7 @@ template <>
 std::array<unsigned int, 1>
 PolynomialSpace<1>::compute_index(const unsigned int i) const
 {
-  Assert(i < index_map.size(), ExcIndexRange(i, 0, index_map.size()));
+  AssertIndexRange(i, index_map.size());
   return {{index_map[i]}};
 }
 
@@ -57,7 +57,7 @@ template <>
 std::array<unsigned int, 2>
 PolynomialSpace<2>::compute_index(const unsigned int i) const
 {
-  Assert(i < index_map.size(), ExcIndexRange(i, 0, index_map.size()));
+  AssertIndexRange(i, index_map.size());
   const unsigned int n = index_map[i];
   // there should be a better way to
   // write this function (not
@@ -83,7 +83,7 @@ template <>
 std::array<unsigned int, 3>
 PolynomialSpace<3>::compute_index(const unsigned int i) const
 {
-  Assert(i < index_map.size(), ExcIndexRange(i, 0, index_map.size()));
+  AssertIndexRange(i, index_map.size());
   const unsigned int n = index_map[i];
   // there should be a better way to
   // write this function (not

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -1063,8 +1063,7 @@ Quadrature<dim>
 QProjector<dim>::project_to_child(const Quadrature<dim> &quadrature,
                                   const unsigned int     child_no)
 {
-  Assert(child_no < GeometryInfo<dim>::max_children_per_cell,
-         ExcIndexRange(child_no, 0, GeometryInfo<dim>::max_children_per_cell));
+  AssertIndexRange(child_no, GeometryInfo<dim>::max_children_per_cell);
 
   const unsigned int n_q_points = quadrature.size();
 

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -686,7 +686,7 @@ QGaussOneOverR<2>::QGaussOneOverR(const unsigned int n,
   // general one, you should use the
   // one with the Point<2> in the
   // constructor.
-  Assert(vertex_index < 4, ExcIndexRange(vertex_index, 0, 4));
+  AssertIndexRange(vertex_index, 4);
 
   // Start with the gauss quadrature formula on the (u,v) reference
   // element.
@@ -698,7 +698,7 @@ QGaussOneOverR<2>::QGaussOneOverR(const unsigned int n,
   // quadrilateral. We are planning to do this also for the support
   // points of arbitrary FE_Q elements, to allow the use of this
   // class in boundary element programs with higher order mappings.
-  Assert(vertex_index < 4, ExcIndexRange(vertex_index, 0, 4));
+  AssertIndexRange(vertex_index, 4);
 
   // We create only the first one. All other pieces are rotation of
   // this one.

--- a/source/base/tensor.cc
+++ b/source/base/tensor.cc
@@ -24,15 +24,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
-template <int dim, typename Number>
-constexpr unsigned int Tensor<0, dim, Number>::n_independent_components;
-
-template <int rank, int dim, typename Number>
-constexpr unsigned int Tensor<rank, dim, Number>::n_independent_components;
-
-
 #include "tensor.inst"
-
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -834,7 +834,7 @@ namespace Utilities
 
     for (unsigned int i = 0; i < n; ++i)
       {
-        Assert(permutation[i] < n, ExcIndexRange(permutation[i], 0, n));
+        AssertIndexRange(permutation[i], n);
         out[permutation[i]] = i;
       }
 
@@ -870,7 +870,7 @@ namespace Utilities
 
     for (unsigned long long int i = 0; i < n; ++i)
       {
-        Assert(permutation[i] < n, ExcIndexRange(permutation[i], 0, n));
+        AssertIndexRange(permutation[i], n);
         out[permutation[i]] = i;
       }
 
@@ -909,7 +909,7 @@ namespace Utilities
 
     for (unsigned int i = 0; i < n; ++i)
       {
-        Assert(permutation[i] < n, ExcIndexRange(permutation[i], 0, n));
+        AssertIndexRange(permutation[i], n);
         out[permutation[i]] = i;
       }
 

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -379,11 +379,8 @@ namespace parallel
     Triangulation<dim, spacedim>::coarse_cell_index_to_coarse_cell_id(
       const unsigned int coarse_cell_index) const
     {
-      Assert(coarse_cell_index <
-               coarse_cell_index_to_coarse_cell_id_vector.size(),
-             ExcIndexRange(coarse_cell_index,
-                           0,
-                           coarse_cell_index_to_coarse_cell_id_vector.size()));
+      AssertIndexRange(coarse_cell_index,
+                       coarse_cell_index_to_coarse_cell_id_vector.size());
 
       const auto coarse_cell_id =
         coarse_cell_index_to_coarse_cell_id_vector[coarse_cell_index];

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2533,8 +2533,7 @@ namespace DoFTools
   {
     static const int space_dim = DoFHandlerType::space_dimension;
     (void)space_dim;
-    Assert(0 <= direction && direction < space_dim,
-           ExcIndexRange(direction, 0, space_dim));
+    AssertIndexRange(direction, space_dim);
 
     Assert(b_id1 != b_id2,
            ExcMessage("The boundary indicators b_id1 and b_id2 must be "
@@ -2571,8 +2570,7 @@ namespace DoFTools
     (void)dim;
     (void)space_dim;
 
-    Assert(0 <= direction && direction < space_dim,
-           ExcIndexRange(direction, 0, space_dim));
+    AssertIndexRange(direction, space_dim);
 
     Assert(dim == space_dim, ExcNotImplemented());
 

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -306,19 +306,13 @@ FiniteElement<dim, spacedim>::get_restriction_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Restriction matrices are only available for refined cells!"));
-  Assert(child <
-           GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(
-                         RefinementCase<dim>(refinement_case))));
+  AssertIndexRange(
+    child, GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)));
   // we use refinement_case-1 here. the -1 takes care of the origin of the
   // vector, as for RefinementCase<dim>::no_refinement (=0) there is no data
   // available and so the vector indices are shifted
@@ -335,19 +329,13 @@ FiniteElement<dim, spacedim>::get_prolongation_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Prolongation matrices are only available for refined cells!"));
-  Assert(child <
-           GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(
-                         RefinementCase<dim>(refinement_case))));
+  AssertIndexRange(
+    child, GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)));
   // we use refinement_case-1 here. the -1 takes care
   // of the origin of the vector, as for
   // RefinementCase::no_refinement (=0) there is no
@@ -365,8 +353,7 @@ unsigned int
 FiniteElement<dim, spacedim>::component_to_block_index(
   const unsigned int index) const
 {
-  Assert(index < this->n_components(),
-         ExcIndexRange(index, 0, this->n_components()));
+  AssertIndexRange(index, this->n_components());
 
   return first_block_of_base(component_to_base_table[index].first.first) +
          component_to_base_table[index].second;
@@ -553,10 +540,8 @@ FiniteElement<dim, spacedim>::face_to_cell_index(const unsigned int face_index,
                                                  const bool face_flip,
                                                  const bool face_rotation) const
 {
-  Assert(face_index < this->dofs_per_face,
-         ExcIndexRange(face_index, 0, this->dofs_per_face));
-  Assert(face < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(face_index, this->dofs_per_face);
+  AssertIndexRange(face, GeometryInfo<dim>::faces_per_cell);
 
   // TODO: we could presumably solve the 3d case below using the
   // adjust_quad_dof_index_for_face_orientation_table field. for the
@@ -653,8 +638,7 @@ FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
   // in 3d), so we don't need the table, but
   // the function should also not have been
   // called
-  Assert(index < this->dofs_per_quad,
-         ExcIndexRange(index, 0, this->dofs_per_quad));
+  AssertIndexRange(index, this->dofs_per_quad);
   Assert(adjust_quad_dof_index_for_face_orientation_table.n_elements() ==
            8 * this->dofs_per_quad,
          ExcInternalError());
@@ -677,8 +661,7 @@ FiniteElement<dim, spacedim>::adjust_line_dof_index_for_line_orientation(
   if (dim < 3)
     return index;
 
-  Assert(index < this->dofs_per_line,
-         ExcIndexRange(index, 0, this->dofs_per_line));
+  AssertIndexRange(index, this->dofs_per_line);
   Assert(adjust_line_dof_index_for_line_orientation_table.size() ==
            this->dofs_per_line,
          ExcInternalError());
@@ -1054,8 +1037,7 @@ template <int dim, int spacedim>
 Point<dim>
 FiniteElement<dim, spacedim>::unit_support_point(const unsigned int index) const
 {
-  Assert(index < this->dofs_per_cell,
-         ExcIndexRange(index, 0, this->dofs_per_cell));
+  AssertIndexRange(index, this->dofs_per_cell);
   Assert(unit_support_points.size() == this->dofs_per_cell,
          ExcFEHasNoSupportPoints());
   return unit_support_points[index];
@@ -1117,8 +1099,7 @@ Point<dim - 1>
 FiniteElement<dim, spacedim>::unit_face_support_point(
   const unsigned int index) const
 {
-  Assert(index < this->dofs_per_face,
-         ExcIndexRange(index, 0, this->dofs_per_face));
+  AssertIndexRange(index, this->dofs_per_face);
   Assert(unit_face_support_points.size() == this->dofs_per_face,
          ExcFEHasNoSupportPoints());
   return unit_face_support_points[index];
@@ -1295,7 +1276,7 @@ const FiniteElement<dim, spacedim> &
 FiniteElement<dim, spacedim>::base_element(const unsigned int index) const
 {
   (void)index;
-  Assert(index == 0, ExcIndexRange(index, 0, 1));
+  AssertIndexRange(index, 1);
   // This function should not be
   // called for a system element
   Assert(base_to_block_indices.size() == 1, ExcInternalError());

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -491,10 +491,8 @@ bool
 FE_ABF<dim>::has_support_on_face(const unsigned int shape_index,
                                  const unsigned int face_index) const
 {
-  Assert(shape_index < this->dofs_per_cell,
-         ExcIndexRange(shape_index, 0, this->dofs_per_cell));
-  Assert(face_index < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_index, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   // Return computed values if we
   // know them easily. Otherwise, it

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -139,7 +139,7 @@ FE_DGPNonparametric<dim, spacedim>::shape_value(const unsigned int i,
 {
   (void)i;
   (void)p;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
   return 0;
@@ -157,8 +157,8 @@ FE_DGPNonparametric<dim, spacedim>::shape_value_component(
   (void)i;
   (void)p;
   (void)component;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component == 0, ExcIndexRange(component, 0, 1));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, 1);
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
   return 0;
@@ -173,7 +173,7 @@ FE_DGPNonparametric<dim, spacedim>::shape_grad(const unsigned int i,
 {
   (void)i;
   (void)p;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
   return Tensor<1, dim>();
@@ -190,8 +190,8 @@ FE_DGPNonparametric<dim, spacedim>::shape_grad_component(
   (void)i;
   (void)p;
   (void)component;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component == 0, ExcIndexRange(component, 0, 1));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, 1);
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
   return Tensor<1, dim>();
@@ -206,7 +206,7 @@ FE_DGPNonparametric<dim, spacedim>::shape_grad_grad(const unsigned int i,
 {
   (void)i;
   (void)p;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
   return Tensor<2, dim>();
@@ -224,8 +224,8 @@ FE_DGPNonparametric<dim, spacedim>::shape_grad_grad_component(
   (void)i;
   (void)p;
   (void)component;
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component == 0, ExcIndexRange(component, 0, 1));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, 1);
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
   return Tensor<2, dim>();

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -400,17 +400,12 @@ FE_DGQ<dim, spacedim>::get_prolongation_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Prolongation matrices are only available for refined cells!"));
-  Assert(child < GeometryInfo<dim>::n_children(refinement_case),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(refinement_case)));
+  AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
@@ -480,17 +475,12 @@ FE_DGQ<dim, spacedim>::get_restriction_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Restriction matrices are only available for refined cells!"));
-  Assert(child < GeometryInfo<dim>::n_children(refinement_case),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(refinement_case)));
+  AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
@@ -719,10 +709,8 @@ bool
 FE_DGQ<dim, spacedim>::has_support_on_face(const unsigned int shape_index,
                                            const unsigned int face_index) const
 {
-  Assert(shape_index < this->dofs_per_cell,
-         ExcIndexRange(shape_index, 0, this->dofs_per_cell));
-  Assert(face_index < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_index, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   unsigned int n = this->degree + 1;
 

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -2036,10 +2036,8 @@ bool
 FE_Nedelec<dim>::has_support_on_face(const unsigned int shape_index,
                                      const unsigned int face_index) const
 {
-  Assert(shape_index < this->dofs_per_cell,
-         ExcIndexRange(shape_index, 0, this->dofs_per_cell));
-  Assert(face_index < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_index, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   const unsigned int deg = this->degree - 1;
   switch (dim)
@@ -2959,17 +2957,12 @@ FE_Nedelec<dim>::get_prolongation_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Prolongation matrices are only available for refined cells!"));
-  Assert(child < GeometryInfo<dim>::n_children(refinement_case),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(refinement_case)));
+  AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
@@ -3019,19 +3012,13 @@ FE_Nedelec<dim>::get_restriction_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Restriction matrices are only available for refined cells!"));
-  Assert(child <
-           GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(
-                         RefinementCase<dim>(refinement_case))));
+  AssertIndexRange(
+    child, GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)));
 
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -218,7 +218,7 @@ FE_PolyTensor<dim, spacedim>::get_mapping_kind(const unsigned int i) const
   if (single_mapping_kind())
     return mapping_kind[0];
 
-  Assert(i < mapping_kind.size(), ExcIndexRange(i, 0, mapping_kind.size()));
+  AssertIndexRange(i, mapping_kind.size());
   return mapping_kind[i];
 }
 
@@ -243,8 +243,8 @@ FE_PolyTensor<dim, spacedim>::shape_value_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component < dim, ExcIndexRange(component, 0, dim));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, dim);
 
   std::lock_guard<std::mutex> lock(cache_mutex);
 
@@ -288,8 +288,8 @@ FE_PolyTensor<dim, spacedim>::shape_grad_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component < dim, ExcIndexRange(component, 0, dim));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, dim);
 
   std::lock_guard<std::mutex> lock(cache_mutex);
 
@@ -334,8 +334,8 @@ FE_PolyTensor<dim, spacedim>::shape_grad_grad_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component < dim, ExcIndexRange(component, 0, dim));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, dim);
 
   std::lock_guard<std::mutex> lock(cache_mutex);
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -1034,10 +1034,8 @@ FE_Q_Base<PolynomialType, dim, spacedim>::face_to_cell_index(
   const bool         face_flip,
   const bool         face_rotation) const
 {
-  Assert(face_index < this->dofs_per_face,
-         ExcIndexRange(face_index, 0, this->dofs_per_face));
-  Assert(face < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(face_index, this->dofs_per_face);
+  AssertIndexRange(face, GeometryInfo<dim>::faces_per_cell);
 
   // TODO: we could presumably solve the 3d case below using the
   // adjust_quad_dof_index_for_face_orientation_table field. for the
@@ -1172,17 +1170,12 @@ FE_Q_Base<PolynomialType, dim, spacedim>::get_prolongation_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Prolongation matrices are only available for refined cells!"));
-  Assert(child < GeometryInfo<dim>::n_children(refinement_case),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(refinement_case)));
+  AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
@@ -1374,17 +1367,12 @@ FE_Q_Base<PolynomialType, dim, spacedim>::get_restriction_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Restriction matrices are only available for refined cells!"));
-  Assert(child < GeometryInfo<dim>::n_children(refinement_case),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(refinement_case)));
+  AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
@@ -1521,10 +1509,8 @@ FE_Q_Base<PolynomialType, dim, spacedim>::has_support_on_face(
   const unsigned int shape_index,
   const unsigned int face_index) const
 {
-  Assert(shape_index < this->dofs_per_cell,
-         ExcIndexRange(shape_index, 0, this->dofs_per_cell));
-  Assert(face_index < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_index, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   // in 1d, things are simple. since there is only one degree of freedom per
   // vertex in this class, the first is on vertex 0 (==face 0 in some sense),

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -462,17 +462,12 @@ FE_Q_Bubbles<dim, spacedim>::get_prolongation_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Prolongation matrices are only available for refined cells!"));
-  Assert(child < GeometryInfo<dim>::n_children(refinement_case),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(refinement_case)));
+  AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   Assert(this->prolongation[refinement_case - 1][child].n() != 0,
          ExcMessage("This prolongation matrix has not been computed yet!"));
@@ -488,17 +483,12 @@ FE_Q_Bubbles<dim, spacedim>::get_restriction_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Restriction matrices are only available for refined cells!"));
-  Assert(child < GeometryInfo<dim>::n_children(refinement_case),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(refinement_case)));
+  AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   Assert(this->restriction[refinement_case - 1][child].n() != 0,
          ExcMessage("This restriction matrix has not been computed yet!"));

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -45,8 +45,7 @@ namespace internal
         std::vector<unsigned int> out(in.size());
         for (unsigned int i = 0; i < in.size(); ++i)
           {
-            Assert(in[i] < out.size(),
-                   dealii::ExcIndexRange(in[i], 0, out.size()));
+            AssertIndexRange(in[i], out.size());
             out[in[i]] = i;
           }
         return out;
@@ -206,10 +205,7 @@ FE_Q_Hierarchical<dim>::get_prolongation_matrix(
     ExcMessage(
       "Prolongation matrices are only available for isotropic refinement!"));
 
-  Assert(child < GeometryInfo<dim>::n_children(refinement_case),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(refinement_case)));
+  AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   return this->prolongation[refinement_case - 1][child];
 }
@@ -2143,10 +2139,8 @@ bool
 FE_Q_Hierarchical<1>::has_support_on_face(const unsigned int shape_index,
                                           const unsigned int face_index) const
 {
-  Assert(shape_index < this->dofs_per_cell,
-         ExcIndexRange(shape_index, 0, this->dofs_per_cell));
-  Assert(face_index < GeometryInfo<1>::faces_per_cell,
-         ExcIndexRange(face_index, 0, GeometryInfo<1>::faces_per_cell));
+  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(face_index, GeometryInfo<1>::faces_per_cell);
 
 
   // in 1d, things are simple. since
@@ -2166,10 +2160,8 @@ bool
 FE_Q_Hierarchical<dim>::has_support_on_face(const unsigned int shape_index,
                                             const unsigned int face_index) const
 {
-  Assert(shape_index < this->dofs_per_cell,
-         ExcIndexRange(shape_index, 0, this->dofs_per_cell));
-  Assert(face_index < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_index, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   // first, special-case interior
   // shape functions, since they

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -442,10 +442,8 @@ bool
 FE_RaviartThomas<dim>::has_support_on_face(const unsigned int shape_index,
                                            const unsigned int face_index) const
 {
-  Assert(shape_index < this->dofs_per_cell,
-         ExcIndexRange(shape_index, 0, this->dofs_per_cell));
-  Assert(face_index < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_index, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   // Return computed values if we
   // know them easily. Otherwise, it

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -278,10 +278,8 @@ FE_RaviartThomasNodal<dim>::has_support_on_face(
   const unsigned int shape_index,
   const unsigned int face_index) const
 {
-  Assert(shape_index < this->dofs_per_cell,
-         ExcIndexRange(shape_index, 0, this->dofs_per_cell));
-  Assert(face_index < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_index, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   // The first degrees of freedom are
   // on the faces and each face has

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -69,8 +69,7 @@ typename FiniteElement<dim, spacedim>::InternalDataBase &
 FESystem<dim, spacedim>::InternalData::get_fe_data(
   const unsigned int base_no) const
 {
-  Assert(base_no < base_fe_datas.size(),
-         ExcIndexRange(base_no, 0, base_fe_datas.size()));
+  AssertIndexRange(base_no, base_fe_datas.size());
   return *base_fe_datas[base_no];
 }
 
@@ -82,8 +81,7 @@ FESystem<dim, spacedim>::InternalData::set_fe_data(
   const unsigned int base_no,
   std::unique_ptr<typename FiniteElement<dim, spacedim>::InternalDataBase> ptr)
 {
-  Assert(base_no < base_fe_datas.size(),
-         ExcIndexRange(base_no, 0, base_fe_datas.size()));
+  AssertIndexRange(base_no, base_fe_datas.size());
   base_fe_datas[base_no] = std::move(ptr);
 }
 
@@ -94,8 +92,7 @@ internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim> &
 FESystem<dim, spacedim>::InternalData::get_fe_output_object(
   const unsigned int base_no) const
 {
-  Assert(base_no < base_fe_output_objects.size(),
-         ExcIndexRange(base_no, 0, base_fe_output_objects.size()));
+  AssertIndexRange(base_no, base_fe_output_objects.size());
   return base_fe_output_objects[base_no];
 }
 
@@ -389,7 +386,7 @@ double
 FESystem<dim, spacedim>::shape_value(const unsigned int i,
                                      const Point<dim> & p) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   Assert(this->is_primitive(i),
          (typename FiniteElement<dim, spacedim>::ExcShapeFunctionNotPrimitive(
            i)));
@@ -407,9 +404,8 @@ FESystem<dim, spacedim>::shape_value_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component < this->n_components(),
-         ExcIndexRange(component, 0, this->n_components()));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, this->n_components());
 
   // if this value is supposed to be
   // zero, then return right away...
@@ -442,7 +438,7 @@ Tensor<1, dim>
 FESystem<dim, spacedim>::shape_grad(const unsigned int i,
                                     const Point<dim> & p) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   Assert(this->is_primitive(i),
          (typename FiniteElement<dim, spacedim>::ExcShapeFunctionNotPrimitive(
            i)));
@@ -460,9 +456,8 @@ FESystem<dim, spacedim>::shape_grad_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component < this->n_components(),
-         ExcIndexRange(component, 0, this->n_components()));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, this->n_components());
 
   // if this value is supposed to be zero, then return right away...
   if (this->nonzero_components[i][component] == false)
@@ -488,7 +483,7 @@ Tensor<2, dim>
 FESystem<dim, spacedim>::shape_grad_grad(const unsigned int i,
                                          const Point<dim> & p) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   Assert(this->is_primitive(i),
          (typename FiniteElement<dim, spacedim>::ExcShapeFunctionNotPrimitive(
            i)));
@@ -506,9 +501,8 @@ FESystem<dim, spacedim>::shape_grad_grad_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component < this->n_components(),
-         ExcIndexRange(component, 0, this->n_components()));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, this->n_components());
 
   // if this value is supposed to be zero, then return right away...
   if (this->nonzero_components[i][component] == false)
@@ -534,7 +528,7 @@ Tensor<3, dim>
 FESystem<dim, spacedim>::shape_3rd_derivative(const unsigned int i,
                                               const Point<dim> & p) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   Assert(this->is_primitive(i),
          (typename FiniteElement<dim, spacedim>::ExcShapeFunctionNotPrimitive(
            i)));
@@ -552,9 +546,8 @@ FESystem<dim, spacedim>::shape_3rd_derivative_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component < this->n_components(),
-         ExcIndexRange(component, 0, this->n_components()));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, this->n_components());
 
   // if this value is supposed to be zero, then return right away...
   if (this->nonzero_components[i][component] == false)
@@ -580,7 +573,7 @@ Tensor<4, dim>
 FESystem<dim, spacedim>::shape_4th_derivative(const unsigned int i,
                                               const Point<dim> & p) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
+  AssertIndexRange(i, this->dofs_per_cell);
   Assert(this->is_primitive(i),
          (typename FiniteElement<dim, spacedim>::ExcShapeFunctionNotPrimitive(
            i)));
@@ -598,9 +591,8 @@ FESystem<dim, spacedim>::shape_4th_derivative_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  Assert(i < this->dofs_per_cell, ExcIndexRange(i, 0, this->dofs_per_cell));
-  Assert(component < this->n_components(),
-         ExcIndexRange(component, 0, this->n_components()));
+  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(component, this->n_components());
 
   // if this value is supposed to be zero, then return right away...
   if (this->nonzero_components[i][component] == false)
@@ -703,17 +695,12 @@ FESystem<dim, spacedim>::get_restriction_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Restriction matrices are only available for refined cells!"));
-  Assert(child < GeometryInfo<dim>::n_children(refinement_case),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(refinement_case)));
+  AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
@@ -799,17 +786,12 @@ FESystem<dim, spacedim>::get_prolongation_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
-  Assert(refinement_case < RefinementCase<dim>::isotropic_refinement + 1,
-         ExcIndexRange(refinement_case,
-                       0,
-                       RefinementCase<dim>::isotropic_refinement + 1));
+  AssertIndexRange(refinement_case,
+                   RefinementCase<dim>::isotropic_refinement + 1);
   Assert(refinement_case != RefinementCase<dim>::no_refinement,
          ExcMessage(
            "Restriction matrices are only available for refined cells!"));
-  Assert(child < GeometryInfo<dim>::n_children(refinement_case),
-         ExcIndexRange(child,
-                       0,
-                       GeometryInfo<dim>::n_children(refinement_case)));
+  AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   // initialization upon first request, construction completely analogous to
   // restriction matrix
@@ -2303,8 +2285,7 @@ template <int dim, int spacedim>
 const FiniteElement<dim, spacedim> &
 FESystem<dim, spacedim>::base_element(const unsigned int index) const
 {
-  Assert(index < base_elements.size(),
-         ExcIndexRange(index, 0, base_elements.size()));
+  AssertIndexRange(index, base_elements.size());
   return *base_elements[index].first;
 }
 
@@ -2327,8 +2308,7 @@ template <int dim, int spacedim>
 Point<dim>
 FESystem<dim, spacedim>::unit_support_point(const unsigned int index) const
 {
-  Assert(index < this->dofs_per_cell,
-         ExcIndexRange(index, 0, this->dofs_per_cell));
+  AssertIndexRange(index, this->dofs_per_cell);
   Assert((this->unit_support_points.size() == this->dofs_per_cell) ||
            (this->unit_support_points.size() == 0),
          (typename FiniteElement<dim, spacedim>::ExcFEHasNoSupportPoints()));
@@ -2349,8 +2329,7 @@ template <int dim, int spacedim>
 Point<dim - 1>
 FESystem<dim, spacedim>::unit_face_support_point(const unsigned int index) const
 {
-  Assert(index < this->dofs_per_face,
-         ExcIndexRange(index, 0, this->dofs_per_face));
+  AssertIndexRange(index, this->dofs_per_face);
   Assert((this->unit_face_support_points.size() == this->dofs_per_face) ||
            (this->unit_face_support_points.size() == 0),
          (typename FiniteElement<dim, spacedim>::ExcFEHasNoSupportPoints()));

--- a/source/fe/fe_trace.cc
+++ b/source/fe/fe_trace.cc
@@ -102,10 +102,8 @@ FE_TraceQ<dim, spacedim>::has_support_on_face(
   const unsigned int shape_index,
   const unsigned int face_index) const
 {
-  Assert(shape_index < this->dofs_per_cell,
-         ExcIndexRange(shape_index, 0, this->dofs_per_cell));
-  Assert(face_index < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_index, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   // FE_TraceQ shares the numbering of elemental degrees of freedom with FE_Q
   // except for the missing interior ones (quad dofs in 2D and hex dofs in

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -147,8 +147,7 @@ namespace FEValuesViews
     , shape_function_data(this->fe_values->fe->dofs_per_cell)
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
-    Assert(component < fe.n_components(),
-           ExcIndexRange(component, 0, fe.n_components()));
+    AssertIndexRange(component, fe.n_components());
 
     // TODO: we'd like to use the fields with the same name as these
     // variables from FEValuesBase, but they aren't initialized yet
@@ -193,10 +192,7 @@ namespace FEValuesViews
     , shape_function_data(this->fe_values->fe->dofs_per_cell)
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
-    Assert(first_vector_component + spacedim - 1 < fe.n_components(),
-           ExcIndexRange(first_vector_component + spacedim - 1,
-                         0,
-                         fe.n_components()));
+    AssertIndexRange(first_vector_component + spacedim - 1, fe.n_components());
 
     // TODO: we'd like to use the fields with the same name as these
     // variables from FEValuesBase, but they aren't initialized yet
@@ -364,10 +360,7 @@ namespace FEValuesViews
     , shape_function_data(this->fe_values->fe->dofs_per_cell)
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
-    Assert(first_tensor_component + dim * dim - 1 < fe.n_components(),
-           ExcIndexRange(first_tensor_component + dim * dim - 1,
-                         0,
-                         fe.n_components()));
+    AssertIndexRange(first_tensor_component + dim * dim - 1, fe.n_components());
     // TODO: we'd like to use the fields with the same name as these
     // variables from FEValuesBase, but they aren't initialized yet
     // at the time we get here, so re-create it all
@@ -4767,8 +4760,7 @@ FEFaceValues<dim, spacedim>::reinit(
              cell->get_dof_handler().get_fe(cell->active_fe_index())),
          (typename FEValuesBase<dim, spacedim>::ExcFEDontMatch()));
 
-  Assert(face_no < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
   this->maybe_invalidate_previous_present_cell(cell);
   reset_pointer_in_place_if_possible<
@@ -4803,8 +4795,7 @@ FEFaceValues<dim, spacedim>::reinit(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
   const unsigned int                                          face_no)
 {
-  Assert(face_no < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
   this->maybe_invalidate_previous_present_cell(cell);
   reset_pointer_in_place_if_possible<
@@ -4970,8 +4961,7 @@ FESubfaceValues<dim, spacedim>::reinit(
            static_cast<const FiniteElementData<dim> &>(
              cell->get_dof_handler().get_fe(cell->active_fe_index())),
          (typename FEValuesBase<dim, spacedim>::ExcFEDontMatch()));
-  Assert(face_no < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
   // We would like to check for subface_no < cell->face(face_no)->n_children(),
   // but unfortunately the current function is also called for
   // faces without children (see tests/fe/mapping.cc). Therefore,
@@ -5027,25 +5017,17 @@ FESubfaceValues<dim, spacedim>::reinit(
   const unsigned int                                          face_no,
   const unsigned int                                          subface_no)
 {
-  Assert(face_no < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(face_no, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
   // We would like to check for subface_no < cell->face(face_no)->n_children(),
   // but unfortunately the current function is also called for
   // faces without children for periodic faces, which have hanging nodes on
-  // the other side (see
-  // include/deal.II/matrix_free/mapping_info.templates.h).
-  Assert(subface_no < cell->face(face_no)->n_children() ||
-           (cell->has_periodic_neighbor(face_no) &&
-            subface_no < cell->periodic_neighbor(face_no)
-                           ->face(cell->periodic_neighbor_face_no(face_no))
-                           ->n_children()),
-         ExcIndexRange(subface_no,
-                       0,
-                       (cell->has_periodic_neighbor(face_no) ?
-                          cell->periodic_neighbor(face_no)
-                            ->face(cell->periodic_neighbor_face_no(face_no))
-                            ->n_children() :
-                          cell->face(face_no)->n_children())));
+  // the other side (see include/deal.II/matrix_free/mapping_info.templates.h).
+  AssertIndexRange(subface_no,
+                   (cell->has_periodic_neighbor(face_no) ?
+                      cell->periodic_neighbor(face_no)
+                        ->face(cell->periodic_neighbor_face_no(face_no))
+                        ->n_children() :
+                      cell->face(face_no)->n_children()));
 
   this->maybe_invalidate_previous_present_cell(cell);
   reset_pointer_in_place_if_possible<

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -89,10 +89,7 @@ MappingFEField<dim, spacedim, DoFHandlerType, VectorType>::InternalData::shape(
   const unsigned int qpoint,
   const unsigned int shape_nr)
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_values.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_values.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr, shape_values.size());
   return shape_values[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -102,10 +99,8 @@ const Tensor<1, dim> &
 MappingFEField<dim, spacedim, DoFHandlerType, VectorType>::InternalData::
   derivative(const unsigned int qpoint, const unsigned int shape_nr) const
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_derivatives.size());
   return shape_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -116,10 +111,8 @@ Tensor<1, dim> &
 MappingFEField<dim, spacedim, DoFHandlerType, VectorType>::InternalData::
   derivative(const unsigned int qpoint, const unsigned int shape_nr)
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_derivatives.size());
   return shape_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -130,11 +123,8 @@ MappingFEField<dim, spacedim, DoFHandlerType, VectorType>::InternalData::
   second_derivative(const unsigned int qpoint,
                     const unsigned int shape_nr) const
 {
-  Assert(qpoint * n_shape_functions + shape_nr <
-           shape_second_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_second_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_second_derivatives.size());
   return shape_second_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -145,11 +135,8 @@ Tensor<2, dim> &
 MappingFEField<dim, spacedim, DoFHandlerType, VectorType>::InternalData::
   second_derivative(const unsigned int qpoint, const unsigned int shape_nr)
 {
-  Assert(qpoint * n_shape_functions + shape_nr <
-           shape_second_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_second_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_second_derivatives.size());
   return shape_second_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -159,10 +146,8 @@ const Tensor<3, dim> &
 MappingFEField<dim, spacedim, DoFHandlerType, VectorType>::InternalData::
   third_derivative(const unsigned int qpoint, const unsigned int shape_nr) const
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_third_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_third_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_third_derivatives.size());
   return shape_third_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -173,10 +158,8 @@ Tensor<3, dim> &
 MappingFEField<dim, spacedim, DoFHandlerType, VectorType>::InternalData::
   third_derivative(const unsigned int qpoint, const unsigned int shape_nr)
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_third_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_third_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_third_derivatives.size());
   return shape_third_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -187,11 +170,8 @@ MappingFEField<dim, spacedim, DoFHandlerType, VectorType>::InternalData::
   fourth_derivative(const unsigned int qpoint,
                     const unsigned int shape_nr) const
 {
-  Assert(qpoint * n_shape_functions + shape_nr <
-           shape_fourth_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_fourth_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_fourth_derivatives.size());
   return shape_fourth_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -202,11 +182,8 @@ Tensor<4, dim> &
 MappingFEField<dim, spacedim, DoFHandlerType, VectorType>::InternalData::
   fourth_derivative(const unsigned int qpoint, const unsigned int shape_nr)
 {
-  Assert(qpoint * n_shape_functions + shape_nr <
-           shape_fourth_derivatives.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_fourth_derivatives.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr,
+                   shape_fourth_derivatives.size());
   return shape_fourth_derivatives[qpoint * n_shape_functions + shape_nr];
 }
 
@@ -364,10 +341,7 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::InternalData::shape(
   const unsigned int qpoint,
   const unsigned int shape_nr) const
 {
-  Assert(qpoint * n_shape_functions + shape_nr < shape_values.size(),
-         ExcIndexRange(qpoint * n_shape_functions + shape_nr,
-                       0,
-                       shape_values.size()));
+  AssertIndexRange(qpoint * n_shape_functions + shape_nr, shape_values.size());
   return shape_values[qpoint * n_shape_functions + shape_nr];
 }
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -5493,63 +5493,58 @@ namespace GridGenerator
   {
     Assert((inner_radius > 0) && (inner_radius < outer_radius),
            ExcInvalidRadii());
+    AssertIndexRange(n, 5);
 
-    if (n <= 5)
+    // These are for the two lower squares
+    const double d = outer_radius / std::sqrt(2.0);
+    const double a = inner_radius / std::sqrt(2.0);
+    // These are for the two upper square
+    const double b = a / 2.0;
+    const double c = d / 2.0;
+    // And so are these
+    const double hb = inner_radius * std::sqrt(3.0) / 2.0;
+    const double hc = outer_radius * std::sqrt(3.0) / 2.0;
+
+    Point<3> vertices[16] = {
+      center + Point<3>(0, d, -d),
+      center + Point<3>(0, -d, -d),
+      center + Point<3>(0, a, -a),
+      center + Point<3>(0, -a, -a),
+      center + Point<3>(0, a, a),
+      center + Point<3>(0, -a, a),
+      center + Point<3>(0, d, d),
+      center + Point<3>(0, -d, d),
+
+      center + Point<3>(hc, c, -c),
+      center + Point<3>(hc, -c, -c),
+      center + Point<3>(hb, b, -b),
+      center + Point<3>(hb, -b, -b),
+      center + Point<3>(hb, b, b),
+      center + Point<3>(hb, -b, b),
+      center + Point<3>(hc, c, c),
+      center + Point<3>(hc, -c, c),
+    };
+
+    int cell_vertices[5][8] = {{0, 1, 8, 9, 2, 3, 10, 11},
+                               {0, 2, 8, 10, 6, 4, 14, 12},
+                               {1, 7, 9, 15, 3, 5, 11, 13},
+                               {6, 4, 14, 12, 7, 5, 15, 13},
+                               {8, 10, 9, 11, 14, 12, 15, 13}};
+
+    std::vector<CellData<3>> cells(5, CellData<3>());
+
+    for (unsigned int i = 0; i < 5; ++i)
       {
-        // These are for the two lower squares
-        const double d = outer_radius / std::sqrt(2.0);
-        const double a = inner_radius / std::sqrt(2.0);
-        // These are for the two upper square
-        const double b = a / 2.0;
-        const double c = d / 2.0;
-        // And so are these
-        const double hb = inner_radius * std::sqrt(3.0) / 2.0;
-        const double hc = outer_radius * std::sqrt(3.0) / 2.0;
-
-        Point<3> vertices[16] = {
-          center + Point<3>(0, d, -d),
-          center + Point<3>(0, -d, -d),
-          center + Point<3>(0, a, -a),
-          center + Point<3>(0, -a, -a),
-          center + Point<3>(0, a, a),
-          center + Point<3>(0, -a, a),
-          center + Point<3>(0, d, d),
-          center + Point<3>(0, -d, d),
-
-          center + Point<3>(hc, c, -c),
-          center + Point<3>(hc, -c, -c),
-          center + Point<3>(hb, b, -b),
-          center + Point<3>(hb, -b, -b),
-          center + Point<3>(hb, b, b),
-          center + Point<3>(hb, -b, b),
-          center + Point<3>(hc, c, c),
-          center + Point<3>(hc, -c, c),
-        };
-
-        int cell_vertices[5][8] = {{0, 1, 8, 9, 2, 3, 10, 11},
-                                   {0, 2, 8, 10, 6, 4, 14, 12},
-                                   {1, 7, 9, 15, 3, 5, 11, 13},
-                                   {6, 4, 14, 12, 7, 5, 15, 13},
-                                   {8, 10, 9, 11, 14, 12, 15, 13}};
-
-        std::vector<CellData<3>> cells(5, CellData<3>());
-
-        for (unsigned int i = 0; i < 5; ++i)
-          {
-            for (unsigned int j = 0; j < 8; ++j)
-              cells[i].vertices[j] = cell_vertices[i][j];
-            cells[i].material_id = 0;
-          }
-
-        tria.create_triangulation(std::vector<Point<3>>(std::begin(vertices),
-                                                        std::end(vertices)),
-                                  cells,
-                                  SubCellData()); // no boundary information
+        for (unsigned int j = 0; j < 8; ++j)
+          cells[i].vertices[j] = cell_vertices[i][j];
+        cells[i].material_id = 0;
       }
-    else
-      {
-        Assert(false, ExcIndexRange(n, 0, 5));
-      }
+
+    tria.create_triangulation(std::vector<Point<3>>(std::begin(vertices),
+                                                    std::end(vertices)),
+                              cells,
+                              SubCellData()); // no boundary information
+
     if (colorize)
       {
         // We want to use a standard boundary description where

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -831,8 +831,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
                                std::numeric_limits<types::material_id>::max()));
           // we use only material_ids in the range from 0 to
           // numbers::invalid_material_id-1
-          Assert(material_id < numbers::invalid_material_id,
-                 ExcIndexRange(material_id, 0, numbers::invalid_material_id));
+          AssertIndexRange(material_id, numbers::invalid_material_id);
 
           if (apply_all_indicators_to_manifolds)
             cells.back().manifold_id =
@@ -873,10 +872,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
                                std::numeric_limits<types::boundary_id>::max()));
           // we use only boundary_ids in the range from 0 to
           // numbers::internal_face_boundary_id-1
-          Assert(material_id < numbers::internal_face_boundary_id,
-                 ExcIndexRange(material_id,
-                               0,
-                               numbers::internal_face_boundary_id));
+          AssertIndexRange(material_id, numbers::internal_face_boundary_id);
 
           // Make sure to set both manifold id and boundary id appropriately in
           // both cases:
@@ -927,10 +923,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
                                std::numeric_limits<types::boundary_id>::max()));
           // we use only boundary_ids in the range from 0 to
           // numbers::internal_face_boundary_id-1
-          Assert(material_id < numbers::internal_face_boundary_id,
-                 ExcIndexRange(material_id,
-                               0,
-                               numbers::internal_face_boundary_id));
+          AssertIndexRange(material_id, numbers::internal_face_boundary_id);
 
           // Make sure to set both manifold id and boundary id appropriately in
           // both cases:
@@ -1853,10 +1846,7 @@ GridIn<dim, spacedim>::read_msh(std::istream &in)
                          std::numeric_limits<types::material_id>::max()));
                 // we use only material_ids in the range from 0 to
                 // numbers::invalid_material_id-1
-                Assert(material_id < numbers::invalid_material_id,
-                       ExcIndexRange(material_id,
-                                     0,
-                                     numbers::invalid_material_id));
+                AssertIndexRange(material_id, numbers::invalid_material_id);
 
                 cells.back().material_id =
                   static_cast<types::material_id>(material_id);
@@ -1895,10 +1885,8 @@ GridIn<dim, spacedim>::read_msh(std::istream &in)
                          std::numeric_limits<types::boundary_id>::max()));
                 // we use only boundary_ids in the range from 0 to
                 // numbers::internal_face_boundary_id-1
-                Assert(material_id < numbers::internal_face_boundary_id,
-                       ExcIndexRange(material_id,
-                                     0,
-                                     numbers::internal_face_boundary_id));
+                AssertIndexRange(material_id,
+                                 numbers::internal_face_boundary_id);
 
                 subcelldata.boundary_lines.back().boundary_id =
                   static_cast<types::boundary_id>(material_id);
@@ -1937,10 +1925,8 @@ GridIn<dim, spacedim>::read_msh(std::istream &in)
                          std::numeric_limits<types::boundary_id>::max()));
                 // we use only boundary_ids in the range from 0 to
                 // numbers::internal_face_boundary_id-1
-                Assert(material_id < numbers::internal_face_boundary_id,
-                       ExcIndexRange(material_id,
-                                     0,
-                                     numbers::internal_face_boundary_id));
+                AssertIndexRange(material_id,
+                                 numbers::internal_face_boundary_id);
 
                 subcelldata.boundary_quads.back().boundary_id =
                   static_cast<types::boundary_id>(material_id);

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1601,8 +1601,7 @@ namespace GridTools
     // make sure that the given vertex is
     // an active vertex of the underlying
     // triangulation
-    Assert(vertex < mesh.get_triangulation().n_vertices(),
-           ExcIndexRange(0, mesh.get_triangulation().n_vertices(), vertex));
+    AssertIndexRange(vertex, mesh.get_triangulation().n_vertices());
     Assert(mesh.get_triangulation().get_used_vertices()[vertex],
            ExcVertexNotUsed(vertex));
 

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -202,8 +202,7 @@ namespace GridTools
     // make sure that the given vertex is
     // an active vertex of the underlying
     // triangulation
-    Assert(vertex < mesh.get_triangulation().n_vertices(),
-           ExcIndexRange(0, mesh.get_triangulation().n_vertices(), vertex));
+    AssertIndexRange(vertex, mesh.get_triangulation().n_vertices());
     Assert(mesh.get_triangulation().get_used_vertices()[vertex],
            ExcVertexNotUsed(vertex));
 
@@ -2047,8 +2046,7 @@ namespace GridTools
   {
     static const int space_dim = CellIterator::AccessorType::space_dimension;
     (void)space_dim;
-    Assert(0 <= direction && direction < space_dim,
-           ExcIndexRange(direction, 0, space_dim));
+    AssertIndexRange(direction, space_dim);
 
 #ifdef DEBUG
     {
@@ -2143,8 +2141,7 @@ namespace GridTools
     static const int space_dim = MeshType::space_dimension;
     (void)dim;
     (void)space_dim;
-    Assert(0 <= direction && direction < space_dim,
-           ExcIndexRange(direction, 0, space_dim));
+    AssertIndexRange(direction, space_dim);
 
     Assert(dim == space_dim, ExcNotImplemented());
 
@@ -2226,8 +2223,7 @@ namespace GridTools
     static const int space_dim = MeshType::space_dimension;
     (void)dim;
     (void)space_dim;
-    Assert(0 <= direction && direction < space_dim,
-           ExcIndexRange(direction, 0, space_dim));
+    AssertIndexRange(direction, space_dim);
 
     // Loop over all cells on the highest level and collect all boundary
     // faces belonging to b_id1 and b_id2:
@@ -2308,8 +2304,7 @@ namespace GridTools
                       const Tensor<1, spacedim> &offset,
                       const FullMatrix<double> & matrix)
   {
-    Assert(0 <= direction && direction < spacedim,
-           ExcIndexRange(direction, 0, spacedim));
+    AssertIndexRange(direction, spacedim);
 
     Assert(matrix.m() == matrix.n(), ExcInternalError());
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -10277,8 +10277,7 @@ Triangulation<dim, spacedim>::set_manifold(
   const types::manifold_id       m_number,
   const Manifold<dim, spacedim> &manifold_object)
 {
-  Assert(m_number < numbers::flat_manifold_id,
-         ExcIndexRange(m_number, 0, numbers::flat_manifold_id));
+  AssertIndexRange(m_number, numbers::flat_manifold_id);
 
   manifold[m_number] = manifold_object.clone();
 }
@@ -10297,8 +10296,7 @@ template <int dim, int spacedim>
 void
 Triangulation<dim, spacedim>::reset_manifold(const types::manifold_id m_number)
 {
-  Assert(m_number < numbers::flat_manifold_id,
-         ExcIndexRange(m_number, 0, numbers::flat_manifold_id));
+  AssertIndexRange(m_number, numbers::flat_manifold_id);
 
   // delete the entry located at number.
   manifold.erase(m_number);
@@ -12756,7 +12754,7 @@ template <>
 unsigned int
 Triangulation<1, 1>::n_raw_lines(const unsigned int level) const
 {
-  Assert(level < n_levels(), ExcIndexRange(level, 0, n_levels()));
+  AssertIndexRange(level, n_levels());
   return levels[level]->cells.cells.size();
 }
 
@@ -12775,7 +12773,7 @@ template <>
 unsigned int
 Triangulation<1, 2>::n_raw_lines(const unsigned int level) const
 {
-  Assert(level < n_levels(), ExcIndexRange(level, 0, n_levels()));
+  AssertIndexRange(level, n_levels());
   return levels[level]->cells.cells.size();
 }
 
@@ -12793,7 +12791,7 @@ template <>
 unsigned int
 Triangulation<1, 3>::n_raw_lines(const unsigned int level) const
 {
-  Assert(level < n_levels(), ExcIndexRange(level, 0, n_levels()));
+  AssertIndexRange(level, n_levels());
   return levels[level]->cells.cells.size();
 }
 
@@ -12828,8 +12826,7 @@ template <int dim, int spacedim>
 unsigned int
 Triangulation<dim, spacedim>::n_lines(const unsigned int level) const
 {
-  Assert(level < number_cache.n_lines_level.size(),
-         ExcIndexRange(level, 0, number_cache.n_lines_level.size()));
+  AssertIndexRange(level, number_cache.n_lines_level.size());
   Assert(dim == 1, ExcFacesHaveNoLevel());
   return number_cache.n_lines_level[level];
 }
@@ -12847,8 +12844,7 @@ template <int dim, int spacedim>
 unsigned int
 Triangulation<dim, spacedim>::n_active_lines(const unsigned int level) const
 {
-  Assert(level < number_cache.n_lines_level.size(),
-         ExcIndexRange(level, 0, number_cache.n_lines_level.size()));
+  AssertIndexRange(level, number_cache.n_lines_level.size());
   Assert(dim == 1, ExcFacesHaveNoLevel());
 
   return number_cache.n_active_lines_level[level];
@@ -13014,8 +13010,7 @@ unsigned int
 Triangulation<dim, spacedim>::n_quads(const unsigned int level) const
 {
   Assert(dim == 2, ExcFacesHaveNoLevel());
-  Assert(level < number_cache.n_quads_level.size(),
-         ExcIndexRange(level, 0, number_cache.n_quads_level.size()));
+  AssertIndexRange(level, number_cache.n_quads_level.size());
   return number_cache.n_quads_level[level];
 }
 
@@ -13025,7 +13020,7 @@ template <>
 unsigned int
 Triangulation<2, 2>::n_raw_quads(const unsigned int level) const
 {
-  Assert(level < n_levels(), ExcIndexRange(level, 0, n_levels()));
+  AssertIndexRange(level, n_levels());
   return levels[level]->cells.cells.size();
 }
 
@@ -13035,7 +13030,7 @@ template <>
 unsigned int
 Triangulation<2, 3>::n_raw_quads(const unsigned int level) const
 {
-  Assert(level < n_levels(), ExcIndexRange(level, 0, n_levels()));
+  AssertIndexRange(level, n_levels());
   return levels[level]->cells.cells.size();
 }
 
@@ -13081,8 +13076,7 @@ template <int dim, int spacedim>
 unsigned int
 Triangulation<dim, spacedim>::n_active_quads(const unsigned int level) const
 {
-  Assert(level < number_cache.n_quads_level.size(),
-         ExcIndexRange(level, 0, number_cache.n_quads_level.size()));
+  AssertIndexRange(level, number_cache.n_quads_level.size());
   Assert(dim == 2, ExcFacesHaveNoLevel());
 
   return number_cache.n_active_quads_level[level];
@@ -13145,8 +13139,7 @@ template <>
 unsigned int
 Triangulation<3, 3>::n_hexs(const unsigned int level) const
 {
-  Assert(level < number_cache.n_hexes_level.size(),
-         ExcIndexRange(level, 0, number_cache.n_hexes_level.size()));
+  AssertIndexRange(level, number_cache.n_hexes_level.size());
 
   return number_cache.n_hexes_level[level];
 }
@@ -13157,7 +13150,7 @@ template <>
 unsigned int
 Triangulation<3, 3>::n_raw_hexs(const unsigned int level) const
 {
-  Assert(level < n_levels(), ExcIndexRange(level, 0, n_levels()));
+  AssertIndexRange(level, n_levels());
   return levels[level]->cells.cells.size();
 }
 
@@ -13175,8 +13168,7 @@ template <>
 unsigned int
 Triangulation<3, 3>::n_active_hexs(const unsigned int level) const
 {
-  Assert(level < number_cache.n_hexes_level.size(),
-         ExcIndexRange(level, 0, number_cache.n_hexes_level.size()));
+  AssertIndexRange(level, number_cache.n_hexes_level.size());
 
   return number_cache.n_active_hexes_level[level];
 }

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1470,7 +1470,7 @@ double
 TriaAccessor<1, 1, 1>::extent_in_direction(const unsigned int axis) const
 {
   (void)axis;
-  Assert(axis == 0, ExcIndexRange(axis, 0, 1));
+  AssertIndexRange(axis, 1);
 
   return this->diameter();
 }
@@ -1481,7 +1481,7 @@ double
 TriaAccessor<1, 1, 2>::extent_in_direction(const unsigned int axis) const
 {
   (void)axis;
-  Assert(axis == 0, ExcIndexRange(axis, 0, 1));
+  AssertIndexRange(axis, 1);
 
   return this->diameter();
 }
@@ -1495,7 +1495,7 @@ TriaAccessor<2, 2, 2>::extent_in_direction(const unsigned int axis) const
     {2, 3},  /// Lines along x-axis, see GeometryInfo
     {0, 1}}; /// Lines along y-axis
 
-  Assert(axis < 2, ExcIndexRange(axis, 0, 2));
+  AssertIndexRange(axis, 2);
 
   return std::max(this->line(lines[axis][0])->diameter(),
                   this->line(lines[axis][1])->diameter());
@@ -1509,7 +1509,7 @@ TriaAccessor<2, 2, 3>::extent_in_direction(const unsigned int axis) const
     {2, 3},  /// Lines along x-axis, see GeometryInfo
     {0, 1}}; /// Lines along y-axis
 
-  Assert(axis < 2, ExcIndexRange(axis, 0, 2));
+  AssertIndexRange(axis, 2);
 
   return std::max(this->line(lines[axis][0])->diameter(),
                   this->line(lines[axis][1])->diameter());
@@ -1525,7 +1525,7 @@ TriaAccessor<3, 3, 3>::extent_in_direction(const unsigned int axis) const
     {0, 1, 4, 5},    /// Lines along y-axis
     {8, 9, 10, 11}}; /// Lines along z-axis
 
-  Assert(axis < 3, ExcIndexRange(axis, 0, 3));
+  AssertIndexRange(axis, 3);
 
   double lengths[4] = {this->line(lines[axis][0])->diameter(),
                        this->line(lines[axis][1])->diameter(),
@@ -1945,8 +1945,7 @@ CellAccessor<dim, spacedim>::set_material_id(
   const types::material_id mat_id) const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(mat_id < numbers::invalid_material_id,
-         ExcIndexRange(mat_id, 0, numbers::invalid_material_id));
+  AssertIndexRange(mat_id, numbers::invalid_material_id);
   this->tria->levels[this->present_level]
     ->cells.boundary_or_material_id[this->present_index]
     .material_id = mat_id;
@@ -2789,8 +2788,7 @@ bool
 CellAccessor<dim, spacedim>::at_boundary(const unsigned int i) const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(i < GeometryInfo<dim>::faces_per_cell,
-         ExcIndexRange(i, 0, GeometryInfo<dim>::faces_per_cell));
+  AssertIndexRange(i, GeometryInfo<dim>::faces_per_cell);
 
   return (neighbor_index(i) == -1);
 }
@@ -2921,8 +2919,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
           const typename Triangulation<dim, spacedim>::face_iterator
                              mother_face    = this->face(face);
           const unsigned int total_children = mother_face->number_of_children();
-          Assert(subface < total_children,
-                 ExcIndexRange(subface, 0, total_children));
+          AssertIndexRange(subface, total_children);
           Assert(total_children <= GeometryInfo<3>::max_children_per_face,
                  ExcInternalError());
 

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -330,10 +330,10 @@ namespace hp
   FECollection<dim, spacedim>::next_in_hierarchy(
     const unsigned int fe_index) const
   {
-    Assert(fe_index < size(), ExcIndexRange(fe_index, 0, size()));
+    AssertIndexRange(fe_index, size());
 
     const unsigned int new_fe_index = hierarchy_next(*this, fe_index);
-    Assert(new_fe_index < size(), ExcIndexRange(new_fe_index, 0, size()));
+    AssertIndexRange(new_fe_index, size());
 
     return new_fe_index;
   }
@@ -345,10 +345,10 @@ namespace hp
   FECollection<dim, spacedim>::previous_in_hierarchy(
     const unsigned int fe_index) const
   {
-    Assert(fe_index < size(), ExcIndexRange(fe_index, 0, size()));
+    AssertIndexRange(fe_index, size());
 
     const unsigned int new_fe_index = hierarchy_prev(*this, fe_index);
-    Assert(new_fe_index < size(), ExcIndexRange(new_fe_index, 0, size()));
+    AssertIndexRange(new_fe_index, size());
 
     return new_fe_index;
   }

--- a/source/hp/fe_values.cc
+++ b/source/hp/fe_values.cc
@@ -71,12 +71,9 @@ namespace hp
     const unsigned int mapping_index,
     const unsigned int q_index)
   {
-    Assert(fe_index < fe_collection->size(),
-           ExcIndexRange(fe_index, 0, fe_collection->size()));
-    Assert(mapping_index < mapping_collection->size(),
-           ExcIndexRange(mapping_index, 0, mapping_collection->size()));
-    Assert(q_index < q_collection.size(),
-           ExcIndexRange(q_index, 0, q_collection.size()));
+    AssertIndexRange(fe_index, fe_collection->size());
+    AssertIndexRange(mapping_index, mapping_collection->size());
+    AssertIndexRange(q_index, q_collection.size());
 
 
     // set the triple of indices
@@ -163,14 +160,9 @@ namespace hp
       real_fe_index = cell->active_fe_index();
 
     // some checks
-    Assert(real_q_index < this->q_collection.size(),
-           ExcIndexRange(real_q_index, 0, this->q_collection.size()));
-    Assert(real_mapping_index < this->mapping_collection->size(),
-           ExcIndexRange(real_mapping_index,
-                         0,
-                         this->mapping_collection->size()));
-    Assert(real_fe_index < this->fe_collection->size(),
-           ExcIndexRange(real_fe_index, 0, this->fe_collection->size()));
+    AssertIndexRange(real_q_index, this->q_collection.size());
+    AssertIndexRange(real_mapping_index, this->mapping_collection->size());
+    AssertIndexRange(real_fe_index, this->fe_collection->size());
 
     // now finally actually get the
     // corresponding object and
@@ -204,14 +196,9 @@ namespace hp
       real_fe_index = 0;
 
     // some checks
-    Assert(real_q_index < this->q_collection.size(),
-           ExcIndexRange(real_q_index, 0, this->q_collection.size()));
-    Assert(real_mapping_index < this->mapping_collection->size(),
-           ExcIndexRange(real_mapping_index,
-                         0,
-                         this->mapping_collection->size()));
-    Assert(real_fe_index < this->fe_collection->size(),
-           ExcIndexRange(real_fe_index, 0, this->fe_collection->size()));
+    AssertIndexRange(real_q_index, this->q_collection.size());
+    AssertIndexRange(real_mapping_index, this->mapping_collection->size());
+    AssertIndexRange(real_fe_index, this->fe_collection->size());
 
     // now finally actually get the
     // corresponding object and
@@ -285,14 +272,9 @@ namespace hp
       real_fe_index = cell->active_fe_index();
 
     // some checks
-    Assert(real_q_index < this->q_collection.size(),
-           ExcIndexRange(real_q_index, 0, this->q_collection.size()));
-    Assert(real_mapping_index < this->mapping_collection->size(),
-           ExcIndexRange(real_mapping_index,
-                         0,
-                         this->mapping_collection->size()));
-    Assert(real_fe_index < this->fe_collection->size(),
-           ExcIndexRange(real_fe_index, 0, this->fe_collection->size()));
+    AssertIndexRange(real_q_index, this->q_collection.size());
+    AssertIndexRange(real_mapping_index, this->mapping_collection->size());
+    AssertIndexRange(real_fe_index, this->fe_collection->size());
 
     // now finally actually get the
     // corresponding object and
@@ -327,14 +309,9 @@ namespace hp
       real_fe_index = 0;
 
     // some checks
-    Assert(real_q_index < this->q_collection.size(),
-           ExcIndexRange(real_q_index, 0, this->q_collection.size()));
-    Assert(real_mapping_index < this->mapping_collection->size(),
-           ExcIndexRange(real_mapping_index,
-                         0,
-                         this->mapping_collection->size()));
-    Assert(real_fe_index < this->fe_collection->size(),
-           ExcIndexRange(real_fe_index, 0, this->fe_collection->size()));
+    AssertIndexRange(real_q_index, this->q_collection.size());
+    AssertIndexRange(real_mapping_index, this->mapping_collection->size());
+    AssertIndexRange(real_fe_index, this->fe_collection->size());
 
     // now finally actually get the
     // corresponding object and
@@ -409,14 +386,9 @@ namespace hp
       real_fe_index = cell->active_fe_index();
 
     // some checks
-    Assert(real_q_index < this->q_collection.size(),
-           ExcIndexRange(real_q_index, 0, this->q_collection.size()));
-    Assert(real_mapping_index < this->mapping_collection->size(),
-           ExcIndexRange(real_mapping_index,
-                         0,
-                         this->mapping_collection->size()));
-    Assert(real_fe_index < this->fe_collection->size(),
-           ExcIndexRange(real_fe_index, 0, this->fe_collection->size()));
+    AssertIndexRange(real_q_index, this->q_collection.size());
+    AssertIndexRange(real_mapping_index, this->mapping_collection->size());
+    AssertIndexRange(real_fe_index, this->fe_collection->size());
 
     // now finally actually get the
     // corresponding object and
@@ -452,14 +424,9 @@ namespace hp
       real_fe_index = 0;
 
     // some checks
-    Assert(real_q_index < this->q_collection.size(),
-           ExcIndexRange(real_q_index, 0, this->q_collection.size()));
-    Assert(real_mapping_index < this->mapping_collection->size(),
-           ExcIndexRange(real_mapping_index,
-                         0,
-                         this->mapping_collection->size()));
-    Assert(real_fe_index < this->fe_collection->size(),
-           ExcIndexRange(real_fe_index, 0, this->fe_collection->size()));
+    AssertIndexRange(real_q_index, this->q_collection.size());
+    AssertIndexRange(real_mapping_index, this->mapping_collection->size());
+    AssertIndexRange(real_fe_index, this->fe_collection->size());
 
     // now finally actually get the
     // corresponding object and

--- a/source/lac/chunk_sparsity_pattern.cc
+++ b/source/lac/chunk_sparsity_pattern.cc
@@ -345,8 +345,8 @@ ChunkSparsityPattern::add(const size_type i, const size_type j)
 bool
 ChunkSparsityPattern::exists(const size_type i, const size_type j) const
 {
-  Assert(i < rows, ExcIndexRange(i, 0, rows));
-  Assert(j < cols, ExcIndexRange(j, 0, cols));
+  AssertIndexRange(i, rows);
+  AssertIndexRange(j, cols);
 
   return sparsity_pattern.exists(i / chunk_size, j / chunk_size);
 }
@@ -369,7 +369,7 @@ ChunkSparsityPattern::symmetrize()
 ChunkSparsityPattern::size_type
 ChunkSparsityPattern::row_length(const size_type i) const
 {
-  Assert(i < rows, ExcIndexRange(i, 0, rows));
+  AssertIndexRange(i, rows);
 
   // find out if we did padding and if this row is affected by it
   if (n_cols() % chunk_size == 0)

--- a/source/lac/dynamic_sparsity_pattern.cc
+++ b/source/lac/dynamic_sparsity_pattern.cc
@@ -356,8 +356,8 @@ DynamicSparsityPattern::max_entries_per_row() const
 bool
 DynamicSparsityPattern::exists(const size_type i, const size_type j) const
 {
-  Assert(i < rows, ExcIndexRange(i, 0, rows));
-  Assert(j < cols, ExcIndexRange(j, 0, cols));
+  AssertIndexRange(i, rows);
+  AssertIndexRange(j, cols);
   Assert(
     rowset.size() == 0 || rowset.is_element(i),
     ExcMessage(
@@ -657,14 +657,8 @@ DynamicSparsityPattern::column_index(
   const DynamicSparsityPattern::size_type row,
   const DynamicSparsityPattern::size_type col) const
 {
-  Assert(row < n_rows(),
-         ExcIndexRangeType<DynamicSparsityPattern::size_type>(row,
-                                                              0,
-                                                              n_rows()));
-  Assert(col < n_cols(),
-         ExcIndexRangeType<DynamicSparsityPattern::size_type>(row,
-                                                              0,
-                                                              n_cols()));
+  AssertIndexRange(row, n_rows());
+  AssertIndexRange(col, n_cols());
   Assert(rowset.size() == 0 || rowset.is_element(row), ExcInternalError());
 
   const DynamicSparsityPattern::size_type local_row =

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -254,7 +254,7 @@ namespace PETScWrappers
     Vector::create_vector(const size_type n, const size_type local_size)
     {
       (void)n;
-      Assert(local_size <= n, ExcIndexRange(local_size, 0, n));
+      AssertIndexRange(local_size, n + 1);
       ghosted = false;
 
       const PetscErrorCode ierr =
@@ -272,7 +272,7 @@ namespace PETScWrappers
                           const IndexSet &ghostnodes)
     {
       (void)n;
-      Assert(local_size <= n, ExcIndexRange(local_size, 0, n));
+      AssertIndexRange(local_size, n + 1);
       ghosted       = true;
       ghost_indices = ghostnodes;
 

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -34,7 +34,7 @@ namespace PETScWrappers
   {
     VectorReference::operator PetscScalar() const
     {
-      Assert(index < vector.size(), ExcIndexRange(index, 0, vector.size()));
+      AssertIndexRange(index, vector.size());
 
       // The vector may have ghost entries. In that case, we first need to
       // figure out which elements we own locally, then get a pointer to the

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -663,8 +663,8 @@ SparsityPattern::size_type
 SparsityPattern::operator()(const size_type i, const size_type j) const
 {
   Assert((rowstart != nullptr) && (colnums != nullptr), ExcEmptyObject());
-  Assert(i < rows, ExcIndexRange(i, 0, rows));
-  Assert(j < cols, ExcIndexRange(j, 0, cols));
+  AssertIndexRange(i, rows);
+  AssertIndexRange(j, cols);
   Assert(compressed, ExcNotCompressed());
 
   // let's see whether there is something in this line
@@ -701,8 +701,8 @@ void
 SparsityPatternBase::add(const size_type i, const size_type j)
 {
   Assert((rowstart != nullptr) && (colnums != nullptr), ExcEmptyObject());
-  Assert(i < rows, ExcIndexRange(i, 0, rows));
-  Assert(j < cols, ExcIndexRange(j, 0, cols));
+  AssertIndexRange(i, rows);
+  AssertIndexRange(j, cols);
   Assert(compressed == false, ExcMatrixIsCompressed());
 
   for (std::size_t k = rowstart[i]; k < rowstart[i + 1]; k++)
@@ -778,8 +778,8 @@ bool
 SparsityPatternBase::exists(const size_type i, const size_type j) const
 {
   Assert((rowstart != nullptr) && (colnums != nullptr), ExcEmptyObject());
-  Assert(i < rows, ExcIndexRange(i, 0, rows));
-  Assert(j < cols, ExcIndexRange(j, 0, cols));
+  AssertIndexRange(i, rows);
+  AssertIndexRange(j, cols);
 
   for (size_type k = rowstart[i]; k < rowstart[i + 1]; ++k)
     {
@@ -796,8 +796,8 @@ SparsityPatternBase::size_type
 SparsityPatternBase::row_position(const size_type i, const size_type j) const
 {
   Assert((rowstart != nullptr) && (colnums != nullptr), ExcEmptyObject());
-  Assert(i < rows, ExcIndexRange(i, 0, rows));
-  Assert(j < cols, ExcIndexRange(j, 0, cols));
+  AssertIndexRange(i, rows);
+  AssertIndexRange(j, cols);
 
   for (size_type k = rowstart[i]; k < rowstart[i + 1]; ++k)
     {
@@ -814,8 +814,7 @@ std::pair<SparsityPatternBase::size_type, SparsityPatternBase::size_type>
 SparsityPatternBase::matrix_position(const std::size_t global_index) const
 {
   Assert(compressed == true, ExcNotCompressed());
-  Assert(global_index < n_nonzero_elements(),
-         ExcIndexRange(global_index, 0, n_nonzero_elements()));
+  AssertIndexRange(global_index, n_nonzero_elements());
 
   // first find the row in which the entry is located. for this note that the
   // rowstart array indexes the global indices at which each row starts. since

--- a/source/lac/tridiagonal_matrix.cc
+++ b/source/lac/tridiagonal_matrix.cc
@@ -264,7 +264,7 @@ number
 TridiagonalMatrix<number>::eigenvalue(const size_type i) const
 {
   Assert(state == LAPACKSupport::eigenvalues, ExcState(state));
-  Assert(i < n(), ExcIndexRange(i, 0, n()));
+  AssertIndexRange(i, n());
   return diagonal[i];
 }
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -42,7 +42,7 @@ namespace TrilinosWrappers
   {
     VectorReference::operator TrilinosScalar() const
     {
-      Assert(index < vector.size(), ExcIndexRange(index, 0, vector.size()));
+      AssertIndexRange(index, vector.size());
 
       // Trilinos allows for vectors to be referenced by the [] or ()
       // operators but only () checks index bounds. We check these bounds by

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -104,8 +104,7 @@ namespace
     std::vector<std::vector<types::global_dof_index>> &ndofs)
   {
     const unsigned int n_blocks = mg_dof.get_fe().n_blocks();
-    Assert(selected_block < n_blocks,
-           ExcIndexRange(selected_block, 0, n_blocks));
+    AssertIndexRange(selected_block, n_blocks);
 
     std::vector<bool> selected(n_blocks, false);
     selected[selected_block] = true;

--- a/source/multigrid/mg_transfer_component.cc
+++ b/source/multigrid/mg_transfer_component.cc
@@ -276,8 +276,7 @@ MGTransferComponentBase::build_matrices(const DoFHandler<dim, spacedim> &,
 
       for (unsigned int i = 0; i < target_component.size(); ++i)
         {
-          Assert(i < target_component.size(),
-                 ExcIndexRange(i, 0, target_component.size()));
+          AssertIndexRange(i, target_component.size());
         }
     }
   // Do the same for the multilevel
@@ -297,8 +296,7 @@ MGTransferComponentBase::build_matrices(const DoFHandler<dim, spacedim> &,
 
       for (unsigned int i = 0; i < mg_target_component.size(); ++i)
         {
-          Assert(i < mg_target_component.size(),
-                 ExcIndexRange(i, 0, mg_target_component.size()));
+          AssertIndexRange(i, mg_target_component.size());
         }
     }
 

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -985,8 +985,7 @@ namespace DerivativeApproximation
              ExcVectorLengthVsNActiveCells(
                derivative_norm.size(),
                dof_handler.get_triangulation().n_active_cells()));
-      Assert(component < dof_handler.get_fe(0).n_components(),
-             ExcIndexRange(component, 0, dof_handler.get_fe(0).n_components()));
+      AssertIndexRange(component, dof_handler.get_fe(0).n_components());
 
       using Iterators = std::tuple<
         TriaActiveIterator<

--- a/tests/base/slice_vector.debug.output
+++ b/tests/base/slice_vector.debug.output
@@ -1,4 +1,4 @@
 
 DEAL::	0	1	2	0	1	2	3
 DEAL::	2	0	1
-DEAL::ExcIndexRange(length, 0, v.size() - start + 1)
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(length), decltype(v.size() - start + 1)>::type)>:: type>((length), 0, (v.size() - start + 1))

--- a/tests/fe/block_mask_02.debug.output
+++ b/tests/fe/block_mask_02.debug.output
@@ -1,3 +1,3 @@
 
-DEAL::ExcIndexRange (block_index, 0, block_mask.size())
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(block_index), decltype(block_mask.size())>::type)>:: type>((block_index), 0, (block_mask.size()))
 DEAL::OK

--- a/tests/fe/fe_values_view_invalid_01.debug.output
+++ b/tests/fe/fe_values_view_invalid_01.debug.output
@@ -1,4 +1,4 @@
 
-DEAL::ExcIndexRange (scalar.component, 0, fe_values_views_cache.scalars.size())
-DEAL::ExcIndexRange (scalar.component, 0, fe_values_views_cache.scalars.size())
-DEAL::ExcIndexRange (scalar.component, 0, fe_values_views_cache.scalars.size())
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(scalar.component), decltype(fe_values_views_cache.scalars.size())>::type)>:: type>((scalar.component), 0, (fe_values_views_cache.scalars.size()))
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(scalar.component), decltype(fe_values_views_cache.scalars.size())>::type)>:: type>((scalar.component), 0, (fe_values_views_cache.scalars.size()))
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(scalar.component), decltype(fe_values_views_cache.scalars.size())>::type)>:: type>((scalar.component), 0, (fe_values_views_cache.scalars.size()))

--- a/tests/fe/fe_values_view_invalid_02.debug.output
+++ b/tests/fe/fe_values_view_invalid_02.debug.output
@@ -1,4 +1,4 @@
 
-DEAL::ExcIndexRange (vector.first_vector_component, 0, fe_values_views_cache.vectors.size())
-DEAL::ExcIndexRange (vector.first_vector_component, 0, fe_values_views_cache.vectors.size())
-DEAL::ExcIndexRange (vector.first_vector_component, 0, fe_values_views_cache.vectors.size())
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(vector.first_vector_component), decltype(fe_values_views_cache.vectors.size())>::type)>:: type>((vector.first_vector_component), 0, (fe_values_views_cache.vectors.size()))
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(vector.first_vector_component), decltype(fe_values_views_cache.vectors.size())>::type)>:: type>((vector.first_vector_component), 0, (fe_values_views_cache.vectors.size()))
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(vector.first_vector_component), decltype(fe_values_views_cache.vectors.size())>::type)>:: type>((vector.first_vector_component), 0, (fe_values_views_cache.vectors.size()))

--- a/tests/fe/fe_values_view_invalid_03_nonsymmetric.debug.output
+++ b/tests/fe/fe_values_view_invalid_03_nonsymmetric.debug.output
@@ -1,4 +1,4 @@
 
-DEAL::ExcIndexRange (tensor.first_tensor_component, 0, fe_values_views_cache.second_order_tensors.size())
-DEAL::ExcIndexRange (tensor.first_tensor_component, 0, fe_values_views_cache.second_order_tensors.size())
-DEAL::ExcIndexRange (tensor.first_tensor_component, 0, fe_values_views_cache.second_order_tensors.size())
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(tensor.first_tensor_component), decltype(fe_values_views_cache.second_order_tensors.size())>::type)>:: type>((tensor.first_tensor_component), 0, (fe_values_views_cache.second_order_tensors.size()))
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(tensor.first_tensor_component), decltype(fe_values_views_cache.second_order_tensors.size())>::type)>:: type>((tensor.first_tensor_component), 0, (fe_values_views_cache.second_order_tensors.size()))
+DEAL::dealii::ExcIndexRangeType<typename ::dealii::internal::argument_type<void( typename std::common_type<decltype(tensor.first_tensor_component), decltype(fe_values_views_cache.second_order_tensors.size())>::type)>:: type>((tensor.first_tensor_component), 0, (fe_values_views_cache.second_order_tensors.size()))


### PR DESCRIPTION
Mostly generated by
```
find include/ source/ \( -name "*.cc" -o -name "*.h" \) -exec perl -0777 -i.original -pe 's/Assert\(([^<]*)[\s]*<([^,]*),[^E]*ExcIndexRange[^(]*\([\s]*\1,[\s]*0,[\s]*\2[\s]*\)[\s]*\);/AssertIndexRange(\1,\2);/igs' {} \;
```