### PR TITLE
Add ParameterHandler::subsection_path_exists

### DIFF
--- a/doc/news/changes/minor/20200129PasqualeClaudioAfrica
+++ b/doc/news/changes/minor/20200129PasqualeClaudioAfrica
@@ -1,0 +1,3 @@
+New: added ParameterHandler::subsection_path_exists() method.
+<br>
+(Pasquale Claudio Africa, 2020/01/29)

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1192,6 +1192,14 @@ public:
   leave_subsection();
 
   /**
+   * Check whether a subsection or a subsection path exists in current tree.
+   * The input parameter @p sub_path is assumed to be relative to the
+   * currently selected path.
+   */
+  bool
+  subsection_path_exists(const std::vector<std::string> &sub_path) const;
+
+  /**
    * Return value of entry @p entry_string.  If the entry was changed,
    * then the changed value is returned, otherwise the default value. If the
    * value of an undeclared entry is required, an @p Assert will fail.

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -825,6 +825,27 @@ ParameterHandler::leave_subsection()
 
 
 
+bool
+ParameterHandler::subsection_path_exists(
+  const std::vector<std::string> &sub_path) const
+{
+  // Get full path to sub_path (i.e. prepend subsection_path to sub_path).
+  std::vector<std::string> full_path(subsection_path);
+  full_path.insert(full_path.end(), sub_path.begin(), sub_path.end());
+
+  boost::optional<const boost::property_tree::ptree &> subsection(
+    entries->get_child_optional(
+      collate_path_string(path_separator, full_path)));
+
+  // If subsection is boost::null (i.e. it does not exist)
+  // or it exists as a parameter/alias node, return false.
+  // Otherwise (i.e. it exists as a subsection node), return true.
+  return !(!subsection || is_parameter_node(subsection.get()) ||
+           is_alias_node(subsection.get()));
+}
+
+
+
 std::string
 ParameterHandler::get(const std::string &entry_string) const
 {

--- a/tests/parameter_handler/parameter_handler_subsection_exists.cc
+++ b/tests/parameter_handler/parameter_handler_subsection_exists.cc
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test ParameterHandler::subsection_path_exists().
+
+#include <deal.II/base/parameter_handler.h>
+
+#include <iomanip>
+
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  ParameterHandler prm;
+  prm.enter_subsection("Section 1");
+  {
+    prm.declare_entry("string list",
+                      "a",
+                      Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")),
+                      "docs 1");
+    prm.declare_entry("int", "1", Patterns::Integer());
+    prm.declare_entry("double", "3.1415926", Patterns::Double(), "docs 3");
+  }
+  prm.leave_subsection();
+
+  prm.enter_subsection("Section 2");
+  {
+    prm.declare_entry("int", "1", Patterns::Integer());
+    prm.declare_entry("double", "3.1415926", Patterns::Double(), "docs 3");
+
+    prm.enter_subsection("string list");
+    {
+      prm.declare_entry("string list",
+                        "a",
+                        Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")),
+                        "docs 1");
+    }
+    prm.leave_subsection();
+  }
+  prm.leave_subsection();
+
+  prm.print_parameters(deallog.get_file_stream(),
+                       ParameterHandler::Text,
+                       false);
+
+  deallog << std::boolalpha;
+  deallog << "Subsection \"Section 3\" of root exists: "
+          << prm.subsection_path_exists({"Section 3"}) << std::endl;
+  deallog << "Subsection \"Section 1.string list\" of root exists: "
+          << prm.subsection_path_exists({"Section 1", "string list"})
+          << std::endl;
+
+  deallog << "Subsection \"Section 2.string list\" of root exists: "
+          << prm.subsection_path_exists({"Section 2", "string list"})
+          << std::endl;
+
+  prm.enter_subsection("Section 2");
+  {
+    deallog << "Subsection \"string list\" of \"Section 2\" exists: "
+            << prm.subsection_path_exists({"string list"}) << std::endl;
+  }
+  prm.leave_subsection();
+
+  deallog
+    << "Subsection \"Section 2.string list\" still exists after coming back to root: "
+    << prm.subsection_path_exists({"Section 2", "string list"}) << std::endl;
+
+  return 0;
+}

--- a/tests/parameter_handler/parameter_handler_subsection_exists.output
+++ b/tests/parameter_handler/parameter_handler_subsection_exists.output
@@ -1,0 +1,32 @@
+
+# Listing of Parameters
+# ---------------------
+subsection Section 1
+  # docs 1
+  set string list = a
+  set int         = 1
+
+  # docs 3
+  set double      = 3.1415926
+end
+
+
+subsection Section 2
+  set int    = 1
+  # docs 3
+  set double = 3.1415926
+
+
+  subsection string list
+    # docs 1
+    set string list = a
+  end
+
+end
+
+
+DEAL::Subsection "Section 3" of root exists: false
+DEAL::Subsection "Section 1.string list" of root exists: false
+DEAL::Subsection "Section 2.string list" of root exists: true
+DEAL::Subsection "string list" of "Section 2" exists: true
+DEAL::Subsection "Section 2.string list" still exists after coming back to root: true


### PR DESCRIPTION
This adds a new `ParameterHandler` method to check whether a subsection path has been declared in the current tree.

I needed such a functionality for my application, if you also find it relevant I can implement a small test.