### PR TITLE
Add missing instantiations for DoFTools::extract_hanging_node_dofs

### DIFF
--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -233,9 +233,11 @@ for (deal_II_dimension : DIMENSIONS)
       std::vector<bool> &,
       const std::set<types::boundary_id> &);
 
+    template IndexSet DoFTools::extract_hanging_node_dofs(
+      const DoFHandler<deal_II_dimension> &);
+
     template void DoFTools::extract_hanging_node_dofs(
-      const DoFHandler<deal_II_dimension> &dof_handler,
-      std::vector<bool> &                  selected_dofs);
+      const DoFHandler<deal_II_dimension> &, std::vector<bool> &);
 
     template void
     DoFTools::extract_subdomain_dofs<DoFHandler<deal_II_dimension>>(
@@ -500,10 +502,12 @@ for (deal_II_dimension : DIMENSIONS)
       const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
       std::vector<types::global_dof_index> &);
 
+    template IndexSet DoFTools::extract_hanging_node_dofs(
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &);
 
     template void DoFTools::extract_hanging_node_dofs(
-      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &dof_handler,
-      std::vector<bool> &selected_dofs);
+      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      std::vector<bool> &);
 
     template void DoFTools::map_dof_to_boundary_indices<
       hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1>>(
@@ -528,9 +532,11 @@ for (deal_II_dimension : DIMENSIONS)
     template void DoFTools::map_dof_to_boundary_indices<DoFHandler<1, 3>>(
       const DoFHandler<1, 3> &, std::vector<types::global_dof_index> &);
 
+    template IndexSet DoFTools::extract_hanging_node_dofs(
+      const DoFHandler<1, 3> &);
 
-    template void DoFTools::extract_hanging_node_dofs(
-      const DoFHandler<1, 3> &dof_handler, std::vector<bool> &selected_dofs);
+    template void DoFTools::extract_hanging_node_dofs(const DoFHandler<1, 3> &,
+                                                      std::vector<bool> &);
 
     template void DoFTools::map_dof_to_boundary_indices<hp::DoFHandler<1, 3>>(
       const hp::DoFHandler<1, 3> &,


### PR DESCRIPTION
This should fix https://cdash.43-1.org/viewTest.php?onlydelta&buildid=4189.