### PR TITLE
Multigrid Transfer cleanup

### DIFF
--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -523,7 +523,7 @@ namespace Step16
   void LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     FullMatrix<double> coarse_matrix;
     coarse_matrix.copy_from(mg_matrices[0]);

--- a/examples/step-16b/step-16b.cc
+++ b/examples/step-16b/step-16b.cc
@@ -474,7 +474,7 @@ namespace Step16
   void LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     FullMatrix<double> coarse_matrix;
     coarse_matrix.copy_from(mg_matrices[0]);

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -722,7 +722,7 @@ namespace Step39
     // preconditioner. First, we need transfer between grid levels. The object
     // we are using here generates sparse matrices for these transfers.
     MGTransferPrebuilt<Vector<double>> mg_transfer;
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     // Then, we need an exact solver for the matrix on the coarsest level.
     FullMatrix<double> coarse_matrix;

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -880,7 +880,7 @@ namespace Step56
 
         // Transfer operators between levels
         MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-        mg_transfer.build_matrices(velocity_dof_handler);
+        mg_transfer.build(velocity_dof_handler);
 
         // Setup coarse grid solver
         FullMatrix<double> coarse_matrix;

--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -1060,7 +1060,7 @@ namespace Step63
 
     using Transfer = MGTransferPrebuilt<Vector<double>>;
     Transfer mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     FullMatrix<double> coarse_matrix;
     coarse_matrix.copy_from(mg_matrices[0]);

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -293,7 +293,7 @@ public:
    */
   template <int dim, class InVector, int spacedim>
   void
