### PR TITLE
Simplifies the example codes for glossary entries of boundary_id and manifold_id

### DIFF
--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -327,14 +327,9 @@
  * this, here setting the boundary indicator to 42 for all faces located at
  * $x=-1$:
  * @code
- *   for (typename Triangulation<dim>::active_cell_iterator
- *          cell = triangulation.begin_active();
- *        cell != triangulation.end();
- *        ++cell)
- *     for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
- *       if (cell->face(f)->at_boundary())
- *         if (cell->face(f)->center()[0] == -1)
- *           cell->face(f)->set_boundary_id (42);
+ * for (auto &face : triangulation.active_face_iterators())
+     if (face->center()(0) == -1)
+       face->set_boundary_id(1);
  * @endcode
  * This calls functions TriaAccessor::set_boundary_id. In 3d, it may
  * also be appropriate to call TriaAccessor::set_all_boundary_ids instead
@@ -1273,9 +1268,7 @@
  * center has an $x$ component less than zero:
  *
  * @code
- * for (typename Triangulation<dim>::active_cell_iterator cell =
- *  triangulation.begin_active();
- *  cell != triangulation.end(); ++cell)
+ * for (auto &cell : triangulation.active_cell_iterators())
  *   if (cell->center()[0] < 0)
  *     cell->set_manifold_id (42);
  * @endcode

--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -88,9 +88,7 @@ using namespace dealii;
 // The main class is again almost unchanged. Two additions, however, are made:
 // we have added the <code>refine_grid</code> function, which is used to
 // adaptively refine the grid (instead of the global refinement in the
-// previous examples), and a variable which will hold the constraints. In
-// addition, we have added a destructor to the class for reasons that will
-// become clear when we discuss its implementation.
+// previous examples), and a variable which will hold the constraints.
 template <int dim>
 class Step6
 {


### PR DESCRIPTION
Fixes #9319 