### PR TITLE
Make GridTools::delete_duplicate_vertices() faster.

### DIFF
--- a/doc/news/changes/minor/20200112DavidWells
+++ b/doc/news/changes/minor/20200112DavidWells
@@ -1,0 +1,5 @@
+Improved: GridTools::delete_duplicated_vertices() now runs, for cubelike
+geometries, in $O(n^{3/2})$ time in 2D and $O(n^(5/3))$ time in 3D instead
+of $O(n^2)$ time.
+<br>
+(David Wells, 2020/01/12)

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -374,10 +374,11 @@ namespace GridTools
    *
    * This function is called by some <tt>GridIn::read_*</tt> functions. Only
    * the vertices with indices in @p considered_vertices are tested for
-   * equality. This speeds up the algorithm, which is quadratic and thus quite
-   * slow to begin with. However, if you wish to consider all vertices, simply
-   * pass an empty vector. In that case, the function fills
-   * @p considered_vertices with all vertices.
+   * equality. This speeds up the algorithm, which is, for worst-case hyper
+   * cube geometries $O(N^{3/2})$ in 2D and $O(N^{5/3})$ in 3D: quite slow.
+   * However, if you wish to consider all vertices, simply pass an empty
+   * vector. In that case, the function fills @p considered_vertices with all
+   * vertices.
    *
    * Two vertices are considered equal if their difference in each coordinate
    * direction is less than @p tol.


### PR DESCRIPTION
I am working on a different implementation of #6188 that resolves the outstanding review comments. I am mostly done, but while profiling the result I realized that about 90% of the time in my 3D example was spent in `GridTools::delete_duplicated_vertices()`. I took a look at this function and made some improvements.

This change makes this function, for cube-like geometries, O(n^(3/2)) in 2D and O(n^(5/3)) in 3D rather than O(n^2) by presorting vertices by value in a single component and then only comparing vertices which are nearby in that component.