### PR TITLE
Rewrite wording in headers/docs such that we now have gender neutral wording throughout

### DIFF
--- a/doc/doxygen/headers/fe_vs_mapping_vs_fevalues.h
+++ b/doc/doxygen/headers/fe_vs_mapping_vs_fevalues.h
@@ -145,7 +145,7 @@
  * <h2>What to compute?</h2>
  *
  * Let's say a user wants to compute the gradients of shape functions,
- * for example to compute the integral above. Then she would initialize
+ * for example to compute the integral above. Then they would initialize
  * an FEValues object by giving the update_gradients flag (as is done
  * in basically every tutorial program, starting with step-3). What
  * this indicates is that the user expects the FEValues object to be

--- a/doc/doxygen/headers/update_flags.h
+++ b/doc/doxygen/headers/update_flags.h
@@ -150,7 +150,7 @@
  * 
  * As outlined above, we have now determined the final set of things that are
  * necessary to satisfy a user's desired pieces of information as conveyed by
- * the update flags she provided. This information will then typically be queried
+ * the update flags they provided. This information will then typically be queried
  * on every cell the user code visits in a subsequent integration loop.
  * 
  * Given that many of the things mappings or finite element classes compute are

--- a/doc/news/3.1.0-vs-3.1.1.h
+++ b/doc/news/3.1.0-vs-3.1.1.h
@@ -109,7 +109,7 @@ All entries are signed with the names of the author.
        class="class">SparseMatrix&lt;long double&gt;</code> are removed as a
        prerelease of gcc3.0 fails to compile it. Now the user of <code
        class="class">SparseMatrix&lt;long double&gt;</code> needs to include
-       <code>lac/include/lac/sparse_matrix.templates.h</code> into his
+       <code>lac/include/lac/sparse_matrix.templates.h</code> into their
        source file and to use a different compiler, e.g. gcc 2.95.2 or
        a future version of gcc3.0 (that will then hopefully be fixed).
        <br>

--- a/doc/news/3.1.0-vs-3.2.0.h
+++ b/doc/news/3.1.0-vs-3.2.0.h
@@ -572,7 +572,7 @@ All entries are signed with the names of the author.
        removed as a prerelease of gcc3.0 fails to compile it. A user
        of <code>SparseMatrix&lt;long double&gt;</code>
        needs now to include
-       <code>lac/include/lac/sparse_matrix.templates.h</code> into his
+       <code>lac/include/lac/sparse_matrix.templates.h</code> into their
        source file and to use an appropriate compiler, e.g. gcc2.95.2 or
        a future version of gcc3.0 (that will then hopefully be fixed).
        <br>
@@ -932,7 +932,7 @@ All entries are signed with the names of the author.
        class="member">create_mass_matrix</code> function with two
        arguments is removed, as it relied on the <code
        class="member">get_local_mass_matrix</code> function. If in
-       future the user wants to create a mass matrix he needs to use
+       future the user wants to create a mass matrix they need to use
        one of the remaining <code
        class="class">MatrixCreator</code>::<code
        class="member">create_mass_matrix</code> functions that require

--- a/examples/step-17/doc/intro.dox
+++ b/examples/step-17/doc/intro.dox
@@ -128,7 +128,7 @@ into the mail and it will be delivered. But that's the extent to which
 you can control things. If you want the receiver to do something
 with the content of the letter, for example return to you data you want
 from over there, then two things need to happen: (i) the receiver needs
-to actually go check whether there is anything in her mailbox, and (ii) if
+to actually go check whether there is anything in their mailbox, and (ii) if
 there is, react appropriately, for example by sending data back. If you
 wait for this return message but the original receiver was distracted
 and not paying attention, then you're out of luck: you'll simply have to

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -782,7 +782,7 @@ namespace StandardExceptions
    *
    * We usually leave in these assertions even after we are confident that the
    * implementation is correct, since if someone later changes or extends the
-   * algorithm, these exceptions will indicate to him if he violates
+   * algorithm, these exceptions will indicate to them if they violate
    * assumptions that are used later in the algorithm. Furthermore, it
    * sometimes happens that an algorithm does not work in very rare corner
    * cases. These cases will then be trapped sooner or later by the exception,

--- a/include/deal.II/base/job_identifier.h
+++ b/include/deal.II/base/job_identifier.h
@@ -43,7 +43,7 @@ public:
    * This function returns an identifier for the running program. Currently,
    * the library provides a function returning "JobID".
    *
-   * The user may define a replacement of this function in his source code and
+   * The user may define a replacement of this function in their source code and
    * avoid linking the library version. Unfortunately, this mechanism does not
    * work with shared libraries.
    */

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -164,7 +164,7 @@ namespace internal
  * renumbering. Using this array, the renumber_dofs() function of the present
  * class is called, which actually performs the change from old DoF indices to
  * the ones given in the array. In some cases, however, a user may want to
