### PR TITLE
Revert introduction of deprecated functions.

### DIFF
--- a/doc/news/changes/minor/20200205Bangerth
+++ b/doc/news/changes/minor/20200205Bangerth
@@ -1,0 +1,6 @@
+Removed: The DataOutBase namespace contained a number of `write_*`
+functions that had already been deprecated in deal.II 9.1. These were
+removed, but all were of mostly internal interest and unlikely to be
+used in user programs.
+<br>
+(Wolfgang Bangerth, 2020/02/05)

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1625,20 +1625,6 @@ namespace DataOutBase
     hdf5
   };
 
-  /**
-   * Write the given list of patches to the output stream in OpenDX format.
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_dx(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &            nonscalar_data_ranges,
-    const DXFlags &flags,
-    std::ostream & out);
 
   /**
    * Write the given list of patches to the output stream in OpenDX format.
@@ -1656,38 +1642,6 @@ namespace DataOutBase
       &            nonscalar_data_ranges,
     const DXFlags &flags,
     std::ostream & out);
-
-  /**
-   * Write the given list of patches to the output stream in eps format.
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int spacedim>
-  DEAL_II_DEPRECATED void
-  write_eps(
-    const std::vector<Patch<2, spacedim>> &patches,
-    const std::vector<std::string> &       data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const EpsFlags &flags,
-    std::ostream &  out);
-
-  /**
-   * This is the same function as above except for domains that are not two-
-   * dimensional. This function is not implemented (and will throw an error if
-   * called) but is declared to allow for dimension-independent programs.
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_eps(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const EpsFlags &flags,
-    std::ostream &  out);
 
   /**
    * Write the given list of patches to the output stream in eps format.
@@ -1751,23 +1705,6 @@ namespace DataOutBase
    * This is the same function as above except for domains that are not two-
    * dimensional. This function is not implemented (and will throw an error if
    * called) but is declared to allow for dimension-independent programs.
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_eps(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const EpsFlags &flags,
-    std::ostream &  out);
-
-  /**
-   * This is the same function as above except for domains that are not two-
-   * dimensional. This function is not implemented (and will throw an error if
-   * called) but is declared to allow for dimension-independent programs.
    */
   template <int dim, int spacedim>
   void
@@ -1783,20 +1720,6 @@ namespace DataOutBase
     const EpsFlags &flags,
     std::ostream &  out);
 
-  /**
-   * Write the given list of patches to the output stream in GMV format.
-   *
-   *@deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_gmv(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const GmvFlags &flags,
-    std::ostream &  out);
 
   /**
    * Write the given list of patches to the output stream in GMV format.
@@ -1820,21 +1743,6 @@ namespace DataOutBase
       &             nonscalar_data_ranges,
     const GmvFlags &flags,
     std::ostream &  out);
-
-  /**
-   * Write the given list of patches to the output stream in gnuplot format.
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_gnuplot(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                 nonscalar_data_ranges,
-    const GnuplotFlags &flags,
-    std::ostream &      out);
 
   /**
    * Write the given list of patches to the output stream in gnuplot format.
@@ -1910,22 +1818,6 @@ namespace DataOutBase
    * Write the given list of patches to the output stream for the Povray
    * raytracer.
    *
-   *@deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_povray(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                nonscalar_data_ranges,
-    const PovrayFlags &flags,
-    std::ostream &     out);
-
-  /**
-   * Write the given list of patches to the output stream for the Povray
-   * raytracer.
-   *
    * Output in this format creates a povray source file, include standard
    * camera and light source definition for rendering with povray 3.1 At
    * present, this format only supports output for two-dimensional data, with
@@ -1986,24 +1878,6 @@ namespace DataOutBase
    * format (FEBLOCK).
    *
    * For more information consult the Tecplot Users and Reference manuals.
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_tecplot(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                 nonscalar_data_ranges,
-    const TecplotFlags &flags,
-    std::ostream &      out);
-
-  /**
-   * Write the given list of patches to the output stream in Tecplot ASCII
-   * format (FEBLOCK).
-   *
-   * For more information consult the Tecplot Users and Reference manuals.
    */
   template <int dim, int spacedim>
   void