-  copy_to_mg(const DoFHandler<dim, spacedim> &mg_dof,
+  copy_to_mg(const DoFHandler<dim, spacedim> &dof_handler,
              MGLevelObject<VectorType> &      dst,
              const InVector &                 src) const;
 
@@ -306,7 +306,7 @@ public:
    */
   template <int dim, class OutVector, int spacedim>
   void
-  copy_from_mg(const DoFHandler<dim, spacedim> &mg_dof,
+  copy_from_mg(const DoFHandler<dim, spacedim> &dof_handler,
                OutVector &                      dst,
                const MGLevelObject<VectorType> &src) const;
 
@@ -317,7 +317,7 @@ public:
    */
   template <int dim, class OutVector, int spacedim>
   void
-  copy_from_mg_add(const DoFHandler<dim, spacedim> &mg_dof,
+  copy_from_mg_add(const DoFHandler<dim, spacedim> &dof_handler,
                    OutVector &                      dst,
                    const MGLevelObject<VectorType> &src) const;
 
@@ -357,7 +357,8 @@ protected:
    */
   template <int dim, int spacedim>
   void
-  fill_and_communicate_copy_indices(const DoFHandler<dim, spacedim> &mg_dof);
+  fill_and_communicate_copy_indices(
+    const DoFHandler<dim, spacedim> &dof_handler);
 
   /**
    * Sizes of the multi-level vectors.
@@ -450,7 +451,7 @@ public:
    */
   template <int dim, typename Number2, int spacedim>
   void
-  copy_to_mg(const DoFHandler<dim, spacedim> &                          mg_dof,
+  copy_to_mg(const DoFHandler<dim, spacedim> &dof_handler,
              MGLevelObject<LinearAlgebra::distributed::Vector<Number>> &dst,
              const LinearAlgebra::distributed::Vector<Number2> &src) const;
 
@@ -464,8 +465,8 @@ public:
   template <int dim, typename Number2, int spacedim>
   void
   copy_from_mg(
-    const DoFHandler<dim, spacedim> &                                mg_dof,
-    LinearAlgebra::distributed::Vector<Number2> &                    dst,
+    const DoFHandler<dim, spacedim> &            dof_handler,
+    LinearAlgebra::distributed::Vector<Number2> &dst,
     const MGLevelObject<LinearAlgebra::distributed::Vector<Number>> &src) const;
 
   /**
@@ -476,8 +477,8 @@ public:
   template <int dim, typename Number2, int spacedim>
   void
   copy_from_mg_add(
-    const DoFHandler<dim, spacedim> &                                mg_dof,
-    LinearAlgebra::distributed::Vector<Number2> &                    dst,
+    const DoFHandler<dim, spacedim> &            dof_handler,
+    LinearAlgebra::distributed::Vector<Number2> &dst,
     const MGLevelObject<LinearAlgebra::distributed::Vector<Number>> &src) const;
 
   /**
@@ -517,7 +518,7 @@ protected:
    */
   template <int dim, typename Number2, int spacedim>
   void
-  copy_to_mg(const DoFHandler<dim, spacedim> &                          mg_dof,
+  copy_to_mg(const DoFHandler<dim, spacedim> &dof_handler,
              MGLevelObject<LinearAlgebra::distributed::Vector<Number>> &dst,
              const LinearAlgebra::distributed::Vector<Number2> &        src,
              const bool solution_transfer) const;
@@ -527,7 +528,8 @@ protected:
    */
   template <int dim, int spacedim>
   void
-  fill_and_communicate_copy_indices(const DoFHandler<dim, spacedim> &mg_dof);
+  fill_and_communicate_copy_indices(
+    const DoFHandler<dim, spacedim> &dof_handler);
 
   /**
    * Sizes of the multi-level vectors.
@@ -681,13 +683,13 @@ public:
   virtual ~MGTransferPrebuilt() override = default;
 
   /**
-   * Initialize the constraints to be used in build_matrices().
+   * Initialize the constraints to be used in build().
    */
   void
   initialize_constraints(const MGConstrainedDoFs &mg_constrained_dofs);
 
   /**
-   * Initialize the constraints to be used in build_matrices().
+   * Initialize the constraints to be used in build().
    *
    * @deprecated @p constraints is unused.
    */
@@ -703,11 +705,22 @@ public:
   clear();
 
   /**
-   * Actually build the prolongation matrices for each level.
+   * Actually build the information required for the transfer operations. Needs
+   * to be called before prolongate() or restrict_and_add() can be used.
    */
   template <int dim, int spacedim>
   void
-  build_matrices(const DoFHandler<dim, spacedim> &mg_dof);
+  build(const DoFHandler<dim, spacedim> &dof_handler);
+
+  /**
+   * Actually build the prolongation matrices for each level.
+   *
+   * @deprecated use build() instead.
+   */
+  DEAL_II_DEPRECATED
+  template <int dim, int spacedim>
+  void
+  build_matrices(const DoFHandler<dim, spacedim> &dof_handler);
 
   /**
    * Prolongate a vector from level <tt>to_level-1</tt> to level
@@ -751,7 +764,7 @@ public:
   DeclException0(ExcNoProlongation);
 
   /**
-   * You have to call build_matrices() before using this object.
+   * You have to call build() before using this object.
    */
   DeclException0(ExcMatricesNotBuilt);
 

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -717,9 +717,8 @@ public:
    *
    * @deprecated use build() instead.
    */
-  DEAL_II_DEPRECATED
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED void
   build_matrices(const DoFHandler<dim, spacedim> &dof_handler);
 
   /**

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -99,6 +99,20 @@ protected:
    */
   template <int dim, int spacedim>
   void
+  build(const DoFHandler<dim, spacedim> &dof_handler);
+
+  /**
+   * Actually build the prolongation matrices for each level.
+   *
+   * This function is only called by derived classes. These can also set the
+   * member variables #selected and others to restrict the transfer matrices
+   * to certain blocks.
+   *
+   * @deprecated Use build() instead.
+   */
+  DEAL_II_DEPRECATED
+  template <int dim, int spacedim>
+  void
   build_matrices(const DoFHandler<dim, spacedim> &dof,
                  const DoFHandler<dim, spacedim> &mg_dof);
 
@@ -143,7 +157,7 @@ protected:
   std::vector<std::vector<types::global_dof_index>> mg_block_start;
 
   /**
-   * Call build_matrices() function first.
+   * Call build() function first.
    */
   DeclException0(ExcMatricesNotBuilt);
 
@@ -225,6 +239,20 @@ public:
    */
   template <int dim, int spacedim>
   void
+  build(const DoFHandler<dim, spacedim> &dof_handler,
+        const std::vector<bool> &        selected);
+
+  /**
+   * Build the prolongation matrices for each level.
+   *
+   * This function is a front-end for the same function in
+   * MGTransferBlockBase.
+   *
+   * @deprecated Use the build() function instead.
+   */
+  DEAL_II_DEPRECATED
+  template <int dim, int spacedim>
+  void
   build_matrices(const DoFHandler<dim, spacedim> &dof,
                  const DoFHandler<dim, spacedim> &mg_dof,
                  const std::vector<bool> &        selected);
@@ -252,7 +280,7 @@ public:
    */
   template <int dim, typename number2, int spacedim>
   void
-  copy_to_mg(const DoFHandler<dim, spacedim> &   mg_dof,
+  copy_to_mg(const DoFHandler<dim, spacedim> &   dof_handler,
              MGLevelObject<BlockVector<number>> &dst,
              const BlockVector<number2> &        src) const;
 
@@ -264,7 +292,7 @@ public:
    */
   template <int dim, typename number2, int spacedim>
   void
-  copy_from_mg(const DoFHandler<dim, spacedim> &         mg_dof,
+  copy_from_mg(const DoFHandler<dim, spacedim> &         dof_handler,
                BlockVector<number2> &                    dst,
                const MGLevelObject<BlockVector<number>> &src) const;
 
@@ -275,7 +303,7 @@ public:
    */
   template <int dim, typename number2, int spacedim>
   void
-  copy_from_mg_add(const DoFHandler<dim, spacedim> &         mg_dof,
+  copy_from_mg_add(const DoFHandler<dim, spacedim> &         dof_handler,
                    BlockVector<number2> &                    dst,
                    const MGLevelObject<BlockVector<number>> &src) const;
 
@@ -346,12 +374,26 @@ public:
    * This function is a front-end for the same function in
    * MGTransferBlockBase.
    *
-   * @arg selected: Number of the block of the global vector to be copied from
-   * and to the multilevel vector.
-   *
-   * @arg mg_selected: Number of the component for which the transfer matrices
+   * @param dof_handler The DoFHandler to use.
+   * @param selected Number of the block for which the transfer matrices
    * should be built.
    */
+  template <int dim, int spacedim>
+  void
+  build(const DoFHandler<dim, spacedim> &dof_handler, unsigned int selected);
+
+  /**
+   * Actually build the prolongation matrices for grouped blocks.
+   *
+   * This function is a front-end for the same function in
+   * MGTransferBlockBase.
+   *
+   * @param selected Number of the block of the global vector to be copied from
+   * and to the multilevel vector.
+   *
+   * @deprecated Use build() instead.
+   */
+  DEAL_II_DEPRECATED
   template <int dim, int spacedim>
   void
   build_matrices(const DoFHandler<dim, spacedim> &dof,
@@ -382,7 +424,7 @@ public:
    */
   template <int dim, typename number2, int spacedim>
   void
-  copy_to_mg(const DoFHandler<dim, spacedim> &mg_dof,
+  copy_to_mg(const DoFHandler<dim, spacedim> &dof_handler,
              MGLevelObject<Vector<number>> &  dst,
              const Vector<number2> &          src) const;
 
@@ -394,7 +436,7 @@ public:
    */
   template <int dim, typename number2, int spacedim>
   void
-  copy_from_mg(const DoFHandler<dim, spacedim> &    mg_dof,
+  copy_from_mg(const DoFHandler<dim, spacedim> &    dof_handler,
                Vector<number2> &                    dst,
                const MGLevelObject<Vector<number>> &src) const;
 
@@ -405,7 +447,7 @@ public:
    */
   template <int dim, typename number2, int spacedim>
   void
-  copy_from_mg_add(const DoFHandler<dim, spacedim> &    mg_dof,
+  copy_from_mg_add(const DoFHandler<dim, spacedim> &    dof_handler,
                    Vector<number2> &                    dst,
                    const MGLevelObject<Vector<number>> &src) const;
 
@@ -418,7 +460,7 @@ public:
    */
   template <int dim, typename number2, int spacedim>
   void
-  copy_to_mg(const DoFHandler<dim, spacedim> &mg_dof,
+  copy_to_mg(const DoFHandler<dim, spacedim> &dof_handler,
              MGLevelObject<Vector<number>> &  dst,
              const BlockVector<number2> &     src) const;
 
@@ -430,7 +472,7 @@ public:
    */
   template <int dim, typename number2, int spacedim>
   void
-  copy_from_mg(const DoFHandler<dim, spacedim> &    mg_dof,
+  copy_from_mg(const DoFHandler<dim, spacedim> &    dof_handler,
                BlockVector<number2> &               dst,
                const MGLevelObject<Vector<number>> &src) const;
 
@@ -441,7 +483,7 @@ public:
    */
   template <int dim, typename number2, int spacedim>
   void
-  copy_from_mg_add(const DoFHandler<dim, spacedim> &    mg_dof,
+  copy_from_mg_add(const DoFHandler<dim, spacedim> &    dof_handler,
                    BlockVector<number2> &               dst,
                    const MGLevelObject<Vector<number>> &src) const;
 
@@ -457,7 +499,7 @@ private:
    */
   template <int dim, class OutVector, int spacedim>
   void
-  do_copy_from_mg(const DoFHandler<dim, spacedim> &    mg_dof,
+  do_copy_from_mg(const DoFHandler<dim, spacedim> &    dof_handler,
                   OutVector &                          dst,
                   const MGLevelObject<Vector<number>> &src,
                   const unsigned int                   offset) const;
@@ -467,7 +509,7 @@ private:
    */
   template <int dim, class OutVector, int spacedim>
   void
-  do_copy_from_mg_add(const DoFHandler<dim, spacedim> &    mg_dof,
+  do_copy_from_mg_add(const DoFHandler<dim, spacedim> &    dof_handler,
                       OutVector &                          dst,
                       const MGLevelObject<Vector<number>> &src,
                       const unsigned int                   offset) const;
@@ -477,7 +519,7 @@ private:
    */
   template <int dim, class InVector, int spacedim>
   void
-  do_copy_to_mg(const DoFHandler<dim, spacedim> &mg_dof,
+  do_copy_to_mg(const DoFHandler<dim, spacedim> &dof_handler,
                 MGLevelObject<Vector<number>> &  dst,
                 const InVector &                 src,
                 const unsigned int               offset) const;

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -110,9 +110,8 @@ protected:
    *
    * @deprecated Use build() instead.
    */
-  DEAL_II_DEPRECATED
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED void
   build_matrices(const DoFHandler<dim, spacedim> &dof,
                  const DoFHandler<dim, spacedim> &mg_dof);
 
@@ -250,9 +249,8 @@ public:
    *
    * @deprecated Use the build() function instead.
    */
-  DEAL_II_DEPRECATED
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED void
   build_matrices(const DoFHandler<dim, spacedim> &dof,
                  const DoFHandler<dim, spacedim> &mg_dof,
                  const std::vector<bool> &        selected);
@@ -393,9 +391,8 @@ public:
    *
    * @deprecated Use build() instead.
    */
-  DEAL_II_DEPRECATED
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED void
   build_matrices(const DoFHandler<dim, spacedim> &dof,
                  const DoFHandler<dim, spacedim> &mg_dof,
                  unsigned int                     selected);

--- a/include/deal.II/multigrid/mg_transfer_block.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_block.templates.h
@@ -46,12 +46,12 @@ template <typename number>
 template <int dim, typename number2, int spacedim>
 void
 MGTransferBlockSelect<number>::copy_from_mg(
-  const DoFHandler<dim, spacedim> &    mg_dof_handler,
+  const DoFHandler<dim, spacedim> &    dof_handler,
   BlockVector<number2> &               dst,
   const MGLevelObject<Vector<number>> &src) const
 {
   for (unsigned int level = 0;
-       level < mg_dof_handler.get_triangulation().n_levels();
+       level < dof_handler.get_triangulation().n_levels();
        ++level)
     for (IT i = copy_indices[selected_block][level].begin();
          i != copy_indices[selected_block][level].end();
@@ -65,12 +65,12 @@ template <typename number>
 template <int dim, typename number2, int spacedim>
 void
 MGTransferBlockSelect<number>::copy_from_mg(
-  const DoFHandler<dim, spacedim> &    mg_dof_handler,
+  const DoFHandler<dim, spacedim> &    dof_handler,
   Vector<number2> &                    dst,
   const MGLevelObject<Vector<number>> &src) const
 {
   for (unsigned int level = 0;
-       level < mg_dof_handler.get_triangulation().n_levels();
+       level < dof_handler.get_triangulation().n_levels();
        ++level)
     for (IT i = copy_indices[selected_block][level].begin();
          i != copy_indices[selected_block][level].end();
@@ -84,12 +84,12 @@ template <typename number>
 template <int dim, typename number2, int spacedim>
 void
 MGTransferBlockSelect<number>::copy_from_mg_add(
-  const DoFHandler<dim, spacedim> &    mg_dof_handler,
+  const DoFHandler<dim, spacedim> &    dof_handler,
   BlockVector<number2> &               dst,
   const MGLevelObject<Vector<number>> &src) const
 {
   for (unsigned int level = 0;
-       level < mg_dof_handler.get_triangulation().n_levels();
+       level < dof_handler.get_triangulation().n_levels();
        ++level)
     for (IT i = copy_indices[selected_block][level].begin();
          i != copy_indices[selected_block][level].end();
@@ -103,12 +103,12 @@ template <typename number>
 template <int dim, typename number2, int spacedim>
 void
 MGTransferBlockSelect<number>::copy_from_mg_add(
-  const DoFHandler<dim, spacedim> &    mg_dof_handler,
+  const DoFHandler<dim, spacedim> &    dof_handler,
   Vector<number2> &                    dst,
   const MGLevelObject<Vector<number>> &src) const
 {
   for (unsigned int level = 0;
-       level < mg_dof_handler.get_triangulation().n_levels();
+       level < dof_handler.get_triangulation().n_levels();
        ++level)
     for (IT i = copy_indices[selected_block][level].begin();
          i != copy_indices[selected_block][level].end();
@@ -134,14 +134,14 @@ template <typename number>
 template <int dim, typename number2, int spacedim>
 void
 MGTransferBlock<number>::copy_from_mg(
-  const DoFHandler<dim, spacedim> &         mg_dof_handler,
+  const DoFHandler<dim, spacedim> &         dof_handler,
   BlockVector<number2> &                    dst,
   const MGLevelObject<BlockVector<number>> &src) const
 {
   for (unsigned int block = 0; block < selected.size(); ++block)
     if (selected[block])
       for (unsigned int level = 0;
-           level < mg_dof_handler.get_triangulation().n_levels();
+           level < dof_handler.get_triangulation().n_levels();
            ++level)
         for (IT i = copy_indices[block][level].begin();
              i != copy_indices[block][level].end();
@@ -156,14 +156,14 @@ template <typename number>
 template <int dim, typename number2, int spacedim>
 void
 MGTransferBlock<number>::copy_from_mg_add(
-  const DoFHandler<dim, spacedim> &         mg_dof_handler,
+  const DoFHandler<dim, spacedim> &         dof_handler,
   BlockVector<number2> &                    dst,
   const MGLevelObject<BlockVector<number>> &src) const
 {
   for (unsigned int block = 0; block < selected.size(); ++block)
     if (selected[block])
       for (unsigned int level = 0;
-           level < mg_dof_handler.get_triangulation().n_levels();
+           level < dof_handler.get_triangulation().n_levels();
            ++level)
         for (IT i = copy_indices[block][level].begin();
              i != copy_indices[block][level].end();

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -83,6 +83,23 @@ protected:
    */
   template <int dim, int spacedim>
   void
+  build(const DoFHandler<dim, spacedim> &dof_handler);
+
+  /**
+   * Actually build the prolongation matrices for each level.
+   *
+   * This function is only called by derived classes. These can also set the
+   * member variables <code>selected_component</code> and
+   * <code>mg_selected_component</code> member variables to restrict the
+   * transfer matrices to certain components. Furthermore, they use
+   * <code>target_component</code> and <code>mg_target_component</code> for
+   * re-ordering and grouping of components.
+   *
+   * @deprecated Use build() instead.
+   */
+  DEAL_II_DEPRECATED
+  template <int dim, int spacedim>
+  void
   build_matrices(const DoFHandler<dim, spacedim> &dof,
                  const DoFHandler<dim, spacedim> &mg_dof);
 
@@ -130,7 +147,7 @@ protected:
   std::vector<std::vector<types::global_dof_index>> mg_component_start;
 
   /**
-   * Call build_matrices() function first.
+   * Call build() function first.
    */
   DeclException0(ExcMatricesNotBuilt);
 
@@ -220,7 +237,10 @@ public:
    * It also affects the behavior of the <tt>selected</tt> argument
    *
    * @arg boundary_indices: holds the boundary indices on each level.
+   *
+   * @deprecated Use build() instead.
    */
+  DEAL_II_DEPRECATED
   template <int dim, int spacedim>
   void
   build_matrices(
@@ -234,6 +254,43 @@ public:
       std::vector<unsigned int>(),
     const std::vector<std::set<types::global_dof_index>> &boundary_indices =
       std::vector<std::set<types::global_dof_index>>());
+
+  /**
+   * Actually build the prolongation matrices for grouped components.
+   *
+   * This function is a front-end for the same function in
+   * MGTransferComponentBase.
+   *
+   * @arg selected Number of the block of the global vector to be copied from
+   * and to the multilevel vector. This number refers to the renumbering by
+   * <tt>target_component</tt>.
+   *
+   * @arg mg_selected Number of the block for which the transfer matrices
+   * should be built.
+   *
+   * If <tt>mg_target_component</tt> is present, this refers to the renumbered
+   * components.
+   *
+   * @arg target_component this argument allows grouping and renumbering of
+   * components in the fine-level vector (see DoFRenumbering::component_wise).
+   *
+   * @arg mg_target_component this argument allows grouping and renumbering
+   * of components in the level vectors (see DoFRenumbering::component_wise).
+   * It also affects the behavior of the <tt>selected</tt> argument
+   *
+   * @arg boundary_indices holds the boundary indices on each level.
+   */
+  template <int dim, int spacedim>
+  void
+  build(const DoFHandler<dim, spacedim> &dof,
+        unsigned int                     selected,
+        unsigned int                     mg_selected,
+        const std::vector<unsigned int> &target_component =
+          std::vector<unsigned int>(),
+        const std::vector<unsigned int> &mg_target_component =
+          std::vector<unsigned int>(),
+        const std::vector<std::set<types::global_dof_index>> &boundary_indices =
+          std::vector<std::set<types::global_dof_index>>());
 
   /**
    * Change selected component. Handle with care!

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -97,9 +97,8 @@ protected:
    *
    * @deprecated Use build() instead.
    */
-  DEAL_II_DEPRECATED
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED void
   build_matrices(const DoFHandler<dim, spacedim> &dof,
                  const DoFHandler<dim, spacedim> &mg_dof);
 
@@ -240,9 +239,8 @@ public:
    *
    * @deprecated Use build() instead.
    */
-  DEAL_II_DEPRECATED
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED void
   build_matrices(
     const DoFHandler<dim, spacedim> &dof,
     const DoFHandler<dim, spacedim> &mg_dof,

--- a/include/deal.II/multigrid/mg_transfer_internal.h
+++ b/include/deal.II/multigrid/mg_transfer_internal.h
@@ -44,7 +44,7 @@ namespace internal
     template <int dim, int spacedim>
     void
     fill_copy_indices(
-      const DoFHandler<dim, spacedim> &mg_dof,
+      const DoFHandler<dim, spacedim> &dof_handler,
       const MGConstrainedDoFs *        mg_constrained_dofs,
       std::vector<std::vector<
         std::pair<types::global_dof_index, types::global_dof_index>>>
@@ -122,7 +122,7 @@ namespace internal
     template <int dim, typename Number>
     void
     setup_transfer(
-      const DoFHandler<dim> &  mg_dof,
+      const DoFHandler<dim> &  dof_handler,
       const MGConstrainedDoFs *mg_constrained_dofs,
       const std::vector<std::shared_ptr<const Utilities::MPI::Partitioner>>
         &                                     external_partitioners,

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -172,7 +172,7 @@ public:
 #ifndef _MSC_VER
   DEAL_II_DEPRECATED
 #endif
-  Multigrid(const DoFHandler<dim> &             mg_dof_handler,
+  Multigrid(const DoFHandler<dim> &             dof_handler,
             const MGMatrixBase<VectorType> &    matrix,
             const MGCoarseGridBase<VectorType> &coarse,
             const MGTransferBase<VectorType> &  transfer,
@@ -638,7 +638,7 @@ private:
 
 template <typename VectorType>
 template <int dim>
-Multigrid<VectorType>::Multigrid(const DoFHandler<dim> &         mg_dof_handler,
+Multigrid<VectorType>::Multigrid(const DoFHandler<dim> &         dof_handler,
                                  const MGMatrixBase<VectorType> &matrix,
                                  const MGCoarseGridBase<VectorType> &coarse,
                                  const MGTransferBase<VectorType> &  transfer,
@@ -659,7 +659,7 @@ Multigrid<VectorType>::Multigrid(const DoFHandler<dim> &         mg_dof_handler,
   , debug(0)
 {
   const unsigned int dof_handler_max_level =
-    mg_dof_handler.get_triangulation().n_global_levels() - 1;
+    dof_handler.get_triangulation().n_global_levels() - 1;
   if (max_level == numbers::invalid_unsigned_int)
     maxlevel = dof_handler_max_level;
   else

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -205,7 +205,7 @@ MGTransferBlock<number>::copy_to_mg(
 template <int dim, int spacedim>
 void
 MGTransferBlockBase::build_matrices(
-  const DoFHandler<dim, spacedim> &dof,
+  const DoFHandler<dim, spacedim> & /*dof*/,
   const DoFHandler<dim, spacedim> &mg_dof_handler)
 {
   build(mg_dof_handler);

--- a/source/multigrid/mg_transfer_block.inst.in
+++ b/source/multigrid/mg_transfer_block.inst.in
@@ -17,21 +17,37 @@
 
 for (deal_II_dimension : DIMENSIONS)
   {
+    template void MGTransferBlock<float>::build<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &, const std::vector<bool> &);
+
+    template void MGTransferBlock<double>::build<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &, const std::vector<bool> &);
+
+    template void MGTransferBlockSelect<float>::build<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &, const unsigned int);
+
+    template void MGTransferBlockSelect<double>::build<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &, const unsigned int);
+
+    // deprecated:
     template void MGTransferBlock<float>::build_matrices<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &,
       const DoFHandler<deal_II_dimension> &,
       const std::vector<bool> &);
 
+    // deprecated:
     template void MGTransferBlock<double>::build_matrices<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &,
       const DoFHandler<deal_II_dimension> &,
       const std::vector<bool> &);
 
+    // deprecated:
     template void MGTransferBlockSelect<float>::build_matrices<
       deal_II_dimension>(const DoFHandler<deal_II_dimension> &,
                          const DoFHandler<deal_II_dimension> &,
                          const unsigned int);
 
+    // deprecated:
     template void MGTransferBlockSelect<double>::build_matrices<
       deal_II_dimension>(const DoFHandler<deal_II_dimension> &,
                          const DoFHandler<deal_II_dimension> &,

--- a/source/multigrid/mg_transfer_component.inst.in
+++ b/source/multigrid/mg_transfer_component.inst.in
@@ -17,6 +17,23 @@
 
 for (deal_II_dimension : DIMENSIONS)
   {
+    template void MGTransferSelect<float>::build<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &,
+      unsigned int,
+      unsigned int,
+      const std::vector<unsigned int> &,
+      const std::vector<unsigned int> &,
+      const std::vector<std::set<types::global_dof_index>> &);
+
+    template void MGTransferSelect<double>::build<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &,
+      unsigned int,
+      unsigned int,
+      const std::vector<unsigned int> &,
+      const std::vector<unsigned int> &,
+      const std::vector<std::set<types::global_dof_index>> &);
+
+    // deprecated:
     template void MGTransferSelect<float>::build_matrices<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &d,
       const DoFHandler<deal_II_dimension> &,
@@ -26,6 +43,7 @@ for (deal_II_dimension : DIMENSIONS)
       const std::vector<unsigned int> &,
       const std::vector<std::set<types::global_dof_index>> &);
 
+    // deprecated:
     template void MGTransferSelect<double>::build_matrices<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &d,
       const DoFHandler<deal_II_dimension> &,

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -95,14 +95,15 @@ MGTransferMatrixFree<dim, Number>::clear()
 template <int dim, typename Number>
 void
 MGTransferMatrixFree<dim, Number>::build(
-  const DoFHandler<dim, dim> &mg_dof,
+  const DoFHandler<dim, dim> &dof_handler,
   const std::vector<std::shared_ptr<const Utilities::MPI::Partitioner>>
     &external_partitioners)
 {
-  this->fill_and_communicate_copy_indices(mg_dof);
+  this->fill_and_communicate_copy_indices(dof_handler);
 
   vector_partitioners.resize(0,
-                             mg_dof.get_triangulation().n_global_levels() - 1);
+                             dof_handler.get_triangulation().n_global_levels() -
+                               1);
   for (unsigned int level = 0; level <= this->ghosted_level_vector.max_level();
        ++level)
     vector_partitioners[level] =
@@ -113,7 +114,7 @@ MGTransferMatrixFree<dim, Number>::build(
   internal::MGTransfer::ElementInfo<Number> elem_info;
 
   internal::MGTransfer::setup_transfer<dim, Number>(
-    mg_dof,
+    dof_handler,
     this->mg_constrained_dofs,
     external_partitioners,
     elem_info,
@@ -149,7 +150,8 @@ MGTransferMatrixFree<dim, Number>::build(
 
   // reshuffle into aligned vector of vectorized arrays
   const unsigned int vec_size = VectorizedArray<Number>::n_array_elements;
-  const unsigned int n_levels = mg_dof.get_triangulation().n_global_levels();
+  const unsigned int n_levels =
+    dof_handler.get_triangulation().n_global_levels();
 
   const unsigned int n_weights_per_cell = Utilities::fixed_power<dim>(3);
   weights_on_refined.resize(n_levels - 1);
@@ -717,10 +719,10 @@ MGTransferBlockMatrixFree<dim, Number>::clear()
 template <int dim, typename Number>
 void
 MGTransferBlockMatrixFree<dim, Number>::build(
-  const DoFHandler<dim, dim> &mg_dof)
+  const DoFHandler<dim, dim> &dof_handler)
 {
   AssertDimension(matrix_free_transfer_vector.size(), 1);
-  matrix_free_transfer_vector[0].build(mg_dof);
+  matrix_free_transfer_vector[0].build(dof_handler);
 }
 
 
@@ -728,11 +730,11 @@ MGTransferBlockMatrixFree<dim, Number>::build(
 template <int dim, typename Number>
 void
 MGTransferBlockMatrixFree<dim, Number>::build(
-  const std::vector<const DoFHandler<dim, dim> *> &mg_dof)
+  const std::vector<const DoFHandler<dim, dim> *> &dof_handler)
 {
-  AssertDimension(matrix_free_transfer_vector.size(), mg_dof.size());
-  for (unsigned int i = 0; i < mg_dof.size(); ++i)
-    matrix_free_transfer_vector[i].build(*mg_dof[i]);
+  AssertDimension(matrix_free_transfer_vector.size(), dof_handler.size());
+  for (unsigned int i = 0; i < dof_handler.size(); ++i)
+    matrix_free_transfer_vector[i].build(*dof_handler[i]);
 }
 
 

--- a/source/multigrid/mg_transfer_prebuilt.inst.in
+++ b/source/multigrid/mg_transfer_prebuilt.inst.in
@@ -22,6 +22,9 @@ for (V1 : VECTORS_WITH_MATRIX)
 
 for (deal_II_dimension : DIMENSIONS; V1 : VECTORS_WITH_MATRIX)
   {
+    template void MGTransferPrebuilt<V1>::build<deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &mg_dof);
+
     template void MGTransferPrebuilt<V1>::build_matrices<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &mg_dof);
   }

--- a/tests/bits/step-16.cc
+++ b/tests/bits/step-16.cc
@@ -255,7 +255,7 @@ void
 LaplaceProblem<dim>::solve()
 {
   MGTransferPrebuilt<Vector<double>> mg_transfer;
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
 
   FullMatrix<float> coarse_matrix;
   coarse_matrix.copy_from(mg_matrices[0]);

--- a/tests/examples/step-56.cc
+++ b/tests/examples/step-56.cc
@@ -900,7 +900,7 @@ namespace Step56
 
         // Transfer operators between levels
         MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-        mg_transfer.build_matrices(velocity_dof_handler);
+        mg_transfer.build(velocity_dof_handler);
 
         // Setup coarse grid solver
         FullMatrix<double> coarse_matrix;

--- a/tests/fe/transfer.cc
+++ b/tests/fe/transfer.cc
@@ -57,7 +57,7 @@ print_matrix(Triangulation<dim> &      tr,
   dof.distribute_mg_dofs();
 
   MGTransferPrebuilt<Vector<double>> transfer;
-  transfer.build_matrices(dof);
+  transfer.build(dof);
 
   unsigned int   n_coarse = dof.n_dofs(level - 1);
   unsigned int   n_fine   = dof.n_dofs(level);

--- a/tests/matrix_free/multigrid_dg_periodic.cc
+++ b/tests/matrix_free/multigrid_dg_periodic.cc
@@ -580,7 +580,7 @@ do_test(const DoFHandler<dim> &dof)
   mg_smoother.initialize(mg_matrices, smoother_data);
 
   MGTransferMF<LevelMatrixType> mg_transfer(mg_matrices);
-  mg_transfer.build_matrices(dof);
+  mg_transfer.build(dof);
 
   mg::Matrix<LinearAlgebra::distributed::Vector<double>> mg_matrix(mg_matrices);
 

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -379,7 +379,7 @@ do_test(const DoFHandler<dim> &dof)
     }
 
   MGTransferPrebuiltMF<LevelMatrixType> mg_transfer(mg_matrices);
-  mg_transfer.build_matrices(dof);
+  mg_transfer.build(dof);
 
   MGCoarseIterative<LevelMatrixType, number> mg_coarse;
   mg_coarse.initialize(mg_matrices[0]);

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -560,7 +560,7 @@ do_test(const DoFHandler<dim> &dof)
     mg_interface_matrices[level].initialize(mg_matrices[level]);
 
   MGTransferMF<LevelMatrixType> mg_transfer(mg_matrices, mg_constrained_dofs);
-  mg_transfer.build_matrices(dof);
+  mg_transfer.build(dof);
 
   MGCoarseIterative<LevelMatrixType, number> mg_coarse;
   mg_coarse.initialize(mg_matrices[0]);

--- a/tests/matrix_free/step-37.cc
+++ b/tests/matrix_free/step-37.cc
@@ -575,7 +575,7 @@ namespace Step37
   LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<Vector<double>> mg_transfer;
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     MGCoarseGridHouseholder<float, Vector<double>> mg_coarse;
     mg_coarse.initialize(coarse_matrix);

--- a/tests/meshworker/step-50-mesh_loop.cc
+++ b/tests/meshworker/step-50-mesh_loop.cc
@@ -452,7 +452,7 @@ namespace Step50
   LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(mg_dof_handler);
+    mg_transfer.build(mg_dof_handler);
 
     matrix_t &coarse_matrix = mg_matrices[0];
 

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -404,7 +404,7 @@ namespace Step50
   LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(mg_dof_handler);
+    mg_transfer.build(mg_dof_handler);
 
     matrix_t coarse_matrix;
     coarse_matrix.copy_from(mg_matrices[0]);

--- a/tests/mpi/multigrid_uniform.cc
+++ b/tests/mpi/multigrid_uniform.cc
@@ -391,7 +391,7 @@ namespace Step50
   LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(mg_dof_handler);
+    mg_transfer.build(mg_dof_handler);
 
     matrix_t coarse_matrix;
     coarse_matrix.copy_from(mg_matrices[0]);

--- a/tests/mpi/step-39-block.cc
+++ b/tests/mpi/step-39-block.cc
@@ -630,7 +630,7 @@ namespace Step39
     SolverCG<TrilinosWrappers::MPI::Vector> solver(control);
 
     MGTransferPrebuilt<TrilinosWrappers::MPI::Vector> mg_transfer;
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     SolverControl coarse_solver_control(1000, 1e-10, false, false);
     SolverCG<TrilinosWrappers::MPI::Vector> coarse_solver(

--- a/tests/mpi/step-39.cc
+++ b/tests/mpi/step-39.cc
@@ -631,7 +631,7 @@ namespace Step39
     SolverCG<TrilinosWrappers::MPI::Vector> solver(control);
 
     MGTransferPrebuilt<TrilinosWrappers::MPI::Vector> mg_transfer;
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     SolverControl coarse_solver_control(1000, 1e-10, false, false);
     SolverCG<TrilinosWrappers::MPI::Vector> coarse_solver(

--- a/tests/multigrid/events_01.cc
+++ b/tests/multigrid/events_01.cc
@@ -390,7 +390,7 @@ namespace Step50
     const MGCoarseGridBase<vector_t> &coarse_grid_solver)
   {
     MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(mg_dof_handler);
+    mg_transfer.build(mg_dof_handler);
 
     typedef LA::MPI::PreconditionJacobi                  Smoother;
     MGSmootherPrecondition<matrix_t, Smoother, vector_t> mg_smoother;

--- a/tests/multigrid/mg_coarse_01.cc
+++ b/tests/multigrid/mg_coarse_01.cc
@@ -461,7 +461,7 @@ namespace Step50
     const MGCoarseGridBase<vector_t> &coarse_grid_solver)
   {
     MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(mg_dof_handler);
+    mg_transfer.build(mg_dof_handler);
 
     typedef LA::MPI::PreconditionJacobi                  Smoother;
     MGSmootherPrecondition<matrix_t, Smoother, vector_t> mg_smoother;

--- a/tests/multigrid/mg_output_dirichlet.cc
+++ b/tests/multigrid/mg_output_dirichlet.cc
@@ -243,11 +243,11 @@ check_simple(const FiniteElement<dim> &fe)
                                             dirichlet_boundary_functions);
 
   MGTransferPrebuilt<Vector<double>> transfer(mg_constrained_dofs);
-  transfer.build_matrices(mgdof);
+  transfer.build(mgdof);
 
   MGTransferPrebuilt<Vector<double>> transfer_renumbered(
     mg_constrained_dofs_renumbered);
-  transfer_renumbered.build_matrices(mgdof_renumbered);
+  transfer_renumbered.build(mgdof_renumbered);
 
   Vector<double> u(mgdof.n_dofs());
   initialize(mgdof, u);

--- a/tests/multigrid/mg_output_neumann.cc
+++ b/tests/multigrid/mg_output_neumann.cc
@@ -241,11 +241,11 @@ check_simple(const FiniteElement<dim> &fe)
                                             dirichlet_boundary_functions);
 
   MGTransferPrebuilt<Vector<double>> transfer(mg_constrained_dofs);
-  transfer.build_matrices(mgdof);
+  transfer.build(mgdof);
 
   MGTransferPrebuilt<Vector<double>> transfer_renumbered(
     mg_constrained_dofs_renumbered);
-  transfer_renumbered.build_matrices(mgdof_renumbered);
+  transfer_renumbered.build(mgdof_renumbered);
 
   // Fill vector u with some cell based numbering
   Vector<double> u(mgdof.n_dofs());

--- a/tests/multigrid/mg_renumbered_01.cc
+++ b/tests/multigrid/mg_renumbered_01.cc
@@ -359,10 +359,10 @@ LaplaceProblem<dim>::test()
                                             dirichlet_boundary);
 
   MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
   MGTransferPrebuilt<Vector<double>> mg_transfer_renumbered(
     mg_constrained_dofs_renumbered);
-  mg_transfer_renumbered.build_matrices(mg_dof_handler_renumbered);
+  mg_transfer_renumbered.build(mg_dof_handler_renumbered);
 
   FullMatrix<double> coarse_matrix;
   coarse_matrix.copy_from(mg_matrices[0]);

--- a/tests/multigrid/mg_renumbered_03.cc
+++ b/tests/multigrid/mg_renumbered_03.cc
@@ -360,10 +360,10 @@ LaplaceProblem<dim>::test()
                                             dirichlet_boundary);
 
   MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
   MGTransferPrebuilt<Vector<double>> mg_transfer_renumbered(
     mg_constrained_dofs_renumbered);
-  mg_transfer_renumbered.build_matrices(mg_dof_handler_renumbered);
+  mg_transfer_renumbered.build(mg_dof_handler_renumbered);
 
   Vector<double> test;
   test.reinit(mg_dof_handler.n_dofs());

--- a/tests/multigrid/step-16-02.cc
+++ b/tests/multigrid/step-16-02.cc
@@ -474,7 +474,7 @@ void
 LaplaceProblem<dim>::solve()
 {
   MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
 
   FullMatrix<double> coarse_matrix;
   coarse_matrix.copy_from(mg_matrices[0]);

--- a/tests/multigrid/step-16-03.cc
+++ b/tests/multigrid/step-16-03.cc
@@ -365,7 +365,7 @@ void
 LaplaceProblem<dim>::solve()
 {
   MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
 
   FullMatrix<double> coarse_matrix;
   coarse_matrix.copy_from(mg_matrices[min_level]);

--- a/tests/multigrid/step-16-04.cc
+++ b/tests/multigrid/step-16-04.cc
@@ -375,7 +375,7 @@ LaplaceProblem<dim>::solve()
 {
   MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>> mg_transfer(
     mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
 
   SolverControl coarse_solver_control(1000, 1e-10, false, false);
   SolverCG<LinearAlgebra::distributed::Vector<double>> coarse_solver(

--- a/tests/multigrid/step-16-05.cc
+++ b/tests/multigrid/step-16-05.cc
@@ -376,7 +376,7 @@ LaplaceProblem<dim>::solve()
 {
   MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>> mg_transfer(
     hanging_node_constraints, mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
 
   SolverControl coarse_solver_control(1000, 1e-10, false, false);
   SolverCG<LinearAlgebra::distributed::Vector<double>> coarse_solver(

--- a/tests/multigrid/step-16-06.cc
+++ b/tests/multigrid/step-16-06.cc
@@ -376,7 +376,7 @@ LaplaceProblem<dim>::solve()
 {
   MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>> mg_transfer(
     hanging_node_constraints, mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
 
   SolverControl coarse_solver_control(1000, 1e-10, false, false);
   SolverCG<LinearAlgebra::distributed::Vector<double>> coarse_solver(

--- a/tests/multigrid/step-16-07.cc
+++ b/tests/multigrid/step-16-07.cc
@@ -448,7 +448,7 @@ void
 LaplaceProblem<dim>::solve()
 {
   MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
 
   FullMatrix<double> coarse_matrix;
   coarse_matrix.copy_from(mg_matrices[0]);

--- a/tests/multigrid/step-16-50-mpi-linear-operator.cc
+++ b/tests/multigrid/step-16-50-mpi-linear-operator.cc
@@ -439,7 +439,7 @@ namespace Step50
   LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(mg_dof_handler);
+    mg_transfer.build(mg_dof_handler);
 
     matrix_t &coarse_matrix = mg_matrices[0];
 

--- a/tests/multigrid/step-16-50-mpi-smoother.cc
+++ b/tests/multigrid/step-16-50-mpi-smoother.cc
@@ -439,7 +439,7 @@ namespace Step50
   LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(mg_dof_handler);
+    mg_transfer.build(mg_dof_handler);
 
     // pre and post smoothers:
     typedef LA::MPI::PreconditionJacobi                  Smoother;

--- a/tests/multigrid/step-16-50-mpi.cc
+++ b/tests/multigrid/step-16-50-mpi.cc
@@ -439,7 +439,7 @@ namespace Step50
   LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(mg_dof_handler);
+    mg_transfer.build(mg_dof_handler);
 
     matrix_t &coarse_matrix = mg_matrices[0];
 

--- a/tests/multigrid/step-16-50-serial.cc
+++ b/tests/multigrid/step-16-50-serial.cc
@@ -369,7 +369,7 @@ LaplaceProblem<dim>::solve()
   typedef Vector<double>       vector_t;
 
   MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
 
   matrix_t &coarse_matrix = mg_matrices[0];
 

--- a/tests/multigrid/step-16-bdry1.cc
+++ b/tests/multigrid/step-16-bdry1.cc
@@ -491,7 +491,7 @@ void
 LaplaceProblem<dim>::solve(bool use_mw)
 {
   MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
 
   FullMatrix<double> coarse_matrix;
   coarse_matrix.copy_from(mg_matrices[0]);

--- a/tests/multigrid/step-16.cc
+++ b/tests/multigrid/step-16.cc
@@ -448,7 +448,7 @@ void
 LaplaceProblem<dim>::solve()
 {
   MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
-  mg_transfer.build_matrices(mg_dof_handler);
+  mg_transfer.build(mg_dof_handler);
 
   FullMatrix<double> coarse_matrix;
   coarse_matrix.copy_from(mg_matrices[0]);

--- a/tests/multigrid/step-39-02.cc
+++ b/tests/multigrid/step-39-02.cc
@@ -591,7 +591,7 @@ namespace Step39
     SolverCG<Vector<double>> solver(control);
 
     MGTransferPrebuilt<Vector<double>> mg_transfer;
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     FullMatrix<double> coarse_matrix;
     coarse_matrix.copy_from(mg_matrix[0]);

--- a/tests/multigrid/step-39-02a.cc
+++ b/tests/multigrid/step-39-02a.cc
@@ -598,7 +598,7 @@ namespace Step39
     SolverCG<Vector<double>> solver(control);
 
     MGTransferPrebuilt<Vector<double>> mg_transfer;
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     FullMatrix<double> coarse_matrix;
     coarse_matrix.copy_from(mg_matrix[0]);

--- a/tests/multigrid/step-39-03.cc
+++ b/tests/multigrid/step-39-03.cc
@@ -597,7 +597,7 @@ namespace Step39
     SolverGMRES<Vector<double>> solver(control);
 
     MGTransferPrebuilt<Vector<double>> mg_transfer;
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     FullMatrix<double> coarse_matrix;
     coarse_matrix.copy_from(mg_matrix[0]);

--- a/tests/multigrid/step-39.cc
+++ b/tests/multigrid/step-39.cc
@@ -581,7 +581,7 @@ namespace Step39
     SolverCG<Vector<double>> solver(control);
 
     MGTransferPrebuilt<Vector<double>> mg_transfer;
-    mg_transfer.build_matrices(dof_handler);
+    mg_transfer.build(dof_handler);
 
     FullMatrix<double> coarse_matrix;
     coarse_matrix.copy_from(mg_matrix[0]);

--- a/tests/multigrid/step-50_01.cc
+++ b/tests/multigrid/step-50_01.cc
@@ -438,7 +438,7 @@ namespace Step50
   LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(mg_dof_handler);
+    mg_transfer.build(mg_dof_handler);
 
     matrix_t &coarse_matrix = mg_matrices[0];
 

--- a/tests/multigrid/step-50_02.cc
+++ b/tests/multigrid/step-50_02.cc
@@ -448,7 +448,7 @@ namespace Step50
   LaplaceProblem<dim>::solve()
   {
     MGTransferPrebuilt<vector_t> mg_transfer(mg_constrained_dofs);
-    mg_transfer.build_matrices(mg_dof_handler);
+    mg_transfer.build(mg_dof_handler);
 
     matrix_t &coarse_matrix = mg_matrices[0];
 

--- a/tests/multigrid/transfer_01.cc
+++ b/tests/multigrid/transfer_01.cc
@@ -70,7 +70,7 @@ check_simple(const FiniteElement<dim> &fe)
   mgdof.distribute_mg_dofs();
 
   MGTransferPrebuilt<Vector<double>> transfer;
-  transfer.build_matrices(mgdof);
+  transfer.build(mgdof);
 
   MGLevelObject<Vector<double>> u(0, tr.n_levels() - 1);
   reinit_vector(mgdof, u);

--- a/tests/multigrid/transfer_02.cc
+++ b/tests/multigrid/transfer_02.cc
@@ -103,7 +103,7 @@ check_simple(const FiniteElement<dim> &fe)
   mgdof.distribute_mg_dofs();
 
   MGTransferPrebuilt<Vector<double>> transfer;
-  transfer.build_matrices(mgdof);
+  transfer.build(mgdof);
 
   MGLevelObject<Vector<double>> u(0, tr.n_levels() - 1);
   reinit_vector(mgdof, u);

--- a/tests/multigrid/transfer_03.cc
+++ b/tests/multigrid/transfer_03.cc
@@ -208,10 +208,10 @@ check_simple(const FiniteElement<dim> &fe)
     DoFRenumbering::component_wise(mgdof_renumbered, level, block_component);
 
   MGTransferPrebuilt<Vector<double>> transfer;
-  transfer.build_matrices(mgdof);
+  transfer.build(mgdof);
 
   MGTransferPrebuilt<Vector<double>> transfer_renumbered;
-  transfer_renumbered.build_matrices(mgdof_renumbered);
+  transfer_renumbered.build(mgdof_renumbered);
 
   Vector<double> u(mgdof.n_dofs());
   initialize(mgdof, u);

--- a/tests/multigrid/transfer_04.cc
+++ b/tests/multigrid/transfer_04.cc
@@ -136,7 +136,7 @@ check_fe(FiniteElement<dim> &fe)
   hanging_node_constraints.close();
 
   MGTransferPrebuilt<vector_t> transfer(mg_constrained_dofs);
-  transfer.build_matrices(dofh);
+  transfer.build(dofh);
   // transfer.print_indices(deallog.get_file_stream());
 
   MGLevelObject<vector_t> u(0, tr.n_global_levels() - 1);

--- a/tests/multigrid/transfer_04a.cc
+++ b/tests/multigrid/transfer_04a.cc
@@ -130,7 +130,7 @@ check_fe(FiniteElement<dim> &fe)
   typedef TrilinosWrappers::MPI::Vector vector_t;
   {}
   MGTransferPrebuilt<vector_t> transfer;
-  transfer.build_matrices(dofh);
+  transfer.build(dofh);
   transfer.print_indices(deallog.get_file_stream());
 
   MGLevelObject<vector_t> u(0, tr.n_global_levels() - 1);

--- a/tests/multigrid/transfer_04b.cc
+++ b/tests/multigrid/transfer_04b.cc
@@ -130,7 +130,7 @@ check_fe(FiniteElement<dim> &fe)
   typedef PETScWrappers::MPI::Vector vector_t;
   {}
   MGTransferPrebuilt<vector_t> transfer;
-  transfer.build_matrices(dofh);
+  transfer.build(dofh);
   transfer.print_indices(deallog.get_file_stream());
 
   MGLevelObject<vector_t> u(0, tr.n_global_levels() - 1);

--- a/tests/multigrid/transfer_block.cc
+++ b/tests/multigrid/transfer_block.cc
@@ -96,8 +96,7 @@ check_block(const FiniteElement<dim> &fe,
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 
-  DoFHandler<dim>  mgdof(tr);
-  DoFHandler<dim> &dof = mgdof;
+  DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
   mgdof.distribute_mg_dofs();
   DoFRenumbering::component_wise(mgdof);
@@ -125,7 +124,7 @@ check_block(const FiniteElement<dim> &fe,
 
   PrimitiveVectorMemory<Vector<double>> mem;
   MGTransferBlock<double>               transfer;
-  transfer.build_matrices(dof, mgdof, selected);
+  transfer.build(mgdof, selected);
   if (factors.size() > 0)
     transfer.initialize(factors, mem);
 

--- a/tests/multigrid/transfer_block_select.cc
+++ b/tests/multigrid/transfer_block_select.cc
@@ -82,8 +82,7 @@ check_select(const FiniteElement<dim> &fe, unsigned int selected)
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 
-  DoFHandler<dim>  mgdof(tr);
-  DoFHandler<dim> &dof = mgdof;
+  DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
   mgdof.distribute_mg_dofs();
   DoFRenumbering::component_wise(mgdof);
@@ -110,7 +109,7 @@ check_select(const FiniteElement<dim> &fe, unsigned int selected)
     }
 
   MGTransferBlockSelect<double> transfer;
-  transfer.build_matrices(dof, mgdof, selected);
+  transfer.build(mgdof, selected);
 
   // First, prolongate the constant
   // function from the coarsest mesh

--- a/tests/multigrid/transfer_compare_01.cc
+++ b/tests/multigrid/transfer_compare_01.cc
@@ -126,8 +126,7 @@ check_block(const FiniteElement<dim> &fe)
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 
-  DoFHandler<dim>  mgdof(tr);
-  DoFHandler<dim> &dof = mgdof;
+  DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
   mgdof.distribute_mg_dofs();
 
@@ -136,8 +135,8 @@ check_block(const FiniteElement<dim> &fe)
   Tensor<1, dim> direction;
   for (unsigned int d = 0; d < dim; ++d)
     direction[d] = d * d * d;
-  DoFRenumbering::downstream(dof, direction);
-  DoFRenumbering::component_wise(dof);
+  DoFRenumbering::downstream(mgdof, direction);
+  DoFRenumbering::component_wise(mgdof);
   for (unsigned int l = 0; l < tr.n_levels(); ++l)
     {
       DoFRenumbering::downstream(mgdof, l, direction);
@@ -155,9 +154,9 @@ check_block(const FiniteElement<dim> &fe)
   MGTransferPrebuilt<BlockVector<double>> transfer;
   MGTransferBlock<double>                 transfer_block;
   MGTransferBlockSelect<double>           transfer_select;
-  transfer.build_matrices(mgdof);
-  transfer_block.build_matrices(dof, mgdof, selected);
-  transfer_select.build_matrices(dof, mgdof, 0);
+  transfer.build(mgdof);
+  transfer_block.build(mgdof, selected);
+  transfer_select.build(mgdof, 0);
 
   BlockVector<double> u2(mg_ndofs[2]);
   BlockVector<double> u1(mg_ndofs[1]);

--- a/tests/multigrid/transfer_matrix_free_01.cc
+++ b/tests/multigrid/transfer_matrix_free_01.cc
@@ -76,7 +76,7 @@ check(const unsigned int fe_degree)
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>
         transfer_ref(mg_constrained_dofs);
-      transfer_ref.build_matrices(mgdof);
+      transfer_ref.build(mgdof);
 
       // build matrix-free transfer
       MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);

--- a/tests/multigrid/transfer_matrix_free_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02.cc
@@ -105,7 +105,7 @@ check(const unsigned int fe_degree)
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>
         transfer_ref(mg_constrained_dofs);
-      transfer_ref.build_matrices(mgdof);
+      transfer_ref.build(mgdof);
 
       // build matrix-free transfer
       MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);

--- a/tests/multigrid/transfer_matrix_free_03.cc
+++ b/tests/multigrid/transfer_matrix_free_03.cc
@@ -74,7 +74,7 @@ check(const unsigned int fe_degree)
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>
         transfer_ref(mg_constrained_dofs);
-      transfer_ref.build_matrices(mgdof);
+      transfer_ref.build(mgdof);
 
       // build matrix-free transfer
       MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);

--- a/tests/multigrid/transfer_matrix_free_04.cc
+++ b/tests/multigrid/transfer_matrix_free_04.cc
@@ -71,7 +71,7 @@ check(const unsigned int fe_degree)
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>
         transfer_ref;
-      transfer_ref.build_matrices(mgdof);
+      transfer_ref.build(mgdof);
 
       // build matrix-free transfer
       MGTransferMatrixFree<dim, Number> transfer;

--- a/tests/multigrid/transfer_matrix_free_05.cc
+++ b/tests/multigrid/transfer_matrix_free_05.cc
@@ -98,7 +98,7 @@ check(const unsigned int fe_degree)
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>
         transfer_ref;
-      transfer_ref.build_matrices(mgdof);
+      transfer_ref.build(mgdof);
 
       // build matrix-free transfer
       MGTransferMatrixFree<dim, Number> transfer;

--- a/tests/multigrid/transfer_matrix_free_06.cc
+++ b/tests/multigrid/transfer_matrix_free_06.cc
@@ -107,7 +107,7 @@ check(const unsigned int fe_degree)
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>
         transfer_ref(mg_constrained_dofs);
-      transfer_ref.build_matrices(mgdof);
+      transfer_ref.build(mgdof);
 
       // build matrix-free transfer
       MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);

--- a/tests/multigrid/transfer_matrix_free_07.cc
+++ b/tests/multigrid/transfer_matrix_free_07.cc
@@ -98,7 +98,7 @@ check(const unsigned int fe_degree)
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>
         transfer_ref;
-      transfer_ref.build_matrices(mgdof);
+      transfer_ref.build(mgdof);
 
       // build matrix-free transfer
       MGTransferMatrixFree<dim, Number> transfer;

--- a/tests/multigrid/transfer_matrix_free_11.cc
+++ b/tests/multigrid/transfer_matrix_free_11.cc
@@ -63,7 +63,7 @@ check(const unsigned int fe_degree)
   // build reference
   MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>> transfer_ref(
     mg_constrained_dofs);
-  transfer_ref.build_matrices(mgdof);
+  transfer_ref.build(mgdof);
   deallog << "Transfer matrices: " << std::endl;
   transfer_ref.print_matrices(deallog.get_file_stream());
   deallog << std::endl;

--- a/tests/multigrid/transfer_prebuilt_01.cc
+++ b/tests/multigrid/transfer_prebuilt_01.cc
@@ -61,7 +61,7 @@ check_simple(const FiniteElement<dim> &fe)
   mgdof.distribute_mg_dofs();
 
   MGTransferPrebuilt<Vector<double>> transfer;
-  transfer.build_matrices(mgdof);
+  transfer.build(mgdof);
 
   transfer.print_matrices(deallog.get_file_stream());
   transfer.print_indices(deallog.get_file_stream());

--- a/tests/multigrid/transfer_prebuilt_02.cc
+++ b/tests/multigrid/transfer_prebuilt_02.cc
@@ -66,7 +66,7 @@ check_simple(const FiniteElement<dim> &fe)
   mg_constrained_dofs.initialize(mgdof);
 
   MGTransferPrebuilt<Vector<double>> transfer(mg_constrained_dofs);
-  transfer.build_matrices(mgdof);
+  transfer.build(mgdof);
 
   transfer.print_matrices(deallog.get_file_stream());
   transfer.print_indices(deallog.get_file_stream());

--- a/tests/multigrid/transfer_prebuilt_03.cc
+++ b/tests/multigrid/transfer_prebuilt_03.cc
@@ -71,7 +71,7 @@ check_simple(const FiniteElement<dim> &fe)
   mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
 
   MGTransferPrebuilt<Vector<double>> transfer(mg_constrained_dofs);
-  transfer.build_matrices(mgdof);
+  transfer.build(mgdof);
 
   transfer.print_matrices(deallog.get_file_stream());
   transfer.print_indices(deallog.get_file_stream());

--- a/tests/multigrid/transfer_prebuilt_04.cc
+++ b/tests/multigrid/transfer_prebuilt_04.cc
@@ -92,7 +92,7 @@ check()
         // create this if we have Trilinos
         MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>
           transfer_ref(mg_constrained_dofs);
-        transfer_ref.build_matrices(mgdof);
+        transfer_ref.build(mgdof);
       }
 #endif
       {

--- a/tests/multigrid/transfer_select.cc
+++ b/tests/multigrid/transfer_select.cc
@@ -55,14 +55,13 @@ check_select(const FiniteElement<dim> &fe,
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 
-  DoFHandler<dim>  mgdof(tr);
-  DoFHandler<dim> &dof = mgdof;
+  DoFHandler<dim> mgdof(tr);
   mgdof.distribute_dofs(fe);
   mgdof.distribute_mg_dofs();
   DoFRenumbering::component_wise(mgdof, target_component);
   vector<types::global_dof_index> ndofs(
     *std::max_element(target_component.begin(), target_component.end()) + 1);
-  DoFTools::count_dofs_per_component(dof, ndofs, true, target_component);
+  DoFTools::count_dofs_per_component(mgdof, ndofs, true, target_component);
 
   for (unsigned int l = 0; l < tr.n_levels(); ++l)
     DoFRenumbering::component_wise(mgdof, l, mg_target_component);
@@ -85,8 +84,8 @@ check_select(const FiniteElement<dim> &fe,
 
 
   MGTransferSelect<double> transfer;
-  transfer.build_matrices(
-    dof, mgdof, selected, mg_selected, target_component, mg_target_component);
+  transfer.build(
+    mgdof, selected, mg_selected, target_component, mg_target_component);
 
   Vector<double> u2(mg_ndofs[2][mg_selected]);
   Vector<double> u1(mg_ndofs[1][mg_selected]);

--- a/tests/multigrid/transfer_system_01.cc
+++ b/tests/multigrid/transfer_system_01.cc
@@ -104,7 +104,7 @@ check(const FiniteElement<dim> &fe)
     DoFRenumbering::component_wise(mg_dof_handler, level);
 
   MGTransferPrebuilt<Vector<double>> transfer;
-  transfer.build_matrices(mg_dof_handler);
+  transfer.build(mg_dof_handler);
 
   FullMatrix<double> prolong_0_1(mg_dof_handler.n_dofs(1),
                                  mg_dof_handler.n_dofs(0));

--- a/tests/multigrid/transfer_system_02.cc
+++ b/tests/multigrid/transfer_system_02.cc
@@ -109,12 +109,11 @@ check(const FiniteElement<dim> &fe)
   // group all components into one
   // block, and do the transfer
   // matrices on this block
-  transfer.build_matrices(mg_dof_handler,
-                          mg_dof_handler,
-                          0,
-                          0,
-                          std::vector<unsigned int>(2, 0U),
-                          std::vector<unsigned int>(2, 0U));
+  transfer.build(mg_dof_handler,
+                 0,
+                 0,
+                 std::vector<unsigned int>(2, 0U),
+                 std::vector<unsigned int>(2, 0U));
 
   FullMatrix<double> prolong_0_1(mg_dof_handler.n_dofs(1),
                                  mg_dof_handler.n_dofs(0));

--- a/tests/multigrid/transfer_system_03.cc
+++ b/tests/multigrid/transfer_system_03.cc
@@ -110,7 +110,7 @@ check(const FiniteElement<dim> &fe)
   std::vector<unsigned int> mask(2);
   mask[0] = 0;
   mask[1] = 1;
-  transfer.build_matrices(mg_dof_handler, mg_dof_handler, 0, 0, mask, mask);
+  transfer.build(mg_dof_handler, 0, 0, mask, mask);
 
   // use only the first half of all
   // components

--- a/tests/multigrid/transfer_system_04.cc
+++ b/tests/multigrid/transfer_system_04.cc
@@ -110,8 +110,7 @@ check(const FiniteElement<dim> &fe)
 
   MGTransferSelect<double> transfer;
 
-  transfer.build_matrices(
-    mg_dof_handler, mg_dof_handler, 0, 0, block_component, block_component);
+  transfer.build(mg_dof_handler, 0, 0, block_component, block_component);
 
   std::vector<std::vector<types::global_dof_index>> dofs_per_block(
     tr.n_levels(), std::vector<types::global_dof_index>(2));

--- a/tests/multigrid/transfer_system_05.cc
+++ b/tests/multigrid/transfer_system_05.cc
@@ -67,12 +67,11 @@ check(const FiniteElement<dim> &fe, const unsigned int selected_block)
 
   MGTransferSelect<double> transfer;
 
-  transfer.build_matrices(mg_dof_handler,
-                          mg_dof_handler,
-                          selected_block,
-                          selected_block,
-                          block_component,
-                          block_component);
+  transfer.build(mg_dof_handler,
+                 selected_block,
+                 selected_block,
+                 block_component,
+                 block_component);
 
   std::vector<types::global_dof_index> dofs_per_block(3);
   DoFTools::count_dofs_per_block(mg_dof_handler,

--- a/tests/multigrid/transfer_system_adaptive_01.cc
+++ b/tests/multigrid/transfer_system_adaptive_01.cc
@@ -152,7 +152,7 @@ check(const FiniteElement<dim> &fe)
     DoFRenumbering::component_wise(mg_dof_handler, level);
 
   MGTransferPrebuilt<Vector<double>> transfer;
-  transfer.build_matrices(mg_dof_handler);
+  transfer.build(mg_dof_handler);
 
   FullMatrix<double> prolong_0_1(mg_dof_handler.n_dofs(1),
                                  mg_dof_handler.n_dofs(0));

--- a/tests/multigrid/transfer_system_adaptive_02.cc
+++ b/tests/multigrid/transfer_system_adaptive_02.cc
@@ -160,7 +160,7 @@ check(const FiniteElement<dim> &fe)
   mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
 
   MGTransferPrebuilt<Vector<double>> transfer(mg_constrained_dofs);
-  transfer.build_matrices(mg_dof_handler);
+  transfer.build(mg_dof_handler);
 
   FullMatrix<double> prolong_0_1(mg_dof_handler.n_dofs(1),
                                  mg_dof_handler.n_dofs(0));

--- a/tests/multigrid/transfer_system_adaptive_03.cc
+++ b/tests/multigrid/transfer_system_adaptive_03.cc
@@ -154,8 +154,7 @@ check(const FiniteElement<dim> &fe)
 
   std::vector<unsigned int> block_selected(2, 0U);
   MGTransferSelect<double>  transfer;
-  transfer.build_matrices(
-    mg_dof_handler, mg_dof_handler, 0, 0, block_selected, block_selected);
+  transfer.build(mg_dof_handler, 0, 0, block_selected, block_selected);
 
   FullMatrix<double> prolong_0_1(mg_dof_handler.n_dofs(1),
                                  mg_dof_handler.n_dofs(0));

--- a/tests/multigrid/transfer_system_adaptive_04.cc
+++ b/tests/multigrid/transfer_system_adaptive_04.cc
@@ -163,13 +163,8 @@ check(const FiniteElement<dim> &fe)
 
   std::vector<unsigned int> block_selected(2, 0U);
   MGTransferSelect<double>  transfer;
-  transfer.build_matrices(mg_dof_handler,
-                          mg_dof_handler,
-                          0,
-                          0,
-                          block_selected,
-                          block_selected,
-                          boundary_indices);
+  transfer.build(
+    mg_dof_handler, 0, 0, block_selected, block_selected, boundary_indices);
 
   FullMatrix<double> prolong_0_1(mg_dof_handler.n_dofs(1),
                                  mg_dof_handler.n_dofs(0));

--- a/tests/multigrid/transfer_system_adaptive_05.cc
+++ b/tests/multigrid/transfer_system_adaptive_05.cc
@@ -157,8 +157,7 @@ check(const FiniteElement<dim> &fe)
   block_selected[0] = 0;
   block_selected[1] = 1;
   MGTransferSelect<double> transfer;
-  transfer.build_matrices(
-    mg_dof_handler, mg_dof_handler, 0, 0, block_selected, block_selected);
+  transfer.build(mg_dof_handler, 0, 0, block_selected, block_selected);
 
   // use only the first half of all
   // components

--- a/tests/multigrid/transfer_system_adaptive_06.cc
+++ b/tests/multigrid/transfer_system_adaptive_06.cc
@@ -165,13 +165,8 @@ check(const FiniteElement<dim> &fe)
   block_selected[0] = 0;
   block_selected[1] = 1;
   MGTransferSelect<double> transfer;
-  transfer.build_matrices(mg_dof_handler,
-                          mg_dof_handler,
-                          0,
-                          0,
-                          block_selected,
-                          block_selected,
-                          boundary_indices);
+  transfer.build(
+    mg_dof_handler, 0, 0, block_selected, block_selected, boundary_indices);
 
   // use only the first half of all
   // components

--- a/tests/multigrid/transfer_system_adaptive_07.cc
+++ b/tests/multigrid/transfer_system_adaptive_07.cc
@@ -157,8 +157,7 @@ check(const FiniteElement<dim> &fe)
     DoFRenumbering::component_wise(mg_dof_handler, level, block_selected);
 
   MGTransferSelect<double> transfer;
-  transfer.build_matrices(
-    mg_dof_handler, mg_dof_handler, 0, 0, block_selected, block_selected);
+  transfer.build(mg_dof_handler, 0, 0, block_selected, block_selected);
 
   std::vector<std::vector<types::global_dof_index>> dofs_per_block(
     tr.n_levels(), std::vector<types::global_dof_index>(2));

--- a/tests/multigrid/transfer_system_adaptive_08.cc
+++ b/tests/multigrid/transfer_system_adaptive_08.cc
@@ -166,13 +166,8 @@ check(const FiniteElement<dim> &fe)
                               boundary_indices);
 
   MGTransferSelect<double> transfer;
-  transfer.build_matrices(mg_dof_handler,
-                          mg_dof_handler,
-                          0,
-                          0,
-                          block_selected,
-                          block_selected,
-                          boundary_indices);
+  transfer.build(
+    mg_dof_handler, 0, 0, block_selected, block_selected, boundary_indices);
 
   std::vector<std::vector<types::global_dof_index>> dofs_per_block(
     tr.n_levels(), std::vector<types::global_dof_index>(2));

--- a/tests/multigrid/transfer_system_adaptive_09.cc
+++ b/tests/multigrid/transfer_system_adaptive_09.cc
@@ -113,12 +113,11 @@ check(const FiniteElement<dim> &fe, const unsigned int selected_block)
 
   MGTransferSelect<double> transfer;
 
-  transfer.build_matrices(mg_dof_handler,
-                          mg_dof_handler,
-                          selected_block,
-                          selected_block,
-                          block_component,
-                          block_component);
+  transfer.build(mg_dof_handler,
+                 selected_block,
+                 selected_block,
+                 block_component,
+                 block_component);
 
   std::vector<types::global_dof_index> dofs_per_block(3);
   DoFTools::count_dofs_per_block(mg_dof_handler,

--- a/tests/trilinos/mg_transfer_prebuilt_01.cc
+++ b/tests/trilinos/mg_transfer_prebuilt_01.cc
@@ -81,7 +81,7 @@ check_simple(const FiniteElement<dim> &fe)
   mgdof.distribute_mg_dofs();
 
   MGTransferPrebuilt<TrilinosWrappers::MPI::Vector> transfer;
-  transfer.build_matrices(mgdof);
+  transfer.build(mgdof);
 
   MGLevelObject<TrilinosWrappers::MPI::Vector> u(0, tr.n_levels() - 1);
   reinit_vector(mgdof, u);


### PR DESCRIPTION
- rename mg_dof argument to dof_handler everywhere
- deprecate build_matrices() in favor of build() in MGTransferSelect,
MGTransferComponentBase, MGTransferPrebuilt, ... to be identical to
MGTransferMatrixFree
- remove redundant dof,mg_dof parameters from the new build() functions