### PR TITLE
Use types::global_dof_index rather than unsigned int in MGTransfer

### DIFF
--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -263,8 +263,8 @@ namespace internal
               const IndexSet &is_local =
                 dof_handler.locally_owned_mg_dofs(level);
 
-              std::vector<unsigned int> level_dof_indices;
-              std::vector<unsigned int> global_dof_indices;
+              std::vector<types::global_dof_index> level_dof_indices;
+              std::vector<types::global_dof_index> global_dof_indices;
               for (const auto &dofpair : send_data_temp)
                 if (dofpair.level == level)
                   {


### PR DESCRIPTION
As discussed in #8937, we used `unsigned int` for some indices that represent global dof indices in the setup of the indices along refinement edges in geometric multigrid. These should be global indices.

This might address #8937 or at least the reduced test case that @tjhei and @tcclevenger constructed, but my job asserting this is still in the queue of the machine. Given the large size (>200 nodes), I also do not see how we could test this feature in the test suite.