### PR TITLE
Fix particle probability density mpi problem

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -82,3 +82,6 @@ Alexander Grayver <agrayver@erdw.ethz.ch> <agrayver@agrayver-VirtualBox.(none)>
 Krishnakumar Gopalakrishnan <krishna.kumar@ucl.ac.uk>
 Krishnakumar Gopalakrishnan <krishna.kumar@ucl.ac.uk> <krishnak@vt.edu>
 Krishnakumar Gopalakrishnan <krishna.kumar@ucl.ac.uk> <krishnakumarg1984@users.noreply.github.com>
+
+#
+Menno Fraters <menno.fraters@outlook.com>

--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -312,7 +312,8 @@ namespace Particles
         // Calcualate number of local particles
         const types::particle_index end_particle_id =
           llround(static_cast<double>(n_particles_to_create) *
-                  local_end_weight / global_weight_integral);
+                  ((local_start_weight + local_weight_integral) /
+                   global_weight_integral));
         n_local_particles = end_particle_id - start_particle_id;
 
         if (random_cell_selection)

--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -304,13 +304,16 @@ namespace Particles
           }
 #endif
 
-        // Calculate start id and number of local particles
+        // Calculate start id
         start_particle_id =
           std::llround(static_cast<double>(n_particles_to_create) *
                        local_start_weight / global_weight_integral);
