### PR TITLE
Fix SymmetricTensor and Tensor ProductType

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -72,6 +72,24 @@ DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE Number
 
 namespace internal
 {
+  template <int rank, int dim, typename T, typename U>
+  struct ProductTypeImpl<SymmetricTensor<rank, dim, T>, std::complex<U>>
+  {
+    using type =
+      SymmetricTensor<rank,
+                      dim,
+                      std::complex<typename ProductType<T, U>::type>>;
+  };
+
+  template <typename T, int rank, int dim, typename U>
+  struct ProductTypeImpl<std::complex<T>, SymmetricTensor<rank, dim, U>>
+  {
+    using type =
+      SymmetricTensor<rank,
+                      dim,
+                      std::complex<typename ProductType<T, U>::type>>;
+  };
+
   /**
    * A namespace for functions and classes that are internal to how the
    * SymmetricTensor class (and its associate functions) works.

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -755,6 +755,20 @@ private:
 
 namespace internal
 {
+  template <int rank, int dim, typename T, typename U>
+  struct ProductTypeImpl<Tensor<rank, dim, T>, std::complex<U>>
+  {
+    using type =
+      Tensor<rank, dim, std::complex<typename ProductType<T, U>::type>>;
+  };
+
+  template <typename T, int rank, int dim, typename U>
+  struct ProductTypeImpl<std::complex<T>, Tensor<rank, dim, U>>
+  {
+    using type =
+      Tensor<rank, dim, std::complex<typename ProductType<T, U>::type>>;
+  };
+
   /**
    * The structs below are needed to initialize nested Tensor objects.
    * Also see numbers.h for another specialization.


### PR DESCRIPTION
I ran into an issue building master with my super old compiler that desperately needs to be updated. 
```
In file included from <path>/deal.II/dealii/source/fe/fe_values.cc:16:
In file included from <path>/deal.II/dealii/include/deal.II/base/array_view.h:23:
In file included from <path>/deal.II/dealii/include/deal.II/base/symmetric_tensor.h:24:
<path>/deal.II/dealii/include/deal.II/base/template_constraints.h:426:71: error: no type named 'type' in 'dealii::internal::ProductTypeImpl<std::__1::complex<double>, dealii::SymmetricTensor<2, 1, double> >'
                                       typename std::decay<U>::type>::type;
                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
<path>/deal.II/dealii/include/deal.II/base/complex_overloads.h:79:36: note: in instantiation of template class 'dealii::ProductType<std::__1::complex<double>, dealii::SymmetricTensor<2, 1, double> >' requested here
                          typename ProductType<std::complex<T>, U>::type>::type
                                   ^
<path>/deal.II/dealii/include/deal.II/base/template_constraints.h:366:45: note: while substituting deduced template arguments into function template 'operator*'
      [with T = double, U = dealii::SymmetricTensor<2, 1, double>]
    using type = decltype(std::declval<T>() * std::declval<U>());
                                            ^
<path>/deal.II/dealii/include/deal.II/base/template_constraints.h:425:24: note: in instantiation of template class 'dealii::internal::ProductTypeImpl<std::__1::complex<double>, dealii::SymmetricTensor<2, 1, double> >'
      requested here
    typename internal::ProductTypeImpl<typename std::decay<T>::type,
                       ^
<path>/deal.II/dealii/source/fe/fe_values.cc:1176:18: note: in instantiation of template class 'dealii::ProductType<const std::__1::complex<double>, dealii::SymmetricTensor<2, 1, double> >' requested here
        typename ProductType<Number,
                 ^
<path>/deal.II/dealii/source/fe/fe_values.cc:1614:5: note: while substituting deduced template arguments into function template 'do_function_values' [with dim = 1, spacedim = 1, Number = const std::__1::complex<double>]
    internal::do_function_values<dim, spacedim>(
    ^
<path>/deal.II/dealii/build/source/fe/fe_values.inst:36274:2: note: in instantiation of function template specialization 'dealii::FEValuesViews::Scalar<1,
      1>::get_function_values_from_local_dof_values<std::__1::vector<std::__1::complex<double>, std::__1::allocator<std::__1::complex<double> > > >' requested here
 get_function_values_from_local_dof_values< std::vector < std::complex<double> >>(
 ^
....
```
So this PR fixes a compiler error on the old Apple Clang 8.0.0 compiler, where the product type between complex numbers and tensors could not be determined.