### PR TITLE
replace Assert with AssertThrow in tests/base

### DIFF
--- a/doc/developers/testsuite.html
+++ b/doc/developers/testsuite.html
@@ -658,6 +658,15 @@ int main ()
     </p>
 
     <p>
+    In addition to creating meaningful test output using <code>deallog</code>,
+    you can check post-conditions and software guarantees
+    by using the <code>AssertThrow</code> macro within the test code. Note
+    that we make use of the <code>AssertThrow</code> macro instead of
+    <code>Assert</code> because we like to assert post-conditions in both
+    debug and release builds.
+    </p>
+
+    <p>
     There are a number of directories where you can put a new test.
     Extensive tests of individual classes or groups of classes
     have traditionally been into the <code>base/</code>,

--- a/tests/base/array_view_01.cc
+++ b/tests/base/array_view_01.cc
@@ -29,14 +29,14 @@ test()
   ArrayView<int> a(&v[4], 3); // writable view
   a[2] = 42;
 
-  Assert(a[2] == 42, ExcInternalError());
-  Assert(v[6] == 42, ExcInternalError());
+  AssertThrow(a[2] == 42, ExcInternalError());
+  AssertThrow(v[6] == 42, ExcInternalError());
 
   ArrayView<const int> a2(&v[4], 3); // readable view
-  Assert(a2[2] == 42, ExcInternalError());
+  AssertThrow(a2[2] == 42, ExcInternalError());
 
   ArrayView<const int> a3(a); // readable view, converted from 'a'
