### PR TITLE
improve FunctionMap deprecation message

### DIFF
--- a/include/deal.II/dofs/deprecated_function_map.h
+++ b/include/deal.II/dofs/deprecated_function_map.h
@@ -79,7 +79,9 @@ struct DEAL_II_DEPRECATED FunctionMap
    * (as that would ambiguate a possible constructor of this class), name it
    * in the fashion of the standard container local alias.
    *
-   * @deprecated Use the alias type directly.
+   * @deprecated Directly use the type
+   * <tt>std::map<types::boundary_id, const Function<dim, Number> *></tt>
+   * in your code instead of this alias.
    */
   using type DEAL_II_DEPRECATED =
     std::map<types::boundary_id, const Function<dim, Number> *>;

--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -101,11 +101,12 @@ namespace hp
    * @code
    * // step 1: flag cells for refinement or coarsening
    * Vector<float> estimated_error_per_cell (triangulation.n_active_cells());
-   * KellyErrorEstimator<dim>::estimate(hp_dof_handler,
-   *                                    QGauss<dim-1> (quadrature_points),
-   *                                    typename FunctionMap<dim>::type(),
-   *                                    solution,
-   *                                    estimated_error_per_cell);
+   * KellyErrorEstimator<dim>::estimate(
+   *     hp_dof_handler,
+   *     QGauss<dim-1> (quadrature_points),
+   *     std::map<types::boundary_id, const Function<dim, Number> *>(),
+   *     solution,
+   *     estimated_error_per_cell);
    * GridRefinement::refine_and_coarsen_fixed_fraction(triangulation,
    *                                                   estimated_error_per_cell,
    *                                                   top_fraction,


### PR DESCRIPTION
I was confused by this help message and decided to clarify. Also fix one
occurrence of FunctionMap in a code example.