### PR TITLE
Fix subscript in step-12 intro

### DIFF
--- a/examples/step-12/doc/intro.dox
+++ b/examples/step-12/doc/intro.dox
@@ -74,7 +74,7 @@ $u^{\text{upwind}}$ is defined to be $u^+$ if $\beta \cdot n>0$ and $u^-$ otherw
 As a result, the mesh-dependent weak form reads:
 @f[
 \sum_{T\in \mathbb T_h} -\bigl(\nabla \phi_i,{\mathbf \beta}\cdot \phi_j \bigr)_T +
-\sum_{F\in\mathbb F_h^i} \bigl< [\phi_i], \phi_i^{upwind} \beta\cdot \mathbf n\bigr>_{F} +
+\sum_{F\in\mathbb F_h^i} \bigl< [\phi_i], \phi_j^{upwind} \beta\cdot \mathbf n\bigr>_{F} +
 \bigl<\phi_i, \phi_j \beta\cdot \mathbf n\bigr>_{\Gamma_+}
 = -\bigl<\phi_i, g \beta\cdot\mathbf n\bigr>_{\Gamma_-}.
 @f]


### PR DESCRIPTION
I believe the subscript on \phi^upwind in the weak form should be j, rather than i. This matches the code and the corresponding comments.