### PR TITLE
Create separate artifacts in GitHub workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - name: archive
       uses: actions/upload-artifact@v1
       with:
-        name: detailed.log
+        name: serial-detailed.log
         path: detailed.log
     - name: build
       run: |
@@ -60,7 +60,7 @@ jobs:
     - name: archive
       uses: actions/upload-artifact@v1
       with:
-        name: detailed.log
+        name: parallel-detailed.log
         path: detailed.log
     - name: build
       run: |


### PR DESCRIPTION
Currently, the workflow CI run only creates one artifact which I guess is due to them having the same name. Let's see if choosing different names help.