### PR TITLE
Add ParameterHandler::declare_entry flag to append pattern description to entry documentation

### DIFF
--- a/doc/news/changes/minor/20200129PasqualeClaudioAfrica
+++ b/doc/news/changes/minor/20200129PasqualeClaudioAfrica
@@ -1,0 +1,4 @@
+New: ParameterHandler::declare_entry() can now optionally append
+the pattern description along with the entry documentation.
+<br>
+(Pasquale Claudio Africa, 2020/01/29)

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2019 by the deal.II authors
+// Copyright (C) 1998 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -1046,10 +1046,15 @@ public:
    * Declare a new entry with name <tt>entry</tt>, default and for which any
    * input has to match the <tt>pattern</tt> (default: any pattern).
    *
-   * The last parameter defaulting to an empty string is used to add a
+   * The parameter @p documentation defaulting to an empty string is used to add a
    * documenting text to each entry which will be printed as a comment when
    * this class is asked to write out all declarations to a stream using the
    * print_parameters() function.
+   *
+   * The last optional argument allows to append the pattern description
+   * to the provided documentation. In this way, the print_parameters() method
+   * will print information on the admissible values along with the entry
+   * documentation.
    *
    * The function generates an exception of type ExcValueDoesNotMatchPattern
    * if the default value doesn't match the given pattern, using the C++ throw
@@ -1065,7 +1070,8 @@ public:
   declare_entry(const std::string &          entry,
                 const std::string &          default_value,
                 const Patterns::PatternBase &pattern = Patterns::Anything(),
-                const std::string &          documentation = "");
+                const std::string &          documentation = "",
+                const bool document_pattern_description    = false);
 
   /**
    * Attach an action to the parameter with name @p entry in the current

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2019 by the deal.II authors
+// Copyright (C) 1998 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -605,14 +605,27 @@ void
 ParameterHandler::declare_entry(const std::string &          entry,
                                 const std::string &          default_value,
                                 const Patterns::PatternBase &pattern,
-                                const std::string &          documentation)
+                                const std::string &          documentation,
+                                const bool document_pattern_description)
 {
   entries->put(get_current_full_path(entry) + path_separator + "value",
                default_value);
   entries->put(get_current_full_path(entry) + path_separator + "default_value",
                default_value);
+
+  std::string doc(documentation);
+
+  // Append pattern description to documentation, if needed.
+  if (document_pattern_description)
+    {
+      if (!doc.empty())
+        doc += "\n";
+
+      doc += pattern.description(Patterns::PatternBase::Text);
+    }
+
   entries->put(get_current_full_path(entry) + path_separator + "documentation",
-               documentation);
+               doc);
 
   patterns.reserve(patterns.size() + 1);
   patterns.emplace_back(pattern.clone());

--- a/tests/parameter_handler/parameter_handler_3_with_documented_pattern.cc
+++ b/tests/parameter_handler/parameter_handler_3_with_documented_pattern.cc
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// like _3, but test the "declare_entry()" method with
+// "document_pattern_description" parameter enabled.
+
+#include <deal.II/base/parameter_handler.h>
+
+#include "../tests.h"
+
+
+int
+main()
+{
+  try
+    {
+      initlog();
+
+      ParameterHandler prm;
+      prm.enter_subsection("Testing");
+      prm.declare_entry("string list",
+                        "a",
+                        Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")),
+                        "docs 1",
+                        true);
+      prm.declare_entry("int", "1", Patterns::Integer(), "", true);
+      prm.declare_entry(
+        "double", "3.1415926", Patterns::Double(), "docs 3", true);
+      prm.leave_subsection();
+
+      // read and then write parameters
+      prm.parse_input(SOURCE_DIR "/prm/parameter_handler_3.prm");
+      prm.print_parameters(deallog.get_file_stream(), ParameterHandler::Text);
+    }
+  catch (std::exception &exc)
+    {
+      deallog << std::endl
+              << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      deallog << "Exception on processing: " << std::endl
+              << exc.what() << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      deallog << std::endl
+              << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      deallog << "Unknown exception!" << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      return 1;
+    };
+
+  return 0;
+}

--- a/tests/parameter_handler/parameter_handler_3_with_documented_pattern.output
+++ b/tests/parameter_handler/parameter_handler_3_with_documented_pattern.output
@@ -1,0 +1,18 @@
+
+# Listing of Parameters
+# ---------------------
+subsection Testing
+  # docs 3
+  # A floating point number v such that -MAX_DOUBLE <= v <= MAX_DOUBLE
+  set double      = 3.1415926
+
+  # An integer n such that -2147483648 <= n <= 2147483647
+  set int         = 3         # default: 1
+
+  # docs 1
+  # A list of 0 to 4294967295 elements where each element is [Any one of a, b,
+  # c, d, e, f, g, h]
+  set string list = a, b, c   # default: a
+end
+
+


### PR DESCRIPTION
Another small modification to the `ParameterHandler` class that allows to attach the pattern description to documentation entries through an optional input to the `declare_entry()` method.

This can be useful to print the admissible values along with the parameter documentation.

A small test has also been implemented.