### PR TITLE
Indent script: Do not use --diff-filter=d

### DIFF
--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -307,8 +307,9 @@ process_changed()
   esac
 
   ( git ls-files --others --exclude-standard -- ${1};
-    git diff --name-only --diff-filter=d $COMMON_ANCESTOR_WITH_MASTER -- ${1} )|
+    git diff --name-only $COMMON_ANCESTOR_WITH_MASTER -- ${1} )|
       sort -u |
+      xargs -n 1 ls -d 2>/dev/null |
       grep -E "^${2}$" |
       ${XARGS} '\n' -n 1 -P 10 -I {} bash -c "${3} {}"
 }


### PR DESCRIPTION
This hopefully fixes some compatibility issues with ancient git versions
not supporting the --diff-filter option.

Closes #9489