### PR TITLE
CI: disable cxx14 for the serial linux build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,6 +133,7 @@ pipeline
                  -D DEAL_II_CXX_FLAGS='-Werror' \
                  -D CMAKE_BUILD_TYPE=Debug \
                  -D DEAL_II_WITH_MPI=OFF \
+                 -D DEAL_II_WITH_CXX14=OFF \
                  -D DEAL_II_UNITY_BUILD=ON \
                  $WORKSPACE/
                time ninja -j $NP


### PR DESCRIPTION
This makes the tester compile in c++11 mode so we catch incompatibilities earlier.