### PR TITLE
Replace the Dataout::first_cell/next_cell() mechanism

### DIFF
--- a/doc/news/changes/minor/20200111Bangerth
+++ b/doc/news/changes/minor/20200111Bangerth
@@ -1,0 +1,6 @@
+New: The mechanism implemented by DataOut via the `first_cell()` and
+`next_cell()` virtual functions has been deprecated. In its place, the
+DataOut::set_cell_selection() function allows doing the same but
+without the need for deriving classes.
+<br>
+(Wolfgang Bangerth, 2020/01/11)

--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -786,7 +786,8 @@ private:
  * explicitly specify the type of the base iterator by hand -- it is deduced
  * automatically here.
  *
- * @author Wolfgang Bangerth @relatesalso FilteredIterator
+ * @author Wolfgang Bangerth
+ * @relatesalso FilteredIterator
  */
 template <typename BaseIterator, typename Predicate>
 FilteredIterator<BaseIterator>

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -20,6 +20,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/grid/filtered_iterator.h>
+
 #include <deal.II/numerics/data_out_dof_data.h>
 
 #include <memory>
@@ -111,40 +113,32 @@ namespace internal
  * <h3>Extensions</h3>
  *
  * By default, this class produces patches for all active cells. Sometimes,
- * this is not what you want, maybe because they are simply too many (and too
+ * this is not what you want, maybe because there are simply too many (and too
  * small to be seen individually) or because you only want to see a certain
- * region of the domain (for example in parallel programs such as the step-18
- * example program), or for some other reason.
+ * region of the domain (for example only in the fluid part of the domain in
+ * step-46), or for some other reason.
  *
  * For this, internally build_patches() does not generate the sequence of
- * cells to be converted into patches itself, but relies on the two functions
- * first_cell() and next_cell(). By default, they return the first active
- * cell, and the next active cell, respectively. Since they are @p virtual
- * functions, you can write your own class derived from DataOut in which you
- * overload these two functions to select other cells for output. This may,
+ * cells to be converted into patches itself, but relies on the two function
+ * that we'll call first_cell() and next_cell(). By default, they return the
+ * first active cell, and the next active cell, respectively. But this can
+ * be changed using the set_cell_selection() function that allows you to
+ * replace this behavior. What set_cell_selection() wants to know is how
+ * you want to pick out the first cell on which output should be generated,
+ * and how given one cell on which output is generated you want to pick the
+ * next cell.
+ *
+ * This may,
  * for example, include only cells that are in parts of a domain (e.g., if you
  * don't care about the solution elsewhere, think for example a buffer region
  * in which you attenuate outgoing waves in the Perfectly Matched Layer
  * method) or if you don't want output to be generated at all levels of an
  * adaptively refined mesh because this creates too much data (in this case,
- * the set of cells returned by your implementations of first_cell() and
- * next_cell() will include non-active cells, and DataOut::build_patches()
+ * the set of cells returned by your implementations of the `first_cell` and
+ * `next_cell` arguments to set_cell_selection() will include
+ * non-active cells, and DataOut::build_patches()
  * will simply take interpolated values of the solution instead of the exact
- * values on these cells children for output). Once you derive your own class,
- * you would just create an object of this type instead of an object of type
- * DataOut, and everything else will remain the same.
- *
- * The two functions are not constant, so you may store information within
- * your derived class about the last accessed cell. This is useful if the
- * information of the last cell which was accessed is not sufficient to
- * determine the next one.
- *
- * There is one caveat, however: if you have cell data (in contrast to nodal,
- * or dof, data) such as error indicators, then you must make sure that
- * first_cell() and next_cell() only walk over active cells, since cell data
- * cannot be interpolated to a coarser cell. If you do have cell data and use
- * this pair of functions and they return a non-active cell, then an exception
- * will be thrown.
+ * values on these cells children for output).
  *
  * @ingroup output
  * @author Wolfgang Bangerth, 1999
@@ -159,6 +153,8 @@ public:
                 "The dimension given explicitly as a template argument to "
                 "this class must match the dimension of the DoFHandler "
                 "template argument");
+  static constexpr unsigned int spacedim = DoFHandlerType::space_dimension;
+
   /**
    * Typedef to the iterator type of the dof handler class under
    * consideration.
@@ -211,6 +207,11 @@ public:
      */
     curved_inner_cells
   };
