### PR TITLE
Fix the dealcoloneq command.

### DIFF
--- a/doc/doxygen/extra.sty
+++ b/doc/doxygen/extra.sty
@@ -18,4 +18,4 @@
 
 % Note: If you add an entry here, also put it into
 % ./doc/doxygen/scripts/mod_header.pl.in
-\newcommand{\dealcoloneq}{\mathrel{\vcenter{:}}=}
+\newcommand{\dealcoloneq}{\mathrel{\vcenter{:}=}}

--- a/doc/doxygen/scripts/mod_header.pl.in
+++ b/doc/doxygen/scripts/mod_header.pl.in
@@ -43,6 +43,6 @@ if (eof)
 {
     print '<!--Extra macros for MathJax:-->', "\n";
     print '<div style="display:none">', "\n";
-    print '\(\newcommand{\dealcoloneq}{\mathrel{\vcenter{:}}=}\)', "\n";
+    print '\(\newcommand{\dealcoloneq}{\mathrel{\vcenter{:}=}}\)', "\n";
     print '</div>', "\n";
 }


### PR DESCRIPTION
It leads to funny spacing in latex (non-MathJax) mode because we accidentally
delimited only the ':' with the mathrel command, when we really wanted all of
the ':=' to be the operator.