-  Assert(a3[2] == 42, ExcInternalError());
+  AssertThrow(a3[2] == 42, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/array_view_02.cc
+++ b/tests/base/array_view_02.cc
@@ -29,14 +29,14 @@ test()
   ArrayView<int> a = make_array_view(v, 4, 3); // writable view
   a[2]             = 42;
 
-  Assert(a[2] == 42, ExcInternalError());
-  Assert(v[6] == 42, ExcInternalError());
+  AssertThrow(a[2] == 42, ExcInternalError());
+  AssertThrow(v[6] == 42, ExcInternalError());
 
   ArrayView<const int> a2 = make_array_view(v, 4, 3); // readable view
-  Assert(a2[2] == 42, ExcInternalError());
+  AssertThrow(a2[2] == 42, ExcInternalError());
 
   ArrayView<const int> a3(a); // readable view, converted from 'a'
-  Assert(a3[2] == 42, ExcInternalError());
+  AssertThrow(a3[2] == 42, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/array_view_03.cc
+++ b/tests/base/array_view_03.cc
@@ -29,15 +29,15 @@ test()
   ArrayView<int> a = make_array_view(v); // writable view
   a[2]             = 42;
 
-  Assert(a[2] == 42, ExcInternalError());
-  Assert(v[2] == 42, ExcInternalError());
+  AssertThrow(a[2] == 42, ExcInternalError());
+  AssertThrow(v[2] == 42, ExcInternalError());
 
   ArrayView<const int> a2 = make_array_view(v); // readable view
-  Assert(a2[2] == 42, ExcInternalError());
+  AssertThrow(a2[2] == 42, ExcInternalError());
 
   ArrayView<const int> a3 =
     make_array_view(const_cast<const std::vector<int> &>(v));
-  Assert(a3[2] == 42, ExcInternalError());
+  AssertThrow(a3[2] == 42, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/array_view_04.cc
+++ b/tests/base/array_view_04.cc
@@ -29,17 +29,17 @@ test()
   ArrayView<int> a = make_array_view(v, 4); // writable view to whole row
   a[2]             = 42;
 
-  Assert(a[2] == 42, ExcInternalError());
-  Assert(v[4][2] == 42, ExcInternalError());
+  AssertThrow(a[2] == 42, ExcInternalError());
+  AssertThrow(v[4][2] == 42, ExcInternalError());
 
   ArrayView<const int> a2 = make_array_view(v, 4); // readable view
-  Assert(a2[2] == 42, ExcInternalError());
+  AssertThrow(a2[2] == 42, ExcInternalError());
 
 
   // also check a different way of creating a readable view
   ArrayView<const int> a3 =
     make_array_view(const_cast<const Table<2, int> &>(v), 4);
-  Assert(a3[2] == 42, ExcInternalError());
+  AssertThrow(a3[2] == 42, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/array_view_05.cc
+++ b/tests/base/array_view_05.cc
@@ -30,17 +30,17 @@ test()
     make_array_view(v, 4, 7, 3); // writable view to part of a row
   a[2] = 42;
 
-  Assert(a[2] == 42, ExcInternalError());
-  Assert(v[4][9] == 42, ExcInternalError());
+  AssertThrow(a[2] == 42, ExcInternalError());
+  AssertThrow(v[4][9] == 42, ExcInternalError());
 
   ArrayView<const int> a2 = make_array_view(v, 4, 7, 3); // readable view
-  Assert(a2[2] == 42, ExcInternalError());
+  AssertThrow(a2[2] == 42, ExcInternalError());
 
 
   // also check a different way of creating a readable view
   ArrayView<const int> a3 =
     make_array_view(const_cast<const Table<2, int> &>(v), 4, 7, 3);
-  Assert(a3[2] == 42, ExcInternalError());
+  AssertThrow(a3[2] == 42, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/array_view_14.cc
+++ b/tests/base/array_view_14.cc
@@ -31,15 +31,15 @@ test()
   a.reinit(&v[4], 3); // writable view
   a[2] = 42;
 
-  Assert(a[2] == 42, ExcInternalError());
-  Assert(v[6] == 42, ExcInternalError());
+  AssertThrow(a[2] == 42, ExcInternalError());
+  AssertThrow(v[6] == 42, ExcInternalError());
 
   ArrayView<const int> a2;
   a2.reinit(&v[4], 3); // readable view
-  Assert(a2[2] == 42, ExcInternalError());
+  AssertThrow(a2[2] == 42, ExcInternalError());
 
   ArrayView<const int> a3(a); // readable view, converted from 'a'
-  Assert(a3[2] == 42, ExcInternalError());
+  AssertThrow(a3[2] == 42, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/array_view_15.cc
+++ b/tests/base/array_view_15.cc
@@ -28,17 +28,17 @@ test()
 
   ArrayView<int> a1(v); // writable view
 
-  Assert(a1.size() == 1, ExcInternalError());
-  Assert(a1[0] == 9, ExcInternalError());
+  AssertThrow(a1.size() == 1, ExcInternalError());
+  AssertThrow(a1[0] == 9, ExcInternalError());
   v = 10;
-  Assert(a1[0] == 10, ExcInternalError());
+  AssertThrow(a1[0] == 10, ExcInternalError());
   a1[0] = 11;
-  Assert(a1[0] == 11, ExcInternalError());
+  AssertThrow(a1[0] == 11, ExcInternalError());
 
   ArrayView<int> a2(v); // writable view
 
-  Assert(a2.size() == 1, ExcInternalError());
-  Assert(a2[0] == 11, ExcInternalError());
+  AssertThrow(a2.size() == 1, ExcInternalError());
+  AssertThrow(a2[0] == 11, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/auto_derivative_function.cc
+++ b/tests/base/auto_derivative_function.cc
@@ -70,8 +70,8 @@ template <int dim>
 void
 AutoSinExp<dim>::vector_value(const Point<dim> &p, Vector<double> &values) const
 {
-  Assert(values.size() == this->n_components,
-         ExcDimensionMismatch(values.size(), this->n_components));
+  AssertThrow(values.size() == this->n_components,
+              ExcDimensionMismatch(values.size(), this->n_components));
   values(0) = 0;
   values(1) = value(p);
 }
@@ -114,8 +114,8 @@ ExactSinExp<dim>::vector_gradient(
   const Point<dim> &                    p,
   typename std::vector<Tensor<1, dim>> &gradients) const
 {
-  Assert(gradients.size() == this->n_components,
-         ExcDimensionMismatch(gradients.size(), this->n_components));
+  AssertThrow(gradients.size() == this->n_components,
+              ExcDimensionMismatch(gradients.size(), this->n_components));
 
   gradients[0].clear();
   gradients[1] = gradient(p);

--- a/tests/base/derivative_forms_02.cc
+++ b/tests/base/derivative_forms_02.cc
@@ -48,10 +48,10 @@ test()
   deallog << "||dF||: " << dF.norm() << std::endl;
   deallog << "||ddF||: " << ddF.norm() << std::endl;
 
-  Assert(std::fabs(dF.norm() - std::sqrt(dF_norm_sqr)) < 1e-12,
-         ExcInternalError());
-  Assert(std::fabs(ddF.norm() - std::sqrt(ddF_norm_sqr)) < 1e-12,
-         ExcInternalError());
+  AssertThrow(std::fabs(dF.norm() - std::sqrt(dF_norm_sqr)) < 1e-12,
+              ExcInternalError());
+  AssertThrow(std::fabs(ddF.norm() - std::sqrt(ddF_norm_sqr)) < 1e-12,
+              ExcInternalError());
 }
 
 int

--- a/tests/base/derivative_forms_03.cc
+++ b/tests/base/derivative_forms_03.cc
@@ -49,10 +49,10 @@ test()
   deallog << "||dF||: " << dF.norm() << std::endl;
   deallog << "||ddF||: " << ddF.norm() << std::endl;
 
-  Assert(std::fabs(dF.norm() - std::sqrt(dF_norm_sqr)) < 1e-12,
-         ExcInternalError());
-  Assert(std::fabs(ddF.norm() - std::sqrt(ddF_norm_sqr)) < 1e-12,
-         ExcInternalError());
+  AssertThrow(std::fabs(dF.norm() - std::sqrt(dF_norm_sqr)) < 1e-12,
+              ExcInternalError());
+  AssertThrow(std::fabs(ddF.norm() - std::sqrt(ddF_norm_sqr)) < 1e-12,
+              ExcInternalError());
 }
 
 int

--- a/tests/base/dynamic_unique_cast.cc
+++ b/tests/base/dynamic_unique_cast.cc
@@ -39,16 +39,16 @@ test()
   std::unique_ptr<B> b = Utilities::dynamic_unique_cast<B>(std::move(d));
 
   // Ownership now rests with b, but it's still a D. Verify this:
-  Assert(d.get() == nullptr, ExcInternalError());
-  Assert(b.get() != nullptr, ExcInternalError());
-  Assert(dynamic_cast<D *>(b.get()) != nullptr, ExcInternalError());
+  AssertThrow(d.get() == nullptr, ExcInternalError());
+  AssertThrow(b.get() != nullptr, ExcInternalError());
+  AssertThrow(dynamic_cast<D *>(b.get()) != nullptr, ExcInternalError());
 
   // Check that we can again upcast to D:
   std::unique_ptr<D> dd = Utilities::dynamic_unique_cast<D>(std::move(b));
 
   // Ownership now rests with b, but it's still a D. Verify this:
-  Assert(b.get() == nullptr, ExcInternalError());
-  Assert(dd.get() != nullptr, ExcInternalError());
+  AssertThrow(b.get() == nullptr, ExcInternalError());
+  AssertThrow(dd.get() != nullptr, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/function_parser_03.cc
+++ b/tests/base/function_parser_03.cc
@@ -43,12 +43,13 @@ main()
   fp.initialize("s,t", "s*t+1", constants);
 
   double value = fp.value(Point<2>(2.0, 2.5));
-  Assert(std::abs(1.0 + 2.0 * 2.5 - value) < 1e-10, ExcMessage("wrong value"));
+  AssertThrow(std::abs(1.0 + 2.0 * 2.5 - value) < 1e-10,
+              ExcMessage("wrong value"));
 
   std::vector<std::string> expressions;
   expressions.push_back("sin(2*mypi*x)+y");
   constants["mypi"] = numbers::PI;
   fp.initialize("x,y", expressions, constants);
   double value1 = fp.value(Point<2>(1.0, 2.5), 0);
-  Assert(std::abs(2.5 - value1) < 1e-10, ExcMessage("wrong value"));
+  AssertThrow(std::abs(2.5 - value1) < 1e-10, ExcMessage("wrong value"));
 }

--- a/tests/base/function_parser_04.cc
+++ b/tests/base/function_parser_04.cc
@@ -50,7 +50,8 @@ assemble(const std::vector<int>::iterator &it,
 {
   double s     = *it;
   double value = fp.value(Point<2>(s, 2.5));
-  Assert(std::abs(1.0 + s * 2.5 - value) < 1e-10, ExcMessage("wrong value"));
+  AssertThrow(std::abs(1.0 + s * 2.5 - value) < 1e-10,
+              ExcMessage("wrong value"));
   std::cout << data.value << std::endl;
 
   data.value = (std::abs(1.0 + s * 2.5 - value) < 1e-10) ? 1 : 0;
@@ -83,7 +84,7 @@ test2()
                   copy_data());
   std::cout << "result: " << result << std::endl;
 
-  Assert((unsigned int)result == v.size(), ExcMessage("uhuh!"));
+  AssertThrow((unsigned int)result == v.size(), ExcMessage("uhuh!"));
 }
 
 

--- a/tests/base/function_parser_08.cc
+++ b/tests/base/function_parser_08.cc
@@ -82,7 +82,7 @@ test2()
   // We can also only evaluate the 2nd component:
   double c = vector_function.value(point, 1);
 
-  Assert(c == result[1], ExcInternalError());
+  AssertThrow(c == result[1], ExcInternalError());
 
   // Output the evaluated function
   deallog << "Function '" << expressions[0] << "," << expressions[1] << "'"

--- a/tests/base/functions_02.cc
+++ b/tests/base/functions_02.cc
@@ -149,7 +149,7 @@ check_laplacian(const Function<dim> &f)
   Point<dim> p;
   for (unsigned int i = 0; i < dim; ++i)
     p[i] = i + 1;
-  Assert(std::fabs(f.laplacian(p)) < 1e-12, ExcInternalError());
+  AssertThrow(std::fabs(f.laplacian(p)) < 1e-12, ExcInternalError());
 }
 
 template <int dim>
@@ -168,7 +168,7 @@ check_laplacian_list(const Function<dim> &f)
   std::vector<double> values(max_points);
   f.laplacian_list(point_vector, values);
   for (unsigned int j = 0; j < max_points; ++j)
-    Assert(std::fabs(values[j]) < 1e-12, ExcInternalError());
+    AssertThrow(std::fabs(values[j]) < 1e-12, ExcInternalError());
 }
 
 int

--- a/tests/base/functions_06.cc
+++ b/tests/base/functions_06.cc
@@ -29,7 +29,7 @@ check1()
 {
   VectorFunctionFromScalarFunctionObject<dim> object(&Point<dim>::norm, 1, 3);
 
-  Assert(object.n_components == 3, ExcInternalError());
+  AssertThrow(object.n_components == 3, ExcInternalError());
 
   for (unsigned int i = 0; i < 10; ++i)
     {

--- a/tests/base/functions_07.cc
+++ b/tests/base/functions_07.cc
@@ -31,7 +31,7 @@ public:
   double
   laplacian(const Point<dim> &p, const unsigned int c) const
   {
-    Assert(c == 0, ExcInternalError());
+    AssertThrow(c == 0, ExcInternalError());
     return p.norm();
   }
 };

--- a/tests/base/functions_spherical_01.cc
+++ b/tests/base/functions_spherical_01.cc
@@ -47,7 +47,7 @@ public:
   {
     Tensor<1, dim> dist = p - origin;
     const double   r    = dist.norm();
-    Assert(r > 0.0, ExcMessage("r is not positive"));
+    AssertThrow(r > 0.0, ExcMessage("r is not positive"));
     dist /= r;
     return -Z * std::exp(-Z * r) * dist;
   }
@@ -57,7 +57,7 @@ public:
   {
     Tensor<1, dim> dir = p - origin;
     const double   r   = dir.norm();
-    Assert(r > 0.0, ExcMessage("r is not positive"));
+    AssertThrow(r > 0.0, ExcMessage("r is not positive"));
     dir /= r;
     SymmetricTensor<2, dim> dir_x_dir;
     for (unsigned int i = 0; i < dim; i++)

--- a/tests/base/functions_spherical_02.cc
+++ b/tests/base/functions_spherical_02.cc
@@ -68,7 +68,7 @@ public:
   {
     Tensor<1, dim> dist = p - origin;
     const double   r    = dist.norm();
-    Assert(r > 0.0, ExcMessage("r is not positive"));
+    AssertThrow(r > 0.0, ExcMessage("r is not positive"));
     Tensor<1, dim> res;
     const double   x  = dist[0];
     const double   y  = dist[1];
@@ -89,7 +89,7 @@ public:
   {
     const Tensor<1, dim> dist = p - origin;
     const double         r    = dist.norm();
-    Assert(r > 0.0, ExcMessage("r is not positive"));
+    AssertThrow(r > 0.0, ExcMessage("r is not positive"));
     const double x  = dist[0];
     const double y  = dist[1];
     const double z  = dist[2];

--- a/tests/base/geometric_utilities_01.cc
+++ b/tests/base/geometric_utilities_01.cc
@@ -45,7 +45,7 @@ template <int dim>
 void
 test()
 {
-  Assert(dim > 1, ExcNotImplemented());
+  AssertThrow(dim > 1, ExcNotImplemented());
 
   const Point<dim> origin;
 

--- a/tests/base/index_set_04.cc
+++ b/tests/base/index_set_04.cc
@@ -37,7 +37,7 @@ test()
   index_set.add_index(7);
 
   deallog << (index_set.is_contiguous() ? "true" : "false") << std::endl;
-  Assert(index_set.is_contiguous() == true, ExcInternalError());
+  AssertThrow(index_set.is_contiguous() == true, ExcInternalError());
 
   for (unsigned int i = 0; i < index_set.size(); ++i)
     deallog << i << ' ' << (index_set.is_element(i) ? "true" : "false")

--- a/tests/base/index_set_05.cc
+++ b/tests/base/index_set_05.cc
@@ -35,7 +35,7 @@ test()
 
 
   deallog << (index_set.is_contiguous() ? "true" : "false") << std::endl;
-  Assert(index_set.is_contiguous() == true, ExcInternalError());
+  AssertThrow(index_set.is_contiguous() == true, ExcInternalError());
 
   for (unsigned int i = 0; i < index_set.size(); ++i)
     deallog << i << ' ' << (index_set.is_element(i) ? "true" : "false")

--- a/tests/base/index_set_06.cc
+++ b/tests/base/index_set_06.cc
@@ -35,7 +35,7 @@ test()
 
 
   deallog << (index_set.is_contiguous() ? "true" : "false") << std::endl;
-  Assert(index_set.is_contiguous() == true, ExcInternalError());
+  AssertThrow(index_set.is_contiguous() == true, ExcInternalError());
 
   for (unsigned int i = 0; i < index_set.size(); ++i)
     deallog << i << ' ' << (index_set.is_element(i) ? "true" : "false")

--- a/tests/base/index_set_07.cc
+++ b/tests/base/index_set_07.cc
@@ -38,7 +38,7 @@ test()
 
 
   deallog << (index_set.is_contiguous() ? "true" : "false") << std::endl;
-  Assert(index_set.is_contiguous() == true, ExcInternalError());
+  AssertThrow(index_set.is_contiguous() == true, ExcInternalError());
 
   for (unsigned int i = 0; i < index_set.size(); ++i)
     deallog << i << ' ' << (index_set.is_element(i) ? "true" : "false")

--- a/tests/base/index_set_08.cc
+++ b/tests/base/index_set_08.cc
@@ -40,7 +40,7 @@ test()
 
 
   deallog << (index_set.is_contiguous() ? "true" : "false") << std::endl;
-  Assert(index_set.is_contiguous() == true, ExcInternalError());
+  AssertThrow(index_set.is_contiguous() == true, ExcInternalError());
 
   for (unsigned int i = 0; i < index_set.size(); ++i)
     deallog << i << ' ' << (index_set.is_element(i) ? "true" : "false")

--- a/tests/base/index_set_11.cc
+++ b/tests/base/index_set_11.cc
@@ -37,7 +37,7 @@ test()
                           array + sizeof(array) / sizeof(array[0]));
   }
 
-  Assert(index_set.is_contiguous() == false, ExcInternalError());
+  AssertThrow(index_set.is_contiguous() == false, ExcInternalError());
 
   for (unsigned int i = 0; i < index_set.size(); ++i)
     deallog << i << ' ' << (index_set.is_element(i) ? "true" : "false")
@@ -50,7 +50,7 @@ test()
                           array + sizeof(array) / sizeof(array[0]));
   }
 
-  Assert(index_set.is_contiguous() == true, ExcInternalError());
+  AssertThrow(index_set.is_contiguous() == true, ExcInternalError());
 
   for (unsigned int i = 0; i < index_set.size(); ++i)
     deallog << i << ' ' << (index_set.is_element(i) ? "true" : "false")

--- a/tests/base/index_set_12.cc
+++ b/tests/base/index_set_12.cc
@@ -40,8 +40,9 @@ test()
   for (unsigned int i = 0; i < index_set.n_elements(); ++i)
     {
       deallog << index_set.nth_index_in_set(i) << std::endl;
-      Assert(index_set.index_within_set(index_set.nth_index_in_set(i)) == i,
-             ExcInternalError());
+      AssertThrow(index_set.index_within_set(index_set.nth_index_in_set(i)) ==
+                    i,
+                  ExcInternalError());
     }
   deallog << "OK" << std::endl;
 

--- a/tests/base/index_set_19.cc
+++ b/tests/base/index_set_19.cc
@@ -46,7 +46,7 @@ test()
   deallog << std::endl;
 
   for (unsigned int i = 0; i < indices.size(); i++)
-    Assert(is1.index_within_set(indices[i]) == i, ExcInternalError());
+    AssertThrow(is1.index_within_set(indices[i]) == i, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/index_set_20.cc
+++ b/tests/base/index_set_20.cc
@@ -41,8 +41,9 @@ testor(IndexSet &a, IndexSet &other, bool verbose = true)
 
   for (unsigned int i = 0; i < merged.size(); ++i)
     {
-      Assert(merged.is_element(i) == (a.is_element(i) || other.is_element(i)),
-             ExcInternalError());
+      AssertThrow(merged.is_element(i) ==
+                    (a.is_element(i) || other.is_element(i)),
+                  ExcInternalError());
     }
 }
 

--- a/tests/base/index_set_20_offset.cc
+++ b/tests/base/index_set_20_offset.cc
@@ -41,10 +41,10 @@ testor(IndexSet &a, IndexSet &other, unsigned int offset, bool verbose)
 
   for (unsigned int i = 0; i < merged.size(); ++i)
     {
-      Assert(merged.is_element(i) ==
-               (a.is_element(i) ||
-                (i >= offset && other.is_element(i - offset))),
-             ExcInternalError());
+      AssertThrow(merged.is_element(i) ==
+                    (a.is_element(i) ||
+                     (i >= offset && other.is_element(i - offset))),
+                  ExcInternalError());
     }
 }
 

--- a/tests/base/index_set_22.cc
+++ b/tests/base/index_set_22.cc
@@ -41,7 +41,7 @@ test()
   is1.print(deallog);
 
   for (unsigned int i = 0; i < is1.size(); i++)
-    Assert(is1.is_element(i) == zeros_and_ones[i], ExcInternalError());
+    AssertThrow(is1.is_element(i) == zeros_and_ones[i], ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/index_set_23.cc
+++ b/tests/base/index_set_23.cc
@@ -32,8 +32,8 @@ test()
   is1.add_range(0, 10);
   is2.add_range(0, 20);
 
-  Assert((is1 == is2) == false, ExcInternalError());
-  Assert((is1 != is2) == true, ExcInternalError());
+  AssertThrow((is1 == is2) == false, ExcInternalError());
+  AssertThrow((is1 != is2) == true, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/index_set_64bit_01.cc
+++ b/tests/base/index_set_64bit_01.cc
@@ -48,8 +48,8 @@ test()
   {
     deallog << "* complete:" << std::endl;
     IndexSet s = complete_index_set(N);
-    Assert(s.size() == N, ExcInternalError());
-    Assert(s.n_elements() == N, ExcInternalError());
+    AssertThrow(s.size() == N, ExcInternalError());
+    AssertThrow(s.n_elements() == N, ExcInternalError());
     print(s);
 
     IndexSet::size_type x = s.index_within_set(large2);
@@ -61,7 +61,7 @@ test()
     deallog << "* interval far in:" << std::endl;
     IndexSet s(N);
     s.add_range(large, large2);
-    Assert(s.size() == N, ExcInternalError());
+    AssertThrow(s.size() == N, ExcInternalError());
     print(s);
 
     IndexSet::size_type x = s.index_within_set(large + 1);
@@ -84,7 +84,7 @@ test()
     other.add_range(large, large2);
     s.subtract_set(other);
 
-    Assert(s.size() == N, ExcInternalError());
+    AssertThrow(s.size() == N, ExcInternalError());
     print(s);
 
     IndexSet::size_type x = s.index_within_set(large2 + 1);
@@ -101,7 +101,7 @@ test()
     other.add_index(1);
     other.add_range(4, 7);
     s.add_indices(other, large);
-    Assert(s.size() == N, ExcInternalError());
+    AssertThrow(s.size() == N, ExcInternalError());
     print(s);
   }
 

--- a/tests/base/index_set_iterate_01.cc
+++ b/tests/base/index_set_iterate_01.cc
@@ -25,12 +25,12 @@ test(IndexSet &index_set)
 {
   index_set.print(deallog);
 
-  Assert((int)index_set.n_intervals() ==
-           index_set.end_intervals() - index_set.begin_intervals(),
-         ExcInternalError());
+  AssertThrow((int)index_set.n_intervals() ==
+                index_set.end_intervals() - index_set.begin_intervals(),
+              ExcInternalError());
 
   IndexSet::IntervalIterator endit = index_set.end_intervals();
-  Assert(!endit->is_valid(), ExcInternalError());
+  AssertThrow(!endit->is_valid(), ExcInternalError());
 
   // print intervals
   for (IndexSet::IntervalIterator it = index_set.begin_intervals(); it != endit;
@@ -58,24 +58,26 @@ test(IndexSet &index_set)
        ++it, ++c)
     {
       IndexSet::IntervalIterator it2 = it;
-      Assert(it == it2, ExcInternalError());
-      Assert(it - it2 == 0, ExcInternalError());
-      Assert(endit != it, ExcInternalError());
-      Assert(it != endit, ExcInternalError());
+      AssertThrow(it == it2, ExcInternalError());
+      AssertThrow(it - it2 == 0, ExcInternalError());
+      AssertThrow(endit != it, ExcInternalError());
+      AssertThrow(it != endit, ExcInternalError());
 
       IndexSet::IntervalIterator it3 = it2++;
-      Assert(it == it3, ExcInternalError());
-      Assert(it2 - it3 == 1, ExcInternalError());
-      Assert(it3 < it2, ExcInternalError());
-      Assert(++it3 == it2, ExcInternalError());
+      AssertThrow(it == it3, ExcInternalError());
+      AssertThrow(it2 - it3 == 1, ExcInternalError());
+      AssertThrow(it3 < it2, ExcInternalError());
+      AssertThrow(++it3 == it2, ExcInternalError());
 
-      Assert(it->is_valid(), ExcInternalError());
+      AssertThrow(it->is_valid(), ExcInternalError());
 
-      Assert(it < endit, ExcInternalError());
-      Assert(!(it < it), ExcInternalError());
+      AssertThrow(it < endit, ExcInternalError());
+      AssertThrow(!(it < it), ExcInternalError());
 
-      Assert((it - index_set.begin_intervals()) == (int)c, ExcInternalError());
-      Assert((index_set.begin_intervals() - it) == -(int)c, ExcInternalError());
+      AssertThrow((it - index_set.begin_intervals()) == (int)c,
+                  ExcInternalError());
+      AssertThrow((index_set.begin_intervals() - it) == -(int)c,
+                  ExcInternalError());
 
       deallog << c << ": n_el: " << it->n_elements() << std::endl;
     }
@@ -87,18 +89,18 @@ test(IndexSet &index_set)
     unsigned int c = 0;
     for (; it != index_set.end(); ++it, ++c)
       {
-        Assert(it < index_set.end(), ExcInternalError());
+        AssertThrow(it < index_set.end(), ExcInternalError());
 
         IndexSet::ElementIterator it2 = it;
-        Assert(it == it2, ExcInternalError());
-        Assert(!(it < it2), ExcInternalError());
+        AssertThrow(it == it2, ExcInternalError());
+        AssertThrow(!(it < it2), ExcInternalError());
         IndexSet::ElementIterator it3 = it2++;
-        Assert(it == it3, ExcInternalError());
-        Assert(it < it2, ExcInternalError());
-        Assert(it != it2, ExcInternalError());
+        AssertThrow(it == it3, ExcInternalError());
+        AssertThrow(it < it2, ExcInternalError());
+        AssertThrow(it != it2, ExcInternalError());
 
-        Assert((it - index_set.begin()) == c, ExcInternalError());
-        Assert((index_set.begin() - it) == -(int)c, ExcInternalError());
+        AssertThrow((it - index_set.begin()) == c, ExcInternalError());
+        AssertThrow((index_set.begin() - it) == -(int)c, ExcInternalError());
       }
   }
 
@@ -109,7 +111,7 @@ test(IndexSet &index_set)
     IndexSet::ElementIterator it2 = index_set.begin();
 
     for (; it != index_set.end(); ++it, it2++)
-      Assert(it == it2, ExcInternalError());
+      AssertThrow(it == it2, ExcInternalError());
   }
 
   // pre vs post increment, part 2
@@ -118,23 +120,25 @@ test(IndexSet &index_set)
     IndexSet::IntervalIterator it2 = index_set.begin_intervals();
 
     for (; it != index_set.end_intervals(); ++it, it2++)
-      Assert(it == it2, ExcInternalError());
+      AssertThrow(it == it2, ExcInternalError());
   }
 
   // Assignment
   {
     IndexSet::IntervalIterator it = index_set.begin_intervals();
-    Assert(it->is_valid() || index_set.n_elements() == 0, ExcInternalError());
+    AssertThrow(it->is_valid() || index_set.n_elements() == 0,
+                ExcInternalError());
     it = index_set.end_intervals();
-    Assert(!it->is_valid(), ExcInternalError());
+    AssertThrow(!it->is_valid(), ExcInternalError());
   }
 
   // Construct empty iterator
   {
     IndexSet::IntervalIterator it;
-    Assert(!it->is_valid(), ExcInternalError());
+    AssertThrow(!it->is_valid(), ExcInternalError());
     it = index_set.begin_intervals();
-    Assert(it->is_valid() || index_set.n_elements() == 0, ExcInternalError());
+    AssertThrow(it->is_valid() || index_set.n_elements() == 0,
+                ExcInternalError());
   }
 }
 

--- a/tests/base/index_set_readwrite_01.cc
+++ b/tests/base/index_set_readwrite_01.cc
@@ -37,7 +37,7 @@ test()
   std::ifstream in("a.idxset");
   is2.read(in);
 
-  Assert(is1 == is2, ExcInternalError());
+  AssertThrow(is1 == is2, ExcInternalError());
 
 
   IndexSet is3(11);
@@ -45,7 +45,7 @@ test()
   std::ifstream in2("a.idxset");
   is3.read(in2);
 
-  Assert(is1 == is3, ExcInternalError());
+  AssertThrow(is1 == is3, ExcInternalError());
 
   deallog << "OK" << std::endl;
 

--- a/tests/base/index_set_readwrite_02.cc
+++ b/tests/base/index_set_readwrite_02.cc
@@ -40,7 +40,7 @@ test()
   std::ifstream in("a.idxset");
   is2.block_read(in);
 
-  Assert(is1 == is2, ExcInternalError());
+  AssertThrow(is1 == is2, ExcInternalError());
 
 
   IndexSet is3(11);
@@ -48,7 +48,7 @@ test()
   std::ifstream in2("a.idxset");
   is3.block_read(in2);
 
-  Assert(is1 == is3, ExcInternalError());
+  AssertThrow(is1 == is3, ExcInternalError());
 
   deallog << "OK" << std::endl;
 

--- a/tests/base/index_set_readwrite_03.cc
+++ b/tests/base/index_set_readwrite_03.cc
@@ -40,7 +40,7 @@ test()
   std::ifstream in("a.idxset");
   is2.block_read(in);
 
-  Assert(is1 == is2, ExcInternalError());
+  AssertThrow(is1 == is2, ExcInternalError());
 
   deallog << is1.is_element(4) << " " << is2.is_element(4) << std::endl;
 

--- a/tests/base/is_contiguous_pointers.cc
+++ b/tests/base/is_contiguous_pointers.cc
@@ -31,7 +31,7 @@ test()
   // pointer overload which we know always returns true
   constexpr bool b = internal::ArrayViewHelper::is_contiguous(p, q);
 
-  Assert(b == true, ExcInternalError());
+  AssertThrow(b == true, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/parallel_accumulate.cc
+++ b/tests/base/parallel_accumulate.cc
@@ -39,7 +39,7 @@ main()
   const int N = 10000;
   const int s = parallel::accumulate_from_subranges<int>(&sum, 0, N, 10);
 
-  Assert(s == N * (N - 1) / 2, ExcInternalError());
+  AssertThrow(s == N * (N - 1) / 2, ExcInternalError());
 
   deallog << s << std::endl;
 }

--- a/tests/base/parallel_transform_02.cc
+++ b/tests/base/parallel_transform_02.cc
@@ -46,7 +46,7 @@ main()
                       [](double i, double j) { return i + 2 * j; },
                       10);
 
-  Assert(z.l2_norm() == 0, ExcInternalError());
+  AssertThrow(z.l2_norm() == 0, ExcInternalError());
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/polynomial_jacobi.cc
+++ b/tests/base/polynomial_jacobi.cc
@@ -43,9 +43,11 @@ main()
 
           // assert that roots are increasing
           for (unsigned int i = 1; i < roots.size(); ++i)
-            Assert(roots[i] > roots[i - 1], ExcInternalError());
-          Assert(roots.size() == 0 || roots.front() > -1., ExcInternalError());
-          Assert(roots.size() == 0 || roots.back() < 1., ExcInternalError());
+            AssertThrow(roots[i] > roots[i - 1], ExcInternalError());
+          AssertThrow(roots.size() == 0 || roots.front() > -1.,
+                      ExcInternalError());
+          AssertThrow(roots.size() == 0 || roots.back() < 1.,
+                      ExcInternalError());
 
           for (unsigned int i = 0; i < roots.size(); ++i)
             deallog << roots[i] << " ";

--- a/tests/base/quadrature_check_tensor_product.cc
+++ b/tests/base/quadrature_check_tensor_product.cc
@@ -28,7 +28,7 @@ void
 check_tensor_product(const std::vector<Quadrature<dim>> &quadratures,
                      const std::vector<std::string> &    quadrature_names)
 {
-  Assert(false, ExcNotImplemented());
+  AssertThrow(false, ExcNotImplemented());
 }
 
 template <>

--- a/tests/base/quadrature_point_data.cc
+++ b/tests/base/quadrature_point_data.cc
@@ -76,14 +76,14 @@ public:
   virtual void
   pack_values(std::vector<double> &scalars) const
   {
-    Assert(scalars.size() == 1, ExcInternalError());
+    AssertThrow(scalars.size() == 1, ExcInternalError());
     scalars[0] = value;
   }
 
   virtual void
   unpack_values(const std::vector<double> &scalars)
   {
-    Assert(scalars.size() == 1, ExcInternalError());
+    AssertThrow(scalars.size() == 1, ExcInternalError());
     value = scalars[0];
   }
 };

--- a/tests/base/quadrature_point_data_02.cc
+++ b/tests/base/quadrature_point_data_02.cc
@@ -78,7 +78,7 @@ struct MyQData : public TransferableQuadraturePointData
   virtual void
   pack_values(std::vector<double> &scalars) const
   {
-    Assert(scalars.size() == 2, ExcInternalError());
+    AssertThrow(scalars.size() == 2, ExcInternalError());
     scalars[0] = value1;
     scalars[1] = value2;
   }
@@ -86,7 +86,7 @@ struct MyQData : public TransferableQuadraturePointData
   virtual void
   unpack_values(const std::vector<double> &scalars)
   {
-    Assert(scalars.size() == 2, ExcInternalError());
+    AssertThrow(scalars.size() == 2, ExcInternalError());
     value1 = scalars[0];
     value2 = scalars[1];
   }

--- a/tests/base/quadrature_point_data_03.cc
+++ b/tests/base/quadrature_point_data_03.cc
@@ -85,7 +85,7 @@ struct MyData : public MyDataBase
   virtual void
   pack_values(std::vector<double> &scalars) const
   {
-    Assert(scalars.size() == 2, ExcInternalError());
+    AssertThrow(scalars.size() == 2, ExcInternalError());
     scalars[0] = value1;
     scalars[1] = value2;
   }
@@ -93,7 +93,7 @@ struct MyData : public MyDataBase
   virtual void
   unpack_values(const std::vector<double> &scalars)
   {
-    Assert(scalars.size() == 2, ExcInternalError());
+    AssertThrow(scalars.size() == 2, ExcInternalError());
     value1 = scalars[0];
     value2 = scalars[1];
   }

--- a/tests/base/quadrature_selector.cc
+++ b/tests/base/quadrature_selector.cc
@@ -33,8 +33,9 @@ check(const std::string &    name,
       const unsigned int     order,
       const Quadrature<dim> &q)
 {
-  Assert(QuadratureSelector<dim>(name, order).get_points() == q.get_points(),
-         ExcInternalError());
+  AssertThrow(QuadratureSelector<dim>(name, order).get_points() ==
+                q.get_points(),
+              ExcInternalError());
   deallog << name << ' ' << order << " ok" << std::endl;
 }
 

--- a/tests/base/task_03.cc
+++ b/tests/base/task_03.cc
@@ -51,7 +51,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/task_04.cc
+++ b/tests/base/task_04.cc
@@ -56,7 +56,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/task_06.cc
+++ b/tests/base/task_06.cc
@@ -53,7 +53,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/task_07.cc
+++ b/tests/base/task_07.cc
@@ -46,7 +46,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/task_08.cc
+++ b/tests/base/task_08.cc
@@ -45,7 +45,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/task_11.cc
+++ b/tests/base/task_11.cc
@@ -87,9 +87,9 @@ main()
       test();
     }
   else