+
+  /**
+   * Constructor.
+   */
+  DataOut();
 
   /**
    * This is the central function of this class since it builds the list of
@@ -310,16 +311,93 @@ public:
                 const CurvedCellRegion curved_region  = curved_boundary);
 
   /**
+   * A function that allows selecting for which cells output should be
+   * generated. This function takes two arguments, both `std::function`
+   * objects that can be used what the first cell on which output is
+   * generated is supposed to be, and what given one cell the next
+   * function is supposed to be. Through these function objects,
+   * it is possible to select a subset of cells on which output should
+   * be produced (e.g., only selecting those cells that belong to a
+   * part of the domain -- say, the fluid domain in a code such as step-46),
+   * or to completely change *where* output is produced (e.g., to produce
+   * output on non-active cells of a multigrid hierarchy or if the finest
+   * level of a mesh is so fine that generating graphical output would lead
+   * to an overwhelming amount of data).
+   *
+   * @param[in] first_cell A function object that takes as argument the
+   *   triangulation this class works on and that should return the first cell
+   *   on which output should be generated.
+   * @param[in] next_cell A function object that takes as arguments the
+   *   triangulation as well as the last cell
+   *   on which output was generated, and that should return the next
+   *   cell on which output should be generated. If there is no next
+   *   cell, i.e., if the input argument to the `next_cell` function object
+   *   is the last cell on which output is to be generated, then `next_cell`
+   *   must return `triangulation.end()`.
+   *
+   * These function objects are not difficult to write, but also not immediately
+   * obvious. As a consequence, there is a second variation of this function
+   * that takes a IteratorFilter argument and generates the corresponding
+   * functions itself.
+   *
+   * @note This function is also called in the constructor of this class,
+   *   where the default behavior is set. By default, this class will select all
+   *   @ref GlossLocallyOwnedCell "locally owned"
+   *   and
+   *   @ref GlossActive "active"
+   *   cells for output.
+   *
+   * @note If you have cell data (in contrast to nodal, or dof, data) such as
+   *   error indicators, then you must make sure that the `first_cell` and
+   *   `next_cell` function objects only walk over active cells, since cell data
+   *   cannot be interpolated to a coarser cell. If you do have cell data and
+   *   use this pair of functions and they return a non-active cell, then an
+   *   exception will be thrown.
+   */
+  void
+  set_cell_selection(
+    const std::function<cell_iterator(const Triangulation<dim, spacedim> &)>
+      &                                                        first_cell,
+    const std::function<cell_iterator(const Triangulation<dim, spacedim> &,
+                                      const cell_iterator &)> &next_cell);
+
+  /**
+   * A variation of the previous function that selects a subset of all
+   * cells for output based on the filter encoded in the FilteredIterator
+   * object given as argument. A typical way to generate the argument
+   * is via the make_filtered_iterator() function.
+   *
+   * @note Not all filters will result in subsets of cells for which
+   *   output can actually be generated. For example, if you are working
+   *   on parallel meshes where data is only available on some cells,
+   *   then you better make sure that your `filtered_iterator` only
+   *   loops over the
+   *   @ref GlossLocallyOwnedCell "locally owned"
+   *   cells; likewise, in most cases you will probably only want to work on
+   *   @ref GlossActive "active"
+   *   cells since this is where the solution actually lives. In particular,
+   *   if you have added vectors that represent data defined on cells
+   *   (instead of nodal data), then you can not generate output on non-active
+   *   cells and your iterator filter should reflect this.
+   */
+  void
+  set_cell_selection(const FilteredIterator<cell_iterator> &filtered_iterator);
+
+  /**
    * Return the first cell which we want output for. The default
    * implementation returns the first active cell, but you might want to
    * return other cells in a derived class.
+   *
+   * @deprecated Use the set_cell_selection() function instead.
    */
+  DEAL_II_DEPRECATED
   virtual cell_iterator
   first_cell();
 
   /**
    * Return the next cell after @p cell which we want output for.  If there
-   * are no more cells, <tt>#dofs->end()</tt> shall be returned.
+   * are no more cells, any implementation of this function should return
+   * <tt>dof_handler->end()</tt>.
    *
    * The default implementation returns the next active cell, but you might
    * want to return other cells in a derived class. Note that the default
@@ -327,16 +405,39 @@ public:
    * guaranteed as long as first_cell() is also used from the default
    * implementation. Overloading only one of the two functions might not be a
    * good idea.
+   *
+   * @deprecated Use the set_cell_selection() function instead.
    */
