### PR TITLE
use github CI for OSX

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,63 @@
+name: github-CI
+
+on: [push, pull_request]
+
+jobs:
+  osx-serial:
+    # simple serial build using apple clang
+
+    name: OSX serial build
+    runs-on: [macos-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: info
+      run: |
+        g++ -v
+        cmake --version
+    - name: configure
+      run: |
+        cmake -D CMAKE_BUILD_TYPE=Debug -D DEAL_II_CXX_FLAGS='-Werror' .
+    - name: archive
+      uses: actions/upload-artifact@v1
+      with:
+        name: detailed.log
+        path: detailed.log
+    - name: build
+      run: |
+        make -j 2
+        make -j 2 test # quicktests
+
+  osx-parallel:
+    # MPI build using apple clang
+
+    name: OSX parallel build
+    runs-on: [macos-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: setup
+      run: |
+        brew install openmpi
+        cmake --version
+        # uncomment these for a gcc based build
+        #export OMPI_CXX=g++-9
+        #export OMPI_CC=gcc-9
+        #export OMPI_FC=gfortran-9
+    - name: info
+      run: |
+        g++-9 -v
+        mpicxx -v
+        cmake --version
+    - name: configure
+      run: |
+        CC=mpicc CXX=mpic++ cmake -D CMAKE_BUILD_TYPE=Debug -D DEAL_II_CXX_FLAGS='-Werror' -D DEAL_II_WITH_MPI=on .
+    - name: archive
+      uses: actions/upload-artifact@v1
+      with:
+        name: detailed.log
+        path: detailed.log
+    - name: build
+      run: |
+        make -j 2
+        make -j 2 test #quicktests


### PR DESCRIPTION
Test a simple serial and parallel debug build with github actions on OSX Catalina.

I don't have access to a machine that can run OSX 10.15 using Jenkins, so this seems to be the easiest way to check if we can compile. Builds will run in parallel and currently take about 60 minutes, which should not slow down our testing. Note that https://jenkins.tjhei.info/job/dealii-OSX/ will continue to run (currently OSX 10.12).

