### PR TITLE
GridGenerator::half_hyper_shell warning

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1063,9 +1063,10 @@ namespace GridGenerator
    * rotational symmetry, in which case the half shell in 2d represents a
    * shell in 3d.
    *
-   * If the number of initial cells is zero (as is the default), then it is
-   * computed adaptively such that the resulting elements have the least
-   * aspect ratio.
+   * If the number of initial cells @p n_cells is zero in 2d (as is the
+   * default), then it is computed adaptively such that the resulting elements
+   * have the least aspect ratio. The argument is ignored in 3d, where the
+   * coarse mesh always has 5 cells.
    *
    * If colorize is set to <code>true</code>, the inner, outer, and the part
    * of the boundary where $x=0$, get indicator 0, 1, and 2,

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -5484,16 +5484,15 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void half_hyper_shell(Triangulation<3> & tria,
-                        const Point<3> &   center,
-                        const double       inner_radius,
-                        const double       outer_radius,
-                        const unsigned int n,
-                        const bool         colorize)
+  void half_hyper_shell(Triangulation<3> &tria,
+                        const Point<3> &  center,
+                        const double      inner_radius,
+                        const double      outer_radius,
+                        const unsigned int /*n_cells*/,
+                        const bool colorize)
   {
     Assert((inner_radius > 0) && (inner_radius < outer_radius),
            ExcInvalidRadii());
-    AssertIndexRange(n, 5);
 
     // These are for the two lower squares
     const double d = outer_radius / std::sqrt(2.0);


### PR DESCRIPTION
- remove unused variable warning in release mode
- document that n_cells is not used