### PR TITLE
Introduce CellAccessor::is_active().

### DIFF
--- a/doc/news/changes/minor/20200116Bangerth
+++ b/doc/news/changes/minor/20200116Bangerth
@@ -1,0 +1,7 @@
+Deprecated: The CellAccessor::active() function did not satisfy the
+usual naming scheme of that class in which functions are called
+CellAccessor::is_ghost(), CellAccessor::is_locally_owned(), etc. As a
+consequence, there is now a new function CellAccessor::is_active(),
+with the old function deprecated.
+<br>
+(Wolfgang Bangerth, 2020/01/16)

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -1055,7 +1055,7 @@ namespace Step9
           // Then check whether the neighbor is active. If it is, then it
           // is on the same level or one level coarser (if we are not in
           // 1D), and we are interested in it in any case.
-          if (neighbor->active())
+          if (neighbor->is_active())
             scratch_data.active_neighbors.push_back(neighbor);
           else
             {

--- a/include/deal.II/distributed/cell_data_transfer.templates.h
+++ b/include/deal.II/distributed/cell_data_transfer.templates.h
@@ -314,7 +314,7 @@ namespace parallel
                        ++child_index)
                     {
                       const auto child = cell->child(child_index);
-                      Assert(child->active() && child->coarsen_flag_set(),
+                      Assert(child->is_active() && child->coarsen_flag_set(),
                              typename dealii::Triangulation<
                                dim>::ExcInconsistentCoarseningFlags());
 

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -3810,7 +3810,7 @@ inline void
 DoFCellAccessor<DoFHandlerType, level_dof_access>::get_dof_indices(
   std::vector<types::global_dof_index> &dof_indices) const
 {
-  Assert(this->active(),
+  Assert(this->is_active(),
          ExcMessage("get_dof_indices() only works on active cells."));
   Assert(this->is_artificial() == false,
          ExcMessage("Can't ask for DoF indices on artificial cells."));

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -534,7 +534,7 @@ namespace FETools
           // check if at least one child is locally owned on our process
           for (unsigned int child_n = 0; child_n < dealii_cell->n_children();
                ++child_n)
-            if (dealii_cell->child(child_n)->active())
+            if (dealii_cell->child(child_n)->is_active())
               if (dealii_cell->child(child_n)->is_locally_owned())
                 {
                   locally_owned_children = true;
@@ -880,7 +880,7 @@ namespace FETools
 
           for (unsigned int child_n = 0; child_n < dealii_cell->n_children();
                ++child_n)
-            if (dealii_cell->child(child_n)->active())
+            if (dealii_cell->child(child_n)->is_active())
               if (dealii_cell->child(child_n)->is_locally_owned())
                 {
                   locally_owned_children = true;
@@ -1730,7 +1730,7 @@ namespace FETools
                                                               dof2.end(level);
 
           for (; cell != endc; ++cell)
-            if (!cell->active())
+            if (!cell->is_active())
               {
                 // check whether this
                 // cell has active
@@ -1738,7 +1738,7 @@ namespace FETools
                 bool active_children = false;
                 for (unsigned int child_n = 0; child_n < cell->n_children();
                      ++child_n)
-                  if (cell->child(child_n)->active())
+                  if (cell->child(child_n)->is_active())
                     {
                       active_children = true;
                       break;

--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -402,7 +402,7 @@ namespace IteratorFilters
  *     template <class Iterator>
  *     bool operator () (const Iterator &i) const
  *     {
- *       return (i->active());
+ *       return (i->is_active());
  *     }
  *   };
  * @endcode
@@ -1164,7 +1164,7 @@ namespace IteratorFilters
   inline bool
   Active::operator()(const Iterator &i) const
   {
-    return (i->active());
+    return (i->is_active());
   }
 
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3259,7 +3259,7 @@ namespace GridTools
               // children bound to the present cell
               typename MeshType::cell_iterator neighbor_child =
                 cell->neighbor(n);
-              if (!neighbor_child->active())
+              if (!neighbor_child->is_active())
                 {
                   while (neighbor_child->has_children())
                     neighbor_child = neighbor_child->child(n == 0 ? 1 : 0);
@@ -3284,7 +3284,7 @@ namespace GridTools
                 {
                   // the neighbor must be active
                   // himself
-                  Assert(cell->neighbor(n)->active(), ExcInternalError());
+                  Assert(cell->neighbor(n)->is_active(), ExcInternalError());
                   active_neighbors.push_back(cell->neighbor(n));
                 }
             }

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -3411,15 +3411,32 @@ public:
    */
 
   /**
-   * Test whether the cell has children (this is the criterion for activity of
-   * a cell).
+   * Test that the cell has no children (this is the criterion for whether a
+   * cell is called "active").
+   *
+   * See the
+   * @ref GlossActive "glossary"
+   * for more information.
+   *
+   * @deprecated This function is deprecated. Use the is_active()
+   *   function instead, which satisfies the naming scheme of other
+   *   functions inquiring about yes/no properties of cells (e.g.,
+   *   is_ghost(), is_locally_owned(), etc.).
+   */
+  DEAL_II_DEPRECATED
+  bool
+  active() const;
+
+  /**
+   * Test that the cell has no children (this is the criterion for whether a
+   * cell is called "active").
    *
    * See the
    * @ref GlossActive "glossary"
    * for more information.
    */
   bool
-  active() const;
+  is_active() const;
 
   /**
    * Return whether this cell is owned by the current processor or is owned by

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -3299,8 +3299,8 @@ CellAccessor<dim, spacedim>::refine_flag_set() const
   // but activity may change when refinement is
   // executed and for some reason the refine
   // flag is not cleared).
-  Assert(this->active() || !this->tria->levels[this->present_level]
-                              ->refine_flags[this->present_index],
+  Assert(this->is_active() || !this->tria->levels[this->present_level]
+                                 ->refine_flags[this->present_index],
          ExcRefineCellNotActive());
   return RefinementCase<dim>(
     this->tria->levels[this->present_level]->refine_flags[this->present_index]);
@@ -3313,7 +3313,7 @@ inline void
 CellAccessor<dim, spacedim>::set_refine_flag(
   const RefinementCase<dim> refinement_case) const
 {
-  Assert(this->used() && this->active(), ExcRefineCellNotActive());
+  Assert(this->used() && this->is_active(), ExcRefineCellNotActive());
   Assert(!coarsen_flag_set(), ExcCellFlaggedForCoarsening());
 
   this->tria->levels[this->present_level]->refine_flags[this->present_index] =
@@ -3326,7 +3326,7 @@ template <int dim, int spacedim>
 inline void
 CellAccessor<dim, spacedim>::clear_refine_flag() const
 {
-  Assert(this->used() && this->active(), ExcRefineCellNotActive());
+  Assert(this->used() && this->is_active(), ExcRefineCellNotActive());
   this->tria->levels[this->present_level]->refine_flags[this->present_index] =
     RefinementCase<dim>::no_refinement;
 }
@@ -3523,8 +3523,8 @@ CellAccessor<dim, spacedim>::coarsen_flag_set() const
   // but activity may change when refinement is
   // executed and for some reason the refine
   // flag is not cleared).
-  Assert(this->active() || !this->tria->levels[this->present_level]
-                              ->coarsen_flags[this->present_index],
+  Assert(this->is_active() || !this->tria->levels[this->present_level]
+                                 ->coarsen_flags[this->present_index],
          ExcRefineCellNotActive());
   return this->tria->levels[this->present_level]
     ->coarsen_flags[this->present_index];
@@ -3536,7 +3536,7 @@ template <int dim, int spacedim>
 inline void
 CellAccessor<dim, spacedim>::set_coarsen_flag() const
 {
-  Assert(this->used() && this->active(), ExcRefineCellNotActive());
+  Assert(this->used() && this->is_active(), ExcRefineCellNotActive());
   Assert(!refine_flag_set(), ExcCellFlaggedForRefinement());
 
   this->tria->levels[this->present_level]->coarsen_flags[this->present_index] =
@@ -3549,7 +3549,7 @@ template <int dim, int spacedim>
 inline void
 CellAccessor<dim, spacedim>::clear_coarsen_flag() const
 {
-  Assert(this->used() && this->active(), ExcRefineCellNotActive());
+  Assert(this->used() && this->is_active(), ExcRefineCellNotActive());
   this->tria->levels[this->present_level]->coarsen_flags[this->present_index] =
     false;
 }
@@ -3594,7 +3594,7 @@ template <int dim, int spacedim>
 inline bool
 CellAccessor<dim, spacedim>::is_locally_owned() const
 {
-  Assert(this->active(),
+  Assert(this->is_active(),
          ExcMessage("is_locally_owned() can only be called on active cells!"));
 #ifndef DEAL_II_WITH_MPI
   return true;
@@ -3636,7 +3636,7 @@ template <int dim, int spacedim>
 inline bool
 CellAccessor<dim, spacedim>::is_ghost() const
 {
-  Assert(this->active(),
+  Assert(this->is_active(),
          ExcMessage("is_ghost() can only be called on active cells!"));
   if (this->has_children())
     return false;
@@ -3664,7 +3664,7 @@ template <int dim, int spacedim>
 inline bool
 CellAccessor<dim, spacedim>::is_artificial() const
 {
-  Assert(this->active(),
+  Assert(this->is_active(),
          ExcMessage("is_artificial() can only be called on active cells!"));
 #ifndef DEAL_II_WITH_MPI
   return false;
@@ -3687,7 +3687,7 @@ inline types::subdomain_id
 CellAccessor<dim, spacedim>::subdomain_id() const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(this->active(),
+  Assert(this->is_active(),
          ExcMessage("subdomain_id() can only be called on active cells!"));
   return this->tria->levels[this->present_level]
     ->subdomain_ids[this->present_index];

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -3583,6 +3583,15 @@ CellAccessor<dim, spacedim>::active() const
 
 template <int dim, int spacedim>
 inline bool
+CellAccessor<dim, spacedim>::is_active() const
+{
+  return !this->has_children();
+}
+
+
+
+template <int dim, int spacedim>
+inline bool
 CellAccessor<dim, spacedim>::is_locally_owned() const
 {
   Assert(this->active(),

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -225,7 +225,7 @@ namespace CUDAWrappers
                ++line)
             {
               const unsigned int line_idx = cell->line(line)->index();
-              if (cell->active())
+              if (cell->is_active())
                 line_to_cells[line_idx].push_back(std::make_pair(cell, line));
               else
                 line_to_inactive_cells[line_idx].push_back(

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -182,7 +182,7 @@ namespace internal
           {
             typename dealii::Triangulation<dim>::cell_iterator dcell(
               &triangulation, cell_level.first, cell_level.second);
-            Assert(dcell->active(), ExcInternalError());
+            Assert(dcell->is_active(), ExcInternalError());
           }
 #  endif
 
@@ -578,7 +578,7 @@ namespace internal
           typename dealii::Triangulation<dim>::cell_iterator dcell(
             &triangulation, cell_levels[i].first, cell_levels[i].second);
           if (use_active_cells)
-            Assert(dcell->active(), ExcNotImplemented());
+            Assert(dcell->is_active(), ExcNotImplemented());
           for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
             {
               if (dcell->at_boundary(f) && !dcell->has_periodic_neighbor(f))

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2049,7 +2049,7 @@ namespace internal
                   fe_val.reinit(cell_it, face);
 
                   const bool is_local =
-                    (cell_it->active() ?
+                    (cell_it->is_active() ?
                        cell_it->is_locally_owned() :
                        cell_it->is_locally_owned_on_level()) &&
                     (!cell_it->at_boundary(face) ||

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -697,7 +697,7 @@ namespace internal
       else if (subdomain_id == numbers::invalid_subdomain_id ||
                cell->subdomain_id() == subdomain_id)
         {
-          Assert(cell->active(), ExcInternalError());
+          Assert(cell->is_active(), ExcInternalError());
           cell_its.emplace_back(cell->level(), cell->index());
         }
     }

--- a/include/deal.II/meshworker/loop.h
+++ b/include/deal.II/meshworker/loop.h
@@ -275,7 +275,7 @@ namespace MeshWorker
               if (neighbor->is_level_cell())
                 neighbid = neighbor->level_subdomain_id();
               // subdomain id is only valid for active cells
-              else if (neighbor->active())
+              else if (neighbor->is_active())
                 neighbid = neighbor->subdomain_id();
 
               const bool own_neighbor =

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -316,7 +316,7 @@ namespace MeshWorker
                 if (neighbor->is_level_cell())
                   neighbor_subdomain_id = neighbor->level_subdomain_id();
                 // subdomain id is only valid for active cells
-                else if (neighbor->active())
+                else if (neighbor->is_active())
                   neighbor_subdomain_id = neighbor->subdomain_id();
 
                 const bool own_neighbor =

--- a/include/deal.II/numerics/cell_data_transfer.templates.h
+++ b/include/deal.II/numerics/cell_data_transfer.templates.h
@@ -105,7 +105,7 @@ CellDataTransfer<dim, spacedim, VectorType>::
                    ++child_index)
                 {
                   const auto sibling = parent->child(child_index);
-                  Assert(sibling->active() && sibling->coarsen_flag_set(),
+                  Assert(sibling->is_active() && sibling->coarsen_flag_set(),
                          typename dealii::Triangulation<
                            dim>::ExcInconsistentCoarseningFlags());
 
@@ -150,7 +150,7 @@ CellDataTransfer<dim, spacedim, VectorType>::unpack(const VectorType &in,
   // Transfer data of persisting cells.
   for (const auto &persisting : persisting_cells_active_index)
     {
-      Assert(persisting.first->active(), ExcInternalError());
+      Assert(persisting.first->is_active(), ExcInternalError());
       out[persisting.first->active_cell_index()] = in[persisting.second];
     }
 
@@ -162,7 +162,7 @@ CellDataTransfer<dim, spacedim, VectorType>::unpack(const VectorType &in,
          ++child_index)
       {
         const auto child = refined.first->child(child_index);
-        Assert(child->active(), ExcInternalError());
+        Assert(child->is_active(), ExcInternalError());
         out[child->active_cell_index()] = in[refined.second];
       }
 
@@ -184,7 +184,7 @@ CellDataTransfer<dim, spacedim, VectorType>::unpack(const VectorType &in,
       const value_type parent_value = coarsening_strategy(children_values);
 
       // Set value for the parent cell.
-      Assert(coarsened.first->active(), ExcInternalError());
+      Assert(coarsened.first->is_active(), ExcInternalError());
       out[coarsened.first->active_cell_index()] = parent_value;
     }
 

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -821,7 +821,7 @@ namespace VectorTools
     bool
     is_locally_owned(const cell_iterator &cell)
     {
-      if (cell->active())
+      if (cell->is_active())
         return cell->is_locally_owned();
 
       for (unsigned int c = 0; c < cell->n_children(); ++c)
@@ -881,7 +881,7 @@ namespace VectorTools
         if (cell1->level() != cell2->level())
           continue;
         // .. or none of them is active.
-        if (!cell1->active() && !cell2->active())
+        if (!cell1->is_active() && !cell2->is_active())
           continue;
 
         Assert(
@@ -891,14 +891,14 @@ namespace VectorTools
             "The two Triangulations are required to have the same parallel partitioning."));
 
         // Skip foreign cells.
-        if (cell1->active() && !cell1->is_locally_owned())
+        if (cell1->is_active() && !cell1->is_locally_owned())
           continue;
-        if (cell2->active() && !cell2->is_locally_owned())
+        if (cell2->is_active() && !cell2->is_locally_owned())
           continue;
 
         // Get and set the corresponding
         // dof_values by interpolation.
-        if (cell1->active())
+        if (cell1->is_active())
           {
             cache.reinit(cell1->get_fe().dofs_per_cell);
             cell1->get_interpolated_dof_values(u1,

--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -193,7 +193,7 @@ namespace parallel
                  ++child_index)
               {
                 const auto child = cell->child(child_index);
-                Assert(child->active() && child->coarsen_flag_set(),
+                Assert(child->is_active() && child->coarsen_flag_set(),
                        typename dealii::Triangulation<
                          dim>::ExcInconsistentCoarseningFlags());
 

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -223,7 +223,7 @@ namespace parallel
           //     (level_)subdomain_ids in the next step)
           for (auto cell = this->begin(); cell != this->end(); ++cell)
             {
-              if (cell->active())
+              if (cell->is_active())
                 cell->set_subdomain_id(
                   dealii::numbers::artificial_subdomain_id);
 
@@ -243,7 +243,7 @@ namespace parallel
                     ++cell;
 
                   // subdomain id
-                  if (cell->active())
+                  if (cell->is_active())
                     cell->set_subdomain_id(cell_info->subdomain_id);
 
                   // level subdomain id

--- a/source/distributed/fully_distributed_tria_util.cc
+++ b/source/distributed/fully_distributed_tria_util.cc
@@ -199,7 +199,7 @@ namespace parallel
             std::vector<bool> vertices_owned_by_locally_owned_cells(
               tria.n_vertices());
             for (auto cell : tria.cell_iterators())
-              if (cell->active() && cell->subdomain_id() == my_rank)
+              if (cell->is_active() && cell->subdomain_id() == my_rank)
                 add_vertices_of_cell_to_vertices_owned_by_locally_owned_cells(
                   cell, vertices_owned_by_locally_owned_cells);
 
@@ -224,7 +224,7 @@ namespace parallel
             construction_data.cell_infos.resize(1);
 
             for (auto cell : tria.cell_iterators())
-              if (cell->active() && is_locally_relevant(cell))
+              if (cell->is_active() && is_locally_relevant(cell))
                 {
                   // to be filled
                   CellData<dim> cell_info;
@@ -343,7 +343,7 @@ namespace parallel
                     tria.n_vertices());
                 for (auto cell : tria.cell_iterators_on_level(level))
                   if (cell->level_subdomain_id() == my_rank ||
-                      (cell->active() && cell->subdomain_id() == my_rank))
+                      (cell->is_active() && cell->subdomain_id() == my_rank))
                     add_vertices_of_cell_to_vertices_owned_by_locally_owned_cells(
                       cell, vertices_owned_by_locally_owned_cells_on_level);
 
@@ -439,7 +439,7 @@ namespace parallel
             // on active level
             auto is_locally_relevant_on_active_level =
               [&](TriaIterator<CellAccessor<dim, spacedim>> &cell) {
-                if (cell->active())
+                if (cell->is_active())
                   for (unsigned int v = 0;
                        v < GeometryInfo<dim>::vertices_per_cell;
                        ++v)
@@ -459,7 +459,7 @@ namespace parallel
                     tria.n_vertices());
                 for (auto cell : tria.cell_iterators_on_level(level))
                   if (cell->level_subdomain_id() == my_rank ||
-                      (cell->active() && cell->subdomain_id() == my_rank))
+                      (cell->is_active() && cell->subdomain_id() == my_rank))
                     add_vertices_of_cell_to_vertices_owned_by_locally_owned_cells(
                       cell, vertices_owned_by_locally_owned_cells_on_level);
 

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -337,7 +337,7 @@ namespace parallel
                        ++child_index)
                     {
                       const auto child = cell->child(child_index);
-                      Assert(child->active() && child->coarsen_flag_set(),
+                      Assert(child->is_active() && child->coarsen_flag_set(),
                              typename dealii::Triangulation<
                                dim>::ExcInconsistentCoarseningFlags());
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -371,7 +371,7 @@ namespace
         // *---*---*
         // |   | M |
         // *---*---*
-        if (!used && dealii_cell->active() &&
+        if (!used && dealii_cell->is_active() &&
             dealii_cell->is_artificial() == false &&
             dealii_cell->level() + 1 < static_cast<int>(marked_vertices.size()))
           {
@@ -388,7 +388,7 @@ namespace
           }
 
         // Like above, but now the other way around
-        if (!used && dealii_cell->active() &&
+        if (!used && dealii_cell->is_active() &&
             dealii_cell->is_artificial() == false && dealii_cell->level() > 0)
           {
             for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
@@ -1209,7 +1209,7 @@ namespace parallel
                   CELL_REFINE:
                   // double check the condition that we will only ever attach
                   // data to active cells when we get here
-                  Assert(dealii_cell->active(), ExcInternalError());
+                  Assert(dealii_cell->is_active(), ExcInternalError());
                   break;
 
                 case parallel::distributed::Triangulation<dim, spacedim>::
@@ -1218,11 +1218,12 @@ namespace parallel
                   // data to cells with children when we get here. however, we
                   // can only tolerate one level of coarsening at a time, so
                   // check that the children are all active
-                  Assert(dealii_cell->active() == false, ExcInternalError());
+                  Assert(dealii_cell->is_active() == false, ExcInternalError());
                   for (unsigned int c = 0;
                        c < GeometryInfo<dim>::max_children_per_cell;
                        ++c)
-                    Assert(dealii_cell->child(c)->active(), ExcInternalError());
+                    Assert(dealii_cell->child(c)->is_active(),
+                           ExcInternalError());
                   break;
 
                 case parallel::distributed::Triangulation<dim, spacedim>::
@@ -3385,13 +3386,13 @@ namespace parallel
                  ++cell)
               {
                 // nothing to do if we are already on the finest level
-                if (cell->active())
+                if (cell->is_active())
                   continue;
 
                 const unsigned int n_children       = cell->n_children();
                 unsigned int       flagged_children = 0;
                 for (unsigned int child = 0; child < n_children; ++child)
-                  if (cell->child(child)->active() &&
+                  if (cell->child(child)->is_active() &&
                       cell->child(child)->coarsen_flag_set())
                     ++flagged_children;
 
@@ -3399,7 +3400,7 @@ namespace parallel
                 // coarsen flags
                 if (flagged_children < n_children)
                   for (unsigned int child = 0; child < n_children; ++child)
-                    if (cell->child(child)->active())
+                    if (cell->child(child)->is_active())
                       cell->child(child)->clear_coarsen_flag();
               }
           }
@@ -4029,7 +4030,7 @@ namespace parallel
                 cell = this->begin(maybe_coarser_lvl),
                 endc = this->end(lvl);
               for (; cell != endc; ++cell)
-                if (cell->level() == static_cast<int>(lvl) || cell->active())
+                if (cell->level() == static_cast<int>(lvl) || cell->is_active())
                   {
                     const bool is_level_artificial =
                       (cell->level_subdomain_id() ==

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -445,7 +445,7 @@ namespace DoFTools
             typename DoFHandlerType::level_cell_iterator cell = dof.begin(0);
             while (!cell->at_boundary(direction))
               cell = cell->neighbor(direction);
-            while (!cell->active())
+            while (!cell->is_active())
               cell = cell->child(direction);
 
             const unsigned int dofs_per_vertex = cell->get_fe().dofs_per_vertex;
@@ -665,7 +665,7 @@ namespace DoFTools
                       // face twice and hence put the indices the other way
                       // around
                       if (!cell->neighbor_or_periodic_neighbor(face)
-                             ->active() ||
+                             ->is_active() ||
                           (neighbor->subdomain_id() != cell->subdomain_id()))
                         {
                           constraints.add_entries_local_to_global(
@@ -854,7 +854,7 @@ namespace DoFTools
                       // the total ordering.
                       if (neighbor->level() == cell->level() &&
                           neighbor->index() > cell->index() &&
-                          neighbor->active() && neighbor->is_locally_owned())
+                          neighbor->is_active() && neighbor->is_locally_owned())
                         continue;
                       // If we are more refined then the neighbor, then we
                       // will automatically find the active neighbor cell when
@@ -1152,7 +1152,7 @@ namespace DoFTools
                       // is 'greater' in the total ordering.
                       if (neighbor->level() == cell->level() &&
                           neighbor->index() > cell->index() &&
-                          neighbor->active() && neighbor->is_locally_owned())
+                          neighbor->is_active() && neighbor->is_locally_owned())
                         continue;
                       // Again, like the non-hp case: If we are more refined
                       // then the neighbor, then we will automatically find

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -367,7 +367,7 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::get_vertices(
   const typename DoFHandler<dim, spacedim>::cell_iterator dof_cell(
     *cell, euler_dof_handler);
 
-  Assert(uses_level_dofs || dof_cell->active() == true, ExcInactiveCell());
+  Assert(uses_level_dofs || dof_cell->is_active() == true, ExcInactiveCell());
   AssertDimension(GeometryInfo<dim>::vertices_per_cell,
                   fe_values.n_quadrature_points);
   AssertDimension(fe_to_real.size(),
@@ -2429,7 +2429,7 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::update_internal_dofs(
          ExcMessage("euler_dof_handler is empty"));
 
   typename DoFHandlerType::cell_iterator dof_cell(*cell, euler_dof_handler);
-  Assert(uses_level_dofs || dof_cell->active() == true, ExcInactiveCell());
+  Assert(uses_level_dofs || dof_cell->is_active() == true, ExcInactiveCell());
   if (uses_level_dofs)
     {
       AssertIndexRange(cell->level(), euler_vector.size());

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -74,7 +74,7 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::get_vertices(
 
   // We require the cell to be active since we can only then get nodal
   // values for the shifts
-  Assert(dof_cell->active() == true, ExcInactiveCell());
+  Assert(dof_cell->is_active() == true, ExcInactiveCell());
 
   // now get the values of the shift vectors at the vertices
   Vector<typename VectorType::value_type> mapping_values(

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -193,7 +193,7 @@ MappingQEulerian<dim, VectorType, spacedim>::MappingQEulerianGeneric::
   typename DoFHandler<dim, spacedim>::cell_iterator dof_cell(
     *cell, mapping_q_eulerian.euler_dof_handler);
 
-  Assert(mg_vector || dof_cell->active() == true, ExcInactiveCell());
+  Assert(mg_vector || dof_cell->is_active() == true, ExcInactiveCell());
 
   // our quadrature rule is chosen so that each quadrature point corresponds
   // to a support point in the undeformed configuration. We can then query

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -1386,7 +1386,7 @@ GridOut::write_xfig(const Triangulation<2> &tria,
   for (const auto &cell : tria.cell_iterators())
     {
       // If depth is not encoded, write finest level only
-      if (!xfig_flags.level_depth && !cell->active())
+      if (!xfig_flags.level_depth && !cell->is_active())
         continue;
       // Code for polygon
       out << "2 3  " << xfig_flags.line_style << ' '
@@ -1633,7 +1633,7 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
 
       materials.insert(cell->material_id());
       levels.insert(cell->level());
-      if (cell->active())
+      if (cell->is_active())
         subdomains.insert(cell->subdomain_id() + 2);
       level_subdomains.insert(cell->level_subdomain_id() + 2);
     }
@@ -2106,7 +2106,7 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
     {
       for (const auto &cell : tria.cell_iterators_on_level(level_index))
         {
-          if (!svg_flags.convert_level_number_to_height && !cell->active())
+          if (!svg_flags.convert_level_number_to_height && !cell->is_active())
             continue;
 
           // draw the current cell
@@ -2116,7 +2116,8 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
             {
               out << " class=\"p";
 
-              if (!cell->active() && svg_flags.convert_level_number_to_height)
+              if (!cell->is_active() &&
+                  svg_flags.convert_level_number_to_height)
                 out << 's';
 
               switch (svg_flags.coloring)
@@ -2128,7 +2129,7 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
                     out << static_cast<unsigned int>(cell->level());
                     break;
                   case GridOutFlags::Svg::subdomain_id:
-                    if (cell->active())
+                    if (cell->is_active())
                       out << cell->subdomain_id() + 2;
                     else
                       out << 'X';
@@ -2353,7 +2354,7 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
                   if (svg_flags.label_level_number ||
                       svg_flags.label_cell_index || svg_flags.label_material_id)
                     out << ',';
-                  if (cell->active())
+                  if (cell->is_active())
                     out << static_cast<
                       std::make_signed<types::subdomain_id>::type>(
                       cell->subdomain_id());

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1724,7 +1724,7 @@ namespace GridTools
                       GeometryInfo<dim>::vertex_to_face[v][vface];
 
                     if (!cell->at_boundary(face) &&
-                        cell->neighbor(face)->active())
+                        cell->neighbor(face)->is_active())
                       {
                         // there is a (possibly) coarser cell behind a
                         // face to which the vertex belongs. the
@@ -2048,7 +2048,7 @@ namespace GridTools
         bool has_predicate =
           false; // Start assuming there's no cells with predicate inside
         std::vector<typename MeshType::active_cell_iterator> active_cells;
-        if (parent_cell->active())
+        if (parent_cell->is_active())
           active_cells = {parent_cell};
         else
           // Finding all active cells descendants of the current one (or the
@@ -2359,7 +2359,7 @@ namespace GridTools
         for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
           {
             if ((cell->at_boundary(i) == false) &&
-                (cell->neighbor(i)->active()))
+                (cell->neighbor(i)->is_active()))
               {
                 typename Triangulation<dim, spacedim>::active_cell_iterator
                   adjacent_cell = cell->neighbor(i);
@@ -2507,7 +2507,7 @@ namespace GridTools
               {
                 if (cell->at_boundary(i) == false)
                   {
-                    if (cell->neighbor(i)->active())
+                    if (cell->neighbor(i)->is_active())
                       {
                         typename Triangulation<dim,
                                                spacedim>::active_cell_iterator
@@ -3068,7 +3068,7 @@ namespace GridTools
                                            const unsigned int n_active_cells,
                                            const unsigned int n_partitions)
     {
-      if (cell->active())
+      if (cell->is_active())
         {
           while (current_cell_idx >=
                  std::floor(static_cast<uint_least64_t>(n_active_cells) *
@@ -3163,12 +3163,12 @@ namespace GridTools
           endc = triangulation.end();
         for (; cell != endc; ++cell)
           {
-            if (cell->active())
+            if (cell->is_active())
               continue;
             bool                                 all_children_active = true;
             std::map<unsigned int, unsigned int> map_cpu_n_cells;
             for (unsigned int n = 0; n < cell->n_children(); ++n)
-              if (!cell->child(n)->active())
+              if (!cell->child(n)->is_active())
                 {
                   all_children_active = false;
                   break;
@@ -3855,7 +3855,7 @@ namespace GridTools
         const typename Triangulation<dim, spacedim>::cell_iterator cell =
           *cell_ptr;
 
-        Assert(!cell->active(),
+        Assert(!cell->is_active(),
                ExcMessage(
                  "This function is only valid for a list of cells that "
                  "have children (i.e., no cell in the list may be active)."));

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -272,7 +272,7 @@ namespace GridTools
                       GeometryInfo<dim>::vertex_to_face[v][vface];
 
                     if (!cell->at_boundary(face) &&
-                        cell->neighbor(face)->active())
+                        cell->neighbor(face)->is_active())
                       {
                         // there is a (possibly) coarser cell behind a
                         // face to which the vertex belongs. the
@@ -1190,9 +1190,9 @@ namespace GridTools
           {
             // at least one cell is active
             if (remove_ghost_cells &&
-                ((cell_pair->first->active() &&
+                ((cell_pair->first->is_active() &&
                   !cell_pair->first->is_locally_owned()) ||
-                 (cell_pair->second->active() &&
+                 (cell_pair->second->is_active() &&
                   !cell_pair->second->is_locally_owned())))
               {
                 // we only exclude ghost cells for distributed Triangulations
@@ -1209,7 +1209,7 @@ namespace GridTools
     // least one active iterator or have different refinement_cases
     for (cell_pair = cell_list.begin(); cell_pair != cell_list.end();
          ++cell_pair)
-      Assert(cell_pair->first->active() || cell_pair->second->active() ||
+      Assert(cell_pair->first->is_active() || cell_pair->second->is_active() ||
                (cell_pair->first->refinement_case() !=
                 cell_pair->second->refinement_case()),
              ExcInternalError());

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1973,7 +1973,7 @@ CellAccessor<dim, spacedim>::set_subdomain_id(
   const types::subdomain_id new_subdomain_id) const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(this->active(),
+  Assert(this->is_active(),
          ExcMessage("set_subdomain_id() can only be called on active cells!"));
   this->tria->levels[this->present_level]->subdomain_ids[this->present_index] =
     new_subdomain_id;

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -1139,7 +1139,7 @@ namespace internal
                              ++child_index)
                           {
                             const auto sibling = parent->child(child_index);
-                            Assert(sibling->active() &&
+                            Assert(sibling->is_active() &&
                                      sibling->coarsen_flag_set(),
                                    typename dealii::Triangulation<
                                      dim>::ExcInconsistentCoarseningFlags());
@@ -1194,7 +1194,7 @@ namespace internal
 
               if (cell->is_locally_owned())
                 {
-                  Assert(cell->active(), ExcInternalError());
+                  Assert(cell->is_active(), ExcInternalError());
                   cell->set_active_fe_index(persist.second);
                 }
             }
@@ -1210,7 +1210,7 @@ namespace internal
                    ++child_index)
                 {
                   const auto &child = parent->child(child_index);
-                  Assert(child->is_locally_owned() && child->active(),
+                  Assert(child->is_locally_owned() && child->is_active(),
                          ExcInternalError());
                   child->set_active_fe_index(refine.second);
                 }
@@ -1221,7 +1221,7 @@ namespace internal
           for (const auto &coarsen : fe_transfer->coarsened_cells_fe_index)
             {
               const auto &cell = coarsen.first;
-              Assert(cell->is_locally_owned() && cell->active(),
+              Assert(cell->is_locally_owned() && cell->is_active(),
                      ExcInternalError());
               cell->set_active_fe_index(coarsen.second);
             }

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -602,7 +602,7 @@ namespace hp
                      ++child_index)
                   {
                     const auto &child = parent->child(child_index);
-                    if (child->active())
+                    if (child->is_active())
                       {
                         if (child->coarsen_flag_set())
                           ++h_flagged_children;
@@ -623,7 +623,7 @@ namespace hp
                   // drop all h coarsening flags.
                   for (unsigned int child_index = 0; child_index < n_children;
                        ++child_index)
-                    if (parent->child(child_index)->active())
+                    if (parent->child(child_index)->is_active())
                       parent->child(child_index)->clear_coarsen_flag();
               }
           }

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -918,7 +918,7 @@ DataOut<dim, DoFHandlerType>::build_patches(
       {
         // move forward until active_cell points at the cell (cell) we are
         // looking at to compute the current active_index
-        while (active_cell != this->triangulation->end() && cell->active() &&
+        while (active_cell != this->triangulation->end() && cell->is_active() &&
                decltype(active_cell)(cell) != active_cell)
           {
             ++active_cell;

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -295,7 +295,7 @@ DataOutFaces<dim, DoFHandlerType>::build_one_patch(
           // belongs in order to access the cell data. this is not readily
           // available, so choose the following rather inefficient way:
           Assert(
-            cell_and_face->first->active(),
+            cell_and_face->first->is_active(),
             ExcMessage(
               "The current function is trying to generate cell-data output "
               "for a face that does not belong to an active cell. This is "

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -413,7 +413,7 @@ DataOutRotation<dim, DoFHandlerType>::build_one_patch(
               // we need to get at the number of the cell to which this face
               // belongs in order to access the cell data. this is not readily
               // available, so choose the following rather inefficient way:
-              Assert((*cell)->active(),
+              Assert((*cell)->is_active(),
                      ExcMessage("Cell must be active for cell data"));
               const unsigned int cell_number = std::distance(
                 this->triangulation->begin_active(),

--- a/source/numerics/solution_transfer.cc
+++ b/source/numerics/solution_transfer.cc
@@ -308,7 +308,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::
   for (typename DoFHandlerType::cell_iterator cell = dof_handler->begin();
        cell != dof_handler->end();
        ++cell)
-    if (!cell->active() && cell->child(0)->coarsen_flag_set())
+    if (!cell->is_active() && cell->child(0)->coarsen_flag_set())
       ++n_coarsen_fathers;
   Assert(n_cells_to_coarsen >= 2 * n_coarsen_fathers, ExcInternalError());
 
@@ -339,7 +339,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::
        ++cell)
     {
       // CASE 1: active cell that remains as it is
-      if (cell->active() && !cell->coarsen_flag_set())
+      if (cell->is_active() && !cell->coarsen_flag_set())
         {
           const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
           indices_on_cell[n_sr].resize(dofs_per_cell);
@@ -367,7 +367,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::
                ++child_index)
             {
               const auto child = cell->child(child_index);
-              Assert(child->active() && child->coarsen_flag_set(),
+              Assert(child->is_active() && child->coarsen_flag_set(),
                      typename dealii::Triangulation<
                        dim>::ExcInconsistentCoarseningFlags());
 

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -581,9 +581,9 @@ namespace
     // no problem at all, if it is on a lower
     // level than the present one, then it
     // will be refined below anyway.
-    if (new_cell->active())
+    if (new_cell->is_active())
       {
-        if (new_cell->refine_flag_set() && old_cell->active())
+        if (new_cell->refine_flag_set() && old_cell->is_active())
           {
             if (old_cell->coarsen_flag_set())
               old_cell->clear_coarsen_flag();

--- a/tests/aniso/up_and_down.cc
+++ b/tests/aniso/up_and_down.cc
@@ -90,7 +90,7 @@ check_element(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   for (typename DoFHandler<dim>::cell_iterator cell = dof_handler.begin();
        cell != dof_handler.end();
        ++cell)
-    if (cell->has_children() && cell->child(0)->active())
+    if (cell->has_children() && cell->child(0)->is_active())
       {
         // first make sure that what
         // we do is reasonable. for
@@ -98,7 +98,7 @@ check_element(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
         // to be active, not only
         // some of them
         for (unsigned int c = 0; c < cell->n_children(); ++c)
-          AssertThrow(cell->child(c)->active(), ExcInternalError());
+          AssertThrow(cell->child(c)->is_active(), ExcInternalError());
 
         // then restrict and prolongate
         cell->get_interpolated_dof_values(tmp, v);
@@ -114,7 +114,7 @@ check_element(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   for (typename DoFHandler<dim>::cell_iterator cell = dof_handler.begin();
        cell != dof_handler.end();
        ++cell)
-    if (cell->has_children() && cell->child(0)->active())
+    if (cell->has_children() && cell->child(0)->is_active())
       {
         cell->get_interpolated_dof_values(x, v);
         cell->set_dof_values_by_interpolation(v, x2);

--- a/tests/fail/rt_6.cc
+++ b/tests/fail/rt_6.cc
@@ -83,7 +83,7 @@ check_element(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   for (typename DoFHandler<dim>::cell_iterator cell = dof_handler.begin();
        cell != dof_handler.end();
        ++cell)
-    if (cell->has_children() && cell->child(0)->active())
+    if (cell->has_children() && cell->child(0)->is_active())
       {
         // first make sure that what
         // we do is reasonable. for
@@ -92,7 +92,7 @@ check_element(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
         // some of them
         for (unsigned int c = 0; c < GeometryInfo<dim>::max_children_per_cell;
              ++c)
-          Assert(cell->child(c)->active(), ExcInternalError());
+          Assert(cell->child(c)->is_active(), ExcInternalError());
 
         // then restrict and prolongate
         cell->get_interpolated_dof_values(tmp, v);
@@ -108,7 +108,7 @@ check_element(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   for (typename DoFHandler<dim>::cell_iterator cell = dof_handler.begin();
        cell != dof_handler.end();
        ++cell)
-    if (cell->has_children() && cell->child(0)->active())
+    if (cell->has_children() && cell->child(0)->is_active())
       {
         cell->get_interpolated_dof_values(x, v);
         cell->set_dof_values_by_interpolation(v, x2);

--- a/tests/fe/up_and_down.cc
+++ b/tests/fe/up_and_down.cc
@@ -84,7 +84,7 @@ check_element(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   for (typename DoFHandler<dim>::cell_iterator cell = dof_handler.begin();
        cell != dof_handler.end();
        ++cell)
-    if (cell->has_children() && cell->child(0)->active())
+    if (cell->has_children() && cell->child(0)->is_active())
       {
         // first make sure that what
         // we do is reasonable. for
@@ -93,7 +93,7 @@ check_element(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
         // some of them
         for (unsigned int c = 0; c < GeometryInfo<dim>::max_children_per_cell;
              ++c)
-          AssertThrow(cell->child(c)->active(), ExcInternalError());
+          AssertThrow(cell->child(c)->is_active(), ExcInternalError());
 
         // then restrict and prolongate
         cell->get_interpolated_dof_values(tmp, v);
@@ -109,7 +109,7 @@ check_element(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   for (typename DoFHandler<dim>::cell_iterator cell = dof_handler.begin();
        cell != dof_handler.end();
        ++cell)
-    if (cell->has_children() && cell->child(0)->active())
+    if (cell->has_children() && cell->child(0)->is_active())
       {
         cell->get_interpolated_dof_values(x, v);
         cell->set_dof_values_by_interpolation(v, x2);

--- a/tests/grid/intergrid_constraints.cc
+++ b/tests/grid/intergrid_constraints.cc
@@ -158,7 +158,7 @@ check()
       cell = dof_1.begin();
       endc = dof_1.end();
       for (unsigned int index = 0; cell != endc; ++cell)
-        if (cell->active())
+        if (cell->is_active())
           {
             ++index;
             if (index % (2 * dim) == 0)
@@ -187,7 +187,7 @@ check()
       cell = dof_2.begin();
       endc = dof_2.end();
       for (unsigned int index = 0; cell != endc; ++cell)
-        if (cell->active())
+        if (cell->is_active())
           {
             ++index;
             if (index % (2 * dim) == 1)

--- a/tests/grid/intergrid_map.cc
+++ b/tests/grid/intergrid_map.cc
@@ -87,7 +87,7 @@ check()
       // produces quite random grids
       cell = dof_1.begin();
       for (unsigned int index = 0; cell != endc; ++cell)
-        if (cell->active())
+        if (cell->is_active())
           {
             ++index;
             if (index % 3 == 0)
@@ -97,7 +97,7 @@ check()
       cell = dof_2.begin();
       endc = dof_2.end();
       for (unsigned int index = 0; cell != endc; ++cell)
-        if (cell->active())
+        if (cell->is_active())
           {
             ++index;
             if (index % 3 == 1)

--- a/tests/grid/mesh_smoothing_02.cc
+++ b/tests/grid/mesh_smoothing_02.cc
@@ -58,11 +58,11 @@ template <int dim>
 bool
 cell_is_patch_level_1(const typename Triangulation<dim>::cell_iterator &cell)
 {
-  Assert(cell->active() == false, ExcInternalError());
+  Assert(cell->is_active() == false, ExcInternalError());
 
   unsigned int n_active_children = 0;
   for (unsigned int i = 0; i < cell->n_children(); ++i)
-    if (cell->child(i)->active())
+    if (cell->child(i)->is_active())
       ++n_active_children;
 
   return (n_active_children == 0) || (n_active_children == cell->n_children());
@@ -90,8 +90,8 @@ test()
        ++cell)
     {
       deallog << "Cell = " << cell
-              << (cell->active() ? " is active " : " is not active ");
-      if (!cell->active())
+              << (cell->is_active() ? " is active " : " is not active ");
+      if (!cell->is_active())
         {
           deallog << "and has children: ";
           for (unsigned int i = 0; i < 4; ++i)
@@ -118,7 +118,7 @@ test()
       AssertThrow((cell->refine_flag_set() == false) &&
                     (cell->coarsen_flag_set() == false),
                   ExcInternalError());
-      if (!cell->active())
+      if (!cell->is_active())
         AssertThrow(cell_is_patch_level_1<2>(cell), ExcInternalError());
     }
 

--- a/tests/hp/p_adaptivity_absolute_threshold.cc
+++ b/tests/hp/p_adaptivity_absolute_threshold.cc
@@ -65,12 +65,12 @@ setup(Triangulation<dim> &         tria,
                                               endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)
     {
-      Assert(!cell->active(), ExcInternalError());
+      Assert(!cell->is_active(), ExcInternalError());
       for (unsigned int child_index = 0; child_index < cell->n_children();
            ++child_index)
         {
           const auto &child = cell->child(child_index);
-          Assert(child->active(), ExcInternalError());
+          Assert(child->is_active(), ExcInternalError());
 
           child->set_active_fe_index(1);
 

--- a/tests/hp/p_adaptivity_fixed_number.cc
+++ b/tests/hp/p_adaptivity_fixed_number.cc
@@ -65,12 +65,12 @@ setup(Triangulation<dim> &         tria,
                                               endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)
     {
-      Assert(!cell->active(), ExcInternalError());
+      Assert(!cell->is_active(), ExcInternalError());
       for (unsigned int child_index = 0; child_index < cell->n_children();
            ++child_index)
         {
           const auto &child = cell->child(child_index);
-          Assert(child->active(), ExcInternalError());
+          Assert(child->is_active(), ExcInternalError());
 
           child->set_active_fe_index(1);
 

--- a/tests/hp/p_adaptivity_flags.cc
+++ b/tests/hp/p_adaptivity_flags.cc
@@ -65,12 +65,12 @@ setup(Triangulation<dim> &         tria,
                                               endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)
     {
-      Assert(!cell->active(), ExcInternalError());
+      Assert(!cell->is_active(), ExcInternalError());
       for (unsigned int child_index = 0; child_index < cell->n_children();
            ++child_index)
         {
           const auto &child = cell->child(child_index);
-          Assert(child->active(), ExcInternalError());
+          Assert(child->is_active(), ExcInternalError());
 
           child->set_active_fe_index(1);
 

--- a/tests/hp/p_adaptivity_full.cc
+++ b/tests/hp/p_adaptivity_full.cc
@@ -65,12 +65,12 @@ setup(Triangulation<dim> &         tria,
                                               endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)
     {
-      Assert(!cell->active(), ExcInternalError());
+      Assert(!cell->is_active(), ExcInternalError());
       for (unsigned int child_index = 0; child_index < cell->n_children();
            ++child_index)
         {
           const auto &child = cell->child(child_index);
-          Assert(child->active(), ExcInternalError());
+          Assert(child->is_active(), ExcInternalError());
 
           child->set_active_fe_index(1);
 

--- a/tests/hp/p_adaptivity_reference.cc
+++ b/tests/hp/p_adaptivity_reference.cc
@@ -65,12 +65,12 @@ setup(Triangulation<dim> &         tria,
                                               endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)
     {
-      Assert(!cell->active(), ExcInternalError());
+      Assert(!cell->is_active(), ExcInternalError());
       for (unsigned int child_index = 0; child_index < cell->n_children();
            ++child_index)
         {
           const auto &child = cell->child(child_index);
-          Assert(child->active(), ExcInternalError());
+          Assert(child->is_active(), ExcInternalError());
 
           child->set_active_fe_index(1);
 

--- a/tests/hp/p_adaptivity_regularity.cc
+++ b/tests/hp/p_adaptivity_regularity.cc
@@ -65,12 +65,12 @@ setup(Triangulation<dim> &         tria,
                                               endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)
     {
-      Assert(!cell->active(), ExcInternalError());
+      Assert(!cell->is_active(), ExcInternalError());
       for (unsigned int child_index = 0; child_index < cell->n_children();
            ++child_index)
         {
           const auto &child = cell->child(child_index);
-          Assert(child->active(), ExcInternalError());
+          Assert(child->is_active(), ExcInternalError());
 
           child->set_active_fe_index(1);
 

--- a/tests/hp/p_adaptivity_relative_threshold.cc
+++ b/tests/hp/p_adaptivity_relative_threshold.cc
@@ -65,12 +65,12 @@ setup(Triangulation<dim> &         tria,
                                               endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)
     {
-      Assert(!cell->active(), ExcInternalError());
+      Assert(!cell->is_active(), ExcInternalError());
       for (unsigned int child_index = 0; child_index < cell->n_children();
            ++child_index)
         {
           const auto &child = cell->child(child_index);
-          Assert(child->active(), ExcInternalError());
+          Assert(child->is_active(), ExcInternalError());
 
           child->set_active_fe_index(1);
 

--- a/tests/mpi/distribute_flux_sparsity_pattern.cc
+++ b/tests/mpi/distribute_flux_sparsity_pattern.cc
@@ -268,7 +268,7 @@ namespace LinearAdvectionTest
                       }
                     // If the neighbor is not active, then it is at a higher
                     // refinement level (so we do not need to integrate now)
-                    if (neighbor_cell->active())
+                    if (neighbor_cell->is_active())
                       {
                         if (neighbor_cell->is_locally_owned())
                           {

--- a/tests/mpi/p4est_2d_constraintmatrix_04.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_04.cc
@@ -216,7 +216,7 @@ test()
           if (coarsen_me)
             for (unsigned int i = 0; i < cell->n_children(); ++i)
               {
-                if (cell->child(i)->active() &&
+                if (cell->child(i)->is_active() &&
                     cell->child(i)->is_locally_owned())
                   {
                     cell->child(i)->clear_refine_flag();

--- a/tests/mpi/p4est_3d_constraintmatrix_03.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_03.cc
@@ -217,7 +217,7 @@ test()
           if (coarsen_me)
             for (unsigned int i = 0; i < cell->n_children(); ++i)
               {
-                if (cell->child(i)->active() &&
+                if (cell->child(i)->is_active() &&
                     cell->child(i)->is_locally_owned())
                   {
                     cell->child(i)->clear_refine_flag();

--- a/tests/mpi/step-40_cuthill_mckee.cc
+++ b/tests/mpi/step-40_cuthill_mckee.cc
@@ -166,7 +166,7 @@ namespace Step40
                    ++face)
                 {
                   if ((cell->face(face)->at_boundary()) ||
-                      (cell->neighbor(face)->active() &&
+                      (cell->neighbor(face)->is_active() &&
                        cell->neighbor(face)->is_ghost()))
                     {
                       fe_face_values.reinit(cell, face);

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
@@ -167,7 +167,7 @@ namespace Step40
                    ++face)
                 {
                   if ((cell->face(face)->at_boundary()) ||
-                      (cell->neighbor(face)->active() &&
+                      (cell->neighbor(face)->is_active() &&
                        cell->neighbor(face)->is_ghost()))
                     {
                       fe_face_values.reinit(cell, face);

--- a/tests/serialization/dof_handler_01.cc
+++ b/tests/serialization/dof_handler_01.cc
@@ -70,7 +70,7 @@ namespace dealii
               }
           }
 
-        if (c1->active() && c2->active() &&
+        if (c1->is_active() && c2->is_active() &&
             (c1->subdomain_id() != c2->subdomain_id()))
           return false;
 

--- a/tests/serialization/hp_dof_handler_01.cc
+++ b/tests/serialization/hp_dof_handler_01.cc
@@ -71,7 +71,7 @@ namespace dealii
               }
           }
 
-        if (c1->active() && c2->active() &&
+        if (c1->is_active() && c2->is_active() &&
             (c1->subdomain_id() != c2->subdomain_id()))
           return false;
 
@@ -84,15 +84,15 @@ namespace dealii
         if (c1->user_flag_set() != c2->user_flag_set())
           return false;
 
-        if (c1->active() && c2->active() &&
+        if (c1->is_active() && c2->is_active() &&
             c1->get_fe().get_name() != c2->get_fe().get_name())
           return false;
 
-        if (c1->active() && c2->active() &&
+        if (c1->is_active() && c2->is_active() &&
             c1->active_fe_index() != c2->active_fe_index())
           return false;
 
-        if (c1->active() && c2->active() &&
+        if (c1->is_active() && c2->is_active() &&
             c1->future_fe_index() != c2->future_fe_index())
           return false;
 

--- a/tests/serialization/triangulation_01.cc
+++ b/tests/serialization/triangulation_01.cc
@@ -75,7 +75,7 @@ namespace dealii
               }
           }
 
-        if (c1->active() && c2->active() &&
+        if (c1->is_active() && c2->is_active() &&
             (c1->subdomain_id() != c2->subdomain_id()))
           return false;
 
@@ -94,7 +94,7 @@ namespace dealii
         if (c1->manifold_id() != c2->manifold_id())
           return false;
 
-        if (c1->active() && c2->active())
+        if (c1->is_active() && c2->is_active())
           if (c1->active_cell_index() != c2->active_cell_index())
             return false;
 

--- a/tests/serialization/triangulation_02.cc
+++ b/tests/serialization/triangulation_02.cc
@@ -77,7 +77,7 @@ namespace dealii
               }
           }
 
-        if (c1->active() && c2->active() &&
+        if (c1->is_active() && c2->is_active() &&
             (c1->subdomain_id() != c2->subdomain_id()))
           return false;
 
@@ -96,7 +96,7 @@ namespace dealii
         if (c1->manifold_id() != c2->manifold_id())
           return false;
 
-        if (c1->active() && c2->active())
+        if (c1->is_active() && c2->is_active())
           if (c1->active_cell_index() != c2->active_cell_index())
             return false;
 

--- a/tests/sharedtria/tria_custom_refine02.cc
+++ b/tests/sharedtria/tria_custom_refine02.cc
@@ -55,7 +55,7 @@ mypartition(parallel::shared::Triangulation<dim> &tria)
                                                                        lvl);
       for (; cell != endc; ++cell)
         {
-          if (cell->active())
+          if (cell->is_active())
             cell->set_level_subdomain_id(cell->subdomain_id());
           else
             cell->set_level_subdomain_id(cell->child(0)->level_subdomain_id());

--- a/tests/trilinos/elide_zeros.cc
+++ b/tests/trilinos/elide_zeros.cc
@@ -263,7 +263,7 @@ namespace LinearAdvectionTest
                       }
                     // If the neighbor is not active, then it is at a higher
                     // refinement level (so we do not need to integrate now)
-                    if (neighbor_cell->active())
+                    if (neighbor_cell->is_active())
                       {
                         if (neighbor_cell->is_locally_owned())
                           {


### PR DESCRIPTION
The `CellAccessor::active()` function did not satisfy the usual naming scheme of that class in which functions are called `CellAccessor::is_ghost()`, `CellAccessor::is_locally_owned()`, etc. I have been caught by this so many times, thinking that there is no `is_active()` function, and then just wrote `!cell->has_childen()`. But the function exists, it is just poorly named.

As a consequence, there is now a new function `CellAccessor::is_active()`, with the old function deprecated.

I've also converted all of the occurrences of `->active(` by `->is_active()` in the third commit. The only really interesting part is the first commit.