@@ -2015,22 +1889,6 @@ namespace DataOutBase
                  unsigned int,
                  std::string,
                  DataComponentInterpretation::DataComponentInterpretation>>
-      &                 nonscalar_data_ranges,
-    const TecplotFlags &flags,
-    std::ostream &      out);
-
-  /**
-   * Write the given list of patches to the output stream in Tecplot binary
-   * format.
-   *
-   * @deprecated Using Tecplot binary output is deprecated.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_tecplot_binary(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
       &                 nonscalar_data_ranges,
     const TecplotFlags &flags,
     std::ostream &      out);
@@ -2072,22 +1930,6 @@ namespace DataOutBase
 
   /**
    * Write the given list of patches to the output stream in UCD format
-   * described in the AVS developer's guide (now AVS).
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_ucd(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const UcdFlags &flags,
-    std::ostream &  out);
-
-  /**
-   * Write the given list of patches to the output stream in UCD format
    * described in the AVS developer's guide (now AVS). Due to limitations in
    * the present format, only node based data can be output, which in one
    * reason why we invented the patch concept. In order to write higher order
@@ -2112,23 +1954,6 @@ namespace DataOutBase
                  DataComponentInterpretation::DataComponentInterpretation>>
       &             nonscalar_data_ranges,
     const UcdFlags &flags,
-    std::ostream &  out);
-
-  /**
-   * Write the given list of patches to the output stream in VTK format. The
-   * data is written in the traditional VTK format as opposed to the XML-based
-   * format that write_vtu() produces.
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_vtk(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const VtkFlags &flags,
     std::ostream &  out);
 
   /**
@@ -2164,22 +1989,6 @@ namespace DataOutBase
     const VtkFlags &flags,
     std::ostream &  out);
 
-  /**
-   * Write the given list of patches to the output stream in VTU format. The
-   * data is written in the XML-based VTK format as opposed to the traditional
-   * format that write_vtk() produces.
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_vtu(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const VtkFlags &flags,
-    std::ostream &  out);
 
   /**
    * Write the given list of patches to the output stream in VTU format. The
@@ -2240,24 +2049,6 @@ namespace DataOutBase
    * routine is used internally together with
    * DataOutInterface::write_vtu_header() and
    * DataOutInterface::write_vtu_footer() by DataOutBase::write_vtu().
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_vtu_main(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const VtkFlags &flags,
-    std::ostream &  out);
-
-  /**
-   * This function writes the main part for the xml based vtu file format. This
-   * routine is used internally together with
-   * DataOutInterface::write_vtu_header() and
-   * DataOutInterface::write_vtu_footer() by DataOutBase::write_vtu().
    */
   template <int dim, int spacedim>
   void
@@ -2272,25 +2063,6 @@ namespace DataOutBase
       &             nonscalar_data_ranges,
     const VtkFlags &flags,
     std::ostream &  out);
