### PR TITLE
Introduce \jump and \average commands to be used in the documentation.

### DIFF
--- a/doc/doxygen/extra.sty
+++ b/doc/doxygen/extra.sty
@@ -20,3 +20,5 @@
 % ./doc/doxygen/scripts/mod_header.pl.in
 \newcommand{\vcentcolon}{\mathrel{\mathop{:}}}
 \newcommand{\dealcoloneq}{\vcentcolon\mathrel{\mkern-1.2mu}=}
+\newcommand{\jump}[1]{\left[\!\left[ #1 \right]\!\right]}
+\newcommand{\average}[1]{\left\{\!\left\{ #1 \right\}\!\right\}}

--- a/doc/doxygen/scripts/mod_header.pl.in
+++ b/doc/doxygen/scripts/mod_header.pl.in
@@ -45,5 +45,7 @@ if (eof)
     print '<div style="display:none">', "\n";
     print '\(\newcommand{\vcentcolon}{\mathrel{\mathop{:}}}\)', "\n";
     print '\(\newcommand{\dealcoloneq}{\vcentcolon\mathrel{\mkern-1.2mu}=}\)', "\n";
+    print '\(\newcommand{\jump}[1]{\left[\!\left[ #1 \right]\!\right]}\)', "\n";
+    print '\(\newcommand{\average}[1]{\left\{\!\left\{ #1 \right\}\!\right\}}\)', "\n";
     print '</div>', "\n";
 }

--- a/examples/step-39/doc/intro.dox
+++ b/examples/step-39/doc/intro.dox
@@ -16,7 +16,7 @@ a face, and let the traces of functions <i>u<sub>i</sub></i> and the
 outer normal vectors <b>n</b><i><sub>i</sub></i> be labeled
 accordingly. Then, on the face, we let
 @f[
-	\{\!\{ u \}\!\} = \frac{u_1 + u_2}2
+	\average{ u } = \frac{u_1 + u_2}2
 @f]
 
 Note, that if such an expression contains a normal vector, the
@@ -28,9 +28,9 @@ becomes
 @f{multline*}
   \sum_{K\in \mathbb T_h} (\nabla u, \nabla v)_K
   \\
-  + \sum_{F \in F_h^i} \biggl\{4\sigma_F (\{\!\{ u \mathbf n\}\!\}, \{\!\{ v \mathbf n \}\!\})_F
-  - 2 (\{\!\{ \nabla u \}\!\},\{\!\{ v\mathbf n \}\!\})_F
-  - 2 (\{\!\{ \nabla v \}\!\},\{\!\{ u\mathbf n \}\!\})_F
+  + \sum_{F \in F_h^i} \biggl\{4\sigma_F (\average{ u \mathbf n}, \average{ v \mathbf n })_F
+  - 2 (\average{ \nabla u },\average{ v\mathbf n })_F
+  - 2 (\average{ \nabla v },\average{ u\mathbf n })_F
   \biggr\}
   \\
   + \sum_{F \in F_h^b} \biggl\{2\sigma_F (u, v)_F
@@ -70,7 +70,7 @@ structure, since it can be written as
   \eta_K^2 &= \sum_{K\in \mathbb T_h} h^2 \|f + \Delta u_h\|^2
   \\
   \eta_F^2 &= \sum_{F \in F_h^i} \biggl\{
-    4 \sigma_F \| \{\!\{u_h\mathbf n\}\!\} \|^2 + h \|\{\!\{\partial_n u_h\}\!\}\|^2 \biggr\}
+    4 \sigma_F \| \average{u_h\mathbf n} \|^2 + h \|\average{\partial_n u_h}\|^2 \biggr\}
   \\
   \eta_B^2 &= \sum_{F \in F_h^b} 2\sigma_F \| u_h-u^D \|^2.
 @f}

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -327,7 +327,7 @@ namespace Step39
   // them are equivalent to each other uniformly with mesh size (some not
   // uniformly with polynomial degree). Here, we choose @f[ \|u\|_{1,h} =
   // \sum_{K\in \mathbb T_h} \|\nabla u\|_K^2 + \sum_{F \in F_h^i}
-  // 4\sigma_F\|\{\!\{ u \mathbf n\}\!\}\|^2_F + \sum_{F \in F_h^b}
+  // 4\sigma_F\|\average{ u \mathbf n}\|^2_F + \sum_{F \in F_h^b}
   // 2\sigma_F\|u\|^2_F @f]
 
   template <int dim>

--- a/examples/step-59/doc/intro.dox
+++ b/examples/step-59/doc/intro.dox
@@ -51,12 +51,12 @@ one used for the step-39 tutorial program. The discretization of the Laplacian
 is given by the following weak form
 @f{align*}
 &\sum_{K\in\text{cells}} \left(\nabla v_h, \nabla u_h\right)_{K}+\\
-&\sum_{F\in\text{faces}}\Big(-\left<[\![v_h]\!], \{\!\{\nabla u_h\}\!\}\right>_{F} - \left<\{\!\{\nabla v_h\}\!\}, [\![u_h]\!]\right>_{F} + \left<[\![v_h]\!], \sigma [\![u_h]\!]\right>_{F}\Big) \\
+&\sum_{F\in\text{faces}}\Big(-\left<\jump{v_h}, \average{\nabla u_h}\right>_{F} - \left<\average{\nabla v_h}, \jump{u_h}\right>_{F} + \left<\jump{v_h}, \sigma \jump{u_h}\right>_{F}\Big) \\
 &= \sum_{K\in\text{cells}}\left(v_h, f\right)_{K},
 @f}
-where $[\![v]\!] = v^- \mathbf{n}^- + v^+ \mathbf{n}^+ = \mathbf n^{-}
+where $\jump{v} = v^- \mathbf{n}^- + v^+ \mathbf{n}^+ = \mathbf n^{-}
 \left(v^- - v^+\right)$ denotes the directed jump of the quantity $v$ from the
-two associated cells $K^-$ and $K^+$, and $\{\!\{v\}\!\}=\frac{v^- + v^+}{2}$
+two associated cells $K^-$ and $K^+$, and $\average{v}=\frac{v^- + v^+}{2}$
 is the average from both sides.
 
 The terms in the equation represent the cell integral after integration by
@@ -68,7 +68,7 @@ length of the cells in direction normal to face multiplied by $k(k+1)$, see
 step-39. The penalty term is chosen such that an inverse estimate holds and
 the final weak form is coercive, i.e., positive definite in the discrete
 setting. The adjoint consistency term and the penalty term involve the jump
-$[\![u_h]\!]$ at the element interfaces, which disappears for the analytic
+$\jump{u_h}$ at the element interfaces, which disappears for the analytic
 solution $u$. Thus, these terms are consistent with the original PDE, ensuring
 that the method can retain optimal orders of convergence.
 

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -297,7 +297,7 @@ public:
               const unsigned int component = 0) const;
 
   /**
-   * Return the jump $[u]=u_{\text{cell0}} - u_{\text{cell1}}$ on the
+   * Return the jump $\jump{u}=u_{\text{cell0}} - u_{\text{cell1}}$ on the
    * interface
    * for the shape function @p interface_dof_index at the quadrature point
    * @p q_point of component @p component.
@@ -308,7 +308,7 @@ public:
    * here uses "value here minus value there", as seen from the first cell.
    *
    * If this is a boundary face (at_boundary() returns true), then
-   * $[u]=u_{\text{cell0}}$.
+   * $\jump{u}=u_{\text{cell0}}$.
    */
   double
   jump(const unsigned int interface_dof_index,
@@ -316,13 +316,13 @@ public:
        const unsigned int component = 0) const;
 
   /**
-   * Return the average $\{u\}=\frac{1}{2}u_{\text{cell0}} +
+   * Return the average $\average{u}=\frac{1}{2}u_{\text{cell0}} +
    * \frac{1}{2}u_{\text{cell1}}$ on the interface
    * for the shape function @p interface_dof_index at the quadrature point
    * @p q_point of component @p component.
    *
    * If this is a boundary face (at_boundary() returns true), then
-   * $\{u\}=u_{\text{cell0}}$.
+   * $\average{u}=u_{\text{cell0}}$.
    */
   double
   average(const unsigned int interface_dof_index,
@@ -330,13 +330,13 @@ public:
           const unsigned int component = 0) const;
 
   /**
-   * Return the average of the gradient $\{\nabla u \} = \frac{1}{2}\nabla
+   * Return the average of the gradient $\average{\nabla u} = \frac{1}{2}\nabla
    * u_{\text{cell0}} + \frac{1}{2} \nabla u_{\text{cell1}}$ on the interface
    * for the shape function @p interface_dof_index at the quadrature point @p
    * q_point of component @p component.
    *
    * If this is a boundary face (at_boundary() returns true), then
-   * $\{\nabla u\}=\nabla u_{\text{cell0}}$.
+   * $\average{\nabla u}=\nabla u_{\text{cell0}}$.
    */
   Tensor<1, dim>
   average_gradient(const unsigned int interface_dof_index,
@@ -344,13 +344,14 @@ public:
                    const unsigned int component = 0) const;
 
   /**
-   * Return the average of the Hessian $\{\nabla^2 u \} = \frac{1}{2}\nabla^2
-   * u_{\text{cell0}} + \frac{1}{2} \nabla^2 u_{\text{cell1}}$ on the interface
+   * Return the average of the Hessian $\average{\nabla^2 u} =
+   * \frac{1}{2}\nabla^2 u_{\text{cell0}} + \frac{1}{2} \nabla^2
+   * u_{\text{cell1}}$ on the interface
    * for the shape function @p interface_dof_index at the quadrature point @p
    * q_point of component @p component.
    *
    * If this is a boundary face (at_boundary() returns true), then
-   * $\{\nabla^2 u\}=\nabla^2 u_{\text{cell0}}$.
+   * $\average{\nabla^2 u}=\nabla^2 u_{\text{cell0}}$.
    */
   Tensor<2, dim>
   average_hessian(const unsigned int interface_dof_index,
@@ -358,13 +359,13 @@ public:
                   const unsigned int component = 0) const;
 
   /**
-   * Return the jump in the gradient $[\nabla u]=\nabla u_{\text{cell0}} -
+   * Return the jump in the gradient $\jump{\nabla u}=\nabla u_{\text{cell0}} -
    * \nabla u_{\text{cell1}}$ on the interface for the shape function @p
    * interface_dof_index at the quadrature point @p q_point of component @p
    * component.
    *
    * If this is a boundary face (at_boundary() returns true), then
-   * $[\nabla u]=\nabla u_{\text{cell0}}$.
+   * $\jump{\nabla u}=\nabla u_{\text{cell0}}$.
    */
   Tensor<1, dim>
   jump_gradient(const unsigned int interface_dof_index,


### PR DESCRIPTION
This makes sure that we can be consistent in how we denote these operators: single or double brackets/braces; with or without spaces, etc.
