### PR TITLE
Fix ParameterHandler::read_xml_recursively for actions

### DIFF
--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1574,17 +1574,11 @@ public:
    * Exception for when an entry in an XML parameter file does not match the
    * provided pattern. The arguments are, in order, the entry value, entry
    * name, and a description of the pattern.
+   *
+   * @deprecated Use ExcValueDoesNotMatchPattern instead of ExcInvalidEntryForPatternXML.
    */
-  DeclException3(ExcInvalidEntryForPatternXML,
-                 std::string,
-                 std::string,
-                 std::string,
-                 << "    The entry value \n"
-                 << "        " << arg1 << '\n'
-                 << "    for the entry named\n"
-                 << "        " << arg2 << '\n'
-                 << "    does not match the given pattern:\n"
-                 << "        " << arg3);
+  using ExcInvalidEntryForPatternXML DEAL_II_DEPRECATED =
+    ExcValueDoesNotMatchPattern;
 
   /**
    * Exception for when the file given in an include statement cannot be

--- a/tests/parameter_handler/parameter_handler_read_json.cc
+++ b/tests/parameter_handler/parameter_handler_read_json.cc
@@ -27,16 +27,25 @@ main()
 {
   initlog();
 
+  // default values
+  int         int1         = 1;
+  int         int2         = 2;
+  double      double1      = 1.234;
+  double      double2      = 4.321;
+  std::string str          = "< & > ; /";
+  int         intint       = 2;
+  double      doubledouble = 6.1415926;
+
   ParameterHandler prm;
-  prm.declare_entry("int1", "1", Patterns::Integer(), "doc 1");
-  prm.declare_entry("int2", "2", Patterns::Integer(), "doc 2");
+  prm.add_parameter("int1", int1, "doc 1");
+  prm.add_parameter("int2", int2, "doc 2");
   prm.enter_subsection("ss1");
   {
-    prm.declare_entry("double 1", "1.234", Patterns::Double(), "doc 3");
+    prm.add_parameter("double 1", double1, "doc 3");
 
     prm.enter_subsection("ss2");
     {
-      prm.declare_entry("double 2", "4.321", Patterns::Double(), "doc 4");
+      prm.add_parameter("double 2", double2, "doc 4");
     }
     prm.leave_subsection();
   }
@@ -45,21 +54,23 @@ main()
   // things with strange characters
   prm.enter_subsection("Testing%testing");
   {
-    prm.declare_entry("string&list",
-                      "< & > ; /",
-                      Patterns::Anything(),
-                      "docs 1");
-    prm.declare_entry("int*int", "2", Patterns::Integer());
-    prm.declare_entry("double+double",
-                      "6.1415926",
-                      Patterns::Double(),
-                      "docs 3");
+    prm.add_parameter("string&list", str, "docs 1");
+    prm.add_parameter("int*int", intint);
+    prm.add_parameter("double+double", doubledouble, "docs 3");
   }
   prm.leave_subsection();
 
   // read from json
   std::ifstream in(SOURCE_DIR "/prm/parameter_handler_read_json.prm");
   prm.parse_input_from_json(in);
+
+  Assert(int1 == 2, ExcNotImplemented());
+  Assert(int2 == 3, ExcNotImplemented());
+  Assert(double1 == 2.234, ExcNotImplemented());
+  Assert(double2 == 5.321, ExcNotImplemented());
+  Assert(str == "< & > ; /", ExcNotImplemented());
+  Assert(intint == 2, ExcNotImplemented());
+  Assert(doubledouble == 7.1415926, ExcNotImplemented());
 
   // write it out again
   prm.print_parameters(deallog.get_file_stream(), ParameterHandler::JSON);

--- a/tests/parameter_handler/parameter_handler_read_json.output
+++ b/tests/parameter_handler/parameter_handler_read_json.output
@@ -6,7 +6,8 @@
         "default_value": "1",
         "documentation": "doc 1",
         "pattern": "0",
-        "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
+        "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]",
+        "actions": "0"
     },
     "int2":
     {
@@ -14,7 +15,8 @@
         "default_value": "2",
         "documentation": "doc 2",
         "pattern": "1",
-        "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
+        "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]",
+        "actions": "1"
     },
     "ss1":
     {
@@ -24,7 +26,8 @@
             "default_value": "1.234",
             "documentation": "doc 3",
             "pattern": "2",
-            "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+            "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]",
+            "actions": "2"
         },
         "ss2":
         {
@@ -34,7 +37,8 @@
                 "default_value": "4.321",
                 "documentation": "doc 4",
                 "pattern": "3",
-                "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+                "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]",
+                "actions": "3"
             }
         }
     },
@@ -46,7 +50,8 @@
             "default_value": "< & > ; \/",
             "documentation": "docs 1",
             "pattern": "4",
-            "pattern_description": "[Anything]"
+            "pattern_description": "[Anything]",
+            "actions": "4"
         },
         "int_2aint":
         {
@@ -54,15 +59,17 @@
             "default_value": "2",
             "documentation": "",
             "pattern": "5",
-            "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
+            "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]",
+            "actions": "5"
         },
         "double_2bdouble":
         {
             "value": "7.1415926",
-            "default_value": "6.1415926",
+            "default_value": "6.14159",
             "documentation": "docs 3",
             "pattern": "6",
-            "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+            "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]",
+            "actions": "6"
         }
     }
 }

--- a/tests/parameter_handler/parameter_handler_read_xml_error_01.output
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_01.output
@@ -1,3 +1,3 @@
 
-DEAL::ParameterHandler::ExcEntryUndeclared (p->first)
-You can't ask for entry <int1234> you have not yet declared.
+DEAL::ExcEntryUndeclared(entry_string)
+    You can't ask for entry <int1234> you have not yet declared.

--- a/tests/parameter_handler/parameter_handler_read_xml_error_02.cc
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_02.cc
@@ -64,7 +64,7 @@ main()
     {
       prm.parse_input_from_xml(in);
     }
-  catch (const ParameterHandler::ExcInvalidEntryForPatternXML &exc)
+  catch (const ParameterHandler::ExcValueDoesNotMatchPattern &exc)
     {
       deallog << exc.get_exc_name() << std::endl;
       exc.print_info(deallog.get_file_stream());

--- a/tests/parameter_handler/parameter_handler_read_xml_error_02.output
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_02.output
@@ -1,8 +1,3 @@
 
-DEAL::ParameterHandler::ExcInvalidEntryForPatternXML (Utilities::trim(new_value), p->first, patterns[pattern_index]->description())
-    The entry value 
-        __2
-    for the entry named
-        int_2aint
-    does not match the given pattern:
-        [Integer range -2147483648...2147483647 (inclusive)]
+DEAL::ExcValueDoesNotMatchPattern(new_value, entries->get<std::string>( path + path_separator + "pattern_description"))
+    The string <__2> does not match the given pattern <[Integer range -2147483648...2147483647 (inclusive)]>.

--- a/tests/parameter_handler/parameter_handler_read_xml_error_04.cc
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_04.cc
@@ -64,7 +64,7 @@ main()
     {
       prm.parse_input_from_xml(in);
     }
-  catch (const ParameterHandler::ExcInvalidEntryForPatternXML &exc)
+  catch (const ParameterHandler::ExcValueDoesNotMatchPattern &exc)
     {
       deallog << exc.get_exc_name() << std::endl;
       exc.print_info(deallog.get_file_stream());

--- a/tests/parameter_handler/parameter_handler_read_xml_error_04.output
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_04.output
@@ -1,8 +1,3 @@
 
-DEAL::ParameterHandler::ExcInvalidEntryForPatternXML (Utilities::trim(new_value), p->first, patterns[pattern_index]->description())
-    The entry value 
-        2x
-    for the entry named
-        int1
-    does not match the given pattern:
-        [Integer range -2147483648...2147483647 (inclusive)]
+DEAL::ExcValueDoesNotMatchPattern(new_value, entries->get<std::string>( path + path_separator + "pattern_description"))
+    The string <2x> does not match the given pattern <[Integer range -2147483648...2147483647 (inclusive)]>.


### PR DESCRIPTION
@luca-heltai this is practically how you described it. ~I just had problems with relative (`get_current_full_path`) and absolute paths which is the reason for the new flag.~

closes #9427

FYI @lpsaavedra