### PR TITLE
Avoid correcting higher derivatives if mapping is Cartesian

### DIFF
--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -455,6 +455,30 @@ protected:
   };
 
   /**
+   * Correct the shape Hessians by subtracting the terms corresponding to the
+   * Jacobian pushed forward gradient.
+   *
+   * Before the correction, the Hessians would be given by
+   * @f[
+   * D_{ijk} = \frac{d^2\phi_i}{d \hat x_J d \hat x_K} (J_{jJ})^{-1}
+   * (J_{kK})^{-1},
+   * @f]
+   * where $J_{iI}=\frac{d x_i}{d \hat x_I}$. After the correction, the
+   * correct Hessians would be given by
+   * @f[
+   * \frac{d^2 \phi_i}{d x_j d x_k} = D_{ijk} - H_{mjk} \frac{d \phi_i}{d x_m},
+   * @f]
+   * where $H_{ijk}$ is the Jacobian pushed-forward derivative.
+   */
+  void
+  correct_hessians(
+    internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim>
+      &output_data,
+    const internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &                mapping_data,
+    const unsigned int n_q_points) const;
+
+  /**
    * Correct the shape third derivatives by subtracting the terms
    * corresponding to the Jacobian pushed forward gradient and second
    * derivative.
@@ -484,6 +508,7 @@ protected:
       &                mapping_data,
     const unsigned int n_q_points,
     const unsigned int dof) const;
+
 
   /**
    * The polynomial space. Its type is given by the template parameter

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -506,8 +506,7 @@ protected:
       &output_data,
     const internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
       &                mapping_data,
-    const unsigned int n_q_points,
-    const unsigned int dof) const;
+    const unsigned int n_q_points) const;
 
 
   /**

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -27,6 +27,7 @@
 
 #include <deal.II/fe/fe_poly.h>
 #include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_cartesian.h>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -223,6 +224,46 @@ FE_Poly<PolynomialType, dim, spacedim>::requires_update_flags(
 //---------------------------------------------------------------------------
 
 
+
+/**
+ * Returns whether we need to correct the Hessians and third derivatives with
+ * the derivatives of the Jacobian. This is determined by checking if
+ * the jacobian_pushed_forward are zero.
+ *
+ * Especially for the third derivatives, the correction term is very expensive,
+ * which is why we check if the derivatives are zero before computing the
+ * correction.
+ */
+template <int dim, int spacedim>
+bool
+higher_derivatives_need_correcting(
+  const Mapping<dim, spacedim> &mapping,
+  const internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+    &                mapping_data,
+  const unsigned int n_q_points,
+  const UpdateFlags  update_flags)
+{
+  // If higher derivatives weren't requested we don't need to correct them.
+  const bool update_higher_derivatives =
+    (update_flags & update_hessians) || (update_flags & update_3rd_derivatives);
+  if (!update_higher_derivatives)
+    return false;
+
+  // If we have a Cartesian mapping, we know that jacoban_pushed_forward_grads
+  // are identically zero.
+  if (dynamic_cast<const MappingCartesian<dim> *>(&mapping))
+    return false;
+
+  // Here, we should check if jacobian_pushed_forward_grads are zero at the
+  // quadrature points. This is yet to be implemented.
+  (void)mapping_data;
+  (void)n_q_points;
+
+  return true;
+}
+
+
+
 template <class PolynomialType, int dim, int spacedim>
 void
 FE_Poly<PolynomialType, dim, spacedim>::fill_fe_values(
@@ -249,6 +290,12 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_values(
 
   const UpdateFlags flags(fe_data.update_each);
 
+  const bool need_to_correct_higher_derivatives =
+    higher_derivatives_need_correcting(mapping,
+                                       mapping_data,
+                                       quadrature.size(),
+                                       flags);
+
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
   // we were in get_data()
@@ -268,7 +315,8 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_values(
                           mapping_internal,
                           make_array_view(output_data.shape_hessians, k));
 
-      correct_hessians(output_data, mapping_data, quadrature.size());
+      if (need_to_correct_higher_derivatives)
+        correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
   if (flags & update_3rd_derivatives &&
@@ -281,7 +329,8 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_values(
                           make_array_view(output_data.shape_3rd_derivatives,
                                           k));
 
-      correct_third_derivatives(output_data, mapping_data, quadrature.size());
+      if (need_to_correct_higher_derivatives)
+        correct_third_derivatives(output_data, mapping_data, quadrature.size());
     }
 }
 
@@ -324,6 +373,12 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_face_values(
 
   const UpdateFlags flags(fe_data.update_each);
 
+  const bool need_to_correct_higher_derivatives =
+    higher_derivatives_need_correcting(mapping,
+                                       mapping_data,
+                                       quadrature.size(),
+                                       flags);
+
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
@@ -349,7 +404,8 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_face_values(
           mapping_internal,
           make_array_view(output_data.shape_hessians, k));
 
-      correct_hessians(output_data, mapping_data, quadrature.size());
+      if (need_to_correct_higher_derivatives)
+        correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
   if (flags & update_3rd_derivatives)
@@ -364,7 +420,8 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_face_values(
                           make_array_view(output_data.shape_3rd_derivatives,
                                           k));
 
-      correct_third_derivatives(output_data, mapping_data, quadrature.size());
+      if (need_to_correct_higher_derivatives)
+        correct_third_derivatives(output_data, mapping_data, quadrature.size());
     }
 }
 
