### PR TITLE
Update GridGenerator::half_hyper_shell documentation for correctness

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1126,7 +1126,9 @@ namespace GridGenerator
    *
    * If colorize is set to <code>true</code>, the inner, outer, and the part
    * of the boundary where $x=0$, get indicator 0, 1, and 2,
-   * respectively. Otherwise all indicators are set to 0 (see
+   * respectively. Additionally, in 2d, the boundary indicator 3 is given to
+   * the vertical edge below the x-axis. Otherwise, if colorize is set to
+   * <code>false</code> all indicators are set to 0 (see
    * @ref GlossColorization "the glossary entry on colorization").
    *
    * All manifold ids are set to zero, and a SphericalManifold is attached

--- a/tests/grid/grid_generator_half_hyper_shell.cc
+++ b/tests/grid/grid_generator_half_hyper_shell.cc
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2005 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Test boundary ids for GridGenerator::half_hyper_shell()
+
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+dim_test()
+{
+  Triangulation<dim> tr;
+  double             r_inner = 1.;
+  double             r_outer = 2.;
+
+  GridGenerator::half_hyper_shell(tr, Point<dim>(), r_inner, r_outer, 0, true);
+
+  typename Triangulation<dim>::cell_iterator cell = tr.begin();
+
+  for (; cell != tr.end(); ++cell)
+    {
+      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        {
+          if (cell->face(f)->at_boundary())
+            deallog << "half_hyper_shell<" << dim << ">:: cell "
+                    << cell->index() << ", face " << f << ", id "
+                    << cell->face(f)->boundary_id() << std::endl;
+        }
+    }
+}
+
+
+int
+main()
+{
+  initlog();
+
+  dim_test<2>();
+  dim_test<3>();
+}

--- a/tests/grid/grid_generator_half_hyper_shell.output
+++ b/tests/grid/grid_generator_half_hyper_shell.output
@@ -1,0 +1,27 @@
+
+DEAL::half_hyper_shell<2>:: cell 0, face 0, id 3
+DEAL::half_hyper_shell<2>:: cell 0, face 2, id 1
+DEAL::half_hyper_shell<2>:: cell 0, face 3, id 0
+DEAL::half_hyper_shell<2>:: cell 1, face 2, id 1
+DEAL::half_hyper_shell<2>:: cell 1, face 3, id 0
+DEAL::half_hyper_shell<2>:: cell 2, face 2, id 1
+DEAL::half_hyper_shell<2>:: cell 2, face 3, id 0
+DEAL::half_hyper_shell<2>:: cell 3, face 2, id 1
+DEAL::half_hyper_shell<2>:: cell 3, face 3, id 0
+DEAL::half_hyper_shell<2>:: cell 4, face 1, id 2
+DEAL::half_hyper_shell<2>:: cell 4, face 2, id 1
+DEAL::half_hyper_shell<2>:: cell 4, face 3, id 0
+DEAL::half_hyper_shell<3>:: cell 0, face 2, id 2
+DEAL::half_hyper_shell<3>:: cell 0, face 4, id 0
+DEAL::half_hyper_shell<3>:: cell 0, face 5, id 0
+DEAL::half_hyper_shell<3>:: cell 1, face 0, id 0
+DEAL::half_hyper_shell<3>:: cell 1, face 1, id 0
+DEAL::half_hyper_shell<3>:: cell 1, face 2, id 2
+DEAL::half_hyper_shell<3>:: cell 2, face 2, id 2
+DEAL::half_hyper_shell<3>:: cell 2, face 4, id 0
+DEAL::half_hyper_shell<3>:: cell 2, face 5, id 0
+DEAL::half_hyper_shell<3>:: cell 3, face 0, id 0
+DEAL::half_hyper_shell<3>:: cell 3, face 1, id 0
+DEAL::half_hyper_shell<3>:: cell 3, face 2, id 2
+DEAL::half_hyper_shell<3>:: cell 4, face 0, id 1
+DEAL::half_hyper_shell<3>:: cell 4, face 1, id 0


### PR DESCRIPTION
This closes #9442

Only in 2d, we additionally use the boundary indicator 3 for the edge on the bottom half of the HHS.
In 2d, the indicators are 0 for the inner circle, 1 for the outer circle, 2 for the vertical edge on the top half, and 3 for the vertical edge on the bottom half.