### PR TITLE
Avoid using deprecated functions

### DIFF
--- a/examples/doxygen/block_dynamic_sparsity_pattern.cc
+++ b/examples/doxygen/block_dynamic_sparsity_pattern.cc
@@ -53,8 +53,8 @@ int main()
   DoFTools::make_hanging_node_constraints(dof, constraints);
   constraints.close();
 
-  std::vector<unsigned int> dofs_per_block(fe.n_blocks());
-  DoFTools::count_dofs_per_block(dof, dofs_per_block);
+  const std::vector<unsigned int> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof);
 
   BlockDynamicSparsityPattern dsp(fe.n_blocks(), fe.n_blocks());
   for (unsigned int i = 0; i < fe.n_blocks(); ++i)

--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -341,11 +341,11 @@ namespace Step20
 
     // The next thing is that we want to figure out the sizes of these blocks
     // so that we can allocate an appropriate amount of space. To this end, we
-    // call the DoFTools::count_dofs_per_component() function that
+    // call the DoFTools::count_dofs_per_fe_component() function that
     // counts how many shape functions are non-zero for a particular vector
     // component. We have <code>dim+1</code> vector components, and
-    // DoFTools::count_dofs_per_component() will count how many shape functions
-    // belong to each of these components.
+    // DoFTools::count_dofs_per_fe_component() will count how many shape
+    // functions belong to each of these components.
     //
     // There is one problem here. As described in the documentation of that
     // function, it <i>wants</i> to put the number of $x$-velocity shape
@@ -369,13 +369,13 @@ namespace Step20
     // the vector and matrix block sizes, as well as create output.
     //
     // @note If you find this concept difficult to understand, you may
-    // want to consider using the function DoFTools::count_dofs_per_block()
+    // want to consider using the function DoFTools::count_dofs_per_fe_block()
     // instead, as we do in the corresponding piece of code in step-22.
     // You might also want to read up on the difference between
     // @ref GlossBlock "blocks" and @ref GlossComponent "components"
     // in the glossary.
-    std::vector<types::global_dof_index> dofs_per_component(dim + 1);
-    DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+    const std::vector<types::global_dof_index> dofs_per_component =
+      DoFTools::count_dofs_per_fe_component(dof_handler);
     const unsigned int n_u = dofs_per_component[0],
                        n_p = dofs_per_component[dim];
 

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -534,8 +534,8 @@ namespace Step21
     dof_handler.distribute_dofs(fe);
     DoFRenumbering::component_wise(dof_handler);
 
-    std::vector<types::global_dof_index> dofs_per_component(dim + 2);
-    DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+    const std::vector<types::global_dof_index> dofs_per_component =
+      DoFTools::count_dofs_per_fe_component(dof_handler);
     const unsigned int n_u = dofs_per_component[0],
                        n_p = dofs_per_component[dim],
                        n_s = dofs_per_component[dim + 1];

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -492,13 +492,11 @@ namespace Step22
     // In analogy to step-20, we count the dofs in the individual components.
     // We could do this in the same way as there, but we want to operate on
     // the block structure we used already for the renumbering: The function
-    // <code>DoFTools::count_dofs_per_block</code> does the same as
-    // <code>DoFTools::count_dofs_per_component</code>, but now grouped as
+    // <code>DoFTools::count_dofs_per_fe_block</code> does the same as
+    // <code>DoFTools::count_dofs_per_fe_component</code>, but now grouped as
     // velocity and pressure block via <code>block_component</code>.
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
     const unsigned int n_u = dofs_per_block[0];
     const unsigned int n_p = dofs_per_block[1];
 

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -866,10 +866,8 @@ namespace Step31
       temperature_constraints.close();
     }
 
-    std::vector<types::global_dof_index> stokes_dofs_per_block(2);
-    DoFTools::count_dofs_per_block(stokes_dof_handler,
-                                   stokes_dofs_per_block,
-                                   stokes_sub_blocks);
+    const std::vector<types::global_dof_index> stokes_dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(stokes_dof_handler, stokes_sub_blocks);
 
     const unsigned int n_u = stokes_dofs_per_block[0],
                        n_p = stokes_dofs_per_block[1],

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -1860,10 +1860,8 @@ namespace Step32
 
     temperature_dof_handler.distribute_dofs(temperature_fe);
 
-    std::vector<types::global_dof_index> stokes_dofs_per_block(2);
-    DoFTools::count_dofs_per_block(stokes_dof_handler,
-                                   stokes_dofs_per_block,
-                                   stokes_sub_blocks);
+    const std::vector<types::global_dof_index> stokes_dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(stokes_dof_handler, stokes_sub_blocks);
 
     const unsigned int n_u = stokes_dofs_per_block[0],
                        n_p = stokes_dofs_per_block[1],

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -693,10 +693,9 @@ namespace Step43
     }
 
 
-    std::vector<types::global_dof_index> darcy_dofs_per_block(2);
-    DoFTools::count_dofs_per_block(darcy_dof_handler,
-                                   darcy_dofs_per_block,
-                                   darcy_block_component);
+    const std::vector<types::global_dof_index> darcy_dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(darcy_dof_handler,
+                                        darcy_block_component);
     const unsigned int n_u = darcy_dofs_per_block[0],
                        n_p = darcy_dofs_per_block[1],
                        n_s = saturation_dof_handler.n_dofs();

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -1509,9 +1509,9 @@ namespace Step44
     dof_handler.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler);
     DoFRenumbering::component_wise(dof_handler, block_component);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
 
     std::cout << "Triangulation:"
               << "\n\t Number of active cells: "

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -364,10 +364,8 @@ namespace Step45
     block_component[dim] = 1;
     DoFRenumbering::component_wise(dof_handler, block_component);
 
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
     const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
 
     {

--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -262,7 +262,7 @@ mapping the problem on to the hp framework makes sense:
   the same (here, <code>2*dim+1</code>). This makes all sorts of
   things possible since a uniform description allows for code
   re-use. For example, counting degrees of freedom per vector
-  component (DoFTools::count_dofs_per_component), sorting degrees of
+  component (DoFTools::count_dofs_per_fe_component), sorting degrees of
   freedom by component (DoFRenumbering::component_wise), subsequent
   partitioning of matrices and vectors into blocks and many other
   functions work as they always did without the need to add special

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -362,12 +362,11 @@ namespace Step55
     stokes_sub_blocks[dim] = 1;
     DoFRenumbering::component_wise(dof_handler, stokes_sub_blocks);
 
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   stokes_sub_blocks);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, stokes_sub_blocks);
 
