### PR TITLE
Clarify a channel limit.

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -524,7 +524,9 @@ namespace LinearAlgebra
        * compress_finish() is invoked, it is mandatory to specify a unique
        * communication channel to each such call, in order to avoid several
        * messages with the same ID that will corrupt this operation. Any
-       * communication channel less than 100 is a valid value.
+       * communication channel less than 100 is a valid value (in particular,
+       * the range $[100, 200)$ is reserved for
+       * LinearAlgebra::distributed::BlockVector).
        */
       void
       compress_start(
@@ -562,7 +564,9 @@ namespace LinearAlgebra
        * update_ghost_values_finish() is invoked, it is mandatory to specify a
        * unique communication channel to each such call, in order to avoid
        * several messages with the same ID that will corrupt this operation.
-       * Any communication channel less than 100 is a valid value.
+       * Any communication channel less than 100 is a valid value (in
+       * particular, the range $[100, 200)$ is reserved for
+       * LinearAlgebra::distributed::BlockVector).
        */
       void
       update_ghost_values_start(

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -900,7 +900,7 @@ namespace LinearAlgebra
       const unsigned int                communication_channel,
       ::dealii::VectorOperation::values operation)
     {
-      AssertIndexRange(communication_channel, 100);
+      AssertIndexRange(communication_channel, 200);
       Assert(vector_is_ghosted == false,
              ExcMessage("Cannot call compress() on a ghosted vector"));
 
@@ -1080,7 +1080,7 @@ namespace LinearAlgebra
     Vector<Number, MemorySpaceType>::update_ghost_values_start(
       const unsigned int communication_channel) const
     {
-      AssertIndexRange(communication_channel, 100);
+      AssertIndexRange(communication_channel, 200);
 #ifdef DEAL_II_WITH_MPI
       // nothing to do when we neither have import nor ghost indices.
       if (partitioner->n_ghost_indices() == 0 &&


### PR DESCRIPTION
Quick fix for #9401. This is a bit tricky since the BlockVector needs channels 100 to 200, but the class itself should only use 0 to 100. I don't see a clear way to check whether or not we are inside a block vector so the index range assertion is a bit imprecise.