-        n_local_particles =
-          std::llround(static_cast<double>(n_particles_to_create) *
-                       local_weight_integral / global_weight_integral);
+
+        // Calcualate number of local particles
+        const types::particle_index end_particle_id =
+          llround(static_cast<double>(n_particles_to_create) *
+                  local_end_weight / global_weight_integral);
+        n_local_particles = end_particle_id - start_particle_id;
 
         if (random_cell_selection)
           {

--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -311,9 +311,9 @@ namespace Particles
 
         // Calcualate number of local particles
         const types::particle_index end_particle_id =
-          llround(static_cast<double>(n_particles_to_create) *
-                  ((local_start_weight + local_weight_integral) /
-                   global_weight_integral));
+          std::llround(static_cast<double>(n_particles_to_create) *
+                       ((local_start_weight + local_weight_integral) /
+                        global_weight_integral));
         n_local_particles = end_particle_id - start_particle_id;
 
         if (random_cell_selection)

--- a/tests/particles/generators_09.cc
+++ b/tests/particles/generators_09.cc
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check the particle generation using the
+// Particles::Generator::probabilistic_locations function
+// using different probability distributions. In particular
+// check that for a non-random cell selection the domain
+// has the expected number of particles according when there
+// are more mpi ranks than particles.
+
+#include <deal.II/base/function_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/generators.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test(Function<spacedim> &probability_density_function)
+{
+  {
+    parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+    GridGenerator::hyper_cube(tr);
+    tr.refine_global(1);
+
+    MappingQ<dim, spacedim> mapping(1);
+
+    Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
+
+    Particles::Generators::probabilistic_locations(
+      tr, probability_density_function, false, 1, particle_handler, mapping);
+
+    if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+      {
+        deallog << "Locally owned active cells: "
+                << tr.n_locally_owned_active_cells() << std::endl;
+
+        deallog << "Global particles: " << particle_handler.n_global_particles()
+                << std::endl;
+
+        for (const auto &cell : tr.active_cell_iterators())
+          {
+            if (cell->is_locally_owned())
+              {
+                deallog << "Cell " << cell << " has "
+                        << particle_handler.n_particles_in_cell(cell)
+                        << " particles." << std::endl;
+              }
+          }
+
+        for (const auto &particle : particle_handler)
+          {
+            deallog << "Particle index " << particle.get_id() << " is in cell "
+                    << particle.get_surrounding_cell(tr) << std::endl;
+            deallog << "Particle location: " << particle.get_location()
+                    << std::endl;
+          }
+      }
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  initlog();
+
+  {
+    deallog.push("2d/2d");
+    Functions::ConstantFunction<2> probability_density_function(1.0);
+    test<2, 2>(probability_density_function);
+    deallog.pop();
+  }
+  {
+    deallog.push("2d/3d");
+    Functions::ConstantFunction<3> probability_density_function(1.0);
+    test<2, 3>(probability_density_function);
+  }
+  {
+    deallog.pop();
+    deallog.push("3d/3d");
+    Functions::ConstantFunction<3> probability_density_function(1.0);
+    test<3, 3>(probability_density_function);
+    deallog.pop();
+  }
+
+  {
+    deallog.push("2d/2d");
+    Functions::Q1WedgeFunction<2> probability_density_function;
+    test<2, 2>(probability_density_function);
+    deallog.pop();
+  }
+  {
+    deallog.push("2d/3d");
+    Functions::Q1WedgeFunction<3> probability_density_function;
+    test<2, 3>(probability_density_function);
+  }
+  {
+    deallog.pop();
+    deallog.push("3d/3d");
+    Functions::Q1WedgeFunction<3> probability_density_function;
+    test<3, 3>(probability_density_function);
+    deallog.pop();
+  }
+}

--- a/tests/particles/generators_09.with_p4est=true.mpirun=3.output
+++ b/tests/particles/generators_09.with_p4est=true.mpirun=3.output
@@ -1,0 +1,22 @@
+
+DEAL:2d/2d::OK
+DEAL:2d/3d::OK
+DEAL:3d/3d::OK
+DEAL:2d/2d::OK
+DEAL:2d/3d::OK
+DEAL:3d/3d::OK
+EAL:2d/3d::Locally owned active cells: 0
+DEAL:2d/3d::Global particles: 1
+DEAL:2d/3d::OK
+DEAL:3d/3d::Locally owned active cells: 0
+DEAL:3d/3d::Global particles: 1
+DEAL:3d/3d::OK
+DEAL:2d/2d::Locally owned active cells: 0
+DEAL:2d/2d::Global particles: 1
+DEAL:2d/2d::OK
+DEAL:2d/3d::Locally owned active cells: 0
+DEAL:2d/3d::Global particles: 1
+DEAL:2d/3d::OK
+DEAL:3d/3d::Locally owned active cells: 0
+DEAL:3d/3d::Global particles: 1
+DEAL:3d/3d::OK

--- a/tests/particles/generators_10.cc
+++ b/tests/particles/generators_10.cc
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check the particle generation using the
+// Particles::Generator::probabilistic_locations function
+// using different probability distributions. In particular
+// check that for a non-random cell selection the domain
+// has the expected number of particles according when there
+// are more mpi ranks than particles.
+
+#include <deal.II/base/function_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/generators.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test(Function<spacedim> &probability_density_function)
+{
+  {
+    parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+    GridGenerator::hyper_cube(tr);
+    tr.refine_global(1);
+
+    MappingQ<dim, spacedim> mapping(1);
+
+    Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
+
+    Particles::Generators::probabilistic_locations(
+      tr, probability_density_function, false, 2, particle_handler, mapping);
+
+    if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+      {
+        deallog << "Locally owned active cells: "
+                << tr.n_locally_owned_active_cells() << std::endl;
+
+        deallog << "Global particles: " << particle_handler.n_global_particles()
+                << std::endl;
+
+        for (const auto &cell : tr.active_cell_iterators())
+          {
+            if (cell->is_locally_owned())
+              {
+                deallog << "Cell " << cell << " has "
+                        << particle_handler.n_particles_in_cell(cell)
+                        << " particles." << std::endl;
+              }
+          }
+
+        for (const auto &particle : particle_handler)
+          {
+            deallog << "Particle index " << particle.get_id() << " is in cell "
+                    << particle.get_surrounding_cell(tr) << std::endl;
+            deallog << "Particle location: " << particle.get_location()
+                    << std::endl;
+          }
+      }
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  initlog();
+
+  {
+    deallog.push("2d/2d");
+    Functions::ConstantFunction<2> probability_density_function(1.0);
+    test<2, 2>(probability_density_function);
+    deallog.pop();
+  }
+  {
+    deallog.push("2d/3d");
+    Functions::ConstantFunction<3> probability_density_function(1.0);
+    test<2, 3>(probability_density_function);
+  }
+  {
+    deallog.pop();
+    deallog.push("3d/3d");
+    Functions::ConstantFunction<3> probability_density_function(1.0);
+    test<3, 3>(probability_density_function);
+    deallog.pop();
+  }
+
+  {
+    deallog.push("2d/2d");
+    Functions::Q1WedgeFunction<2> probability_density_function;
+    test<2, 2>(probability_density_function);
+    deallog.pop();
+  }
+  {
+    deallog.push("2d/3d");
+    Functions::Q1WedgeFunction<3> probability_density_function;
+    test<2, 3>(probability_density_function);
+  }
+  {
+    deallog.pop();
+    deallog.push("3d/3d");
+    Functions::Q1WedgeFunction<3> probability_density_function;
+    test<3, 3>(probability_density_function);
+    deallog.pop();
+  }
+}

--- a/tests/particles/generators_10.with_p4est=true.mpirun=3.output
+++ b/tests/particles/generators_10.with_p4est=true.mpirun=3.output
@@ -1,0 +1,22 @@
+
+DEAL:2d/2d::OK
+DEAL:2d/3d::OK
+DEAL:3d/3d::OK
+DEAL:2d/2d::OK
+DEAL:2d/3d::OK
+DEAL:3d/3d::OK
+EAL:2d/3d::Locally owned active cells: 0
+DEAL:2d/3d::Global particles: 2
+DEAL:2d/3d::OK
+DEAL:3d/3d::Locally owned active cells: 0
+DEAL:3d/3d::Global particles: 2
+DEAL:3d/3d::OK
+DEAL:2d/2d::Locally owned active cells: 0
+DEAL:2d/2d::Global particles: 2
+DEAL:2d/2d::OK
+DEAL:2d/3d::Locally owned active cells: 0
+DEAL:2d/3d::Global particles: 2
+DEAL:2d/3d::OK
+DEAL:3d/3d::Locally owned active cells: 0
+DEAL:3d/3d::Global particles: 2
+DEAL:3d/3d::OK

--- a/tests/particles/generators_11.cc
+++ b/tests/particles/generators_11.cc
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check the particle generation using the
+// Particles::Generator::probabilistic_locations function
+// using different probability distributions. In particular
+// check that for a non-random cell selection the domain
+// has the expected number of particles according when there
+// are more mpi ranks than particles.
+
+#include <deal.II/base/function_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/generators.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test(Function<spacedim> &probability_density_function)
+{
+  {
+    parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+    GridGenerator::hyper_cube(tr);
+    tr.refine_global(1);
+
+    MappingQ<dim, spacedim> mapping(1);
+
+    Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
+
+    Particles::Generators::probabilistic_locations(
+      tr, probability_density_function, false, 3, particle_handler, mapping);
+
+    if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+      {
+        deallog << "Locally owned active cells: "
+                << tr.n_locally_owned_active_cells() << std::endl;
+
+        deallog << "Global particles: " << particle_handler.n_global_particles()
+                << std::endl;
+
+        for (const auto &cell : tr.active_cell_iterators())
+          {
+            if (cell->is_locally_owned())
+              {
+                deallog << "Cell " << cell << " has "
+                        << particle_handler.n_particles_in_cell(cell)
+                        << " particles." << std::endl;
+              }
+          }
+
+        for (const auto &particle : particle_handler)
+          {
+            deallog << "Particle index " << particle.get_id() << " is in cell "
+                    << particle.get_surrounding_cell(tr) << std::endl;
+            deallog << "Particle location: " << particle.get_location()
+                    << std::endl;
+          }
+      }
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  initlog();
+
+  {
+    deallog.push("2d/2d");
+    Functions::ConstantFunction<2> probability_density_function(1.0);
+    test<2, 2>(probability_density_function);
+    deallog.pop();
+  }
+  {
+    deallog.push("2d/3d");
+    Functions::ConstantFunction<3> probability_density_function(1.0);
+    test<2, 3>(probability_density_function);
+  }
+  {
+    deallog.pop();
+    deallog.push("3d/3d");
+    Functions::ConstantFunction<3> probability_density_function(1.0);
+    test<3, 3>(probability_density_function);
+    deallog.pop();
+  }
+
+  {
+    deallog.push("2d/2d");
+    Functions::Q1WedgeFunction<2> probability_density_function;
+    test<2, 2>(probability_density_function);
+    deallog.pop();
+  }
+  {
+    deallog.push("2d/3d");
+    Functions::Q1WedgeFunction<3> probability_density_function;
+    test<2, 3>(probability_density_function);
+  }
+  {
+    deallog.pop();
+    deallog.push("3d/3d");
+    Functions::Q1WedgeFunction<3> probability_density_function;
+    test<3, 3>(probability_density_function);
+    deallog.pop();
+  }
+}

--- a/tests/particles/generators_11.with_p4est=true.mpirun=3.output
+++ b/tests/particles/generators_11.with_p4est=true.mpirun=3.output
@@ -1,0 +1,22 @@
+
+DEAL:2d/2d::OK
+DEAL:2d/3d::OK
+DEAL:3d/3d::OK
+DEAL:2d/2d::OK
+DEAL:2d/3d::OK
+DEAL:3d/3d::OK
+EAL:2d/3d::Locally owned active cells: 0
+DEAL:2d/3d::Global particles: 3
+DEAL:2d/3d::OK
+DEAL:3d/3d::Locally owned active cells: 0
+DEAL:3d/3d::Global particles: 3
+DEAL:3d/3d::OK
+DEAL:2d/2d::Locally owned active cells: 0
+DEAL:2d/2d::Global particles: 3
+DEAL:2d/2d::OK
+DEAL:2d/3d::Locally owned active cells: 0
+DEAL:2d/3d::Global particles: 3
+DEAL:2d/3d::OK
+DEAL:3d/3d::Locally owned active cells: 0
+DEAL:3d/3d::Global particles: 3
+DEAL:3d/3d::OK

--- a/tests/particles/generators_12.cc
+++ b/tests/particles/generators_12.cc
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check the particle generation using the
+// Particles::Generator::probabilistic_locations function
+// using different probability distributions. In particular
+// check that for a non-random cell selection the domain
+// has the expected number of particles according when there
+// are more mpi ranks than particles.
+
+#include <deal.II/base/function_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/generators.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test(Function<spacedim> &probability_density_function)
+{
+  {
+    parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+    GridGenerator::hyper_cube(tr);
+    tr.refine_global(1);
+
+    MappingQ<dim, spacedim> mapping(1);
+
+    Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
+
+    Particles::Generators::probabilistic_locations(
+      tr, probability_density_function, false, 4, particle_handler, mapping);
+
+    if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+      {
+        deallog << "Locally owned active cells: "
+                << tr.n_locally_owned_active_cells() << std::endl;
+
+        deallog << "Global particles: " << particle_handler.n_global_particles()
+                << std::endl;
+
+        for (const auto &cell : tr.active_cell_iterators())
+          {
+            if (cell->is_locally_owned())
+              {
+                deallog << "Cell " << cell << " has "
+                        << particle_handler.n_particles_in_cell(cell)
+                        << " particles." << std::endl;
+              }
+          }
+
+        for (const auto &particle : particle_handler)
+          {
+            deallog << "Particle index " << particle.get_id() << " is in cell "
+                    << particle.get_surrounding_cell(tr) << std::endl;
+            deallog << "Particle location: " << particle.get_location()
+                    << std::endl;
+          }
+      }
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  initlog();
+
+  {
+    deallog.push("2d/2d");
+    Functions::ConstantFunction<2> probability_density_function(1.0);
+    test<2, 2>(probability_density_function);
+    deallog.pop();
+  }
+  {
+    deallog.push("2d/3d");
+    Functions::ConstantFunction<3> probability_density_function(1.0);
+    test<2, 3>(probability_density_function);
+  }
+  {
+    deallog.pop();
+    deallog.push("3d/3d");
+    Functions::ConstantFunction<3> probability_density_function(1.0);
+    test<3, 3>(probability_density_function);
+    deallog.pop();
+  }
+
+  {
+    deallog.push("2d/2d");
+    Functions::Q1WedgeFunction<2> probability_density_function;
+    test<2, 2>(probability_density_function);
+    deallog.pop();
+  }
+  {
+    deallog.push("2d/3d");
+    Functions::Q1WedgeFunction<3> probability_density_function;
+    test<2, 3>(probability_density_function);
+  }
+  {
+    deallog.pop();
+    deallog.push("3d/3d");
+    Functions::Q1WedgeFunction<3> probability_density_function;
+    test<3, 3>(probability_density_function);
+    deallog.pop();
+  }
+}

--- a/tests/particles/generators_12.with_p4est=true.mpirun=3.output
+++ b/tests/particles/generators_12.with_p4est=true.mpirun=3.output
@@ -1,0 +1,22 @@
+
+DEAL:2d/2d::OK
+DEAL:2d/3d::OK
+DEAL:3d/3d::OK
+DEAL:2d/2d::OK
+DEAL:2d/3d::OK
+DEAL:3d/3d::OK
+EAL:2d/3d::Locally owned active cells: 0
+DEAL:2d/3d::Global particles: 4
+DEAL:2d/3d::OK
+DEAL:3d/3d::Locally owned active cells: 0
+DEAL:3d/3d::Global particles: 4
+DEAL:3d/3d::OK
+DEAL:2d/2d::Locally owned active cells: 0
+DEAL:2d/2d::Global particles: 4
+DEAL:2d/2d::OK
+DEAL:2d/3d::Locally owned active cells: 0
+DEAL:2d/3d::Global particles: 4
+DEAL:2d/3d::OK
+DEAL:3d/3d::Locally owned active cells: 0
+DEAL:3d/3d::Global particles: 4
+DEAL:3d/3d::OK


### PR DESCRIPTION
Same fix as in https://github.com/geodynamics/aspect/pull/3349.

Found a problem where for the probability density function particle generator does not generate the right ammount of particles when there are less particles then mpi ranks:

  1.  setting 1 particle in input, while having 3 mpi processes, no particles are created;
  2.  setting 2 particles in input, while having 3 mpi processes, creates 3 particles.

This should fix the problem and I added some tests (2 of which would have failed without this code). The problem was in how the number of particles per mpi process was computed, which is fixed now with the help of @gassmoeller. I tested all the particle generator tests in aspect locally and they all still pass (also added some new tests there which now show the right results). Did not test it with the dealii tests because I am having some problems getting the dealii tester to work on my laptop (on master).