@@ -410,6 +467,12 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_subface_values(
 
   const UpdateFlags flags(fe_data.update_each);
 
+  const bool need_to_correct_higher_derivatives =
+    higher_derivatives_need_correcting(mapping,
+                                       mapping_data,
+                                       quadrature.size(),
+                                       flags);
+
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
@@ -435,7 +498,8 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_subface_values(
           mapping_internal,
           make_array_view(output_data.shape_hessians, k));
 
-      correct_hessians(output_data, mapping_data, quadrature.size());
+      if (need_to_correct_higher_derivatives)
+        correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
   if (flags & update_3rd_derivatives)
@@ -450,7 +514,8 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_subface_values(
                           make_array_view(output_data.shape_3rd_derivatives,
                                           k));
 
-      correct_third_derivatives(output_data, mapping_data, quadrature.size());
+      if (need_to_correct_higher_derivatives)
+        correct_third_derivatives(output_data, mapping_data, quadrature.size());
     }
 }
 

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -281,11 +281,7 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_values(
                           make_array_view(output_data.shape_3rd_derivatives,
                                           k));
 
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
-        correct_third_derivatives(output_data,
-                                  mapping_data,
-                                  quadrature.size(),
-                                  k);
+      correct_third_derivatives(output_data, mapping_data, quadrature.size());
     }
 }
 
@@ -368,11 +364,7 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_face_values(
                           make_array_view(output_data.shape_3rd_derivatives,
                                           k));
 
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
-        correct_third_derivatives(output_data,
-                                  mapping_data,
-                                  quadrature.size(),
-                                  k);
+      correct_third_derivatives(output_data, mapping_data, quadrature.size());
     }
 }
 
@@ -458,11 +450,7 @@ FE_Poly<PolynomialType, dim, spacedim>::fill_fe_subface_values(
                           make_array_view(output_data.shape_3rd_derivatives,
                                           k));
 
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
-        correct_third_derivatives(output_data,
-                                  mapping_data,
-                                  quadrature.size(),
-                                  k);
+      correct_third_derivatives(output_data, mapping_data, quadrature.size());
     }
 }
 
