### PR TITLE
Upgrade checkdoxygen.py to check for multiple-defined section headers

### DIFF
--- a/contrib/utilities/checkdoxygen.py
+++ b/contrib/utilities/checkdoxygen.py
@@ -49,6 +49,45 @@ def check_empty_lines_in_tables(lines):
 
     return
 
+# have more than one header with the same name in a tutorial?
+def check_multiple_defined_headers(lines):
+    headers = []
+    for l in lines:
+        # this may break if a header splits across a line
+        if "<h" in l:
+            # convert thisheader to the doxygen header name equivalent
+            thisheader = l                             # take this line
+            thisheader = thisheader.replace(' ', '')   # remove all whitespace
+            thisheader = thisheader.split('<h')[1]     # remove header tag '<h'
+            if thisheader[0] in ['1', '2', '3', '4', '5']:  # make sure the next character is 1-5
+                thisheader = thisheader[2:]            # remove '*>'
+                if len(thisheader.split('</h'))==2:    # check for close header on the same line
+                    thisheader = thisheader.split('</h')[0]    # remove close header tag
+                    thisheader = ''.join(ch for ch in thisheader if ch.isalnum()) # remove nonalphanumeric
+                    if thisheader in headers:
+                        sys.exit("Error: repeated header title '%s' in file group '%s'"%(thisheader,args[0]))
+                    else:
+                        headers.append(thisheader)
+                else:
+                    sys.exit("Error: mismatched html header flags in file group '%s'"%(args[0]))
+            # do not check else here because it may match with template arguments like '<hsize_t>'
+        
+        # detect @sect[1-5]{ ... }
+        if "@sect" in l:
+            thisheader = l                             # take this line
+            thisheader = thisheader.replace(' ', '')   # remove all whitespace
+            thisheader = thisheader.split('@sect')[1]  # remove '@sect'
+            if thisheader[0] in ['1', '2', '3', '4', '5']:  # make sure the next character is 1-5
+                thisheader = thisheader[2:]          # remove the number
+                thisheader = ''.join(ch for ch in thisheader if ch.isalnum()) # remove nonalphanumeric
+
+                if thisheader in headers:
+                    sys.exit("Error: repeated header title '%s' in file group '%s'"%(thisheader,args[0]))
+                else:
+                    headers.append(thisheader)
+
+    return
+
 
 args = sys.argv
 args.pop(0)
@@ -60,4 +99,29 @@ f.close()
 check_doxygen_groups(lines)
 check_empty_lines_in_tables(lines)
 
+# if it's intro.dox, combine it with step-**.cc and results.dox and check headers
+if 'intro.dox' in args[0]:
+    # get stepname.cc
+    stepname = args[0].split('/doc',1)[0]
+    stepname = stepname + '/' + stepname.split('/',1)[1] + '.cc'
+
+    # get results.dox
+    resultsname = args[0].split('intro.dox',1)[0] + 'results.dox'
+    
+    # try to open the '.cc' file, otherwise try to open a '.cu' file
+    try:
+        fstep = open(stepname)
+    except IOError:
+        stepname = stepname[:-2] + 'cu'
+        fstep = open(stepname)
+
+    lines += fstep.readlines()
+    fstep.close()
+
+    fres = open(resultsname)
+    lines.append(fres.readlines())
+    fres.close()
+    
+    # check the file group
+    check_multiple_defined_headers(lines)
 


### PR DESCRIPTION
This is related to #9460. `checkdoxygen.py` will now additionally do the following:
1. If it is reading an `intro.dox` file, concatenate the corresponding `step-**.cc` file and the `results.dox` file into one list.
2. Iterate through the list. Every time a `<h` or a `@sect` is found, its contents (with spaces and nonalphanumerics removed, to match the anchors) are added to a dictionary if it is a new title
3. If this header was already found, throw an error with a helpful message to check the file

Running the script on my end yields the following:
```
$ find doc examples include \( -name "*.h" -o -name "*.dox" \) -print | xargs -n 1 contrib/utilities/checkdoxygen.py
Error: repeated header title 'Privatememberfunctions' in file group 'examples/step-28/doc/intro.dox'
Error: repeated header title 'Settingupperiodicityconstraintsondistributedtriangulations' in file group 'examples/step-45/doc/intro.dox'
Error: repeated header title 'ThePointValueEvaluationclass' in file group 'examples/step-14/doc/intro.dox'
Error: repeated header title 'LaplaceProblemLaplaceProblem' in file group 'examples/step-27/doc/intro.dox'
Error: repeated header title 'HelmholtzProblemHelmholtzProblem' in file group 'examples/step-7/doc/intro.dox'
Error: repeated header title 'Streamlinediffusion' in file group 'examples/step-63/doc/intro.dox'
Error: repeated header title 'Linearsolversandpreconditioners' in file group 'examples/step-20/doc/intro.dox'
Error: repeated header title 'TheRightHandSideclass' in file group 'examples/step-62/doc/intro.dox'
Error: repeated header title 'ElasticProblemElasticProblem' in file group 'examples/step-8/doc/intro.dox'
```

I'm working to verify that these are true statements and if those doxygen links are indeed broken, but I thought I'd share nontheless :)