### PR TITLE
Avoid calling into MPI functions with MinMaxAvg in serial

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -570,6 +570,7 @@ namespace Utilities
               result[i].min_index = 0;
               result[i].max_index = 0;
             }
+          return;
         }
 
       AssertDimension(Utilities::MPI::min(my_values.size(), mpi_communicator),


### PR DESCRIPTION
This leads to a series of test failures, e.g. here:
https://cdash.43-1.org/viewTest.php?onlydelta&buildid=4309
The failure was introduced by a change in #9473.