### PR TITLE
Fix gcc 4.9.4 warning

### DIFF
--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -2709,7 +2709,7 @@ GeometryInfo<3>::unit_cell_vertex(const unsigned int vertex)
 inline std::array<unsigned int, 0>
 GeometryInfo<0>::face_indices()
 {
-  return {};
+  return {{}};
 }
 
 


### PR DESCRIPTION
Fixes most of the warnings in https://cdash.43-1.org/viewBuildError.php?type=1&buildid=3944.