### PR TITLE
Update constraints documentation module to reflect recent updates to step-6

### DIFF
--- a/doc/doxygen/headers/constraints.h
+++ b/doc/doxygen/headers/constraints.h
@@ -179,7 +179,7 @@
  * see the discussion below.
  *
  *
- * <h5>Condensing vectors</h5>
+ * <h4>Condensing vectors</h4>
  *
  * Condensing vectors works exactly as described above for matrices. Note that
  * condensation is an idempotent operation, i.e. doing it more than once on a

--- a/doc/doxygen/headers/constraints.h
+++ b/doc/doxygen/headers/constraints.h
@@ -164,8 +164,7 @@
  * auxiliary vectors (e.g. methods using explicit orthogonalization
  * procedures).
  * Nevertheless, this process is more efficient due to its lower
- * memory consumption and is discussed in the first few programs
- * of the @ref Tutorial , for example in step-6.
+ * memory consumption.
  *
  * The condensation functions exist for different argument types: SparsityPattern,
  * SparseMatrix and

--- a/doc/doxygen/headers/constraints.h
+++ b/doc/doxygen/headers/constraints.h
@@ -94,8 +94,7 @@
  * AffineConstraints::distribute() function. Note that the
  * AffineConstraints::condense() function is applied to matrix and right hand
  * side of the linear system, while the AffineConstraints::distribute()
- * function is applied to the solution vector. This is the method used in
- * the first few tutorial programs, see for example step-6.
+ * function is applied to the solution vector.
  *
  * This scheme of first building a linear system and then eliminating
  * constrained degrees of freedom is inefficient, and a bottleneck if there


### PR DESCRIPTION
Removes a stale sentence that incorrectly stated that the step-6 tutorial uses the `condense` followed by `distribute` approach to constraint-handling. It now appears that step-6 has been updated to use the distribute_local_to_global() approach.


The real questions to the developers are the following:

What are the plans for the simplistic (first) approach to handling constraints?  Will this functionality be marked for deprecation (as a legacy feature) in future releases of deal.II (since it doesn't possess any advantages that decisively outweigh the 2nd approach for the user's problems). Is there any reason to keep the 1st approach? If not, then the documentation on constraints can be simplified considerably and made more readable.