-
-  /**
-   * Some visualization programs, such as ParaView, can read several separate
-   * VTU files that all form part of the same simulation, in order to
-   * parallelize visualization. In that case, you need a
-   * <code>.pvtu</code> file that describes which VTU files (written, for
-   * example, through the DataOutInterface::write_vtu() function) form a group.
-   * The current function can generate such a master record.
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  DEAL_II_DEPRECATED
-  void
-  write_pvtu_record(
-    std::ostream &                  out,
-    const std::vector<std::string> &piece_names,
-    const std::vector<std::string> &data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &nonscalar_data_ranges);
 
   /**
    * Some visualization programs, such as ParaView, can read several separate
@@ -2487,21 +2259,6 @@ namespace DataOutBase
   /**
    * Write the given list of patches to the output stream in SVG format.
    *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int spacedim>
-  DEAL_II_DEPRECATED void
-  write_svg(
-    const std::vector<Patch<2, spacedim>> &patches,
-    const std::vector<std::string> &       data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const SvgFlags &flags,
-    std::ostream &  out);
-
-  /**
-   * Write the given list of patches to the output stream in SVG format.
-   *
    * SVG (Scalable Vector Graphics) is an XML-based vector image format
    * developed and maintained by the World Wide Web Consortium (W3C). This
    * function conforms to the latest specification SVG 1.1, released on August
@@ -2532,27 +2289,6 @@ namespace DataOutBase
       &             nonscalar_data_ranges,
     const SvgFlags &flags,
     std::ostream &  out);
-
-  /**
-   * Write the given list of patches to the output stream in deal.II
-   * intermediate format. This is not a format understood by any other
-   * graphics program, but is rather a direct dump of the intermediate
-   * internal format used by deal.II. This internal format is generated by the
-   * various classes that can generate output using the DataOutBase class, for
-   * example from a finite element solution, and is then converted in the
-   * present class to the final graphics format.
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_deal_II_intermediate(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                              nonscalar_data_ranges,
-    const Deal_II_IntermediateFlags &flags,
-    std::ostream &                   out);
 
   /**
    * Write the given list of patches to the output stream in deal.II
@@ -2631,23 +2367,6 @@ namespace DataOutBase
                       const std::string &                      mesh_filename,
                       const std::string &solution_filename,
                       MPI_Comm           comm);
-
-  /**
-   * DataOutFilter is an intermediate data format that reduces the amount of
-   * data that will be written to files. The object filled by this function
-   * can then later be used again to write data in a concrete file format;
-   * see, for example, DataOutBase::write_hdf5_parallel().
-   *
-   * @deprecated Use the version using DataComponentInterpretation instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  write_filtered_data(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &            nonscalar_data_ranges,
-    DataOutFilter &filtered_data);
 
   /**
    * DataOutFilter is an intermediate data format that reduces the amount of
@@ -3305,17 +3024,6 @@ protected:
    */
   virtual std::vector<std::string>
   get_dataset_names() const = 0;
-
-  /**
-   * This functions returns information about how the individual components of
-   * output files that consist of more than one data set are to be
-   * interpreted.
-   *
-   * @deprecated Use get_nonscalar_data_ranges instead.
-   */
-  DEAL_II_DEPRECATED
-  virtual std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-  get_vector_data_ranges() const;
 
   /**
    * This functions returns information about how the individual components of

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -2982,29 +2982,6 @@ namespace DataOutBase
   write_ucd(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
-    const UcdFlags &flags,
-    std::ostream &  out)
-  {
-    write_ucd(
-      patches,
-      data_names,
-      std::vector<
-        std::tuple<unsigned int,
-                   unsigned int,
-                   std::string,
-                   DataComponentInterpretation::DataComponentInterpretation>>{},
-      flags,
-      out);
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_ucd(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
     const std::vector<
       std::tuple<unsigned int,
                  unsigned int,
@@ -3089,30 +3066,6 @@ namespace DataOutBase
     // assert the stream is still ok
     AssertThrow(out, ExcIO());
   }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_dx(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
-    const DXFlags &flags,
-    std::ostream & out)
-  {
-    write_dx(
-      patches,
-      data_names,
-      std::vector<
-        std::tuple<unsigned int,
-                   unsigned int,
-                   std::string,
-                   DataComponentInterpretation::DataComponentInterpretation>>{},
-      flags,
-      out);
-  }
-
 
 
   template <int dim, int spacedim>
@@ -3403,29 +3356,6 @@ namespace DataOutBase
   write_gnuplot(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
-    const GnuplotFlags &flags,
-    std::ostream &      out)
-  {
-    write_gnuplot(
-      patches,
-      data_names,
-      std::vector<
-        std::tuple<unsigned int,
-                   unsigned int,
-                   std::string,
-                   DataComponentInterpretation::DataComponentInterpretation>>{},
-      flags,
-      out);
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_gnuplot(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
     const std::vector<
       std::tuple<unsigned int,
                  unsigned int,
@@ -3624,29 +3554,6 @@ namespace DataOutBase
     out.flush();
 
     AssertThrow(out, ExcIO());
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_povray(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
-    const PovrayFlags &flags,
-    std::ostream &     out)
-  {
-    write_povray(
-      patches,
-      data_names,
-      std::vector<
-        std::tuple<unsigned int,
-                   unsigned int,
-                   std::string,
-                   DataComponentInterpretation::DataComponentInterpretation>>{},
-      flags,
-      out);
   }
 
 
@@ -3983,21 +3890,6 @@ namespace DataOutBase
   write_eps(
     const std::vector<Patch<dim, spacedim>> & /*patches*/,
     const std::vector<std::string> & /*data_names*/,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
