### PR TITLE
Fix \coloneq again.

### DIFF
--- a/doc/doxygen/extra.sty
+++ b/doc/doxygen/extra.sty
@@ -18,4 +18,5 @@
 
 % Note: If you add an entry here, also put it into
 % ./doc/doxygen/scripts/mod_header.pl.in
-\newcommand{\dealcoloneq}{\mathrel{\vcenter{:}=}}
+\newcommand{\vcentcolon}{\mathrel{\mathop{:}}}
+\newcommand{\dealcoloneq}{\vcentcolon\mathrel{\mkern-1.2mu}=}

--- a/doc/doxygen/scripts/mod_header.pl.in
+++ b/doc/doxygen/scripts/mod_header.pl.in
@@ -43,6 +43,7 @@ if (eof)
 {
     print '<!--Extra macros for MathJax:-->', "\n";
     print '<div style="display:none">', "\n";
-    print '\(\newcommand{\dealcoloneq}{\mathrel{\vcenter{:}=}}\)', "\n";
+    print '\(\newcommand{\vcentcolon}{\mathrel{\mathop{:}}}\)', "\n";
+    print '\(\newcommand{\dealcoloneq}{\vcentcolon\mathrel{\mkern-1.2mu}=}\)', "\n";
     print '</div>', "\n";
 }


### PR DESCRIPTION
It turned out that my previous attempt at fixing the spacing in `\coloneq` in #9277 did not actually work -- but it's really hard to tell between browsers willing to cache nearly everything and doxygen having its own system of deciding which formulas need to be run through latex again.

Anyway, I verified that this finally works now: I just blew away the doxygen directories and forced it to re-generate everything.