### PR TITLE
Update uses of compute() to evaluate()

### DIFF
--- a/include/deal.II/base/polynomial_space.h
+++ b/include/deal.II/base/polynomial_space.h
@@ -154,7 +154,7 @@ public:
    * Compute the value of the <tt>i</tt>th polynomial at unit point
    * <tt>p</tt>.
    *
-   * Consider using compute() instead.
+   * Consider using evaluate() instead.
    */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const;
@@ -163,7 +163,7 @@ public:
    * Compute the <tt>order</tt>th derivative of the <tt>i</tt>th polynomial
    * at unit point <tt>p</tt>.
    *
-   * Consider using compute() instead.
+   * Consider using evaluate() instead.
    *
    * @tparam order The order of the derivative.
    */
@@ -175,7 +175,7 @@ public:
    * Compute the gradient of the <tt>i</tt>th polynomial at unit point
    * <tt>p</tt>.
    *
-   * Consider using compute() instead.
+   * Consider using evaluate() instead.
    */
   Tensor<1, dim>
   compute_grad(const unsigned int i, const Point<dim> &p) const;
@@ -184,7 +184,7 @@ public:
    * Compute the second derivative (grad_grad) of the <tt>i</tt>th polynomial
    * at unit point <tt>p</tt>.
    *
-   * Consider using compute() instead.
+   * Consider using evaluate() instead.
    */
   Tensor<2, dim>
   compute_grad_grad(const unsigned int i, const Point<dim> &p) const;

--- a/include/deal.II/base/polynomials_adini.h
+++ b/include/deal.II/base/polynomials_adini.h
@@ -61,15 +61,15 @@ public:
    */
 
   void
-  compute(const Point<2> &           unit_point,
-          std::vector<double> &      values,
-          std::vector<Tensor<1, 2>> &grads,
-          std::vector<Tensor<2, 2>> &grad_grads) const;
+  evaluate(const Point<2> &           unit_point,
+           std::vector<double> &      values,
+           std::vector<Tensor<1, 2>> &grads,
+           std::vector<Tensor<2, 2>> &grad_grads) const;
 
   /**
    * Compute the value of the <tt>i</tt>th polynomial at <tt>unit_point</tt>.
    *
-   * Consider using compute() instead.
+   * Consider using evaluate() instead.
    */
 
   double
@@ -79,7 +79,7 @@ public:
    * Compute the gradient of the <tt>i</tt>th polynomial at
    * <tt>unit_point</tt>.
    *
-   * Consider using compute() instead.
+   * Consider using evaluate() instead.
    */
 
   Tensor<1, 2>
@@ -88,7 +88,7 @@ public:
    * Compute the second derivative (grad_grad) of the <tt>i</tt>th polynomial
    * at <tt>unit_point</tt>.
    *
-   * Consider using compute() instead.
+   * Consider using evaluate() instead.
    */
 
   Tensor<2, 2>

--- a/include/deal.II/base/polynomials_rannacher_turek.h
+++ b/include/deal.II/base/polynomials_rannacher_turek.h
@@ -63,7 +63,7 @@ public:
   /**
    * <tt>order</tt>-th of basis function @p i at @p p.
    *
-   * Consider using compute() instead.
+   * Consider using evaluate() instead.
    */
   template <int order>
   Tensor<order, dim>

--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -142,7 +142,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each point value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function with
+   * several times.  Instead use the evaluate() function with
    * <tt>values.size()==</tt>n() to get the point values of all tensor
    * polynomials all at once and in a much more efficient way.
    */
@@ -157,7 +157,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each derivative value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function, see above, with the
+   * several times.  Instead use the evaluate() function, see above, with the
    * size of the appropriate parameter set to n() to get the point value of
    * all tensor polynomials all at once and in a much more efficient way.
    *
@@ -175,7 +175,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each derivative value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function, see above, with
+   * several times.  Instead use the evaluate() function, see above, with
    * <tt>grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
    */
@@ -190,7 +190,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each derivative value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function, see above, with
+   * several times.  Instead use the evaluate() function, see above, with
    * <tt>grad_grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
    */
@@ -350,7 +350,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each derivative value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function, see above, with the
+   * several times.  Instead use the evaluate() function, see above, with the
    * size of the appropriate parameter set to n() to get the point value of
    * all tensor polynomials all at once and in a much more efficient way.
    *

--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -115,7 +115,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each point value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function with
+   * several times.  Instead use the evaluate() function with
    * <tt>values.size()==</tt>n() to get the point values of all tensor
    * polynomials all at once and in a much more efficient way.
    */
@@ -130,7 +130,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each derivative value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function, see above, with the
+   * several times.  Instead use the evaluate() function, see above, with the
    * size of the appropriate parameter set to n() to get the point value of
    * all tensor polynomials all at once and in a much more efficient way.
    */
@@ -146,7 +146,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each derivative value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function, see above, with
+   * several times.  Instead use the evaluate() function, see above, with
    * <tt>grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
    */
@@ -161,7 +161,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each derivative value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function, see above, with
+   * several times.  Instead use the evaluate() function, see above, with
    * <tt>grad_grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
    */

--- a/include/deal.II/base/tensor_product_polynomials_const.h
+++ b/include/deal.II/base/tensor_product_polynomials_const.h
@@ -116,7 +116,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each point value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function with
+   * several times.  Instead use the evaluate() function with
    * <tt>values.size()==</tt>n() to get the point values of all tensor
    * polynomials all at once and in a much more efficient way.
    */
@@ -131,7 +131,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each derivative value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function, see above, with the
+   * several times.  Instead use the evaluate() function, see above, with the
    * size of the appropriate parameter set to n() to get the point value of
    * all tensor polynomials all at once and in a much more efficient way.
    *
@@ -149,7 +149,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each derivative value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function, see above, with
+   * several times.  Instead use the evaluate() function, see above, with
    * <tt>grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
    */
@@ -164,7 +164,7 @@ public:
    * Note, that using this function within a loop over all tensor product
    * polynomials is not efficient, because then each derivative value of the
    * underlying (one-dimensional) polynomials is (unnecessarily) computed
-   * several times.  Instead use the compute() function, see above, with
+   * several times.  Instead use the evaluate() function, see above, with
    * <tt>grad_grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
    */

--- a/source/base/polynomials_adini.cc
+++ b/source/base/polynomials_adini.cc
@@ -126,10 +126,10 @@ PolynomialsAdini::PolynomialsAdini()
 }
 
 void
-PolynomialsAdini::compute(const Point<2> &           unit_point,
-                          std::vector<double> &      values,
-                          std::vector<Tensor<1, 2>> &grads,
-                          std::vector<Tensor<2, 2>> &grad_grads) const
+PolynomialsAdini::evaluate(const Point<2> &           unit_point,
+                           std::vector<double> &      values,
+                           std::vector<Tensor<1, 2>> &grads,
+                           std::vector<Tensor<2, 2>> &grad_grads) const
 {
   if (values.empty() == false) // do not bother if empty
     {


### PR DESCRIPTION
There are a few places where polynomial classes refer to `compute()` instead of `evaluate()`.

`PolynomialsAdini` had a method named `compute()` still, and the remaining classes referred to `compute()` instead of `evaluate()` in their documentation. This should be cleaned up now.

Related to #8619, #1973, and probably some others that I can't think of at the moment.