+  DEAL_II_DEPRECATED
   virtual cell_iterator
   next_cell(const cell_iterator &cell);
 
 private:
   /**
+   * A function object that is used to select what the first cell is going to
+   * be on which to generate graphical output. See the set_cell_selection()
+   * function for more information.
+   */
+  std::function<cell_iterator(const Triangulation<dim, spacedim> &)>
+    first_cell_function;
+
+  /**
+   * A function object that is used to select what the next cell is going to
+   * be on which to generate graphical output, given a previous cell. See
+   * the set_cell_selection() function for more information.
+   */
+  std::function<cell_iterator(const Triangulation<dim, spacedim> &,
+                              const cell_iterator &)>
+    next_cell_function;
+
+  /**
    * Return the first cell produced by the first_cell()/next_cell() function
    * pair that is locally owned. If this object operates on a non-distributed
    * triangulation, the result equals what first_cell() returns.
+   *
+   * @deprecated Use the set_cell_selection() function instead.
    */
+  DEAL_II_DEPRECATED
   virtual cell_iterator
   first_locally_owned_cell();
 
@@ -344,7 +445,10 @@ private:
    * Return the next cell produced by the next_cell() function that is locally
    * owned. If this object operates on a non-distributed triangulation, the
    * result equals what first_cell() returns.
+   *
+   * @deprecated Use the set_cell_selection() function instead.
    */
+  DEAL_II_DEPRECATED
   virtual cell_iterator
   next_locally_owned_cell(const cell_iterator &cell);
 

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -367,6 +367,23 @@ public:
    * object given as argument. A typical way to generate the argument
    * is via the make_filtered_iterator() function.
    *
+   * Alternatively, since FilteredIterator objects can be created from
+   * just a predicate (i.e., a function object that returns a `bool`), it is
+   * possible to call this function with just a lambda function, which will then
+   * automatically be converted to a FilteredIterator object. For example, the
+   * following piece of code works:
+   * @code
+   *   DataOut<dim> data_out;
+   *   data_out.set_cell_selection(
+   *          [](const typename Triangulation<dim>::cell_iterator &cell) {
+   *              return (!cell->has_children() && cell->subdomain_id() == 0);
+   *          });
+   * @endcode
+   * In this case, the lambda function selects all of those cells that are
+   * @ref GlossActive "active"
+   * and whose subdomain id is zero. These will then be the only cells on
+   * which output is generated.
+   *
    * @note Not all filters will result in subsets of cells for which
    *   output can actually be generated. For example, if you are working
    *   on parallel meshes where data is only available on some cells,

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -146,13 +146,6 @@ namespace internal
  * this pair of functions and they return a non-active cell, then an exception
  * will be thrown.
  *
- * @pre This class only makes sense if the first template argument,
- * <code>dim</code> equals the dimension of the DoFHandler type given as the
- * second template argument, i.e., if <code>dim ==
- * DoFHandlerType::dimension</code>. This redundancy is a historical relic
- * from the time where the library had only a single DoFHandler class and this
- * class consequently only a single template argument.
- *
  * @ingroup output
  * @author Wolfgang Bangerth, 1999
  */
