### PR TITLE
Replace !has_children() by is_active().

### DIFF
--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -1555,8 +1555,7 @@ namespace Step33
                       Assert(neighbor_child->face(neighbor2) ==
                                cell->face(face_no)->child(subface_no),
                              ExcInternalError());
-                      Assert(neighbor_child->has_children() == false,
-                             ExcInternalError());
+                      Assert(neighbor_child->is_active(), ExcInternalError());
 
                       fe_v_subface.reinit(cell, face_no, subface_no);
                       fe_v_face_neighbor.reinit(neighbor_child, neighbor2);

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -3887,7 +3887,7 @@ DoFCellAccessor<DoFHandlerType, level_dof_access>::get_dof_values(
   (void)local_values_end;
   Assert(this->is_artificial() == false,
          ExcMessage("Can't ask for DoF indices on artificial cells."));
-  Assert(!this->has_children(), ExcMessage("Cell must be active."));
+  Assert(this->is_active(), ExcMessage("Cell must be active."));
   Assert(this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
 
   Assert(static_cast<unsigned int>(local_values_end - local_values_begin) ==
@@ -3919,7 +3919,7 @@ DoFCellAccessor<DoFHandlerType, level_dof_access>::get_dof_values(
 {
   Assert(this->is_artificial() == false,
          ExcMessage("Can't ask for DoF indices on artificial cells."));
-  Assert(!this->has_children(), ExcMessage("Cell must be active."));
+  Assert(this->is_active(), ExcMessage("Cell must be active."));
 
   Assert(static_cast<unsigned int>(local_values_end - local_values_begin) ==
            this->get_fe().dofs_per_cell,
@@ -3949,7 +3949,7 @@ DoFCellAccessor<DoFHandlerType, level_dof_access>::set_dof_values(
 {
   Assert(this->is_artificial() == false,
          ExcMessage("Can't ask for DoF indices on artificial cells."));
-  Assert(!this->has_children(), ExcMessage("Cell must be active."));
+  Assert(this->is_active(), ExcMessage("Cell must be active."));
 
   Assert(static_cast<unsigned int>(local_values.size()) ==
            this->get_fe().dofs_per_cell,
@@ -3979,7 +3979,7 @@ DoFCellAccessor<DoFHandlerType, level_dof_access>::get_fe() const
     (dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,
                                            DoFHandlerType::space_dimension> *>(
        this->dof_handler) != nullptr) ||
-      (this->has_children() == false),
+      this->is_active(),
     ExcMessage("In hp::DoFHandler objects, finite elements are only associated "
                "with active cells. Consequently, you can not ask for the "
                "active finite element on cells with children."));
@@ -3997,7 +3997,7 @@ DoFCellAccessor<DoFHandlerType, level_dof_access>::active_fe_index() const
     (dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,
                                            DoFHandlerType::space_dimension> *>(
        this->dof_handler) != nullptr) ||
-      (this->has_children() == false),
+      this->is_active(),
     ExcMessage("You can not ask for the active_fe_index on a cell that has "
                "children because no degrees of freedom are assigned "
                "to this cell and, consequently, no finite element "
@@ -4026,7 +4026,7 @@ DoFCellAccessor<DoFHandlerType, level_dof_access>::set_active_fe_index(
     (dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,
                                            DoFHandlerType::space_dimension> *>(
        this->dof_handler) != nullptr) ||
-      (this->has_children() == false),
+      this->is_active(),
     ExcMessage("You can not set the active_fe_index on a cell that has "
                "children because no degrees of freedom will be assigned "
                "to this cell."));
@@ -4058,7 +4058,7 @@ DoFCellAccessor<DoFHandlerType, level_dof_access>::get_future_fe() const
     (dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,
                                            DoFHandlerType::space_dimension> *>(
        this->dof_handler) != nullptr) ||
-      (this->has_children() == false),
+      this->is_active(),
     ExcMessage("In hp::DoFHandler objects, finite elements are only associated "
                "with active cells. Consequently, you can not ask for the "
                "future finite element on cells with children."));

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -590,7 +590,7 @@ namespace FETools
         Vector<value_type> &   interpolated_values,
         std::vector<CellData> &new_needs)
     {
-      if (!dealii_cell->has_children())
+      if (dealii_cell->is_active())
         {
           if (dealii_cell->is_locally_owned())
             {
@@ -730,7 +730,7 @@ namespace FETools
         dealii_cell->get_dof_handler().get_fe();
       const unsigned int dofs_per_cell = fe.dofs_per_cell;
 
-      if (!dealii_cell->has_children())
+      if (dealii_cell->is_active())
         {
           if (dealii_cell->is_locally_owned())
             {

--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -402,7 +402,7 @@ namespace IteratorFilters
  *     template <class Iterator>
  *     bool operator () (const Iterator &i) const
  *     {
- *       return (i->is_active());
+ *       return i->is_active();
  *     }
  *   };
  * @endcode
@@ -1165,7 +1165,7 @@ namespace IteratorFilters
   inline bool
   Active::operator()(const Iterator &i) const
   {
-    return (i->is_active());
+    return i->is_active();
   }
 
 

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -623,8 +623,8 @@ namespace internal
                   // side). We process a face locally when we are more refined
                   // (in the active cell case) or when the face is listed in
                   // the `shared_faces` data structure that we built above.
-                  if ((id1 == id2 && (use_active_cells == false ||
-                                      neighbor->has_children() == false)) ||
+                  if ((id1 == id2 &&
+                       (use_active_cells == false || neighbor->is_active())) ||
                       dcell->level() > neighbor->level() ||
                       std::binary_search(
                         inner_faces_at_proc_boundary[id2].shared_faces.begin(),

--- a/include/deal.II/meshworker/loop.h
+++ b/include/deal.II/meshworker/loop.h
@@ -307,8 +307,8 @@ namespace MeshWorker
                   (periodic_neighbor &&
                    cell->periodic_neighbor_is_coarser(face_no)))
                 {
-                  Assert(!cell->has_children(), ExcInternalError());
-                  Assert(!neighbor->has_children(), ExcInternalError());
+                  Assert(cell->is_active(), ExcInternalError());
+                  Assert(neighbor->is_active(), ExcInternalError());
 
                   // skip if only one processor needs to assemble the face
                   // to a ghost cell and the fine cell is not ours.

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -351,8 +351,8 @@ namespace MeshWorker
                     (periodic_neighbor &&
                      cell->periodic_neighbor_is_coarser(face_no)))
                   {
-                    Assert(!cell->has_children(), ExcInternalError());
-                    Assert(!neighbor->has_children(), ExcInternalError());
+                    Assert(cell->is_active(), ExcInternalError());
+                    Assert(neighbor->is_active(), ExcInternalError());
 
                     // skip if only one processor needs to assemble the face
                     // to a ghost cell and the fine cell is not ours.

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -561,7 +561,7 @@ MGTransferMatrixFree<dim, Number>::interpolate_to_mg(
             // if we get to a cell without children (== active), we can
             // skip it as there values should be already set by the
             // equivalent of copy_to_mg()
-            if (!cell->has_children())
+            if (cell->is_active())
               continue;
 
             std::fill(dof_values_coarse.begin(), dof_values_coarse.end(), 0.);

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -376,7 +376,7 @@ public:
    *   DataOut<dim> data_out;
    *   data_out.set_cell_selection(
    *          [](const typename Triangulation<dim>::cell_iterator &cell) {
-   *              return (!cell->has_children() && cell->subdomain_id() == 0);
+   *              return (cell->is_active() && cell->subdomain_id() == 0);
    *          });
    * @endcode
    * In this case, the lambda function selects all of those cells that are

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -846,7 +846,7 @@ namespace internal
         // get an iterator pointing to the cell behind the present subface
         const typename DoFHandlerType::active_cell_iterator neighbor_child =
           cell->neighbor_child_on_subface(face_no, subface_no);
-        Assert(!neighbor_child->has_children(), ExcInternalError());
+        Assert(neighbor_child->is_active(), ExcInternalError());
 
         // restrict the finite element on the present cell to the subface
         fe_subface_values.reinit(cell,

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -228,7 +228,7 @@ namespace parallel
                       // also keep its level subdomain id since it is either
                       // owned by this processor or in the ghost layer of the
                       // active mesh.
-                      if (!cell->has_children() &&
+                      if (cell->is_active() &&
                           cell->subdomain_id() !=
                             numbers::artificial_subdomain_id)
                         continue;

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -468,7 +468,7 @@ namespace
       {
         // yes, cell found in local part of p4est
         delete_all_children<dim, spacedim>(dealii_cell);
-        if (!dealii_cell->has_children())
+        if (dealii_cell->is_active())
           dealii_cell->set_subdomain_id(my_subdomain);
       }
     else
@@ -478,7 +478,7 @@ namespace
         // no children of its own, we need to refine it, and if it does
         // already have children then loop over all children and see if they
         // are locally available as well
-        if (dealii_cell->has_children() == false)
+        if (dealii_cell->is_active())
           dealii_cell->set_refine_flag();
         else
           {
@@ -549,7 +549,7 @@ namespace
         typename Triangulation<dim, spacedim>::cell_iterator cell(tria,
                                                                   i,
                                                                   dealii_index);
-        if (cell->has_children() == false)
+        if (cell->is_active())
           {
             cell->clear_coarsen_flag();
             cell->set_refine_flag();
@@ -721,7 +721,7 @@ namespace
     const typename internal::p4est::types<dim>::quadrant &      p4est_cell,
     const types::subdomain_id                                   my_subdomain)
   {
-    if (!cell->has_children())
+    if (cell->is_active())
       {
         if (cell->subdomain_id() == my_subdomain)
           {
@@ -2521,7 +2521,7 @@ namespace parallel
                                                               quadrant))
             {
               Assert(!dealii_cell->is_artificial(), ExcInternalError());
-              Assert(!dealii_cell->has_children(), ExcInternalError());
+              Assert(dealii_cell->is_active(), ExcInternalError());
               Assert(!dealii_cell->is_locally_owned(), ExcInternalError());
 
               const unsigned int n_vertices = vertex_indices[0];
@@ -2533,7 +2533,7 @@ namespace parallel
               return;
             }
 
-          if (!dealii_cell->has_children())
+          if (dealii_cell->is_active())
             return;
 
           if (!dealii::internal::p4est::quadrant_is_ancestor<dim>(p4est_cell,
@@ -3548,7 +3548,7 @@ namespace parallel
                   false)
                 {
                   delete_all_children<dim, spacedim>(cell);
-                  if (!cell->has_children())
+                  if (cell->is_active())
                     cell->set_subdomain_id(numbers::artificial_subdomain_id);
                 }
 
@@ -3673,7 +3673,7 @@ namespace parallel
                 endc = this->end(lvl);
               for (cell = this->begin(lvl); cell != endc; ++cell)
                 {
-                  if ((!cell->has_children() &&
+                  if ((cell->is_active() &&
                        cell->subdomain_id() ==
                          this->locally_owned_subdomain()) ||
                       (cell->has_children() &&

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -50,8 +50,8 @@ DoFCellAccessor<DoFHandlerType, lda>::get_interpolated_dof_values(
   Vector<number> &   interpolated_values,
   const unsigned int fe_index) const
 {
-  if (!this->has_children())
-    // if this cell has no children: simply return the exact values on this
+  if (this->is_active())
+    // If this cell is active: simply return the exact values on this
     // cell unless the finite element we need to interpolate to is different
     // than the one we have on the current cell
     {
@@ -89,7 +89,8 @@ DoFCellAccessor<DoFHandlerType, lda>::get_interpolated_dof_values(
         }
     }
   else
-    // otherwise obtain them from the children
+    // The cell is not active; we need to obtain data them from
+    // children recursively.
     {
       // we are on a non-active cell. these do not have any finite
       // element associated with them in the hp context (in the non-hp

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -50,7 +50,7 @@ DoFCellAccessor<DoFHandlerType, lda>::set_dof_values_by_interpolation(
   OutputVector &        values,
   const unsigned int    fe_index) const
 {
-  if (!this->has_children() && !this->is_artificial())
+  if (this->is_active() && !this->is_artificial())
     {
       if ((dynamic_cast<DoFHandler<DoFHandlerType::dimension,
                                    DoFHandlerType::space_dimension> *>(

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -4235,7 +4235,7 @@ namespace internal
               return; // we are done
             }
 
-          if (!dealii_cell->has_children())
+          if (dealii_cell->is_active())
             return;
 
           if (!dealii_cell->id().is_ancestor_of(CellId(quadrant)))
@@ -4334,7 +4334,7 @@ namespace internal
               return;
             }
 
-          if (!dealii_cell->has_children())
+          if (dealii_cell->is_active())
             return;
 
           if (!dealii_cell->id().is_ancestor_of(CellId(quadrant)))

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -2620,7 +2620,7 @@ namespace DoFTools
 
     for (unsigned int block = 0; pcell != endc; ++pcell)
       {
-        if (!pcell->has_children())
+        if (pcell->is_active())
           continue;
 
         for (unsigned int child = 0; child < pcell->n_children(); ++child)

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -278,7 +278,7 @@ namespace DoFTools
         const cell_iterator cell_row = cell_pair.first;
         const cell_iterator cell_col = cell_pair.second;
 
-        if (!cell_row->has_children() && !cell_col->has_children())
+        if (cell_row->is_active() && cell_col->is_active())
           {
             const unsigned int dofs_per_cell_row =
               cell_row->get_fe().dofs_per_cell;

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2840,7 +2840,7 @@ FEValuesBase<dim, spacedim>::CellIterator<CI>::get_interpolated_dof_values(
   const IndexSet &              in,
   Vector<IndexSet::value_type> &out) const
 {
-  Assert(cell->has_children() == false, ExcNotImplemented());
+  Assert(cell->is_active(), ExcNotImplemented());
 
   std::vector<types::global_dof_index> dof_indices(
     cell->get_fe().dofs_per_cell);

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -2897,7 +2897,7 @@ namespace
             patch.data(2, v) =
               static_cast<std::make_signed<types::material_id>::type>(
                 cell->material_id());
-            if (!cell->has_children())
+            if (cell->is_active())
               patch.data(3, v) =
                 static_cast<std::make_signed<types::subdomain_id>::type>(
                   cell->subdomain_id());
@@ -3330,7 +3330,7 @@ GridOut::write_mesh_per_processor_as_vtu(
           if (cell->has_children() &&
               cell->level_subdomain_id() == numbers::artificial_subdomain_id)
             continue;
-          else if (!cell->has_children() &&
+          else if (cell->is_active() &&
                    cell->level_subdomain_id() ==
                      numbers::artificial_subdomain_id &&
                    cell->subdomain_id() == numbers::artificial_subdomain_id)
@@ -3345,7 +3345,7 @@ GridOut::write_mesh_per_processor_as_vtu(
         {
           patch.vertices[vertex] = cell->vertex(vertex);
           patch.data(0, vertex)  = cell->level();
-          if (!cell->has_children())
+          if (cell->is_active())
             patch.data(1, vertex) = static_cast<double>(
               static_cast<std::make_signed<types::subdomain_id>::type>(
                 cell->subdomain_id()));

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -3206,7 +3206,7 @@ namespace GridTools
           endc = triangulation.end(lvl);
         for (; cell != endc; ++cell)
           {
-            if (!cell->has_children())
+            if (cell->is_active())
               cell->set_level_subdomain_id(cell->subdomain_id());
             else
               {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -13892,7 +13892,7 @@ namespace
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const bool allow_anisotropic_smoothing)
   {
-    Assert(cell->has_children() == false, ExcInternalError());
+    Assert(cell->is_active(), ExcInternalError());
     Assert(cell->refine_flag_set() == false, ExcInternalError());
 
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2078,8 +2078,7 @@ template <int dim, int spacedim>
 unsigned int
 CellAccessor<dim, spacedim>::active_cell_index() const
 {
-  Assert(this->has_children() == false,
-         TriaAccessorExceptions::ExcCellNotActive());
+  Assert(this->is_active(), TriaAccessorExceptions::ExcCellNotActive());
   return this->tria->levels[this->present_level]
     ->active_cell_indices[this->present_index];
 }

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -304,7 +304,7 @@ namespace internal
                 cell = dof_handler.begin_active(level),
                 endc = dof_handler.end_active(level);
               for (; cell != endc; ++cell)
-                if (!cell->has_children() && !cell->is_artificial())
+                if (cell->is_active() && !cell->is_artificial())
                   {
                     dof_handler.levels[level]->dof_offsets[cell->index()] =
                       next_free_dof;
@@ -335,7 +335,7 @@ namespace internal
               types::global_dof_index counter = 0;
               for (const auto &cell :
                    dof_handler.active_cell_iterators_on_level(level))
-                if (!cell->has_children() && !cell->is_artificial())
+                if (cell->is_active() && !cell->is_artificial())
                   counter += cell->get_fe().template n_dofs_per_object<dim>();
 
               Assert(dof_handler.levels[level]->dof_indices.size() == counter,
@@ -348,7 +348,7 @@ namespace internal
               unsigned int n_active_non_artificial_cells = 0;
               for (const auto &cell :
                    dof_handler.active_cell_iterators_on_level(level))
-                if (!cell->has_children() && !cell->is_artificial())
+                if (cell->is_active() && !cell->is_artificial())
                   ++n_active_non_artificial_cells;
 
               Assert(static_cast<unsigned int>(std::count(

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -1140,8 +1140,8 @@ DataOut<dim, DoFHandlerType>::first_locally_owned_cell()
 
   // skip cells if the current one has no children (is active) and is a ghost
   // or artificial cell
-  while ((cell != this->triangulation->end()) &&
-         (cell->has_children() == false) && !cell->is_locally_owned())
+  while ((cell != this->triangulation->end()) && cell->is_active() &&
+         !cell->is_locally_owned())
     cell = next_cell(cell);
 
   return cell;
@@ -1156,8 +1156,8 @@ DataOut<dim, DoFHandlerType>::next_locally_owned_cell(
 {
   typename DataOut<dim, DoFHandlerType>::cell_iterator cell =
     next_cell(old_cell);
-  while ((cell != this->triangulation->end()) &&
-         (cell->has_children() == false) && !cell->is_locally_owned())
+  while ((cell != this->triangulation->end()) && cell->is_active() &&
+         !cell->is_locally_owned())
     cell = next_cell(cell);
   return cell;
 }


### PR DESCRIPTION
Follow-up to #9352. I've gone through all places where we ask `has_children() == false` or `!has_children()` and thought about what it is that we're asking here. In those places where it seemed like we're asking whether something is active, I've replaced it by `is_active()`.

/rebuild