@@ -494,26 +482,26 @@ FE_Poly<PolynomialType, dim, spacedim>::correct_third_derivatives(
     &output_data,
   const internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
     &                mapping_data,
-  const unsigned int n_q_points,
-  const unsigned int dof) const
+  const unsigned int n_q_points) const
 {
-  for (unsigned int i = 0; i < n_q_points; ++i)
-    for (unsigned int j = 0; j < spacedim; ++j)
-      for (unsigned int k = 0; k < spacedim; ++k)
-        for (unsigned int l = 0; l < spacedim; ++l)
-          for (unsigned int m = 0; m < spacedim; ++m)
-            {
-              output_data.shape_3rd_derivatives[dof][i][j][k][l] -=
-                (mapping_data.jacobian_pushed_forward_grads[i][m][j][l] *
-                 output_data.shape_hessians[dof][i][k][m]) +
-                (mapping_data.jacobian_pushed_forward_grads[i][m][k][l] *
-                 output_data.shape_hessians[dof][i][j][m]) +
-                (mapping_data.jacobian_pushed_forward_grads[i][m][j][k] *
-                 output_data.shape_hessians[dof][i][l][m]) +
-                (mapping_data
-                   .jacobian_pushed_forward_2nd_derivatives[i][m][j][k][l] *
-                 output_data.shape_gradients[dof][i][m]);
-            }
+  for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+    for (unsigned int i = 0; i < n_q_points; ++i)
+      for (unsigned int j = 0; j < spacedim; ++j)
+        for (unsigned int k = 0; k < spacedim; ++k)
+          for (unsigned int l = 0; l < spacedim; ++l)
+            for (unsigned int m = 0; m < spacedim; ++m)
+              {
+                output_data.shape_3rd_derivatives[dof][i][j][k][l] -=
+                  (mapping_data.jacobian_pushed_forward_grads[i][m][j][l] *
+                   output_data.shape_hessians[dof][i][k][m]) +
+                  (mapping_data.jacobian_pushed_forward_grads[i][m][k][l] *
+                   output_data.shape_hessians[dof][i][j][m]) +
+                  (mapping_data.jacobian_pushed_forward_grads[i][m][j][k] *
+                   output_data.shape_hessians[dof][i][l][m]) +
+                  (mapping_data
+                     .jacobian_pushed_forward_2nd_derivatives[i][m][j][k][l] *
+                   output_data.shape_gradients[dof][i][m]);
+              }
 }
 
 namespace internal

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -70,12 +70,7 @@ FE_Poly<TensorProductPolynomials<1>, 1, 2>::fill_fe_values(
                           mapping_internal,
                           make_array_view(output_data.shape_hessians, k));
 
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
-        for (unsigned int i = 0; i < quadrature.size(); ++i)
-          for (unsigned int j = 0; j < 2; ++j)
-            output_data.shape_hessians[k][i] -=
-              mapping_data.jacobian_pushed_forward_grads[i][j] *
-              output_data.shape_gradients[k][i][j];
+      correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
   if (fe_data.update_each & update_3rd_derivatives &&
@@ -139,12 +134,7 @@ FE_Poly<TensorProductPolynomials<2>, 2, 3>::fill_fe_values(
                           mapping_internal,
                           make_array_view(output_data.shape_hessians, k));
 
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
-        for (unsigned int i = 0; i < quadrature.size(); ++i)
-          for (unsigned int j = 0; j < 3; ++j)
-            output_data.shape_hessians[k][i] -=
-              mapping_data.jacobian_pushed_forward_grads[i][j] *
-              output_data.shape_gradients[k][i][j];
+      correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
   if (fe_data.update_each & update_3rd_derivatives &&

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -83,11 +83,7 @@ FE_Poly<TensorProductPolynomials<1>, 1, 2>::fill_fe_values(
                           make_array_view(output_data.shape_3rd_derivatives,
                                           k));
 
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
-        correct_third_derivatives(output_data,
-                                  mapping_data,
-                                  quadrature.size(),
-                                  k);
+      correct_third_derivatives(output_data, mapping_data, quadrature.size());
     }
 }
 