-    const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
+    const unsigned int n_u = dofs_per_block[0];
+    const unsigned int n_p = dofs_per_block[1];
 
     pcout << "   Number of degrees of freedom: " << dof_handler.n_dofs() << " ("
           << n_u << '+' << n_p << ')' << std::endl;

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -553,11 +553,10 @@ namespace Step56
           }
       }
 
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
-    const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
+    const unsigned int n_u = dofs_per_block[0];
+    const unsigned int n_p = dofs_per_block[1];
 
     {
       constraints.clear();

--- a/examples/step-57/step-57.cc
+++ b/examples/step-57/step-57.cc
@@ -290,10 +290,8 @@ namespace Step57
     block_component[dim] = 1;
     DoFRenumbering::component_wise(dof_handler, block_component);
 
-    dofs_per_block.resize(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
     unsigned int dof_u = dofs_per_block[0];
     unsigned int dof_p = dofs_per_block[1];
 

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -2303,7 +2303,7 @@ namespace DoFTools
    */
   template <typename DoFHandlerType>
   std::vector<types::global_dof_index>
-  count_dofs_per_component(
+  count_dofs_per_fe_component(
     const DoFHandlerType &           dof_handler,
     const bool                       vector_valued_once = false,
     const std::vector<unsigned int> &target_component   = {});
@@ -2338,9 +2338,9 @@ namespace DoFTools
    */
   template <typename DoFHandlerType>
   std::vector<types::global_dof_index>
-  count_dofs_per_block(const DoFHandlerType &           dof,
-                       const std::vector<unsigned int> &target_block =
-                         std::vector<unsigned int>());
+  count_dofs_per_fe_block(const DoFHandlerType &           dof,
+                          const std::vector<unsigned int> &target_block =
+                            std::vector<unsigned int>());
 
   /**
    * @deprecated A version of the previous function that returns its

--- a/include/deal.II/multigrid/mg_transfer_component.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_component.templates.h
@@ -112,10 +112,8 @@ MGTransferSelect<number>::copy_from_mg(
       // the block back to dst.
       const unsigned int n_blocks =
         *std::max_element(target_component.begin(), target_component.end()) + 1;
-      std::vector<types::global_dof_index> dofs_per_block(n_blocks);
-      DoFTools::count_dofs_per_block(mg_dof_handler,
-                                     dofs_per_block,
-                                     target_component);
+      const std::vector<types::global_dof_index> dofs_per_block =
+        DoFTools::count_dofs_per_fe_block(mg_dof_handler, target_component);
       BlockVector<number> tmp;
       tmp.reinit(n_blocks);
       for (unsigned int b = 0; b < n_blocks; ++b)

--- a/source/dofs/block_info.cc
+++ b/source/dofs/block_info.cc
@@ -33,9 +33,8 @@ BlockInfo::initialize(const DoFHandler<dim, spacedim> &dof,
 {
   if (!levels_only && dof.has_active_dofs())
     {
-      const FiniteElement<dim, spacedim> & fe = dof.get_fe();
-      std::vector<types::global_dof_index> sizes(fe.n_blocks());
-      DoFTools::count_dofs_per_block(dof, sizes);
+      const std::vector<types::global_dof_index> sizes =
+        DoFTools::count_dofs_per_fe_block(dof);
       bi_global.reinit(sizes);
     }
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1910,16 +1910,17 @@ namespace DoFTools
     const std::vector<unsigned int> &     target_component)
   {
     dofs_per_component =
-      count_dofs_per_component(dof_handler, only_once, target_component);
+      count_dofs_per_fe_component(dof_handler, only_once, target_component);
   }
 
 
 
   template <typename DoFHandlerType>
   std::vector<types::global_dof_index>
-  count_dofs_per_component(const DoFHandlerType &           dof_handler,
-                           const bool                       only_once,
-                           const std::vector<unsigned int> &target_component_)
+  count_dofs_per_fe_component(
+    const DoFHandlerType &           dof_handler,
+    const bool                       only_once,
+    const std::vector<unsigned int> &target_component_)
   {
     const unsigned int n_components = dof_handler.get_fe(0).n_components();
 
@@ -2015,15 +2016,15 @@ namespace DoFTools
                        std::vector<types::global_dof_index> &dofs_per_block,
                        const std::vector<unsigned int> &     target_block)
   {
-    dofs_per_block = count_dofs_per_block(dof_handler, target_block);
+    dofs_per_block = count_dofs_per_fe_block(dof_handler, target_block);
   }
 
 
 
   template <typename DoFHandlerType>
   std::vector<types::global_dof_index>
-  count_dofs_per_block(const DoFHandlerType &           dof_handler,
-                       const std::vector<unsigned int> &target_block_)
+  count_dofs_per_fe_block(const DoFHandlerType &           dof_handler,
+                          const std::vector<unsigned int> &target_block_)
   {
     const dealii::hp::FECollection<DoFHandlerType::dimension,
                                    DoFHandlerType::space_dimension>

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -56,6 +56,7 @@ for (DoFHandler : DOFHANDLER_TEMPLATES;
           &                  dof_handler,
         const ComponentMask &components);
 
+      // deprecated versions of the count_dofs_per_*() functions
       template void
       count_dofs_per_component<
         DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
@@ -70,6 +71,21 @@ for (DoFHandler : DOFHANDLER_TEMPLATES;
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
         std::vector<types::global_dof_index> &,
         const std::vector<unsigned int> &);
+
+      // new versions of the count_dofs_per_*() functions
+      template std::vector<types::global_dof_index>
+      count_dofs_per_fe_component<
+        DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const bool,
+        const std::vector<unsigned int> &);
+
+      template std::vector<types::global_dof_index>
+      count_dofs_per_fe_block<
+        DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const std::vector<unsigned int> &);
+
 
       template unsigned int
       count_dofs_on_patch<

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -3186,15 +3186,15 @@ namespace DoFTools
 
     // get an array in which we store which dof on the coarse grid is a
     // parameter and which is not
-    std::vector<bool> coarse_dof_is_parameter(coarse_grid.n_dofs());
-    if (true)
-      {
-        std::vector<bool> mask(coarse_grid.get_fe(0).n_components(), false);
-        mask[coarse_component] = true;
+    IndexSet coarse_dof_is_parameter;
+    {
+      std::vector<bool> mask(coarse_grid.get_fe(0).n_components(), false);
+      mask[coarse_component] = true;
+
+      coarse_dof_is_parameter =
         extract_dofs<DoFHandler<dim, spacedim>>(coarse_grid,
-                                                ComponentMask(mask),
-                                                coarse_dof_is_parameter);
-      }
+                                                ComponentMask(mask));
+    }
 
     // now we know that the weights in each row constitute a constraint. enter
     // this into the constraints object
@@ -3210,7 +3210,7 @@ namespace DoFTools
     for (types::global_dof_index parameter_dof = 0;
          parameter_dof < n_coarse_dofs;
          ++parameter_dof)
-      if (coarse_dof_is_parameter[parameter_dof] == true)
+      if (coarse_dof_is_parameter.is_element(parameter_dof))
         {
           // if this is the line of a parameter dof on the coarse grid, then it
           // should have at least one dependent node on the fine grid

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -256,9 +256,8 @@ MGTransferBlockBase::build(const DoFHandler<dim, spacedim> &dof_handler)
         }
     }
 
-  block_start.resize(n_blocks);
-  DoFTools::count_dofs_per_block(
-    static_cast<const DoFHandler<dim, spacedim> &>(dof_handler), block_start);
+  block_start = DoFTools::count_dofs_per_fe_block(
+    static_cast<const DoFHandler<dim, spacedim> &>(dof_handler));
 
   types::global_dof_index k = 0;
   for (types::global_dof_index &first_index : block_start)

--- a/source/multigrid/mg_transfer_component.cc
+++ b/source/multigrid/mg_transfer_component.cc
@@ -348,9 +348,7 @@ MGTransferComponentBase::build(const DoFHandler<dim, spacedim> &mg_dof)
         }
     }
 
-  component_start.resize(
-    *std::max_element(target_component.begin(), target_component.end()) + 1);
-  DoFTools::count_dofs_per_block(mg_dof, component_start, target_component);
+  component_start = DoFTools::count_dofs_per_fe_block(mg_dof, target_component);
 
   types::global_dof_index k = 0;
   for (types::global_dof_index &first_index : component_start)

--- a/tests/ad_common_tests/step-44-helper_res_lin_01.h
+++ b/tests/ad_common_tests/step-44-helper_res_lin_01.h
@@ -866,9 +866,8 @@ namespace Step44
     dof_handler_ref.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
-    DoFTools::count_dofs_per_block(dof_handler_ref,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler_ref, block_component);
     std::cout << "Triangulation:"
               << "\n\t Number of active cells: "
               << triangulation.n_active_cells()

--- a/tests/ad_common_tests/step-44-helper_scalar_01.h
+++ b/tests/ad_common_tests/step-44-helper_scalar_01.h
@@ -1269,9 +1269,8 @@ namespace Step44
     dof_handler_ref.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
-    DoFTools::count_dofs_per_block(dof_handler_ref,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler_ref, block_component);
     std::cout << "Triangulation:"
               << "\n\t Number of active cells: "
               << triangulation.n_active_cells()

--- a/tests/ad_common_tests/step-44-helper_var_form_01.h
+++ b/tests/ad_common_tests/step-44-helper_var_form_01.h
@@ -832,9 +832,8 @@ namespace Step44
     dof_handler_ref.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
-    DoFTools::count_dofs_per_block(dof_handler_ref,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler_ref, block_component);
     std::cout << "Triangulation:"
               << "\n\t Number of active cells: "
               << triangulation.n_active_cells()

--- a/tests/ad_common_tests/step-44-helper_vector_01.h
+++ b/tests/ad_common_tests/step-44-helper_vector_01.h
@@ -867,9 +867,8 @@ namespace Step44
     dof_handler_ref.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
-    DoFTools::count_dofs_per_block(dof_handler_ref,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler_ref, block_component);
     std::cout << "Triangulation:"
               << "\n\t Number of active cells: "
               << triangulation.n_active_cells()

--- a/tests/adolc/step-44.cc
+++ b/tests/adolc/step-44.cc
@@ -1104,9 +1104,8 @@ namespace Step44
     dof_handler_ref.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
-    DoFTools::count_dofs_per_block(dof_handler_ref,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler_ref, block_component);
     std::cout << "Triangulation:"
               << "\n\t Number of active cells: "
               << triangulation.n_active_cells()

--- a/tests/bits/anna_3.cc
+++ b/tests/bits/anna_3.cc
@@ -16,7 +16,7 @@
 
 
 // check some things about Nedelec elements, here that
-// DoFTools::component_select and DoFTools::count_dofs_per_component
+// DoFTools::component_select and DoFTools::count_dofs_per_fe_component
 // works
 //
 // this program is a modified version of one by Anna Schneebeli,
@@ -91,17 +91,17 @@ SystemTest<dim>::check()
     {
       deallog << "Checking for component " << c << std::endl;
       std::vector<bool> x(fe.n_components(), false);
-      x[c]         = true;
-      IndexSet sel = DoFTools::extract_dofs(dof_handler, ComponentMask(x));
+      x[c] = true;
+      const IndexSet sel =
+        DoFTools::extract_dofs(dof_handler, ComponentMask(x));
 
       for (unsigned int i = 0; i < sel.size(); ++i)
         if (sel.is_element(i))
           deallog << "  DoF " << i << std::endl;
     };
 
-  std::vector<types::global_dof_index> dofs_per_component(
-    fe.n_components(), static_cast<types::global_dof_index>(0));
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   deallog << "DoFs per component: ";
   for (unsigned int i = 0; i < fe.n_components(); ++i)
     deallog << dofs_per_component[i] << ' ';

--- a/tests/bits/anna_6.cc
+++ b/tests/bits/anna_6.cc
@@ -154,8 +154,8 @@ void
 ImposeBC<dim>::get_ready()
 {
   dof_handler.distribute_dofs(fe);
-  std::vector<types::global_dof_index> dofs_per_comp(fe.n_components());
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_comp);
+  const std::vector<types::global_dof_index> dofs_per_comp =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   // For an FESystem with Nedelec-elements as
   // first component and bilinear elements as

--- a/tests/bits/count_dofs_per_block_01.cc
+++ b/tests/bits/count_dofs_per_block_01.cc
@@ -75,14 +75,14 @@ check()
 
   // no grouping
   {
-    std::vector<types::global_dof_index> dpc(dim + 1);
-    DoFTools::count_dofs_per_component(dof_handler, dpc);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler);
     print(dpc);
   }
 
   {
-    std::vector<types::global_dof_index> dpc(dim + 1);
-    DoFTools::count_dofs_per_block(dof_handler, dpc);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler);
     print(dpc);
   }
 
@@ -92,8 +92,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 0);
     group[dim] = 1;
-    std::vector<types::global_dof_index> dpc(2);
-    DoFTools::count_dofs_per_component(dof_handler, dpc, false, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler, false, group);
     Assert(dpc.size() == 2, ExcInternalError());
     print(dpc);
   }
@@ -101,8 +101,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 0);
     group[dim] = 1;
-    std::vector<types::global_dof_index> dpc(2);
-    DoFTools::count_dofs_per_block(dof_handler, dpc, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler, group);
     Assert(dpc.size() == 2, ExcInternalError());
     print(dpc);
   }
@@ -112,8 +112,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 2 * dim);
     group[dim] = 0;
-    std::vector<types::global_dof_index> dpc(2 * dim + 1);
-    DoFTools::count_dofs_per_component(dof_handler, dpc, false, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler, false, group);
     Assert(dpc.size() == 2 * dim + 1, ExcInternalError());
     print(dpc);
   }
@@ -121,8 +121,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 2 * dim);
     group[dim] = 0;
-    std::vector<types::global_dof_index> dpc(2 * dim + 1);
-    DoFTools::count_dofs_per_block(dof_handler, dpc, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler, group);
     Assert(dpc.size() == 2 * dim + 1, ExcInternalError());
     print(dpc);
   }

--- a/tests/bits/count_dofs_per_block_02.cc
+++ b/tests/bits/count_dofs_per_block_02.cc
@@ -73,14 +73,14 @@ check()
 
   // no grouping
   {
-    std::vector<types::global_dof_index> dpc(dim + 1);
-    DoFTools::count_dofs_per_component(dof_handler, dpc);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler);
     print(dpc);
   }
 
   {
-    std::vector<types::global_dof_index> dpc(2);
-    DoFTools::count_dofs_per_block(dof_handler, dpc);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler);
     print(dpc);
   }
 
@@ -90,8 +90,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 0);
     group[dim] = 1;
-    std::vector<types::global_dof_index> dpc(2);
-    DoFTools::count_dofs_per_component(dof_handler, dpc, false, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler, false, group);
     Assert(dpc.size() == 2, ExcInternalError());
     print(dpc);
   }
@@ -99,8 +99,8 @@ check()
   {
     std::vector<unsigned int> group(2, 0);
     group[1] = 1;
-    std::vector<types::global_dof_index> dpc(2);
-    DoFTools::count_dofs_per_block(dof_handler, dpc, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler, group);
     Assert(dpc.size() == 2, ExcInternalError());
     print(dpc);
   }
@@ -110,8 +110,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 2 * dim);
     group[dim] = 0;
-    std::vector<types::global_dof_index> dpc(2 * dim + 1);
-    DoFTools::count_dofs_per_component(dof_handler, dpc, false, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler, false, group);
     Assert(dpc.size() == 2 * dim + 1, ExcInternalError());
     print(dpc);
   }
@@ -119,8 +119,8 @@ check()
   {
     std::vector<unsigned int> group(2, 2 * dim);
     group[1] = 0;
-    std::vector<types::global_dof_index> dpc(2 * dim + 1);
-    DoFTools::count_dofs_per_block(dof_handler, dpc, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler, group);
     Assert(dpc.size() == 2 * dim + 1, ExcInternalError());
     print(dpc);
   }

--- a/tests/bits/count_dofs_per_component_hp_01.cc
+++ b/tests/bits/count_dofs_per_component_hp_01.cc
@@ -61,10 +61,10 @@ test()
   dof_handler.distribute_dofs(fe_system);
 
   // count dofs per component and show them on the screen
-  std::vector<types::global_dof_index> dofs_per_component(3, 0);
-  std::vector<types::global_dof_index> dofs_per_component_hp(3, 0);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
-  DoFTools::count_dofs_per_component(hp_dof_handler, dofs_per_component_hp);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
+  const std::vector<types::global_dof_index> dofs_per_component_hp =
+    DoFTools::count_dofs_per_fe_component(hp_dof_handler);
 
   for (unsigned int i = 0; i < 3; i++)
     {

--- a/tests/bits/count_dofs_per_component_hp_02.cc
+++ b/tests/bits/count_dofs_per_component_hp_02.cc
@@ -68,8 +68,8 @@ test()
   hp_dof_handler.distribute_dofs(fe_collection);
 
   // count dofs per component and show them on the screen
-  std::vector<types::global_dof_index> dofs_per_component_hp(3, 0);
-  DoFTools::count_dofs_per_component(hp_dof_handler, dofs_per_component_hp);
+  const std::vector<types::global_dof_index> dofs_per_component_hp =
+    DoFTools::count_dofs_per_fe_component(hp_dof_handler);
 
   for (unsigned int i = 0; i < 3; i++)
     {

--- a/tests/distributed_grids/count_dofs_per_block_01.cc
+++ b/tests/distributed_grids/count_dofs_per_block_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// Test DoFTools::count_dofs_per_block
+// Test DoFTools::count_dofs_per_fe_block
 
 
 #include <deal.II/base/tensor.h>
@@ -90,8 +90,8 @@ test()
       triangulation.execute_coarsening_and_refinement();
       dof_handler.distribute_dofs(fe);
 
-      std::vector<types::global_dof_index> dofs_per_block(fe.n_components());
-      DoFTools::count_dofs_per_block(dof_handler, dofs_per_block);
+      const std::vector<types::global_dof_index> dofs_per_block =
+        DoFTools::count_dofs_per_fe_block(dof_handler);
 
       AssertThrow(std::accumulate(dofs_per_block.begin(),
                                   dofs_per_block.end(),

--- a/tests/distributed_grids/count_dofs_per_component_01.cc
+++ b/tests/distributed_grids/count_dofs_per_component_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// Test DoFTools::count_dofs_per_component
+// Test DoFTools::count_dofs_per_fe_component
 
 
 #include <deal.II/base/tensor.h>
@@ -55,8 +55,8 @@ test()
   triangulation.refine_global(2);
   dof_handler.distribute_dofs(fe);
 
-  std::vector<types::global_dof_index> dofs_per_component(fe.n_components());
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   Assert(std::accumulate(dofs_per_component.begin(),
                          dofs_per_component.end(),

--- a/tests/distributed_grids/hp_count_dofs_per_block_01.cc
+++ b/tests/distributed_grids/hp_count_dofs_per_block_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// Test DoFTools::count_dofs_per_block
+// Test DoFTools::count_dofs_per_fe_block
 //
 // like the test without the hp_ prefix, but for hp::DoFHandler
 
@@ -98,8 +98,8 @@ test()
       triangulation.execute_coarsening_and_refinement();
       dof_handler.distribute_dofs(fe);
 
-      std::vector<types::global_dof_index> dofs_per_block(fe.n_components());
-      DoFTools::count_dofs_per_block(dof_handler, dofs_per_block);
+      const std::vector<types::global_dof_index> dofs_per_block =
+        DoFTools::count_dofs_per_fe_block(dof_handler);
 
       AssertThrow(std::accumulate(dofs_per_block.begin(),
                                   dofs_per_block.end(),

--- a/tests/distributed_grids/hp_count_dofs_per_component_01.cc
+++ b/tests/distributed_grids/hp_count_dofs_per_component_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// Test DoFTools::count_dofs_per_component
+// Test DoFTools::count_dofs_per_fe_component
 //
 // like the test without the hp_ prefix, but for hp::DoFHandler
 
@@ -63,8 +63,8 @@ test()
   triangulation.refine_global(2);
   dof_handler.distribute_dofs(fe);
 
-  std::vector<types::global_dof_index> dofs_per_component(fe.n_components());
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   Assert(std::accumulate(dofs_per_component.begin(),
                          dofs_per_component.end(),

--- a/tests/dofs/dof_tools_00a.cc
+++ b/tests/dofs/dof_tools_00a.cc
@@ -32,14 +32,14 @@ check_this(const DoFHandlerType &dof_handler)
 
   deallog << "n_dofs:" << dof_handler.n_dofs() << std::endl;
 
-  std::vector<types::global_dof_index> dofs_per_component(n_components);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   for (unsigned int i = 0; i < n_components; ++i)
     deallog << ' ' << dofs_per_component[i];
   deallog << std::endl;
 
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component, true);
+  dofs_per_component = DoFTools::count_dofs_per_fe_component(dof_handler, true);
 
   for (unsigned int i = 0; i < n_components; ++i)
     deallog << ' ' << dofs_per_component[i];
@@ -48,21 +48,20 @@ check_this(const DoFHandlerType &dof_handler)
   if (n_components > 1)
     {
       std::vector<unsigned int> target_component(n_components, 0U);
-      dofs_per_component.resize(1);
-      DoFTools::count_dofs_per_component(dof_handler,
-                                         dofs_per_component,
-                                         false,
-                                         target_component);
+      dofs_per_component =
+        DoFTools::count_dofs_per_fe_component(dof_handler,
+                                              false,
+                                              target_component);
       for (unsigned int i = 0;
            i < std::min(n_components, (unsigned int)dofs_per_component.size());
            ++i)
         deallog << ' ' << dofs_per_component[i];
       deallog << std::endl;
 
-      DoFTools::count_dofs_per_component(dof_handler,
-                                         dofs_per_component,
-                                         true,
-                                         target_component);
+      dofs_per_component =
+        DoFTools::count_dofs_per_fe_component(dof_handler,
+                                              true,
+                                              target_component);
       for (unsigned int i = 0;
            i < std::min(n_components, (unsigned int)dofs_per_component.size());
            ++i)
@@ -73,19 +72,19 @@ check_this(const DoFHandlerType &dof_handler)
         target_component[i] = 1;
       dofs_per_component.resize(2);
 
-      DoFTools::count_dofs_per_component(dof_handler,
-                                         dofs_per_component,
-                                         false,
-                                         target_component);
+      dofs_per_component =
+        DoFTools::count_dofs_per_fe_component(dof_handler,
+                                              false,
+                                              target_component);
       for (unsigned int i = 0;
            i < std::min(n_components, (unsigned int)dofs_per_component.size());
            ++i)
         deallog << ' ' << dofs_per_component[i];
       deallog << std::endl;
-      DoFTools::count_dofs_per_component(dof_handler,
-                                         dofs_per_component,
-                                         true,
-                                         target_component);
+      dofs_per_component =
+        DoFTools::count_dofs_per_fe_component(dof_handler,
+                                              true,
+                                              target_component);
       for (unsigned int i = 0;
            i < std::min(n_components, (unsigned int)dofs_per_component.size());
            ++i)

--- a/tests/dofs/dof_tools_01c.cc
+++ b/tests/dofs/dof_tools_01c.cc
@@ -43,8 +43,8 @@ check_this(const DoFHandlerType &dof_handler)
   // create sparsity pattern
   const unsigned int   n_components = dof_handler.get_fe().n_components();
   BlockSparsityPattern sp(n_components, n_components);
-  std::vector<types::global_dof_index> dofs_per_component(n_components);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   for (unsigned int i = 0; i < n_components; ++i)
     for (unsigned int j = 0; j < n_components; ++j)
       sp.block(i, j).reinit(dofs_per_component[i],

--- a/tests/dofs/dof_tools_01d.cc
+++ b/tests/dofs/dof_tools_01d.cc
@@ -42,9 +42,9 @@ check_this(const DoFHandlerType &dof_handler)
 
   // create sparsity pattern
   const unsigned int n_components = dof_handler.get_fe().n_components();
-  BlockDynamicSparsityPattern          sp(n_components, n_components);
-  std::vector<types::global_dof_index> dofs_per_component(n_components);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  BlockDynamicSparsityPattern                sp(n_components, n_components);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   for (unsigned int i = 0; i < n_components; ++i)
     for (unsigned int j = 0; j < n_components; ++j)
       sp.block(i, j).reinit(dofs_per_component[i], dofs_per_component[j]);

--- a/tests/dofs/dof_tools_02c.cc
+++ b/tests/dofs/dof_tools_02c.cc
@@ -51,9 +51,9 @@ check_this(const DoFHandlerType &dof_handler)
     return;
 
   // create sparsity pattern
-  BlockSparsityPattern                 sp(n_components, n_components);
-  std::vector<types::global_dof_index> dofs_per_component(n_components);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  BlockSparsityPattern                       sp(n_components, n_components);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   for (unsigned int i = 0; i < n_components; ++i)
     for (unsigned int j = 0; j < n_components; ++j)
       sp.block(i, j).reinit(dofs_per_component[i],

--- a/tests/dofs/dof_tools_02d.cc
+++ b/tests/dofs/dof_tools_02d.cc
@@ -51,9 +51,9 @@ check_this(const DoFHandlerType &dof_handler)
     return;
 
   // create sparsity pattern
-  BlockDynamicSparsityPattern          sp(n_components, n_components);
-  std::vector<types::global_dof_index> dofs_per_component(n_components);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  BlockDynamicSparsityPattern                sp(n_components, n_components);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   for (unsigned int i = 0; i < n_components; ++i)
     for (unsigned int j = 0; j < n_components; ++j)
       sp.block(i, j).reinit(dofs_per_component[i], dofs_per_component[j]);

--- a/tests/dofs/dof_tools_04.cc
+++ b/tests/dofs/dof_tools_04.cc
@@ -29,20 +29,18 @@ check_this(const DoFHandlerType &dof_handler)
 {
   const types::global_dof_index n_dofs = dof_handler.n_dofs();
 
-  std::vector<bool> hanging_node_dofs(n_dofs);
-  DoFTools::extract_hanging_node_dofs(dof_handler, hanging_node_dofs);
+  const IndexSet hanging_node_dofs =
+    DoFTools::extract_hanging_node_dofs(dof_handler);
 
   AffineConstraints<double> constraints;
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();
 
   for (types::global_dof_index dof = 0; dof < n_dofs; ++dof)
-    if (hanging_node_dofs[dof])
+    if (hanging_node_dofs.is_element(dof))
       AssertThrow(constraints.is_constrained(dof), ExcInternalError());
 
-  AssertThrow((unsigned int)std::count(hanging_node_dofs.begin(),
-                                       hanging_node_dofs.end(),
-                                       true) == constraints.n_constraints(),
+  AssertThrow(hanging_node_dofs.n_elements() == constraints.n_constraints(),
               ExcInternalError());
   output_bool_vector(hanging_node_dofs);
 }

--- a/tests/dofs/dof_tools_04a.cc
+++ b/tests/dofs/dof_tools_04a.cc
@@ -53,20 +53,19 @@ check_this(const DoFHandler<dim> &dof_handler)
   IndexSet locally_relevant_dofs;
   DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
 
-  std::vector<bool> is_hanging_node_constrained(n_dofs);
-  DoFTools::extract_hanging_node_dofs(dof_handler, is_hanging_node_constrained);
+  const IndexSet is_hanging_node_constrained =
+    DoFTools::extract_hanging_node_dofs(dof_handler);
 
   AffineConstraints<double> constraints(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();
 
   for (const auto &dof : locally_relevant_dofs)
-    if (is_hanging_node_constrained[dof])
+    if (is_hanging_node_constrained.is_element(dof))
       AssertThrow(constraints.is_constrained(dof), ExcInternalError());
 
-  AssertThrow((unsigned int)(std::count(is_hanging_node_constrained.begin(),
-                                        is_hanging_node_constrained.end(),
-                                        true)) == constraints.n_constraints(),
+  AssertThrow(is_hanging_node_constrained.n_elements() ==
+                constraints.n_constraints(),
               ExcInternalError());
 
   deallog << "OK" << std::endl;

--- a/tests/dofs/dof_tools_07.cc
+++ b/tests/dofs/dof_tools_07.cc
@@ -19,7 +19,7 @@
 #include "dof_tools_common_fake_hp.h"
 
 // check
-//   DoFTools::count_dofs_per_component
+//   DoFTools::count_dofs_per_fe_component
 
 
 
@@ -27,9 +27,8 @@ template <typename DoFHandlerType>
 void
 check_this(const DoFHandlerType &dof_handler)
 {
-  std::vector<types::global_dof_index> n_dofs(
-    dof_handler.get_fe().n_components());
-  DoFTools::count_dofs_per_component(dof_handler, n_dofs);
+  const std::vector<types::global_dof_index> n_dofs =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   for (unsigned int i = 0; i < n_dofs.size(); ++i)
     deallog << n_dofs[i] << " ";
   deallog << std::endl;

--- a/tests/dofs/dof_tools_17c.cc
+++ b/tests/dofs/dof_tools_17c.cc
@@ -43,8 +43,8 @@ check_this(const DoFHandlerType &dof_handler)
   // create sparsity pattern
   const unsigned int   n_components = dof_handler.get_fe().n_components();
   BlockSparsityPattern sp(n_components, n_components);
-  std::vector<types::global_dof_index> dofs_per_component(n_components);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   for (unsigned int i = 0; i < n_components; ++i)
     for (unsigned int j = 0; j < n_components; ++j)
       sp.block(i, j).reinit(dofs_per_component[i],

--- a/tests/dofs/dof_tools_17d.cc
+++ b/tests/dofs/dof_tools_17d.cc
@@ -42,9 +42,9 @@ check_this(const DoFHandlerType &dof_handler)
 
   // create sparsity pattern
   const unsigned int n_components = dof_handler.get_fe().n_components();
-  BlockDynamicSparsityPattern          sp(n_components, n_components);
-  std::vector<types::global_dof_index> dofs_per_component(n_components);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  BlockDynamicSparsityPattern                sp(n_components, n_components);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   for (unsigned int i = 0; i < n_components; ++i)
     for (unsigned int j = 0; j < n_components; ++j)
       sp.block(i, j).reinit(dofs_per_component[i], dofs_per_component[j]);

--- a/tests/dofs/dof_tools_18c.cc
+++ b/tests/dofs/dof_tools_18c.cc
@@ -64,8 +64,8 @@ check_this(const DoFHandlerType &dof_handler)
   // create sparsity pattern
   const unsigned int   n_components = dof_handler.get_fe().n_components();
   BlockSparsityPattern sp(n_components, n_components);
-  std::vector<types::global_dof_index> dofs_per_component(n_components);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   for (unsigned int i = 0; i < n_components; ++i)
     for (unsigned int j = 0; j < n_components; ++j)
       sp.block(i, j).reinit(dofs_per_component[i],

--- a/tests/dofs/dof_tools_18d.cc
+++ b/tests/dofs/dof_tools_18d.cc
@@ -63,9 +63,9 @@ check_this(const DoFHandlerType &dof_handler)
 
   // create sparsity pattern
   const unsigned int n_components = dof_handler.get_fe().n_components();
-  BlockDynamicSparsityPattern          sp(n_components, n_components);
-  std::vector<types::global_dof_index> dofs_per_component(n_components);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  BlockDynamicSparsityPattern                sp(n_components, n_components);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   for (unsigned int i = 0; i < n_components; ++i)
     for (unsigned int j = 0; j < n_components; ++j)
       sp.block(i, j).reinit(dofs_per_component[i], dofs_per_component[j]);

--- a/tests/dofs/extract_dofs_by_component_05.cc
+++ b/tests/dofs/extract_dofs_by_component_05.cc
@@ -20,7 +20,7 @@
 //
 // this particular test checks the call path to
 // internal::extract_dofs_by_component from
-// DoFTools::count_dofs_per_component with argument only_once=false
+// DoFTools::count_dofs_per_fe_component with argument only_once=false
 
 
 #include <deal.II/dofs/dof_handler.h>
@@ -59,8 +59,8 @@ check()
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(element);
 
-  std::vector<types::global_dof_index> count(element.n_components());
-  DoFTools::count_dofs_per_component(dof, count, false);
+  const std::vector<types::global_dof_index> count =
+    DoFTools::count_dofs_per_fe_component(dof, false);
 
   for (unsigned int d = 0; d < count.size(); ++d)
     deallog << count[d] << std::endl;

--- a/tests/dofs/extract_dofs_by_component_05_hp.cc
+++ b/tests/dofs/extract_dofs_by_component_05_hp.cc
@@ -20,7 +20,7 @@
 //
 // this particular test checks the call path to
 // internal::extract_dofs_by_component from
-// DoFTools::count_dofs_per_component with argument only_once=false
+// DoFTools::count_dofs_per_fe_component with argument only_once=false
 
 
 #include <deal.II/dofs/dof_tools.h>
@@ -60,8 +60,8 @@ check()
   dof.begin_active()->set_active_fe_index(1);
   dof.distribute_dofs(element);
 
-  std::vector<types::global_dof_index> count(element.n_components());
-  DoFTools::count_dofs_per_component(dof, count, false);
+  const std::vector<types::global_dof_index> count =
+    DoFTools::count_dofs_per_fe_component(dof, false);
 
   for (unsigned int d = 0; d < count.size(); ++d)
     deallog << count[d] << std::endl;

--- a/tests/dofs/extract_dofs_by_component_06.cc
+++ b/tests/dofs/extract_dofs_by_component_06.cc
@@ -20,7 +20,7 @@
 //
 // this particular test checks the call path to
 // internal::extract_dofs_by_component from
-// DoFTools::count_dofs_per_component with argument only_once=true
+// DoFTools::count_dofs_per_fe_component with argument only_once=true
 
 
 #include <deal.II/dofs/dof_handler.h>
@@ -59,8 +59,8 @@ check()
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(element);
 
-  std::vector<types::global_dof_index> count(element.n_components());
-  DoFTools::count_dofs_per_component(dof, count, true);
+  const std::vector<types::global_dof_index> count =
+    DoFTools::count_dofs_per_fe_component(dof, true);
 
   for (unsigned int d = 0; d < count.size(); ++d)
     deallog << count[d] << std::endl;

--- a/tests/dofs/extract_dofs_by_component_06_hp.cc
+++ b/tests/dofs/extract_dofs_by_component_06_hp.cc
@@ -20,7 +20,7 @@
 //
 // this particular test checks the call path to
 // internal::extract_dofs_by_component from
-// DoFTools::count_dofs_per_component with argument only_once=true
+// DoFTools::count_dofs_per_fe_component with argument only_once=true
 
 
 #include <deal.II/dofs/dof_tools.h>
@@ -60,8 +60,8 @@ check()
   dof.begin_active()->set_active_fe_index(1);
   dof.distribute_dofs(element);
 
-  std::vector<types::global_dof_index> count(element.n_components());
-  DoFTools::count_dofs_per_component(dof, count, true);
+  const std::vector<types::global_dof_index> count =
+    DoFTools::count_dofs_per_fe_component(dof, true);
 
   for (unsigned int d = 0; d < count.size(); ++d)
     deallog << count[d] << std::endl;

--- a/tests/examples/step-56.cc
+++ b/tests/examples/step-56.cc
@@ -564,10 +564,8 @@ namespace Step56
           }
       }
 
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
     const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
 
     {

--- a/tests/fe/fe_q_dg0.cc
+++ b/tests/fe/fe_q_dg0.cc
@@ -469,10 +469,8 @@ namespace Step22
 
     constraints.close();
 
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
     const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
 
     deallog << "   Number of active cells: " << triangulation.n_active_cells()

--- a/tests/fe/fe_values_view_21.cc
+++ b/tests/fe/fe_values_view_21.cc
@@ -116,8 +116,8 @@ MixedElastoPlasticity<dim>::make_grid_and_dofs()
   DoFRenumbering::component_wise(dof_handler);
 
   // total number of dof per block component
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, block_component);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
 
   const unsigned int n_stress_dof = dofs_per_block[0];
   const unsigned int n_gamma_dof  = dofs_per_block[1];

--- a/tests/fe/fe_values_view_21_nonsymmetric.cc
+++ b/tests/fe/fe_values_view_21_nonsymmetric.cc
@@ -117,8 +117,8 @@ MixedElastoPlasticity<dim>::make_grid_and_dofs()
   DoFRenumbering::component_wise(dof_handler);
 
   // total number of dof per block component
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, block_component);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
 
   const unsigned int n_stress_dof = dofs_per_block[0];
   const unsigned int n_gamma_dof  = dofs_per_block[1];

--- a/tests/fe/fe_values_view_22.cc
+++ b/tests/fe/fe_values_view_22.cc
@@ -110,8 +110,8 @@ MixedElastoPlasticity<dim>::make_grid_and_dofs()
 
   DoFRenumbering::component_wise(dof_handler);
 
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, block_component);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
 
   const unsigned int n_stress_dof = dofs_per_block[0];
   const unsigned int n_gamma_dof  = dofs_per_block[1];

--- a/tests/fe/fe_values_view_tensor_01.cc
+++ b/tests/fe/fe_values_view_tensor_01.cc
@@ -114,8 +114,8 @@ MixedElastoPlasticity<dim>::make_grid_and_dofs()
   DoFRenumbering::component_wise(dof_handler);
 
   // total number of dof per block component
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, block_component);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
 
   const unsigned int n_stress_dof = dofs_per_block[0];
   const unsigned int n_gamma_dof  = dofs_per_block[1];

--- a/tests/gla/block_mat_02.cc
+++ b/tests/gla/block_mat_02.cc
@@ -77,10 +77,8 @@ test()
   stokes_dof_handler.distribute_dofs(stokes_fe);
   DoFRenumbering::component_wise(stokes_dof_handler, stokes_sub_blocks);
 
-  std::vector<types::global_dof_index> stokes_dofs_per_block(2);
-  DoFTools::count_dofs_per_block(stokes_dof_handler,
-                                 stokes_dofs_per_block,
-                                 stokes_sub_blocks);
+  const std::vector<types::global_dof_index> stokes_dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(stokes_dof_handler, stokes_sub_blocks);
 
   const unsigned int n_u = stokes_dofs_per_block[0],
                      n_p = stokes_dofs_per_block[1];
@@ -174,10 +172,8 @@ test_LA_Trilinos()
   stokes_dof_handler.distribute_dofs(stokes_fe);
   DoFRenumbering::component_wise(stokes_dof_handler, stokes_sub_blocks);
 
-  std::vector<types::global_dof_index> stokes_dofs_per_block(2);
-  DoFTools::count_dofs_per_block(stokes_dof_handler,
-                                 stokes_dofs_per_block,
-                                 stokes_sub_blocks);
+  const std::vector<types::global_dof_index> stokes_dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(stokes_dof_handler, stokes_sub_blocks);
 
   const unsigned int n_u = stokes_dofs_per_block[0],
                      n_p = stokes_dofs_per_block[1];

--- a/tests/gla/block_mat_03.cc
+++ b/tests/gla/block_mat_03.cc
@@ -70,10 +70,10 @@ test()
   dof_handler.distribute_dofs(fe);
   DoFRenumbering::block_wise(dof_handler);
 
-  std::vector<types::global_dof_index> dofs_per_block(fe.n_blocks());
-  std::vector<unsigned int>            sub_blocks(fe.n_blocks(), 0);
+  std::vector<unsigned int> sub_blocks(fe.n_blocks(), 0);
   sub_blocks[1] = 1;
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, sub_blocks);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, sub_blocks);
 
   deallog << "size: " << dofs_per_block[0] << " " << dofs_per_block[1]
           << std::endl;
@@ -176,10 +176,10 @@ test_alt()
   dof_handler.distribute_dofs(fe);
   DoFRenumbering::block_wise(dof_handler);
 
-  std::vector<types::global_dof_index> dofs_per_block(fe.n_blocks());
-  std::vector<unsigned int>            sub_blocks(fe.n_blocks(), 0);
+  std::vector<unsigned int> sub_blocks(fe.n_blocks(), 0);
   sub_blocks[1] = 1;
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, sub_blocks);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, sub_blocks);
 
   deallog << "size: " << dofs_per_block[0] << " " << dofs_per_block[1]
           << std::endl;

--- a/tests/hp/count_dofs_per_block_01.cc
+++ b/tests/hp/count_dofs_per_block_01.cc
@@ -85,14 +85,14 @@ check()
 
   // no grouping
   {
-    std::vector<types::global_dof_index> dpc(dim + 1);
-    DoFTools::count_dofs_per_component(dof_handler, dpc);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler);
     print(dpc);
   }
 
   {
-    std::vector<types::global_dof_index> dpc(dim + 1);
-    DoFTools::count_dofs_per_block(dof_handler, dpc);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler);
     print(dpc);
   }
 
@@ -102,8 +102,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 0);
     group[dim] = 1;
-    std::vector<types::global_dof_index> dpc(2);
-    DoFTools::count_dofs_per_component(dof_handler, dpc, false, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler, false, group);
     Assert(dpc.size() == 2, ExcInternalError());
     print(dpc);
   }
@@ -111,8 +111,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 0);
     group[dim] = 1;
-    std::vector<types::global_dof_index> dpc(2);
-    DoFTools::count_dofs_per_block(dof_handler, dpc, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler, group);
     Assert(dpc.size() == 2, ExcInternalError());
     print(dpc);
   }
@@ -122,8 +122,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 2 * dim);
     group[dim] = 0;
-    std::vector<types::global_dof_index> dpc(2 * dim + 1);
-    DoFTools::count_dofs_per_component(dof_handler, dpc, false, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler, false, group);
     Assert(dpc.size() == 2 * dim + 1, ExcInternalError());
     print(dpc);
   }
@@ -131,8 +131,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 2 * dim);
     group[dim] = 0;
-    std::vector<types::global_dof_index> dpc(2 * dim + 1);
-    DoFTools::count_dofs_per_block(dof_handler, dpc, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler, group);
     Assert(dpc.size() == 2 * dim + 1, ExcInternalError());
     print(dpc);
   }

--- a/tests/hp/count_dofs_per_block_02.cc
+++ b/tests/hp/count_dofs_per_block_02.cc
@@ -85,14 +85,14 @@ check()
 
   // no grouping
   {
-    std::vector<types::global_dof_index> dpc(dim + 1);
-    DoFTools::count_dofs_per_component(dof_handler, dpc);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler);
     print(dpc);
   }
 
   {
-    std::vector<types::global_dof_index> dpc(dim + 1);
-    DoFTools::count_dofs_per_block(dof_handler, dpc);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler);
     print(dpc);
   }
 
@@ -102,8 +102,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 0);
     group[dim] = 1;
-    std::vector<types::global_dof_index> dpc(2);
-    DoFTools::count_dofs_per_component(dof_handler, dpc, false, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler, false, group);
     Assert(dpc.size() == 2, ExcInternalError());
     print(dpc);
   }
@@ -111,8 +111,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 0);
     group[dim] = 1;
-    std::vector<types::global_dof_index> dpc(2);
-    DoFTools::count_dofs_per_block(dof_handler, dpc, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler, group);
     Assert(dpc.size() == 2, ExcInternalError());
     print(dpc);
   }
@@ -122,8 +122,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 2 * dim);
     group[dim] = 0;
-    std::vector<types::global_dof_index> dpc(2 * dim + 1);
-    DoFTools::count_dofs_per_component(dof_handler, dpc, false, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_component(dof_handler, false, group);
     Assert(dpc.size() == 2 * dim + 1, ExcInternalError());
     print(dpc);
   }
@@ -131,8 +131,8 @@ check()
   {
     std::vector<unsigned int> group(dim + 1, 2 * dim);
     group[dim] = 0;
-    std::vector<types::global_dof_index> dpc(2 * dim + 1);
-    DoFTools::count_dofs_per_block(dof_handler, dpc, group);
+    const std::vector<types::global_dof_index> dpc =
+      DoFTools::count_dofs_per_fe_block(dof_handler, group);
     Assert(dpc.size() == 2 * dim + 1, ExcInternalError());
     print(dpc);
   }

--- a/tests/hp/fe_nothing_18.cc
+++ b/tests/hp/fe_nothing_18.cc
@@ -354,7 +354,8 @@ ElasticProblem<dim>::setup_system()
     dof_handler); // do renumberring; must be done
                   // right after distributing DoF !!!
   DoFRenumbering::component_wise(dof_handler, block_component);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, block_component);
+  dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
 
   deallog << "dofs per block:  U=" << dofs_per_block[u_block]
           << " L=" << dofs_per_block[lambda_block] << std::endl;

--- a/tests/hp/solution_transfer_15.cc
+++ b/tests/hp/solution_transfer_15.cc
@@ -61,9 +61,9 @@ initialize_indexsets(IndexSet &             locally_owned_dofs,
   locally_relevant_dofs = DoFTools::locally_relevant_dofs_per_subdomain(
     dof_handler)[this_mpi_process];
 
-  const unsigned int                   n_blocks = block_component.size();
-  std::vector<types::global_dof_index> dofs_per_block(n_blocks);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, block_component);
+  const unsigned int                         n_blocks = block_component.size();
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
 
   locally_owned_partitioning.clear();
   locally_relevant_partitioning.clear();

--- a/tests/lac/block_linear_operator_01.cc
+++ b/tests/lac/block_linear_operator_01.cc
@@ -58,8 +58,8 @@ main()
 
   dof_handler.distribute_dofs(fe);
 
-  std::vector<types::global_dof_index> dofs_per_component(2);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   const unsigned int n_u = dofs_per_component[0], n_p = dofs_per_component[1];
 
   BlockDynamicSparsityPattern dsp(2, 2);

--- a/tests/lac/block_linear_operator_02.cc
+++ b/tests/lac/block_linear_operator_02.cc
@@ -58,8 +58,8 @@ main()
 
   dof_handler.distribute_dofs(fe);
 
-  std::vector<types::global_dof_index> dpc(3);
-  DoFTools::count_dofs_per_component(dof_handler, dpc);
+  const std::vector<types::global_dof_index> dpc =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   BlockDynamicSparsityPattern dsp(3, 3);
   for (unsigned int i = 0; i < 3; ++i)

--- a/tests/lac/block_linear_operator_06.cc
+++ b/tests/lac/block_linear_operator_06.cc
@@ -58,8 +58,8 @@ main()
 
   dof_handler.distribute_dofs(fe);
 
-  std::vector<types::global_dof_index> dofs_per_component(2);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   const unsigned int n_u = dofs_per_component[0], n_p = dofs_per_component[1];
 
   BlockDynamicSparsityPattern dsp(2, 2);

--- a/tests/lac/constraints_block_01.cc
+++ b/tests/lac/constraints_block_01.cc
@@ -147,12 +147,8 @@ main()
         block_component[comp] = 2;
     } // comp
 
-  std::vector<types::global_dof_index> dofs_per_block(
-    3, 0); // 3 blocks, count dofs:
-  DoFTools::count_dofs_per_component(dh,
-                                     dofs_per_block,
-                                     false,
-                                     block_component);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_component(dh, false, block_component);
 
   DoFRenumbering::component_wise(dh, block_component);
 

--- a/tests/lac/linear_operator_03.cc
+++ b/tests/lac/linear_operator_03.cc
@@ -68,8 +68,8 @@ main()
 
   dof_handler.distribute_dofs(fe);
 
-  std::vector<types::global_dof_index> dofs_per_component(2);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
   const unsigned int n_u = dofs_per_component[0], n_p = dofs_per_component[1];
 
   BlockDynamicSparsityPattern dsp(2, 2);

--- a/tests/lac/linear_operator_13.cc
+++ b/tests/lac/linear_operator_13.cc
@@ -79,7 +79,8 @@ build_matrix_vector(TrilinosWrappers::BlockSparseMatrix &matrix,
   // Setup system
   dof_handler.distribute_dofs(fe);
   DoFRenumbering::component_wise(dof_handler, block_component);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, block_component);
+  dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
   std::vector<IndexSet> partitioning(2);
   partitioning[0] = complete_index_set(dofs_per_block[0]);
   partitioning[1] = complete_index_set(dofs_per_block[1]);

--- a/tests/lac/linear_operator_14.cc
+++ b/tests/lac/linear_operator_14.cc
@@ -97,7 +97,8 @@ build_matrix_vector(TrilinosWrappers::BlockSparseMatrix &matrix,
   // Setup system
   dof_handler.distribute_dofs(fe);
   DoFRenumbering::component_wise(dof_handler, block_component);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, block_component);
+  dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
 
   locally_owned_dofs = dof_handler.locally_owned_dofs();
   locally_owned_partitioning.push_back(

--- a/tests/lac/schur_complement_03.cc
+++ b/tests/lac/schur_complement_03.cc
@@ -181,10 +181,8 @@ namespace Step22
                                                fe.component_mask(velocities));
     }
     constraints.close();
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
     const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
     deallog << "   Number of active cells: " << triangulation.n_active_cells()
             << std::endl

--- a/tests/matrix_free/copy_feevaluation.cc
+++ b/tests/matrix_free/copy_feevaluation.cc
@@ -187,10 +187,8 @@ test()
   DoFTools::make_hanging_node_constraints(dof_handler_p, constraints_p);
   constraints_p.close();
 
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof_handler,
-                                 dofs_per_block,
-                                 stokes_sub_blocks);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, stokes_sub_blocks);
 
   // std::cout << "Number of active cells: "
   //          << triangulation.n_active_cells()

--- a/tests/matrix_free/matrix_vector_stokes.cc
+++ b/tests/matrix_free/matrix_vector_stokes.cc
@@ -161,8 +161,8 @@ test()
 
   constraints.close();
 
-  std::vector<types::global_dof_index> dofs_per_block(dim + 1);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_block);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   // std::cout << "   Number of active cells: "
   //          << triangulation.n_active_cells()

--- a/tests/matrix_free/matrix_vector_stokes_base.cc
+++ b/tests/matrix_free/matrix_vector_stokes_base.cc
@@ -149,8 +149,8 @@ test()
   DoFTools::make_hanging_node_constraints(dof_p, constraints_p);
   constraints_p.close();
 
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof, dofs_per_block, stokes_sub_blocks);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof, stokes_sub_blocks);
   {
     BlockDynamicSparsityPattern csp(2, 2);
 

--- a/tests/matrix_free/matrix_vector_stokes_flux.cc
+++ b/tests/matrix_free/matrix_vector_stokes_flux.cc
@@ -170,10 +170,8 @@ test()
                                                constraints);
   constraints.close();
 
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof_handler,
-                                 dofs_per_block,
-                                 stokes_sub_blocks);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, stokes_sub_blocks);
   {
     BlockDynamicSparsityPattern csp(2, 2);
 

--- a/tests/matrix_free/matrix_vector_stokes_noflux.cc
+++ b/tests/matrix_free/matrix_vector_stokes_noflux.cc
@@ -182,10 +182,8 @@ test()
   DoFTools::make_hanging_node_constraints(dof_handler_p, constraints_p);
   constraints_p.close();
 
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof_handler,
-                                 dofs_per_block,
-                                 stokes_sub_blocks);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, stokes_sub_blocks);
 
   // std::cout << "Number of active cells: "
   //          << triangulation.n_active_cells()

--- a/tests/matrix_free/matrix_vector_stokes_notempl.cc
+++ b/tests/matrix_free/matrix_vector_stokes_notempl.cc
@@ -178,10 +178,8 @@ test(const unsigned int fe_degree)
   DoFTools::make_hanging_node_constraints(dof_handler_p, constraints_p);
   constraints_p.close();
 
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof_handler,
-                                 dofs_per_block,
-                                 stokes_sub_blocks);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, stokes_sub_blocks);
 
   // std::cout << "Number of active cells: "
   //          << triangulation.n_active_cells()

--- a/tests/matrix_free/matrix_vector_stokes_qdg0.cc
+++ b/tests/matrix_free/matrix_vector_stokes_qdg0.cc
@@ -163,8 +163,8 @@ test()
 
   constraints.close();
 
-  std::vector<types::global_dof_index> dofs_per_block(dim + 1);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_block);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   // std::cout << "   Number of active cells: "
   //          << triangulation.n_active_cells()

--- a/tests/matrix_free/matrix_vector_stokes_qdg0b.cc
+++ b/tests/matrix_free/matrix_vector_stokes_qdg0b.cc
@@ -160,8 +160,8 @@ test(const unsigned int fe_degree)
 
   constraints.close();
 
-  std::vector<types::global_dof_index> dofs_per_block(dim + 1);
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_block);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   // std::cout << "   Number of active cells: "
   //          << triangulation.n_active_cells()

--- a/tests/mpi/count_dofs_per_block_01.cc
+++ b/tests/mpi/count_dofs_per_block_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// test DoFTools::count_dofs_per_block in parallel
+// test DoFTools::count_dofs_per_fe_block in parallel
 
 
 #include <deal.II/base/tensor.h>
@@ -55,8 +55,8 @@ test()
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(fe);
 
-  std::vector<types::global_dof_index> dofs_per_block(fe.n_blocks());
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler);
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int i = 0; i < fe.n_blocks(); ++i)

--- a/tests/mpi/count_dofs_per_block_02.cc
+++ b/tests/mpi/count_dofs_per_block_02.cc
@@ -15,7 +15,7 @@
 
 
 
-// Test DoFTools::count_dofs_per_block
+// Test DoFTools::count_dofs_per_fe_block
 
 
 #include <deal.II/base/tensor.h>
@@ -90,8 +90,8 @@ test()
       triangulation.execute_coarsening_and_refinement();
       dof_handler.distribute_dofs(fe);
 
-      std::vector<types::global_dof_index> dofs_per_block(fe.n_components());
-      DoFTools::count_dofs_per_block(dof_handler, dofs_per_block);
+      const std::vector<types::global_dof_index> dofs_per_block =
+        DoFTools::count_dofs_per_fe_block(dof_handler);
 
       AssertThrow(std::accumulate(dofs_per_block.begin(),
                                   dofs_per_block.end(),

--- a/tests/mpi/count_dofs_per_component_01.cc
+++ b/tests/mpi/count_dofs_per_component_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// Test DoFTools::count_dofs_per_component
+// Test DoFTools::count_dofs_per_fe_component
 
 
 #include <deal.II/base/tensor.h>
@@ -55,8 +55,8 @@ test()
   triangulation.refine_global(2);
   dof_handler.distribute_dofs(fe);
 
-  std::vector<types::global_dof_index> dofs_per_component(fe.n_components());
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   AssertThrow(std::accumulate(dofs_per_component.begin(),
                               dofs_per_component.end(),

--- a/tests/mpi/muelu_periodicity.cc
+++ b/tests/mpi/muelu_periodicity.cc
@@ -324,9 +324,9 @@ namespace Step22
     DoFRenumbering::component_wise(dof_handler, block_component);
 
     std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+    DoFTools::count_dofs_per_fe_block(dof_handler,
+                                      dofs_per_block,
+                                      block_component);
     const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
 
     {

--- a/tests/mpi/parallel_vector_back_interpolate_02.cc
+++ b/tests/mpi/parallel_vector_back_interpolate_02.cc
@@ -71,8 +71,8 @@ test()
   std::vector<IndexSet> owned_partitioning1;
   std::vector<IndexSet> relevant_partitioning1;
   {
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof1, dofs_per_block);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof1);
     const unsigned int n1 = dofs_per_block[0], n2 = dofs_per_block[1];
 
     owned_partitioning1.push_back(locally_owned_dofs1.get_view(0, n1));

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -325,10 +325,8 @@ namespace Step22
     block_component[dim] = 1;
     DoFRenumbering::component_wise(dof_handler, block_component);
 
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
     const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
 
     {

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -253,10 +253,8 @@ namespace Step22
     block_component[dim] = 1;
     DoFRenumbering::component_wise(dof_handler, block_component);
 
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
     const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
 
     {

--- a/tests/mpi/project_bv_div_conf.cc
+++ b/tests/mpi/project_bv_div_conf.cc
@@ -168,10 +168,8 @@ namespace ResFlow
     // Renumber to yield block structure
     DoFRenumbering::block_wise(dof_handler);
 
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   resflow_sub_blocks);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, resflow_sub_blocks);
 
     const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
     pcout << "   Number of degrees of freedom: " << dof_handler.n_dofs() << " ("

--- a/tests/mpi/solution_transfer_03.cc
+++ b/tests/mpi/solution_transfer_03.cc
@@ -59,9 +59,9 @@ initialize_indexsets(IndexSet &             locally_owned_dofs,
   locally_relevant_dofs = DoFTools::locally_relevant_dofs_per_subdomain(
     dof_handler)[this_mpi_process];
 
-  const unsigned int                   n_blocks = block_component.size();
-  std::vector<types::global_dof_index> dofs_per_block(n_blocks);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, block_component);
+  const unsigned int                         n_blocks = block_component.size();
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
 
   locally_owned_partitioning.clear();
   locally_relevant_partitioning.clear();

--- a/tests/multigrid/transfer_block.cc
+++ b/tests/multigrid/transfer_block.cc
@@ -100,8 +100,9 @@ check_block(const FiniteElement<dim> &fe,
   mgdof.distribute_dofs(fe);
   mgdof.distribute_mg_dofs();
   DoFRenumbering::component_wise(mgdof);
-  vector<types::global_dof_index> ndofs(fe.n_blocks());
-  DoFTools::count_dofs_per_block(mgdof, ndofs);
+  const vector<types::global_dof_index> ndofs =
+    DoFTools::count_dofs_per_fe_block(mgdof);
+  Assert(ndofs.size() == fe.n_blocks(), ExcInternalError());
 
   for (unsigned int l = 0; l < tr.n_levels(); ++l)
     DoFRenumbering::component_wise(mgdof, l);

--- a/tests/multigrid/transfer_block_select.cc
+++ b/tests/multigrid/transfer_block_select.cc
@@ -86,8 +86,8 @@ check_select(const FiniteElement<dim> &fe, unsigned int selected)
   mgdof.distribute_dofs(fe);
   mgdof.distribute_mg_dofs();
   DoFRenumbering::component_wise(mgdof);
-  vector<types::global_dof_index> ndofs(fe.n_blocks());
-  DoFTools::count_dofs_per_block(mgdof, ndofs);
+  const vector<types::global_dof_index> ndofs =
+    DoFTools::count_dofs_per_fe_block(mgdof);
 
   for (unsigned int l = 0; l < tr.n_levels(); ++l)
     DoFRenumbering::component_wise(mgdof, l);

--- a/tests/multigrid/transfer_compare_01.cc
+++ b/tests/multigrid/transfer_compare_01.cc
@@ -144,8 +144,8 @@ check_block(const FiniteElement<dim> &fe)
     }
 
   // Store sizes
-  vector<types::global_dof_index> ndofs(fe.n_blocks());
-  DoFTools::count_dofs_per_block(mgdof, ndofs);
+  const vector<types::global_dof_index> ndofs =
+    DoFTools::count_dofs_per_fe_block(mgdof);
   std::vector<std::vector<types::global_dof_index>> mg_ndofs(
     mgdof.get_triangulation().n_levels(),
     std::vector<types::global_dof_index>(fe.n_blocks()));

--- a/tests/multigrid/transfer_select.cc
+++ b/tests/multigrid/transfer_select.cc
@@ -59,9 +59,12 @@ check_select(const FiniteElement<dim> &fe,
   mgdof.distribute_dofs(fe);
   mgdof.distribute_mg_dofs();
   DoFRenumbering::component_wise(mgdof, target_component);
-  vector<types::global_dof_index> ndofs(
-    *std::max_element(target_component.begin(), target_component.end()) + 1);
-  DoFTools::count_dofs_per_component(mgdof, ndofs, true, target_component);
+  const vector<types::global_dof_index> ndofs =
+    DoFTools::count_dofs_per_fe_component(mgdof, true, target_component);
+  Assert(ndofs.size() ==
+           *std::max_element(target_component.begin(), target_component.end()) +
+             1,
+         ExcInternalError());
 
   for (unsigned int l = 0; l < tr.n_levels(); ++l)
     DoFRenumbering::component_wise(mgdof, l, mg_target_component);

--- a/tests/multigrid/transfer_system_05.cc
+++ b/tests/multigrid/transfer_system_05.cc
@@ -73,10 +73,8 @@ check(const FiniteElement<dim> &fe, const unsigned int selected_block)
                  block_component,
                  block_component);
 
-  std::vector<types::global_dof_index> dofs_per_block(3);
-  DoFTools::count_dofs_per_block(mg_dof_handler,
-                                 dofs_per_block,
-                                 block_component);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(mg_dof_handler, block_component);
   std::vector<std::vector<types::global_dof_index>> mg_dofs_per_block(
     tr.n_levels(), std::vector<types::global_dof_index>(3));
   MGTools::count_dofs_per_block(mg_dof_handler,

--- a/tests/multigrid/transfer_system_adaptive_09.cc
+++ b/tests/multigrid/transfer_system_adaptive_09.cc
@@ -119,10 +119,8 @@ check(const FiniteElement<dim> &fe, const unsigned int selected_block)
                  block_component,
                  block_component);
 
-  std::vector<types::global_dof_index> dofs_per_block(3);
-  DoFTools::count_dofs_per_block(mg_dof_handler,
-                                 dofs_per_block,
-                                 block_component);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(mg_dof_handler, block_component);
   std::vector<std::vector<types::global_dof_index>> mg_dofs_per_block(
     tr.n_levels(), std::vector<types::global_dof_index>(3));
   MGTools::count_dofs_per_block(mg_dof_handler,

--- a/tests/numerics/point_value_history_02.cc
+++ b/tests/numerics/point_value_history_02.cc
@@ -184,7 +184,7 @@ TestPointValueHistory<dim>::run()
 
   //            // BlockVector
   //        std::vector<unsigned int> dofs_per_block(2);
-  //        DoFTools::count_dofs_per_block(dof_handler, dofs_per_block,
+  //        DoFTools::count_dofs_per_fe_block(dof_handler, dofs_per_block,
   //        block_component); const unsigned int n_u = dofs_per_block[0],
   //                n_p = dofs_per_block[1];
   //        BlockVector<double> solution;

--- a/tests/optimization/step-44.h
+++ b/tests/optimization/step-44.h
@@ -1135,9 +1135,8 @@ namespace Step44
     dof_handler_ref.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
-    DoFTools::count_dofs_per_block(dof_handler_ref,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler_ref, block_component);
     std::cout << "Triangulation:"
               << "\n\t Number of active cells: "
               << triangulation.n_active_cells()

--- a/tests/physics/step-44-standard_tensors-material_push_forward.cc
+++ b/tests/physics/step-44-standard_tensors-material_push_forward.cc
@@ -1300,9 +1300,8 @@ namespace Step44
     dof_handler_ref.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
-    DoFTools::count_dofs_per_block(dof_handler_ref,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler_ref, block_component);
     pcout << "Triangulation:"
           << "\n\t Number of active cells: " << triangulation.n_active_cells()
           << "\n\t Number of degrees of freedom: " << dof_handler_ref.n_dofs()

--- a/tests/physics/step-44-standard_tensors-spatial.cc
+++ b/tests/physics/step-44-standard_tensors-spatial.cc
@@ -1100,9 +1100,8 @@ namespace Step44
     dof_handler_ref.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
-    DoFTools::count_dofs_per_block(dof_handler_ref,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler_ref, block_component);
     pcout << "Triangulation:"
           << "\n\t Number of active cells: " << triangulation.n_active_cells()
           << "\n\t Number of degrees of freedom: " << dof_handler_ref.n_dofs()

--- a/tests/physics/step-44.cc
+++ b/tests/physics/step-44.cc
@@ -1113,9 +1113,8 @@ namespace Step44
     dof_handler_ref.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
-    DoFTools::count_dofs_per_block(dof_handler_ref,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler_ref, block_component);
     pcout << "Triangulation:"
           << "\n\t Number of active cells: " << triangulation.n_active_cells()
           << "\n\t Number of degrees of freedom: " << dof_handler_ref.n_dofs()

--- a/tests/quick_tests/p4est.cc
+++ b/tests/quick_tests/p4est.cc
@@ -15,7 +15,7 @@
 
 
 
-// Test DoFTools::count_dofs_per_component
+// Test DoFTools::count_dofs_per_fe_component
 
 
 #include <deal.II/base/tensor.h>
@@ -54,15 +54,15 @@ test()
   triangulation.refine_global(2);
   dof_handler.distribute_dofs(fe);
 
-  std::vector<types::global_dof_index> dofs_per_component(fe.n_components());
-  DoFTools::count_dofs_per_component(dof_handler, dofs_per_component);
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   Assert(std::accumulate(dofs_per_component.begin(),
                          dofs_per_component.end(),
                          0U) == dof_handler.n_dofs(),
          ExcInternalError());
 
-  unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   if (myid == 0)
     {
       deallog << "Total number of dofs: " << dof_handler.n_dofs() << std::endl;

--- a/tests/trilinos/assemble_matrix_parallel_04.cc
+++ b/tests/trilinos/assemble_matrix_parallel_04.cc
@@ -289,8 +289,8 @@ LaplaceProblem<dim>::setup_system()
            relevant_total;
   DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_total);
 
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, blocks);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, blocks);
   locally_owned[0] = locally_owned_total.get_view(0, dofs_per_block[0]);
   locally_owned[1] =
     locally_owned_total.get_view(dofs_per_block[0], dof_handler.n_dofs());

--- a/tests/trilinos/assemble_matrix_parallel_06.cc
+++ b/tests/trilinos/assemble_matrix_parallel_06.cc
@@ -291,8 +291,8 @@ LaplaceProblem<dim>::setup_system()
            relevant_total;
   DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_total);
 
-  std::vector<types::global_dof_index> dofs_per_block(2);
-  DoFTools::count_dofs_per_block(dof_handler, dofs_per_block, blocks);
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dof_handler, blocks);
   locally_owned[0] = locally_owned_total.get_view(0, dofs_per_block[0]);
   locally_owned[1] =
     locally_owned_total.get_view(dofs_per_block[0], dof_handler.n_dofs());

--- a/tests/trilinos/trilinos_sparsity_pattern_02.cc
+++ b/tests/trilinos/trilinos_sparsity_pattern_02.cc
@@ -90,10 +90,8 @@ namespace Step22
     block_component[dim] = 1;
     DoFRenumbering::component_wise(dof_handler, block_component);
 
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler,
-                                   dofs_per_block,
-                                   block_component);
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
     const unsigned int n_u = dofs_per_block[0], n_p = dofs_per_block[1];
 
     {

--- a/tests/umfpack/umfpack_04.cc
+++ b/tests/umfpack/umfpack_04.cc
@@ -129,8 +129,8 @@ test()
 
   deallog << "Number of dofs = " << dof_handler.n_dofs() << std::endl;
 
-  std::vector<types::global_dof_index> size(dim);
-  DoFTools::count_dofs_per_component(dof_handler, size);
+  const std::vector<types::global_dof_index> size =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
 
   BlockSparsityPattern b_sparsity_pattern;
   SparsityPattern      sparsity_pattern;


### PR DESCRIPTION
I've deprecated a number of functions in `DoFTools` in recent patches, primarily ones that return their information through output arguments. Avoid their use in the library and in the tutorials.