### PR TITLE
Matrixfree hold all faces to owned cells fix

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -480,11 +480,18 @@ namespace internal
        * vector partitioner stored in @p vector_partitioner. These
        * partitioners are used in specialized loops that only import parts of
        * the ghosted region for reducing the amount of communication. There
-       * are three variants of the partitioner initialized, one that queries
-       * only the cell values, one that additionally describes the indices for
-       * evaluating the function values on the faces, and one that describes
-       * the indices for evaluation both the function values and the gradients
-       * on the faces adjacent to the locally owned cells.
+       * are five variants of the partitioner initialized:
+       * - one that queries only the cell values,
+       * - one that additionally describes the indices for
+       *   evaluating the function values on relevant faces,
+       * - one that describes the indices for evaluation both the function
+       *   values and the gradients on relevant faces adjacent to the locally
+       *   owned cells,
+       * - one that additionally describes the indices for
+       *   evaluating the function values on all faces, and
+       * - one that describes the indices for evaluation both the function
+       *   values and the gradients on all faces adjacent to the locally owned
+       *   cells.
        */
       std::array<std::shared_ptr<const Utilities::MPI::Partitioner>, 5>
         vector_partitioner_face_variants;

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1934,6 +1934,15 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                                 di.vector_partitioner_face_variants[4],
                                 loop_over_all_faces);
             }
+          else
+            {
+              di.vector_partitioner_face_variants[3].reset(
+                new Utilities::MPI::Partitioner(part.locally_owned_range(),
+                                                part.get_mpi_communicator()));
+              di.vector_partitioner_face_variants[4].reset(
+                new Utilities::MPI::Partitioner(part.locally_owned_range(),
+                                                part.get_mpi_communicator()));
+            }
         }
     }
 

--- a/tests/matrix_free/face_setup_01.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/matrix_free/face_setup_01.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -3,3 +3,5 @@ DEAL:0::main partitioner: size=2506 local_size=2506 n_ghosts=0
 DEAL:0::partitioner: size=2506 local_size=2506 n_ghosts=0
 DEAL:0::partitioner: size=2506 local_size=2506 n_ghosts=0
 DEAL:0::partitioner: size=2506 local_size=2506 n_ghosts=0
+DEAL:0::partitioner: size=2506 local_size=2506 n_ghosts=0
+DEAL:0::partitioner: size=2506 local_size=2506 n_ghosts=0

--- a/tests/matrix_free/face_setup_01.with_mpi=true.with_p4est=true.mpirun=2.output
+++ b/tests/matrix_free/face_setup_01.with_mpi=true.with_p4est=true.mpirun=2.output
@@ -3,9 +3,13 @@ DEAL:0::main partitioner: size=2506 local_size=1492 n_ghosts=273
 DEAL:0::partitioner: size=2506 local_size=1492 n_ghosts=0
 DEAL:0::partitioner: size=2506 local_size=1492 n_ghosts=273
 DEAL:0::partitioner: size=2506 local_size=1492 n_ghosts=273
+DEAL:0::partitioner: size=2506 local_size=1492 n_ghosts=0
+DEAL:0::partitioner: size=2506 local_size=1492 n_ghosts=0
 
 DEAL:1::main partitioner: size=2506 local_size=1014 n_ghosts=442
 DEAL:1::partitioner: size=2506 local_size=1014 n_ghosts=169
 DEAL:1::partitioner: size=2506 local_size=1014 n_ghosts=442
 DEAL:1::partitioner: size=2506 local_size=1014 n_ghosts=442
+DEAL:1::partitioner: size=2506 local_size=1014 n_ghosts=0
+DEAL:1::partitioner: size=2506 local_size=1014 n_ghosts=0
 


### PR DESCRIPTION
closes #9485

> The problem could have been avoided if any of us had run ctest -R matrix_free locally before the merge, since the CI tests cannot cover all the library and this is a well-defined context, namely matrix-free functionality.

@kronbichler  Done!

>  Is it documented what the five pointers are and that some may be null?

@bangerth  Done!