### PR TITLE
fix write_vtu_in_parallel invalid file if partly empty

### DIFF
--- a/doc/news/changes/minor/20200112TimoHeister
+++ b/doc/news/changes/minor/20200112TimoHeister
@@ -1,0 +1,3 @@
+Fixed: DataOut::write_vtu_in_parallel() used to generate invalid .vtu files if
+some processors had 0 patches to write. This is now fixed.
+<br> (Timo Heister, 2020/01/12)

--- a/tests/mpi/parallel_vtu_01.with_trilinos=true.mpirun=3.with_zlib=on.with_p4est=true.output
+++ b/tests/mpi/parallel_vtu_01.with_trilinos=true.mpirun=3.with_zlib=on.with_p4est=true.output
@@ -7,22 +7,6 @@ DEAL:0::hyper_cube
 -->
 <VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
 <UnstructuredGrid>
-<Piece NumberOfPoints="0" NumberOfCells="0" >
-<Cells>
-<DataArray type="UInt8" Name="types"></DataArray>
-</Cells>
-  <PointData Scalars="scalars">
-    <DataArray type="Float32" Name="x"></DataArray>
-  </PointData>
-</Piece>
-<Piece NumberOfPoints="0" NumberOfCells="0" >
-<Cells>
-<DataArray type="UInt8" Name="types"></DataArray>
-</Cells>
-  <PointData Scalars="scalars">
-    <DataArray type="Float32" Name="x"></DataArray>
-  </PointData>
-</Piece>
 <Piece NumberOfPoints="4" NumberOfCells="1" >
   <Points>
     <DataArray type="Float32" NumberOfComponents="3" format="binary">


### PR DESCRIPTION
Fix generating an invalid vtu file when the first piece written is empty
(this will crash paraview). There is no reason to write empty pieces
anyway, so just skip them.