### PR TITLE
Use AssertThrow when LAPACK or other dependencies are not installed

### DIFF
--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -339,7 +339,7 @@ FunctionParser<dim>::initialize(const std::string &,
                                 const std::map<std::string, double> &,
                                 const bool)
 {
-  Assert(false, ExcNeedsFunctionparser());
+  AssertThrow(false, ExcNeedsFunctionparser());
 }
 
 template <int dim>
@@ -349,7 +349,7 @@ FunctionParser<dim>::initialize(const std::string &,
                                 const std::map<std::string, double> &,
                                 const bool)
 {
-  Assert(false, ExcNeedsFunctionparser());
+  AssertThrow(false, ExcNeedsFunctionparser());
 }
 
 
@@ -358,7 +358,7 @@ template <int dim>
 double
 FunctionParser<dim>::value(const Point<dim> &, unsigned int) const
 {
-  Assert(false, ExcNeedsFunctionparser());
+  AssertThrow(false, ExcNeedsFunctionparser());
   return 0.;
 }
 
@@ -367,7 +367,7 @@ template <int dim>
 void
 FunctionParser<dim>::vector_value(const Point<dim> &, Vector<double> &) const
 {
-  Assert(false, ExcNeedsFunctionparser());
+  AssertThrow(false, ExcNeedsFunctionparser());
 }
 
 

--- a/source/base/tensor_function_parser.cc
+++ b/source/base/tensor_function_parser.cc
@@ -354,7 +354,7 @@ TensorFunctionParser<rank, dim, Number>::initialize(
   const std::map<std::string, double> &,
   const bool)
 {
-  Assert(false, ExcNeedsFunctionparser());
+  AssertThrow(false, ExcNeedsFunctionparser());
 }
 
 template <int rank, int dim, typename Number>
@@ -365,7 +365,7 @@ TensorFunctionParser<rank, dim, Number>::initialize(
   const std::map<std::string, double> &,
   const bool)
 {
-  Assert(false, ExcNeedsFunctionparser());
+  AssertThrow(false, ExcNeedsFunctionparser());
 }
 
 
@@ -374,7 +374,7 @@ template <int rank, int dim, typename Number>
 Tensor<rank, dim, Number>
 TensorFunctionParser<rank, dim, Number>::value(const Point<dim> &) const
 {
-  Assert(false, ExcNeedsFunctionparser());
+  AssertThrow(false, ExcNeedsFunctionparser());
   return Tensor<rank, dim, Number>();
 }
 
@@ -386,7 +386,7 @@ TensorFunctionParser<rank, dim, Number>::value_list(
   const std::vector<Point<dim>> &,
   std::vector<Tensor<rank, dim, Number>> &) const
 {
-  Assert(false, ExcNeedsFunctionparser());
+  AssertThrow(false, ExcNeedsFunctionparser());
 }
 
 

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3122,7 +3122,7 @@ GridIn<dim, spacedim>::read_assimp(const std::string &filename,
   (void)remove_duplicates;
   (void)tol;
   (void)ignore_unsupported_types;
-  Assert(false, ExcNeedsAssimp());
+  AssertThrow(false, ExcNeedsAssimp());
 #endif
 }
 

--- a/source/lac/tridiagonal_matrix.cc
+++ b/source/lac/tridiagonal_matrix.cc
@@ -253,7 +253,7 @@ TridiagonalMatrix<number>::compute_eigenvalues()
 
   state = LAPACKSupport::eigenvalues;
 #else
-  Assert(false, ExcNeedsLAPACK());
+  AssertThrow(false, ExcNeedsLAPACK());
 #endif
 }
 


### PR DESCRIPTION
This bit me on a run in release mode on a cluster today, because my
deal.II didn't have a working LAPACK.