### PR TITLE
Remove unused included file from step-6

### DIFF
--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -23,7 +23,6 @@
 // The first few files have already been covered in previous examples and will
 // thus not be further commented on.
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/function_lib.h>
 
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>


### PR DESCRIPTION
This closes #9424.

My understanding is that `function_lib.h` is a collection of specific `Function` definitions that may be useful for examples, but it is not required for step-6. step-6 only requires the `ZeroFunction`, which is defined in `function.h`.

We should test it just to be certain. :stuck_out_tongue: 