### PR TITLE
Update tutorial programs to fix all broken dox links

### DIFF
--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -1388,7 +1388,7 @@ namespace Step14
     };
 
 
-    // @sect4{The PointValueEvaluation class}
+    // @sect4{The dual functional PointValueEvaluation class}
 
     // As a first application, we consider the functional corresponding to the
     // evaluation of the solution's value at a given point which again we
@@ -1465,7 +1465,7 @@ namespace Step14
     }
 
 
-    // @sect4{The PointXDerivativeEvaluation class}
+    // @sect4{The dual functional PointXDerivativeEvaluation class}
 
     // As second application, we again consider the evaluation of the
     // x-derivative of the solution at one point. Again, the declaration of

--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -559,7 +559,7 @@ namespace Step20
   }
 
 
-  // @sect3{Linear solvers and preconditioners}
+  // @sect3{Implementation of linear solvers and preconditioners}
 
   // The linear solvers and preconditioners we use in this example have
   // been discussed in significant detail already in the introduction. We

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -155,7 +155,7 @@ namespace Step27
 
   // @sect3{Implementation of the main class}
 
-  // @sect4{LaplaceProblem::LaplaceProblem}
+  // @sect4{LaplaceProblem::LaplaceProblem constructor}
 
   // The constructor of this class is fairly straightforward. It associates
   // the hp::DoFHandler object with the triangulation, and then sets the
@@ -240,7 +240,7 @@ namespace Step27
   }
 
 
-  // @sect4{LaplaceProblem::~LaplaceProblem}
+  // @sect4{LaplaceProblem::~LaplaceProblem destructor}
 
   // The destructor is unchanged from what we already did in step-6:
   template <int dim>

--- a/examples/step-28/step-28.cc
+++ b/examples/step-28/step-28.cc
@@ -392,7 +392,7 @@ namespace Step28
   class EnergyGroup
   {
   public:
-    // @sect5{Public member functions}
+    // @sect5{<code>EnergyGroup</code> public member functions}
     //
     // The class has a good number of public member functions, since its the
     // way it operates is controlled from the outside, and therefore all
@@ -458,7 +458,7 @@ namespace Step28
                      const double         refine_threshold,
                      const double         coarsen_threshold);
 
-    // @sect5{Public data members}
+    // @sect5{<code>EnergyGroup</code> public data members}
     //
     // As is good practice in object oriented programming, we hide most data
     // members by making them private. However, we have to grant the class
@@ -471,7 +471,7 @@ namespace Step28
     Vector<double> solution_old;
 
 
-    // @sect5{Private data members}
+    // @sect5{<code>EnergyGroup</code> private data members}
     //
     // The rest of the data members are private. Compared to all the previous
     // tutorial programs, the only new data members are an integer storing
@@ -501,7 +501,7 @@ namespace Step28
     AffineConstraints<double>                 hanging_node_constraints;
 
 
-    // @sect5{Private member functions}
+    // @sect5{<code>EnergyGroup</code> private member functions}
     //
     // There is one private member function in this class. It recursively
     // walks over cells of two meshes to compute the cross-group right hand
@@ -1170,7 +1170,7 @@ namespace Step28
     void run();
 
   private:
-    // @sect5{Private member functions}
+    // @sect5{<code>NeutronDiffusionProblem</code> private member functions}
 
     // There are not that many member functions in this class since most of
     // the functionality has been moved into the <code>EnergyGroup</code>
@@ -1183,7 +1183,7 @@ namespace Step28
     double get_total_fission_source() const;
 
 
-    // @sect5{Private member variables}
+    // @sect5{<code>NeutronDiffusionProblem</code> private member variables}
 
     // Next, we have a few member variables. In particular, these are (i) a
     // reference to the parameter object (owned by the main function of this

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -358,7 +358,7 @@ namespace step62
 
   // @sect3{Implementation of the auxiliary classes}
 
-  // @sect4{The `RightHandSide` class}
+  // @sect4{The `RightHandSide` class implementation}
 
   // The constructor reads all the parameters from the HDF5::Group `data` using
   // the HDF5::Group::get_attribute() function.
@@ -420,7 +420,7 @@ namespace step62
 
 
 
-  // @sect4{The `PML` class}
+  // @sect4{The `PML` class implementation}
 
   // As before, the constructor reads all the parameters from the HDF5::Group
   // `data` using the HDF5::Group::get_attribute() function. As we have
@@ -483,7 +483,7 @@ namespace step62
 
 
 
-  // @sect4{The `Rho` class}
+  // @sect4{The `Rho` class implementation}
 
   // This class is used to define the mass density. As we have explaine before,
   // a phononic superlattice cavity is formed by two
@@ -646,7 +646,7 @@ namespace step62
 
 
 
-  // @sect4{The `Parameters` class}
+  // @sect4{The `Parameters` class implementation}
 
   // The constructor reads all the parameters from the HDF5::Group `data` using
   // the HDF5::Group::get_attribute() function.
@@ -677,7 +677,7 @@ namespace step62
 
 
 
-  // @sect4{The `QuadratureCache` class}
+  // @sect4{The `QuadratureCache` class implementation}
 
   // We need to reserve enough space for the mass and stiffness matrices and the
   // right hand side vector.

--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -451,7 +451,7 @@ namespace Step63
 
 
 
-  // @sect3{Streamline diffusion}
+  // @sect3{Streamline diffusion implementation}
 
   // The streamline diffusion method has a stabilization constant that
   // we need to be able to compute. The choice of how this parameter

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -441,7 +441,7 @@ namespace Step7
 
   // @sect3{The HelmholtzProblem class implementation}
 
-  // @sect4{HelmholtzProblem::HelmholtzProblem}
+  // @sect4{HelmholtzProblem::HelmholtzProblem constructor}
 
   // In the constructor of this class, we only set the variables passed as
   // arguments, and associate the DoF handler object with the triangulation
@@ -455,7 +455,7 @@ namespace Step7
   {}
 
 
-  // @sect4{HelmholtzProblem::~HelmholtzProblem}
+  // @sect4{HelmholtzProblem::~HelmholtzProblem destructor}
 
   // This is no different than before:
   template <int dim>

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -179,7 +179,7 @@ namespace Step8
 
   // @sect3{The <code>ElasticProblem</code> class implementation}
 
-  // @sect4{ElasticProblem::ElasticProblem}
+  // @sect4{ElasticProblem::ElasticProblem constructor}
 
   // Following is the constructor of the main class. As said before, we would
   // like to construct a vector-valued finite element that is composed of
@@ -204,7 +204,7 @@ namespace Step8
 
 
 
-  // @sect4{ElasticProblem::~ElasticProblem}
+  // @sect4{ElasticProblem::~ElasticProblem destructor}
 
   // The destructor, on the other hand, is exactly as in step-6:
   template <int dim>


### PR DESCRIPTION
Well, this fixes all of them *except* step-45. :stuck_out_tongue: Feel free to suggest better names than the ones I chose.

This closes #9460. These were spotted due to the work in #9505.

@masterleinad, how should we rename the sections in step-45?