-    const EpsFlags & /*flags*/,
-    std::ostream & /*out*/)
-  {
-    // not implemented, see the documentation of the function
-    AssertThrow(dim == 2, ExcNotImplemented());
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_eps(
-    const std::vector<Patch<dim, spacedim>> & /*patches*/,
-    const std::vector<std::string> & /*data_names*/,
     const std::vector<
       std::tuple<unsigned int,
                  unsigned int,
@@ -4009,30 +3901,6 @@ namespace DataOutBase
     // not implemented, see the documentation of the function
     AssertThrow(dim == 2, ExcNotImplemented());
   }
-
-
-
-  template <int spacedim>
-  void
-  write_eps(
-    const std::vector<Patch<2, spacedim>> &patches,
-    const std::vector<std::string> &       data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
-    const EpsFlags &flags,
-    std::ostream &  out)
-  {
-    write_eps(
-      patches,
-      data_names,
-      std::vector<
-        std::tuple<unsigned int,
-                   unsigned int,
-                   std::string,
-                   DataComponentInterpretation::DataComponentInterpretation>>{},
-      flags,
-      out);
-  }
-
 
 
   template <int spacedim>
@@ -4354,29 +4222,6 @@ namespace DataOutBase
   write_gmv(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
-    const GmvFlags &flags,
-    std::ostream &  out)
-  {
-    write_gmv(
-      patches,
-      data_names,
-      std::vector<
-        std::tuple<unsigned int,
-                   unsigned int,
-                   std::string,
-                   DataComponentInterpretation::DataComponentInterpretation>>{},
-      flags,
-      out);
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_gmv(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
     const std::vector<
       std::tuple<unsigned int,
                  unsigned int,
@@ -4505,29 +4350,6 @@ namespace DataOutBase
 
     // assert the stream is still ok
     AssertThrow(out, ExcIO());
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_tecplot(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
-    const TecplotFlags &flags,
-    std::ostream &      out)
-  {
-    write_tecplot(
-      patches,
-      data_names,
-      std::vector<
-        std::tuple<unsigned int,
-                   unsigned int,
-                   std::string,
-                   DataComponentInterpretation::DataComponentInterpretation>>{},
-      flags,
-      out);
   }
 
 
@@ -4760,42 +4582,6 @@ namespace DataOutBase
 
 #endif
   //---------------------------------------------------------------------------
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_tecplot_binary(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                 nonscalar_data_ranges,
-    const TecplotFlags &flags,
-    std::ostream &      out)
-  {
-    const unsigned int size = nonscalar_data_ranges.size();
-    std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-      new_nonscalar_data_ranges(size);
-    for (unsigned int i = 0; i < size; ++i)
-      {
-        new_nonscalar_data_ranges[i] =
-          std::tuple<unsigned int,
-                     unsigned int,
-                     std::string,
-                     DataComponentInterpretation::DataComponentInterpretation>(
-            std::get<0>(nonscalar_data_ranges[i]),
-            std::get<1>(nonscalar_data_ranges[i]),
-            std::get<2>(nonscalar_data_ranges[i]),
-            DataComponentInterpretation::component_is_part_of_vector);
-      }
-
-    write_tecplot_binary(
-      patches, data_names, new_nonscalar_data_ranges, flags, out);
-  }
 
 
 
@@ -5129,41 +4915,6 @@ namespace DataOutBase
   write_vtk(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const VtkFlags &flags,
-    std::ostream &  out)
-  {
-    const unsigned int size = nonscalar_data_ranges.size();
-    std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-      new_nonscalar_data_ranges(size);
-    for (unsigned int i = 0; i < size; ++i)
-      {
-        new_nonscalar_data_ranges[i] =
-          std::tuple<unsigned int,
-                     unsigned int,
-                     std::string,
-                     DataComponentInterpretation::DataComponentInterpretation>(
-            std::get<0>(nonscalar_data_ranges[i]),
-            std::get<1>(nonscalar_data_ranges[i]),
-            std::get<2>(nonscalar_data_ranges[i]),
-            DataComponentInterpretation::component_is_part_of_vector);
-      }
-
-    write_vtk(patches, data_names, new_nonscalar_data_ranges, flags, out);
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_vtk(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
     const std::vector<
       std::tuple<unsigned int,
                  unsigned int,
@@ -5459,25 +5210,6 @@ namespace DataOutBase
   write_vtu(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const VtkFlags &flags,
-    std::ostream &  out)
-  {
-    write_vtu_header(out, flags);
-    write_vtu_main(patches, data_names, nonscalar_data_ranges, flags, out);
-    write_vtu_footer(out);
-
-    out << std::flush;
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_vtu(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
     const std::vector<
       std::tuple<unsigned int,
                  unsigned int,
@@ -5493,42 +5225,6 @@ namespace DataOutBase
 
     out << std::flush;
   }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_vtu_main(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &             nonscalar_data_ranges,
-    const VtkFlags &flags,
-    std::ostream &  out)
-  {
-    const unsigned int size = nonscalar_data_ranges.size();
-    std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-      new_nonscalar_data_ranges(size);
-    for (unsigned int i = 0; i < size; ++i)
-      {
-        new_nonscalar_data_ranges[i] =
-          std::tuple<unsigned int,
-                     unsigned int,
-                     std::string,
-                     DataComponentInterpretation::DataComponentInterpretation>(
-            std::get<0>(nonscalar_data_ranges[i]),
-            std::get<1>(nonscalar_data_ranges[i]),
-            std::get<2>(nonscalar_data_ranges[i]),
-            DataComponentInterpretation::component_is_part_of_vector);
-      }
-
-    write_vtu_main(patches, data_names, new_nonscalar_data_ranges, flags, out);
-  }
-
 
 
   template <int dim, int spacedim>
@@ -5929,39 +5625,6 @@ namespace DataOutBase
     std::ostream &                  out,
     const std::vector<std::string> &piece_names,
     const std::vector<std::string> &data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &nonscalar_data_ranges)
-  {
-    const unsigned int size = nonscalar_data_ranges.size();
-    std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-      new_nonscalar_data_ranges(size);
-    for (unsigned int i = 0; i < size; ++i)
-      {
-        new_nonscalar_data_ranges[i] =
-          std::tuple<unsigned int,
-                     unsigned int,
-                     std::string,
-                     DataComponentInterpretation::DataComponentInterpretation>(
-            std::get<0>(nonscalar_data_ranges[i]),
-            std::get<1>(nonscalar_data_ranges[i]),
-            std::get<2>(nonscalar_data_ranges[i]),
-            DataComponentInterpretation::component_is_part_of_vector);
-      }
-
-    write_pvtu_record(out, piece_names, data_names, new_nonscalar_data_ranges);
-  }
-
-
-
-  void
-  write_pvtu_record(
-    std::ostream &                  out,
-    const std::vector<std::string> &piece_names,
-    const std::vector<std::string> &data_names,
     const std::vector<
       std::tuple<unsigned int,
                  unsigned int,
@@ -6184,20 +5847,6 @@ namespace DataOutBase
   write_svg(
     const std::vector<Patch<dim, spacedim>> &,
     const std::vector<std::string> &,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &,
-    const SvgFlags &,
-    std::ostream &)
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_svg(
-    const std::vector<Patch<dim, spacedim>> &,
-    const std::vector<std::string> &,
     const std::vector<
       std::tuple<unsigned int,
                  unsigned int,
@@ -6208,32 +5857,6 @@ namespace DataOutBase
   {
     Assert(false, ExcNotImplemented());
   }
-
-
-
-  template <int spacedim>
-  void
-  write_svg(
-    const std::vector<Patch<2, spacedim>> &patches,
-    const std::vector<std::string> &       data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>> &
-    /*nonscalar_data_ranges*/,
-    const SvgFlags &flags,
-    std::ostream &  out)
-  {
-    write_svg(
-      patches,
-      data_names,
-      std::vector<
-        std::tuple<unsigned int,
-                   unsigned int,
-                   std::string,
-                   DataComponentInterpretation::DataComponentInterpretation>>{},
-      flags,
-      out);
-  }
-
-
 
   template <int spacedim>
   void
@@ -7199,42 +6822,6 @@ namespace DataOutBase
   write_deal_II_intermediate(
     const std::vector<Patch<dim, spacedim>> &patches,
     const std::vector<std::string> &         data_names,
-    const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-      &                              nonscalar_data_ranges,
-    const Deal_II_IntermediateFlags &flags,
-    std::ostream &                   out)
-  {
-    const unsigned int size = nonscalar_data_ranges.size();
-    std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-      new_nonscalar_data_ranges(size);
-    for (unsigned int i = 0; i < size; ++i)
-      {
-        new_nonscalar_data_ranges[i] =
-          std::tuple<unsigned int,
-                     unsigned int,
-                     std::string,
-                     DataComponentInterpretation::DataComponentInterpretation>(
-            std::get<0>(nonscalar_data_ranges[i]),
-            std::get<1>(nonscalar_data_ranges[i]),
-            std::get<2>(nonscalar_data_ranges[i]),
-            DataComponentInterpretation::component_is_part_of_vector);
-      }
-
-    write_deal_II_intermediate(
-      patches, data_names, new_nonscalar_data_ranges, flags, out);
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  write_deal_II_intermediate(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string> &         data_names,
     const std::vector<
       std::tuple<unsigned int,
                  unsigned int,
@@ -7790,43 +7377,6 @@ DataOutInterface<dim, spacedim>::write_filtered_data(
   DataOutBase::write_filtered_data(get_patches(),
                                    get_dataset_names(),
                                    get_nonscalar_data_ranges(),
-                                   filtered_data);
-}
-
-
-
-template <int dim, int spacedim>
-void
-DataOutBase::write_filtered_data(
-  const std::vector<Patch<dim, spacedim>> &patches,
-  const std::vector<std::string> &         data_names,
-  const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-    &                         nonscalar_data_ranges,
-  DataOutBase::DataOutFilter &filtered_data)
-{
-  const unsigned int size = nonscalar_data_ranges.size();
-  std::vector<
-    std::tuple<unsigned int,
-               unsigned int,
-               std::string,
-               DataComponentInterpretation::DataComponentInterpretation>>
-    new_nonscalar_data_ranges(size);
-  for (unsigned int i = 0; i < size; ++i)
-    {
-      new_nonscalar_data_ranges[i] =
-        std::tuple<unsigned int,
-                   unsigned int,
-                   std::string,
-                   DataComponentInterpretation::DataComponentInterpretation>(
-          std::get<0>(nonscalar_data_ranges[i]),
-          std::get<1>(nonscalar_data_ranges[i]),
-          std::get<2>(nonscalar_data_ranges[i]),
-          DataComponentInterpretation::component_is_part_of_vector);
-    }
-
-  DataOutBase::write_filtered_data(patches,
-                                   data_names,
-                                   new_nonscalar_data_ranges,
                                    filtered_data);
 }
 
@@ -8610,29 +8160,6 @@ DataOutInterface<dim, spacedim>::get_nonscalar_data_ranges() const
                std::string,
                DataComponentInterpretation::DataComponentInterpretation>>();
 }
-
-
-
-template <int dim, int spacedim>
-std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-DataOutInterface<dim, spacedim>::get_vector_data_ranges() const
-{
-  const auto &nonscalar_data_ranges = get_nonscalar_data_ranges();
-
-  const unsigned int size = nonscalar_data_ranges.size();
-  std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-    vector_data_ranges(size);
-  for (unsigned int i = 0; i < size; ++i)
-    {
-      vector_data_ranges[i] =
-        std::tuple<unsigned int, unsigned int, std::string>(
-          std::get<0>(nonscalar_data_ranges[i]),
-          std::get<1>(nonscalar_data_ranges[i]),
-          std::get<2>(nonscalar_data_ranges[i]));
-    }
-  return vector_data_ranges;
-}
-
 
 
 template <int dim, int spacedim>

--- a/source/base/data_out_base.inst.in
+++ b/source/base/data_out_base.inst.in
@@ -39,31 +39,11 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             nonscalar_data_ranges,
-        const VtkFlags &flags,
-        std::ostream &  out);
-
-      template void
-      write_vtk(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
         const std::vector<
           std::tuple<unsigned int,
                      unsigned int,
                      std::string,
                      DataComponentInterpretation::DataComponentInterpretation>>
-          &             nonscalar_data_ranges,
-        const VtkFlags &flags,
-        std::ostream &  out);
-
-      template void
-      write_vtu(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
           &             nonscalar_data_ranges,
         const VtkFlags &flags,
         std::ostream &  out);
@@ -87,16 +67,6 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             nonscalar_data_ranges,
-        const UcdFlags &flags,
-        std::ostream &  out);
-
-      template void
-      write_ucd(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
         const std::vector<
           std::tuple<unsigned int,
                      unsigned int,
@@ -105,16 +75,6 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
           &             nonscalar_data_ranges,
         const UcdFlags &flags,
         std::ostream &  out);
-
-      template void
-      write_dx(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &            nonscalar_data_ranges,
-        const DXFlags &flags,
-        std::ostream & out);
 
       template void
       write_dx(
@@ -135,16 +95,6 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &                 nonscalar_data_ranges,
-        const GnuplotFlags &flags,
-        std::ostream &      out);
-
-      template void
-      write_gnuplot(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
         const std::vector<
           std::tuple<unsigned int,
                      unsigned int,
@@ -153,16 +103,6 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
           &                 nonscalar_data_ranges,
         const GnuplotFlags &flags,
         std::ostream &      out);
-
-      template void
-      write_povray(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &                nonscalar_data_ranges,
-        const PovrayFlags &flags,
-        std::ostream &     out);
 
       template void
       write_povray(
@@ -183,16 +123,6 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             nonscalar_data_ranges,
-        const EpsFlags &flags,
-        std::ostream &  out);
-
-      template void
-      write_eps(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
         const std::vector<
           std::tuple<unsigned int,
                      unsigned int,
@@ -200,16 +130,6 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
                      DataComponentInterpretation::DataComponentInterpretation>>
           &             nonscalar_data_ranges,
         const EpsFlags &flags,
-        std::ostream &  out);
-
-      template void
-      write_gmv(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             nonscalar_data_ranges,
-        const GmvFlags &flags,
         std::ostream &  out);
 
       template void
@@ -231,31 +151,11 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &                 nonscalar_data_ranges,
-        const TecplotFlags &flags,
-        std::ostream &      out);
-
-      template void
-      write_tecplot(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
         const std::vector<
           std::tuple<unsigned int,
                      unsigned int,
                      std::string,
                      DataComponentInterpretation::DataComponentInterpretation>>
-          &                 nonscalar_data_ranges,
-        const TecplotFlags &flags,
-        std::ostream &      out);
-
-      template void
-      write_tecplot_binary(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
           &                 nonscalar_data_ranges,
         const TecplotFlags &flags,
         std::ostream &      out);
@@ -280,16 +180,6 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
           &                             patches,
         const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &             nonscalar_data_ranges,
-        const SvgFlags &flags,
-        std::ostream &  out);
-
-      template void
-      write_svg(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
         const std::vector<
           std::tuple<unsigned int,
                      unsigned int,
@@ -299,17 +189,6 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const SvgFlags &flags,
         std::ostream &  out);
 #  endif
-
-      template void
-      write_deal_II_intermediate(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                             patches,
-        const std::vector<std::string> &data_names,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &                              nonscalar_data_ranges,
-        const Deal_II_IntermediateFlags &flags,
-        std::ostream &                   out);
-
       template void
       write_deal_II_intermediate(
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
@@ -331,14 +210,6 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const DataOutFilter &data_filter,
         const std::string &  filename,
         MPI_Comm             comm);
-
-      template void
-      write_filtered_data(
-        const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>> &,
-        const std::vector<std::string> &,
-        const std::vector<std::tuple<unsigned int, unsigned int, std::string>>
-          &,
-        DataOutBase::DataOutFilter &);
 
       template void
       write_filtered_data(


### PR DESCRIPTION
In #6830, @masterleinad introduced a whole functions that retained
backward compatibility for functions that @davydden had changed in #6818.
This was before the 9.1 release. It is time to remove these backward
compatibility functions again.

Relates to #6828. Fixes #6832.

Passes the test suite for me.
/rebuild