-    Assert(false,
-           ExcInternalError(
-             "did somebody mess with LimitConcurrency in tests.h?"));
+    AssertThrow(false,
+                ExcInternalError(
+                  "did somebody mess with LimitConcurrency in tests.h?"));
 
   deallog << "* now with thread limit 1:" << std::endl;
   MultithreadInfo::set_thread_limit(1);

--- a/tests/base/task_12.cc
+++ b/tests/base/task_12.cc
@@ -51,7 +51,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/task_12_capture.cc
+++ b/tests/base/task_12_capture.cc
@@ -59,7 +59,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/task_13.cc
+++ b/tests/base/task_13.cc
@@ -56,7 +56,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/thread_12.cc
+++ b/tests/base/thread_12.cc
@@ -51,7 +51,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/thread_local_storage_02.cc
+++ b/tests/base/thread_local_storage_02.cc
@@ -29,12 +29,12 @@ struct X
 {
   X()
   {
-    Assert(false, ExcInternalError());
+    AssertThrow(false, ExcInternalError());
   };
   X(int n)
   {
     deallog << "Creating" << std::endl;
-    Assert(n == 42, ExcInternalError());
+    AssertThrow(n == 42, ExcInternalError());
   };
   X(const X &)
   {

--- a/tests/base/thread_validity_03.cc
+++ b/tests/base/thread_validity_03.cc
@@ -34,7 +34,7 @@ struct X
   void
   execute()
   {
-    Assert(i == 42, ExcInternalError());
+    AssertThrow(i == 42, ExcInternalError());
     deallog << "OK" << std::endl;
   }
 

--- a/tests/base/thread_validity_04.cc
+++ b/tests/base/thread_validity_04.cc
@@ -35,7 +35,7 @@ struct X
   void
   execute() const
   {
-    Assert(i == 42, ExcInternalError());
+    AssertThrow(i == 42, ExcInternalError());
     deallog << "OK" << std::endl;
   }
 

--- a/tests/base/thread_validity_05.cc
+++ b/tests/base/thread_validity_05.cc
@@ -34,13 +34,13 @@ struct X
   void
   execute()
   {
-    Assert(false, ExcInternalError());
+    AssertThrow(false, ExcInternalError());
   }
 
   void
   execute() const
   {
-    Assert(i == 42, ExcInternalError());
+    AssertThrow(i == 42, ExcInternalError());
     deallog << "OK" << std::endl;
   }
 
@@ -70,14 +70,14 @@ struct Y
   void
   execute()
   {
-    Assert(i == 42, ExcInternalError());
+    AssertThrow(i == 42, ExcInternalError());
     deallog << "OK" << std::endl;
   }
 
   void
   execute() const
   {
-    Assert(false, ExcInternalError());
+    AssertThrow(false, ExcInternalError());
   }
 
 private:

--- a/tests/base/thread_validity_06.cc
+++ b/tests/base/thread_validity_06.cc
@@ -47,7 +47,7 @@ struct X
 void
 execute_ref(const X &x)
 {
-  Assert(x.i == 0, ExcInternalError());
+  AssertThrow(x.i == 0, ExcInternalError());
   deallog << unify_pretty_function(__PRETTY_FUNCTION__) << ' ' << x.i
           << std::endl;
   deallog << "OK" << std::endl;
@@ -56,7 +56,7 @@ execute_ref(const X &x)
 void
 execute_value(X x)
 {
-  Assert(x.i > 0, ExcInternalError());
+  AssertThrow(x.i > 0, ExcInternalError());
   deallog << unify_pretty_function(__PRETTY_FUNCTION__) << ' '
           << (x.i > 0 ? "OK" : "not OK") << std::endl;
   deallog << "OK" << std::endl;

--- a/tests/base/thread_validity_07.cc
+++ b/tests/base/thread_validity_07.cc
@@ -58,7 +58,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/threads_02.cc
+++ b/tests/base/threads_02.cc
@@ -3664,7 +3664,7 @@ main()
 
   std::ofstream *out_stream =
     dynamic_cast<std::ofstream *>(&deallog.get_file_stream());
-  Assert(out_stream != nullptr, ExcInternalError());
+  AssertThrow(out_stream != nullptr, ExcInternalError());
   deallog.detach();
   out_stream->close();
   sort_file_contents("output");

--- a/tests/base/timer_07.cc
+++ b/tests/base/timer_07.cc
@@ -91,11 +91,11 @@ main(int argc, char **argv)
                   output.rend(),
                   '|')
           .base();
-      Assert(start_pipe != output.end(), ExcInternalError());
+      AssertThrow(start_pipe != output.end(), ExcInternalError());
       const std::string::iterator end_pipe =
         std::find(next_number, output.end(), '|');
-      Assert(end_pipe != output.end(), ExcInternalError());
-      Assert(end_pipe - start_pipe > 1, ExcInternalError());
+      AssertThrow(end_pipe != output.end(), ExcInternalError());
+      AssertThrow(end_pipe - start_pipe > 1, ExcInternalError());
 
       std::fill(start_pipe + 1, end_pipe - 1, 'x');
       next_number = std::find_if(next_number, output.end(), is_digit);

--- a/tests/base/transpose_table_iterators_0.cc
+++ b/tests/base/transpose_table_iterators_0.cc
@@ -87,14 +87,15 @@ main()
   // Test an empty table
   {
     TransposeTable<double> transpose_table;
-    Assert(transpose_table.begin() == transpose_table.end(),
-           ExcMessage("The beginning and end iterators should be equal for an "
-                      "empty table."));
+    AssertThrow(transpose_table.begin() == transpose_table.end(),
+                ExcMessage(
+                  "The beginning and end iterators should be equal for an "
+                  "empty table."));
     TransposeTable<double>::const_iterator begin = transpose_table.begin();
     TransposeTable<double>::const_iterator end   = transpose_table.end();
-    Assert(begin == end,
-           ExcMessage("The beginning and end const iterators should"
-                      " be equal for an empty table."));
+    AssertThrow(begin == end,
+                ExcMessage("The beginning and end const iterators should"
+                           " be equal for an empty table."));
   }
 
   // test some things with accessors

--- a/tests/base/utilities_04.cc
+++ b/tests/base/utilities_04.cc
@@ -49,13 +49,13 @@ test_function(const std::string &original_text,
   std::vector<std::string> should_be_vec = split_string(result);
 
 
-  Assert(res_vec.size() == should_be_vec.size(), ExcInternalError());
+  AssertThrow(res_vec.size() == should_be_vec.size(), ExcInternalError());
   for (unsigned int i = 0; i < res_vec.size(); ++i)
     {
       if (res_vec[i] != should_be_vec[i])
         std::cout << "'" << res_vec[i] << "!=" << should_be_vec[i] << "'"
                   << std::endl;
-      Assert(res_vec[i] == should_be_vec[i], ExcInternalError());
+      AssertThrow(res_vec[i] == should_be_vec[i], ExcInternalError());
     }
 }
 

--- a/tests/base/utilities_06.cc
+++ b/tests/base/utilities_06.cc
@@ -38,7 +38,7 @@ verify(const std::string &s)
     {
       exception_caught = true;
     }
-  Assert(exception_caught == true, ExcMessage("Function is broken!"));
+  AssertThrow(exception_caught == true, ExcMessage("Function is broken!"));
 
   deallog << "Done correctly: " << s << std::endl;
 }

--- a/tests/base/utilities_07.cc
+++ b/tests/base/utilities_07.cc
@@ -38,7 +38,7 @@ verify(const std::string &s)
     {
       exception_caught = true;
     }
-  Assert(exception_caught == true, ExcMessage("Function is broken!"));
+  AssertThrow(exception_caught == true, ExcMessage("Function is broken!"));
 
   deallog << "Done correctly: " << s << std::endl;
 }

--- a/tests/base/utilities_10.cc
+++ b/tests/base/utilities_10.cc
@@ -46,9 +46,10 @@ test()
     deallog << Utilities::split_string_list("   ", ' ').size() << std::endl;
   }
 
