### PR TITLE
More work on the tutorial graph

### DIFF
--- a/doc/doxygen/scripts/steps.pl
+++ b/doc/doxygen/scripts/steps.pl
@@ -27,13 +27,14 @@ while (my $line = <TUTORIAL>)
 }
 
 # List of additional node and edge attributes to highlight purpose and state of
-# a tutorial or code gallery program
+# a tutorial or code gallery program. For a list of colors, take a look here:
+#   https://www.graphviz.org/doc/info/colors.html
 my %colors = (
  "basic"          => 'green',
  "techniques"     => 'orange',
  "fluids"         => 'yellow2',
  "solids"         => 'lightblue',
- "time dependent" => 'blue',
+ "time dependent" => 'dodgerblue1',
  "unfinished"     => 'black',
  "code-gallery"   => 'black',
     );

--- a/doc/doxygen/scripts/steps.pl
+++ b/doc/doxygen/scripts/steps.pl
@@ -168,10 +168,23 @@ foreach $step (@ARGV)
         # Determine the style of the arrow that connects
         # the two nodes. If the two nodes are of the same
         # kind, use the same color as the nodes as this makes
-        # reading the flow of the graph a bit easier.
+        # reading the flow of the graph a bit easier. Furthermore,
+        # set the edge weight to 5 (instead of the default of 1)
+        # to try and keep programs of the same kind together. The
+        # exception is the "basic" tutorial programs: these are
+        # going to be connected by edges of weight 100, ensuring
+        # that they are all essentially aligned vertically.
         if ($kind_map{$source} eq $kind_map{$destination})
         {
             $edge_attributes = "color=\"$colors{$kind_map{$source}}\",";
+            if ($kind_map{$source} eq "basic")
+            {
+                $edge_attributes .= "weight=100,";
+            }
+            else
+            {
+                $edge_attributes .= "weight=5,";
+            }
         }
 
         # If the destination is a code gallery program, used a dashed line


### PR DESCRIPTION
This is a follow-up to #9342. It changes two things:
* It gives greater weight to edges between programs of the same kind. This keeps them closer together and leads to better grouping. It gives heavy weight between "basic" tutorial programs, and they are now all arranged in a nearly vertical fashion.
* It changes the blue color for one category to a lighter blue, as requested by @tjhei in https://github.com/dealii/dealii/pull/9342#pullrequestreview-343512307 This makes the black text much easier to read.