### PR TITLE
Fix tests using DataOut::active_cell_iterator

### DIFF
--- a/tests/data_out/data_out_08.cc
+++ b/tests/data_out/data_out_08.cc
@@ -86,8 +86,8 @@ public:
         const IteratorFilters::SubdomainEqualTo predicate(subdomain_id);
 
         return ++(
-          FilteredIterator<typename DataOut<dim>::cell_iterator>(predicate,
-                                                                 old_cell));
+          FilteredIterator<typename Triangulation<dim>::active_cell_iterator>(
+            predicate, old_cell));
       }
     else
       return old_cell;

--- a/tests/mpi/p4est_2d_constraintmatrix_04.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_04.cc
@@ -67,8 +67,7 @@ public:
   virtual typename DataOut<dim>::cell_iterator
   first_cell()
   {
-    typename DataOut<dim>::active_cell_iterator cell =
-      this->triangulation->begin_active();
+    auto cell = this->triangulation->begin_active();
     while ((cell != this->triangulation->end()) &&
            (cell->subdomain_id() != subdomain_id))
       ++cell;
@@ -83,8 +82,9 @@ public:
       {
         const IteratorFilters::SubdomainEqualTo predicate(subdomain_id);
 
-        return ++(FilteredIterator<typename DataOut<dim>::active_cell_iterator>(
-          predicate, old_cell));
+        return ++(
+          FilteredIterator<typename Triangulation<dim>::active_cell_iterator>(
+            predicate, old_cell));
       }
     else
       return old_cell;

--- a/tests/mpi/p4est_3d_constraintmatrix_03.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_03.cc
@@ -67,8 +67,7 @@ public:
   virtual typename DataOut<dim>::cell_iterator
   first_cell()
   {
-    typename DataOut<dim>::active_cell_iterator cell =
-      this->triangulation->begin_active();
+    auto cell = this->triangulation->begin_active();
     while ((cell != this->triangulation->end()) &&
            (cell->subdomain_id() != subdomain_id))
       ++cell;
@@ -83,8 +82,9 @@ public:
       {
         const IteratorFilters::SubdomainEqualTo predicate(subdomain_id);
 
-        return ++(FilteredIterator<typename DataOut<dim>::active_cell_iterator>(
-          predicate, old_cell));
+        return ++(
+          FilteredIterator<typename Triangulation<dim>::active_cell_iterator>(
+            predicate, old_cell));
       }
     else
       return old_cell;


### PR DESCRIPTION
FIxes the failing tests in https://cdash.43-1.org/viewTest.php?onlydelta&buildid=3762.  `data_out/data_out_08` originally also used `DataOut<dim>::active_cell_iterator` so I changed it here again for consistency.