@@ -147,11 +143,7 @@ FE_Poly<TensorProductPolynomials<2>, 2, 3>::fill_fe_values(
                           make_array_view(output_data.shape_3rd_derivatives,
                                           k));
 
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
-        correct_third_derivatives(output_data,
-                                  mapping_data,
-                                  quadrature.size(),
-                                  k);
+      correct_third_derivatives(output_data, mapping_data, quadrature.size());
     }
 }
 

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -50,6 +50,12 @@ FE_Poly<TensorProductPolynomials<1>, 1, 2>::fill_fe_values(
   const InternalData &fe_data =
     static_cast<const InternalData &>(fe_internal); // NOLINT
 
+  const bool need_to_correct_higher_derivatives =
+    higher_derivatives_need_correcting(mapping,
+                                       mapping_data,
+                                       quadrature.size(),
+                                       fe_data.update_each);
+
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
   // we were in get_data()
@@ -70,7 +76,8 @@ FE_Poly<TensorProductPolynomials<1>, 1, 2>::fill_fe_values(
                           mapping_internal,
                           make_array_view(output_data.shape_hessians, k));
 
-      correct_hessians(output_data, mapping_data, quadrature.size());
+      if (need_to_correct_higher_derivatives)
+        correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
   if (fe_data.update_each & update_3rd_derivatives &&
@@ -83,7 +90,8 @@ FE_Poly<TensorProductPolynomials<1>, 1, 2>::fill_fe_values(
                           make_array_view(output_data.shape_3rd_derivatives,
                                           k));
 
-      correct_third_derivatives(output_data, mapping_data, quadrature.size());
+      if (need_to_correct_higher_derivatives)
+        correct_third_derivatives(output_data, mapping_data, quadrature.size());
     }
 }
 
@@ -110,6 +118,12 @@ FE_Poly<TensorProductPolynomials<2>, 2, 3>::fill_fe_values(
   const InternalData &fe_data =
     static_cast<const InternalData &>(fe_internal); // NOLINT
 
+  const bool need_to_correct_higher_derivatives =
+    higher_derivatives_need_correcting(mapping,
+                                       mapping_data,
+                                       quadrature.size(),
+                                       fe_data.update_each);
+
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
   // we were in get_data()
@@ -130,7 +144,8 @@ FE_Poly<TensorProductPolynomials<2>, 2, 3>::fill_fe_values(
                           mapping_internal,
                           make_array_view(output_data.shape_hessians, k));
 
-      correct_hessians(output_data, mapping_data, quadrature.size());
+      if (need_to_correct_higher_derivatives)
+        correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
   if (fe_data.update_each & update_3rd_derivatives &&
@@ -143,7 +158,8 @@ FE_Poly<TensorProductPolynomials<2>, 2, 3>::fill_fe_values(
                           make_array_view(output_data.shape_3rd_derivatives,
                                           k));
 
-      correct_third_derivatives(output_data, mapping_data, quadrature.size());
+      if (need_to_correct_higher_derivatives)
+        correct_third_derivatives(output_data, mapping_data, quadrature.size());
     }
 }
 


### PR DESCRIPTION
I'm using higher derivatives on a perfectly Cartesian mesh. I noticed some bottlenecks in my code, so I did the following test:

On a 10x10x10 mesh, using `FE_Q<3>(3)` elements and `MappingCartesian`, I called `FEFaceValues::reinit` on all faces in the mesh with different update flags. This gave me the following times spend in `FEFaceValues::reinit`:

``` 
UpdateFlags                time/s
update_values              0.25
update_gradients           0.35
update_hessians            3.25
update_3rd_derivatives     71.33
```

Clearly computing 3rd derivatives is very expensive. However, almost all of the time is spent in `FE_Poly::correct_third_derivatives`, which corrects the computation with the derivatives of the Jacobian. When using a `MappingCartesian`, this correction is just 0.

This pull-request changes so that we first check if the mapping is Cartesian before we compute the correction terms for the Hessian and the third derivatives. For the same example as above, this gives the following times:

``` 
UpdateFlags                time/s
update_values              0.24
update_gradients           0.35
update_hessians            1.38
update_3rd_derivatives     5.06
```