@@ -162,6 +155,10 @@ class DataOut : public DataOut_DoFData<DoFHandlerType,
                                        DoFHandlerType::space_dimension>
 {
 public:
+  static_assert(dim == DoFHandlerType::dimension,
+                "The dimension given explicitly as a template argument to "
+                "this class must match the dimension of the DoFHandler "
+                "template argument");
   /**
    * Typedef to the iterator type of the dof handler class under
    * consideration.

--- a/tests/data_out/data_out_08_set_cell_selection_01.cc
+++ b/tests/data_out/data_out_08_set_cell_selection_01.cc
@@ -14,6 +14,13 @@
 // ---------------------------------------------------------------------
 
 
+// This test is an adaptation of the _08 test, but using the
+// DataOut::set_cell_selection() function instead of overloading
+// member functions.
+//
+// Because the _08 test is eventually going away (as it uses
+// deprecated functions), here is the description of that test:
+// ....................
 // This test documents two unrelated bugs in DataOut when used with a Filter (by
 // deriving from DataOut):
 // 1. The patch index computation in data_out.cc is wrong and causes an SIGV (or
@@ -59,44 +66,6 @@ sequence of the exception was: 466:     ExcInternalError()
 #include "../tests.h"
 
 
-template <int dim>
-class FilteredDataOut : public DataOut<dim>
-{
-public:
-  FilteredDataOut(const unsigned int subdomain_id)
-    : subdomain_id(subdomain_id)
-  {}
-
-  virtual typename DataOut<dim>::cell_iterator
-  first_cell()
-  {
-    auto cell = this->dofs->begin_active();
-    while ((cell != this->dofs->end()) &&
-           (cell->subdomain_id() != subdomain_id))
-      ++cell;
-
-    return cell;
-  }
-
-  virtual typename DataOut<dim>::cell_iterator
-  next_cell(const typename DataOut<dim>::cell_iterator &old_cell)
-  {
-    if (old_cell != this->dofs->end())
-      {
-        const IteratorFilters::SubdomainEqualTo predicate(subdomain_id);
-
-        return ++(
-          FilteredIterator<typename DataOut<dim>::cell_iterator>(predicate,
-                                                                 old_cell));
-      }
-    else
-      return old_cell;
-  }
-
-private:
-  const unsigned int subdomain_id;
-};
-
 
 template <int dim>
 void
@@ -120,7 +89,32 @@ check()
 
   // we pick only subdomain==0 which will
   // skip the first of the four cells
-  FilteredDataOut<dim> data_out(0);
+  DataOut<dim> data_out;
+  data_out.set_cell_selection(
+    [](const Triangulation<dim> &t) {
+      auto cell = t.begin_active();
+      while ((cell != t.end()) && (cell->subdomain_id() != 0))
+        ++cell;
+
+      return cell;
+    },
+
+    [](const Triangulation<dim> &                        t,
+       const typename Triangulation<dim>::cell_iterator &old_cell) ->
+    typename Triangulation<dim>::cell_iterator {
+      if (old_cell != t.end())
+        {
+          const IteratorFilters::SubdomainEqualTo predicate(0);
+
+          return ++(
+            FilteredIterator<typename Triangulation<dim>::active_cell_iterator>(
+              predicate, old_cell));
+        }
+      else
+        return old_cell;
+    });
+
+
   data_out.attach_dof_handler(dof_handler);
 
   data_out.add_data_vector(cell_data,

--- a/tests/data_out/data_out_08_set_cell_selection_01.output
+++ b/tests/data_out/data_out_08_set_cell_selection_01.output
@@ -1,0 +1,38 @@
+
+2 2
+[deal.II intermediate format graphics data]
+[written by deal.II x.y.z]
+[Version: 3]
+1
+cell_data
+3
+[deal.II intermediate Patch<2,2>]
+0.50 0.0 1.0 0.0 1.0 0.50 0.50 0.50 
+4294967295 4294967295 4294967295 2 
+0 1
+0
+1 4
+1.0 1.0 1.0 1.0 
+
+
+[deal.II intermediate Patch<2,2>]
+0.0 0.50 0.50 0.50 0.50 1.0 0.0 1.0 
+4294967295 2 4294967295 4294967295 
+1 1
+0
+1 4
+2.0 2.0 2.0 2.0 
+
+
+[deal.II intermediate Patch<2,2>]
+0.50 0.50 1.0 0.50 1.0 1.0 0.50 1.0 
+1 4294967295 0 4294967295 
+2 1
+0
+1 4
+3.0 3.0 3.0 3.0 
+
+
+0
+
+DEAL::OK

--- a/tests/data_out/data_out_08_set_cell_selection_02.output
+++ b/tests/data_out/data_out_08_set_cell_selection_02.output
@@ -1,0 +1,38 @@
+
+2 2
+[deal.II intermediate format graphics data]
+[written by deal.II x.y.z]
+[Version: 3]
+1
+cell_data
+3
+[deal.II intermediate Patch<2,2>]
+0.50 0.0 1.0 0.0 1.0 0.50 0.50 0.50 
+4294967295 4294967295 4294967295 2 
+0 1
+0
+1 4
+1.0 1.0 1.0 1.0 
+
+
+[deal.II intermediate Patch<2,2>]
+0.0 0.50 0.50 0.50 0.50 1.0 0.0 1.0 
+4294967295 2 4294967295 4294967295 
+1 1
+0
+1 4
+2.0 2.0 2.0 2.0 
+
+
+[deal.II intermediate Patch<2,2>]
+0.50 0.50 1.0 0.50 1.0 1.0 0.50 1.0 
+1 4294967295 0 4294967295 
+2 1
+0
+1 4
+3.0 3.0 3.0 3.0 
+
+
+0
+
+DEAL::OK

--- a/tests/data_out/data_out_08_set_cell_selection_03.cc
+++ b/tests/data_out/data_out_08_set_cell_selection_03.cc
@@ -1,0 +1,124 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// This test is an adaptation of the _08 test, but using the
+// DataOut::set_cell_selection() function with the FilteredIterator
+// argument instead of overloading member functions. Since
+// FilteredIterators can be created directly from lambda functions, we
+// check that passing a lambda function to set_cell_selection() as
+// argument works as well.
+//
+// Because the _08 test is eventually going away (as it uses
+// deprecated functions), here is the description of that test:
+// ....................
+// This test documents two unrelated bugs in DataOut when used with a Filter (by
+// deriving from DataOut):
+// 1. The patch index computation in data_out.cc is wrong and causes an SIGV (or
+// an Assert after adding that):
+/*
+466: --------------------------------------------------------
+466: An error occurred in line <306> of file
+</ssd/branch_port_the_testsuite/deal.II/source/numerics/data_out.cc> in function
+466:     void dealii::DataOut<dim, DoFHandlerType>::build_one_patch(const
+std::pair<typename dealii::DataOut_DoFData<DoFHandlerType, DoFHandlerType::
+dimension, DoFHandlerType:: space_dimension>::cell_iterator, unsigned int>*,
+dealii::internal::DataOut::ParallelData<DoFHandlerType:: dimension,
+DoFHandlerType:: space_dimension>&, dealii::DataOutBase::Patch<DoFHandlerType::
+dimension, DoFHandlerType:: space_dimension>&, dealii::DataOut<dim,
+DoFHandlerType>::CurvedCellRegion,
+std::vector<dealii::DataOutBase::Patch<DoFHandlerType:: dimension,
+DoFHandlerType:: space_dimension> >&) [with int dim = 2, DoFHandlerType =
+dealii::DoFHandler<2>, typename dealii::DataOut_DoFData<DoFHandlerType,
+DoFHandlerType:: dimension, DoFHandlerType:: space_dimension>::cell_iterator =
+dealii::TriaIterator<dealii::CellAccessor<2, 2> >] 466: The violated condition
+was: 466:     cell_and_index->second < patches.size() 466: The name and call
+sequence of the exception was: 466:     ExcInternalError()
+*/
+// 2. DataOut used begin_active() instead of first_cell() in two places which
+// caused a wrong patch to be generated when the first active cell is not picked
+// by the filter.
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_dgq.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/data_out.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+check()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, 0., 1.);
+  tria.refine_global(1);
+
+  Vector<double> cell_data(4);
+  for (unsigned int i = 0; i < 4; ++i)
+    cell_data(i) = i * 1.0;
+
+  // this should skip the first cell
+  typename Triangulation<dim>::active_cell_iterator it = tria.begin_active();
+  it->set_subdomain_id(1);
+
+  FE_DGQ<dim>     fe(0);
+  DoFHandler<dim> dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+
+  // we pick only subdomain==0 which will
+  // skip the first of the four cells
+  DataOut<dim> data_out;
+  data_out.set_cell_selection(
+    [](const typename Triangulation<dim>::cell_iterator &cell) {
+      return (!cell->has_children() && cell->subdomain_id() == 0);
+    });
+
+
+  data_out.attach_dof_handler(dof_handler);
+
+  data_out.add_data_vector(cell_data,
+                           "cell_data",
+                           DataOut<dim>::type_cell_data);
+  data_out.build_patches();
+
+  data_out.write_deal_II_intermediate(deallog.get_file_stream());
+
+  deallog << "OK" << std::endl;
+}
+
+int
+main(int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  deallog << std::setprecision(2);
+  logfile << std::setprecision(2);
+  deallog.attach(logfile);
+
+  check<2>();
+
+  return 0;
+}

