### PR TITLE
Lots of documentation fixes to Step-49 tutorial

### DIFF
--- a/examples/step-49/doc/intro.dox
+++ b/examples/step-49/doc/intro.dox
@@ -54,7 +54,7 @@ If there is no good fit in the GridGenerator namespace for what you want to
 do, you can always create a
 Triangulation in your program "by hand". For that, you need a list of vertices
 with their coordinates and a list of cells referencing those vertices. You can
-find an example in the function create_coarse_grid in step-14.
+find an example in the function <tt>create_coarse_grid()</tt> in step-14.
 All the functions in GridGenerator are implemented in this fashion.
 
 We are happy to accept more functions to be added to GridGenerator. So, if
@@ -84,7 +84,7 @@ supported at the time of writing this tutorial (early 2013).
 
 In Gmsh, a mesh is described in a text based <code>.geo</code> file, that can
 contain computations, loops, variables, etc. It is very flexible. The mesh is
-generated from a surface representation, which is build from a list of line
+generated from a surface representation, which is built from a list of line
 loops, which is build from a list of lines, which are in turn built from
 points. The <code>.geo</code> script can be written and edited by hand or it
 can be generated automatically by creating objects graphically inside Gmsh. In
@@ -99,7 +99,7 @@ indicators as well as the mesh discussed further down below):
 <img src="https://www.dealii.org/images/steps/developer/step-49.gmsh_picture.png" alt="">
 
 You might want to open the <code>example.geo</code> file in a text editor (it
-is located in the same directory as the <code>step-49.cc</code> source file) to
+is located in the same directory as the <tt>step-49.cc</tt> source file) to
 see how it is structured. You can see how the boundary of the domain is
 composed of a number of lines and how later on we combine several lines into
 "physical lines" (or "physical surfaces") that list the logical lines'
@@ -277,5 +277,3 @@ refinement. This is not difficult &mdash; in fact, there is nothing else to do
 often not the case if you have a more complex geometry and more steps than
 just creating the mesh are necessary. We will go over some of these steps in
 the <a href="#Results">results section</a> below.
-
-

--- a/examples/step-49/doc/results.dox
+++ b/examples/step-49/doc/results.dox
@@ -344,7 +344,7 @@ cells and their faces and identify the correct faces (for example using
 `cell->center()` to query the coordinates of the center of a cell as we
 do in step-1, or using `cell->face(f)->get_boundary_id()` to query the current
 boundary indicator of the $f$th face of the cell). You can then use
-cell->face(f)->set_boundary_id() to set the boundary id to something different.
+`cell->face(f)->set_boundary_id()` to set the boundary id to something different.
 You can take a look back at step-1 how iteration over the meshes is done there.
 
 <h4> Extracting a boundary mesh </h4>
@@ -354,10 +354,10 @@ mesh embedded into a higher dimensional space. While some can be constructed
 using the GridGenerator namespace or loaded from a file, it is sometimes
 useful to extract a surface mesh from a volume mesh.
 
-Use the function GridTools::extract_boundary_mesh() to extract the surface
-elements of a mesh. Using the function on a 3d mesh (a Triangulation<3,3>, for
-example from grid_4()), this will return a Triangulation<2,3> that you can use
-in step-38.  Also try extracting the boundary mesh of a Triangulation<2,2>.
+Use the function GridGenerator::extract_boundary_mesh() to extract the surface
+elements of a mesh. Using the function on a 3d mesh (a `Triangulation<3,3>`, for
+example from `grid_4()`), this will return a `Triangulation<2,3>` that you can use
+in step-38.  Also try extracting the boundary mesh of a `Triangulation<2,2>`.
 
 
 <!--

--- a/examples/step-49/step-49.cc
+++ b/examples/step-49/step-49.cc
@@ -72,14 +72,9 @@ void print_mesh_info(const Triangulation<dim> &triangulation,
   // we then increment it):
   {
     std::map<types::boundary_id, unsigned int> boundary_count;
-    for (const auto &cell : triangulation.active_cell_iterators())
-      {
-        for (const auto &face : cell->face_iterators())
-          {
-            if (face->at_boundary())
-              boundary_count[face->boundary_id()]++;
-          }
-      }
+    for (const auto &face : triangulation.active_face_iterators())
+      if (face->at_boundary())
+        boundary_count[face->boundary_id()]++;
 
     std::cout << " boundary indicators: ";
     for (const std::pair<const types::boundary_id, unsigned int> &pair :
@@ -250,7 +245,7 @@ void grid_5()
 
   GridTools::transform(
     [](const Point<2> &in) -> Point<2> {
-      return {in[0], in[1] + std::sin(in[0] / 5.0 * numbers::PI)};
+      return {in[0], in[1] + std::sin(numbers::PI * in[0] / 5.0)};
     },
     triangulation);
   print_mesh_info(triangulation, "grid-5.vtu");


### PR DESCRIPTION
aims to wrap create_coarse_grid function in monospace font

fixes a minor typo

trying to fix the monospace font of step-49.cc file

in step 49, simplify the boundary_count loop by directly using active_face_iterators

In step-49, updates the transform code to directly correspond 1:1 with the given math formula

semantic font use for code in step-49 results/extension

Fixes a documentation error. Move extract_boundary_mesh from GridTools to GridGenerator namespace in step-49

semantic font use for code in step-49 results/extension