### PR TITLE
Ensure to have valid quadrature point data for all SIMD lanes

### DIFF
--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1457,6 +1457,11 @@ namespace internal
                                 face_data.normal_vectors[q][d][v] =
                                   face_data.normal_vectors[q][d][0];
                               }
+                          if (fe_face_values.get_update_flags() &
+                              update_quadrature_points)
+                            for (unsigned int d = 0; d < dim; ++d)
+                              face_data.quadrature_points[q][d][v] =
+                                face_data.quadrature_points[q][d][0];
                         }
                     }
                   if (is_boundary_face == false &&


### PR DESCRIPTION
For the vectorization across several faces with the matrix-free framework, we need to ensure that all SIMD lanes contain valid geometry data. If the respective SIMD lane does not hold real data because the number of faces is not divisible by the SIMD length, we do the right thing when accessing result vectors, but the geometry might still get evaluated depending on the user code. We already copied the data for the Jacobians, JxW values, and normal vectors, but we forgot to do so for the quadrature points. This fixes that case.