--- a/tests/data_out/data_out_08_set_cell_selection_03.output
+++ b/tests/data_out/data_out_08_set_cell_selection_03.output
@@ -1,0 +1,38 @@
+
+2 2
+[deal.II intermediate format graphics data]
+[written by deal.II x.y.z]
+[Version: 3]
+1
+cell_data
+3
+[deal.II intermediate Patch<2,2>]
+0.50 0.0 1.0 0.0 1.0 0.50 0.50 0.50 
+4294967295 4294967295 4294967295 2 
+0 1
+0
+1 4
+1.0 1.0 1.0 1.0 
+
+
+[deal.II intermediate Patch<2,2>]
+0.0 0.50 0.50 0.50 0.50 1.0 0.0 1.0 
+4294967295 2 4294967295 4294967295 
+1 1
+0
+1 4
+2.0 2.0 2.0 2.0 
+
+
+[deal.II intermediate Patch<2,2>]
+0.50 0.50 1.0 0.50 1.0 1.0 0.50 1.0 
+1 4294967295 0 4294967295 
+2 1
+0
+1 4
+3.0 3.0 3.0 3.0 
+
+
+0
+
+DEAL::OK


### PR DESCRIPTION
Instead, use function objects that can be used with lambda functions. This addresses the idea mentioned in https://github.com/dealii/dealii/issues/9099#issuecomment-571775767

The current approach is backward compatible in that the new function objects by default just call the old function. As a consequence, all of the patches currently floating around (#9100, #9096) should continue to work -- but could be streamlined a bit by just calling `DataOut::set_cell_selection()` in their constructors instead of implementing several more functions.

/rebuild