-  Assert(Utilities::split_string_list(" ; ", ';').size() == 1,
-         ExcInternalError());
-  Assert(Utilities::split_string_list(" ; ", ';')[0] == "", ExcInternalError());
+  AssertThrow(Utilities::split_string_list(" ; ", ';').size() == 1,
+              ExcInternalError());
+  AssertThrow(Utilities::split_string_list(" ; ", ';')[0] == "",
+              ExcInternalError());
 }
 
 

--- a/tests/base/utilities_11.cc
+++ b/tests/base/utilities_11.cc
@@ -26,40 +26,44 @@ void
 test()
 {
   const auto i = static_cast<unsigned long long int>(std::pow(2, 33));
-  Assert(Utilities::to_string(i) == "8589934592", ExcInternalError());
-  Assert(Utilities::to_string(i, 11) == "08589934592", ExcInternalError());
+  AssertThrow(Utilities::to_string(i) == "8589934592", ExcInternalError());
+  AssertThrow(Utilities::to_string(i, 11) == "08589934592", ExcInternalError());
 
   const auto j = static_cast<unsigned long long int>(std::pow(2, 31));
-  Assert(Utilities::to_string(j) == "2147483648", ExcInternalError());
+  AssertThrow(Utilities::to_string(j) == "2147483648", ExcInternalError());
 
   const int k = static_cast<int>(-std::pow(2, 30));
-  Assert(Utilities::to_string(k) == "-1073741824", ExcInternalError());
-  Assert(Utilities::to_string(k, 12) == "-01073741824", ExcInternalError());
+  AssertThrow(Utilities::to_string(k) == "-1073741824", ExcInternalError());
+  AssertThrow(Utilities::to_string(k, 12) == "-01073741824",
+              ExcInternalError());
 
   const auto l = static_cast<long long int>(-std::pow(2, 35));
-  Assert(Utilities::to_string(l) == "-34359738368", ExcInternalError());
-  Assert(Utilities::to_string(l, 13) == "-034359738368", ExcInternalError());
+  AssertThrow(Utilities::to_string(l) == "-34359738368", ExcInternalError());
+  AssertThrow(Utilities::to_string(l, 13) == "-034359738368",
+              ExcInternalError());
 
   float f(-3.14159265358979323846264338327950288419716939937510);
-  Assert(Utilities::to_string(f) == "-3.14159274", ExcInternalError());
-  Assert(Utilities::to_string(f, 13) == "-003.14159274", ExcInternalError());
+  AssertThrow(Utilities::to_string(f) == "-3.14159274", ExcInternalError());
+  AssertThrow(Utilities::to_string(f, 13) == "-003.14159274",
+              ExcInternalError());
 
   double d(-3.14159265358979323846264338327950288419716939937510);
-  Assert(Utilities::to_string(d) == "-3.1415926535897931", ExcInternalError());
-  Assert(Utilities::to_string(d, 20) == "-03.1415926535897931",
-         ExcInternalError());
+  AssertThrow(Utilities::to_string(d) == "-3.1415926535897931",
+              ExcInternalError());
+  AssertThrow(Utilities::to_string(d, 20) == "-03.1415926535897931",
+              ExcInternalError());
 
   long double ld(-3.14159265358979323846264338327950288419716939937510L);
-  Assert(Utilities::to_string(ld) == "-3.14159265358979323851",
-         ExcInternalError());
-  Assert(Utilities::to_string(ld, 24) == "-03.14159265358979323851",
-         ExcInternalError());
+  AssertThrow(Utilities::to_string(ld) == "-3.14159265358979323851",
+              ExcInternalError());
+  AssertThrow(Utilities::to_string(ld, 24) == "-03.14159265358979323851",
+              ExcInternalError());
 
   double ed(-3.1415926535e-115);
-  Assert(Utilities::to_string(ed) == "-3.1415926534999999e-115",
-         ExcInternalError());
-  Assert(Utilities::to_string(ed, 28) == "-00003.1415926534999999e-115",
-         ExcInternalError());
+  AssertThrow(Utilities::to_string(ed) == "-3.1415926534999999e-115",
+              ExcInternalError());
+  AssertThrow(Utilities::to_string(ed, 28) == "-00003.1415926534999999e-115",
+              ExcInternalError());
 
   deallog << "Ok." << std::endl;
 }

