### PR TITLE
Remove MPI_COMM_WORLD as default argument in write_vtu_with_pvtu_record

### DIFF
--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -1279,7 +1279,7 @@ namespace Step18
     // this single time step:
     const std::string pvtu_master_filename =
       data_out.write_vtu_with_pvtu_record(
-        "./", "solution", timestep_no, 4, mpi_communicator);
+        "./", "solution", timestep_no, mpi_communicator, 4);
 
     // The record files must be written only once and not by each processor,
     // so we do this on processor 0:

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -3243,7 +3243,7 @@ namespace Step32
 
     static int out_index = 0;
     data_out.write_vtu_with_pvtu_record(
-      "./", "solution", out_index, 5, MPI_COMM_WORLD);
+      "./", "solution", out_index, MPI_COMM_WORLD, 5);
 
     out_index++;
   }

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -1132,7 +1132,7 @@ namespace Step37
     flags.compression_level = DataOutBase::VtkFlags::best_speed;
     data_out.set_flags(flags);
     data_out.write_vtu_with_pvtu_record(
-      "./", "solution", cycle, 3, MPI_COMM_WORLD);
+      "./", "solution", cycle, MPI_COMM_WORLD, 3);
 
     time_details << "Time write output          (CPU/wall) " << time.cpu_time()
                  << "s/" << time.wall_time() << "s\n";

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -576,7 +576,7 @@ namespace Step40
     // in parallel with the help of MPI-IO. Additionally a PVTU record is
     // generated, which groups the written VTU files.
     data_out.write_vtu_with_pvtu_record(
-      "./", "solution", cycle, 2, mpi_communicator, 8);
+      "./", "solution", cycle, mpi_communicator, 2, 8);
   }
 
 

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -2036,7 +2036,7 @@ namespace Step42
     // Paraview, the Visit visualization program, by creating a matching
     // <code>.visit</code> file.
     const std::string master_name = data_out.write_vtu_with_pvtu_record(
-      output_dir, "solution", current_refinement_cycle, 2, mpi_communicator);
+      output_dir, "solution", current_refinement_cycle, mpi_communicator, 2);
     pcout << master_name << std::endl;
 
     TrilinosWrappers::MPI::Vector tmp(solution);

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -737,7 +737,7 @@ namespace Step45
     data_out.build_patches(mapping, degree + 1);
 
     data_out.write_vtu_with_pvtu_record(
-      "./", "solution", refinement_cycle, 2, MPI_COMM_WORLD);
+      "./", "solution", refinement_cycle, MPI_COMM_WORLD, 2);
   }
 
 

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -501,7 +501,7 @@ namespace Step48
     data_out.build_patches();
 
     data_out.write_vtu_with_pvtu_record(
-      "./", "solution", timestep_number, 3, MPI_COMM_WORLD);
+      "./", "solution", timestep_number, MPI_COMM_WORLD, 3);
   }
 
 

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -851,7 +851,7 @@ namespace Step50
     data_out.build_patches(0);
 
     const auto filename = data_out.write_vtu_with_pvtu_record(
-      "", "solution", cycle, 5, mpi_communicator, 8);
+      "", "solution", cycle, mpi_communicator, 5, 8);
     pcout << "    wrote " << filename << std::endl;
   }
 

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -749,7 +749,7 @@ namespace Step55
     data_out.build_patches();
 
     data_out.write_vtu_with_pvtu_record(
-      "./", "solution", cycle, 2, mpi_communicator);
+      "./", "solution", cycle, mpi_communicator, 2);
   }
 
 

--- a/examples/step-64/step-64.cu
+++ b/examples/step-64/step-64.cu
@@ -548,7 +548,7 @@ namespace Step64
     flags.compression_level = DataOutBase::VtkFlags::best_speed;
     data_out.set_flags(flags);
     data_out.write_vtu_with_pvtu_record(
-      "./", "solution", cycle, 2, mpi_communicator);
+      "./", "solution", cycle, mpi_communicator, 2);
 
     Vector<float> cellwise_norm(triangulation.n_active_cells());
     VectorTools::integrate_difference(dof_handler,

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2756,7 +2756,7 @@ public:
    * DataOutInterface::write_pvtu_record().
    *
    * For example, running
-   * <code> write_vtu_with_pvtu_record("output/", "solution", 3, 4, comm, 2)
+   * <code> write_vtu_with_pvtu_record("output/", "solution", 3, comm, 4, 2)
    * </code> on 10 processes generates the files
    * @code
    * output/solution_0003.0.vtu
@@ -2782,7 +2782,7 @@ public:
    * In a
    * parallel setting, several files are typically written per time step. The
    * number of files written in parallel depends on the number of MPI processes
-   * (see parameter @p mpi_communicator with default value MPI_COMM_WORLD), and a
+   * (see parameter @p mpi_communicator), and a
    * specified number of @p n_groups with default value 0. The background is that
    * VTU file output supports grouping files from several CPUs into a given
    * number of files using MPI I/O when writing on a parallel filesystem. The
@@ -2812,8 +2812,8 @@ public:
     const std::string &directory,
     const std::string &filename_without_extension,
     const unsigned int counter,
+    const MPI_Comm &   mpi_communicator,
     const unsigned int n_digits_for_counter = numbers::invalid_unsigned_int,
-    const MPI_Comm &   mpi_communicator     = MPI_COMM_WORLD,
     const unsigned int n_groups             = 0) const;
 
   /**

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7149,8 +7149,8 @@ DataOutInterface<dim, spacedim>::write_vtu_with_pvtu_record(
   const std::string &directory,
   const std::string &filename_without_extension,
   const unsigned int counter,
-  const unsigned int n_digits_for_counter,
   const MPI_Comm &   mpi_communicator,
+  const unsigned int n_digits_for_counter,
   const unsigned int n_groups) const
 {
   const unsigned int rank = Utilities::MPI::this_mpi_process(mpi_communicator);


### PR DESCRIPTION
With the consent of @nfehn, I remove the default argument of the MPI communicator. ~Once everyone agrees, I will also update the tutorials, which use this new function.~