### PR TITLE
Replace the use of VECTORS_WITH_MATRIX by VECTOR_TYPES in .inst.in files.

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -165,27 +165,6 @@ EXTERNAL_PARALLEL_VECTORS := { @DEAL_II_EXPAND_TRILINOS_MPI_VECTOR@;
                                @DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR@
                              }
 
-// TODO: I don't understand this one. LA::distributed::Vector does not have a
-// native matrix type, especially if we don't compile with Trilinos. Currently
-// only used: mg_transfer_prebuilt.inst.in and
-// mg_level_global_transfer.inst.in
-VECTORS_WITH_MATRIX := { Vector<double>;
-                         Vector<float> ;
-
-                         BlockVector<double>;
-                         BlockVector<float>;
-
-                         LinearAlgebra::distributed::Vector<double>;
-
-                         @DEAL_II_EXPAND_TRILINOS_MPI_VECTOR@;
-                         @DEAL_II_EXPAND_EPETRA_VECTOR@;
-                         @DEAL_II_EXPAND_TPETRA_VECTOR_DOUBLE@;
-                         @DEAL_II_EXPAND_TPETRA_VECTOR_FLOAT@;
-                         @DEAL_II_EXPAND_TPETRA_VECTOR_COMPLEX_DOUBLE@;
-                         @DEAL_II_EXPAND_TPETRA_VECTOR_COMPLEX_FLOAT@;
-                         @DEAL_II_EXPAND_PETSC_MPI_VECTOR@;
-                       }
-
 // Matrices
 SPARSE_MATRICES := { SparseMatrix<double>;
                      SparseMatrix<float>;

--- a/source/multigrid/mg_level_global_transfer.cc
+++ b/source/multigrid/mg_level_global_transfer.cc
@@ -27,6 +27,9 @@
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/la_vector.h>
+#include <deal.II/lac/petsc_block_vector.h>
+#include <deal.II/lac/petsc_vector.h>
 #include <deal.II/lac/trilinos_epetra_vector.h>
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_vector.h>
@@ -451,10 +454,5 @@ MGLevelGlobalTransfer<
 
 // explicit instantiation
 #include "mg_level_global_transfer.inst"
-
-// create an additional instantiation currently not supported by the automatic
-// template instantiation scheme
-template class MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<float>>;
-
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/multigrid/mg_level_global_transfer.inst.in
+++ b/source/multigrid/mg_level_global_transfer.inst.in
@@ -15,12 +15,12 @@
 
 
 
-for (V1 : VECTORS_WITH_MATRIX)
+for (V1 : VECTOR_TYPES)
   {
     template class MGLevelGlobalTransfer<V1>;
   }
 
-for (deal_II_dimension : DIMENSIONS; V1 : VECTORS_WITH_MATRIX)
+for (deal_II_dimension : DIMENSIONS; V1 : VECTOR_TYPES)
   {
     template void MGLevelGlobalTransfer<V1>::
       fill_and_communicate_copy_indices<deal_II_dimension, deal_II_dimension>(
@@ -46,10 +46,6 @@ for (deal_II_dimension : DIMENSIONS; V1, V2 : DEAL_II_VEC_TEMPLATES;
 
 for (deal_II_dimension : DIMENSIONS)
   {
-    template void
-    MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<float>>::
-      fill_and_communicate_copy_indices<deal_II_dimension, deal_II_dimension>(
-        const DoFHandler<deal_II_dimension, deal_II_dimension> &mg_dof);
     template void
     MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<float>>::
       copy_to_mg(const DoFHandler<deal_II_dimension> &,

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -30,6 +30,9 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/la_vector.h>
+#include <deal.II/lac/petsc_block_vector.h>
+#include <deal.II/lac/petsc_vector.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/lac/trilinos_epetra_vector.h>

--- a/source/multigrid/mg_transfer_prebuilt.inst.in
+++ b/source/multigrid/mg_transfer_prebuilt.inst.in
@@ -15,12 +15,12 @@
 
 
 
-for (V1 : VECTOR_TYPES)
+for (V1 : REAL_VECTOR_TYPES)
   {
     template class MGTransferPrebuilt<V1>;
   }
 
-for (deal_II_dimension : DIMENSIONS; V1 : VECTOR_TYPES)
+for (deal_II_dimension : DIMENSIONS; V1 : REAL_VECTOR_TYPES)
   {
     template void MGTransferPrebuilt<V1>::build<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &mg_dof);

--- a/source/multigrid/mg_transfer_prebuilt.inst.in
+++ b/source/multigrid/mg_transfer_prebuilt.inst.in
@@ -15,12 +15,12 @@
 
 
 
-for (V1 : VECTORS_WITH_MATRIX)
+for (V1 : VECTOR_TYPES)
   {
     template class MGTransferPrebuilt<V1>;
   }
 
-for (deal_II_dimension : DIMENSIONS; V1 : VECTORS_WITH_MATRIX)
+for (deal_II_dimension : DIMENSIONS; V1 : VECTOR_TYPES)
   {
     template void MGTransferPrebuilt<V1>::build<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &mg_dof);


### PR DESCRIPTION
This requires also adding a couple of include files, and removing
duplicate instantiatiosn.

Fixes #3922.