--- a/tests/base/utilities_13.cc
+++ b/tests/base/utilities_13.cc
@@ -116,25 +116,25 @@ test3()
   {
     const Number  v = 0.2;
     const Integer i = (Integer)(v * (Number)max);
-    Assert(i > 0 && i < max, ExcInternalError());
+    AssertThrow(i > 0 && i < max, ExcInternalError());
   }
 
   {
     const Number  v = 0.7;
     const Integer i = (Integer)(v * (Number)max);
-    Assert(i > 0 && i < max, ExcInternalError());
+    AssertThrow(i > 0 && i < max, ExcInternalError());
   }
 
   {
     const Number  v = 0.;
     const Integer i = (Integer)(v * (Number)max);
-    Assert(i == 0, ExcInternalError());
+    AssertThrow(i == 0, ExcInternalError());
   }
 
   {
     const Number  v = 1.;
     const Integer i = (Integer)(v * (Number)max);
-    Assert(i == max, ExcInternalError());
+    AssertThrow(i == max, ExcInternalError());
   }
 }
 

--- a/tests/base/utilities_17.cc
+++ b/tests/base/utilities_17.cc
@@ -38,7 +38,7 @@
 void
 test(const unsigned int plane = 1)
 {
-  Assert(plane < 3, ExcInternalError());
+  AssertThrow(plane < 3, ExcInternalError());
   const std::vector<Point<2>> points = {Point<2>(0, 0),
                                         Point<2>(1, 0),
                                         Point<2>(1, 1),

--- a/tests/base/utilities_18.cc
+++ b/tests/base/utilities_18.cc
@@ -26,7 +26,7 @@
 void
 test(unsigned int plane = 1)
 {
-  Assert(plane < 3, ExcInternalError());
+  AssertThrow(plane < 3, ExcInternalError());
   const std::vector<Point<1>> points = {
     Point<1>(1), Point<1>(0), Point<1>(13), Point<1>(-2), Point<1>(22)};
 

--- a/tests/base/work_stream_03.cc
+++ b/tests/base/work_stream_03.cc
@@ -169,7 +169,7 @@ do_project()
                       8,
                       1);
 
-      Assert(std::fabs(sum - 288.) < 1e-12, ExcInternalError());
+      AssertThrow(std::fabs(sum - 288.) < 1e-12, ExcInternalError());
       deallog << sum << std::endl;
     }
 }

--- a/tests/base/work_stream_03_graph.cc
+++ b/tests/base/work_stream_03_graph.cc
@@ -180,7 +180,7 @@ do_project()
                       8,
                       1);
 
-      Assert(std::fabs(sum - 288.) < 1e-12, ExcInternalError());
+      AssertThrow(std::fabs(sum - 288.) < 1e-12, ExcInternalError());
       deallog << sum << std::endl;
     }
 }


### PR DESCRIPTION
The first attempt to address [this comment](https://github.com/dealii/dealii/pull/9492#discussion_r376660548).

I only modified the tests in `tests/base/` except `tests/base/assertion_macros.cc`. I added a paragraph to the documentation for developers specifying that we prefer `AssertThrow` to `Assert` in the test codes. Since the Jenkins CI doesn't check the tests in the release build, I ran the test suite on my machine and the tests passed as expected. I will apply this to the rest of the test suite soon.