- * compute her own renumbering order; in this case, one can allocate an array
+ * compute their own renumbering order; in this case, one can allocate an array
  * with one element per degree of freedom and fill it with the number that the
  * respective degree of freedom shall be assigned. This number may, for
  * example, be obtained by sorting the support points of the degrees of

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -133,7 +133,7 @@ public:
    * sizes may be varying, the maximum number of elements per row may be
    * varying, etc. It is simpler not to reproduce the interface of the
    * SparsityPattern class here but rather let the user call whatever function
-   * she desires.
+   * they desire.
    */
   void
   reinit(const size_type n_block_rows, const size_type n_block_columns);

--- a/include/deal.II/lac/petsc_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_block_sparse_matrix.h
@@ -137,7 +137,7 @@ namespace PETScWrappers
        * the sizes may be varying, the maximum number of elements per row may
        * be varying, etc. It is simpler not to reproduce the interface of the
        * SparsityPattern class here but rather let the user call whatever
-       * function she desires.
+       * function they desire.
        */
       void
       reinit(const size_type n_block_rows, const size_type n_block_columns);

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -91,7 +91,7 @@ class SparseMatrix;
  * @endcode
  * Now the use of the @p SolverSelector in combination with the @p
  * PreconditionSelector allows the user to select both, the solver and the
- * preconditioner, at the beginning of his program and each time the solver is
+ * preconditioner, at the beginning of their program and each time the solver is
  * started (that is several times e.g. in a nonlinear iteration) this
  * preselected solver and preconditioner is called.
  *

--- a/include/deal.II/lac/solver_selector.h
+++ b/include/deal.II/lac/solver_selector.h
@@ -80,9 +80,9 @@ DEAL_II_NAMESPACE_OPEN
  *
  *
  * If at some time there exists a new solver "xyz" then the user does not need
- * to change his program. Only in the implementation of the @p SolverSelector
+ * to change their program. Only in the implementation of the @p SolverSelector
  * the calling of this solver has to be added and each user with program lines
- * quoted above only needs to 'set solver = xyz' in his parameter file to get
+ * quoted above only needs to 'set solver = xyz' in their parameter file to get
  * access to that new solver.
  *
  * @author Ralf Hartmann, 1999

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -142,7 +142,7 @@ namespace TrilinosWrappers
      * the sizes may be varying, the maximum number of elements per row may be
      * varying, etc. It is simpler not to reproduce the interface of the @p
      * SparsityPattern class here but rather let the user call whatever
-     * function she desires.
+     * function they desire.
      */
     void
     reinit(const size_type n_block_rows, const size_type n_block_columns);

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -1300,7 +1300,7 @@ namespace TrilinosWrappers
        * smoothing), but not the way the solver classes expect a
        * preconditioner to work (where one ignores the content in <tt>dst</tt>
        * for the preconditioner application). The user should really know what
-       * she is doing when touching this flag.
+       * they are doing when touching this flag.
        */
       bool nonzero_starting;
     };

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -7988,7 +7988,7 @@ namespace VectorTools
       {
         // we need to return double as a norm, but mean value is a complex
         // number. Panic and return real-part while warning the user that
-        // he shall never do that.
+        // they shall never do that.
         Assert(
           false,
           ExcMessage(

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2745,7 +2745,7 @@ private:
  * be possible to call FEValues::reinit() with a tria iterator only; this class
  * makes this possible, but whenever one of the functions of FEValues tries to
  * call any of the functions of this class, an exception will be raised
- * reminding the user that if she wants to use these features, then the FEValues
+ * reminding the user that if they want to use these features, then the FEValues
  * object has to be reinitialized with a cell iterator that allows to extract
  * degree of freedom information.
  *

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -9732,7 +9732,7 @@ namespace internal
         // indicate anisotropic refinemnt cases on faces. all data
         // should be cleared by now, but the information whether we
         // used indices or pointers is still present. reset it now to
-        // enable the user to use whichever he likes later on.
+        // enable the user to use whichever they like later on.
         triangulation.faces->quads.clear_user_data();
 
         // return the list with distorted children

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -246,7 +246,7 @@ namespace TrilinosWrappers
       // Otherwise, we have to check that the two vectors are already of the
       // same size, create an object for the data exchange and then insert all
       // the data. The first assertion is only a check whether the user knows
-      // what she is doing.
+      // what they are doing.
       else
         {
           Assert(omit_zeroing_entries == false,


### PR DESCRIPTION
he -> they
she -> they
him -> them
her -> them
his -> their
