### PR TITLE
Fix the instantiations of GridOut::write_svg().

### DIFF
--- a/doc/news/changes/minor/20200114Bangerth
+++ b/doc/news/changes/minor/20200114Bangerth
@@ -1,0 +1,4 @@
+Fixed: The GridOut::write_svg() function was not instantiated for the
+case `dim=3, spacedim=3` by accident. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2020/01/14)

--- a/source/grid/grid_out.inst.in
+++ b/source/grid/grid_out.inst.in
@@ -24,11 +24,6 @@ for (deal_II_dimension : DIMENSIONS)
       const Triangulation<deal_II_dimension> &, std::ostream &) const;
 #endif
 
-#if deal_II_dimension != 2
-    template void GridOut::write_svg(const Triangulation<deal_II_dimension> &,
-                                     std::ostream &) const;
-#endif
-
     template void GridOut::write_msh(const Triangulation<deal_II_dimension> &,
                                      std::ostream &) const;
 
@@ -72,13 +67,18 @@ for (deal_II_dimension : DIMENSIONS)
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
-#if deal_II_dimension < deal_II_space_dimension
-
-#  if deal_II_dimension != 2
+#if deal_II_dimension <= deal_II_space_dimension
+    // Instantiate write_svg exception for the <2,2> case for which there
+    // is an overload that takes care of that case.
+#  if !(deal_II_dimension == 2 && deal_II_space_dimension == 2)
     template void GridOut::write_svg(
       const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
       std::ostream &) const;
 #  endif
+#endif
+
+
+#if deal_II_dimension < deal_II_space_dimension
 
     template void GridOut::write_msh(
       const Triangulation<deal_II_dimension, deal_II_space_dimension> &,


### PR DESCRIPTION
By accident, we didn't instantiate the <3,3> case and users consequently
get funny linker errors that they have a hard time interpreting. Fix this.

Fixes #9299.