### PR TITLE
Avoid an internal compiler error in gcc 7.4.0.

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1795,6 +1795,10 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                            const bool         ext,
                            const bool         flag) {
                     (void)v;
+                    // The following statement could be simplified
+                    // using AssertIndexRange, but that leads to an
+                    // internal compiler error with GCC 7.4. Do things
+                    // by hand instead.
                     Assert(
                       face_info.faces[f].cells_interior[v] <
                         n_macro_cells_before *

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1794,6 +1794,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                            const unsigned int v,
                            const bool         ext,
                            const bool         flag) {
+                    (void)v;
                     Assert(
                       face_info.faces[f].cells_interior[v] <
                         n_macro_cells_before *

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1794,9 +1794,14 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                            const unsigned int v,
                            const bool         ext,
                            const bool         flag) {
-                    AssertIndexRange(face_info.faces[f].cells_interior[v],
-                                     n_macro_cells_before *
-                                       VectorizedArrayType::n_array_elements);
+                    Assert(
+                      face_info.faces[f].cells_interior[v] <
+                        n_macro_cells_before *
+                          VectorizedArrayType::n_array_elements,
+                      ExcIndexRange(face_info.faces[f].cells_interior[v],
+                                    0,
+                                    n_macro_cells_before *
+                                      VectorizedArrayType::n_array_elements));
                     if (flag ||
                         (di.index_storage_variants
                              [ext ? internal::MatrixFreeFunctions::DoFInfo::


### PR DESCRIPTION
Why that happens is not clear to me, but a simple replacement of assertions does the trick to get me going again...